### PR TITLE
Prepare v3.7

### DIFF
--- a/LitCalAllFestivities.php
+++ b/LitCalAllFestivities.php
@@ -22,8 +22,8 @@ $LatinMissals = array_filter( RomanMissal::$values, function($item){
 });
 
 $LOCALE = isset( $_GET["locale"] ) ? $_GET["locale"] : "la";
-$LOCALE = strtolower( explode('_', $LOCALE)[0] );
 $LOCALE = LitLocale::isValid( $LOCALE ) ? $LOCALE : "la";
+$LOCALE = $LOCALE !== "LA" && $LOCALE !== "la" ? LOCALE::getPrimaryLanguage( $LOCALE ) : "la";
 
 foreach( $LatinMissals as $LatinMissal ) {
     $DataFile = RomanMissal::getSanctoraleFileName( $LatinMissal );

--- a/LitCalEngine.php
+++ b/LitCalEngine.php
@@ -5,7 +5,7 @@
  * Author: John Romano D'Orazio
  * Email: priest@johnromanodorazio.com
  * Licensed under the Apache 2.0 License
- * Version 3.6
+ * Version 3.7
  * Date Created: 27 December 2017
  */
 

--- a/LitCalEngine.php
+++ b/LitCalEngine.php
@@ -5,7 +5,7 @@
  * Author: John Romano D'Orazio
  * Email: priest@johnromanodorazio.com
  * Licensed under the Apache 2.0 License
- * Version 3.4
+ * Version 3.6
  * Date Created: 27 December 2017
  */
 

--- a/README.md
+++ b/README.md
@@ -195,95 +195,106 @@ Two object keys are returned:
  * Fix days before / after Epiphany (handled differently in different national calendars!)
  * Add Dutch translation for Netherlands, thanks to Steven van Roode
 ## [v3.4](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.4) (June 6th 2022)
- * Fix issue with Saint Vincent deacon in national calendar for USA c27289f3c893a184d605e8b1a495a48e2e76669d
- * simplify calculation of Vigil Masses 0afa39b838611554d32fd0d1c2a80a11a92ec696
- * add cache-control headers to the Metadata enpoint 3d77f602f29d6a3afaacefb43b3b147ca1dedaef
- * complete move from MySQL tables to JSON source files d9c73447da1f9997eb0716a6591badc2a0e928ab
- * add DiocesanGroups info to the Metadata endpoint a378f16e5072c4c298b5bf31263222f159148fbb
+ * Fix issue with Saint Vincent deacon in national calendar for USA
+   * [c27289f3c893a184d605e8b1a495a48e2e76669d](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/c27289f3c893a184d605e8b1a495a48e2e76669d)
+ * simplify calculation of Vigil Masses
+   * [0afa39b838611554d32fd0d1c2a80a11a92ec696](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0afa39b838611554d32fd0d1c2a80a11a92ec696)
+ * add cache-control headers to the Metadata enpoint
+   * [3d77f602f29d6a3afaacefb43b3b147ca1dedaef](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/3d77f602f29d6a3afaacefb43b3b147ca1dedaef)
+ * complete move from MySQL tables to JSON source files
+   * [d9c73447da1f9997eb0716a6591badc2a0e928ab](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/d9c73447da1f9997eb0716a6591badc2a0e928ab)
+ * add DiocesanGroups info to the Metadata endpoint
+   * [a378f16e5072c4c298b5bf31263222f159148fbb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a378f16e5072c4c298b5bf31263222f159148fbb)
  * move National Calendar data and Wider Region calendar data to JSON source files:
-   * 1716486704a51eca41cdc066e66744c9c832f05b
-   * 4e298779201e49ab820453be2e8c3f1083082935
-   * 15f16c38cd4c1ba0ded4805760f8c369b9584b49
-   * 5b27417ed32f782c50527f4d7a33df1318f60767
-   * 1247b98d309a7d7eb936740a4094213b826a9ef5
-   * cdf8bdb99f8ddaff52382259ec600a6ec33058a2
-   * 62ad9461757c4e7e6b7c22a2ed5b0567f6052bd7
-   * 7395ef4e75ef0548fcf5dff916cc9b2e77d9f8f6
-   * e5d010f093da4599d9b378396a0b89e7d2763a1f
-   * 9ada5aa092888a1c5ab1df31bc19c185273634f5
-   * c9646a6b24ee9998aed74d077b455231f67183de
-   * 25aa01a8ffd4abf2df97f4fd7ce035361310c6bb
-   * ea5beacd4d21c050aaf0629596feef430f4faa5b
-   * b81b8681c1d2307d3ad95c0aefc15fca3cb92aa2
-   * a837f7b739e215af6eba2337b513200af778d71c
-   * 7e9e894e5320ace19eadcdd656e90f5a7ac5e911
-   * 4d1eca213b11a8231cfa4938908cbcca617b88df
-   * e86ccdace21b6545a2f5c6ea6328ddafe849ba39
-   * 445d22c865709f5621f1b4a3098d8471109650e0
-   * a0e693f2abdd458c85d0526fbde09e85850be74c
+   * [1716486704a51eca41cdc066e66744c9c832f05b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1716486704a51eca41cdc066e66744c9c832f05b)
+   * [4e298779201e49ab820453be2e8c3f1083082935](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4e298779201e49ab820453be2e8c3f1083082935)
+   * [15f16c38cd4c1ba0ded4805760f8c369b9584b49](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/15f16c38cd4c1ba0ded4805760f8c369b9584b49)
+   * [5b27417ed32f782c50527f4d7a33df1318f60767](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/5b27417ed32f782c50527f4d7a33df1318f60767)
+   * [1247b98d309a7d7eb936740a4094213b826a9ef5](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1247b98d309a7d7eb936740a4094213b826a9ef5)
+   * [cdf8bdb99f8ddaff52382259ec600a6ec33058a2](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/cdf8bdb99f8ddaff52382259ec600a6ec33058a2)
+   * [62ad9461757c4e7e6b7c22a2ed5b0567f6052bd7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/62ad9461757c4e7e6b7c22a2ed5b0567f6052bd7)
+   * [7395ef4e75ef0548fcf5dff916cc9b2e77d9f8f6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/7395ef4e75ef0548fcf5dff916cc9b2e77d9f8f6)
+   * [e5d010f093da4599d9b378396a0b89e7d2763a1f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/e5d010f093da4599d9b378396a0b89e7d2763a1f)
+   * [9ada5aa092888a1c5ab1df31bc19c185273634f5](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/9ada5aa092888a1c5ab1df31bc19c185273634f5)
+   * [c9646a6b24ee9998aed74d077b455231f67183de](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/c9646a6b24ee9998aed74d077b455231f67183de)
+   * [25aa01a8ffd4abf2df97f4fd7ce035361310c6bb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/25aa01a8ffd4abf2df97f4fd7ce035361310c6bb)
+   * [ea5beacd4d21c050aaf0629596feef430f4faa5b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/ea5beacd4d21c050aaf0629596feef430f4faa5b)
+   * [b81b8681c1d2307d3ad95c0aefc15fca3cb92aa2](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b81b8681c1d2307d3ad95c0aefc15fca3cb92aa2)
+   * [a837f7b739e215af6eba2337b513200af778d71c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a837f7b739e215af6eba2337b513200af778d71c)
+   * [7e9e894e5320ace19eadcdd656e90f5a7ac5e911](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/7e9e894e5320ace19eadcdd656e90f5a7ac5e911)
+   * [4d1eca213b11a8231cfa4938908cbcca617b88df](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4d1eca213b11a8231cfa4938908cbcca617b88df)
+   * [e86ccdace21b6545a2f5c6ea6328ddafe849ba39](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/e86ccdace21b6545a2f5c6ea6328ddafe849ba39)
+   * [445d22c865709f5621f1b4a3098d8471109650e0](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/445d22c865709f5621f1b4a3098d8471109650e0)
+   * [a0e693f2abdd458c85d0526fbde09e85850be74c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a0e693f2abdd458c85d0526fbde09e85850be74c)
  * add cache-control headers to the Main endpoint
-   * d2ae04de03a2b08360c7ab62e04830c41a34a0f7
-   * df7e17da9e9e331cfb84f6b7ccb4af4c5632bd41
- * add WiderRegions info to the Metadata endpoint b3f567f71a7566da8ba20cc943bd4578534c3ac4
- * add methods to FestivityCollection a9e176092f44da4fe0fe505097bd69ddc5ea614a
- * add year limits to Roman Missals 0f939ba6dcca1866b13721bafc5f519c47d8ed16
+   * [d2ae04de03a2b08360c7ab62e04830c41a34a0f7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/d2ae04de03a2b08360c7ab62e04830c41a34a0f7)
+   * [df7e17da9e9e331cfb84f6b7ccb4af4c5632bd41](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/df7e17da9e9e331cfb84f6b7ccb4af4c5632bd41)
+ * add WiderRegions info to the Metadata endpoint 
+   * [b3f567f71a7566da8ba20cc943bd4578534c3ac4](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b3f567f71a7566da8ba20cc943bd4578534c3ac4)
+ * add methods to FestivityCollection
+   * [a9e176092f44da4fe0fe505097bd69ddc5ea614a](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a9e176092f44da4fe0fe505097bd69ddc5ea614a)
+ * add year limits to Roman Missals
+   * [0f939ba6dcca1866b13721bafc5f519c47d8ed16](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0f939ba6dcca1866b13721bafc5f519c47d8ed16)
  * fix enum validations
-   * 4c595c17e1bbf41e6c87e25aa043b97664cbb577
-   * c3d2492f926faeaca5819e27e0b829369669b16a
+   * [4c595c17e1bbf41e6c87e25aa043b97664cbb577](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4c595c17e1bbf41e6c87e25aa043b97664cbb577)
+   * [c3d2492f926faeaca5819e27e0b829369669b16a](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/c3d2492f926faeaca5819e27e0b829369669b16a)
  * various fixes
-   * 8330fa096b7e0a4154dcc6e00a3d7100d81f1896
-   * 6cf80da677a203ccfdd0d6b0a97aeebd63b3e011
-   * a7e85de029fec3f2952129b97fc0428c740232cc
-   * 4e0a5979552a79382f74edb052f4578333d2a007
-   * 8ee7065c334aa93e6fe0a078b312256cad7cf061
-   * 44df76f230d2595c57a0abe44539efb543f0dc4f
-   * 5638ec6950ac5742175d7e6656c18af873b43cfd
-   * 4f7c11f106496a7d31c504444927182676b567c4
-   * 4decc12dd019a11c2fb0d632df9c34298750f5fa
-   * 54500104b1276c826796542919c53b86fb32c4e6
-   * e2c1f6c71b5fbda4757ecd8cef82dda5c570d8f7
-   * fcb11085ca5c7f3bf82b5dc36808e2e57b4cbbdb
-   * ec772a0b228b76d652436ba2c221f4824808b6a6
-   * d804c7e5d686e59d633ee50df76553291df477e9
-   * a52019ed070436b5d271b05591d5d2e7f5d93477
-   * 8eadab79ea5200535b21a6f7a37257a7a13305e7
- * add Roman Missal info to the Metadata endpoint 715c28ac7b8113df0aa2c8ad81092828a13c619b
- * output 404 error for unavailable resources 0bcbd3b09bbe4f8e6d6ddae9cdc1c732a824091a
+   * [8330fa096b7e0a4154dcc6e00a3d7100d81f1896](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8330fa096b7e0a4154dcc6e00a3d7100d81f1896)
+   * [6cf80da677a203ccfdd0d6b0a97aeebd63b3e011](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/6cf80da677a203ccfdd0d6b0a97aeebd63b3e011)
+   * [a7e85de029fec3f2952129b97fc0428c740232cc](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a7e85de029fec3f2952129b97fc0428c740232cc)
+   * [4e0a5979552a79382f74edb052f4578333d2a007](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4e0a5979552a79382f74edb052f4578333d2a007)
+   * [8ee7065c334aa93e6fe0a078b312256cad7cf061](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8ee7065c334aa93e6fe0a078b312256cad7cf061)
+   * [44df76f230d2595c57a0abe44539efb543f0dc4f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/44df76f230d2595c57a0abe44539efb543f0dc4f)
+   * [5638ec6950ac5742175d7e6656c18af873b43cfd](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/5638ec6950ac5742175d7e6656c18af873b43cfd)
+   * [4f7c11f106496a7d31c504444927182676b567c4](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4f7c11f106496a7d31c504444927182676b567c4)
+   * [4decc12dd019a11c2fb0d632df9c34298750f5fa](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4decc12dd019a11c2fb0d632df9c34298750f5fa)
+   * [54500104b1276c826796542919c53b86fb32c4e6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/54500104b1276c826796542919c53b86fb32c4e6)
+   * [e2c1f6c71b5fbda4757ecd8cef82dda5c570d8f7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/e2c1f6c71b5fbda4757ecd8cef82dda5c570d8f7)
+   * [fcb11085ca5c7f3bf82b5dc36808e2e57b4cbbdb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/fcb11085ca5c7f3bf82b5dc36808e2e57b4cbbdb)
+   * [ec772a0b228b76d652436ba2c221f4824808b6a6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/ec772a0b228b76d652436ba2c221f4824808b6a6)
+   * [d804c7e5d686e59d633ee50df76553291df477e9](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/d804c7e5d686e59d633ee50df76553291df477e9)
+   * [a52019ed070436b5d271b05591d5d2e7f5d93477](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a52019ed070436b5d271b05591d5d2e7f5d93477)
+   * [8eadab79ea5200535b21a6f7a37257a7a13305e7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8eadab79ea5200535b21a6f7a37257a7a13305e7)
+ * add Roman Missal info to the Metadata endpoint
+   * [715c28ac7b8113df0aa2c8ad81092828a13c619b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/715c28ac7b8113df0aa2c8ad81092828a13c619b)
+ * output 404 error for unavailable resources
+   * [0bcbd3b09bbe4f8e6d6ddae9cdc1c732a824091a](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0bcbd3b09bbe4f8e6d6ddae9cdc1c732a824091a)
  * define JSON schemas 
-   * b66f4d243834a6e19d33505f7ce123ddee651c51
-   * 0db16a7748e4d10bd6c10e3491cf5325232080ca
-   * 1574c01ab4c66bdbcad1f050ea9e2aa580e2d7a1
-   * a70f38350e6eca9e44979ad900c1b8e75787bd92
-   * a9ac10eb96a3a5c409d306812d4d65e98d4b4dd6
-   * bd2ba8ba4a8ff99a25002cc6835b44280ee00e60
-   * fabf7b65a2996695e510768272d84741c2bf8c3e
-   * 8b8ae2a50ad926b4ebcb932aacc0d66d26eb969b
-   * 85066b8e946117609c5a944987c943b127d084ea
-   * 8a66bf4ab497f3c0e9dff64262c737a0f12bbb55
-   * 3f79b058b666061b71a44b8c3bc7a710c0a25f95
-   * 5e82f30e2ca0386a8445080a5173d36a7675dff3
-   * 552eaa3a8a08e1872865b030e6006a7d2e3f2ca9
-   * f6823001940c4fb2b7bc8ad84c26073cc031c1ae
-   * b48bb7274b3dd436ad22fb2187724cec3e665319
-   * 289f4c2caf21de6b646b699d6a2e7ae5af054fe1
-   * 1245cfcaf9b2014a3cdc63c9d021bd09a2525e31
-   * a4d8bc42692d5609e0d4b4057d7f4c8c2ca2dbb7
-   * 1257b9b839408f9a7abb665828a2d5bae46ec356
-   * baef32b45f91bd7abc05845f1fcb0a91ec62ec3c
-   * 09edca182dfb11dfd0ab81310a20e3494c931688
-   * 228af9cbc07ec41004046af44b37101fab410f1f
+   * [b66f4d243834a6e19d33505f7ce123ddee651c51](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b66f4d243834a6e19d33505f7ce123ddee651c51)
+   * [0db16a7748e4d10bd6c10e3491cf5325232080ca](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0db16a7748e4d10bd6c10e3491cf5325232080ca)
+   * [1574c01ab4c66bdbcad1f050ea9e2aa580e2d7a1](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1574c01ab4c66bdbcad1f050ea9e2aa580e2d7a1)
+   * [a70f38350e6eca9e44979ad900c1b8e75787bd92](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a70f38350e6eca9e44979ad900c1b8e75787bd92)
+   * [a9ac10eb96a3a5c409d306812d4d65e98d4b4dd6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a9ac10eb96a3a5c409d306812d4d65e98d4b4dd6)
+   * [bd2ba8ba4a8ff99a25002cc6835b44280ee00e60](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/bd2ba8ba4a8ff99a25002cc6835b44280ee00e60)
+   * [fabf7b65a2996695e510768272d84741c2bf8c3e](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/fabf7b65a2996695e510768272d84741c2bf8c3e)
+   * [8b8ae2a50ad926b4ebcb932aacc0d66d26eb969b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8b8ae2a50ad926b4ebcb932aacc0d66d26eb969b)
+   * [85066b8e946117609c5a944987c943b127d084ea](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/85066b8e946117609c5a944987c943b127d084ea)
+   * [8a66bf4ab497f3c0e9dff64262c737a0f12bbb55](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8a66bf4ab497f3c0e9dff64262c737a0f12bbb55)
+   * [3f79b058b666061b71a44b8c3bc7a710c0a25f95](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/3f79b058b666061b71a44b8c3bc7a710c0a25f95)
+   * [5e82f30e2ca0386a8445080a5173d36a7675dff3](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/5e82f30e2ca0386a8445080a5173d36a7675dff3)
+   * [552eaa3a8a08e1872865b030e6006a7d2e3f2ca9](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/552eaa3a8a08e1872865b030e6006a7d2e3f2ca9)
+   * [f6823001940c4fb2b7bc8ad84c26073cc031c1ae](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/f6823001940c4fb2b7bc8ad84c26073cc031c1ae)
+   * [b48bb7274b3dd436ad22fb2187724cec3e665319](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b48bb7274b3dd436ad22fb2187724cec3e665319)
+   * [289f4c2caf21de6b646b699d6a2e7ae5af054fe1](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/289f4c2caf21de6b646b699d6a2e7ae5af054fe1)
+   * [1245cfcaf9b2014a3cdc63c9d021bd09a2525e31](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1245cfcaf9b2014a3cdc63c9d021bd09a2525e31)
+   * [a4d8bc42692d5609e0d4b4057d7f4c8c2ca2dbb7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a4d8bc42692d5609e0d4b4057d7f4c8c2ca2dbb7)
+   * [1257b9b839408f9a7abb665828a2d5bae46ec356](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1257b9b839408f9a7abb665828a2d5bae46ec356)
+   * [baef32b45f91bd7abc05845f1fcb0a91ec62ec3c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/baef32b45f91bd7abc05845f1fcb0a91ec62ec3c)
+   * [09edca182dfb11dfd0ab81310a20e3494c931688](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/09edca182dfb11dfd0ab81310a20e3494c931688)
+   * [228af9cbc07ec41004046af44b37101fab410f1f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/228af9cbc07ec41004046af44b37101fab410f1f)
  * create JSON schema validation
-   * 3938a278a7fe78bdda30d5d77de6766baa9c7ea1
-   * 85702b023e78159d140cdb301f06d22f0cad4efe
-   * a296cc556ef5d166e5cea4b66c2ddd2fd83334f0
-   * 21f254090b4be79fef871ca02fb9c7fb4b2f5ebb
-   * 765bac9eba97910f200d6cc6f0030f0ada17975f
-   * 10d7619811bef7f55a6498cf3c3351ddfe1f6ae6
-   * 4828724ff4ce90ed66e1572ccec5ede20aa21004
-   * 9cbb8e637b3785ae2839a75c0eb63434b1232bcb
-   * 16809cbc78ee9aa2b9155f0347f49af81f7322c3
-   * a1de05c641b6d103b89577ca225da3d95073bb65
- * add more data for National Calendars to the Metadata endpoint 34ef54f06d5183b463cce0305f649c182edca2b3
+   * [3938a278a7fe78bdda30d5d77de6766baa9c7ea1](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/3938a278a7fe78bdda30d5d77de6766baa9c7ea1)
+   * [85702b023e78159d140cdb301f06d22f0cad4efe](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/85702b023e78159d140cdb301f06d22f0cad4efe)
+   * [a296cc556ef5d166e5cea4b66c2ddd2fd83334f0](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a296cc556ef5d166e5cea4b66c2ddd2fd83334f0)
+   * [21f254090b4be79fef871ca02fb9c7fb4b2f5ebb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/21f254090b4be79fef871ca02fb9c7fb4b2f5ebb)
+   * [765bac9eba97910f200d6cc6f0030f0ada17975f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/765bac9eba97910f200d6cc6f0030f0ada17975f)
+   * [10d7619811bef7f55a6498cf3c3351ddfe1f6ae6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/10d7619811bef7f55a6498cf3c3351ddfe1f6ae6)
+   * [4828724ff4ce90ed66e1572ccec5ede20aa21004](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4828724ff4ce90ed66e1572ccec5ede20aa21004)
+   * [9cbb8e637b3785ae2839a75c0eb63434b1232bcb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/9cbb8e637b3785ae2839a75c0eb63434b1232bcb)
+   * [16809cbc78ee9aa2b9155f0347f49af81f7322c3](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/16809cbc78ee9aa2b9155f0347f49af81f7322c3)
+   * [a1de05c641b6d103b89577ca225da3d95073bb65](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a1de05c641b6d103b89577ca225da3d95073bb65)
+ * add more data for National Calendars to the Metadata endpoint
+   * [34ef54f06d5183b463cce0305f649c182edca2b3](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/34ef54f06d5183b463cce0305f649c182edca2b3)
  * update translations
 ## [v3.3](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.3) (January 27th 2022)
  * move festivity data from the 2008 Editio Typica Tertia emendata out from the `LitCalAPI.php`, to a JSON file

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Two object keys are returned:
  * fix for Netherlands national calendar data (Ascension on Thursday)
 ## [v3.6](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.6) (December 13th 2022)
  * allow Diocesan calendars to define mobile festivities
- * allow Diocesan calendars to define untilYear properties for festivities that may have changes after a given year
+ * allow Diocesan calendars to define `untilYear` properties for festivities that may have changes after a given year
  * remove hardcoding of English, Latin and the 5 main European languages and allow for any possible language
  * allow for geographic locales, in order to better identify source data for a given national or diocesan calendar
  * remove hardcoding of supported national calendars, and automate the scan for existing calendars
@@ -195,106 +195,23 @@ Two object keys are returned:
  * Fix days before / after Epiphany (handled differently in different national calendars!)
  * Add Dutch translation for Netherlands, thanks to Steven van Roode
 ## [v3.4](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.4) (June 6th 2022)
- * Fix issue with Saint Vincent deacon in national calendar for USA
-   * [c27289f3c893a184d605e8b1a495a48e2e76669d](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/c27289f3c893a184d605e8b1a495a48e2e76669d)
- * simplify calculation of Vigil Masses
-   * [0afa39b838611554d32fd0d1c2a80a11a92ec696](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0afa39b838611554d32fd0d1c2a80a11a92ec696)
- * add cache-control headers to the Metadata enpoint
-   * [3d77f602f29d6a3afaacefb43b3b147ca1dedaef](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/3d77f602f29d6a3afaacefb43b3b147ca1dedaef)
- * complete move from MySQL tables to JSON source files
-   * [d9c73447da1f9997eb0716a6591badc2a0e928ab](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/d9c73447da1f9997eb0716a6591badc2a0e928ab)
- * add DiocesanGroups info to the Metadata endpoint
-   * [a378f16e5072c4c298b5bf31263222f159148fbb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a378f16e5072c4c298b5bf31263222f159148fbb)
- * move National Calendar data and Wider Region calendar data to JSON source files:
-   * [1716486704a51eca41cdc066e66744c9c832f05b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1716486704a51eca41cdc066e66744c9c832f05b)
-   * [4e298779201e49ab820453be2e8c3f1083082935](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4e298779201e49ab820453be2e8c3f1083082935)
-   * [15f16c38cd4c1ba0ded4805760f8c369b9584b49](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/15f16c38cd4c1ba0ded4805760f8c369b9584b49)
-   * [5b27417ed32f782c50527f4d7a33df1318f60767](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/5b27417ed32f782c50527f4d7a33df1318f60767)
-   * [1247b98d309a7d7eb936740a4094213b826a9ef5](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1247b98d309a7d7eb936740a4094213b826a9ef5)
-   * [cdf8bdb99f8ddaff52382259ec600a6ec33058a2](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/cdf8bdb99f8ddaff52382259ec600a6ec33058a2)
-   * [62ad9461757c4e7e6b7c22a2ed5b0567f6052bd7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/62ad9461757c4e7e6b7c22a2ed5b0567f6052bd7)
-   * [7395ef4e75ef0548fcf5dff916cc9b2e77d9f8f6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/7395ef4e75ef0548fcf5dff916cc9b2e77d9f8f6)
-   * [e5d010f093da4599d9b378396a0b89e7d2763a1f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/e5d010f093da4599d9b378396a0b89e7d2763a1f)
-   * [9ada5aa092888a1c5ab1df31bc19c185273634f5](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/9ada5aa092888a1c5ab1df31bc19c185273634f5)
-   * [c9646a6b24ee9998aed74d077b455231f67183de](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/c9646a6b24ee9998aed74d077b455231f67183de)
-   * [25aa01a8ffd4abf2df97f4fd7ce035361310c6bb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/25aa01a8ffd4abf2df97f4fd7ce035361310c6bb)
-   * [ea5beacd4d21c050aaf0629596feef430f4faa5b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/ea5beacd4d21c050aaf0629596feef430f4faa5b)
-   * [b81b8681c1d2307d3ad95c0aefc15fca3cb92aa2](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b81b8681c1d2307d3ad95c0aefc15fca3cb92aa2)
-   * [a837f7b739e215af6eba2337b513200af778d71c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a837f7b739e215af6eba2337b513200af778d71c)
-   * [7e9e894e5320ace19eadcdd656e90f5a7ac5e911](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/7e9e894e5320ace19eadcdd656e90f5a7ac5e911)
-   * [4d1eca213b11a8231cfa4938908cbcca617b88df](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4d1eca213b11a8231cfa4938908cbcca617b88df)
-   * [e86ccdace21b6545a2f5c6ea6328ddafe849ba39](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/e86ccdace21b6545a2f5c6ea6328ddafe849ba39)
-   * [445d22c865709f5621f1b4a3098d8471109650e0](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/445d22c865709f5621f1b4a3098d8471109650e0)
-   * [a0e693f2abdd458c85d0526fbde09e85850be74c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a0e693f2abdd458c85d0526fbde09e85850be74c)
- * add cache-control headers to the Main endpoint
-   * [d2ae04de03a2b08360c7ab62e04830c41a34a0f7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/d2ae04de03a2b08360c7ab62e04830c41a34a0f7)
-   * [df7e17da9e9e331cfb84f6b7ccb4af4c5632bd41](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/df7e17da9e9e331cfb84f6b7ccb4af4c5632bd41)
- * add WiderRegions info to the Metadata endpoint 
-   * [b3f567f71a7566da8ba20cc943bd4578534c3ac4](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b3f567f71a7566da8ba20cc943bd4578534c3ac4)
- * add methods to FestivityCollection
-   * [a9e176092f44da4fe0fe505097bd69ddc5ea614a](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a9e176092f44da4fe0fe505097bd69ddc5ea614a)
- * add year limits to Roman Missals
-   * [0f939ba6dcca1866b13721bafc5f519c47d8ed16](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0f939ba6dcca1866b13721bafc5f519c47d8ed16)
- * fix enum validations
-   * [4c595c17e1bbf41e6c87e25aa043b97664cbb577](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4c595c17e1bbf41e6c87e25aa043b97664cbb577)
-   * [c3d2492f926faeaca5819e27e0b829369669b16a](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/c3d2492f926faeaca5819e27e0b829369669b16a)
- * various fixes
-   * [8330fa096b7e0a4154dcc6e00a3d7100d81f1896](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8330fa096b7e0a4154dcc6e00a3d7100d81f1896)
-   * [6cf80da677a203ccfdd0d6b0a97aeebd63b3e011](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/6cf80da677a203ccfdd0d6b0a97aeebd63b3e011)
-   * [a7e85de029fec3f2952129b97fc0428c740232cc](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a7e85de029fec3f2952129b97fc0428c740232cc)
-   * [4e0a5979552a79382f74edb052f4578333d2a007](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4e0a5979552a79382f74edb052f4578333d2a007)
-   * [8ee7065c334aa93e6fe0a078b312256cad7cf061](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8ee7065c334aa93e6fe0a078b312256cad7cf061)
-   * [44df76f230d2595c57a0abe44539efb543f0dc4f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/44df76f230d2595c57a0abe44539efb543f0dc4f)
-   * [5638ec6950ac5742175d7e6656c18af873b43cfd](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/5638ec6950ac5742175d7e6656c18af873b43cfd)
-   * [4f7c11f106496a7d31c504444927182676b567c4](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4f7c11f106496a7d31c504444927182676b567c4)
-   * [4decc12dd019a11c2fb0d632df9c34298750f5fa](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4decc12dd019a11c2fb0d632df9c34298750f5fa)
-   * [54500104b1276c826796542919c53b86fb32c4e6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/54500104b1276c826796542919c53b86fb32c4e6)
-   * [e2c1f6c71b5fbda4757ecd8cef82dda5c570d8f7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/e2c1f6c71b5fbda4757ecd8cef82dda5c570d8f7)
-   * [fcb11085ca5c7f3bf82b5dc36808e2e57b4cbbdb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/fcb11085ca5c7f3bf82b5dc36808e2e57b4cbbdb)
-   * [ec772a0b228b76d652436ba2c221f4824808b6a6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/ec772a0b228b76d652436ba2c221f4824808b6a6)
-   * [d804c7e5d686e59d633ee50df76553291df477e9](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/d804c7e5d686e59d633ee50df76553291df477e9)
-   * [a52019ed070436b5d271b05591d5d2e7f5d93477](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a52019ed070436b5d271b05591d5d2e7f5d93477)
-   * [8eadab79ea5200535b21a6f7a37257a7a13305e7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8eadab79ea5200535b21a6f7a37257a7a13305e7)
- * add Roman Missal info to the Metadata endpoint
-   * [715c28ac7b8113df0aa2c8ad81092828a13c619b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/715c28ac7b8113df0aa2c8ad81092828a13c619b)
- * output 404 error for unavailable resources
-   * [0bcbd3b09bbe4f8e6d6ddae9cdc1c732a824091a](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0bcbd3b09bbe4f8e6d6ddae9cdc1c732a824091a)
- * define JSON schemas 
-   * [b66f4d243834a6e19d33505f7ce123ddee651c51](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b66f4d243834a6e19d33505f7ce123ddee651c51)
-   * [0db16a7748e4d10bd6c10e3491cf5325232080ca](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0db16a7748e4d10bd6c10e3491cf5325232080ca)
-   * [1574c01ab4c66bdbcad1f050ea9e2aa580e2d7a1](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1574c01ab4c66bdbcad1f050ea9e2aa580e2d7a1)
-   * [a70f38350e6eca9e44979ad900c1b8e75787bd92](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a70f38350e6eca9e44979ad900c1b8e75787bd92)
-   * [a9ac10eb96a3a5c409d306812d4d65e98d4b4dd6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a9ac10eb96a3a5c409d306812d4d65e98d4b4dd6)
-   * [bd2ba8ba4a8ff99a25002cc6835b44280ee00e60](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/bd2ba8ba4a8ff99a25002cc6835b44280ee00e60)
-   * [fabf7b65a2996695e510768272d84741c2bf8c3e](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/fabf7b65a2996695e510768272d84741c2bf8c3e)
-   * [8b8ae2a50ad926b4ebcb932aacc0d66d26eb969b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8b8ae2a50ad926b4ebcb932aacc0d66d26eb969b)
-   * [85066b8e946117609c5a944987c943b127d084ea](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/85066b8e946117609c5a944987c943b127d084ea)
-   * [8a66bf4ab497f3c0e9dff64262c737a0f12bbb55](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8a66bf4ab497f3c0e9dff64262c737a0f12bbb55)
-   * [3f79b058b666061b71a44b8c3bc7a710c0a25f95](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/3f79b058b666061b71a44b8c3bc7a710c0a25f95)
-   * [5e82f30e2ca0386a8445080a5173d36a7675dff3](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/5e82f30e2ca0386a8445080a5173d36a7675dff3)
-   * [552eaa3a8a08e1872865b030e6006a7d2e3f2ca9](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/552eaa3a8a08e1872865b030e6006a7d2e3f2ca9)
-   * [f6823001940c4fb2b7bc8ad84c26073cc031c1ae](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/f6823001940c4fb2b7bc8ad84c26073cc031c1ae)
-   * [b48bb7274b3dd436ad22fb2187724cec3e665319](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b48bb7274b3dd436ad22fb2187724cec3e665319)
-   * [289f4c2caf21de6b646b699d6a2e7ae5af054fe1](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/289f4c2caf21de6b646b699d6a2e7ae5af054fe1)
-   * [1245cfcaf9b2014a3cdc63c9d021bd09a2525e31](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1245cfcaf9b2014a3cdc63c9d021bd09a2525e31)
-   * [a4d8bc42692d5609e0d4b4057d7f4c8c2ca2dbb7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a4d8bc42692d5609e0d4b4057d7f4c8c2ca2dbb7)
-   * [1257b9b839408f9a7abb665828a2d5bae46ec356](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1257b9b839408f9a7abb665828a2d5bae46ec356)
-   * [baef32b45f91bd7abc05845f1fcb0a91ec62ec3c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/baef32b45f91bd7abc05845f1fcb0a91ec62ec3c)
-   * [09edca182dfb11dfd0ab81310a20e3494c931688](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/09edca182dfb11dfd0ab81310a20e3494c931688)
-   * [228af9cbc07ec41004046af44b37101fab410f1f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/228af9cbc07ec41004046af44b37101fab410f1f)
- * create JSON schema validation
-   * [3938a278a7fe78bdda30d5d77de6766baa9c7ea1](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/3938a278a7fe78bdda30d5d77de6766baa9c7ea1)
-   * [85702b023e78159d140cdb301f06d22f0cad4efe](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/85702b023e78159d140cdb301f06d22f0cad4efe)
-   * [a296cc556ef5d166e5cea4b66c2ddd2fd83334f0](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a296cc556ef5d166e5cea4b66c2ddd2fd83334f0)
-   * [21f254090b4be79fef871ca02fb9c7fb4b2f5ebb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/21f254090b4be79fef871ca02fb9c7fb4b2f5ebb)
-   * [765bac9eba97910f200d6cc6f0030f0ada17975f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/765bac9eba97910f200d6cc6f0030f0ada17975f)
-   * [10d7619811bef7f55a6498cf3c3351ddfe1f6ae6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/10d7619811bef7f55a6498cf3c3351ddfe1f6ae6)
-   * [4828724ff4ce90ed66e1572ccec5ede20aa21004](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4828724ff4ce90ed66e1572ccec5ede20aa21004)
-   * [9cbb8e637b3785ae2839a75c0eb63434b1232bcb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/9cbb8e637b3785ae2839a75c0eb63434b1232bcb)
-   * [16809cbc78ee9aa2b9155f0347f49af81f7322c3](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/16809cbc78ee9aa2b9155f0347f49af81f7322c3)
-   * [a1de05c641b6d103b89577ca225da3d95073bb65](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a1de05c641b6d103b89577ca225da3d95073bb65)
- * add more data for National Calendars to the Metadata endpoint
-   * [34ef54f06d5183b463cce0305f649c182edca2b3](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/34ef54f06d5183b463cce0305f649c182edca2b3)
+ * Fix issue with Saint Vincent deacon in national calendar for USA • [c27289f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/c27289f3c893a184d605e8b1a495a48e2e76669d)
+ * simplify calculation of Vigil Masses • [0afa39b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0afa39b838611554d32fd0d1c2a80a11a92ec696)
+ * add cache-control headers to the Metadata enpoint • [3d77f60](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/3d77f602f29d6a3afaacefb43b3b147ca1dedaef)
+ * complete move from MySQL tables to JSON source files • [d9c7344](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/d9c73447da1f9997eb0716a6591badc2a0e928ab)
+ * add DiocesanGroups info to the Metadata endpoint • [a378f16](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a378f16e5072c4c298b5bf31263222f159148fbb)
+ * move National Calendar data and Wider Region calendar data to JSON source files: • [1716486](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1716486704a51eca41cdc066e66744c9c832f05b) • [4e29877](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4e298779201e49ab820453be2e8c3f1083082935) • [15f16c3](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/15f16c38cd4c1ba0ded4805760f8c369b9584b49) • [5b27417](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/5b27417ed32f782c50527f4d7a33df1318f60767) • [1247b98](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1247b98d309a7d7eb936740a4094213b826a9ef5) • [cdf8bdb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/cdf8bdb99f8ddaff52382259ec600a6ec33058a2) • [62ad946](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/62ad9461757c4e7e6b7c22a2ed5b0567f6052bd7) • [7395ef4](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/7395ef4e75ef0548fcf5dff916cc9b2e77d9f8f6) • [e5d010f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/e5d010f093da4599d9b378396a0b89e7d2763a1f) • [9ada5aa](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/9ada5aa092888a1c5ab1df31bc19c185273634f5) • [c9646a6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/c9646a6b24ee9998aed74d077b455231f67183de) • [25aa01a](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/25aa01a8ffd4abf2df97f4fd7ce035361310c6bb) • [ea5beac](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/ea5beacd4d21c050aaf0629596feef430f4faa5b) • [b81b868](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b81b8681c1d2307d3ad95c0aefc15fca3cb92aa2) • [a837f7b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a837f7b739e215af6eba2337b513200af778d71c) • [7e9e894](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/7e9e894e5320ace19eadcdd656e90f5a7ac5e911) • [4d1eca2](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4d1eca213b11a8231cfa4938908cbcca617b88df) • [e86ccda](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/e86ccdace21b6545a2f5c6ea6328ddafe849ba39) • [445d22c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/445d22c865709f5621f1b4a3098d8471109650e0) • [a0e693f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a0e693f2abdd458c85d0526fbde09e85850be74c)
+ * add cache-control headers to the Main endpoint • [d2ae04d](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/d2ae04de03a2b08360c7ab62e04830c41a34a0f7) • [df7e17d](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/df7e17da9e9e331cfb84f6b7ccb4af4c5632bd41)
+ * add WiderRegions info to the Metadata endpoint  • [b3f567f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b3f567f71a7566da8ba20cc943bd4578534c3ac4)
+ * add methods to FestivityCollection • [a9e1760](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a9e176092f44da4fe0fe505097bd69ddc5ea614a)
+ * add year limits to Roman Missals • [0f939ba](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0f939ba6dcca1866b13721bafc5f519c47d8ed16)
+ * fix enum validations • [4c595c1](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4c595c17e1bbf41e6c87e25aa043b97664cbb577) • [c3d2492](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/c3d2492f926faeaca5819e27e0b829369669b16a)
+ * various fixes • [8330fa0](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8330fa096b7e0a4154dcc6e00a3d7100d81f1896) • [6cf80da](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/6cf80da677a203ccfdd0d6b0a97aeebd63b3e011) • [a7e85de](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a7e85de029fec3f2952129b97fc0428c740232cc) • [4e0a597](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4e0a5979552a79382f74edb052f4578333d2a007) • [8ee7065](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8ee7065c334aa93e6fe0a078b312256cad7cf061) • [44df76f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/44df76f230d2595c57a0abe44539efb543f0dc4f) • [5638ec6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/5638ec6950ac5742175d7e6656c18af873b43cfd) • [4f7c11f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4f7c11f106496a7d31c504444927182676b567c4) • [4decc12](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4decc12dd019a11c2fb0d632df9c34298750f5fa) • [5450010](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/54500104b1276c826796542919c53b86fb32c4e6) • [e2c1f6c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/e2c1f6c71b5fbda4757ecd8cef82dda5c570d8f7) • [fcb1108](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/fcb11085ca5c7f3bf82b5dc36808e2e57b4cbbdb) • [ec772a0](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/ec772a0b228b76d652436ba2c221f4824808b6a6) • [d804c7e](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/d804c7e5d686e59d633ee50df76553291df477e9) • [a52019e](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a52019ed070436b5d271b05591d5d2e7f5d93477) • [8eadab7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8eadab79ea5200535b21a6f7a37257a7a13305e7)
+ * add Roman Missal info to the Metadata endpoint • [715c28a](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/715c28ac7b8113df0aa2c8ad81092828a13c619b)
+ * output 404 error for unavailable resources • [0bcbd3b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0bcbd3b09bbe4f8e6d6ddae9cdc1c732a824091a)
+ * define JSON schemas  • [b66f4d2](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b66f4d243834a6e19d33505f7ce123ddee651c51) • [0db16a7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/0db16a7748e4d10bd6c10e3491cf5325232080ca) • [1574c01](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1574c01ab4c66bdbcad1f050ea9e2aa580e2d7a1) • [a70f383](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a70f38350e6eca9e44979ad900c1b8e75787bd92) • [a9ac10e](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a9ac10eb96a3a5c409d306812d4d65e98d4b4dd6) • [bd2ba8b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/bd2ba8ba4a8ff99a25002cc6835b44280ee00e60) • [fabf7b6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/fabf7b65a2996695e510768272d84741c2bf8c3e) • [8b8ae2a](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8b8ae2a50ad926b4ebcb932aacc0d66d26eb969b) • [85066b8](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/85066b8e946117609c5a944987c943b127d084ea) • [8a66bf4](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/8a66bf4ab497f3c0e9dff64262c737a0f12bbb55) • [3f79b05](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/3f79b058b666061b71a44b8c3bc7a710c0a25f95) • [5e82f30](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/5e82f30e2ca0386a8445080a5173d36a7675dff3) • [552eaa3](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/552eaa3a8a08e1872865b030e6006a7d2e3f2ca9) • [f682300](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/f6823001940c4fb2b7bc8ad84c26073cc031c1ae) • [b48bb72](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/b48bb7274b3dd436ad22fb2187724cec3e665319) • [289f4c2](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/289f4c2caf21de6b646b699d6a2e7ae5af054fe1) • [1245cfc](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1245cfcaf9b2014a3cdc63c9d021bd09a2525e31) • [a4d8bc4](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a4d8bc42692d5609e0d4b4057d7f4c8c2ca2dbb7) • [1257b9b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/1257b9b839408f9a7abb665828a2d5bae46ec356) • [baef32b](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/baef32b45f91bd7abc05845f1fcb0a91ec62ec3c) • [09edca1](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/09edca182dfb11dfd0ab81310a20e3494c931688) • [228af9c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/228af9cbc07ec41004046af44b37101fab410f1f)
+ * create JSON schema validation • [3938a27](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/3938a278a7fe78bdda30d5d77de6766baa9c7ea1) • [85702b0](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/85702b023e78159d140cdb301f06d22f0cad4efe) • [a296cc5](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a296cc556ef5d166e5cea4b66c2ddd2fd83334f0) • [21f2540](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/21f254090b4be79fef871ca02fb9c7fb4b2f5ebb) • [765bac9](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/765bac9eba97910f200d6cc6f0030f0ada17975f) • [10d7619](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/10d7619811bef7f55a6498cf3c3351ddfe1f6ae6) • [4828724](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/4828724ff4ce90ed66e1572ccec5ede20aa21004) • [9cbb8e6](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/9cbb8e637b3785ae2839a75c0eb63434b1232bcb) • [16809cb](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/16809cbc78ee9aa2b9155f0347f49af81f7322c3) • [a1de05c](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/a1de05c641b6d103b89577ca225da3d95073bb65)
+ * add more data for National Calendars to the Metadata endpoint • [34ef54f](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/commit/34ef54f06d5183b463cce0305f649c182edca2b3)
  * update translations
 ## [v3.3](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.3) (January 27th 2022)
  * move festivity data from the 2008 Editio Typica Tertia emendata out from the `LitCalAPI.php`, to a JSON file

--- a/README.md
+++ b/README.md
@@ -180,23 +180,109 @@ Two object keys are returned:
 </a>
 
 # CHANGELOG
+## [v3.7](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.7) (December 14th 2022)
+ * fix support for correct ordinal number spelling for any language
+ * fix "Year I", "Year II" references which should only concern weekdays of Ordinary Time
+ * fix: in cases where the diocesancalendar parameter was set, but the nationalcalendar parameter was not, the national calendar settings were not being picked up correctly
+ * fix for Netherlands national calendar data (Ascension on Thursday)
+## [v3.6](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.6) (December 13th 2022)
+ * allow Diocesan calendars to define mobile festivities
+ * allow Diocesan calendars to define untilYear properties for festivities that may have changes after a given year
+ * remove hardcoding of English, Latin and the 5 main European languages and allow for any possible language
+ * allow for geographic locales, in order to better identify source data for a given national or diocesan calendar
+ * remove hardcoding of supported national calendars, and automate the scan for existing calendars
+## [v3.5](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.5) (December 4th 2022)
+ * Fix days before / after Epiphany (handled differently in different national calendars!)
+ * Add Dutch translation for Netherlands, thanks to Steven van Roode
 ## [v3.4](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.4) (June 6th 2022)
  * Fix issue with Saint Vincent deacon in national calendar for USA c27289f3c893a184d605e8b1a495a48e2e76669d
  * simplify calculation of Vigil Masses 0afa39b838611554d32fd0d1c2a80a11a92ec696
  * add cache-control headers to the Metadata enpoint 3d77f602f29d6a3afaacefb43b3b147ca1dedaef
  * complete move from MySQL tables to JSON source files d9c73447da1f9997eb0716a6591badc2a0e928ab
  * add DiocesanGroups info to the Metadata endpoint a378f16e5072c4c298b5bf31263222f159148fbb
- * move National Calendar data and Wider Region calendar data to JSON source files 1716486704a51eca41cdc066e66744c9c832f05b, 4e298779201e49ab820453be2e8c3f1083082935, 15f16c38cd4c1ba0ded4805760f8c369b9584b49, 5b27417ed32f782c50527f4d7a33df1318f60767, 1247b98d309a7d7eb936740a4094213b826a9ef5, cdf8bdb99f8ddaff52382259ec600a6ec33058a2, 62ad9461757c4e7e6b7c22a2ed5b0567f6052bd7, 7395ef4e75ef0548fcf5dff916cc9b2e77d9f8f6, e5d010f093da4599d9b378396a0b89e7d2763a1f, 9ada5aa092888a1c5ab1df31bc19c185273634f5, c9646a6b24ee9998aed74d077b455231f67183de, 25aa01a8ffd4abf2df97f4fd7ce035361310c6bb, ea5beacd4d21c050aaf0629596feef430f4faa5b, b81b8681c1d2307d3ad95c0aefc15fca3cb92aa2, a837f7b739e215af6eba2337b513200af778d71c, 7e9e894e5320ace19eadcdd656e90f5a7ac5e911, 4d1eca213b11a8231cfa4938908cbcca617b88df, e86ccdace21b6545a2f5c6ea6328ddafe849ba39, 445d22c865709f5621f1b4a3098d8471109650e0, a0e693f2abdd458c85d0526fbde09e85850be74c, 
- * add cache-control headers to the Main endpoint d2ae04de03a2b08360c7ab62e04830c41a34a0f7 and df7e17da9e9e331cfb84f6b7ccb4af4c5632bd41
+ * move National Calendar data and Wider Region calendar data to JSON source files:
+   * 1716486704a51eca41cdc066e66744c9c832f05b
+   * 4e298779201e49ab820453be2e8c3f1083082935
+   * 15f16c38cd4c1ba0ded4805760f8c369b9584b49
+   * 5b27417ed32f782c50527f4d7a33df1318f60767
+   * 1247b98d309a7d7eb936740a4094213b826a9ef5
+   * cdf8bdb99f8ddaff52382259ec600a6ec33058a2
+   * 62ad9461757c4e7e6b7c22a2ed5b0567f6052bd7
+   * 7395ef4e75ef0548fcf5dff916cc9b2e77d9f8f6
+   * e5d010f093da4599d9b378396a0b89e7d2763a1f
+   * 9ada5aa092888a1c5ab1df31bc19c185273634f5
+   * c9646a6b24ee9998aed74d077b455231f67183de
+   * 25aa01a8ffd4abf2df97f4fd7ce035361310c6bb
+   * ea5beacd4d21c050aaf0629596feef430f4faa5b
+   * b81b8681c1d2307d3ad95c0aefc15fca3cb92aa2
+   * a837f7b739e215af6eba2337b513200af778d71c
+   * 7e9e894e5320ace19eadcdd656e90f5a7ac5e911
+   * 4d1eca213b11a8231cfa4938908cbcca617b88df
+   * e86ccdace21b6545a2f5c6ea6328ddafe849ba39
+   * 445d22c865709f5621f1b4a3098d8471109650e0
+   * a0e693f2abdd458c85d0526fbde09e85850be74c
+ * add cache-control headers to the Main endpoint
+   * d2ae04de03a2b08360c7ab62e04830c41a34a0f7
+   * df7e17da9e9e331cfb84f6b7ccb4af4c5632bd41
  * add WiderRegions info to the Metadata endpoint b3f567f71a7566da8ba20cc943bd4578534c3ac4
  * add methods to FestivityCollection a9e176092f44da4fe0fe505097bd69ddc5ea614a
  * add year limits to Roman Missals 0f939ba6dcca1866b13721bafc5f519c47d8ed16
- * fix enum validations 4c595c17e1bbf41e6c87e25aa043b97664cbb577, c3d2492f926faeaca5819e27e0b829369669b16a
- * various fixes 8330fa096b7e0a4154dcc6e00a3d7100d81f1896, 6cf80da677a203ccfdd0d6b0a97aeebd63b3e011, a7e85de029fec3f2952129b97fc0428c740232cc, 4e0a5979552a79382f74edb052f4578333d2a007, 8ee7065c334aa93e6fe0a078b312256cad7cf061, 44df76f230d2595c57a0abe44539efb543f0dc4f, 5638ec6950ac5742175d7e6656c18af873b43cfd, 4f7c11f106496a7d31c504444927182676b567c4, 4decc12dd019a11c2fb0d632df9c34298750f5fa, 54500104b1276c826796542919c53b86fb32c4e6, e2c1f6c71b5fbda4757ecd8cef82dda5c570d8f7, fcb11085ca5c7f3bf82b5dc36808e2e57b4cbbdb, ec772a0b228b76d652436ba2c221f4824808b6a6, d804c7e5d686e59d633ee50df76553291df477e9, a52019ed070436b5d271b05591d5d2e7f5d93477, 8eadab79ea5200535b21a6f7a37257a7a13305e7
+ * fix enum validations
+   * 4c595c17e1bbf41e6c87e25aa043b97664cbb577
+   * c3d2492f926faeaca5819e27e0b829369669b16a
+ * various fixes
+   * 8330fa096b7e0a4154dcc6e00a3d7100d81f1896
+   * 6cf80da677a203ccfdd0d6b0a97aeebd63b3e011
+   * a7e85de029fec3f2952129b97fc0428c740232cc
+   * 4e0a5979552a79382f74edb052f4578333d2a007
+   * 8ee7065c334aa93e6fe0a078b312256cad7cf061
+   * 44df76f230d2595c57a0abe44539efb543f0dc4f
+   * 5638ec6950ac5742175d7e6656c18af873b43cfd
+   * 4f7c11f106496a7d31c504444927182676b567c4
+   * 4decc12dd019a11c2fb0d632df9c34298750f5fa
+   * 54500104b1276c826796542919c53b86fb32c4e6
+   * e2c1f6c71b5fbda4757ecd8cef82dda5c570d8f7
+   * fcb11085ca5c7f3bf82b5dc36808e2e57b4cbbdb
+   * ec772a0b228b76d652436ba2c221f4824808b6a6
+   * d804c7e5d686e59d633ee50df76553291df477e9
+   * a52019ed070436b5d271b05591d5d2e7f5d93477
+   * 8eadab79ea5200535b21a6f7a37257a7a13305e7
  * add Roman Missal info to the Metadata endpoint 715c28ac7b8113df0aa2c8ad81092828a13c619b
  * output 404 error for unavailable resources 0bcbd3b09bbe4f8e6d6ddae9cdc1c732a824091a
- * define JSON schemas b66f4d243834a6e19d33505f7ce123ddee651c51, 0db16a7748e4d10bd6c10e3491cf5325232080ca, 1574c01ab4c66bdbcad1f050ea9e2aa580e2d7a1, a70f38350e6eca9e44979ad900c1b8e75787bd92, a9ac10eb96a3a5c409d306812d4d65e98d4b4dd6, bd2ba8ba4a8ff99a25002cc6835b44280ee00e60, fabf7b65a2996695e510768272d84741c2bf8c3e, 8b8ae2a50ad926b4ebcb932aacc0d66d26eb969b, 85066b8e946117609c5a944987c943b127d084ea, 8a66bf4ab497f3c0e9dff64262c737a0f12bbb55, 3f79b058b666061b71a44b8c3bc7a710c0a25f95, 5e82f30e2ca0386a8445080a5173d36a7675dff3, 552eaa3a8a08e1872865b030e6006a7d2e3f2ca9, f6823001940c4fb2b7bc8ad84c26073cc031c1ae, b48bb7274b3dd436ad22fb2187724cec3e665319, 289f4c2caf21de6b646b699d6a2e7ae5af054fe1, 1245cfcaf9b2014a3cdc63c9d021bd09a2525e31, a4d8bc42692d5609e0d4b4057d7f4c8c2ca2dbb7, 1257b9b839408f9a7abb665828a2d5bae46ec356, baef32b45f91bd7abc05845f1fcb0a91ec62ec3c, 09edca182dfb11dfd0ab81310a20e3494c931688, 228af9cbc07ec41004046af44b37101fab410f1f
- * create JSON schema validation 3938a278a7fe78bdda30d5d77de6766baa9c7ea1, 85702b023e78159d140cdb301f06d22f0cad4efe, a296cc556ef5d166e5cea4b66c2ddd2fd83334f0, 21f254090b4be79fef871ca02fb9c7fb4b2f5ebb, 765bac9eba97910f200d6cc6f0030f0ada17975f, 10d7619811bef7f55a6498cf3c3351ddfe1f6ae6, 4828724ff4ce90ed66e1572ccec5ede20aa21004, 9cbb8e637b3785ae2839a75c0eb63434b1232bcb, 16809cbc78ee9aa2b9155f0347f49af81f7322c3, a1de05c641b6d103b89577ca225da3d95073bb65
+ * define JSON schemas 
+   * b66f4d243834a6e19d33505f7ce123ddee651c51
+   * 0db16a7748e4d10bd6c10e3491cf5325232080ca
+   * 1574c01ab4c66bdbcad1f050ea9e2aa580e2d7a1
+   * a70f38350e6eca9e44979ad900c1b8e75787bd92
+   * a9ac10eb96a3a5c409d306812d4d65e98d4b4dd6
+   * bd2ba8ba4a8ff99a25002cc6835b44280ee00e60
+   * fabf7b65a2996695e510768272d84741c2bf8c3e
+   * 8b8ae2a50ad926b4ebcb932aacc0d66d26eb969b
+   * 85066b8e946117609c5a944987c943b127d084ea
+   * 8a66bf4ab497f3c0e9dff64262c737a0f12bbb55
+   * 3f79b058b666061b71a44b8c3bc7a710c0a25f95
+   * 5e82f30e2ca0386a8445080a5173d36a7675dff3
+   * 552eaa3a8a08e1872865b030e6006a7d2e3f2ca9
+   * f6823001940c4fb2b7bc8ad84c26073cc031c1ae
+   * b48bb7274b3dd436ad22fb2187724cec3e665319
+   * 289f4c2caf21de6b646b699d6a2e7ae5af054fe1
+   * 1245cfcaf9b2014a3cdc63c9d021bd09a2525e31
+   * a4d8bc42692d5609e0d4b4057d7f4c8c2ca2dbb7
+   * 1257b9b839408f9a7abb665828a2d5bae46ec356
+   * baef32b45f91bd7abc05845f1fcb0a91ec62ec3c
+   * 09edca182dfb11dfd0ab81310a20e3494c931688
+   * 228af9cbc07ec41004046af44b37101fab410f1f
+ * create JSON schema validation
+   * 3938a278a7fe78bdda30d5d77de6766baa9c7ea1
+   * 85702b023e78159d140cdb301f06d22f0cad4efe
+   * a296cc556ef5d166e5cea4b66c2ddd2fd83334f0
+   * 21f254090b4be79fef871ca02fb9c7fb4b2f5ebb
+   * 765bac9eba97910f200d6cc6f0030f0ada17975f
+   * 10d7619811bef7f55a6498cf3c3351ddfe1f6ae6
+   * 4828724ff4ce90ed66e1572ccec5ede20aa21004
+   * 9cbb8e637b3785ae2839a75c0eb63434b1232bcb
+   * 16809cbc78ee9aa2b9155f0347f49af81f7322c3
+   * a1de05c641b6d103b89577ca225da3d95073bb65
  * add more data for National Calendars to the Metadata endpoint 34ef54f06d5183b463cce0305f649c182edca2b3
  * update translations
 ## [v3.3](https://github.com/JohnRDOrazio/LiturgicalCalendar/releases/tag/v3.3) (January 27th 2022)

--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-13 22:19+0000\n"
+"POT-Creation-Date: 2022-12-13 22:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -67,7 +67,7 @@ msgstr ""
 #: includes/LitCalAPI.php:1644 includes/LitCalAPI.php:1671
 #: includes/LitCalAPI.php:1781 includes/LitCalAPI.php:1794
 #: includes/LitCalAPI.php:1809 includes/LitCalAPI.php:1836
-#: includes/FestivityCollection.php:377
+#: includes/FestivityCollection.php:372
 msgid "Decree of the Congregation for Divine Worship"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Vigil Mass"
 msgstr ""
 
-#: includes/FestivityCollection.php:371
+#: includes/FestivityCollection.php:366
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
@@ -540,7 +540,7 @@ msgid ""
 "is confirmed as are I Vespers."
 msgstr ""
 
-#: includes/FestivityCollection.php:385
+#: includes/FestivityCollection.php:380
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
@@ -549,7 +549,7 @@ msgid ""
 "or an evening Mass."
 msgstr ""
 
-#: includes/FestivityCollection.php:395
+#: includes/FestivityCollection.php:390
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
@@ -558,7 +558,7 @@ msgid ""
 "Vigil Mass or Vespers I."
 msgstr ""
 
-#: includes/FestivityCollection.php:455
+#: includes/FestivityCollection.php:450
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "

--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-13 21:02+0000\n"
+"POT-Creation-Date: 2022-12-13 22:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -67,7 +67,7 @@ msgstr ""
 #: includes/LitCalAPI.php:1644 includes/LitCalAPI.php:1671
 #: includes/LitCalAPI.php:1781 includes/LitCalAPI.php:1794
 #: includes/LitCalAPI.php:1809 includes/LitCalAPI.php:1836
-#: includes/FestivityCollection.php:366
+#: includes/FestivityCollection.php:377
 msgid "Decree of the Congregation for Divine Worship"
 msgstr ""
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Vigil Mass"
 msgstr ""
 
-#: includes/FestivityCollection.php:360
+#: includes/FestivityCollection.php:371
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
@@ -540,7 +540,7 @@ msgid ""
 "is confirmed as are I Vespers."
 msgstr ""
 
-#: includes/FestivityCollection.php:374
+#: includes/FestivityCollection.php:385
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
@@ -549,7 +549,7 @@ msgid ""
 "or an evening Mass."
 msgstr ""
 
-#: includes/FestivityCollection.php:384
+#: includes/FestivityCollection.php:395
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
@@ -558,7 +558,7 @@ msgid ""
 "Vigil Mass or Vespers I."
 msgstr ""
 
-#: includes/FestivityCollection.php:444
+#: includes/FestivityCollection.php:455
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "

--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-13 15:14+0000\n"
+"POT-Creation-Date: 2022-12-13 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -237,12 +237,12 @@ msgid ""
 msgstr ""
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: includes/LitCalAPI.php:1243 includes/LitCalAPI.php:2360
+#: includes/LitCalAPI.php:1243
 msgid "before"
 msgstr ""
 
 #. translators: e.g. 'Monday after Pentecost'
-#: includes/LitCalAPI.php:1248 includes/LitCalAPI.php:2366
+#: includes/LitCalAPI.php:1248
 msgid "after"
 msgstr ""
 

--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-12-13 22:27+0000\n"
+"POT-Creation-Date: 2022-12-14 01:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: includes/LitCalAPI.php:394
+#: includes/LitCalAPI.php:392
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -25,13 +25,13 @@ msgid ""
 msgstr ""
 
 #. translators: name of the Roman Missal
-#: includes/LitCalAPI.php:432
+#: includes/LitCalAPI.php:430
 #, php-format
 msgid "Data for the sanctorale from %s could not be found."
 msgstr ""
 
 #. translators: name of the Roman Missal
-#: includes/LitCalAPI.php:439
+#: includes/LitCalAPI.php:437
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -40,47 +40,47 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: includes/LitCalAPI.php:530 includes/LitCalAPI.php:562
-#: includes/LitCalAPI.php:609 includes/LitCalAPI.php:639
+#: includes/LitCalAPI.php:528 includes/LitCalAPI.php:560
+#: includes/LitCalAPI.php:607 includes/LitCalAPI.php:637
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Festivity date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators: 1: Festivity name, 2: Festivity date, 3: Requested calendar year, 4: Explicatory string for the transferral, 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#: includes/LitCalAPI.php:794 includes/LitCalAPI.php:811
-#: includes/LitCalAPI.php:838
+#: includes/LitCalAPI.php:792 includes/LitCalAPI.php:809
+#: includes/LitCalAPI.php:836
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: includes/LitCalAPI.php:798
+#: includes/LitCalAPI.php:796
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: includes/LitCalAPI.php:803 includes/LitCalAPI.php:820
-#: includes/LitCalAPI.php:847 includes/LitCalAPI.php:877
-#: includes/LitCalAPI.php:1189 includes/LitCalAPI.php:1309
-#: includes/LitCalAPI.php:1366 includes/LitCalAPI.php:1599
-#: includes/LitCalAPI.php:1644 includes/LitCalAPI.php:1671
-#: includes/LitCalAPI.php:1781 includes/LitCalAPI.php:1794
-#: includes/LitCalAPI.php:1809 includes/LitCalAPI.php:1836
+#: includes/LitCalAPI.php:801 includes/LitCalAPI.php:818
+#: includes/LitCalAPI.php:845 includes/LitCalAPI.php:875
+#: includes/LitCalAPI.php:1187 includes/LitCalAPI.php:1307
+#: includes/LitCalAPI.php:1364 includes/LitCalAPI.php:1597
+#: includes/LitCalAPI.php:1642 includes/LitCalAPI.php:1669
+#: includes/LitCalAPI.php:1779 includes/LitCalAPI.php:1792
+#: includes/LitCalAPI.php:1807 includes/LitCalAPI.php:1834
 #: includes/FestivityCollection.php:372
 msgid "Decree of the Congregation for Divine Worship"
 msgstr ""
 
-#: includes/LitCalAPI.php:815
+#: includes/LitCalAPI.php:813
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: includes/LitCalAPI.php:842
+#: includes/LitCalAPI.php:840
 msgid "the following Monday"
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: includes/LitCalAPI.php:854
+#: includes/LitCalAPI.php:852
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -88,7 +88,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year, 4: Decree of the Congregation for Divine Worship
-#: includes/LitCalAPI.php:873
+#: includes/LitCalAPI.php:871
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -96,7 +96,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: includes/LitCalAPI.php:943
+#: includes/LitCalAPI.php:941
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -104,30 +104,30 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: includes/LitCalAPI.php:978 includes/LitCalAPI.php:1003
+#: includes/LitCalAPI.php:976 includes/LitCalAPI.php:1001
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: includes/LitCalAPI.php:1060
+#: includes/LitCalAPI.php:1058
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: includes/LitCalAPI.php:1083
+#: includes/LitCalAPI.php:1081
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: includes/LitCalAPI.php:1113
+#: includes/LitCalAPI.php:1111
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr ""
 
-#: includes/LitCalAPI.php:1120
+#: includes/LitCalAPI.php:1118
 msgid "after Ash Wednesday"
 msgstr ""
 
@@ -155,15 +155,15 @@ msgstr ""
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: includes/LitCalAPI.php:1141 includes/LitCalAPI.php:1478
-#: includes/LitCalAPI.php:1655 includes/LitCalAPI.php:2179
+#: includes/LitCalAPI.php:1139 includes/LitCalAPI.php:1476
+#: includes/LitCalAPI.php:1653 includes/LitCalAPI.php:2176
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: includes/LitCalAPI.php:1175 includes/LitCalAPI.php:1267
+#: includes/LitCalAPI.php:1173 includes/LitCalAPI.php:1265
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -174,7 +174,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: includes/LitCalAPI.php:1221
+#: includes/LitCalAPI.php:1219
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -189,16 +189,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: includes/LitCalAPI.php:1243
+#: includes/LitCalAPI.php:1241
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: includes/LitCalAPI.php:1263
+#: includes/LitCalAPI.php:1261
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: includes/LitCalAPI.php:1286
+#: includes/LitCalAPI.php:1284
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -216,7 +216,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: includes/LitCalAPI.php:1323
+#: includes/LitCalAPI.php:1321
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -229,7 +229,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: includes/LitCalAPI.php:1362
+#: includes/LitCalAPI.php:1360
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -237,17 +237,17 @@ msgid ""
 msgstr ""
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: includes/LitCalAPI.php:1396
+#: includes/LitCalAPI.php:1394
 msgid "before"
 msgstr ""
 
 #. translators: e.g. 'Monday after Pentecost'
-#: includes/LitCalAPI.php:1401
+#: includes/LitCalAPI.php:1399
 msgid "after"
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: includes/LitCalAPI.php:1406 includes/LitCalAPI.php:2525
+#: includes/LitCalAPI.php:1404 includes/LitCalAPI.php:2522
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -255,14 +255,14 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: includes/LitCalAPI.php:1421 includes/LitCalAPI.php:2543
+#: includes/LitCalAPI.php:1419 includes/LitCalAPI.php:2540
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: includes/LitCalAPI.php:1429 includes/LitCalAPI.php:2552
+#: includes/LitCalAPI.php:1427 includes/LitCalAPI.php:2549
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -270,7 +270,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: includes/LitCalAPI.php:1449 includes/LitCalAPI.php:2617
+#: includes/LitCalAPI.php:1447 includes/LitCalAPI.php:2614
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -278,7 +278,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: includes/LitCalAPI.php:1457
+#: includes/LitCalAPI.php:1455
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -291,7 +291,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: includes/LitCalAPI.php:1513
+#: includes/LitCalAPI.php:1511
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -306,7 +306,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: includes/LitCalAPI.php:1535
+#: includes/LitCalAPI.php:1533
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -321,7 +321,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: includes/LitCalAPI.php:1545
+#: includes/LitCalAPI.php:1543
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -334,14 +334,14 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: includes/LitCalAPI.php:1579
+#: includes/LitCalAPI.php:1577
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: includes/LitCalAPI.php:1587
+#: includes/LitCalAPI.php:1585
 msgid "and Doctor of the Church"
 msgstr ""
 
@@ -355,7 +355,7 @@ msgstr ""
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: includes/LitCalAPI.php:1692
+#: includes/LitCalAPI.php:1690
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -372,7 +372,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: includes/LitCalAPI.php:1720
+#: includes/LitCalAPI.php:1718
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -380,7 +380,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: includes/LitCalAPI.php:1779
+#: includes/LitCalAPI.php:1777
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -388,7 +388,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: includes/LitCalAPI.php:1792
+#: includes/LitCalAPI.php:1790
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -396,7 +396,7 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: includes/LitCalAPI.php:1807
+#: includes/LitCalAPI.php:1805
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -405,7 +405,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: includes/LitCalAPI.php:1834
+#: includes/LitCalAPI.php:1832
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -414,26 +414,26 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: includes/LitCalAPI.php:1858
+#: includes/LitCalAPI.php:1856
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr ""
 
-#: includes/LitCalAPI.php:1894 includes/LitCalAPI.php:1923
+#: includes/LitCalAPI.php:1892 includes/LitCalAPI.php:1921
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr ""
 
-#: includes/LitCalAPI.php:1946
+#: includes/LitCalAPI.php:1944
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: includes/LitCalAPI.php:1971 includes/LitCalAPI.php:1974
+#: includes/LitCalAPI.php:1969 includes/LitCalAPI.php:1972
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 
-#: includes/LitCalAPI.php:1981
+#: includes/LitCalAPI.php:1979
 #, php-format
 msgid "Error retrieving and decoding National data from file %s."
 msgstr ""
@@ -446,7 +446,7 @@ msgstr ""
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: includes/LitCalAPI.php:2015
+#: includes/LitCalAPI.php:2012
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -459,21 +459,21 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: includes/LitCalAPI.php:2080
+#: includes/LitCalAPI.php:2077
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials."
 msgstr ""
 
-#: includes/LitCalAPI.php:2143
+#: includes/LitCalAPI.php:2140
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: includes/LitCalAPI.php:2259
+#: includes/LitCalAPI.php:2256
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -487,7 +487,7 @@ msgstr ""
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: includes/LitCalAPI.php:2289
+#: includes/LitCalAPI.php:2286
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -495,13 +495,13 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: includes/LitCalAPI.php:2304
+#: includes/LitCalAPI.php:2301
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: includes/LitCalAPI.php:2349
+#: includes/LitCalAPI.php:2346
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -509,7 +509,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: includes/LitCalAPI.php:2368
+#: includes/LitCalAPI.php:2365
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "

--- a/includes/FestivityCollection.php
+++ b/includes/FestivityCollection.php
@@ -286,10 +286,21 @@ class FestivityCollection {
     public function setCyclesAndVigils() {
         foreach( $this->festivities as $key => $festivity ) {
             if ( self::DateIsNotSunday( $festivity->date ) && (int)$festivity->grade === LitGrade::WEEKDAY ) {
-                if ( $festivity->date < $this->festivities[ "Advent1" ]->date ) {
-                    $this->festivities[ $key ]->liturgicalYear = $this->T[ "YEAR" ] . " " . ( self::WEEKDAY_CYCLE[ ( $this->LitSettings->Year - 1 ) % 2 ] );
-                } else if ( $festivity->date >= $this->festivities[ "Advent1" ]->date ) {
-                    $this->festivities[ $key ]->liturgicalYear = $this->T[ "YEAR" ] . " " . ( self::WEEKDAY_CYCLE[ $this->LitSettings->Year % 2 ] );
+                if( false === $this->inWeekdaysAdventChristmasLent( $festivity->date )
+                    &&
+                    (
+                        ( $festivity->date > $this->festivities[ "BaptismLord" ]->date && $festivity->date < $this->festivities[ "AshWednesday" ]->date )
+                        ||
+                        ( $festivity->date > $this->festivities[ "Pentecost" ]->date && $festivity->date < $this->festivities[ "Advent1" ]->date )
+                    )
+                ) {
+                    //if ( $festivity->date < $this->festivities[ "Advent1" ]->date ) {
+                        $this->festivities[ $key ]->liturgicalYear = $this->T[ "YEAR" ] . " " . ( self::WEEKDAY_CYCLE[ ( $this->LitSettings->Year - 1 ) % 2 ] );
+                    //}
+                    //this case is actually redundant, since we don't consider weekdays of Advent!
+                    //else if ( $festivity->date >= $this->festivities[ "Advent1" ]->date ) {
+                    //    $this->festivities[ $key ]->liturgicalYear = $this->T[ "YEAR" ] . " " . ( self::WEEKDAY_CYCLE[ $this->LitSettings->Year % 2 ] );
+                    //}
                 }
             }
             //if we're dealing with a Sunday or a Solemnity or a Feast of the Lord, then we calculate the Sunday/Festive Cycle

--- a/includes/FestivityCollection.php
+++ b/includes/FestivityCollection.php
@@ -283,24 +283,19 @@ class FestivityCollection {
         unset( $this->festivities[ $key ] );
     }
 
+    private function inOrdinaryTime( LitDateTime $date ) : bool {
+        return (
+            ( $date > $this->festivities[ "BaptismLord" ]->date && $date < $this->festivities[ "AshWednesday" ]->date )
+            ||
+            ( $date > $this->festivities[ "Pentecost" ]->date && $date < $this->festivities[ "Advent1" ]->date )
+        );
+    }
+
     public function setCyclesAndVigils() {
         foreach( $this->festivities as $key => $festivity ) {
             if ( self::DateIsNotSunday( $festivity->date ) && (int)$festivity->grade === LitGrade::WEEKDAY ) {
-                if( false === $this->inWeekdaysAdventChristmasLent( $festivity->date )
-                    &&
-                    (
-                        ( $festivity->date > $this->festivities[ "BaptismLord" ]->date && $festivity->date < $this->festivities[ "AshWednesday" ]->date )
-                        ||
-                        ( $festivity->date > $this->festivities[ "Pentecost" ]->date && $festivity->date < $this->festivities[ "Advent1" ]->date )
-                    )
-                ) {
-                    //if ( $festivity->date < $this->festivities[ "Advent1" ]->date ) {
-                        $this->festivities[ $key ]->liturgicalYear = $this->T[ "YEAR" ] . " " . ( self::WEEKDAY_CYCLE[ ( $this->LitSettings->Year - 1 ) % 2 ] );
-                    //}
-                    //this case is actually redundant, since we don't consider weekdays of Advent!
-                    //else if ( $festivity->date >= $this->festivities[ "Advent1" ]->date ) {
-                    //    $this->festivities[ $key ]->liturgicalYear = $this->T[ "YEAR" ] . " " . ( self::WEEKDAY_CYCLE[ $this->LitSettings->Year % 2 ] );
-                    //}
+                if( $this->inOrdinaryTime( $festivity->date ) ) {
+                    $this->festivities[ $key ]->liturgicalYear = $this->T[ "YEAR" ] . " " . ( self::WEEKDAY_CYCLE[ ( $this->LitSettings->Year - 1 ) % 2 ] );
                 }
             }
             //if we're dealing with a Sunday or a Solemnity or a Feast of the Lord, then we calculate the Sunday/Festive Cycle

--- a/includes/LitCalAPI.php
+++ b/includes/LitCalAPI.php
@@ -22,7 +22,7 @@ include_once( "includes/pgettext.php" );
 
 class LitCalAPI {
 
-    const API_VERSION                               = '3.6';
+    const API_VERSION                               = '3.7';
     public APICore $APICore;
 
     private string $CacheDuration                   = "";

--- a/includes/LitCalAPI.php
+++ b/includes/LitCalAPI.php
@@ -348,8 +348,6 @@ class LitCalAPI {
                 }
             }
         }
-
-        $this->updateSettingsBasedOnDiocesanCalendar();
     }
 
     private function cacheFileIsAvailable() : bool {
@@ -1981,7 +1979,6 @@ class LitCalAPI {
                 $this->Messages[] = sprintf( _( "Error retrieving and decoding National data from file %s." ), $nationalDataFile ) . ": " . json_last_error_msg();
             }
         }
-        $this->updateSettingsBasedOnNationalCalendar();
     }
 
     private function handleMissingFestivity( object $row ) : void {
@@ -2891,8 +2888,10 @@ class LitCalAPI {
     public function Init(){
         $this->APICore->Init();
         $this->initParameterData();
-        $this->loadNationalCalendarData();
         $this->loadDiocesanCalendarData();
+        $this->loadNationalCalendarData();
+        $this->updateSettingsBasedOnNationalCalendar();
+        $this->updateSettingsBasedOnDiocesanCalendar();
         $this->APICore->setResponseContentTypeHeader();
 
         if( $this->cacheFileIsAvailable() ){

--- a/includes/LitCalAPI.php
+++ b/includes/LitCalAPI.php
@@ -2351,21 +2351,21 @@ class LitCalAPI {
                 ) {
                     $festivity = $this->Cal->getFestivity( $row->Metadata->strtotime->festivityKey );
                     if( $festivity !== null ) {
-                        $relString = '';
+                        //$relString = '';
                         $DATE = clone( $festivity->date );
                         switch( $row->Metadata->strtotime->relativeTime ) {
                             case 'before':
                                 $DATE->modify("previous {$row->Metadata->strtotime->dayOfTheWeek}");
                                     /**translators: e.g. 'Monday before Palm Sunday' */
-                                $relString = _( 'before' );
+                                //$relString = _( 'before' );
                                 return $DATE;
-                            break;
+                                //break; //unnecessary seeing we are returning immediately
                             case 'after':
                                 $DATE->modify("next {$row->Metadata->strtotime->dayOfTheWeek}");
                                 /**translators: e.g. 'Monday after Pentecost' */
-                                $relString = _( 'after' );
+                                //$relString = _( 'after' );
                                 return $DATE;
-                            break;
+                                //break; //unnecessary seeing we are returning immediately
                             default:
                                 $this->Messages[] = sprintf(
                                     /**translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to */
@@ -2375,7 +2375,7 @@ class LitCalAPI {
                                     implode(', ', ['\'before\'', '\'after\''])
                                 );
                                 return false;
-                            break;
+                                //break; //unnecessary seeing we are returning immediately
                         }
                         /*
                         $dayOfTheWeek = $this->LitSettings->Locale === LitLocale::LATIN ? LitMessages::LATIN_DAYOFTHEWEEK[ $DATE->format( 'w' ) ] : ucfirst( $this->dayOfTheWeek->format( $row->Festivity->DATE->format( 'U' ) ) );

--- a/includes/LitCalAPI.php
+++ b/includes/LitCalAPI.php
@@ -2405,23 +2405,33 @@ class LitCalAPI {
                 break;
             case 'string':
                 if( $row->Metadata->strtotime !== '' ) {
-                    if( preg_match('/(before|after)/', $row->Metadata->strtotime) !== false ) {
+                    if( preg_match('/(before|after)/', $row->Metadata->strtotime) !== false && preg_match('/(before|after)/', $row->Metadata->strtotime) !== 0 ) {
                         $match = preg_split( '/(before|after)/', $row->Metadata->strtotime, -1, PREG_SPLIT_DELIM_CAPTURE );
-                        $festivityDateTS = strtotime( $match[2] . ' ' . $this->LitSettings->Year . ' UTC'  );
-                        if( $festivityDateTS !== false ) {
-                            $DATE = new LitDateTime( "@$festivityDateTS" );
-                            $DATE->setTimeZone(new DateTimeZone('UTC'));
-                            if( $match[1] === 'before' ) {
-                                $DATE->modify( "previous {$match[0]}" );
-                            } else if ( $match[1] === 'after' ) {
-                                $DATE->modify( "next {$match[0]}" );
+                        if( $match !== false && count($match) === 3 ) {
+                            $festivityDateTS = strtotime( $match[2] . ' ' . $this->LitSettings->Year . ' UTC'  );
+                            if( $festivityDateTS !== false ) {
+                                $DATE = new LitDateTime( "@$festivityDateTS" );
+                                $DATE->setTimeZone(new DateTimeZone('UTC'));
+                                if( $match[1] === 'before' ) {
+                                    $DATE->modify( "previous {$match[0]}" );
+                                } else if ( $match[1] === 'after' ) {
+                                    $DATE->modify( "next {$match[0]}" );
+                                }
+                                return $DATE;
+                            } else {
+                                $this->Messages[] = sprintf(
+                                    /**translators: Do not translate 'strtotime'! */
+                                    'Could not interpret the \'strtotime\' property with value %1$s into a timestamp',
+                                    $row->Metadata->strtotime
+                                );
+                                return false;
                             }
-                            return $DATE;
                         } else {
                             $this->Messages[] = sprintf(
                                 /**translators: Do not translate 'strtotime'! */
-                                'Could not interpret the \'strtotime\' property with value %1$s into a timestamp',
-                                $row->Metadata->strtotime
+                                'Could not interpret the \'strtotime\' property with value %1$s into a timestamp. Splitting failed: %2$s',
+                                $row->Metadata->strtotime,
+                                json_encode($match)
                             );
                             return false;
                         }

--- a/includes/LitCalAPI.php
+++ b/includes/LitCalAPI.php
@@ -22,7 +22,7 @@ include_once( "includes/pgettext.php" );
 
 class LitCalAPI {
 
-    const API_VERSION                               = '3.5';
+    const API_VERSION                               = '3.6';
     public APICore $APICore;
 
     private string $CacheDuration                   = "";

--- a/includes/LitCalAPI.php
+++ b/includes/LitCalAPI.php
@@ -76,8 +76,8 @@ class LitCalAPI {
         'chr', //Cherokee,
         'de', //German : has also spellout-ordinal-n, spellout-ordinal-r, spellout-ordinal-s 
               //        these seem to affect the article "the" preceding the ordinal, 
-              //        making it masculine, feminine, or neuter
-              //        but which is which between n-r-s?
+              //        making it masculine, feminine, or neuter (or plural)
+              //        but which is which between n-r-s? I believe r = masc, n = plural, s = neut?
               //        perhaps depends also on case: genitive, dative, etc.
         'dsb', //Lower Sorbian
         'dz', //Dzongha

--- a/includes/LitMessages.php
+++ b/includes/LitMessages.php
@@ -187,7 +187,8 @@ class LitMessages {
      */
     public static function getOrdinal(int $num, string $LOCALE, NumberFormatter $formatter, array $latinOrdinals) : string {
         $ordinal = "";
-        switch(strtoupper(explode("_", $LOCALE)[0])) {
+        $baseLocale = $LOCALE !== "LA" && $LOCALE !== "la" ? Locale::getPrimaryLanguage($LOCALE) : "LA";
+        switch(strtoupper($baseLocale)) {
             case LitLocale::LATIN:
                 $ordinal = $latinOrdinals[$num];
             break;

--- a/nations/NETHERLANDS/'s-Hertogenbosch.json
+++ b/nations/NETHERLANDS/'s-Hertogenbosch.json
@@ -1,0 +1,185 @@
+{
+    "LitCal": {
+        "VerjaardagvandeWijdingvandekathedraal": {
+            "Festivity": {
+                "name": "Verjaardag van de Wijding van de kathedraal",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Dedication of a Church"
+                ],
+                "day": 25,
+                "month": 8
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HJohannesapostelenevangelistpatroonvanhetbisdom": {
+            "Festivity": {
+                "name": "H. Johannes, apostel en evangelist, patroon van het bisdom",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Proper"
+                ],
+                "day": 27,
+                "month": 12
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "ZPetrusDonderspriester": {
+            "Festivity": {
+                "name": "Z. Petrus Donders, priester",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Pastors:For One Pastor",
+                    "Holy Men and Women:For Those Who Practiced Works of Mercy"
+                ],
+                "day": 14,
+                "month": 1
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "HOdulfuspriester": {
+            "Festivity": {
+                "name": "H. Odulfus, priester",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Pastors"
+                ],
+                "day": 12,
+                "month": 6
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HServatiusbisschop": {
+            "Festivity": {
+                "name": "H. Servatius, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors"
+                ],
+                "day": 13,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "HLambertusbisschopenmartelaar": {
+            "Festivity": {
+                "name": "H. Lambertus, bisschop en martelaar",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Proper"
+                ],
+                "day": 17,
+                "month": 9
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HHubertusbisschop": {
+            "Festivity": {
+                "name": "H. Hubertus, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For a Bishop"
+                ],
+                "day": 3,
+                "month": 11
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 2
+            }
+        },
+        "HeiligeMaagdMariaZoeteMoedervanDenBosch": {
+            "Festivity": {
+                "name": "Heilige Maagd Maria, Zoete Moeder van Den Bosch",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Blessed Virgin Mary"
+                ],
+                "day": 7,
+                "month": 7
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 2
+            }
+        },
+        "ZEustachiusvanLieshoutpriester": {
+            "Festivity": {
+                "name": "Z. Eustachius van Lieshout, priester",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For One Pastor"
+                ],
+                "day": 30,
+                "month": 8
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 3
+            }
+        },
+        "HOdamaagd": {
+            "Festivity": {
+                "name": "H. Oda, maagd",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Virgins:For One Virgin"
+                ],
+                "day": 27,
+                "month": 11
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 4
+            }
+        }
+    }
+}

--- a/nations/NETHERLANDS/Breda.json
+++ b/nations/NETHERLANDS/Breda.json
@@ -1,0 +1,206 @@
+{
+    "LitCal": {
+        "MariaTenhemelopnemingPatroonsfeestvanhetbisdom": {
+            "Festivity": {
+                "name": "Maria Tenhemelopneming, Patroonsfeest van het bisdom",
+                "color": [
+                    "white"
+                ],
+                "grade": 6,
+                "common": [
+                    "Proper"
+                ],
+                "day": 15,
+                "month": 8
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "VerjaardagvandeWijdingvandebisschopskerk": {
+            "Festivity": {
+                "name": "Verjaardag van de Wijding van de bisschopskerk",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Dedication of a Church"
+                ],
+                "day": 20,
+                "month": 12
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1,
+                "untilYear": 2019
+            }
+        },
+        "VerjaardagvandeWijdingvandebisschopskerk_2": {
+            "Festivity": {
+                "name": "Verjaardag van de Wijding van de bisschopskerk",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Dedication of a Church"
+                ],
+                "day": 12,
+                "month": 12
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 2
+            }
+        },
+        "HHMariaAdolfinaengezellinnenmaagdenenmartelaressen": {
+            "Festivity": {
+                "name": "HH. Maria Adolfina en.gezellinnen, maagden en martelaressen",
+                "color": [
+                    "red"
+                ],
+                "grade": 4,
+                "common": [
+                    "Proper"
+                ],
+                "day": 8,
+                "month": 7
+            },
+            "Metadata": {
+                "sinceYear": 2001,
+                "formRowNum": 3
+            }
+        },
+        "ZZMariaAdolfinaengezellinnenmaagdenenmartelaressen": {
+            "Festivity": {
+                "name": "ZZ. Maria Adolfina en gezellinnen, maagden en martelaressen",
+                "color": [
+                    "red"
+                ],
+                "grade": 3,
+                "common": [
+                    "Proper"
+                ],
+                "day": 8,
+                "month": 7
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0,
+                "untilYear": 2000
+            }
+        },
+        "ZPetrusDonderspriester": {
+            "Festivity": {
+                "name": "Z. Petrus Donders, priester",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For One Pastor",
+                    "Holy Men and Women:For Those Who Practiced Works of Mercy"
+                ],
+                "day": 14,
+                "month": 1
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 0
+            }
+        },
+        "HAmandusbisschop": {
+            "Festivity": {
+                "name": "H. Amandus, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For Missionaries"
+                ],
+                "day": 6,
+                "month": 2
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 1
+            }
+        },
+        "HGertrudismaagd": {
+            "Festivity": {
+                "name": "H. Gertrudis, maagd",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Virgins:For One Virgin",
+                    "Holy Men and Women:For Religious"
+                ],
+                "day": 17,
+                "month": 3
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 2
+            }
+        },
+        "HLambertusbisschopenmartelaar": {
+            "Festivity": {
+                "name": "H. Lambertus, bisschop en martelaar",
+                "color": [
+                    "red"
+                ],
+                "grade": 2,
+                "common": [
+                    "Proper"
+                ],
+                "day": 17,
+                "month": 9
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 3
+            }
+        },
+        "HHubertusbisschop": {
+            "Festivity": {
+                "name": "H. Hubertus, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For a Bishop"
+                ],
+                "day": 3,
+                "month": 11
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 4
+            }
+        },
+        "HEligiusbisschop": {
+            "Festivity": {
+                "name": "H. Eligius, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For Missionaries"
+                ],
+                "day": 1,
+                "month": 12
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 5
+            }
+        }
+    }
+}

--- a/nations/NETHERLANDS/Groningen-Leeuwarden.json
+++ b/nations/NETHERLANDS/Groningen-Leeuwarden.json
@@ -1,0 +1,115 @@
+{
+    "LitCal": {
+        "HHBonifatiusbisschoppatroonvanhetbisdomengezellenmartelaren": {
+            "Festivity": {
+                "name": "HH. Bonifatius, bisschop, patroon van het bisdom, en gezellen, martelaren",
+                "color": [
+                    "red",
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Martyrs",
+                    "Pastors:For Missionaries"
+                ],
+                "day": 5,
+                "month": 6
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "VerjaardagvandeWijdingvandekathedraal": {
+            "Festivity": {
+                "name": "Verjaardag van de Wijding van de kathedraal",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Dedication of a Church"
+                ],
+                "day": 19,
+                "month": 9
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1,
+                "untilYear": 2019
+            }
+        },
+        "VerjaardagvandeWijdingvandekathedraal_2": {
+            "Festivity": {
+                "name": "Verjaardag van de Wijding van de kathedraal",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Dedication of a Church"
+                ],
+                "day": 25,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 2
+            }
+        },
+        "HWillehadbisschop": {
+            "Festivity": {
+                "name": "H. Willehad, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Pastors:For Missionaries"
+                ],
+                "day": 8,
+                "month": 11
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "HFrederikabt": {
+            "Festivity": {
+                "name": "H. Frederik, abt",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Holy Men and Women:For Religious"
+                ],
+                "day": 3,
+                "month": 3
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "HLudgerbisschop": {
+            "Festivity": {
+                "name": "H. Ludger, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For Missionaries"
+                ],
+                "day": 26,
+                "month": 3
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        }
+    }
+}

--- a/nations/NETHERLANDS/Haarlem-Amsterdam.json
+++ b/nations/NETHERLANDS/Haarlem-Amsterdam.json
@@ -1,0 +1,189 @@
+{
+    "LitCal": {
+        "HWillibrordbisschopverkondigervanonsgeloofpatroonvanhetbisdom": {
+            "Festivity": {
+                "name": "H. Willibrord, bisschop, verkondiger van ons geloof, patroon van het bisdom",
+                "color": [
+                    "white"
+                ],
+                "grade": 6,
+                "common": [
+                    "Proper"
+                ],
+                "day": 7,
+                "month": 11
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "VerjaardagvandeWijdingvandekathedraal": {
+            "Festivity": {
+                "name": "Verjaardag van de Wijding van de kathedraal",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Dedication of a Church"
+                ],
+                "day": 2,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HAthanasiusbisschopenkerkleraar": {
+            "Festivity": {
+                "name": "H. Athanasius, bisschop en kerkleraar",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Pastors:For a Bishop",
+                    "Doctors"
+                ],
+                "day": 4,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "HHBonifatiusbisschopengezellenmartelarenbijpatronenvanhetbisdom": {
+            "Festivity": {
+                "name": "HH. Bonifatius, bisschop, en gezellen, martelaren, bijpatronen van het bisdom",
+                "color": [
+                    "red",
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Martyrs",
+                    "Pastors:For Missionaries"
+                ],
+                "day": 5,
+                "month": 6
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HAdalbertdiaken": {
+            "Festivity": {
+                "name": "H. Adalbert diaken",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Pastors:For Missionaries"
+                ],
+                "day": 25,
+                "month": 6
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 2
+            }
+        },
+        "OnzeLieveVrouwterNood": {
+            "Festivity": {
+                "name": "Onze Lieve Vrouw ter Nood",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Proper"
+                ],
+                "day": 1,
+                "month": 1
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 3,
+                "strtotime": "last saturday of May"
+            }
+        },
+        "MirakelvanhetHSacramentteAmsterdam": {
+            "Festivity": {
+                "name": "Mirakel van het H. Sacrament te Amsterdam",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Proper"
+                ],
+                "day": 1,
+                "month": 1
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0,
+                "strtotime": "wednesday after March 12"
+            }
+        },
+        "HBavo": {
+            "Festivity": {
+                "name": "H. Bavo",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Proper"
+                ],
+                "day": 1,
+                "month": 10
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HTeresiavanhetKindJezusmaagd": {
+            "Festivity": {
+                "name": "H. Teresia van het Kind Jezus, maagd",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Proper"
+                ],
+                "day": 1,
+                "month": 10
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 2
+            }
+        },
+        "HJozefmariaEscrivpriester": {
+            "Festivity": {
+                "name": "H. Jozefmaria Escrivá, priester",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For One Pastor"
+                ],
+                "day": 26,
+                "month": 6
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 3
+            }
+        }
+    }
+}

--- a/nations/NETHERLANDS/NETHERLANDS.json
+++ b/nations/NETHERLANDS/NETHERLANDS.json
@@ -161,7 +161,7 @@
     ],
     "Settings": {
         "Epiphany": "SUNDAY_JAN2_JAN8",
-        "Ascension": "SUNDAY",
+        "Ascension": "THURSDAY",
         "CorpusChristi": "SUNDAY",
         "Locale": "nl_NL"
     },

--- a/nations/NETHERLANDS/Roermond.json
+++ b/nations/NETHERLANDS/Roermond.json
@@ -1,0 +1,312 @@
+{
+    "LitCal": {
+        "OnbevlekteOntvangenisvandeHeiligeMaagdMariaPatroonsfeestvanhetbisdom": {
+            "Festivity": {
+                "name": "Onbevlekte Ontvangenis van de Heilige Maagd Maria, Patroonsfeest van het bisdom",
+                "color": [
+                    "white"
+                ],
+                "grade": 6,
+                "common": [
+                    "Proper"
+                ],
+                "day": 8,
+                "month": 12
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "ZArnoldJanssenpriester": {
+            "Festivity": {
+                "name": "Z. Arnold Janssen, priester",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Proper"
+                ],
+                "day": 15,
+                "month": 1
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0,
+                "untilYear": 2003
+            }
+        },
+        "HGregoriusdeGrotepausenkerkleraar": {
+            "Festivity": {
+                "name": "H. Gregorius de Grote, paus en kerkleraar",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Pastors:For a Pope",
+                    "Doctors"
+                ],
+                "day": 4,
+                "month": 9
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HGerlachkluizenaar": {
+            "Festivity": {
+                "name": "H. Gerlach, kluizenaar",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Holy Men and Women:For Religious"
+                ],
+                "day": 5,
+                "month": 1
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "HHWiroPlechelmusenOtger": {
+            "Festivity": {
+                "name": "HH. Wiro, Plechelmus en Otger",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For Missionaries"
+                ],
+                "day": 8,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "AlleheiligeBisschoppenvanMaastricht": {
+            "Festivity": {
+                "name": "Alle heilige Bisschoppen van Maastricht",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Proper"
+                ],
+                "day": 14,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 2
+            }
+        },
+        "HLambertusbisschopenmartelaar": {
+            "Festivity": {
+                "name": "H. Lambertus, bisschop en martelaar",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Proper"
+                ],
+                "day": 17,
+                "month": 9
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 3
+            }
+        },
+        "HHubertusbisschop": {
+            "Festivity": {
+                "name": "H. Hubertus, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors"
+                ],
+                "day": 3,
+                "month": 11
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 4
+            }
+        },
+        "HKarelvanSintAndriesKarelHoubenpriester": {
+            "Festivity": {
+                "name": "H. Karel van Sint Andries (Karel Houben), priester",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors"
+                ],
+                "day": 5,
+                "month": 1
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 5
+            }
+        },
+        "ZClaravanhetArmeKindJezuzClaraFeymaagd": {
+            "Festivity": {
+                "name": "Z. Clara van het Arme Kind Jezuz (Clara Fey), maagd",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Virgins"
+                ],
+                "day": 8,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 6
+            }
+        },
+        "ZJosefaStenmannsmaagd": {
+            "Festivity": {
+                "name": "Z. Josefa Stenmanns, maagd",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Virgins"
+                ],
+                "day": 20,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 7
+            }
+        },
+        "ZMariaTeresavandeHJozefAnnaMariaTauschermaagd": {
+            "Festivity": {
+                "name": "Z. Maria Teresa van de H. Jozef (Anna Maria Tauscher), maagd",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Virgins"
+                ],
+                "day": 30,
+                "month": 10
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 8
+            }
+        },
+        "ZMariaHelenaStollenwerkmaagd": {
+            "Festivity": {
+                "name": "Z. Maria Helena Stollenwerk, maagd",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Virgins"
+                ],
+                "day": 28,
+                "month": 11
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 9
+            }
+        },
+        "HServatiusbiscchop": {
+            "Festivity": {
+                "name": "H. Servatius, biscchop",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Proper"
+                ],
+                "day": 13,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "VerjaardagvandeWijdingvandekathedraal": {
+            "Festivity": {
+                "name": "Verjaardag van de Wijding van de kathedraal",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Dedication of a Church"
+                ],
+                "day": 3,
+                "month": 9
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HeiligeMaagdMariaSterrederZee": {
+            "Festivity": {
+                "name": "Heilige Maagd Maria, Sterre der Zee",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Proper"
+                ],
+                "day": 10,
+                "month": 10
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 2
+            }
+        },
+        "HArnoldJanssenpriester": {
+            "Festivity": {
+                "name": "H. Arnold Janssen, priester",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Proper"
+                ],
+                "day": 15,
+                "month": 1
+            },
+            "Metadata": {
+                "sinceYear": 2004,
+                "formRowNum": 3
+            }
+        }
+    }
+}

--- a/nations/NETHERLANDS/Rotterdam.json
+++ b/nations/NETHERLANDS/Rotterdam.json
@@ -1,0 +1,97 @@
+{
+    "LitCal": {
+        "HLaurentiusdiakenenmartelaarpatroonvanhetbisdom": {
+            "Festivity": {
+                "name": "H. Laurentius, diaken en martelaar, patroon van het bisdom",
+                "color": [
+                    "white",
+                    "red"
+                ],
+                "grade": 4,
+                "common": [
+                    "Proper"
+                ],
+                "day": 10,
+                "month": 8
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "VerjaardagvandeWijdingvandekathedraal": {
+            "Festivity": {
+                "name": "Verjaardag van de Wijding van de kathedraal",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Dedication of a Church"
+                ],
+                "day": 8,
+                "month": 5
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HSwietbertbisschop": {
+            "Festivity": {
+                "name": "H. Swietbert, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Proper"
+                ],
+                "day": 1,
+                "month": 3
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "HJeroenpriesterenmartelaar": {
+            "Festivity": {
+                "name": "H. Jeroen, priester en martelaar",
+                "color": [
+                    "red",
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Martyrs:For One Martyr",
+                    "Pastors:For Missionaries"
+                ],
+                "day": 17,
+                "month": 8
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "MariaterWegheOnzeLieveVrouwvanHaastrecht": {
+            "Festivity": {
+                "name": "Maria ter Weghe – Onze Lieve Vrouw van Haastrecht",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Proper"
+                ],
+                "day": 20,
+                "month": 10
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 2
+            }
+        }
+    }
+}

--- a/nations/NETHERLANDS/Utrecht.json
+++ b/nations/NETHERLANDS/Utrecht.json
@@ -1,0 +1,112 @@
+{
+    "LitCal": {
+        "HWillibrordbisschopverkondigervanonsgeloofenpatroonvandeNederlandsekerkprovinciepatroonvanhetaartsbisdomUtrechtenvanhetbisdomHaarlem": {
+            "Festivity": {
+                "name": "H. Willibrord, bisschop, verkondiger van ons geloof en patroon van de Nederlandse kerkprovincie, patroon van het aartsbisdom Utrecht en van het bisdom Haarlem",
+                "color": [
+                    "white"
+                ],
+                "grade": 6,
+                "common": [
+                    "Proper"
+                ],
+                "day": 7,
+                "month": 11
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "VerjaardagvandeWijdingvandekathedraal": {
+            "Festivity": {
+                "name": "Verjaardag van de Wijding van de kathedraal",
+                "color": [
+                    "white"
+                ],
+                "grade": 4,
+                "common": [
+                    "Dedication of a Church"
+                ],
+                "day": 22,
+                "month": 8
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "AlleHHBisschoppenvanUtrechtAlbrikAnsfriedBernulfFrederikHungerRadboudenabtGregorius": {
+            "Festivity": {
+                "name": "Alle HH. Bisschoppen van Utrecht, Albrik Ansfried, Bernulf, Frederik, Hunger, Radboud en abt Gregorius",
+                "color": [
+                    "white"
+                ],
+                "grade": 3,
+                "common": [
+                    "Proper"
+                ],
+                "day": 8,
+                "month": 11
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "HSwietbertbisschop": {
+            "Festivity": {
+                "name": "H. Swietbert, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For Missionaries"
+                ],
+                "day": 1,
+                "month": 3
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 0
+            }
+        },
+        "HLudgerbisschop": {
+            "Festivity": {
+                "name": "H. Ludger, bisschop",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For Missionaries"
+                ],
+                "day": 26,
+                "month": 3
+            },
+            "Metadata": {
+                "sinceYear": 1979,
+                "formRowNum": 1
+            }
+        },
+        "HJozefmariaEscrivpriester": {
+            "Festivity": {
+                "name": "H. Jozefmaria Escrivá, priester",
+                "color": [
+                    "white"
+                ],
+                "grade": 2,
+                "common": [
+                    "Pastors:For One Pastor"
+                ],
+                "day": 26,
+                "month": 6
+            },
+            "Metadata": {
+                "sinceYear": 2020,
+                "formRowNum": 2
+            }
+        }
+    }
+}

--- a/nations/index.json
+++ b/nations/index.json
@@ -47,8 +47,8 @@
         "diocese": "Breda"
     },
     "HAARLEMAMSTERDAM": {
-        "path": "nations\/NETHERLANDS\/Haarlem- Amsterdam.json",
+        "path": "nations\/NETHERLANDS\/Haarlem-Amsterdam.json",
         "nation": "NETHERLANDS",
-        "diocese": "Haarlem- Amsterdam"
+        "diocese": "Haarlem-Amsterdam"
     }
 }


### PR DESCRIPTION
* bugfix: support ordinal number spelling correctly for any language
* bugfix: "Year I", "Year II" references should only concern weekdays of Ordinary Time
* bugfix: in cases where the `diocesancalendar` parameter was set, but the `nationalcalendar` parameter was not, the national calendar settings were not being picked up correctly
* fix for Netherlands national calendar data