### PR TITLE
fix issue #250

### DIFF
--- a/src/Paths/Calendar.php
+++ b/src/Paths/Calendar.php
@@ -4301,7 +4301,7 @@ class Calendar
         $SerializeableLitCal->settings->corpus_christi      = $this->CalendarParams->CorpusChristi;
         $SerializeableLitCal->settings->locale              = $this->CalendarParams->Locale;
         $SerializeableLitCal->settings->return_type         = $this->CalendarParams->ReturnType;
-        $SerializeableLitCal->settings->year_type       = $this->CalendarParams->YearType;
+        $SerializeableLitCal->settings->year_type           = $this->CalendarParams->YearType;
         $SerializeableLitCal->settings->eternal_high_priest = $this->CalendarParams->EternalHighPriest;
         if ($this->CalendarParams->NationalCalendar !== null) {
             $SerializeableLitCal->settings->national_calendar = $this->CalendarParams->NationalCalendar;

--- a/src/Paths/Metadata.php
+++ b/src/Paths/Metadata.php
@@ -109,7 +109,7 @@ class Metadata
      */
     private static function getLocales(): void
     {
-        Metadata::$locales = array_map('basename', glob('i18n/*', GLOB_ONLYDIR));
+        Metadata::$locales = array_merge(['en'], array_map('basename', glob('i18n/*/*', GLOB_ONLYDIR)));
     }
 
     /**


### PR DESCRIPTION
# Issue being addressed
#250

# Summary of changes
add English to the list of supported locales produced by the metadata endpoint (`/calendars' route)
