### PR TITLE
add abbreviated form of liturgical rank

### DIFF
--- a/data/missals/propriumdesanctis_IT_1983/propriumdesanctis_IT_1983.json
+++ b/data/missals/propriumdesanctis_IT_1983/propriumdesanctis_IT_1983.json
@@ -5,7 +5,7 @@
         "event_key": "StAdalbert",
         "name": "Sant'Adalberto, vescovo e martire",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Martyrs:For One Martyr",
             "Pastors:For a Bishop"
@@ -29,7 +29,7 @@
         "event_key": "StLouisGrignonMontfort",
         "name": "San Luigi Grignon de Montfort",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Pastors:For One Pastor"
         ],
@@ -51,7 +51,7 @@
         "event_key": "StPeterJulianEymard",
         "name": "San Pietro Giuliani, sacerdote",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Pastors:For One Pastor",
             "Holy Men and Women:For Religious"
@@ -74,7 +74,7 @@
         "event_key": "StMaximilianKolbe",
         "name": "San Massimiliano Kolbe, sacerdote e martire",
         "grade": 3,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Proper"
         ],
@@ -97,7 +97,7 @@
         "event_key": "StPeterClaver",
         "name": "San Pietro Claver, sacerdote",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Pastors:For One Pastor",
             "Holy Men and Women:For Those Who Practiced Works of Mercy"
@@ -120,7 +120,7 @@
         "event_key": "StAndrewKimTaegon",
         "name": "Santi Andrea Kim Taegon, sacerdote, Paolo Chong Hasang e compagni martiri",
         "grade": 3,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Proper"
         ],
@@ -142,7 +142,7 @@
         "event_key": "StsLawrenceRuiz",
         "name": "Santi Lorenzo Ruiz e compagni martiri",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Martyrs:For Several Martyrs"
         ],
@@ -164,7 +164,7 @@
         "event_key": "StAndrewDungLac",
         "name": "Sant'Andrea Dung-Lac e compagni martiri",
         "grade": 3,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Proper"
         ],

--- a/data/missals/propriumdesanctis_US_2011/propriumdesanctis_US_2011.json
+++ b/data/missals/propriumdesanctis_US_2011/propriumdesanctis_US_2011.json
@@ -5,7 +5,7 @@
         "event_key": "StElizabethSeton",
         "name": "Saint Elizabeth Ann Seton, Religious",
         "grade": 3,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Proper"
         ],
@@ -27,7 +27,7 @@
         "event_key": "StJohnNeumann",
         "name": "Saint John Neumann, Bishop",
         "grade": 3,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Proper"
         ],
@@ -49,7 +49,7 @@
         "event_key": "StAndreBessette",
         "name": "Saint André Bessette, Religious",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Holy Men and Women:For Religious"
         ],
@@ -95,7 +95,7 @@
         "event_key": "StKatharineDrexel",
         "name": "Saint Katharine Drexel, Virgin",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Virgins:For One Virgin"
         ],
@@ -117,7 +117,7 @@
         "event_key": "StDamienVeuster",
         "name": "Saint Damien de Veuster, Priest",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Pastors:For Missionaries"
         ],
@@ -139,7 +139,7 @@
         "event_key": "StIsidore",
         "name": "Saint Isidore",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Holy Men and Women:For One Saint"
         ],
@@ -161,7 +161,7 @@
         "event_key": "JuniperoSerra",
         "name": "Blessed Junípero Serra, Priest",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Pastors:For One Pastor",
             "Pastors:For Missionaries"
@@ -206,7 +206,7 @@
         "event_key": "KateriTekakwitha",
         "name": "Blessed Kateri Tekakwitha, Virgin",
         "grade": 3,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Virgins:For One Virgin"
         ],
@@ -228,7 +228,7 @@
         "event_key": "StPeterClaver",
         "name": "Saint Peter Claver, Priest",
         "grade": 3,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Pastors:For One Pastor",
             "Holy Men and Women:For Those Who Practiced Works of Mercy"
@@ -251,7 +251,7 @@
         "event_key": "MarieDurocher",
         "name": "Blessed Marie Rose Durocher, Virgin",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Virgins:For One Virgin"
         ],
@@ -273,7 +273,7 @@
         "event_key": "StFrancesXCabrini",
         "name": "Saint Frances Xavier Cabrini, Virgin",
         "grade": 3,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Virgins:For One Virgin",
             "Holy Men and Women:For Those Who Practiced Works of Mercy"
@@ -296,7 +296,7 @@
         "event_key": "StRoseDuchesne",
         "name": "Saint Rose Philippine Duchesne, Virgin",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Virgins:For One Virgin"
         ],
@@ -318,7 +318,7 @@
         "event_key": "MiguelPro",
         "name": "Blessed Miguel Agustín Pro, Priest and Martyr",
         "grade": 2,
-        "grade_display": "",
+        "grade_display": null,
         "common": [
             "Martyrs:For One Martyr",
             "Pastors:For One Pastor"

--- a/schemas/LitCal.json
+++ b/schemas/LitCal.json
@@ -342,7 +342,7 @@
                     "type": "string"
                 },
                 "grade_display": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "common": {
                     "$ref": "https://litcal.johnromanodorazio.com/api/dev/schemas/CommonDef.json#/definitions/LitCommon"
@@ -478,7 +478,7 @@
                     "type": "string"
                 },
                 "grade_display": {
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "common": {
                     "$ref": "https://litcal.johnromanodorazio.com/api/dev/schemas/CommonDef.json#/definitions/LitCommon"

--- a/src/FestivityCollection.php
+++ b/src/FestivityCollection.php
@@ -103,36 +103,36 @@ class FestivityCollection
             $this->festivities[ $key ]->grade_display = "";
         }
         if ($festivity->grade >= LitGrade::FEAST_LORD) {
-            $this->solemnities[ $key ]  = $festivity->date;
+            $this->solemnities[ $key ] = $festivity->date;
         }
         if ($festivity->grade === LitGrade::FEAST) {
-            $this->feasts[ $key ]       = $festivity->date;
+            $this->feasts[ $key ]      = $festivity->date;
         }
         if ($festivity->grade === LitGrade::MEMORIAL) {
-            $this->memorials[ $key ]    = $festivity->date;
+            $this->memorials[ $key ]   = $festivity->date;
         }
         // Weekday of Advent from 17 to 24 Dec.
         if (str_starts_with($key, "AdventWeekday")) {
             if ($festivity->date->format('j') >= 17 && $festivity->date->format('j') <= 24) {
                 $this->weekdaysAdventChristmasLent[ $key ] = $festivity->date;
             } else {
-                $this->weekdaysAdventBeforeDec17[ $key ] = $festivity->date;
+                $this->weekdaysAdventBeforeDec17[ $key ]   = $festivity->date;
             }
         } elseif (str_starts_with($key, "ChristmasWeekday")) {
-            $this->weekdaysAdventChristmasLent[ $key ] = $festivity->date;
+            $this->weekdaysAdventChristmasLent[ $key ]     = $festivity->date;
         } elseif (str_starts_with($key, "LentWeekday")) {
-            $this->weekdaysAdventChristmasLent[ $key ] = $festivity->date;
+            $this->weekdaysAdventChristmasLent[ $key ]     = $festivity->date;
         } elseif (str_starts_with($key, "DayBeforeEpiphany") || str_starts_with($key, "DayAfterEpiphany")) {
-            $this->weekdaysEpiphany[ $key ] = $festivity->date;
+            $this->weekdaysEpiphany[ $key ]                = $festivity->date;
         }
         //Sundays of Advent, Lent, Easter
         if (preg_match('/(?:Advent|Lent|Easter)([1-7])/', $key, $matches) === 1) {
-            $this->sundaysAdventLentEaster[] = $festivity->date;
-            $this->festivities[ $key ]->psalter_week = self::psalterWeek(intval($matches[1]));
+            $this->sundaysAdventLentEaster[]               = $festivity->date;
+            $this->festivities[ $key ]->psalter_week       = self::psalterWeek(intval($matches[1]));
         }
         //Ordinary Sunday Psalter Week
         if (preg_match('/OrdSunday([1-9][0-9]*)/', $key, $matches) === 1) {
-            $this->festivities[ $key ]->psalter_week = self::psalterWeek(intval($matches[1]));
+            $this->festivities[ $key ]->psalter_week       = self::psalterWeek(intval($matches[1]));
         }
     }
 
@@ -173,6 +173,7 @@ class FestivityCollection
     public function getCalEventsFromDate(DateTime $date): array
     {
         return array_filter($this->festivities, function ($el) use ($date) {
+            // important: DateTime objects cannot use strict comparison!
             return $el->date == $date;
         });
     }
@@ -716,7 +717,8 @@ class FestivityCollection
             $festivity->color,
             $festivity->type,
             $festivity->grade,
-            $festivity->common
+            $festivity->common,
+            $festivity->grade_display
         );
         $this->festivities[ $key ]->has_vigil_mass                   = true;
         $this->festivities[ $key ]->has_vesper_i                     = true;
@@ -1191,8 +1193,7 @@ class FestivityCollection
                 $gradeAbbr = $this->LitGrade->i18n($festivity->grade, false, true);
                 $festivityAssocArr = [
                     "event_key" => $key,
-                    ...json_decode(json_encode($festivity), true),
-                    "grade_abbr" => $gradeAbbr
+                    ...json_decode(json_encode($festivity), true)
                 ];
                 ksort($festivityAssocArr);
                 $festivitiesCollection[] = $festivityAssocArr;


### PR DESCRIPTION
Fixes #251

# Summary of changes
Not only does this add a `grade_abbr` property, but we also adjust `grade_display` to be nullable so that it will be respected when empty rather than ignored. Null means ignorable, empty means must show as empty.