### PR TITLE
Translations update from JohnRDOrazio Weblate

### DIFF
--- a/i18n/de/LC_MESSAGES/litcal.po
+++ b/i18n/de/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: German <https://translate.johnromanodorazio.com/projects/"
@@ -22,7 +22,18 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -32,7 +43,7 @@ msgstr ""
 "anzufordern."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -41,14 +52,14 @@ msgstr ""
 "ein Fehler aufgetreten: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Beim Versuch, lokalisierte Daten für das Temporale abzurufen, ist ein Fehler "
 "aufgetreten."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
@@ -56,13 +67,13 @@ msgstr ""
 "aufgetreten: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 "Beim Versuch, Daten für das Temporale abzurufen, ist ein Fehler aufgetreten."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -74,7 +85,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -84,7 +95,7 @@ msgstr ""
 "zu dekodieren, ist ein Fehler aufgetreten: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Daten für das Sanctorale von %s konnten nicht gefunden werden."
@@ -93,7 +104,7 @@ msgstr "Daten für das Sanctorale von %s konnten nicht gefunden werden."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -103,11 +114,11 @@ msgstr ""
 "dekodieren, ist ein Fehler aufgetreten: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 msgid "Could not find the Sanctorale data"
 msgstr "Konnte die Sanctorale-Daten nicht finden"
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -117,7 +128,7 @@ msgstr ""
 "Kongregation für den Gottesdienst zu dekodieren, ist ein Fehler aufgetreten: "
 "%s"
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -125,7 +136,7 @@ msgstr ""
 "Konnte keine Übersetzungsdaten für Gedenktage basierend auf Dekreten der "
 "Kongregation für den Gottesdienst finden"
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -139,20 +150,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Wochentag in der Weihnachtszeit"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "oder"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "Barmherzigkeitssonntag"
 
@@ -165,8 +176,8 @@ msgstr "Barmherzigkeitssonntag"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -175,31 +186,31 @@ msgstr ""
 "Das Hochfest '%1$s' fällt im Jahr %3$d auf den %2$s, die Feier wurde auf den "
 "%4$s (%5$s) gemäß dem %6$s verschoben."
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr "der Samstag vor dem Palmsonntag"
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Dekret der Kongregation für den Gottesdienst"
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "der Montag nach dem zweiten Sonntag der Osterzeit"
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr "der folgende Montag"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -215,7 +226,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -225,7 +236,7 @@ msgstr ""
 "zusammenfällt, wurde sie gemäß %4$s um einen Tag vorverlegt."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -235,12 +246,12 @@ msgstr ""
 "%4$s und nicht am Sonntag nach Weihnachten gefeiert."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Unser Herr Jesus Christus, der ewige Hohepriester"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -254,30 +265,30 @@ msgstr ""
 "aufzunehmen: anwendbar für den Kalender '%1$s' im Jahr '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' wird im Jahr %4$d durch den %2$s '%3$s' ersetzt."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "der %s Woche des Advents"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Tag der Oktav von Weihnachten"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "der %s Woche der Fastenzeit"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "nach Aschermittwoch"
 
@@ -305,8 +316,8 @@ msgstr "nach Aschermittwoch"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -315,7 +326,7 @@ msgstr ""
 "Der %1$s '%2$s' wurde seit dem Jahr %4$d (%5$s) am %3$s hinzugefügt, "
 "anwendbar für das Jahr %6$d."
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -328,7 +339,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -346,16 +357,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "Der %1$s '%2$s' wird im Jahr %5$d durch den %3$s '%4$s' verdrängt."
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apostolische Konstitution Missale Romanum"
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -376,7 +387,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -391,7 +402,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -401,17 +412,17 @@ msgstr ""
 "zusammen. Beide werden zu fakultativen Gedenktagen herabgestuft (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr "vor"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr "nach"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -422,7 +433,7 @@ msgstr ""
 "sein"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -431,7 +442,7 @@ msgstr ""
 "'%2$s', nicht erstellen"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -441,7 +452,7 @@ msgstr ""
 "Eigenschaft ein Objekt ist, muss sie Eigenschaften %2$s haben"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -451,7 +462,7 @@ msgstr ""
 "muss entweder ein Objekt oder ein String sein! Derzeit hat es den Typ '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -465,7 +476,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -482,7 +493,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -499,7 +510,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -514,7 +525,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -523,7 +534,7 @@ msgstr ""
 "'%1$s' wurde seit dem Jahr %2$d zum Kirchenlehrer erklärt, gültig für das "
 "Jahr %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "und Kirchenlehrer"
 
@@ -537,7 +548,7 @@ msgstr "und Kirchenlehrer"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -556,7 +567,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -566,7 +577,7 @@ msgstr ""
 "seit dem Jahr %7$d (%8$s) am %6$s hinzugefügt wurde."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -576,7 +587,7 @@ msgstr ""
 "Dezember auf den 12. August verlegt, anwendbar für das Jahr %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -588,7 +599,7 @@ msgstr ""
 "seit dem Jahr 2002 (%2$s) auf den 12. August verlegt, anwendbar für das Jahr "
 "%3$d."
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -600,7 +611,7 @@ msgstr ""
 "Jahr %3$d von einem Sonntag, einer Hochfest oder einem Fest '%4$s' verdrängt."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -613,30 +624,37 @@ msgstr ""
 "gemäß %2$s wiederhergestellt, sodass die örtlichen Kirchen das Gedenken "
 "optional feiern können."
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "der %s Woche der Osterzeit"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "der %s Woche der gewöhnlichen Zeit"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Samstagsgedenken der seligen Jungfrau Maria"
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Fehler beim Abrufen und Dekodieren der Daten der weiteren Region aus der "
 "Datei %s."
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, fuzzy, php-format
+#| msgid "Error retrieving and decoding National data from file %s."
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr ""
 "Fehler beim Abrufen und Dekodieren der nationalen Daten aus der Datei %s."
 
@@ -648,7 +666,7 @@ msgstr ""
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -663,7 +681,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -673,7 +691,7 @@ msgstr ""
 "zusammen. Beide werden zu fakultativen Gedenktagen herabgestuft."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -683,7 +701,7 @@ msgstr ""
 "einem anderen Fest '%3$s' zusammen! Muss etwas dagegen unternommen werden?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -694,7 +712,7 @@ msgstr ""
 "%4$d mit dem Sonntag oder Hochfest '%3$s' zusammen! Muss etwas dagegen "
 "unternommen werden?"
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -703,7 +721,7 @@ msgstr ""
 "Datumsinformationen zu haben, um fortzufahren"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Sanctorale-Datendatei für %s gefunden"
@@ -717,7 +735,7 @@ msgstr "Sanctorale-Datendatei für %s gefunden"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -727,13 +745,13 @@ msgstr ""
 "wurde, wird im Jahr %7$d durch den %5$s '%6$s' ersetzt"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Konnte keine Sanctorale-Datendatei für %s finden"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -743,7 +761,7 @@ msgstr ""
 "für '%3$s' zu schaffen: anwendbar für das Jahr %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -755,7 +773,7 @@ msgstr ""
 "'%8$s' unterdrückt."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -767,7 +785,7 @@ msgstr ""
 "Feierlichkeit '%4$s' zusammen! Muss hier etwas unternommen werden?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -777,7 +795,7 @@ msgstr ""
 "%4$s gefeiert wird, wird im Jahr %6$d durch den Sonntag oder die "
 "Feierlichkeit %5$s unterdrückt"
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/es/LC_MESSAGES/litcal.po
+++ b/i18n/es/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: Spanish <https://translate.johnromanodorazio.com/projects/"
@@ -22,7 +22,18 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -31,7 +42,7 @@ msgstr ""
 "Solo se admiten los años a partir de 1970. Intentaste solicitar el año %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -40,24 +51,24 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Hubo un error al intentar recuperar datos localizados para el Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr "Hubo un error al intentar decodificar datos JSON para el Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr "Hubo un error al intentar recuperar datos para el Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "No se pudieron encontrar datos de traducción para el sanctoral de %s."
@@ -68,7 +79,7 @@ msgstr "No se pudieron encontrar datos de traducción para el sanctoral de %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -78,7 +89,7 @@ msgstr ""
 "Sanctorale del Misal %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "No se pudieron encontrar datos para el Sanctorale de %s."
@@ -87,7 +98,7 @@ msgstr "No se pudieron encontrar datos para el Sanctorale de %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -97,11 +108,11 @@ msgstr ""
 "Misal %1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 msgid "Could not find the Sanctorale data"
 msgstr "No se pudo encontrar la información del Sanctorale"
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -110,7 +121,7 @@ msgstr ""
 "Hubo un error al intentar decodificar datos de traducción para Memorias "
 "basadas en Decretos de la Congregación para el Culto Divino: %s"
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -118,7 +129,7 @@ msgstr ""
 "No se pudo encontrar datos de traducción para los Memoriales basados en los "
 "Decretos de la Congregación para el Culto Divino"
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -131,20 +142,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Día de la Semana de Navidad"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "o"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "domingo de la Misericordia divina"
 
@@ -157,8 +168,8 @@ msgstr "domingo de la Misericordia divina"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -167,31 +178,31 @@ msgstr ""
 "La Solemnidad <i>'%1$s'</i> coincide con <b>%2$s</b> en el año %3$d, por "
 "tanto, la celebración ha sido trasladada a %4$s (%5$s) según el %6$s."
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr "Sábado anterior al Domingo de Ramos"
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decreto de la Congregación para el Culto Divino"
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "el lunes siguiente al Segundo Domingo de Pascua"
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr "el siguiente lunes"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -207,7 +218,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -217,7 +228,7 @@ msgstr ""
 "%3$d, se ha anticipado un día según %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -227,12 +238,12 @@ msgstr ""
 "celebra el %4$s en lugar del domingo después de Navidad."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Nuestro Señor Jesucristo, El Sumo Sacerdote Eterno"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -246,30 +257,30 @@ msgstr ""
 "aplicable al calendario '%1$s' en el año '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' es reemplazado por el %2$s '%3$s' en el año %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "de la %s Semana de Adviento"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Día de la Octava de Navidad"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "de la %s Semana de Cuaresma"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "después del Miércoles de Ceniza"
 
@@ -297,8 +308,8 @@ msgstr "después del Miércoles de Ceniza"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -307,7 +318,7 @@ msgstr ""
 "El %1$s '%2$s' se ha añadido el %3$s desde el año %4$d (%5$s), aplicable al "
 "año %6$d."
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -320,7 +331,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -338,16 +349,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "El %1$s '%2$s' es reemplazado por el %3$s '%4$s' en el año %5$d."
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Constitución Apostólica Missale Romanum"
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -368,7 +379,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -383,7 +394,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -393,17 +404,17 @@ msgstr ""
 "reducen en rango a memorias opcionales (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr "antes"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr "después"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -413,7 +424,7 @@ msgstr ""
 "festividad con clave '%2$s' usando palabras clave %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -422,7 +433,7 @@ msgstr ""
 "clave '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -432,7 +443,7 @@ msgstr ""
 "'strtotime' es un objeto, debe tener propiedades %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -442,7 +453,7 @@ msgstr ""
 "ser un objeto o una cadena. Actualmente tiene el tipo '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -456,7 +467,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -473,7 +484,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -490,7 +501,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -505,7 +516,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -514,7 +525,7 @@ msgstr ""
 "'%1$s' ha sido declarado Doctor de la Iglesia desde el año %2$d, aplicable "
 "al año %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "y Doctor de la Iglesia"
 
@@ -528,7 +539,7 @@ msgstr "y Doctor de la Iglesia"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -547,7 +558,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -557,7 +568,7 @@ msgstr ""
 "el %6$s desde el año %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -567,7 +578,7 @@ msgstr ""
 "agosto desde el año 2002 (%2$s), aplicable al año %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -578,7 +589,7 @@ msgstr ""
 "domingo o solemnidad si fuera el 12 de diciembre, ha sido transferida al 12 "
 "de agosto desde el año 2002 (%2$s), aplicable al año %3$d."
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -591,7 +602,7 @@ msgstr ""
 "%3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -604,29 +615,36 @@ msgstr ""
 "reinstaurada para que las iglesias locales puedan celebrar opcionalmente la "
 "memoria."
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "de la %s Semana de Pascua"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "de la %s Semana del Tiempo Ordinario"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memoria del sábado de la Bienaventurada Virgen María"
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Error al recuperar y decodificar datos de la Región Ampliada del archivo %s."
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, fuzzy, php-format
+#| msgid "Error retrieving and decoding National data from file %s."
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr "Error al recuperar y decodificar datos Nacionales del archivo %s."
 
 #. translators:
@@ -637,7 +655,7 @@ msgstr "Error al recuperar y decodificar datos Nacionales del archivo %s."
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -652,7 +670,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -662,7 +680,7 @@ msgstr ""
 "reducen en rango a memorias opcionales."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -672,7 +690,7 @@ msgstr ""
 "'%3$s' en el año %4$d! ¿Hay que hacer algo al respecto?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -682,7 +700,7 @@ msgstr ""
 "La solemnidad '%1$s', usualmente celebrada el %2$s, coincide con el domingo "
 "o solemnidad '%3$s' en el año %4$d! ¿Hay que hacer algo al respecto?"
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -691,7 +709,7 @@ msgstr ""
 "tenemos la información correcta sobre la fecha para proceder"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Se encontró un archivo de datos del sanctoral para %s"
@@ -705,7 +723,7 @@ msgstr "Se encontró un archivo de datos del sanctoral para %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -715,13 +733,13 @@ msgstr ""
 "reemplazado por el %5$s '%6$s' en el año %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "No se pudo encontrar un archivo de datos del sanctoral para %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -731,7 +749,7 @@ msgstr ""
 "espacio para '%3$s': aplicable al año %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -743,7 +761,7 @@ msgstr ""
 "año %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -755,7 +773,7 @@ msgstr ""
 "%5$d! ¿Se necesita hacer algo al respecto?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -764,7 +782,7 @@ msgstr ""
 "El %1$s '%2$s', propio del calendario del %3$s y usualmente celebrado el "
 "%4$s, es suprimido por el domingo o solemnidad %5$s en el año %6$d"
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/fr/LC_MESSAGES/litcal.po
+++ b/i18n/fr/LC_MESSAGES/litcal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: French <https://translate.johnromanodorazio.com/projects/"
@@ -21,7 +21,18 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -31,7 +42,7 @@ msgstr ""
 "de demander l'année %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -40,14 +51,14 @@ msgstr ""
 "localisées pour le Temporal : %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Une erreur s'est produite lors de la tentative de récupération des données "
 "localisées pour le Temporal."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
@@ -55,14 +66,14 @@ msgstr ""
 "pour le Temporal : %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 "Une erreur s'est produite lors de la tentative de récupération des données "
 "pour le Temporal."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -74,7 +85,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -84,7 +95,7 @@ msgstr ""
 "localisation JSON pour le Sanctoral du Missel %1$s : %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, fuzzy, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Les données pour le sanctoral de %s n'ont pas pu être trouvées."
@@ -93,7 +104,7 @@ msgstr "Les données pour le sanctoral de %s n'ont pas pu être trouvées."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -103,12 +114,12 @@ msgstr ""
 "pour le Sanctoral du Missel %1$s : %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 #, fuzzy
 msgid "Could not find the Sanctorale data"
 msgstr "Impossible de trouver un fichier de données sanctorale pour %s"
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -118,14 +129,14 @@ msgstr ""
 "traduction pour les Mémoires basés sur les Décrets de la Congrégation pour "
 "le Culte Divin : %s"
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 #, fuzzy
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr "Décret de la Congrégation pour le Culte Divin"
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -139,20 +150,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Férie de Noël"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "ou"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "Dimanche de la Miséricorde divine"
 
@@ -165,8 +176,8 @@ msgstr "Dimanche de la Miséricorde divine"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -175,31 +186,31 @@ msgstr ""
 "La Solennité '%1$s' tombe le %2$s en l'année %3$d, la célébration a été "
 "transférée au %4$s (%5$s) selon le %6$s."
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr "le samedi précédant le dimanche des Rameaux"
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Décret de la Congrégation pour le Culte Divin"
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "le lundi suivant le deuxième dimanche de Pâques"
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr "le lundi suivant"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -215,7 +226,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -225,7 +236,7 @@ msgstr ""
 "%3$d, elle a été anticipée d'un jour selon %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -235,12 +246,12 @@ msgstr ""
 "%4$s plutôt que le dimanche après Noël."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Notre Seigneur Jésus-Christ, Souverain Prêtre Éternel"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -254,30 +265,30 @@ msgstr ""
 "applicable au calendrier '%1$s' en l'année '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' est supplanté par le %2$s '%3$s' en l'année %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "de la %s Semaine de l'Avent"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Jour de l'Octave de Noël"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "de la %s semaine de Carême"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "après le Mercredi des Cendres"
 
@@ -305,8 +316,8 @@ msgstr "après le Mercredi des Cendres"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -315,7 +326,7 @@ msgstr ""
 "Le %1$s '%2$s' a été ajouté le %3$s depuis l'année %4$d (%5$s), applicable à "
 "l'année %6$d."
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -328,7 +339,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -346,16 +357,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "Le %1$s '%2$s' est supplanté par le %3$s '%4$s' en l'année %5$d."
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Constitution apostolique Missale Romanum"
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -376,7 +387,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -391,7 +402,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -401,17 +412,17 @@ msgstr ""
 "Elles sont toutes deux réduites en rang à des mémoires facultatives (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr "avant"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr "après"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -421,7 +432,7 @@ msgstr ""
 "fête avec la clé '%2$s' en utilisant les mots-clés %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -430,7 +441,7 @@ msgstr ""
 "'%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -440,7 +451,7 @@ msgstr ""
 "est un objet, elle doit avoir les propriétés %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -451,7 +462,7 @@ msgstr ""
 "type '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr "Impossible de créer la fête mobile '%1$s' sans propriété 'strtotime' !"
@@ -464,7 +475,7 @@ msgstr "Impossible de créer la fête mobile '%1$s' sans propriété 'strtotime'
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -481,7 +492,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -498,7 +509,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -513,7 +524,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -522,7 +533,7 @@ msgstr ""
 "'%1$s' a été déclaré Docteur de l'Église depuis l'année %2$d, applicable à "
 "l'année %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "et Docteur de l'Église"
 
@@ -536,7 +547,7 @@ msgstr "et Docteur de l'Église"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -555,7 +566,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -565,7 +576,7 @@ msgstr ""
 "%6$s depuis l'année %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -575,7 +586,7 @@ msgstr ""
 "l'année 2002 (%2$s), applicable à l'année %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -586,7 +597,7 @@ msgstr ""
 "dimanche ou une solennité si elle avait eu lieu le 12 déc., a cependant été "
 "transférée au 12 août depuis l'année 2002 (%2$s), applicable à l'année %3$d."
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -598,7 +609,7 @@ msgstr ""
 "par un dimanche, une solennité ou une fête '%4$s' en l'année %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -611,30 +622,37 @@ msgstr ""
 "rétablie afin que les églises locales puissent célébrer facultativement la "
 "mémoire."
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "de la %s semaine de Pâques"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "de la %s Semaine du Temps Ordinaire"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Mémoire du samedi de la Bienheureuse Vierge Marie"
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Erreur lors de la récupération et du décodage des données de la région "
 "élargie à partir du fichier %s."
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, fuzzy, php-format
+#| msgid "Error retrieving and decoding National data from file %s."
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr ""
 "Erreur lors de la récupération et du décodage des données nationales à "
 "partir du fichier %s."
@@ -647,7 +665,7 @@ msgstr ""
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -662,7 +680,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -672,7 +690,7 @@ msgstr ""
 "Elles sont toutes deux réduites au rang de mémoires facultatives."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -682,7 +700,7 @@ msgstr ""
 "Fête '%3$s' en l'année %4$d ! Faut-il faire quelque chose à ce sujet ?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -693,7 +711,7 @@ msgstr ""
 "dimanche ou la Solennité '%3$s' en l'année %4$d ! Faut-il faire quelque "
 "chose à ce sujet ?"
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -702,7 +720,7 @@ msgstr ""
 "les informations de date correctes pour procéder"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Fichier de données sanctorale trouvé pour %s"
@@ -716,7 +734,7 @@ msgstr "Fichier de données sanctorale trouvé pour %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -726,13 +744,13 @@ msgstr ""
 "par le %5$s '%6$s' en l'année %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Impossible de trouver un fichier de données sanctorale pour %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -742,7 +760,7 @@ msgstr ""
 "place à '%3$s' : applicable à l'année %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -754,7 +772,7 @@ msgstr ""
 "en l'année %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -766,7 +784,7 @@ msgstr ""
 "Faut-il faire quelque chose à ce sujet ?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -775,7 +793,7 @@ msgstr ""
 "La %1$s '%2$s', propre au calendrier du %3$s et habituellement célébrée le "
 "%4$s, est supprimée par le dimanche ou la solennité %5$s en l'année %6$d"
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/hu/LC_MESSAGES/litcal.po
+++ b/i18n/hu/LC_MESSAGES/litcal.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,7 +15,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -23,30 +34,30 @@ msgid ""
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -57,7 +68,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -65,7 +76,7 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr ""
@@ -74,7 +85,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -82,24 +93,24 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 msgid "Could not find the Sanctorale data"
 msgstr ""
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
 "Decrees of the Congregation for Divine Worship: %s"
 msgstr ""
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr ""
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -110,20 +121,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr ""
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr ""
 
@@ -136,39 +147,39 @@ msgstr ""
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr ""
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -181,7 +192,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -189,7 +200,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -197,12 +208,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -212,30 +223,30 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr ""
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr ""
 
@@ -263,15 +274,15 @@ msgstr ""
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -282,7 +293,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -297,16 +308,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -324,7 +335,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -337,7 +348,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -345,17 +356,17 @@ msgid ""
 msgstr ""
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr ""
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -363,14 +374,14 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -378,7 +389,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -386,7 +397,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -399,7 +410,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -414,7 +425,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -429,7 +440,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -442,14 +453,14 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr ""
 
@@ -463,7 +474,7 @@ msgstr ""
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -480,7 +491,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -488,7 +499,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -496,7 +507,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -504,7 +515,7 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -513,7 +524,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -522,28 +533,34 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr ""
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, php-format
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr ""
 
 #. translators:
@@ -554,7 +571,7 @@ msgstr ""
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -567,7 +584,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -575,7 +592,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -583,7 +600,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -591,14 +608,14 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -612,7 +629,7 @@ msgstr ""
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -620,13 +637,13 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -634,7 +651,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -643,7 +660,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -652,14 +669,14 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
 "on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
 msgstr ""
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/id/LC_MESSAGES/litcal.po
+++ b/i18n/id/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-08-20 15:40+0000\n"
 "Last-Translator: User_425 <user425.itsme@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.johnromanodorazio.com/projects/"
@@ -19,7 +19,18 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -29,30 +40,30 @@ msgstr ""
 "%d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -63,7 +74,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -71,7 +82,7 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr ""
@@ -80,7 +91,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -88,24 +99,24 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 msgid "Could not find the Sanctorale data"
 msgstr ""
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
 "Decrees of the Congregation for Divine Worship: %s"
 msgstr ""
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr ""
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -116,20 +127,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "atau"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "Minggu Kerahiman Ilahi"
 
@@ -142,39 +153,39 @@ msgstr "Minggu Kerahiman Ilahi"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr ""
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -187,7 +198,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -195,7 +206,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -203,12 +214,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -218,30 +229,30 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "Pekan %s Adven"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "Hari %s pada Oktaf Natal"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "Pekan %s Prapaskah"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "setelah Rabu Abu"
 
@@ -269,15 +280,15 @@ msgstr "setelah Rabu Abu"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -288,7 +299,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -303,16 +314,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -330,7 +341,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -343,7 +354,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -351,17 +362,17 @@ msgid ""
 msgstr ""
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr ""
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -369,14 +380,14 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -384,7 +395,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -392,7 +403,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -405,7 +416,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -420,7 +431,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -435,7 +446,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -448,14 +459,14 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "dan Pujangga Gereja"
 
@@ -469,7 +480,7 @@ msgstr "dan Pujangga Gereja"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -486,7 +497,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -494,7 +505,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -502,7 +513,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -510,7 +521,7 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -519,7 +530,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -528,28 +539,34 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "Pekan %s Paskah"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "Pekan Biasa %s"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, php-format
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr ""
 
 #. translators:
@@ -560,7 +577,7 @@ msgstr ""
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -573,7 +590,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -581,7 +598,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -589,7 +606,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -597,14 +614,14 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -618,7 +635,7 @@ msgstr ""
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -626,13 +643,13 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -640,7 +657,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -649,7 +666,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -658,14 +675,14 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
 "on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
 msgstr ""
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/it/LC_MESSAGES/litcal.po
+++ b/i18n/it/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-11-17 07:40+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Italian <https://translate.johnromanodorazio.com/projects/"
@@ -22,7 +22,18 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -32,7 +43,7 @@ msgstr ""
 "richiedere l'anno %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -41,14 +52,14 @@ msgstr ""
 "localizzati per il Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Si è verificato un errore nel tentativo di recuperare i dati localizzati per "
 "il Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
@@ -56,14 +67,14 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 "Si è verificato un errore nel tentativo di recuperare i dati per il "
 "Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Non sono stati trovati dati per la traduzione del santorale di: %s."
@@ -74,7 +85,7 @@ msgstr "Non sono stati trovati dati per la traduzione del santorale di: %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -84,7 +95,7 @@ msgstr ""
 "localizzazione JSON per il Sanctorale del Messale %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Non sono stati trovati dati per il Santorale da %s."
@@ -93,7 +104,7 @@ msgstr "Non sono stati trovati dati per il Santorale da %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -103,11 +114,11 @@ msgstr ""
 "Sanctorale del Messale %1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 msgid "Could not find the Sanctorale data"
 msgstr "Non è stato trovato un file con i dati del Santorale"
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -116,7 +127,7 @@ msgstr ""
 "Si è verificato un errore nel tentativo di decodificare i dati di traduzione "
 "per le Memorie basate sui Decreti della Congregazione per il Culto Divino: %s"
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -124,7 +135,7 @@ msgstr ""
 "Impossibile trovare dati di traduzione per le Memorie basate sui Decreti "
 "della Congregazione per il Culto Divino"
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -137,20 +148,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Giorno feriale di Natale"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "oppure"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "Domenica della Divina Misericordia"
 
@@ -163,8 +174,8 @@ msgstr "Domenica della Divina Misericordia"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -173,31 +184,31 @@ msgstr ""
 "La Solennità <i>'%1$s'</i> cade di %2$s nell'anno %3$d, pertanto la "
 "celebrazione è stata trasferita al %4$s (%5$s) in accordo con il %6$s."
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr "sabato che precede la Domenica delle Palme"
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decreto della Congregazione per il Culto Divino"
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "lunedì che segue la Seconda Domenica di Pasqua"
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr "lunedì seguente"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -213,7 +224,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -223,7 +234,7 @@ msgstr ""
 "nell'anno %3$d, la prima è stata anticipata di un giorno come da %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -233,12 +244,12 @@ msgstr ""
 "<i>'%3$s'</i> viene celebrata il %4$s anziché la Domenica dopo Natale."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Nostro Signore Gesù Cristo, Sommo ed Eterno Sacerdote"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -252,30 +263,30 @@ msgstr ""
 "calendario '%1$s' nell'anno '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "<i>'%1$s'</i> è soppiantata dalla %2$s <i>'%3$s'</i> nell'anno %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "della %s Settimana dell'Avvento"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Giorno dell'Ottava di Natale"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "della %s Settimana di Quaresima"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "dopo il Mercoledì delle Ceneri"
 
@@ -303,8 +314,8 @@ msgstr "dopo il Mercoledì delle Ceneri"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -313,7 +324,7 @@ msgstr ""
 "La %1$s '%2$s' è stata inserita il giorno %3$s a partire dall'anno %4$d "
 "(%5$s), applicabile pertanto all'anno %6$d."
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -326,7 +337,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -344,16 +355,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "La %1$s '%2$s' è soppiantata dalla %3$s '%4$s' nell'anno %5$d."
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Costituzione Apostolica Missale Romanum"
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -374,7 +385,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -389,7 +400,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -399,17 +410,17 @@ msgstr ""
 "e due sono ridotte al grado di memorie facoltative (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr "prima di"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr "dopo"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -419,7 +430,7 @@ msgstr ""
 "festività con chiave '%2$s' utilizzando le parole chiave %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -428,7 +439,7 @@ msgstr ""
 "chiave '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -438,7 +449,7 @@ msgstr ""
 "'strtotime' è un oggetto, deve avere le proprietà %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -448,7 +459,7 @@ msgstr ""
 "essere un oggetto oppure una stringa! Attualmente è di tipo '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -462,7 +473,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -479,7 +490,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -496,7 +507,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -511,7 +522,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -520,7 +531,7 @@ msgstr ""
 "'%1$s' è stato dichiarato Dottore della Chiesa sin dal %2$d, applicabile "
 "pertanto all'anno %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "e Dottore della Chiesa"
 
@@ -534,7 +545,7 @@ msgstr "e Dottore della Chiesa"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -553,7 +564,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -563,7 +574,7 @@ msgstr ""
 "il giorno %6$s sin dal %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -573,7 +584,7 @@ msgstr ""
 "sin dal 2002 (%2$s), applicabile pertanto all'anno %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -585,7 +596,7 @@ msgstr ""
 "trasferita al 12 Agosto sin dal 2002 (%2$s), applicabile pertanto all'anno "
 "%3$d."
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -597,7 +608,7 @@ msgstr ""
 "soppressa da una Domenica, una Solennità o una Festa '%4$s' nell'anno %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -610,30 +621,37 @@ msgstr ""
 "restituita secondo il %2$s in modo che le chiese locali abbiano facoltà di "
 "mantenere la memoria."
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "della %s Settimana di Pasqua"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "della %s Settimana del Tempo Ordinario"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memoria di Santa Maria in sabato"
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Errore nella lettura o nella decodifica dei dati per la Regione più ampia "
 "dal file %s."
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, fuzzy, php-format
+#| msgid "Error retrieving and decoding National data from file %s."
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr ""
 "Errore nella lettura o nella decodifica dei dati Nazionali dal file %s."
 
@@ -645,7 +663,7 @@ msgstr ""
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -660,7 +678,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -670,7 +688,7 @@ msgstr ""
 "e due sono ridotte al grado di memorie facoltative."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -680,7 +698,7 @@ msgstr ""
 "Festa '%3$s' nell'anno %4$d. Dobbiamo rimediare?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -690,7 +708,7 @@ msgstr ""
 "La Solennità '%1$s', solitamente celebrate il %2$s, coincide con la Domenica "
 "o Solennità '%3$s' nell'anno %4$d. Dobbiamo rimediare in qualche modo?"
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -699,7 +717,7 @@ msgstr ""
 "corrette informazioni sulla data per poter procedere"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Trovato un file con dati per il santorale di: %s"
@@ -713,7 +731,7 @@ msgstr "Trovato un file con dati per il santorale di: %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -723,13 +741,13 @@ msgstr ""
 "superata dalla %5$s '%6$s' nell'anno %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Non è stato trovato un file con i dati del santorale di: %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -739,7 +757,7 @@ msgstr ""
 "lasciare luogo a '%3$s': applicabile pertanto all'anno %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -751,7 +769,7 @@ msgstr ""
 "%9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -763,7 +781,7 @@ msgstr ""
 "fare qualcosa a riguardo?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -772,7 +790,7 @@ msgstr ""
 "La %1$s '%2$s', propria del calendario %3$s e solitamente celebrate il "
 "giorno %4$s, è soppressa dalla Domenica o Solennità '%5$s' nell'anno %6$d"
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/la/LC_MESSAGES/litcal.po
+++ b/i18n/la/LC_MESSAGES/litcal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: Latin <https://translate.johnromanodorazio.com/projects/"
@@ -20,7 +20,18 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -29,30 +40,30 @@ msgstr ""
 "Petere potes nisi ab annis MCMLXX et ultra. Tu anno %d conatus est petere."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Translationem datarum pro sanctorali ex %s inveniri non potuit."
@@ -63,7 +74,7 @@ msgstr "Translationem datarum pro sanctorali ex %s inveniri non potuit."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -71,7 +82,7 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, fuzzy, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Data pro sanctorale ex %s reperiri non potuit."
@@ -80,7 +91,7 @@ msgstr "Data pro sanctorale ex %s reperiri non potuit."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -88,26 +99,26 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 #, fuzzy
 msgid "Could not find the Sanctorale data"
 msgstr "Archivum datarum de Sanctorale pro %s non inventa est"
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
 "Decrees of the Congregation for Divine Worship: %s"
 msgstr ""
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 #, fuzzy
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr "Decretum Congregationis pro Cultu Divino"
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -118,20 +129,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "vel"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "Dominica de divina Misericordia"
 
@@ -144,8 +155,8 @@ msgstr "Dominica de divina Misericordia"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -154,31 +165,31 @@ msgstr ""
 "Coincidet enim Sollemnitas <i>'%1$s'</i> cum <b>%2$s</b> in anno %3$d, ergo "
 "traslata est celebratio ad %4$s (%5$s) secundum %6$s."
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr "sabbatum ante Dominicam in Palmis"
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decretum Congregationis pro Cultu Divino"
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "diem Lunæ post Dominicam Secundam Paschæ"
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr "diem Lunæ proximum"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -193,7 +204,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -203,7 +214,7 @@ msgstr ""
 "in anno %3$d, anticipata est ab uno die secundum %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -213,12 +224,12 @@ msgstr ""
 "celebrentur die %4$s quam Dominica post Nativitate."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Dómini nostri Iesu Christi, Summi et Aetérni Sacerdótis"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -232,30 +243,30 @@ msgstr ""
 "applicabile ad calendarium '%1$s' anno '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "<i>'%1$s'</i> subplantata est ab %2$s <i>'%3$s'</i> in anno %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "Hebdomadæ %s Adventus"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "Dies %s Octavæ Nativitatis"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "Hebdomadæ %s Quadragesimæ"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "post Feria IV Cinerum"
 
@@ -283,8 +294,8 @@ msgstr "post Feria IV Cinerum"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -293,7 +304,7 @@ msgstr ""
 "%1$s <i>'%2$s'</i> aggregata est igitur in die %3$s ab anno %4$d (%5$s), "
 "ergo viget in anno %6$d."
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -306,7 +317,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -324,16 +335,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "%1$s '%2$s' subplantata est ab %3$s '%4$s' in anno %5$d."
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apostolica Constitutio Missale Romanum"
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -353,7 +364,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -368,7 +379,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -378,17 +389,17 @@ msgstr ""
 "simul redunctur in gradu Memoriæ ad libitum (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr "ante"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr "postquam"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -398,7 +409,7 @@ msgstr ""
 "clave '%2$s' relativa esse potest, utentem verbis clavum %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -407,7 +418,7 @@ msgstr ""
 "creari non potest"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -417,7 +428,7 @@ msgstr ""
 "obiectum, oportet eam habere proprietates %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -427,7 +438,7 @@ msgstr ""
 "obiectum esse debet aut stringere! Nunc autem habet typum '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -441,7 +452,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -458,7 +469,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -475,7 +486,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -490,7 +501,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -499,7 +510,7 @@ msgstr ""
 "'%1$s' declarato/a est Doctor Ecclesiæ ab anno %2$d, ergo applicatur ad anno "
 "%3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "et Ecclesiæ doctoris"
 
@@ -513,7 +524,7 @@ msgstr "et Ecclesiæ doctoris"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -532,7 +543,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -542,7 +553,7 @@ msgstr ""
 "%6$s ab anno %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -552,7 +563,7 @@ msgstr ""
 "2002 (%2$s), ergo viget in anno %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -563,7 +574,7 @@ msgstr ""
 "Sollemnitate si celebrata fuisset in die 12 Dec., nihilominus traslata est "
 "ad 12 Aug. ab anno 2002 (%2$s), ergo viget in anno %3$d."
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -575,7 +586,7 @@ msgstr ""
 "Dominica, aut Sollemnitate, aut Festu <i>\\'%4$s\\'</i> in anno %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -587,31 +598,40 @@ msgstr ""
 "tamen quamvis sit Annus Pauli Apostoli, restituta est secundum %2$s ut "
 "permittant ecclesias locales ad memoriam celebrandam."
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "Hebdomadæ %s Temporis Paschali"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "Hebdomadæ %s Temporis Ordinarii"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memoria Sanctæ Mariæ in Sabbato"
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Errorem ad recuperandam et interpretandam datam Regionis Latiorem ex archivo "
 "%s."
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, fuzzy, php-format
+#| msgid "Error retrieving and decoding Wider Region data from file %s."
+msgid "Error retrieving and decoding National Calendar data from file %s."
+msgstr ""
+"Errorem ad recuperandam et interpretandam datam Regionis Latiorem ex archivo "
+"%s."
 
 #. translators:
 #.  1. Grade of the festivity
@@ -621,7 +641,7 @@ msgstr ""
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -636,7 +656,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -646,7 +666,7 @@ msgstr ""
 "simul redunctur in gradu Memoriæ ad libitum."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -656,7 +676,7 @@ msgstr ""
 "'%3$s' anno %4$d! Opus est aliquid de hoc agere?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -666,7 +686,7 @@ msgstr ""
 "Solemnitas '%1$s', quae plerumque celebratur die %2$s, coincidet cum "
 "Dominica vel Solemnitate '%3$s' anno %4$d! Opus est aliquid de hoc agere?"
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -675,7 +695,7 @@ msgstr ""
 "informationem de die quo procedere"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Inveni codicem datarum sanctoralium pro %s"
@@ -689,7 +709,7 @@ msgstr "Inveni codicem datarum sanctoralium pro %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -699,13 +719,13 @@ msgstr ""
 "ab %5$s '%6$s' in anno %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Archivum datarum de Sanctorale pro %s non inventa est"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -715,7 +735,7 @@ msgstr ""
 "spatium facere in gratiam '%3$s': ergo viget in anno %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -727,7 +747,7 @@ msgstr ""
 "%9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -736,7 +756,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -745,7 +765,7 @@ msgstr ""
 "%1$s '%2$s', proprio calendario %3$s et plerumque celebratur die %4$s, "
 "supprimatur a Dominica vel Sollemnitate %5$s anno %6$d"
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/nl/LC_MESSAGES/litcal.po
+++ b/i18n/nl/LC_MESSAGES/litcal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: Dutch <https://translate.johnromanodorazio.com/projects/"
@@ -21,7 +21,18 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -30,7 +41,7 @@ msgstr ""
 "Alleen jaren na 1970 worden ondersteund. U probeert het jaar %d op te vragen."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -39,14 +50,14 @@ msgstr ""
 "voor de Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Er is een fout opgetreden bij het ophalen van gelokaliseerde gegevens voor "
 "de Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
@@ -54,13 +65,13 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 "Er is een fout opgetreden bij het ophalen van gegevens voor de Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -73,7 +84,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -83,7 +94,7 @@ msgstr ""
 "voor het Sanctorale voor het Missaal %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, fuzzy, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr ""
@@ -93,7 +104,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -103,12 +114,12 @@ msgstr ""
 "Sanctorale voor het Missaal %1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 #, fuzzy
 msgid "Could not find the Sanctorale data"
 msgstr "Een sanctorale data bestand voor %s is niet gevonden"
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -118,14 +129,14 @@ msgstr ""
 "Herdenkingen op basis van Decreten van de Congregatie voor de Goddelijke "
 "Eredienst: %s"
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 #, fuzzy
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr "Decreet van de Congregatie voor de Goddelijke Eredienst"
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -139,20 +150,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s van de kersttijd"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "of"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "Barmhartige zondag"
 
@@ -165,8 +176,8 @@ msgstr "Barmhartige zondag"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -175,31 +186,31 @@ msgstr ""
 "Het hoogfeest van '%1$s' valt op %2$s in het jaar %3$d, de viering is "
 "verplaatst naar %4$s (%5$s) overeenkomstig %6$s."
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr "de zaterdag voorafgaand aan Palmzondag"
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decreet van de Congregatie voor de Goddelijke Eredienst"
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "maandag na de tweede zondag van pasen"
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr "de volgende maandag"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -215,7 +226,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -225,7 +236,7 @@ msgstr ""
 "jaar %3$d, wordt het een dag eerder gevierd overeenkomstig %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -235,12 +246,12 @@ msgstr ""
 "'%3$s' gevierd op %4$s in plaats van op de zondag na Kerstmis."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Onze Heer Christus Eeuwige Hogepriester"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -255,30 +266,30 @@ msgstr ""
 "'%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' wordt vervangen door het %2$s van '%3$s' in het jaar %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "in de %s week van de advent"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s dag onder het octaaf van Kerstmis"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "in de %s week van de veertigdagentijd"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "na Aswoensdag"
 
@@ -306,8 +317,8 @@ msgstr "na Aswoensdag"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -316,7 +327,7 @@ msgstr ""
 "De %1$s '%2$s' is toegevoegd op %3$s vanaf %4$d (%5$s), van toepassing in "
 "het jaar %6$d."
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -329,7 +340,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -347,16 +358,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "De %1$s '%2$s' heeft voorrang boven de %3$s '%4$s' in het jaar %5$d."
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apostolische Constitutie Missale Romanum"
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -377,7 +388,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -392,7 +403,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -403,17 +414,17 @@ msgstr ""
 "(%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr "voor"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr "na"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -423,7 +434,7 @@ msgstr ""
 "het feest met sleutel '%2$s' met sleutelwoorden %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -432,7 +443,7 @@ msgstr ""
 "feest met sleutel '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -442,7 +453,7 @@ msgstr ""
 "'strtotime' een object is, moet het de eigenschappen '%2$s' hebben"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -452,7 +463,7 @@ msgstr ""
 "moet ofwel een object of een string zijn! Nu heeft hij type '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -467,7 +478,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -484,7 +495,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -501,7 +512,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -516,7 +527,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -525,7 +536,7 @@ msgstr ""
 "'%1$s' is tot Kerkleraar uitgeroepen vanaf het jaar %2$d, van toepassing in "
 "het jaar %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "en kerkleraar"
 
@@ -539,7 +550,7 @@ msgstr "en kerkleraar"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -558,7 +569,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -568,7 +579,7 @@ msgstr ""
 "toegevoegd op %6$s vanaf het jaar %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -578,7 +589,7 @@ msgstr ""
 "vanaf het jaar 2002 (%2$s), van toepassing in het jaar %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -590,7 +601,7 @@ msgstr ""
 "vanaf het jaar 2002 verplaatst naar 12 augustus (%2$s), van toepassing in "
 "het jaar %3$d."
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -602,7 +613,7 @@ msgstr ""
 "wordt vervangen door een zondag, hoogfeest of feest '%4$s' in het jaar %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -614,29 +625,36 @@ msgstr ""
 "zondag valt, maar vanwege het Paulusjaar is het, overeenkomstig %2$s "
 "hersteld, zodat lokale kerken de gedachtenis naar keuze kunnen vieren."
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "na de %s zondag van pasen"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "in de %s week door het jaar"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Maria op zaterdag"
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Fout bij het ophalen en decoderen van Wider Region data uit bestand %s."
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, fuzzy, php-format
+#| msgid "Error retrieving and decoding National data from file %s."
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr "Fout bij het ophalen en decoderen van National data uit bestand %s."
 
 #. translators:
@@ -647,7 +665,7 @@ msgstr "Fout bij het ophalen en decoderen van National data uit bestand %s."
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -662,7 +680,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -672,7 +690,7 @@ msgstr ""
 "jaar %3$d. Ze zijn beide teruggebracht naar de rang van vrije gedachtenis."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -682,7 +700,7 @@ msgstr ""
 "'%3$s' in het jaar %4$d. Moet hier iets aan gedaan worden?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -693,7 +711,7 @@ msgstr ""
 "Zondag of hoogfeest van '%3$s' in het jaar %4$d. Moet hier iets aan gedaan "
 "worden?"
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -702,7 +720,7 @@ msgstr ""
 "verder te gaan lijken niet beschikbaar"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Er is een sanctorale data bestand gevonden voor %s"
@@ -716,7 +734,7 @@ msgstr "Er is een sanctorale data bestand gevonden voor %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -726,13 +744,13 @@ msgstr ""
 "wordt vervangen door de %5$s '%6$s' in het jaar %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Een sanctorale data bestand voor %s is niet gevonden"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -742,7 +760,7 @@ msgstr ""
 "om plaats te maken voor '%3$s': van toepassing in het jaar %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -754,7 +772,7 @@ msgstr ""
 "in het jaar %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -766,7 +784,7 @@ msgstr ""
 "Moet hier iets aan gedaan worden?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -775,7 +793,7 @@ msgstr ""
 "De %1$s '%2$s', eigen aan de kalender van de %3$s en gewoonlijk gevierd op "
 "%4$s, wordt vervangen door de Zondag of hoogfeest '%5$s' in het jaar %6$d"
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/pt/LC_MESSAGES/litcal.po
+++ b/i18n/pt/LC_MESSAGES/litcal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: Portuguese <https://translate.johnromanodorazio.com/projects/"
@@ -21,7 +21,18 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -30,7 +41,7 @@ msgstr ""
 "Apenas anos a partir de 1970 são suportados. Você tentou solicitar o ano %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -39,24 +50,24 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Houve um erro ao tentar recuperar os dados localizados para o Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr "Houve um erro ao tentar decodificar os dados JSON para o Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr "Houve um erro ao tentar recuperar os dados para o Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Dados de tradução para o sanctorale de %s não foram encontrados."
@@ -67,7 +78,7 @@ msgstr "Dados de tradução para o sanctorale de %s não foram encontrados."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -77,7 +88,7 @@ msgstr ""
 "Sanctorale do Missal %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Não foi possível encontrar os dados para o Sanctorale de %s."
@@ -86,7 +97,7 @@ msgstr "Não foi possível encontrar os dados para o Sanctorale de %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -96,11 +107,11 @@ msgstr ""
 "Missal %1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 msgid "Could not find the Sanctorale data"
 msgstr "Não foi possível encontrar os dados do Sanctorale"
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -109,7 +120,7 @@ msgstr ""
 "Houve um erro ao tentar decodificar os dados de tradução para Memoriais com "
 "base nos Decretos da Congregação para o Culto Divino: %s"
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -117,7 +128,7 @@ msgstr ""
 "Não foi possível encontrar dados de tradução para Memoriais baseados em "
 "Decretos da Congregação para o Culto Divino"
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -130,20 +141,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Dia de Semana do Natal"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "ou"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "Domingo da Divina Misericórdia"
 
@@ -156,8 +167,8 @@ msgstr "Domingo da Divina Misericórdia"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -166,31 +177,31 @@ msgstr ""
 "A Solenidade '%1$s' cai em %2$s no ano %3$d, a celebração foi transferida "
 "para %4$s (%5$s) conforme o %6$s."
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr "o sábado anterior ao Domingo de Ramos"
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decreto da Congregação para o Culto Divino"
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "a segunda-feira após o Segundo Domingo de Páscoa"
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr "a próxima segunda-feira"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -205,7 +216,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -215,7 +226,7 @@ msgstr ""
 "ela foi antecipada em um dia conforme %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -225,12 +236,12 @@ msgstr ""
 "em %4$s em vez de no domingo após o Natal."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Nosso Senhor Jesus Cristo, O Eterno Sumo Sacerdote"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -244,30 +255,30 @@ msgstr ""
 "aplicável ao calendário '%1$s' no ano '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' é substituído pelo %2$s '%3$s' no ano %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "da %s Semana do Advento"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Dia da Oitava de Natal"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "da %s Semana da Quaresma"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "após a Quarta-feira de Cinzas"
 
@@ -295,8 +306,8 @@ msgstr "após a Quarta-feira de Cinzas"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -305,7 +316,7 @@ msgstr ""
 "O %1$s '%2$s' foi adicionado em %3$s desde o ano %4$d (%5$s), aplicável ao "
 "ano %6$d."
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -318,7 +329,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -336,16 +347,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "O %1$s '%2$s' é suplantado pelo %3$s '%4$s' no ano %5$d."
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Constituição Apostólica Missale Romanum"
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -365,7 +376,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -380,7 +391,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -390,17 +401,17 @@ msgstr ""
 "reduzidas a memórias opcionais (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr "antes"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr "após"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -410,7 +421,7 @@ msgstr ""
 "festividade com a chave '%2$s' usando as palavras-chave %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -419,7 +430,7 @@ msgstr ""
 "chave '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -429,7 +440,7 @@ msgstr ""
 "'strtotime' é um objeto, deve ter propriedades %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -439,7 +450,7 @@ msgstr ""
 "deve ser um objeto ou uma string! Atualmente tem o tipo '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -454,7 +465,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -471,7 +482,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -488,7 +499,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -503,7 +514,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -512,7 +523,7 @@ msgstr ""
 "'%1$s' foi declarado Doutor da Igreja desde o ano %2$d, aplicável ao ano "
 "%3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "e Doutor da Igreja"
 
@@ -526,7 +537,7 @@ msgstr "e Doutor da Igreja"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -545,7 +556,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -555,7 +566,7 @@ msgstr ""
 "%6$s desde o ano %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -565,7 +576,7 @@ msgstr ""
 "agosto desde o ano de 2002 (%2$s), aplicável ao ano %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -576,7 +587,7 @@ msgstr ""
 "ou solenidade se fosse em 12 de dezembro, foi transferida para 12 de agosto "
 "desde o ano de 2002 (%2$s), aplicável ao ano %3$d."
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -588,7 +599,7 @@ msgstr ""
 "substituída por um domingo, uma solenidade ou uma festa '%4$s' no ano %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -600,28 +611,35 @@ msgstr ""
 "mas sendo o Ano do Apóstolo Paulo, conforme o %2$s, foi restabelecida para "
 "que as igrejas locais possam opcionalmente celebrar a memória."
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "da %s Semana da Páscoa"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "da %s Semana do Tempo Comum"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memória de Sábado da Bem-Aventurada Virgem Maria"
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr "Erro ao recuperar e decodificar dados da Região Ampla do arquivo %s."
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, fuzzy, php-format
+#| msgid "Error retrieving and decoding National data from file %s."
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr "Erro ao recuperar e decodificar dados Nacionais do arquivo %s."
 
 #. translators:
@@ -632,7 +650,7 @@ msgstr "Erro ao recuperar e decodificar dados Nacionais do arquivo %s."
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -647,7 +665,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -657,7 +675,7 @@ msgstr ""
 "reduzidas a memórias opcionais."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -667,7 +685,7 @@ msgstr ""
 "'%3$s' no ano %4$d! Algo precisa ser feito sobre isso?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -677,7 +695,7 @@ msgstr ""
 "A Solenidade '%1$s', geralmente celebrada em %2$s, coincide com o Domingo ou "
 "Solenidade '%3$s' no ano %4$d! Algo precisa ser feito sobre isso?"
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -686,7 +704,7 @@ msgstr ""
 "correta da data para prosseguir"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Arquivo de dados do sanctorale encontrado para %s"
@@ -700,7 +718,7 @@ msgstr "Arquivo de dados do sanctorale encontrado para %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -710,13 +728,13 @@ msgstr ""
 "suplantada pela %5$s '%6$s' no ano %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Não foi possível encontrar um arquivo de dados sanctorale para %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -726,7 +744,7 @@ msgstr ""
 "lugar a '%3$s': aplicável ao ano %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -737,7 +755,7 @@ msgstr ""
 "dar lugar a '%6$s', no entanto é suprimido pelo %7$s '%8$s' no ano %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -749,7 +767,7 @@ msgstr ""
 "feito algo sobre isso?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -758,7 +776,7 @@ msgstr ""
 "A %1$s '%2$s', própria do calendário do %3$s e geralmente celebrada em %4$s, "
 "é suprimida pelo Domingo ou Solenidade %5$s no ano %6$d"
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/sk/LC_MESSAGES/litcal.po
+++ b/i18n/sk/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-10-03 11:32+0000\n"
 "Last-Translator: Milan Šalka <salka.milan@googlemail.com>\n"
 "Language-Team: Slovak <https://translate.johnromanodorazio.com/projects/"
@@ -19,7 +19,18 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -28,7 +39,7 @@ msgstr ""
 "Podporované sú len roky od roku 1970 a neskôr. Skúsili ste požiadať o rok %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -37,24 +48,24 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Vyskytla sa chyba pri pokuse o načítanie lokalizovaných údajov pre Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr "Vyskytla sa chyba pri pokuse dekódovať údaje JSON pre Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr "Vyskytla sa chyba pri pokuse o načítanie údajov pre Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Údaje o sanctorale z %s sa nenašli."
@@ -65,7 +76,7 @@ msgstr "Údaje o sanctorale z %s sa nenašli."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -75,7 +86,7 @@ msgstr ""
 "pre Misál %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Údaje pre Sanctorale z %s sa nenašli."
@@ -84,7 +95,7 @@ msgstr "Údaje pre Sanctorale z %s sa nenašli."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -94,11 +105,11 @@ msgstr ""
 "%1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 msgid "Could not find the Sanctorale data"
 msgstr "Nepodarilo sa nájsť údaje Sanctorale"
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -107,7 +118,7 @@ msgstr ""
 "Vyskytla sa chyba pri pokuse dekódovať prekladové údaje pre Pamätné dni na "
 "základe dekrétov Kongregácie pre Boží kult: %s"
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -115,7 +126,7 @@ msgstr ""
 "Nepodarilo sa nájsť prekladové údaje pre Pamätné dni založené na dekrétoch "
 "Kongregácie pre Boží kult"
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -128,20 +139,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Vianočný všedný deň"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "alebo"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "Nedeľa Božieho milosrdenstva"
 
@@ -154,8 +165,8 @@ msgstr "Nedeľa Božieho milosrdenstva"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -164,31 +175,31 @@ msgstr ""
 "Slávnosť '%1$s' pripadá na %2$s v roku %3$d, oslava bola presunutá na %4$s "
 "(%5$s) podľa %6$s."
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr "sobota pred Kvetnou nedeľou"
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Dekrét Kongregácie pre Boží kult"
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "pondelok po Druhej veľkonočnej nedeli"
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr "nasledujúci pondelok"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -203,7 +214,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -213,7 +224,7 @@ msgstr ""
 "podľa %4$s presunutá o jeden deň dopredu."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -223,12 +234,12 @@ msgstr ""
 "%4$s namiesto nedele po Vianociach."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Náš Pán Ježiš Kristus, Večný Veľkňaz"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -242,30 +253,30 @@ msgstr ""
 "'%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' je nahradený %2$s '%3$s' v roku %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "týždňa adventu %s"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s deň oktávy Vianoc"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "týždňa pôstu %s"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "po Popolcovej strede"
 
@@ -293,8 +304,8 @@ msgstr "po Popolcovej strede"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -302,7 +313,7 @@ msgid ""
 msgstr ""
 "%1$s '%2$s' bol pridaný dňa %3$s od roku %4$d (%5$s), platný pre rok %6$d."
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -315,7 +326,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -333,16 +344,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "%1$s '%2$s' je nahradený %3$s '%4$s' v roku %5$d."
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apoštolská konštitúcia Missale Romanum"
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -362,7 +373,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -377,7 +388,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -387,17 +398,17 @@ msgstr ""
 "sú znížené na ľubovoľné spomienky (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr "predtým"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr "po"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -407,7 +418,7 @@ msgstr ""
 "slávnosti s kľúčom '%2$s' pomocou kľúčových slov %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -415,7 +426,7 @@ msgstr ""
 "Nemožno vytvoriť mobilnú slávnosť '%1$s' vzhľadom na slávnosť s kľúčom '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -425,7 +436,7 @@ msgstr ""
 "objektom, musí mať vlastnosti %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -435,7 +446,7 @@ msgstr ""
 "objekt alebo reťazec! Momentálne má typ '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -449,7 +460,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -466,7 +477,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -483,7 +494,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -498,7 +509,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -507,7 +518,7 @@ msgstr ""
 "'%1$s' bol vyhlásený za učiteľa Cirkvi od roku %2$d, platné pre rok %3$d "
 "(%4$s)."
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "a učiteľ Cirkvi"
 
@@ -521,7 +532,7 @@ msgstr "a učiteľ Cirkvi"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -540,7 +551,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -550,7 +561,7 @@ msgstr ""
 "%7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -560,7 +571,7 @@ msgstr ""
 "roku 2002 (%2$s), platná pre rok %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -571,7 +582,7 @@ msgstr ""
 "slávnosťou, keby bola 12. decembra, bola však od roku 2002 (%2$s) presunutá "
 "na 12. augusta, platná pre rok %3$d."
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -583,7 +594,7 @@ msgstr ""
 "nedeľou, slávnosťou alebo sviatkom '%4$s'."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -595,29 +606,36 @@ msgstr ""
 "avšak keďže je Rok apoštola Pavla, podľa %2$s bol obnovený, aby miestne "
 "cirkvi mohli voliteľne sláviť pamätný deň."
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "týždňa Veľkej noci %s"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "týždňa v období cez rok %s"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Sobotná pamiatka Preblahoslavenej Panny Márie"
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Chyba pri načítaní a dekódovaní údajov z širšieho regiónu zo súboru %s."
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, fuzzy, php-format
+#| msgid "Error retrieving and decoding National data from file %s."
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr "Chyba pri načítaní a dekódovaní národných údajov zo súboru %s."
 
 #. translators:
@@ -628,7 +646,7 @@ msgstr "Chyba pri načítaní a dekódovaní národných údajov zo súboru %s."
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -642,7 +660,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -652,7 +670,7 @@ msgstr ""
 "sú znížené na ľubovoľné spomienky."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -662,7 +680,7 @@ msgstr ""
 "sviatkom '%3$s'! Treba s tým niečo urobiť?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -672,7 +690,7 @@ msgstr ""
 "Slávnosť '%1$s', zvyčajne slávená %2$s, sa v roku %4$d zhoduje s nedeľou "
 "alebo slávnosťou '%3$s'! Treba s tým niečo urobiť?"
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -681,7 +699,7 @@ msgstr ""
 "o dátume, aby sme mohli pokračovať"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Našiel som súbor sanctorale pre %s"
@@ -695,7 +713,7 @@ msgstr "Našiel som súbor sanctorale pre %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -705,13 +723,13 @@ msgstr ""
 "'%6$s' v roku %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Nepodarilo sa nájsť súbor sanctorale pre %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -721,7 +739,7 @@ msgstr ""
 "pre '%3$s': platné pre rok %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -732,7 +750,7 @@ msgstr ""
 "miesto pre '%6$s', avšak je potlačený %7$s '%8$s' v roku %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -743,7 +761,7 @@ msgstr ""
 "%5$d zhoduje s nedeľou alebo slávnosťou '%4$s'! Treba s tým niečo urobiť?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -752,7 +770,7 @@ msgstr ""
 "Slávnosť %1$s '%2$s', vlastná kalendáru %3$s a zvyčajne slávená %4$s, je v "
 "roku %6$d potlačená nedeľou alebo slávnosťou %5$s"
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/vi/LC_MESSAGES/litcal.po
+++ b/i18n/vi/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-17 08:16+0000\n"
+"POT-Creation-Date: 2024-11-28 18:51+0000\n"
 "PO-Revision-Date: 2024-10-03 13:34+0000\n"
 "Last-Translator: OpenAI <noreply-mt-openai@weblate.org>\n"
 "Language-Team: Vietnamese <https://translate.johnromanodorazio.com/projects/"
@@ -19,7 +19,18 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:680
+#: src/Paths/Calendar.php:618
+#, php-format
+msgid ""
+"The name of the diocese could not be derived from the diocese ID \"%s\"."
+msgstr ""
+
+#: src/Paths/Calendar.php:653
+#, php-format
+msgid "The Diocesan calendar \"%s\" was not found in the index file."
+msgstr ""
+
+#: src/Paths/Calendar.php:749
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -27,7 +38,7 @@ msgid ""
 msgstr "Chỉ hỗ trợ từ năm 1970 trở về sau. Bạn đã yêu cầu năm %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:709
+#: src/Paths/Calendar.php:778
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -36,23 +47,23 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:716
+#: src/Paths/Calendar.php:785
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr "Đã xảy ra lỗi khi cố gắng truy xuất dữ liệu bản địa hóa cho Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:746
+#: src/Paths/Calendar.php:815
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr "Đã xảy ra lỗi khi cố gắng giải mã dữ liệu JSON cho Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:753
+#: src/Paths/Calendar.php:822
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr "Đã xảy ra lỗi khi cố gắng truy xuất dữ liệu cho Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:781
+#: src/Paths/Calendar.php:850
 #, fuzzy, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Không tìm thấy dữ liệu dịch cho sanctorale từ %s."
@@ -63,7 +74,7 @@ msgstr "Không tìm thấy dữ liệu dịch cho sanctorale từ %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:800
+#: src/Paths/Calendar.php:869
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -73,7 +84,7 @@ msgstr ""
 "lễ %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:809
+#: src/Paths/Calendar.php:878
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Không tìm thấy dữ liệu cho Sanctorale từ %s."
@@ -82,7 +93,7 @@ msgstr "Không tìm thấy dữ liệu cho Sanctorale từ %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:833
+#: src/Paths/Calendar.php:902
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -92,11 +103,11 @@ msgstr ""
 "%1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:841
+#: src/Paths/Calendar.php:910
 msgid "Could not find the Sanctorale data"
 msgstr "Không thể tìm thấy dữ liệu Sanctorale"
 
-#: src/Paths/Calendar.php:866
+#: src/Paths/Calendar.php:935
 #, fuzzy, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -105,7 +116,7 @@ msgstr ""
 "Đã xảy ra lỗi khi cố gắng giải mã dữ liệu dịch thuật cho Lễ nhớ dựa trên Sắc "
 "lệnh của Thánh bộ Phụng tự: %s"
 
-#: src/Paths/Calendar.php:872
+#: src/Paths/Calendar.php:941
 #, fuzzy
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
@@ -114,7 +125,7 @@ msgstr ""
 "Không tìm thấy dữ liệu dịch thuật cho Lễ nhớ dựa trên Sắc lệnh của Thánh bộ "
 "Phụng tự"
 
-#: src/Paths/Calendar.php:881
+#: src/Paths/Calendar.php:950
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -127,20 +138,20 @@ msgstr ""
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
 #. translators: days before Epiphany when Epiphany is on a Sunday (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany is on a Sunday (not useful in Italian!)
-#: src/Paths/Calendar.php:985 src/Paths/Calendar.php:1037
-#: src/Paths/Calendar.php:1134 src/Paths/Calendar.php:1174
+#: src/Paths/Calendar.php:1054 src/Paths/Calendar.php:1106
+#: src/Paths/Calendar.php:1203 src/Paths/Calendar.php:1243
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Ngày trong tuần Giáng Sinh"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1315 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1384 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "hoặc"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1319
+#: src/Paths/Calendar.php:1388
 msgid "Divine Mercy Sunday"
 msgstr "Chúa Nhật Lòng Thương Xót Chúa"
 
@@ -153,8 +164,8 @@ msgstr "Chúa Nhật Lòng Thương Xót Chúa"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1480 src/Paths/Calendar.php:1500
-#: src/Paths/Calendar.php:1540
+#: src/Paths/Calendar.php:1549 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:1609
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -163,31 +174,31 @@ msgstr ""
 "Lễ Trọng '%1$s' rơi vào ngày %2$s trong năm %3$d, lễ kỷ niệm đã được chuyển "
 "sang ngày %4$s (%5$s) theo %6$s."
 
-#: src/Paths/Calendar.php:1484
+#: src/Paths/Calendar.php:1553
 msgid "the Saturday preceding Palm Sunday"
 msgstr "thứ Bảy trước Chúa Nhật Lễ Lá"
 
-#: src/Paths/Calendar.php:1492 src/Paths/Calendar.php:1512
-#: src/Paths/Calendar.php:1551 src/Paths/Calendar.php:1579
-#: src/Paths/Calendar.php:2094 src/Paths/Calendar.php:2298
-#: src/Paths/Calendar.php:2367 src/Paths/Calendar.php:2711
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2949 src/Paths/Calendar.php:2964
-#: src/Paths/Calendar.php:2981 src/Paths/Calendar.php:3022
+#: src/Paths/Calendar.php:1561 src/Paths/Calendar.php:1581
+#: src/Paths/Calendar.php:1620 src/Paths/Calendar.php:1648
+#: src/Paths/Calendar.php:2163 src/Paths/Calendar.php:2367
+#: src/Paths/Calendar.php:2436 src/Paths/Calendar.php:2780
+#: src/Paths/Calendar.php:2850 src/Paths/Calendar.php:2889
+#: src/Paths/Calendar.php:3018 src/Paths/Calendar.php:3033
+#: src/Paths/Calendar.php:3050 src/Paths/Calendar.php:3091
 #: src/FestivityCollection.php:802
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Sắc lệnh của Bộ Phụng tự và Kỷ luật Bí tích"
 
-#: src/Paths/Calendar.php:1504
+#: src/Paths/Calendar.php:1573
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "thứ Hai sau Chúa nhật thứ Hai Phục Sinh"
 
-#: src/Paths/Calendar.php:1544
+#: src/Paths/Calendar.php:1613
 msgid "the following Monday"
 msgstr "thứ Hai tiếp theo"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1557
+#: src/Paths/Calendar.php:1626
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -202,7 +213,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1590
+#: src/Paths/Calendar.php:1659
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -212,7 +223,7 @@ msgstr ""
 "lên một ngày theo %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1694
+#: src/Paths/Calendar.php:1763
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -222,12 +233,12 @@ msgstr ""
 "%4$s thay vì vào Chủ nhật sau Giáng Sinh."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1725
+#: src/Paths/Calendar.php:1794
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Chúa Giêsu Kitô, Thượng Tế Vĩnh Cửu"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1730
+#: src/Paths/Calendar.php:1799
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -241,30 +252,30 @@ msgstr ""
 "'%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1782 src/Paths/Calendar.php:1823
+#: src/Paths/Calendar.php:1851 src/Paths/Calendar.php:1892
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' bị thay thế bởi %2$s '%3$s' trong năm %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1910
+#: src/Paths/Calendar.php:1979
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "của Tuần %s Mùa Vọng"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1949
+#: src/Paths/Calendar.php:2018
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "Ngày %s trong Tuần Bát Nhật Giáng Sinh"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1992
+#: src/Paths/Calendar.php:2061
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "của Tuần %s Mùa Chay"
 
-#: src/Paths/Calendar.php:2002
+#: src/Paths/Calendar.php:2071
 msgid "after Ash Wednesday"
 msgstr "sau Lễ Tro"
 
@@ -292,8 +303,8 @@ msgstr "sau Lễ Tro"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2033 src/Paths/Calendar.php:2508
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3473
+#: src/Paths/Calendar.php:2102 src/Paths/Calendar.php:2577
+#: src/Paths/Calendar.php:2861 src/Paths/Calendar.php:3579
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -302,7 +313,7 @@ msgstr ""
 "%1$s '%2$s' đã được thêm vào ngày %3$s kể từ năm %4$d (%5$s), áp dụng cho "
 "năm %6$d."
 
-#: src/Paths/Calendar.php:2079 src/Paths/Calendar.php:2242
+#: src/Paths/Calendar.php:2148 src/Paths/Calendar.php:2311
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -313,7 +324,7 @@ msgstr "Họp báo Vatican: Trình bày Editio Typica Tertia của Sách lễ R�
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2136
+#: src/Paths/Calendar.php:2205
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -331,16 +342,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2164 src/Paths/Calendar.php:2206
+#: src/Paths/Calendar.php:2233 src/Paths/Calendar.php:2275
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "%1$s '%2$s' bị thay thế bởi %3$s '%4$s' trong năm %5$d."
 
-#: src/Paths/Calendar.php:2236
+#: src/Paths/Calendar.php:2305
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Hiến chế Tông đồ Missale Romanum"
 
-#: src/Paths/Calendar.php:2262
+#: src/Paths/Calendar.php:2331
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -360,7 +371,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2312
+#: src/Paths/Calendar.php:2381
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -375,7 +386,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2362
+#: src/Paths/Calendar.php:2431
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -385,17 +396,17 @@ msgstr ""
 "giảm cấp xuống thành lễ nhớ tùy chọn (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2473
 msgid "before"
 msgstr "trước"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2409
+#: src/Paths/Calendar.php:2478
 msgid "after"
 msgstr "sau"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2414 src/Paths/Calendar.php:3944
+#: src/Paths/Calendar.php:2483 src/Paths/Calendar.php:4054
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -405,14 +416,14 @@ msgstr ""
 "bằng cách sử dụng từ khóa %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2431 src/Paths/Calendar.php:3926
+#: src/Paths/Calendar.php:2500 src/Paths/Calendar.php:4036
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
 msgstr "Không thể tạo lễ di động '%1$s' liên quan đến lễ có khóa '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2439 src/Paths/Calendar.php:3915
+#: src/Paths/Calendar.php:2508 src/Paths/Calendar.php:4025
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -422,7 +433,7 @@ msgstr ""
 "tượng, nó phải có các thuộc tính %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2459 src/Paths/Calendar.php:4048
+#: src/Paths/Calendar.php:2528 src/Paths/Calendar.php:4158
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -432,7 +443,7 @@ msgstr ""
 "tượng hoặc một chuỗi! Hiện tại nó có kiểu '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2467
+#: src/Paths/Calendar.php:2536
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr "Không thể tạo lễ di động '%1$s' mà không có thuộc tính 'strtotime'!"
@@ -445,7 +456,7 @@ msgstr "Không thể tạo lễ di động '%1$s' mà không có thuộc tính '
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2567
+#: src/Paths/Calendar.php:2636
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -462,7 +473,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2589
+#: src/Paths/Calendar.php:2658
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -479,7 +490,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2599
+#: src/Paths/Calendar.php:2668
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -494,7 +505,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2648
+#: src/Paths/Calendar.php:2717
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -503,7 +514,7 @@ msgstr ""
 "'%1$s' đã được tuyên bố là Tiến sĩ Hội Thánh từ năm %2$d, áp dụng cho năm "
 "%3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2656
+#: src/Paths/Calendar.php:2725
 msgid "and Doctor of the Church"
 msgstr "và Tiến sĩ Hội Thánh"
 
@@ -517,7 +528,7 @@ msgstr "và Tiến sĩ Hội Thánh"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/Calendar.php:2910
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -536,7 +547,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/Calendar.php:2937
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -546,7 +557,7 @@ msgstr ""
 "kể từ năm %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2946
+#: src/Paths/Calendar.php:3015
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -556,7 +567,7 @@ msgstr ""
 "tháng 8 kể từ năm 2002 (%2$s), áp dụng cho năm %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2961
+#: src/Paths/Calendar.php:3030
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -567,7 +578,7 @@ msgstr ""
 "Lễ trọng nếu nó vào ngày 12 tháng 12, tuy nhiên đã được chuyển sang ngày 12 "
 "tháng 8 kể từ năm 2002 (%2$s), áp dụng cho năm %3$d."
 
-#: src/Paths/Calendar.php:2978
+#: src/Paths/Calendar.php:3047
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -579,7 +590,7 @@ msgstr ""
 "một Chúa Nhật, một Lễ Trọng, hoặc một Lễ Kính '%4$s' vào năm %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3019
+#: src/Paths/Calendar.php:3088
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -591,28 +602,35 @@ msgstr ""
 "do là Năm của Tông đồ Phaolô, theo %2$s nó đã được khôi phục để các nhà thờ "
 "địa phương có thể tùy chọn cử hành lễ nhớ."
 
-#: src/Paths/Calendar.php:3054
+#: src/Paths/Calendar.php:3123
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "của Tuần %s Phục Sinh"
 
-#: src/Paths/Calendar.php:3099 src/Paths/Calendar.php:3140
+#: src/Paths/Calendar.php:3168 src/Paths/Calendar.php:3209
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "của Tuần %s Thường Niên"
 
-#: src/Paths/Calendar.php:3166
+#: src/Paths/Calendar.php:3235
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Lễ nhớ Thứ Bảy Đức Mẹ"
 
-#: src/Paths/Calendar.php:3197 src/Paths/Calendar.php:3200
+#: src/Paths/Calendar.php:3258
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr "Lỗi khi truy xuất và giải mã dữ liệu Vùng Rộng từ tệp %s."
 
-#: src/Paths/Calendar.php:3207
+#: src/Paths/Calendar.php:3303
 #, php-format
-msgid "Error retrieving and decoding National data from file %s."
+msgid ""
+"Could not find a %1$s property in the %2$s for the National Calendar %3$s."
+msgstr ""
+
+#: src/Paths/Calendar.php:3311
+#, fuzzy, php-format
+#| msgid "Error retrieving and decoding National data from file %s."
+msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr "Lỗi khi truy xuất và giải mã dữ liệu Quốc gia từ tệp %s."
 
 #. translators:
@@ -623,7 +641,7 @@ msgstr "Lỗi khi truy xuất và giải mã dữ liệu Quốc gia từ tệp %
 #.  5. Name of the superseding festivity
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3252
+#: src/Paths/Calendar.php:3358
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -638,7 +656,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3347
+#: src/Paths/Calendar.php:3453
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -648,7 +666,7 @@ msgstr ""
 "đều bị giảm cấp xuống thành lễ kỷ niệm tùy chọn."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3369
+#: src/Paths/Calendar.php:3475
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -658,7 +676,7 @@ msgstr ""
 "năm %4$d! Có cần làm gì về điều này không?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3383
+#: src/Paths/Calendar.php:3489
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -668,7 +686,7 @@ msgstr ""
 "Lễ trọng '%1$s', thường được cử hành vào %2$s, trùng với Chủ nhật hoặc Lễ "
 "trọng '%3$s' trong năm %4$d! Có cần làm gì về điều này không?"
 
-#: src/Paths/Calendar.php:3427
+#: src/Paths/Calendar.php:3533
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -677,7 +695,7 @@ msgstr ""
 "thông tin ngày tháng chính xác để tiến hành"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3577
+#: src/Paths/Calendar.php:3683
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Tìm thấy tệp dữ liệu sanctorale cho %s"
@@ -691,7 +709,7 @@ msgstr "Tìm thấy tệp dữ liệu sanctorale cho %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3626
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -701,13 +719,13 @@ msgstr ""
 "bởi %5$s '%6$s' trong năm %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3641
+#: src/Paths/Calendar.php:3747
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Không thể tìm thấy tệp dữ liệu sanctorale cho %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3800
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -717,7 +735,7 @@ msgstr ""
 "'%3$s': áp dụng cho năm %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3708
+#: src/Paths/Calendar.php:3818
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -728,7 +746,7 @@ msgstr ""
 "'%6$s', tuy nhiên nó bị thay thế bởi %7$s '%8$s' vào năm %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4108
+#: src/Paths/Calendar.php:4218
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -740,7 +758,7 @@ msgstr ""
 "không?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4142
+#: src/Paths/Calendar.php:4252
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -749,7 +767,7 @@ msgstr ""
 "Lễ %1$s '%2$s', thuộc lịch của %3$s và thường được cử hành vào %4$s, bị thay "
 "thế bởi Chủ nhật hoặc Lễ trọng %5$s trong năm %6$d"
 
-#: src/Paths/Calendar.php:4406
+#: src/Paths/Calendar.php:4516
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""


### PR DESCRIPTION
Translations update from [JohnRDOrazio Weblate](https://translate.johnromanodorazio.com) for [Liturgical Calendar/Proprium de Tempore](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-tempore/).


It also includes following components:

* [Liturgical Calendar/Patron saints of Europe](https://translate.johnromanodorazio.com/projects/liturgical-calendar/patron-saints-of-europe/)

* [Liturgical Calendar/Proprium de Sanctis 2008](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-2008/)

* [Liturgical Calendar/Proprium de Sanctis 1970](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-1970/)

* [Liturgical Calendar/Memorials from Decrees](https://translate.johnromanodorazio.com/projects/liturgical-calendar/memorials-from-decrees/)

* [Liturgical Calendar/Proprium de Sanctis 2002](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-2002/)

* [Liturgical Calendar/API strings](https://translate.johnromanodorazio.com/projects/liturgical-calendar/api-strings/)



Current translation status:

![Weblate translation status](https://translate.johnromanodorazio.com/widget/liturgical-calendar/proprium-de-tempore/horizontal-auto.svg)