### PR TITLE
[Bug]: if a national calendar moves a celebration that was suppressed in the General Roman Calendar, an error occurs

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,5 +1,12 @@
 {
     "version": "2.0.0",
+    "options": {
+        "env": {
+            "APP_PROTOCOL": "http",
+            "APP_HOST": "localhost",
+            "APP_PORT": "8000"
+        }
+    },
     "tasks": [
         {
             "label": "launch-browser",
@@ -8,7 +15,7 @@
                 "command": "${command:workbench.action.terminal.sendSequence}",
                 "args": [
                 {
-                    "text": "start http://localhost:8000\n" // For Windows
+                    "text": "start ${APP_PROTOCOL}://${APP_HOST}:${APP_PORT}\n" // For Windows
                 }
                 ],
                 "problemMatcher": []
@@ -17,19 +24,19 @@
                 "command": "/bin/bash",
                 "args": [
                     "-c",
-                    "if grep -q microsoft /proc/version; then powershell.exe Start-Process http://localhost:8000; else xdg-open http://localhost:8000; fi"
+                    "if grep -q microsoft /proc/version; then powershell.exe Start-Process ${APP_PROTOCOL}://${APP_HOST}:${APP_PORT}; else xdg-open ${APP_PROTOCOL}://${APP_HOST}:${APP_PORT}; fi"
                   ],
                 "problemMatcher": []
             },
             "osx": {
-                "command": "open http://localhost:8000", // For macOS
+                "command": "open ${APP_PROTOCOL}://${APP_HOST}:${APP_PORT}", // For macOS
                 "problemMatcher": []
             }
         },
         {
             "label": "php-server",
             "type": "shell",
-            "command": "PHP_CLI_SERVER_WORKERS=2 php -S localhost:8000",
+            "command": "PHP_CLI_SERVER_WORKERS=2 php -S ${APP_HOST}:${APP_PORT}",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/composer.lock
+++ b/composer.lock
@@ -1269,16 +1269,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.0",
+            "version": "v3.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
-                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
                 "shasum": ""
             },
             "require": {
@@ -1316,7 +1316,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
             },
             "funding": [
                 {
@@ -1332,20 +1332,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-04-18T09:32:20+00:00"
+            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.4.15",
+            "version": "v6.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "9b3165eb2f04aeaa1a5a2cfef73e63fe3b22dff6"
+                "reference": "431771b7a6f662f1575b3cfc8fd7617aa9864d57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/9b3165eb2f04aeaa1a5a2cfef73e63fe3b22dff6",
-                "reference": "9b3165eb2f04aeaa1a5a2cfef73e63fe3b22dff6",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/431771b7a6f662f1575b3cfc8fd7617aa9864d57",
+                "reference": "431771b7a6f662f1575b3cfc8fd7617aa9864d57",
                 "shasum": ""
             },
             "require": {
@@ -1393,7 +1393,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.4.15"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.4.16"
             },
             "funding": [
                 {
@@ -1409,7 +1409,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T16:09:24+00:00"
+            "time": "2024-11-13T18:58:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1569,16 +1569,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v6.4.13",
+            "version": "v6.4.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "640a74250d13f9c30d5ca045b6aaaabcc8215278"
+                "reference": "91e02e606b4b705c2f4fb42f7e7708b7923a3220"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/640a74250d13f9c30d5ca045b6aaaabcc8215278",
-                "reference": "640a74250d13f9c30d5ca045b6aaaabcc8215278",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/91e02e606b4b705c2f4fb42f7e7708b7923a3220",
+                "reference": "91e02e606b4b705c2f4fb42f7e7708b7923a3220",
                 "shasum": ""
             },
             "require": {
@@ -1632,7 +1632,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.4.13"
+                "source": "https://github.com/symfony/routing/tree/v6.4.16"
             },
             "funding": [
                 {
@@ -1648,7 +1648,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-01T08:30:56+00:00"
+            "time": "2024-11-13T15:31:34+00:00"
         }
     ],
     "packages-dev": [

--- a/src/FestivityCollection.php
+++ b/src/FestivityCollection.php
@@ -599,6 +599,21 @@ class FestivityCollection
     }
 
     /**
+     * Adds a Festivity to the collection of suppressed events.
+     *
+     * This method does not perform any checks and simply adds the festivity to the
+     * suppressedEvents collection with the given key.
+     *
+     * @param string $key The key associated with the festivity.
+     * @param Festivity $festivity The festivity to be added.
+     * @return void
+     */
+    public function addSuppressedEvent(string $key, Festivity $festivity): void
+    {
+        $this->suppressedEvents[ $key ] = $festivity;
+    }
+
+    /**
      * Checks if a given key is associated with a suppressed event.
      *
      * @param string $key The key to check.
@@ -615,9 +630,9 @@ class FestivityCollection
      * @param string $key The key of the suppressed event.
      * @return Festivity The suppressed event.
      */
-    public function getSuppressedEventByKey(string $key): Festivity
+    public function getSuppressedEventByKey(string $key): ?Festivity
     {
-        return $this->suppressedEvents[ $key ];
+        return $this->suppressedEvents[ $key ] ?? null;
     }
 
     /**
@@ -644,16 +659,6 @@ class FestivityCollection
     }
 
     /**
-     * Retrieves the keys of all reinstated events.
-     *
-     * @return array An array of event keys, each representing a reinstated event.
-     */
-    public function getReinstatedKeys(): array
-    {
-        return array_keys($this->reinstatedEvents);
-    }
-
-    /**
      * Retrieves an array of suppressed events.
      *
      * The array contains Festivity objects that were previously in the collection
@@ -672,6 +677,16 @@ class FestivityCollection
             ];
         }
         return $suppressedEvents;
+    }
+
+    /**
+     * Retrieves the keys of all reinstated events.
+     *
+     * @return array An array of event keys, each representing a reinstated event.
+     */
+    public function getReinstatedKeys(): array
+    {
+        return array_keys($this->reinstatedEvents);
     }
 
     /**
@@ -1595,5 +1610,7 @@ class FestivityCollection
         $this->solemnitiesLordBVMCollection       = array_merge($this->getSolemnitiesLordBVMCollection(), $festivities->getSolemnitiesLordBVMCollection());
         $this->sundaysAdventLentEasterCollection  = array_merge($this->getSundaysAdventLentEasterCollection(), $festivities->getSundaysAdventLentEasterCollection());
         $this->festivitiesCollection              = array_merge($this->getFestivitiesCollection(), $festivities->getFestivitiesCollection());
+        $this->suppressedEvents                   = array_merge($this->suppressedEvents, $festivities->suppressedEvents);
+        $this->reinstatedEvents                   = array_merge($this->reinstatedEvents, $festivities->reinstatedEvents);
     }
 }


### PR DESCRIPTION
Fixes #271

Better checks for suppressed events when trying to move a celebration in a national calendar. With this fix, `StRayPenyafort` is not however reinstated on Jan 8 2024 for the national calendar of Canada, because the current calculation is treating the weekdays betwen Epiphany and Baptism of the Lord the same way as Christmas weekdays, perhaps this needs to be double checked before merging the PR