### PR TITLE
Translations update from JohnRDOrazio Weblate

### DIFF
--- a/i18n/de/LC_MESSAGES/litcal.po
+++ b/i18n/de/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: German <https://translate.johnromanodorazio.com/projects/"
@@ -946,7 +946,7 @@ msgstr ""
 "%4$s gefeiert wird, wird im Jahr %6$d durch den Sonntag oder die "
 "Feierlichkeit %5$s unterdrückt"
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/de/LC_MESSAGES/litcal.po
+++ b/i18n/de/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: German <https://translate.johnromanodorazio.com/projects/"
@@ -22,7 +22,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
@@ -30,12 +30,12 @@ msgstr ""
 "Der Name der Diözese konnte nicht aus der Diözesen-ID \"%s\" abgeleitet "
 "werden."
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr "Der Diözesankalender \"%s\" wurde nicht in der Indexdatei gefunden."
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -45,7 +45,7 @@ msgstr ""
 "anzufordern."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -54,14 +54,14 @@ msgstr ""
 "ein Fehler aufgetreten: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Beim Versuch, lokalisierte Daten für das Temporale abzurufen, ist ein Fehler "
 "aufgetreten."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
@@ -69,13 +69,13 @@ msgstr ""
 "aufgetreten: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 "Beim Versuch, Daten für das Temporale abzurufen, ist ein Fehler aufgetreten."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -87,7 +87,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -97,7 +97,7 @@ msgstr ""
 "zu dekodieren, ist ein Fehler aufgetreten: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Daten für das Sanctorale von %s konnten nicht gefunden werden."
@@ -106,7 +106,7 @@ msgstr "Daten für das Sanctorale von %s konnten nicht gefunden werden."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -116,11 +116,11 @@ msgstr ""
 "dekodieren, ist ein Fehler aufgetreten: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 msgid "Could not find the Sanctorale data"
 msgstr "Konnte die Sanctorale-Daten nicht finden"
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -130,7 +130,7 @@ msgstr ""
 "Kongregation für den Gottesdienst zu dekodieren, ist ein Fehler aufgetreten: "
 "%s"
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -138,7 +138,7 @@ msgstr ""
 "Konnte keine Übersetzungsdaten für Gedenktage basierend auf Dekreten der "
 "Kongregation für den Gottesdienst finden"
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -150,19 +150,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Wochentag in der Weihnachtszeit"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "oder"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "Barmherzigkeitssonntag"
 
@@ -176,8 +176,8 @@ msgstr "Barmherzigkeitssonntag"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -186,31 +186,31 @@ msgstr ""
 "Das Hochfest '%1$s' fällt im Jahr %3$d auf den %2$s, die Feier wurde auf den "
 "%4$s (%5$s) gemäß dem %6$s verschoben."
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr "der Samstag vor dem Palmsonntag"
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Dekret der Kongregation für den Gottesdienst"
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "der Montag nach dem zweiten Sonntag der Osterzeit"
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr "der folgende Montag"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -226,7 +226,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -236,7 +236,7 @@ msgstr ""
 "zusammenfällt, wurde sie gemäß %4$s um einen Tag vorverlegt."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -246,12 +246,12 @@ msgstr ""
 "%4$s und nicht am Sonntag nach Weihnachten gefeiert."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Unser Herr Jesus Christus, der ewige Hohepriester"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -265,30 +265,30 @@ msgstr ""
 "aufzunehmen: anwendbar für den Kalender '%1$s' im Jahr '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' wird im Jahr %4$d durch den %2$s '%3$s' ersetzt."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "der %s Woche des Advents"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Tag der Oktav von Weihnachten"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "der %s Woche der Fastenzeit"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "nach Aschermittwoch"
 
@@ -316,8 +316,8 @@ msgstr "nach Aschermittwoch"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -326,7 +326,7 @@ msgstr ""
 "Der %1$s '%2$s' wurde seit dem Jahr %4$d (%5$s) am %3$s hinzugefügt, "
 "anwendbar für das Jahr %6$d."
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -339,7 +339,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -357,16 +357,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "Der %1$s '%2$s' wird im Jahr %5$d durch den %3$s '%4$s' verdrängt."
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apostolische Konstitution Missale Romanum"
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -387,7 +387,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -402,7 +402,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -412,17 +412,17 @@ msgstr ""
 "zusammen. Beide werden zu fakultativen Gedenktagen herabgestuft (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr "vor"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr "nach"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -433,7 +433,7 @@ msgstr ""
 "sein"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -442,7 +442,7 @@ msgstr ""
 "'%2$s', nicht erstellen"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -452,7 +452,7 @@ msgstr ""
 "Eigenschaft ein Objekt ist, muss sie Eigenschaften %2$s haben"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -462,7 +462,7 @@ msgstr ""
 "muss entweder ein Objekt oder ein String sein! Derzeit hat es den Typ '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -476,7 +476,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -493,7 +493,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -510,7 +510,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -525,7 +525,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -534,7 +534,7 @@ msgstr ""
 "'%1$s' wurde seit dem Jahr %2$d zum Kirchenlehrer erklärt, gültig für das "
 "Jahr %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "und Kirchenlehrer"
 
@@ -548,7 +548,7 @@ msgstr "und Kirchenlehrer"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -567,7 +567,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -577,7 +577,7 @@ msgstr ""
 "seit dem Jahr %7$d (%8$s) am %6$s hinzugefügt wurde."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -587,7 +587,7 @@ msgstr ""
 "Dezember auf den 12. August verlegt, anwendbar für das Jahr %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -599,7 +599,7 @@ msgstr ""
 "seit dem Jahr 2002 (%2$s) auf den 12. August verlegt, anwendbar für das Jahr "
 "%3$d."
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -611,7 +611,7 @@ msgstr ""
 "Jahr %3$d von einem Sonntag, einer Hochfest oder einem Fest '%4$s' verdrängt."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -624,35 +624,35 @@ msgstr ""
 "gemäß %2$s wiederhergestellt, sodass die örtlichen Kirchen das Gedenken "
 "optional feiern können."
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "der %s Woche der Osterzeit"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "der %s Woche der gewöhnlichen Zeit"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Samstagsgedenken der seligen Jungfrau Maria"
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Fehler beim Abrufen und Dekodieren der Daten der weiteren Region aus der "
 "Datei %s."
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 "Konnte keine %1$s-Eigenschaft im %2$s für den Nationalkalender %3$s finden."
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, fuzzy, php-format
 #| msgid "Error retrieving and decoding National data from file %s."
 msgid "Error retrieving and decoding National Calendar data from file %s."
@@ -668,7 +668,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -688,7 +688,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -706,7 +706,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -716,7 +716,7 @@ msgstr ""
 "zusammen. Beide werden zu fakultativen Gedenktagen herabgestuft."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -726,7 +726,7 @@ msgstr ""
 "einem anderen Fest '%3$s' zusammen! Muss etwas dagegen unternommen werden?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -737,7 +737,7 @@ msgstr ""
 "%4$d mit dem Sonntag oder Hochfest '%3$s' zusammen! Muss etwas dagegen "
 "unternommen werden?"
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -753,7 +753,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -769,7 +769,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -788,7 +788,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -804,7 +804,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -824,7 +824,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -840,7 +840,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -859,7 +859,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -872,7 +872,7 @@ msgstr ""
 "höheren Ranges ist."
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Sanctorale-Datendatei für %s gefunden"
@@ -886,7 +886,7 @@ msgstr "Sanctorale-Datendatei für %s gefunden"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -896,13 +896,13 @@ msgstr ""
 "wurde, wird im Jahr %7$d durch den %5$s '%6$s' ersetzt"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Konnte keine Sanctorale-Datendatei für %s finden"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -912,7 +912,7 @@ msgstr ""
 "für '%3$s' zu schaffen: anwendbar für das Jahr %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -924,7 +924,7 @@ msgstr ""
 "'%8$s' unterdrückt."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -936,7 +936,7 @@ msgstr ""
 "Feierlichkeit '%4$s' zusammen! Muss hier etwas unternommen werden?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -946,7 +946,7 @@ msgstr ""
 "%4$s gefeiert wird, wird im Jahr %6$d durch den Sonntag oder die "
 "Feierlichkeit %5$s unterdrückt"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/de/LC_MESSAGES/litcal.po
+++ b/i18n/de/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: German <https://translate.johnromanodorazio.com/projects/"
@@ -946,7 +946,7 @@ msgstr ""
 "%4$s gefeiert wird, wird im Jahr %6$d durch den Sonntag oder die "
 "Feierlichkeit %5$s unterdrückt"
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/es/LC_MESSAGES/litcal.po
+++ b/i18n/es/LC_MESSAGES/litcal.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Spanish <https://translate.johnromanodorazio.com/projects/"
@@ -23,7 +23,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
@@ -31,12 +31,12 @@ msgstr ""
 "No se pudo derivar el nombre de la diócesis a partir del ID de la diócesis "
 "\"%s\"."
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr "El calendario diocesano \"%s\" no se encontró en el archivo de índice."
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -45,7 +45,7 @@ msgstr ""
 "Solo se admiten los años a partir de 1970. Intentaste solicitar el año %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -54,24 +54,24 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Hubo un error al intentar recuperar datos localizados para el Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr "Hubo un error al intentar decodificar datos JSON para el Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr "Hubo un error al intentar recuperar datos para el Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "No se pudieron encontrar datos de traducción para el sanctoral de %s."
@@ -82,7 +82,7 @@ msgstr "No se pudieron encontrar datos de traducción para el sanctoral de %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -92,7 +92,7 @@ msgstr ""
 "Sanctorale del Misal %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "No se pudieron encontrar datos para el Sanctorale de %s."
@@ -101,7 +101,7 @@ msgstr "No se pudieron encontrar datos para el Sanctorale de %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -111,11 +111,11 @@ msgstr ""
 "Misal %1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 msgid "Could not find the Sanctorale data"
 msgstr "No se pudo encontrar la información del Sanctorale"
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -124,7 +124,7 @@ msgstr ""
 "Hubo un error al intentar decodificar datos de traducción para Memorias "
 "basadas en Decretos de la Congregación para el Culto Divino: %s"
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -132,7 +132,7 @@ msgstr ""
 "No se pudo encontrar datos de traducción para los Memoriales basados en los "
 "Decretos de la Congregación para el Culto Divino"
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -143,19 +143,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Día de la Semana de Navidad"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "o"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "domingo de la Misericordia divina"
 
@@ -169,8 +169,8 @@ msgstr "domingo de la Misericordia divina"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -179,31 +179,31 @@ msgstr ""
 "La Solemnidad <i>'%1$s'</i> coincide con <b>%2$s</b> en el año %3$d, por "
 "tanto, la celebración ha sido trasladada a %4$s (%5$s) según el %6$s."
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr "Sábado anterior al Domingo de Ramos"
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decreto de la Congregación para el Culto Divino"
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "el lunes siguiente al Segundo Domingo de Pascua"
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr "el siguiente lunes"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -219,7 +219,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -229,7 +229,7 @@ msgstr ""
 "%3$d, se ha anticipado un día según %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -239,12 +239,12 @@ msgstr ""
 "celebra el %4$s en lugar del domingo después de Navidad."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Nuestro Señor Jesucristo, El Sumo Sacerdote Eterno"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -258,30 +258,30 @@ msgstr ""
 "aplicable al calendario '%1$s' en el año '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' es reemplazado por el %2$s '%3$s' en el año %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "de la %s Semana de Adviento"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Día de la Octava de Navidad"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "de la %s Semana de Cuaresma"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "después del Miércoles de Ceniza"
 
@@ -309,8 +309,8 @@ msgstr "después del Miércoles de Ceniza"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -319,7 +319,7 @@ msgstr ""
 "El %1$s '%2$s' se ha añadido el %3$s desde el año %4$d (%5$s), aplicable al "
 "año %6$d."
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -332,7 +332,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -350,16 +350,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "El %1$s '%2$s' es reemplazado por el %3$s '%4$s' en el año %5$d."
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Constitución Apostólica Missale Romanum"
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -380,7 +380,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -395,7 +395,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -405,17 +405,17 @@ msgstr ""
 "reducen en rango a memorias opcionales (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr "antes"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr "después"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -425,7 +425,7 @@ msgstr ""
 "festividad con clave '%2$s' usando palabras clave %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -434,7 +434,7 @@ msgstr ""
 "clave '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -444,7 +444,7 @@ msgstr ""
 "'strtotime' es un objeto, debe tener propiedades %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -454,7 +454,7 @@ msgstr ""
 "ser un objeto o una cadena. Actualmente tiene el tipo '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -468,7 +468,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -485,7 +485,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -502,7 +502,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -517,7 +517,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -526,7 +526,7 @@ msgstr ""
 "'%1$s' ha sido declarado Doctor de la Iglesia desde el año %2$d, aplicable "
 "al año %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "y Doctor de la Iglesia"
 
@@ -540,7 +540,7 @@ msgstr "y Doctor de la Iglesia"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -559,7 +559,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -569,7 +569,7 @@ msgstr ""
 "el %6$s desde el año %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -579,7 +579,7 @@ msgstr ""
 "agosto desde el año 2002 (%2$s), aplicable al año %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -590,7 +590,7 @@ msgstr ""
 "domingo o solemnidad si fuera el 12 de diciembre, ha sido transferida al 12 "
 "de agosto desde el año 2002 (%2$s), aplicable al año %3$d."
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -603,7 +603,7 @@ msgstr ""
 "%3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -616,27 +616,27 @@ msgstr ""
 "reinstaurada para que las iglesias locales puedan celebrar opcionalmente la "
 "memoria."
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "de la %s Semana de Pascua"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "de la %s Semana del Tiempo Ordinario"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memoria del sábado de la Bienaventurada Virgen María"
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Error al recuperar y decodificar datos de la Región Ampliada del archivo %s."
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -644,7 +644,7 @@ msgstr ""
 "No se pudo encontrar una propiedad %1$s en el %2$s para el Calendario "
 "Nacional %3$s."
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, fuzzy, php-format
 #| msgid "Error retrieving and decoding National data from file %s."
 msgid "Error retrieving and decoding National Calendar data from file %s."
@@ -659,7 +659,7 @@ msgstr "Error al recuperar y decodificar datos Nacionales del archivo %s."
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -679,7 +679,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -696,7 +696,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -706,7 +706,7 @@ msgstr ""
 "reducen en rango a memorias opcionales."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -716,7 +716,7 @@ msgstr ""
 "'%3$s' en el año %4$d! ¿Hay que hacer algo al respecto?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -726,7 +726,7 @@ msgstr ""
 "La solemnidad '%1$s', usualmente celebrada el %2$s, coincide con el domingo "
 "o solemnidad '%3$s' en el año %4$d! ¿Hay que hacer algo al respecto?"
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -742,7 +742,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -758,7 +758,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -777,7 +777,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -793,7 +793,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -813,7 +813,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -829,7 +829,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -848,7 +848,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -861,7 +861,7 @@ msgstr ""
 "rango."
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Se encontró un archivo de datos del sanctoral para %s"
@@ -875,7 +875,7 @@ msgstr "Se encontró un archivo de datos del sanctoral para %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -885,13 +885,13 @@ msgstr ""
 "reemplazado por el %5$s '%6$s' en el año %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "No se pudo encontrar un archivo de datos del sanctoral para %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -901,7 +901,7 @@ msgstr ""
 "espacio para '%3$s': aplicable al año %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -913,7 +913,7 @@ msgstr ""
 "año %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -925,7 +925,7 @@ msgstr ""
 "%5$d! ¿Se necesita hacer algo al respecto?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -934,7 +934,7 @@ msgstr ""
 "El %1$s '%2$s', propio del calendario del %3$s y usualmente celebrado el "
 "%4$s, es suprimido por el domingo o solemnidad %5$s en el año %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/es/LC_MESSAGES/litcal.po
+++ b/i18n/es/LC_MESSAGES/litcal.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Spanish <https://translate.johnromanodorazio.com/projects/"
@@ -934,7 +934,7 @@ msgstr ""
 "El %1$s '%2$s', propio del calendario del %3$s y usualmente celebrado el "
 "%4$s, es suprimido por el domingo o solemnidad %5$s en el año %6$d"
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/es/LC_MESSAGES/litcal.po
+++ b/i18n/es/LC_MESSAGES/litcal.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Spanish <https://translate.johnromanodorazio.com/projects/"
@@ -934,7 +934,7 @@ msgstr ""
 "El %1$s '%2$s', propio del calendario del %3$s y usualmente celebrado el "
 "%4$s, es suprimido por el domingo o solemnidad %5$s en el año %6$d"
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/fr/LC_MESSAGES/litcal.po
+++ b/i18n/fr/LC_MESSAGES/litcal.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: French <https://translate.johnromanodorazio.com/projects/"
@@ -945,7 +945,7 @@ msgstr ""
 "La %1$s '%2$s', propre au calendrier du %3$s et habituellement célébrée le "
 "%4$s, est supprimée par le dimanche ou la solennité %5$s en l'année %6$d"
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/fr/LC_MESSAGES/litcal.po
+++ b/i18n/fr/LC_MESSAGES/litcal.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: French <https://translate.johnromanodorazio.com/projects/"
@@ -23,19 +23,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr "Le nom du diocèse n'a pas pu être dérivé de l'ID du diocèse \"%s\"."
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr ""
 "Le calendrier diocésain \"%s\" n'a pas été trouvé dans le fichier d'index."
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -45,7 +45,7 @@ msgstr ""
 "de demander l'année %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -54,14 +54,14 @@ msgstr ""
 "localisées pour le Temporal : %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Une erreur s'est produite lors de la tentative de récupération des données "
 "localisées pour le Temporal."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
@@ -69,14 +69,14 @@ msgstr ""
 "pour le Temporal : %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 "Une erreur s'est produite lors de la tentative de récupération des données "
 "pour le Temporal."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -88,7 +88,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -98,7 +98,7 @@ msgstr ""
 "localisation JSON pour le Sanctoral du Missel %1$s : %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, fuzzy, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Les données pour le sanctoral de %s n'ont pas pu être trouvées."
@@ -107,7 +107,7 @@ msgstr "Les données pour le sanctoral de %s n'ont pas pu être trouvées."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -117,12 +117,12 @@ msgstr ""
 "pour le Sanctoral du Missel %1$s : %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 #, fuzzy
 msgid "Could not find the Sanctorale data"
 msgstr "Impossible de trouver un fichier de données sanctorale pour %s"
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -132,14 +132,14 @@ msgstr ""
 "traduction pour les Mémoires basés sur les Décrets de la Congrégation pour "
 "le Culte Divin : %s"
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 #, fuzzy
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr "Décret de la Congrégation pour le Culte Divin"
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -151,19 +151,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Férie de Noël"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "ou"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "Dimanche de la divine Miséricorde"
 
@@ -177,8 +177,8 @@ msgstr "Dimanche de la divine Miséricorde"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -187,31 +187,31 @@ msgstr ""
 "La Solennité '%1$s' tombe le %2$s en l'année %3$d, la célébration a été "
 "transférée au %4$s (%5$s) selon le %6$s."
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr "le samedi précédant le dimanche des Rameaux"
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Décret de la Congrégation pour le Culte Divin"
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "le lundi suivant le deuxième dimanche de Pâques"
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr "le lundi suivant"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -227,7 +227,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -237,7 +237,7 @@ msgstr ""
 "%3$d, elle a été anticipée d'un jour selon %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -247,12 +247,12 @@ msgstr ""
 "%4$s plutôt que le dimanche après Noël."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Notre Seigneur Jésus-Christ, Éternel et Souverain Prêtre"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -266,30 +266,30 @@ msgstr ""
 "applicable au calendrier '%1$s' en l'année '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' est supplanté par le %2$s '%3$s' en l'année %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "de la %s semaine de l'Avent"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s jour dans l'Octave de la Nativité"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "de la %s semaine de Carême"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "après le Mercredi des Cendres"
 
@@ -317,8 +317,8 @@ msgstr "après le Mercredi des Cendres"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -327,7 +327,7 @@ msgstr ""
 "Le %1$s '%2$s' a été ajouté le %3$s depuis l'année %4$d (%5$s), applicable à "
 "l'année %6$d."
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -340,7 +340,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -358,16 +358,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "Le %1$s '%2$s' est supplanté par le %3$s '%4$s' en l'année %5$d."
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Constitution apostolique Missale Romanum"
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -388,7 +388,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -403,7 +403,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -413,17 +413,17 @@ msgstr ""
 "Elles sont toutes deux réduites en rang à des mémoires facultatives (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr "avant"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr "après"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -433,7 +433,7 @@ msgstr ""
 "fête avec la clé '%2$s' en utilisant les mots-clés %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -442,7 +442,7 @@ msgstr ""
 "'%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -452,7 +452,7 @@ msgstr ""
 "est un objet, elle doit avoir les propriétés %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -463,7 +463,7 @@ msgstr ""
 "type '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr "Impossible de créer la fête mobile '%1$s' sans propriété 'strtotime' !"
@@ -476,7 +476,7 @@ msgstr "Impossible de créer la fête mobile '%1$s' sans propriété 'strtotime'
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -493,7 +493,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -510,7 +510,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -525,7 +525,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -534,7 +534,7 @@ msgstr ""
 "'%1$s' a été déclaré Docteur de l'Église depuis l'année %2$d, applicable à "
 "l'année %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "et docteur de l'Église"
 
@@ -548,7 +548,7 @@ msgstr "et docteur de l'Église"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -567,7 +567,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -577,7 +577,7 @@ msgstr ""
 "%6$s depuis l'année %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -587,7 +587,7 @@ msgstr ""
 "l'année 2002 (%2$s), applicable à l'année %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -598,7 +598,7 @@ msgstr ""
 "dimanche ou une solennité si elle avait eu lieu le 12 déc., a cependant été "
 "transférée au 12 août depuis l'année 2002 (%2$s), applicable à l'année %3$d."
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -610,7 +610,7 @@ msgstr ""
 "par un dimanche, une solennité ou une fête '%4$s' en l'année %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -623,28 +623,28 @@ msgstr ""
 "rétablie afin que les églises locales puissent célébrer facultativement la "
 "mémoire."
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "de la %s semaine de Pâques"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "de la %s Semaine du Temps Ordinaire"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Mémoire du samedi de la Bienheureuse Vierge Marie"
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Erreur lors de la récupération et du décodage des données de la région "
 "élargie à partir du fichier %s."
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -652,7 +652,7 @@ msgstr ""
 "Impossible de trouver une propriété %1$s dans le %2$s pour le Calendrier "
 "National %3$s."
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, fuzzy, php-format
 #| msgid "Error retrieving and decoding National data from file %s."
 msgid "Error retrieving and decoding National Calendar data from file %s."
@@ -669,7 +669,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -689,7 +689,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -706,7 +706,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -716,7 +716,7 @@ msgstr ""
 "Elles sont toutes deux réduites au rang de mémoires facultatives."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -726,7 +726,7 @@ msgstr ""
 "Fête '%3$s' en l'année %4$d ! Faut-il faire quelque chose à ce sujet ?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -737,7 +737,7 @@ msgstr ""
 "dimanche ou la Solennité '%3$s' en l'année %4$d ! Faut-il faire quelque "
 "chose à ce sujet ?"
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -753,7 +753,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -769,7 +769,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -788,7 +788,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -804,7 +804,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -824,7 +824,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -840,7 +840,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -859,7 +859,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -872,7 +872,7 @@ msgstr ""
 "supérieur."
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Fichier de données sanctorale trouvé pour %s"
@@ -886,7 +886,7 @@ msgstr "Fichier de données sanctorale trouvé pour %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -896,13 +896,13 @@ msgstr ""
 "par le %5$s '%6$s' en l'année %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Impossible de trouver un fichier de données sanctorale pour %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -912,7 +912,7 @@ msgstr ""
 "place à '%3$s' : applicable à l'année %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -924,7 +924,7 @@ msgstr ""
 "en l'année %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -936,7 +936,7 @@ msgstr ""
 "Faut-il faire quelque chose à ce sujet ?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -945,7 +945,7 @@ msgstr ""
 "La %1$s '%2$s', propre au calendrier du %3$s et habituellement célébrée le "
 "%4$s, est supprimée par le dimanche ou la solennité %5$s en l'année %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/fr/LC_MESSAGES/litcal.po
+++ b/i18n/fr/LC_MESSAGES/litcal.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: French <https://translate.johnromanodorazio.com/projects/"
@@ -945,7 +945,7 @@ msgstr ""
 "La %1$s '%2$s', propre au calendrier du %3$s et habituellement célébrée le "
 "%4$s, est supprimée par le dimanche ou la solennité %5$s en l'année %6$d"
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/hu/LC_MESSAGES/litcal.po
+++ b/i18n/hu/LC_MESSAGES/litcal.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -799,7 +799,7 @@ msgid ""
 "on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
 msgstr ""
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/hu/LC_MESSAGES/litcal.po
+++ b/i18n/hu/LC_MESSAGES/litcal.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,18 +15,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr ""
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -34,30 +34,30 @@ msgid ""
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -68,7 +68,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -76,7 +76,7 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr ""
@@ -85,7 +85,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -93,24 +93,24 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 msgid "Could not find the Sanctorale data"
 msgstr ""
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
 "Decrees of the Congregation for Divine Worship: %s"
 msgstr ""
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr ""
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -119,19 +119,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr ""
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr ""
 
@@ -145,39 +145,39 @@ msgstr ""
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr ""
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -190,7 +190,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -198,7 +198,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -206,12 +206,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -221,30 +221,30 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr ""
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr ""
 
@@ -272,15 +272,15 @@ msgstr ""
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -291,7 +291,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -306,16 +306,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -333,7 +333,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -346,7 +346,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -354,17 +354,17 @@ msgid ""
 msgstr ""
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr ""
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -372,14 +372,14 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -387,7 +387,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -395,7 +395,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -408,7 +408,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -423,7 +423,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -438,7 +438,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -451,14 +451,14 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr ""
 
@@ -472,7 +472,7 @@ msgstr ""
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -489,7 +489,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -497,7 +497,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -505,7 +505,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -513,7 +513,7 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -522,7 +522,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -531,32 +531,32 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr ""
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, php-format
 msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr ""
@@ -570,7 +570,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -587,7 +587,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -601,7 +601,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -609,7 +609,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -617,7 +617,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -625,7 +625,7 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -639,7 +639,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -653,7 +653,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -669,7 +669,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -683,7 +683,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -700,7 +700,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -714,7 +714,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -729,7 +729,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -738,7 +738,7 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -752,7 +752,7 @@ msgstr ""
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -760,13 +760,13 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -774,7 +774,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -783,7 +783,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -792,14 +792,14 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
 "on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
 msgstr ""
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/hu/LC_MESSAGES/litcal.po
+++ b/i18n/hu/LC_MESSAGES/litcal.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -799,7 +799,7 @@ msgid ""
 "on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
 msgstr ""
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/id/LC_MESSAGES/litcal.po
+++ b/i18n/id/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-08-20 15:40+0000\n"
 "Last-Translator: User_425 <user425.itsme@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.johnromanodorazio.com/projects/"
@@ -805,7 +805,7 @@ msgid ""
 "on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
 msgstr ""
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/id/LC_MESSAGES/litcal.po
+++ b/i18n/id/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-08-20 15:40+0000\n"
 "Last-Translator: User_425 <user425.itsme@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.johnromanodorazio.com/projects/"
@@ -805,7 +805,7 @@ msgid ""
 "on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
 msgstr ""
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/id/LC_MESSAGES/litcal.po
+++ b/i18n/id/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-08-20 15:40+0000\n"
 "Last-Translator: User_425 <user425.itsme@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.johnromanodorazio.com/projects/"
@@ -19,18 +19,18 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr ""
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -40,30 +40,30 @@ msgstr ""
 "%d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -74,7 +74,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -82,7 +82,7 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr ""
@@ -91,7 +91,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -99,24 +99,24 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 msgid "Could not find the Sanctorale data"
 msgstr ""
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
 "Decrees of the Congregation for Divine Worship: %s"
 msgstr ""
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr ""
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -125,19 +125,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "atau"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "Minggu Kerahiman Ilahi"
 
@@ -151,39 +151,39 @@ msgstr "Minggu Kerahiman Ilahi"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr ""
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -196,7 +196,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -204,7 +204,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -212,12 +212,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -227,30 +227,30 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "Pekan %s Adven"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "Hari %s pada Oktaf Natal"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "Pekan %s Prapaskah"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "setelah Rabu Abu"
 
@@ -278,15 +278,15 @@ msgstr "setelah Rabu Abu"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -297,7 +297,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -312,16 +312,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -339,7 +339,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -352,7 +352,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -360,17 +360,17 @@ msgid ""
 msgstr ""
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr ""
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -378,14 +378,14 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -393,7 +393,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -401,7 +401,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -414,7 +414,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -429,7 +429,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -444,7 +444,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -457,14 +457,14 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "dan Pujangga Gereja"
 
@@ -478,7 +478,7 @@ msgstr "dan Pujangga Gereja"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -495,7 +495,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -503,7 +503,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -511,7 +511,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -519,7 +519,7 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -528,7 +528,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -537,32 +537,32 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "Pekan %s Paskah"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "Pekan Biasa %s"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, php-format
 msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr ""
@@ -576,7 +576,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -593,7 +593,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -607,7 +607,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -615,7 +615,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -623,7 +623,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -631,7 +631,7 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -645,7 +645,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -659,7 +659,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -675,7 +675,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -689,7 +689,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -706,7 +706,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -720,7 +720,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -735,7 +735,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -744,7 +744,7 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -758,7 +758,7 @@ msgstr ""
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -766,13 +766,13 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -780,7 +780,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -789,7 +789,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -798,14 +798,14 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
 "on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
 msgstr ""
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/it/LC_MESSAGES/litcal.po
+++ b/i18n/it/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Italian <https://translate.johnromanodorazio.com/projects/"
@@ -22,19 +22,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 "Il nome della diocesi non può essere derivato dall'ID della diocesi \"%s\"."
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr "Il calendario diocesano \"%s\" non è stato trovato nel file indice."
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -44,7 +44,7 @@ msgstr ""
 "richiedere l'anno %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -53,14 +53,14 @@ msgstr ""
 "localizzati per il Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Si è verificato un errore nel tentativo di recuperare i dati localizzati per "
 "il Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
@@ -68,14 +68,14 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 "Si è verificato un errore nel tentativo di recuperare i dati per il "
 "Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Non sono stati trovati dati per la traduzione del santorale di: %s."
@@ -86,7 +86,7 @@ msgstr "Non sono stati trovati dati per la traduzione del santorale di: %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -96,7 +96,7 @@ msgstr ""
 "localizzazione JSON per il Sanctorale del Messale %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Non sono stati trovati dati per il Santorale da %s."
@@ -105,7 +105,7 @@ msgstr "Non sono stati trovati dati per il Santorale da %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -115,11 +115,11 @@ msgstr ""
 "Sanctorale del Messale %1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 msgid "Could not find the Sanctorale data"
 msgstr "Non è stato trovato un file con i dati del Santorale"
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -128,7 +128,7 @@ msgstr ""
 "Si è verificato un errore nel tentativo di decodificare i dati di traduzione "
 "per le Memorie basate sui Decreti della Congregazione per il Culto Divino: %s"
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -136,7 +136,7 @@ msgstr ""
 "Impossibile trovare dati di traduzione per le Memorie basate sui Decreti "
 "della Congregazione per il Culto Divino"
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -147,19 +147,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Giorno feriale di Natale"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "oppure"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "Domenica della Divina Misericordia"
 
@@ -173,8 +173,8 @@ msgstr "Domenica della Divina Misericordia"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -183,31 +183,31 @@ msgstr ""
 "La Solennità <i>'%1$s'</i> cade di %2$s nell'anno %3$d, pertanto la "
 "celebrazione è stata trasferita al %4$s (%5$s) in accordo con il %6$s."
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr "sabato che precede la Domenica delle Palme"
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decreto della Congregazione per il Culto Divino"
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "lunedì che segue la Seconda Domenica di Pasqua"
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr "lunedì seguente"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -223,7 +223,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -233,7 +233,7 @@ msgstr ""
 "nell'anno %3$d, la prima è stata anticipata di un giorno come da %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -243,12 +243,12 @@ msgstr ""
 "<i>'%3$s'</i> viene celebrata il %4$s anziché la Domenica dopo Natale."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Nostro Signore Gesù Cristo, Sommo ed Eterno Sacerdote"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -262,30 +262,30 @@ msgstr ""
 "calendario '%1$s' nell'anno '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "<i>'%1$s'</i> è soppiantata dalla %2$s <i>'%3$s'</i> nell'anno %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "della %s Settimana dell'Avvento"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Giorno dell'Ottava di Natale"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "della %s Settimana di Quaresima"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "dopo il Mercoledì delle Ceneri"
 
@@ -313,8 +313,8 @@ msgstr "dopo il Mercoledì delle Ceneri"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -323,7 +323,7 @@ msgstr ""
 "La %1$s '%2$s' è stata inserita il giorno %3$s a partire dall'anno %4$d "
 "(%5$s), applicabile pertanto all'anno %6$d."
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -336,7 +336,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -354,16 +354,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "La %1$s '%2$s' è soppiantata dalla %3$s '%4$s' nell'anno %5$d."
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Costituzione Apostolica Missale Romanum"
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -384,7 +384,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -399,7 +399,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -409,17 +409,17 @@ msgstr ""
 "e due sono ridotte al grado di memorie facoltative (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr "prima di"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr "dopo"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -429,7 +429,7 @@ msgstr ""
 "festività con chiave '%2$s' utilizzando le parole chiave %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -438,7 +438,7 @@ msgstr ""
 "chiave '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -448,7 +448,7 @@ msgstr ""
 "'strtotime' è un oggetto, deve avere le proprietà %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -458,7 +458,7 @@ msgstr ""
 "essere un oggetto oppure una stringa! Attualmente è di tipo '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -472,7 +472,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -489,7 +489,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -506,7 +506,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -521,7 +521,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -530,7 +530,7 @@ msgstr ""
 "'%1$s' è stato dichiarato Dottore della Chiesa sin dal %2$d, applicabile "
 "pertanto all'anno %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "e Dottore della Chiesa"
 
@@ -544,7 +544,7 @@ msgstr "e Dottore della Chiesa"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -563,7 +563,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -573,7 +573,7 @@ msgstr ""
 "il giorno %6$s sin dal %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -583,7 +583,7 @@ msgstr ""
 "sin dal 2002 (%2$s), applicabile pertanto all'anno %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -595,7 +595,7 @@ msgstr ""
 "trasferita al 12 Agosto sin dal 2002 (%2$s), applicabile pertanto all'anno "
 "%3$d."
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -607,7 +607,7 @@ msgstr ""
 "soppressa da una Domenica, una Solennità o una Festa '%4$s' nell'anno %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -620,28 +620,28 @@ msgstr ""
 "restituita secondo il %2$s in modo che le chiese locali abbiano facoltà di "
 "mantenere la memoria."
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "della %s Settimana di Pasqua"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "della %s Settimana del Tempo Ordinario"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memoria di Santa Maria in sabato"
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Errore nella lettura o nella decodifica dei dati per la Regione più ampia "
 "dal file %s."
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -649,7 +649,7 @@ msgstr ""
 "Impossibile trovare una proprietà %1$s nel %2$s per il Calendario Nazionale "
 "%3$s."
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, php-format
 msgid "Error retrieving and decoding National Calendar data from file %s."
 msgstr ""
@@ -665,7 +665,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -685,7 +685,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -702,7 +702,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -712,7 +712,7 @@ msgstr ""
 "e due sono ridotte al grado di memorie facoltative."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -722,7 +722,7 @@ msgstr ""
 "Festa '%3$s' nell'anno %4$d. Dobbiamo rimediare?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -732,7 +732,7 @@ msgstr ""
 "La Solennità '%1$s', solitamente celebrate il %2$s, coincide con la Domenica "
 "o Solennità '%3$s' nell'anno %4$d. Dobbiamo rimediare in qualche modo?"
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -748,7 +748,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -764,7 +764,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -783,7 +783,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -799,7 +799,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -819,7 +819,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -835,7 +835,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -854,7 +854,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -867,7 +867,7 @@ msgstr ""
 "rango superiore."
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Trovato un file con dati per il santorale di: %s"
@@ -881,7 +881,7 @@ msgstr "Trovato un file con dati per il santorale di: %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -891,13 +891,13 @@ msgstr ""
 "superata dalla %5$s '%6$s' nell'anno %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Non è stato trovato un file con i dati del santorale di: %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -907,7 +907,7 @@ msgstr ""
 "lasciare luogo a '%3$s': applicabile pertanto all'anno %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -919,7 +919,7 @@ msgstr ""
 "%9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -931,7 +931,7 @@ msgstr ""
 "fare qualcosa a riguardo?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -940,7 +940,7 @@ msgstr ""
 "La %1$s '%2$s', propria del calendario %3$s e solitamente celebrate il "
 "giorno %4$s, è soppressa dalla Domenica o Solennità '%5$s' nell'anno %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/it/LC_MESSAGES/litcal.po
+++ b/i18n/it/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Italian <https://translate.johnromanodorazio.com/projects/"
@@ -940,7 +940,7 @@ msgstr ""
 "La %1$s '%2$s', propria del calendario %3$s e solitamente celebrate il "
 "giorno %4$s, è soppressa dalla Domenica o Solennità '%5$s' nell'anno %6$d"
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/it/LC_MESSAGES/litcal.po
+++ b/i18n/it/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Italian <https://translate.johnromanodorazio.com/projects/"
@@ -940,7 +940,7 @@ msgstr ""
 "La %1$s '%2$s', propria del calendario %3$s e solitamente celebrate il "
 "giorno %4$s, è soppressa dalla Domenica o Solennità '%5$s' nell'anno %6$d"
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/la/LC_MESSAGES/litcal.po
+++ b/i18n/la/LC_MESSAGES/litcal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: Latin <https://translate.johnromanodorazio.com/projects/"
@@ -921,7 +921,7 @@ msgstr ""
 "%1$s '%2$s', proprio calendario %3$s et plerumque celebratur die %4$s, "
 "supprimatur a Dominica vel Sollemnitate %5$s anno %6$d"
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/la/LC_MESSAGES/litcal.po
+++ b/i18n/la/LC_MESSAGES/litcal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: Latin <https://translate.johnromanodorazio.com/projects/"
@@ -20,18 +20,18 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr ""
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -40,30 +40,30 @@ msgstr ""
 "Petere potes nisi ab annis MCMLXX et ultra. Tu anno %d conatus est petere."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Translationem datarum pro sanctorali ex %s inveniri non potuit."
@@ -74,7 +74,7 @@ msgstr "Translationem datarum pro sanctorali ex %s inveniri non potuit."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -82,7 +82,7 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, fuzzy, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Data pro sanctorale ex %s reperiri non potuit."
@@ -91,7 +91,7 @@ msgstr "Data pro sanctorale ex %s reperiri non potuit."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -99,26 +99,26 @@ msgid ""
 msgstr ""
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 #, fuzzy
 msgid "Could not find the Sanctorale data"
 msgstr "Archivum datarum de Sanctorale pro %s non inventa est"
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
 "Decrees of the Congregation for Divine Worship: %s"
 msgstr ""
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 #, fuzzy
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr "Decretum Congregationis pro Cultu Divino"
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -127,19 +127,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "vel"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "Dominica de divina Misericordia"
 
@@ -153,8 +153,8 @@ msgstr "Dominica de divina Misericordia"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -163,31 +163,31 @@ msgstr ""
 "Coincidet enim Sollemnitas <i>'%1$s'</i> cum <b>%2$s</b> in anno %3$d, ergo "
 "traslata est celebratio ad %4$s (%5$s) secundum %6$s."
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr "sabbatum ante Dominicam in Palmis"
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decretum Congregationis pro Cultu Divino"
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "diem Lunæ post Dominicam Secundam Paschæ"
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr "diem Lunæ proximum"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -202,7 +202,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -212,7 +212,7 @@ msgstr ""
 "in anno %3$d, anticipata est ab uno die secundum %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -222,12 +222,12 @@ msgstr ""
 "celebrentur die %4$s quam Dominica post Nativitate."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Dómini nostri Iesu Christi, Summi et Aetérni Sacerdótis"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -241,30 +241,30 @@ msgstr ""
 "applicabile ad calendarium '%1$s' anno '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "<i>'%1$s'</i> subplantata est ab %2$s <i>'%3$s'</i> in anno %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "Hebdomadæ %s Adventus"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "Dies %s Octavæ Nativitatis"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "Hebdomadæ %s Quadragesimæ"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "post Feria IV Cinerum"
 
@@ -292,8 +292,8 @@ msgstr "post Feria IV Cinerum"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -302,7 +302,7 @@ msgstr ""
 "%1$s <i>'%2$s'</i> aggregata est igitur in die %3$s ab anno %4$d (%5$s), "
 "ergo viget in anno %6$d."
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -315,7 +315,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -333,16 +333,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "%1$s '%2$s' subplantata est ab %3$s '%4$s' in anno %5$d."
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apostolica Constitutio Missale Romanum"
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -362,7 +362,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -377,7 +377,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -387,17 +387,17 @@ msgstr ""
 "simul redunctur in gradu Memoriæ ad libitum (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr "ante"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr "postquam"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -407,7 +407,7 @@ msgstr ""
 "clave '%2$s' relativa esse potest, utentem verbis clavum %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -416,7 +416,7 @@ msgstr ""
 "creari non potest"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -426,7 +426,7 @@ msgstr ""
 "obiectum, oportet eam habere proprietates %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -436,7 +436,7 @@ msgstr ""
 "obiectum esse debet aut stringere! Nunc autem habet typum '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -450,7 +450,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -467,7 +467,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -484,7 +484,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -499,7 +499,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -508,7 +508,7 @@ msgstr ""
 "'%1$s' declarato/a est Doctor Ecclesiæ ab anno %2$d, ergo applicatur ad anno "
 "%3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "et Ecclesiæ doctoris"
 
@@ -522,7 +522,7 @@ msgstr "et Ecclesiæ doctoris"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -541,7 +541,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -551,7 +551,7 @@ msgstr ""
 "%6$s ab anno %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -561,7 +561,7 @@ msgstr ""
 "2002 (%2$s), ergo viget in anno %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -572,7 +572,7 @@ msgstr ""
 "Sollemnitate si celebrata fuisset in die 12 Dec., nihilominus traslata est "
 "ad 12 Aug. ab anno 2002 (%2$s), ergo viget in anno %3$d."
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -584,7 +584,7 @@ msgstr ""
 "Dominica, aut Sollemnitate, aut Festu <i>\\'%4$s\\'</i> in anno %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -596,34 +596,34 @@ msgstr ""
 "tamen quamvis sit Annus Pauli Apostoli, restituta est secundum %2$s ut "
 "permittant ecclesias locales ad memoriam celebrandam."
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "Hebdomadæ %s Temporis Paschali"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "Hebdomadæ %s Temporis Ordinarii"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memoria Sanctæ Mariæ in Sabbato"
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Errorem ad recuperandam et interpretandam datam Regionis Latiorem ex archivo "
 "%s."
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, fuzzy, php-format
 #| msgid "Error retrieving and decoding Wider Region data from file %s."
 msgid "Error retrieving and decoding National Calendar data from file %s."
@@ -640,7 +640,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -662,7 +662,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -681,7 +681,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -691,7 +691,7 @@ msgstr ""
 "simul redunctur in gradu Memoriæ ad libitum."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -701,7 +701,7 @@ msgstr ""
 "'%3$s' anno %4$d! Opus est aliquid de hoc agere?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -711,7 +711,7 @@ msgstr ""
 "Solemnitas '%1$s', quae plerumque celebratur die %2$s, coincidet cum "
 "Dominica vel Solemnitate '%3$s' anno %4$d! Opus est aliquid de hoc agere?"
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -727,7 +727,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -746,7 +746,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -767,7 +767,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -786,7 +786,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -808,7 +808,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -827,7 +827,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -842,7 +842,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -851,7 +851,7 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Inveni codicem datarum sanctoralium pro %s"
@@ -865,7 +865,7 @@ msgstr "Inveni codicem datarum sanctoralium pro %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -875,13 +875,13 @@ msgstr ""
 "ab %5$s '%6$s' in anno %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Archivum datarum de Sanctorale pro %s non inventa est"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -891,7 +891,7 @@ msgstr ""
 "spatium facere in gratiam '%3$s': ergo viget in anno %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -903,7 +903,7 @@ msgstr ""
 "%9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -912,7 +912,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -921,7 +921,7 @@ msgstr ""
 "%1$s '%2$s', proprio calendario %3$s et plerumque celebratur die %4$s, "
 "supprimatur a Dominica vel Sollemnitate %5$s anno %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/la/LC_MESSAGES/litcal.po
+++ b/i18n/la/LC_MESSAGES/litcal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: Latin <https://translate.johnromanodorazio.com/projects/"
@@ -921,7 +921,7 @@ msgstr ""
 "%1$s '%2$s', proprio calendario %3$s et plerumque celebratur die %4$s, "
 "supprimatur a Dominica vel Sollemnitate %5$s anno %6$d"
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/nl/LC_MESSAGES/litcal.po
+++ b/i18n/nl/LC_MESSAGES/litcal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Dutch <https://translate.johnromanodorazio.com/projects/"
@@ -960,7 +960,7 @@ msgstr ""
 "De %1$s '%2$s', eigen aan de kalender van de %3$s en gewoonlijk gevierd op "
 "%4$s, wordt vervangen door de Zondag of hoogfeest '%5$s' in het jaar %6$d"
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/nl/LC_MESSAGES/litcal.po
+++ b/i18n/nl/LC_MESSAGES/litcal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Dutch <https://translate.johnromanodorazio.com/projects/"
@@ -960,7 +960,7 @@ msgstr ""
 "De %1$s '%2$s', eigen aan de kalender van de %3$s en gewoonlijk gevierd op "
 "%4$s, wordt vervangen door de Zondag of hoogfeest '%5$s' in het jaar %6$d"
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/nl/LC_MESSAGES/litcal.po
+++ b/i18n/nl/LC_MESSAGES/litcal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Dutch <https://translate.johnromanodorazio.com/projects/"
@@ -21,19 +21,19 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 "De naam van het bisdom kon niet worden afgeleid van het bisdom-ID \"%s\"."
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr "De diocesane kalender \"%s\" werd niet gevonden in het indexbestand."
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -42,7 +42,7 @@ msgstr ""
 "Alleen jaren na 1970 worden ondersteund. U probeert het jaar %d op te vragen."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -51,14 +51,14 @@ msgstr ""
 "voor de Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Er is een fout opgetreden bij het ophalen van gelokaliseerde gegevens voor "
 "de Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr ""
@@ -66,13 +66,13 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr ""
 "Er is een fout opgetreden bij het ophalen van gegevens voor de Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr ""
@@ -85,7 +85,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -95,7 +95,7 @@ msgstr ""
 "voor het Sanctorale voor het Missaal %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, fuzzy, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr ""
@@ -105,7 +105,7 @@ msgstr ""
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -115,12 +115,12 @@ msgstr ""
 "Sanctorale voor het Missaal %1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 #, fuzzy
 msgid "Could not find the Sanctorale data"
 msgstr "Een sanctorale data bestand voor %s is niet gevonden"
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -130,14 +130,14 @@ msgstr ""
 "Herdenkingen op basis van Decreten van de Congregatie voor de Goddelijke "
 "Eredienst: %s"
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 #, fuzzy
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
 msgstr "Decreet van de Congregatie voor de Goddelijke Eredienst"
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -149,19 +149,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s van de kersttijd"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "of"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "Barmhartige zondag"
 
@@ -175,8 +175,8 @@ msgstr "Barmhartige zondag"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -185,31 +185,31 @@ msgstr ""
 "Het hoogfeest van '%1$s' valt op %2$s in het jaar %3$d, de viering is "
 "verplaatst naar %4$s (%5$s) overeenkomstig %6$s."
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr "de zaterdag voorafgaand aan Palmzondag"
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decreet van de Congregatie voor de Goddelijke Eredienst"
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "maandag na de tweede zondag van pasen"
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr "de volgende maandag"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -225,7 +225,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -235,7 +235,7 @@ msgstr ""
 "jaar %3$d, wordt het een dag eerder gevierd overeenkomstig %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -245,12 +245,12 @@ msgstr ""
 "'%3$s' gevierd op %4$s in plaats van op de zondag na Kerstmis."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Onze Heer Christus Eeuwige Hogepriester"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -265,30 +265,30 @@ msgstr ""
 "'%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' wordt vervangen door het %2$s van '%3$s' in het jaar %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "in de %s week van de advent"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s dag onder het octaaf van Kerstmis"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "in de %s week van de veertigdagentijd"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "na Aswoensdag"
 
@@ -316,8 +316,8 @@ msgstr "na Aswoensdag"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -326,7 +326,7 @@ msgstr ""
 "De %1$s '%2$s' is toegevoegd op %3$s vanaf %4$d (%5$s), van toepassing in "
 "het jaar %6$d."
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -339,7 +339,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -357,16 +357,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "De %1$s '%2$s' heeft voorrang boven de %3$s '%4$s' in het jaar %5$d."
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apostolische Constitutie Missale Romanum"
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -387,7 +387,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -402,7 +402,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -413,17 +413,17 @@ msgstr ""
 "(%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr "voor"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr "na"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -433,7 +433,7 @@ msgstr ""
 "het feest met sleutel '%2$s' met sleutelwoorden %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -442,7 +442,7 @@ msgstr ""
 "feest met sleutel '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -452,7 +452,7 @@ msgstr ""
 "'strtotime' een object is, moet het de eigenschappen '%2$s' hebben"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -462,7 +462,7 @@ msgstr ""
 "moet ofwel een object of een string zijn! Nu heeft hij type '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -477,7 +477,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -494,7 +494,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -511,7 +511,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -526,7 +526,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -535,7 +535,7 @@ msgstr ""
 "'%1$s' is tot Kerkleraar uitgeroepen vanaf het jaar %2$d, van toepassing in "
 "het jaar %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "en kerkleraar"
 
@@ -549,7 +549,7 @@ msgstr "en kerkleraar"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -568,7 +568,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -578,7 +578,7 @@ msgstr ""
 "toegevoegd op %6$s vanaf het jaar %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -588,7 +588,7 @@ msgstr ""
 "vanaf het jaar 2002 (%2$s), van toepassing in het jaar %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -600,7 +600,7 @@ msgstr ""
 "vanaf het jaar 2002 verplaatst naar 12 augustus (%2$s), van toepassing in "
 "het jaar %3$d."
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -612,7 +612,7 @@ msgstr ""
 "wordt vervangen door een zondag, hoogfeest of feest '%4$s' in het jaar %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -624,27 +624,27 @@ msgstr ""
 "zondag valt, maar vanwege het Paulusjaar is het, overeenkomstig %2$s "
 "hersteld, zodat lokale kerken de gedachtenis naar keuze kunnen vieren."
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "na de %s zondag van pasen"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "in de %s week door het jaar"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Maria op zaterdag"
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Fout bij het ophalen en decoderen van Wider Region data uit bestand %s."
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -652,7 +652,7 @@ msgstr ""
 "Kon de %1$s eigenschap niet vinden in de %2$s voor de Nationale Kalender "
 "%3$s."
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, fuzzy, php-format
 #| msgid "Error retrieving and decoding National data from file %s."
 msgid "Error retrieving and decoding National Calendar data from file %s."
@@ -667,7 +667,7 @@ msgstr "Fout bij het ophalen en decoderen van National data uit bestand %s."
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -689,7 +689,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -708,7 +708,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -718,7 +718,7 @@ msgstr ""
 "jaar %3$d. Ze zijn beide teruggebracht naar de rang van vrije gedachtenis."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -728,7 +728,7 @@ msgstr ""
 "'%3$s' in het jaar %4$d. Moet hier iets aan gedaan worden?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -739,7 +739,7 @@ msgstr ""
 "Zondag of hoogfeest van '%3$s' in het jaar %4$d. Moet hier iets aan gedaan "
 "worden?"
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -755,7 +755,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -774,7 +774,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -795,7 +795,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -814,7 +814,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -836,7 +836,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -855,7 +855,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -874,7 +874,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -887,7 +887,7 @@ msgstr ""
 "hogere rang lijkt te vallen."
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Er is een sanctorale data bestand gevonden voor %s"
@@ -901,7 +901,7 @@ msgstr "Er is een sanctorale data bestand gevonden voor %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -911,13 +911,13 @@ msgstr ""
 "wordt vervangen door de %5$s '%6$s' in het jaar %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Een sanctorale data bestand voor %s is niet gevonden"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -927,7 +927,7 @@ msgstr ""
 "om plaats te maken voor '%3$s': van toepassing in het jaar %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -939,7 +939,7 @@ msgstr ""
 "in het jaar %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -951,7 +951,7 @@ msgstr ""
 "Moet hier iets aan gedaan worden?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -960,7 +960,7 @@ msgstr ""
 "De %1$s '%2$s', eigen aan de kalender van de %3$s en gewoonlijk gevierd op "
 "%4$s, wordt vervangen door de Zondag of hoogfeest '%5$s' in het jaar %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/pt/LC_MESSAGES/litcal.po
+++ b/i18n/pt/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Portuguese <https://translate.johnromanodorazio.com/projects/"
@@ -22,18 +22,18 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr "O nome da diocese não pôde ser derivado do ID da diocese \"%s\"."
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr "O calendário diocesano \"%s\" não foi encontrado no arquivo de índice."
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -42,7 +42,7 @@ msgstr ""
 "Apenas anos a partir de 1970 são suportados. Você tentou solicitar o ano %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -51,24 +51,24 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Houve um erro ao tentar recuperar os dados localizados para o Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr "Houve um erro ao tentar decodificar os dados JSON para o Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr "Houve um erro ao tentar recuperar os dados para o Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Dados de tradução para o sanctorale de %s não foram encontrados."
@@ -79,7 +79,7 @@ msgstr "Dados de tradução para o sanctorale de %s não foram encontrados."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -89,7 +89,7 @@ msgstr ""
 "Sanctorale do Missal %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Não foi possível encontrar os dados para o Sanctorale de %s."
@@ -98,7 +98,7 @@ msgstr "Não foi possível encontrar os dados para o Sanctorale de %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -108,11 +108,11 @@ msgstr ""
 "Missal %1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 msgid "Could not find the Sanctorale data"
 msgstr "Não foi possível encontrar os dados do Sanctorale"
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -121,7 +121,7 @@ msgstr ""
 "Houve um erro ao tentar decodificar os dados de tradução para Memoriais com "
 "base nos Decretos da Congregação para o Culto Divino: %s"
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -129,7 +129,7 @@ msgstr ""
 "Não foi possível encontrar dados de tradução para Memoriais baseados em "
 "Decretos da Congregação para o Culto Divino"
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -140,19 +140,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Dia de Semana do Natal"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "ou"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "Domingo da Divina Misericórdia"
 
@@ -166,8 +166,8 @@ msgstr "Domingo da Divina Misericórdia"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -176,31 +176,31 @@ msgstr ""
 "A Solenidade '%1$s' cai em %2$s no ano %3$d, a celebração foi transferida "
 "para %4$s (%5$s) conforme o %6$s."
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr "o sábado anterior ao Domingo de Ramos"
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Decreto da Congregação para o Culto Divino"
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "a segunda-feira após o Segundo Domingo de Páscoa"
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr "a próxima segunda-feira"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -215,7 +215,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -225,7 +225,7 @@ msgstr ""
 "ela foi antecipada em um dia conforme %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -235,12 +235,12 @@ msgstr ""
 "%4$s em vez do domingo após o Natal."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Nosso Senhor Jesus Cristo, O Eterno Sumo Sacerdote"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -254,30 +254,30 @@ msgstr ""
 "aplicável ao calendário '%1$s' no ano '%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' é substituído pelo %2$s '%3$s' no ano %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "da %s Semana do Advento"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Dia da Oitava de Natal"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "da %s Semana da Quaresma"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "após a Quarta-feira de Cinzas"
 
@@ -305,8 +305,8 @@ msgstr "após a Quarta-feira de Cinzas"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -315,7 +315,7 @@ msgstr ""
 "O %1$s '%2$s' foi adicionado em %3$s desde o ano %4$d (%5$s), aplicável ao "
 "ano %6$d."
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -328,7 +328,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -346,16 +346,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "O %1$s '%2$s' é suplantado pelo %3$s '%4$s' no ano %5$d."
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Constituição Apostólica Missale Romanum"
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -375,7 +375,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -390,7 +390,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -400,17 +400,17 @@ msgstr ""
 "reduzidas a memórias opcionais (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr "antes"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr "após"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -420,7 +420,7 @@ msgstr ""
 "festividade com a chave '%2$s' usando as palavras-chave %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -429,7 +429,7 @@ msgstr ""
 "chave '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -439,7 +439,7 @@ msgstr ""
 "'strtotime' é um objeto, deve ter propriedades %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -449,7 +449,7 @@ msgstr ""
 "deve ser um objeto ou uma string! Atualmente tem o tipo '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -464,7 +464,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -481,7 +481,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -498,7 +498,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -513,7 +513,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -522,7 +522,7 @@ msgstr ""
 "'%1$s' foi declarado Doutor da Igreja desde o ano %2$d, aplicável ao ano "
 "%3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "e Doutor da Igreja"
 
@@ -536,7 +536,7 @@ msgstr "e Doutor da Igreja"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -555,7 +555,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -565,7 +565,7 @@ msgstr ""
 "%6$s desde o ano %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -575,7 +575,7 @@ msgstr ""
 "agosto desde o ano de 2002 (%2$s), aplicável ao ano %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -586,7 +586,7 @@ msgstr ""
 "ou solenidade se fosse em 12 de dezembro, foi transferida para 12 de agosto "
 "desde o ano de 2002 (%2$s), aplicável ao ano %3$d."
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -598,7 +598,7 @@ msgstr ""
 "substituída por um domingo, uma solenidade ou uma festa '%4$s' no ano %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -610,26 +610,26 @@ msgstr ""
 "mas sendo o Ano do Apóstolo Paulo, conforme o %2$s, foi restabelecida para "
 "que as igrejas locais possam opcionalmente celebrar a memória."
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "da %s Semana da Páscoa"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "da %s Semana do Tempo Comum"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memória de Sábado da Bem-Aventurada Virgem Maria"
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr "Erro ao recuperar e decodificar dados da Região Ampla do arquivo %s."
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -637,7 +637,7 @@ msgstr ""
 "Não foi possível encontrar uma propriedade %1$s no %2$s para o Calendário "
 "Nacional %3$s."
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, fuzzy, php-format
 #| msgid "Error retrieving and decoding National data from file %s."
 msgid "Error retrieving and decoding National Calendar data from file %s."
@@ -652,7 +652,7 @@ msgstr "Erro ao recuperar e decodificar dados Nacionais do arquivo %s."
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -672,7 +672,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -689,7 +689,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -699,7 +699,7 @@ msgstr ""
 "reduzidas a memórias opcionais."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -709,7 +709,7 @@ msgstr ""
 "'%3$s' no ano %4$d! Algo precisa ser feito sobre isso?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -719,7 +719,7 @@ msgstr ""
 "A Solenidade '%1$s', geralmente celebrada em %2$s, coincide com o Domingo ou "
 "Solenidade '%3$s' no ano %4$d! Algo precisa ser feito sobre isso?"
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -735,7 +735,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -751,7 +751,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -770,7 +770,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -786,7 +786,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -806,7 +806,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -822,7 +822,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -841,7 +841,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -853,7 +853,7 @@ msgstr ""
 "nova data %2$s parece ser um domingo ou uma festividade de maior importância."
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Arquivo de dados do sanctorale encontrado para %s"
@@ -867,7 +867,7 @@ msgstr "Arquivo de dados do sanctorale encontrado para %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -877,13 +877,13 @@ msgstr ""
 "suplantada pela %5$s '%6$s' no ano %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Não foi possível encontrar um arquivo de dados sanctorale para %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -893,7 +893,7 @@ msgstr ""
 "lugar a '%3$s': aplicável ao ano %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -904,7 +904,7 @@ msgstr ""
 "dar lugar a '%6$s', no entanto é suprimido pelo %7$s '%8$s' no ano %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -916,7 +916,7 @@ msgstr ""
 "feito algo sobre isso?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -925,7 +925,7 @@ msgstr ""
 "A %1$s '%2$s', própria do calendário do %3$s e geralmente celebrada em %4$s, "
 "é suprimida pelo Domingo ou Solenidade %5$s no ano %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/pt/LC_MESSAGES/litcal.po
+++ b/i18n/pt/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Portuguese <https://translate.johnromanodorazio.com/projects/"
@@ -925,7 +925,7 @@ msgstr ""
 "A %1$s '%2$s', própria do calendário do %3$s e geralmente celebrada em %4$s, "
 "é suprimida pelo Domingo ou Solenidade %5$s no ano %6$d"
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/pt/LC_MESSAGES/litcal.po
+++ b/i18n/pt/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Portuguese <https://translate.johnromanodorazio.com/projects/"
@@ -925,7 +925,7 @@ msgstr ""
 "A %1$s '%2$s', própria do calendário do %3$s e geralmente celebrada em %4$s, "
 "é suprimida pelo Domingo ou Solenidade %5$s no ano %6$d"
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/sk/LC_MESSAGES/litcal.po
+++ b/i18n/sk/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-10-03 11:32+0000\n"
 "Last-Translator: Milan Šalka <salka.milan@googlemail.com>\n"
 "Language-Team: Slovak <https://translate.johnromanodorazio.com/projects/"
@@ -924,7 +924,7 @@ msgstr ""
 "Slávnosť %1$s '%2$s', vlastná kalendáru %3$s a zvyčajne slávená %4$s, je v "
 "roku %6$d potlačená nedeľou alebo slávnosťou %5$s"
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/sk/LC_MESSAGES/litcal.po
+++ b/i18n/sk/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-10-03 11:32+0000\n"
 "Last-Translator: Milan Šalka <salka.milan@googlemail.com>\n"
 "Language-Team: Slovak <https://translate.johnromanodorazio.com/projects/"
@@ -19,18 +19,18 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr ""
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -39,7 +39,7 @@ msgstr ""
 "Podporované sú len roky od roku 1970 a neskôr. Skúsili ste požiadať o rok %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -48,24 +48,24 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr ""
 "Vyskytla sa chyba pri pokuse o načítanie lokalizovaných údajov pre Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr "Vyskytla sa chyba pri pokuse dekódovať údaje JSON pre Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr "Vyskytla sa chyba pri pokuse o načítanie údajov pre Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Údaje o sanctorale z %s sa nenašli."
@@ -76,7 +76,7 @@ msgstr "Údaje o sanctorale z %s sa nenašli."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -86,7 +86,7 @@ msgstr ""
 "pre Misál %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Údaje pre Sanctorale z %s sa nenašli."
@@ -95,7 +95,7 @@ msgstr "Údaje pre Sanctorale z %s sa nenašli."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -105,11 +105,11 @@ msgstr ""
 "%1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 msgid "Could not find the Sanctorale data"
 msgstr "Nepodarilo sa nájsť údaje Sanctorale"
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -118,7 +118,7 @@ msgstr ""
 "Vyskytla sa chyba pri pokuse dekódovať prekladové údaje pre Pamätné dni na "
 "základe dekrétov Kongregácie pre Boží kult: %s"
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
 "Congregation for Divine Worship"
@@ -126,7 +126,7 @@ msgstr ""
 "Nepodarilo sa nájsť prekladové údaje pre Pamätné dni založené na dekrétoch "
 "Kongregácie pre Boží kult"
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -137,19 +137,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Vianočný všedný deň"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "alebo"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "Nedeľa Božieho milosrdenstva"
 
@@ -163,8 +163,8 @@ msgstr "Nedeľa Božieho milosrdenstva"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -173,31 +173,31 @@ msgstr ""
 "Slávnosť '%1$s' pripadá na %2$s v roku %3$d, oslava bola presunutá na %4$s "
 "(%5$s) podľa %6$s."
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr "sobota pred Kvetnou nedeľou"
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Dekrét Kongregácie pre Boží kult"
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "pondelok po Druhej veľkonočnej nedeli"
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr "nasledujúci pondelok"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -212,7 +212,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -222,7 +222,7 @@ msgstr ""
 "podľa %4$s presunutá o jeden deň dopredu."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -232,12 +232,12 @@ msgstr ""
 "%4$s namiesto nedele po Vianociach."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Náš Pán Ježiš Kristus, Večný Veľkňaz"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -251,30 +251,30 @@ msgstr ""
 "'%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' je nahradený %2$s '%3$s' v roku %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "týždňa adventu %s"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s deň oktávy Vianoc"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "týždňa pôstu %s"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "po Popolcovej strede"
 
@@ -302,8 +302,8 @@ msgstr "po Popolcovej strede"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -311,7 +311,7 @@ msgid ""
 msgstr ""
 "%1$s '%2$s' bol pridaný dňa %3$s od roku %4$d (%5$s), platný pre rok %6$d."
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -324,7 +324,7 @@ msgstr ""
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -342,16 +342,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "%1$s '%2$s' je nahradený %3$s '%4$s' v roku %5$d."
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apoštolská konštitúcia Missale Romanum"
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -371,7 +371,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -386,7 +386,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -396,17 +396,17 @@ msgstr ""
 "sú znížené na ľubovoľné spomienky (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr "predtým"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr "po"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -416,7 +416,7 @@ msgstr ""
 "slávnosti s kľúčom '%2$s' pomocou kľúčových slov %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
@@ -424,7 +424,7 @@ msgstr ""
 "Nemožno vytvoriť mobilnú slávnosť '%1$s' vzhľadom na slávnosť s kľúčom '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -434,7 +434,7 @@ msgstr ""
 "objektom, musí mať vlastnosti %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -444,7 +444,7 @@ msgstr ""
 "objekt alebo reťazec! Momentálne má typ '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr ""
@@ -458,7 +458,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -475,7 +475,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -492,7 +492,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -507,7 +507,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -516,7 +516,7 @@ msgstr ""
 "'%1$s' bol vyhlásený za učiteľa Cirkvi od roku %2$d, platné pre rok %3$d "
 "(%4$s)."
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "a učiteľ Cirkvi"
 
@@ -530,7 +530,7 @@ msgstr "a učiteľ Cirkvi"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -549,7 +549,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -559,7 +559,7 @@ msgstr ""
 "%7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -569,7 +569,7 @@ msgstr ""
 "roku 2002 (%2$s), platná pre rok %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -580,7 +580,7 @@ msgstr ""
 "slávnosťou, keby bola 12. decembra, bola však od roku 2002 (%2$s) presunutá "
 "na 12. augusta, platná pre rok %3$d."
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -592,7 +592,7 @@ msgstr ""
 "nedeľou, slávnosťou alebo sviatkom '%4$s'."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -604,33 +604,33 @@ msgstr ""
 "avšak keďže je Rok apoštola Pavla, podľa %2$s bol obnovený, aby miestne "
 "cirkvi mohli voliteľne sláviť pamätný deň."
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "týždňa Veľkej noci %s"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "týždňa v období cez rok %s"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Sobotná pamiatka Preblahoslavenej Panny Márie"
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr ""
 "Chyba pri načítaní a dekódovaní údajov z širšieho regiónu zo súboru %s."
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, fuzzy, php-format
 #| msgid "Error retrieving and decoding National data from file %s."
 msgid "Error retrieving and decoding National Calendar data from file %s."
@@ -645,7 +645,7 @@ msgstr "Chyba pri načítaní a dekódovaní národných údajov zo súboru %s."
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -666,7 +666,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -684,7 +684,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -694,7 +694,7 @@ msgstr ""
 "sú znížené na ľubovoľné spomienky."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -704,7 +704,7 @@ msgstr ""
 "sviatkom '%3$s'! Treba s tým niečo urobiť?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -714,7 +714,7 @@ msgstr ""
 "Slávnosť '%1$s', zvyčajne slávená %2$s, sa v roku %4$d zhoduje s nedeľou "
 "alebo slávnosťou '%3$s'! Treba s tým niečo urobiť?"
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -730,7 +730,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -749,7 +749,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -770,7 +770,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -789,7 +789,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -811,7 +811,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -829,7 +829,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -844,7 +844,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -853,7 +853,7 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Našiel som súbor sanctorale pre %s"
@@ -867,7 +867,7 @@ msgstr "Našiel som súbor sanctorale pre %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -877,13 +877,13 @@ msgstr ""
 "'%6$s' v roku %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Nepodarilo sa nájsť súbor sanctorale pre %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -893,7 +893,7 @@ msgstr ""
 "pre '%3$s': platné pre rok %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -904,7 +904,7 @@ msgstr ""
 "miesto pre '%6$s', avšak je potlačený %7$s '%8$s' v roku %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -915,7 +915,7 @@ msgstr ""
 "%5$d zhoduje s nedeľou alebo slávnosťou '%4$s'! Treba s tým niečo urobiť?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -924,7 +924,7 @@ msgstr ""
 "Slávnosť %1$s '%2$s', vlastná kalendáru %3$s a zvyčajne slávená %4$s, je v "
 "roku %6$d potlačená nedeľou alebo slávnosťou %5$s"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/sk/LC_MESSAGES/litcal.po
+++ b/i18n/sk/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-10-03 11:32+0000\n"
 "Last-Translator: Milan Šalka <salka.milan@googlemail.com>\n"
 "Language-Team: Slovak <https://translate.johnromanodorazio.com/projects/"
@@ -924,7 +924,7 @@ msgstr ""
 "Slávnosť %1$s '%2$s', vlastná kalendáru %3$s a zvyčajne slávená %4$s, je v "
 "roku %6$d potlačená nedeľou alebo slávnosťou %5$s"
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/vi/LC_MESSAGES/litcal.po
+++ b/i18n/vi/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-22 06:46+0000\n"
+"POT-Creation-Date: 2025-01-25 15:13+0000\n"
 "PO-Revision-Date: 2024-10-03 13:34+0000\n"
 "Last-Translator: OpenAI <noreply-mt-openai@weblate.org>\n"
 "Language-Team: Vietnamese <https://translate.johnromanodorazio.com/projects/"
@@ -923,7 +923,7 @@ msgstr ""
 "Lễ %1$s '%2$s', thuộc lịch của %3$s và thường được cử hành vào %4$s, bị thay "
 "thế bởi Chủ nhật hoặc Lễ trọng %5$s trong năm %6$d"
 
-#: src/Paths/Calendar.php:4654
+#: src/Paths/Calendar.php:4652
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/vi/LC_MESSAGES/litcal.po
+++ b/i18n/vi/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-01-25 15:13+0000\n"
+"POT-Creation-Date: 2025-01-25 15:28+0000\n"
 "PO-Revision-Date: 2024-10-03 13:34+0000\n"
 "Last-Translator: OpenAI <noreply-mt-openai@weblate.org>\n"
 "Language-Team: Vietnamese <https://translate.johnromanodorazio.com/projects/"
@@ -923,7 +923,7 @@ msgstr ""
 "Lễ %1$s '%2$s', thuộc lịch của %3$s và thường được cử hành vào %4$s, bị thay "
 "thế bởi Chủ nhật hoặc Lễ trọng %5$s trong năm %6$d"
 
-#: src/Paths/Calendar.php:4652
+#: src/Paths/Calendar.php:4653
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""

--- a/i18n/vi/LC_MESSAGES/litcal.po
+++ b/i18n/vi/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-29 14:59+0000\n"
+"POT-Creation-Date: 2025-01-22 06:46+0000\n"
 "PO-Revision-Date: 2024-10-03 13:34+0000\n"
 "Last-Translator: OpenAI <noreply-mt-openai@weblate.org>\n"
 "Language-Team: Vietnamese <https://translate.johnromanodorazio.com/projects/"
@@ -19,18 +19,18 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:619
+#: src/Paths/Calendar.php:623
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:654
+#: src/Paths/Calendar.php:658
 #, php-format
 msgid "The Diocesan calendar \"%s\" was not found in the index file."
 msgstr ""
 
-#: src/Paths/Calendar.php:750
+#: src/Paths/Calendar.php:754
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -38,7 +38,7 @@ msgid ""
 msgstr "Chỉ hỗ trợ từ năm 1970 trở về sau. Bạn đã yêu cầu năm %d."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:782
+#: src/Paths/Calendar.php:786
 #, php-format
 msgid ""
 "There was an error trying to decode localized JSON data for the Temporale: %s"
@@ -47,23 +47,23 @@ msgstr ""
 "Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:789
+#: src/Paths/Calendar.php:793
 msgid "There was an error trying to retrieve localized data for the Temporale."
 msgstr "Đã xảy ra lỗi khi cố gắng truy xuất dữ liệu bản địa hóa cho Temporale."
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:822
+#: src/Paths/Calendar.php:826
 #, php-format
 msgid "There was an error trying to decode JSON data for the Temporale: %s"
 msgstr "Đã xảy ra lỗi khi cố gắng giải mã dữ liệu JSON cho Temporale: %s"
 
 #. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:829
+#: src/Paths/Calendar.php:833
 msgid "There was an error trying to retrieve data for the Temporale."
 msgstr "Đã xảy ra lỗi khi cố gắng truy xuất dữ liệu cho Temporale."
 
 #. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:857
+#: src/Paths/Calendar.php:861
 #, fuzzy, php-format
 msgid "Translation data for the sanctorale from %s could not be found."
 msgstr "Không tìm thấy dữ liệu dịch cho sanctorale từ %s."
@@ -74,7 +74,7 @@ msgstr "Không tìm thấy dữ liệu dịch cho sanctorale từ %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:876
+#: src/Paths/Calendar.php:880
 #, php-format
 msgid ""
 "There was an error trying to decode JSON localization data for the "
@@ -84,7 +84,7 @@ msgstr ""
 "lễ %1$s: %2$s"
 
 #. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:885
+#: src/Paths/Calendar.php:889
 #, php-format
 msgid "Data for the Sanctorale from %s could not be found."
 msgstr "Không tìm thấy dữ liệu cho Sanctorale từ %s."
@@ -93,7 +93,7 @@ msgstr "Không tìm thấy dữ liệu cho Sanctorale từ %s."
 #.  1: name of the Roman Missal
 #.  2: error message
 #.
-#: src/Paths/Calendar.php:909
+#: src/Paths/Calendar.php:913
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for the Sanctorale for the "
@@ -103,11 +103,11 @@ msgstr ""
 "%1$s: %2$s."
 
 #. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:917
+#: src/Paths/Calendar.php:921
 msgid "Could not find the Sanctorale data"
 msgstr "Không thể tìm thấy dữ liệu Sanctorale"
 
-#: src/Paths/Calendar.php:943
+#: src/Paths/Calendar.php:947
 #, fuzzy, php-format
 msgid ""
 "There was an error trying to decode translation data for Memorials based on "
@@ -116,7 +116,7 @@ msgstr ""
 "Đã xảy ra lỗi khi cố gắng giải mã dữ liệu dịch thuật cho Lễ nhớ dựa trên Sắc "
 "lệnh của Thánh bộ Phụng tự: %s"
 
-#: src/Paths/Calendar.php:949
+#: src/Paths/Calendar.php:953
 #, fuzzy
 msgid ""
 "Could not find translation data for Memorials based on Decrees of the "
@@ -125,7 +125,7 @@ msgstr ""
 "Không tìm thấy dữ liệu dịch thuật cho Lễ nhớ dựa trên Sắc lệnh của Thánh bộ "
 "Phụng tự"
 
-#: src/Paths/Calendar.php:958
+#: src/Paths/Calendar.php:962
 #, php-format
 msgid ""
 "There was an error trying to decode JSON data for Memorials based on Decrees "
@@ -136,19 +136,19 @@ msgstr ""
 
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1108 src/Paths/Calendar.php:1159
+#: src/Paths/Calendar.php:1112 src/Paths/Calendar.php:1163
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Ngày trong tuần Giáng Sinh"
 
 #. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
 #. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1282 src/Enum/LitCommon.php:424
+#: src/Paths/Calendar.php:1286 src/Enum/LitCommon.php:424
 msgid "or"
 msgstr "hoặc"
 
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1286
+#: src/Paths/Calendar.php:1290
 msgid "Divine Mercy Sunday"
 msgstr "Chúa Nhật Lòng Thương Xót Chúa"
 
@@ -162,8 +162,8 @@ msgstr "Chúa Nhật Lòng Thương Xót Chúa"
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1455 src/Paths/Calendar.php:1475
-#: src/Paths/Calendar.php:1525
+#: src/Paths/Calendar.php:1459 src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1529
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -172,31 +172,31 @@ msgstr ""
 "Lễ Trọng '%1$s' rơi vào ngày %2$s trong năm %3$d, lễ kỷ niệm đã được chuyển "
 "sang ngày %4$s (%5$s) theo %6$s."
 
-#: src/Paths/Calendar.php:1459
+#: src/Paths/Calendar.php:1463
 msgid "the Saturday preceding Palm Sunday"
 msgstr "thứ Bảy trước Chúa Nhật Lễ Lá"
 
-#: src/Paths/Calendar.php:1467 src/Paths/Calendar.php:1487
-#: src/Paths/Calendar.php:1536 src/Paths/Calendar.php:1565
-#: src/Paths/Calendar.php:2080 src/Paths/Calendar.php:2294
-#: src/Paths/Calendar.php:2362 src/Paths/Calendar.php:2706
-#: src/Paths/Calendar.php:2776 src/Paths/Calendar.php:2815
-#: src/Paths/Calendar.php:2947 src/Paths/Calendar.php:2962
-#: src/Paths/Calendar.php:2979 src/Paths/Calendar.php:3020
+#: src/Paths/Calendar.php:1471 src/Paths/Calendar.php:1491
+#: src/Paths/Calendar.php:1540 src/Paths/Calendar.php:1569
+#: src/Paths/Calendar.php:2084 src/Paths/Calendar.php:2298
+#: src/Paths/Calendar.php:2366 src/Paths/Calendar.php:2710
+#: src/Paths/Calendar.php:2780 src/Paths/Calendar.php:2819
+#: src/Paths/Calendar.php:2951 src/Paths/Calendar.php:2966
+#: src/Paths/Calendar.php:2983 src/Paths/Calendar.php:3024
 #: src/FestivityCollection.php:920
 msgid "Decree of the Congregation for Divine Worship"
 msgstr "Sắc lệnh của Bộ Phụng tự và Kỷ luật Bí tích"
 
-#: src/Paths/Calendar.php:1479
+#: src/Paths/Calendar.php:1483
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "thứ Hai sau Chúa nhật thứ Hai Phục Sinh"
 
-#: src/Paths/Calendar.php:1529
+#: src/Paths/Calendar.php:1533
 msgid "the following Monday"
 msgstr "thứ Hai tiếp theo"
 
 #. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1543
+#: src/Paths/Calendar.php:1547
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -211,7 +211,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1576
+#: src/Paths/Calendar.php:1580
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -221,7 +221,7 @@ msgstr ""
 "lên một ngày theo %4$s."
 
 #. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1680
+#: src/Paths/Calendar.php:1684
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -231,12 +231,12 @@ msgstr ""
 "%4$s thay vì vào Chủ nhật sau Giáng Sinh."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1711
+#: src/Paths/Calendar.php:1715
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Chúa Giêsu Kitô, Thượng Tế Vĩnh Cửu"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1716
+#: src/Paths/Calendar.php:1720
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -250,30 +250,30 @@ msgstr ""
 "'%2$d' (%3$s)."
 
 #. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1768 src/Paths/Calendar.php:1809
+#: src/Paths/Calendar.php:1772 src/Paths/Calendar.php:1813
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' bị thay thế bởi %2$s '%3$s' trong năm %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1896
+#: src/Paths/Calendar.php:1900
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "của Tuần %s Mùa Vọng"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1935
+#: src/Paths/Calendar.php:1939
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "Ngày %s trong Tuần Bát Nhật Giáng Sinh"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1978
+#: src/Paths/Calendar.php:1982
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "của Tuần %s Mùa Chay"
 
-#: src/Paths/Calendar.php:1988
+#: src/Paths/Calendar.php:1992
 msgid "after Ash Wednesday"
 msgstr "sau Lễ Tro"
 
@@ -301,8 +301,8 @@ msgstr "sau Lễ Tro"
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2019 src/Paths/Calendar.php:2503
-#: src/Paths/Calendar.php:2787 src/Paths/Calendar.php:3534
+#: src/Paths/Calendar.php:2023 src/Paths/Calendar.php:2507
+#: src/Paths/Calendar.php:2791 src/Paths/Calendar.php:3538
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -311,7 +311,7 @@ msgstr ""
 "%1$s '%2$s' đã được thêm vào ngày %3$s kể từ năm %4$d (%5$s), áp dụng cho "
 "năm %6$d."
 
-#: src/Paths/Calendar.php:2065 src/Paths/Calendar.php:2227
+#: src/Paths/Calendar.php:2069 src/Paths/Calendar.php:2231
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -322,7 +322,7 @@ msgstr "Họp báo Vatican: Trình bày Editio Typica Tertia của Sách lễ R�
 #.  2. Name of the festivity
 #.  3. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2121
+#: src/Paths/Calendar.php:2125
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -340,16 +340,16 @@ msgstr ""
 #.  4. Name of the festivity that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2149 src/Paths/Calendar.php:2191
+#: src/Paths/Calendar.php:2153 src/Paths/Calendar.php:2195
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "%1$s '%2$s' bị thay thế bởi %3$s '%4$s' trong năm %5$d."
 
-#: src/Paths/Calendar.php:2221
+#: src/Paths/Calendar.php:2225
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Hiến chế Tông đồ Missale Romanum"
 
-#: src/Paths/Calendar.php:2247
+#: src/Paths/Calendar.php:2251
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -369,7 +369,7 @@ msgstr ""
 #.  7. Name of the superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2308
+#: src/Paths/Calendar.php:2312
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -384,7 +384,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2357
+#: src/Paths/Calendar.php:2361
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -394,17 +394,17 @@ msgstr ""
 "giảm cấp xuống thành lễ nhớ tùy chọn (%4$s)."
 
 #. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2399
+#: src/Paths/Calendar.php:2403
 msgid "before"
 msgstr "trước"
 
 #. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2404
+#: src/Paths/Calendar.php:2408
 msgid "after"
 msgstr "sau"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2409 src/Paths/Calendar.php:4184
+#: src/Paths/Calendar.php:2413 src/Paths/Calendar.php:4188
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': can only be relative to festivity "
@@ -414,14 +414,14 @@ msgstr ""
 "bằng cách sử dụng từ khóa %3$s"
 
 #. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2426 src/Paths/Calendar.php:4166
+#: src/Paths/Calendar.php:2430 src/Paths/Calendar.php:4170
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
 msgstr "Không thể tạo lễ di động '%1$s' liên quan đến lễ có khóa '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2434 src/Paths/Calendar.php:4155
+#: src/Paths/Calendar.php:2438 src/Paths/Calendar.php:4159
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
@@ -431,7 +431,7 @@ msgstr ""
 "tượng, nó phải có các thuộc tính %2$s"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2454 src/Paths/Calendar.php:4288
+#: src/Paths/Calendar.php:2458 src/Paths/Calendar.php:4292
 #, php-format
 msgid ""
 "Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
@@ -441,7 +441,7 @@ msgstr ""
 "tượng hoặc một chuỗi! Hiện tại nó có kiểu '%2$s'"
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2462
+#: src/Paths/Calendar.php:2466
 #, php-format
 msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
 msgstr "Không thể tạo lễ di động '%1$s' mà không có thuộc tính 'strtotime'!"
@@ -454,7 +454,7 @@ msgstr "Không thể tạo lễ di động '%1$s' mà không có thuộc tính '
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2562
+#: src/Paths/Calendar.php:2566
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -471,7 +471,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2584
+#: src/Paths/Calendar.php:2588
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -488,7 +488,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2594
+#: src/Paths/Calendar.php:2598
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -503,7 +503,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2643
+#: src/Paths/Calendar.php:2647
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -512,7 +512,7 @@ msgstr ""
 "'%1$s' đã được tuyên bố là Tiến sĩ Hội Thánh từ năm %2$d, áp dụng cho năm "
 "%3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2651
+#: src/Paths/Calendar.php:2655
 msgid "and Doctor of the Church"
 msgstr "và Tiến sĩ Hội Thánh"
 
@@ -526,7 +526,7 @@ msgstr "và Tiến sĩ Hội Thánh"
 #.  7. Name of superseding festivity
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2836
+#: src/Paths/Calendar.php:2840
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -545,7 +545,7 @@ msgstr ""
 #.  7. Year from which the festivity has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2863
+#: src/Paths/Calendar.php:2867
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -555,7 +555,7 @@ msgstr ""
 "kể từ năm %7$d (%8$s)."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2944
+#: src/Paths/Calendar.php:2948
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -565,7 +565,7 @@ msgstr ""
 "tháng 8 kể từ năm 2002 (%2$s), áp dụng cho năm %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2959
+#: src/Paths/Calendar.php:2963
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -576,7 +576,7 @@ msgstr ""
 "Lễ trọng nếu nó vào ngày 12 tháng 12, tuy nhiên đã được chuyển sang ngày 12 "
 "tháng 8 kể từ năm 2002 (%2$s), áp dụng cho năm %3$d."
 
-#: src/Paths/Calendar.php:2976
+#: src/Paths/Calendar.php:2980
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -588,7 +588,7 @@ msgstr ""
 "một Chúa Nhật, một Lễ Trọng, hoặc một Lễ Kính '%4$s' vào năm %3$d."
 
 #. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3017
+#: src/Paths/Calendar.php:3021
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -600,32 +600,32 @@ msgstr ""
 "do là Năm của Tông đồ Phaolô, theo %2$s nó đã được khôi phục để các nhà thờ "
 "địa phương có thể tùy chọn cử hành lễ nhớ."
 
-#: src/Paths/Calendar.php:3052
+#: src/Paths/Calendar.php:3056
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "của Tuần %s Phục Sinh"
 
-#: src/Paths/Calendar.php:3097 src/Paths/Calendar.php:3138
+#: src/Paths/Calendar.php:3101 src/Paths/Calendar.php:3142
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "của Tuần %s Thường Niên"
 
-#: src/Paths/Calendar.php:3164
+#: src/Paths/Calendar.php:3168
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Lễ nhớ Thứ Bảy Đức Mẹ"
 
-#: src/Paths/Calendar.php:3187
+#: src/Paths/Calendar.php:3191
 #, php-format
 msgid "Error retrieving and decoding Wider Region data from file %s."
 msgstr "Lỗi khi truy xuất và giải mã dữ liệu Vùng Rộng từ tệp %s."
 
-#: src/Paths/Calendar.php:3232
+#: src/Paths/Calendar.php:3236
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3240
+#: src/Paths/Calendar.php:3244
 #, fuzzy, php-format
 #| msgid "Error retrieving and decoding National data from file %s."
 msgid "Error retrieving and decoding National Calendar data from file %s."
@@ -640,7 +640,7 @@ msgstr "Lỗi khi truy xuất và giải mã dữ liệu Quốc gia từ tệp %
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3290
+#: src/Paths/Calendar.php:3294
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -662,7 +662,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3310
+#: src/Paths/Calendar.php:3314
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -681,7 +681,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3408
+#: src/Paths/Calendar.php:3412
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -691,7 +691,7 @@ msgstr ""
 "đều bị giảm cấp xuống thành lễ kỷ niệm tùy chọn."
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3430
+#: src/Paths/Calendar.php:3434
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -701,7 +701,7 @@ msgstr ""
 "năm %4$d! Có cần làm gì về điều này không?"
 
 #. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3444
+#: src/Paths/Calendar.php:3448
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -711,7 +711,7 @@ msgstr ""
 "Lễ trọng '%1$s', thường được cử hành vào %2$s, trùng với Chủ nhật hoặc Lễ "
 "trọng '%3$s' trong năm %4$d! Có cần làm gì về điều này không?"
 
-#: src/Paths/Calendar.php:3488
+#: src/Paths/Calendar.php:3492
 msgid ""
 "We should be creating a new festivity, however we do not seem to have the "
 "correct date information in order to proceed"
@@ -727,7 +727,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3601
+#: src/Paths/Calendar.php:3605
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -746,7 +746,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3619
+#: src/Paths/Calendar.php:3623
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -767,7 +767,7 @@ msgstr ""
 #.  5. Year from which the grade has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3640
+#: src/Paths/Calendar.php:3644
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -786,7 +786,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3658
+#: src/Paths/Calendar.php:3662
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -808,7 +808,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3690
+#: src/Paths/Calendar.php:3694
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -827,7 +827,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3709
+#: src/Paths/Calendar.php:3713
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -842,7 +842,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3728
+#: src/Paths/Calendar.php:3732
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -851,7 +851,7 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3763
+#: src/Paths/Calendar.php:3767
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Tìm thấy tệp dữ liệu sanctorale cho %s"
@@ -865,7 +865,7 @@ msgstr "Tìm thấy tệp dữ liệu sanctorale cho %s"
 #.  6. Superseding festivity name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3812
+#: src/Paths/Calendar.php:3816
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -875,13 +875,13 @@ msgstr ""
 "bởi %5$s '%6$s' trong năm %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3827
+#: src/Paths/Calendar.php:3831
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Không thể tìm thấy tệp dữ liệu sanctorale cho %s"
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3923
+#: src/Paths/Calendar.php:3927
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -891,7 +891,7 @@ msgstr ""
 "'%3$s': áp dụng cho năm %4$d."
 
 #. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3946
+#: src/Paths/Calendar.php:3950
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -902,7 +902,7 @@ msgstr ""
 "'%6$s', tuy nhiên nó bị thay thế bởi %7$s '%8$s' vào năm %9$d."
 
 #. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4348
+#: src/Paths/Calendar.php:4352
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -914,7 +914,7 @@ msgstr ""
 "không?"
 
 #. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4382
+#: src/Paths/Calendar.php:4386
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
@@ -923,7 +923,7 @@ msgstr ""
 "Lễ %1$s '%2$s', thuộc lịch của %3$s và thường được cử hành vào %4$s, bị thay "
 "thế bởi Chủ nhật hoặc Lễ trọng %5$s trong năm %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/Calendar.php:4654
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""


### PR DESCRIPTION
Translations update from [JohnRDOrazio Weblate](https://translate.johnromanodorazio.com) for [Liturgical Calendar/Proprium de Tempore](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-tempore/).


It also includes following components:

* [Liturgical Calendar/Patron saints of Europe](https://translate.johnromanodorazio.com/projects/liturgical-calendar/patron-saints-of-europe/)

* [Liturgical Calendar/Proprium de Sanctis 2008](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-2008/)

* [Liturgical Calendar/Proprium de Sanctis 1970](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-1970/)

* [Liturgical Calendar/Memorials from Decrees](https://translate.johnromanodorazio.com/projects/liturgical-calendar/memorials-from-decrees/)

* [Liturgical Calendar/Proprium de Sanctis 2002](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-2002/)

* [Liturgical Calendar/API strings](https://translate.johnromanodorazio.com/projects/liturgical-calendar/api-strings/)



Current translation status:

![Weblate translation status](https://translate.johnromanodorazio.com/widget/liturgical-calendar/proprium-de-tempore/horizontal-auto.svg)