### PR TITLE
Translations update from JohnRDOrazio Weblate

### DIFF
--- a/jsondata/sourcedata/calendars/wider_regions/Europe/i18n/hr_HR.json
+++ b/jsondata/sourcedata/calendars/wider_regions/Europe/i18n/hr_HR.json
@@ -1,7 +1,7 @@
 {
-    "StBenedict": "",
-    "StsCyrilMethodius": "",
-    "StBridget": "",
-    "StCatherineSiena": "",
-    "StEdithStein": ""
+    "StBenedict": "sveti Benedikt, opat, zaštitnik Europe",
+    "StsCyrilMethodius": "sveti Ćiril, monah, i Metod, biskup, zaštitnici Europe",
+    "StBridget": "sveta Brigita, redovnica, zaštitnica Europe",
+    "StCatherineSiena": "sveta Katarina Sijenska, djevica i crkvena naučiteljica, zaštitnica Europe",
+    "StEdithStein": "sveta Terezija Benedikta od Križa, djevica i mučenica, zaštitnica Europe"
 }

--- a/jsondata/sourcedata/missals/propriumdesanctis_2008/i18n/hr.json
+++ b/jsondata/sourcedata/missals/propriumdesanctis_2008/i18n/hr.json
@@ -1,0 +1,5 @@
+{
+    "StPioPietrelcina": "",
+    "LadyGuadalupe": "",
+    "JuanDiego": ""
+}


### PR DESCRIPTION
Translations update from [JohnRDOrazio Weblate](https://translate.johnromanodorazio.com) for [Liturgical Calendar/Proprium de Tempore](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-tempore/).


It also includes following components:

* [Liturgical Calendar/Patron saints of Europe](https://translate.johnromanodorazio.com/projects/liturgical-calendar/patron-saints-of-europe/)

* [Liturgical Calendar/Proprium de Sanctis 2008](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-2008/)

* [Liturgical Calendar/Proprium de Sanctis 1970](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-1970/)

* [Liturgical Calendar/Memorials from Decrees](https://translate.johnromanodorazio.com/projects/liturgical-calendar/memorials-from-decrees/)

* [Liturgical Calendar/Proprium de Sanctis 2002](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-2002/)

* [Liturgical Calendar/API strings](https://translate.johnromanodorazio.com/projects/liturgical-calendar/api-strings/)



Current translation status:

![Weblate translation status](https://translate.johnromanodorazio.com/widget/liturgical-calendar/proprium-de-tempore/horizontal-auto.svg)