### PR TITLE
Translations update from JohnRDOrazio Weblate

### DIFF
--- a/i18n/de/LC_MESSAGES/litcal.po
+++ b/i18n/de/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: German <https://translate.johnromanodorazio.com/projects/"
@@ -22,7 +22,724 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "grün"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "violett"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "weiß"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "rot"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "rosa"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Eigen"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Kirchweihe"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Selige Jungfrau Maria"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Märtyrer"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Pastoren"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Kirchenlehrer"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Jungfrauen"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Heilige Männer und Frauen"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Für einen Märtyrer"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Für mehrere Märtyrer"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Für missionarische Märtyrer"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Für einen missionarischen Märtyrer"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Für mehrere missionarische Märtyrer"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Für eine jungfräuliche Märtyrerin"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Für eine heilige Märtyrerin"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Für einen Papst"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Für einen Bischof"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Für einen Pfarrer"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Für mehrere Hirten"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Für Gründer einer Kirche"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Für einen Gründer"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Für mehrere Gründer"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Für Missionare"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Für eine Jungfrau"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Für mehrere Jungfrauen"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Für mehrere Heilige"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Für einen Heiligen"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Für einen Abt"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Für einen Mönch"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Für eine Nonne"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Für Ordensleute"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Für diejenigen, die Werke der Barmherzigkeit praktizierten"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Für Erzieher"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Für heilige Frauen"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr "des"
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr "von"
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr "von"
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr "der"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "Wochentag"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+#, fuzzy
+#| msgid "Commemoration"
+msgid "commemoration"
+msgstr "Gedächtnis"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+#, fuzzy
+#| msgid "Optional memorial"
+msgid "optional memorial"
+msgstr "Nichtgebotener Gedenktag"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Gedenktag"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "FEST"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "FEST DES HERRN"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "HOCHFEST"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "Feier mit Vorrang vor Hochfesten"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "und Kirchenlehrer"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Für einen Papst"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Für einen Bischof"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Für Gründer einer Kirche"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Für einen Heiligen"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Für Ordensleute"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "%s Tag der Oktav von Weihnachten"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Für eine Nonne"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Für einen Märtyrer"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Für Erzieher"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Für einen Märtyrer"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Für eine Jungfrau"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Für einen Heiligen"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Für einen Heiligen"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr "Advent"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr "Weihnachten"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr "Fastenzeit"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr "Österliches Triduum"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr "Osterzeit"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr "Gewöhnliche Zeit"
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "Aus dem Gemeinsamen"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "oder"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "JAHR"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Vigilmesse"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+"Die Vigilmesse für den %1$s '%2$s' fällt im Jahr %5$d mit dem %3$s '%4$s' "
+"zusammen. Gemäß %6$s hat der erste Vorrang, daher wird die Vigilmesse sowie "
+"die I. Vesper bestätigt."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr "Dekret der Kongregation für den Gottesdienst"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+"Die Vigilmesse für das %1$s '%2$s' fällt im Jahr %5$d mit dem %3$s '%4$s' "
+"zusammen. Da die erste Feierlichkeit Vorrang hat, wird sie Vesper I und eine "
+"Vigilmesse haben, während die letzte Feierlichkeit weder Vesper II noch eine "
+"Abendmesse haben wird."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+"Die Vigilmesse für das %1$s '%2$s' fällt im Jahr %5$d mit dem %3$s '%4$s' "
+"zusammen. Diese letzte Feierlichkeit hat Vorrang, daher wird sie Vesper II "
+"und eine Abendmesse beibehalten, während die erste Feierlichkeit keine "
+"Vigilmesse oder Vesper I haben wird."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+"Die Vigilmesse für den %1$s '%2$s' fällt im Jahr %5$d mit dem %3$s '%4$s' "
+"zusammen. Wir sollten die Kongregation für den Gottesdienst fragen, was zu "
+"tun ist!"
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
@@ -30,12 +747,7 @@ msgstr ""
 "Der Name der Diözese konnte nicht aus der Diözesen-ID \"%s\" abgeleitet "
 "werden."
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr "Der Diözesankalender \"%s\" wurde nicht in der Indexdatei gefunden."
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -44,140 +756,30 @@ msgstr ""
 "Nur Jahre ab 1970 werden unterstützt. Du hast versucht, das Jahr %d "
 "anzufordern."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-"Beim Versuch, lokalisierte JSON-Daten für das Temporale zu dekodieren, ist "
-"ein Fehler aufgetreten: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-"Beim Versuch, lokalisierte Daten für das Temporale abzurufen, ist ein Fehler "
-"aufgetreten."
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-"Beim Versuch, JSON-Daten für das Temporale zu dekodieren, ist ein Fehler "
-"aufgetreten: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-"Beim Versuch, Daten für das Temporale abzurufen, ist ein Fehler aufgetreten."
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr ""
-"Übersetzungsdaten für das Sanctorale von %s konnten nicht gefunden werden."
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-"Beim Versuch, JSON-Lokalisierungsdaten für das Sanctorale des Messbuchs %1$s "
-"zu dekodieren, ist ein Fehler aufgetreten: %2$s"
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr "Daten für das Sanctorale von %s konnten nicht gefunden werden."
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-"Beim Versuch, JSON-Daten für das Sanctorale des Messbuchs %1$s zu "
-"dekodieren, ist ein Fehler aufgetreten: %2$s."
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr "Konnte die Sanctorale-Daten nicht finden"
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-"Beim Versuch, Übersetzungsdaten für Gedenktage basierend auf Dekreten der "
-"Kongregation für den Gottesdienst zu dekodieren, ist ein Fehler aufgetreten: "
-"%s"
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-"Konnte keine Übersetzungsdaten für Gedenktage basierend auf Dekreten der "
-"Kongregation für den Gottesdienst finden"
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-"Beim Versuch, JSON-Daten für Gedenktage basierend auf Dekreten der "
-"Kongregation für den Gottesdienst zu dekodieren, ist ein Fehler aufgetreten: "
-"%s"
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Wochentag in der Weihnachtszeit"
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "oder"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Barmherzigkeitssonntag"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -186,31 +788,20 @@ msgstr ""
 "Das Hochfest '%1$s' fällt im Jahr %3$d auf den %2$s, die Feier wurde auf den "
 "%4$s (%5$s) gemäß dem %6$s verschoben."
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr "der Samstag vor dem Palmsonntag"
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr "Dekret der Kongregation für den Gottesdienst"
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "der Montag nach dem zweiten Sonntag der Osterzeit"
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr "der folgende Montag"
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -226,7 +817,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -236,7 +827,7 @@ msgstr ""
 "zusammenfällt, wurde sie gemäß %4$s um einen Tag vorverlegt."
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -246,12 +837,12 @@ msgstr ""
 "%4$s und nicht am Sonntag nach Weihnachten gefeiert."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Unser Herr Jesus Christus, der ewige Hohepriester"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -265,59 +856,59 @@ msgstr ""
 "aufzunehmen: anwendbar für den Kalender '%1$s' im Jahr '%2$d' (%3$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' wird im Jahr %4$d durch den %2$s '%3$s' ersetzt."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "der %s Woche des Advents"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Tag der Oktav von Weihnachten"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "der %s Woche der Fastenzeit"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "nach Aschermittwoch"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -326,7 +917,7 @@ msgstr ""
 "Der %1$s '%2$s' wurde seit dem Jahr %4$d (%5$s) am %3$s hinzugefügt, "
 "anwendbar für das Jahr %6$d."
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -334,12 +925,7 @@ msgstr ""
 "Vatikanische Pressekonferenz: Vorstellung der Editio Typica Tertia des "
 "Römischen Messbuchs"
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -351,22 +937,33 @@ msgstr ""
 "%3$d, Rang herabgestuft zu Gedenken."
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "Der %1$s '%2$s' wird im Jahr %5$d durch den %3$s '%4$s' verdrängt."
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apostolische Konstitution Missale Romanum"
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -378,16 +975,16 @@ msgstr ""
 "Jahr %9$d durch das %7$s '%8$s' unterdrückt."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -402,7 +999,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -411,72 +1008,42 @@ msgstr ""
 "Das Gedenktag '%1$s' fällt im Jahr %3$d mit einem anderen Gedenktag '%2$s' "
 "zusammen. Beide werden zu fakultativen Gedenktagen herabgestuft (%4$s)."
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr "vor"
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr "nach"
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 "Kann mobile Festlichkeit '%1$s' nicht erstellen: kann nur relativ zur "
 "Festlichkeit mit Schlüssel '%2$s' unter Verwendung der Schlüsselwörter %3$s "
 "sein"
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 "Kann das mobile Festivität '%1$s' relativ zum Festivität mit dem Schlüssel "
 "'%2$s', nicht erstellen"
 
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-"Kann mobile Festlichkeit '%1$s' nicht erstellen: wenn die 'strtotime'-"
-"Eigenschaft ein Objekt ist, muss sie Eigenschaften %2$s haben"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-"Kann mobile Festlichkeit '%1$s' nicht erstellen: 'strtotime'-Eigenschaft "
-"muss entweder ein Objekt oder ein String sein! Derzeit hat es den Typ '%2$s'"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
-msgstr ""
-"Kann mobile Festlichkeit '%1$s' ohne 'strtotime'-Eigenschaft nicht erstellen!"
-
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -486,14 +1053,14 @@ msgstr ""
 "anwendbar für das Jahr %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -503,14 +1070,14 @@ msgstr ""
 "anwendbar für das Jahr %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -520,12 +1087,12 @@ msgstr ""
 "anwendbar auf das Jahr %5$d (%6$s)."
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -534,21 +1101,17 @@ msgstr ""
 "'%1$s' wurde seit dem Jahr %2$d zum Kirchenlehrer erklärt, gültig für das "
 "Jahr %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "und Kirchenlehrer"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -559,15 +1122,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -577,7 +1140,7 @@ msgstr ""
 "seit dem Jahr %7$d (%8$s) am %6$s hinzugefügt wurde."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -587,7 +1150,7 @@ msgstr ""
 "Dezember auf den 12. August verlegt, anwendbar für das Jahr %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -599,19 +1162,24 @@ msgstr ""
 "seit dem Jahr 2002 (%2$s) auf den 12. August verlegt, anwendbar für das Jahr "
 "%3$d."
 
-#: src/Paths/Calendar.php:2981
-#, php-format
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
+#, fuzzy, php-format
+#| msgid ""
+#| "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
+#| "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
+#| "superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 "Das optionale Gedenken '%1$s' wurde seit dem Jahr 2002 (%2$s) vom 12. Dez. "
 "auf den 12. Aug. verschoben, anwendbar auf das Jahr %3$d. Es wird jedoch im "
 "Jahr %3$d von einem Sonntag, einer Hochfest oder einem Fest '%4$s' verdrängt."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -624,51 +1192,38 @@ msgstr ""
 "gemäß %2$s wiederhergestellt, sodass die örtlichen Kirchen das Gedenken "
 "optional feiern können."
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "der %s Woche der Osterzeit"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "der %s Woche der gewöhnlichen Zeit"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Samstagsgedenken der seligen Jungfrau Maria"
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-"Fehler beim Abrufen und Dekodieren der Daten der weiteren Region aus der "
-"Datei %s."
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 "Konnte keine %1$s-Eigenschaft im %2$s für den Nationalkalender %3$s finden."
 
-#: src/Paths/Calendar.php:3245
-#, fuzzy, php-format
-#| msgid "Error retrieving and decoding National data from file %s."
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-"Fehler beim Abrufen und Dekodieren der nationalen Daten aus der Datei %s."
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -680,15 +1235,15 @@ msgstr ""
 "%7$s wieder eingeführt."
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -706,7 +1261,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -715,8 +1270,8 @@ msgstr ""
 "Das Gedenken '%1$s' fällt im Jahr %3$d mit einem anderen Gedenken '%2$s' "
 "zusammen. Beide werden zu fakultativen Gedenktagen herabgestuft."
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -725,8 +1280,8 @@ msgstr ""
 "Das Fest '%1$s', normalerweise gefeiert am %2$s, fällt im Jahr %4$d mit "
 "einem anderen Fest '%3$s' zusammen! Muss etwas dagegen unternommen werden?"
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -737,13 +1292,43 @@ msgstr ""
 "%4$d mit dem Sonntag oder Hochfest '%3$s' zusammen! Muss etwas dagegen "
 "unternommen werden?"
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+#, fuzzy
+#| msgid ""
+#| "We should be creating a new festivity, however we do not seem to have the "
+#| "correct date information in order to proceed"
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
 msgstr ""
 "Wir sollten ein neues Fest schaffen, aber wir scheinen nicht die richtigen "
 "Datumsinformationen zu haben, um fortzufahren"
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
+#| "applicable to the year %5$d (%6$s)."
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
+msgstr ""
+"Das %1$s '%2$s' wurde seit dem Jahr %4$d in den Rang von %3$s erhoben, "
+"anwendbar für das Jahr %5$d (%6$s)."
 
 #. translators:
 #.  1. Liturgical grade
@@ -753,7 +1338,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -769,7 +1354,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -786,13 +1371,17 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
-#, php-format
+#: src/Paths/CalendarPath.php:3786
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
+#| "calendar '%4$s' since the year %5$d, applicable to the year %6$d."
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 "Die Einstufung des %1$s '%2$s' wurde im nationalen Kalender '%4$s' seit dem "
 "Jahr %5$d auf '%3$s' geändert, gültig für das Jahr %6$d."
@@ -804,12 +1393,16 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
-#, php-format
+#: src/Paths/CalendarPath.php:3805
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
+#| "national calendar '%3$s' since the year %4$d, but could not be applied to "
+#| "the year %5$d because the celebration was not found."
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 "Der Rang der Feier '%1$s' wurde im nationalen Kalender '%3$s' seit dem Jahr "
 "%4$d auf '%2$s' geändert, konnte jedoch im Jahr %5$d nicht angewendet "
@@ -824,7 +1417,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -840,7 +1433,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -853,26 +1446,38 @@ msgstr ""
 "nicht finden konnten."
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
-#, php-format
+#: src/Paths/CalendarPath.php:3878
+#, fuzzy, php-format
+#| msgid ""
+#| "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
+#| "the national calendar '%4$s', but this could not take place in the year "
+#| "%5$d since the new date %2$s seems to be a Sunday or a festivity of "
+#| "greater rank."
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
 msgstr ""
 "Die liturgische Veranstaltung '%1$s' wurde seit dem Jahr %3$d im nationalen "
 "Kalender '%4$s' auf %2$s verlegt, konnte jedoch im Jahr %5$d nicht "
 "stattfinden, da das neue Datum %2$s anscheinend ein Sonntag oder ein Fest "
 "höheren Ranges ist."
 
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
+msgstr ""
+
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Sanctorale-Datendatei für %s gefunden"
@@ -882,11 +1487,11 @@ msgstr "Sanctorale-Datendatei für %s gefunden"
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -896,13 +1501,13 @@ msgstr ""
 "wurde, wird im Jahr %7$d durch den %5$s '%6$s' ersetzt"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Konnte keine Sanctorale-Datendatei für %s finden"
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -911,8 +1516,8 @@ msgstr ""
 "Das %1$s '%2$s' wird gemäß dem %7$s vom %5$s auf den %6$s verlegt, um Platz "
 "für '%3$s' zu schaffen: anwendbar für das Jahr %4$d."
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -923,8 +1528,49 @@ msgstr ""
 "um Platz für '%6$s' zu machen, wird jedoch im Jahr %9$d durch den %7$s "
 "'%8$s' unterdrückt."
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+"Kann das mobile Festivität '%1$s' relativ zum Festivität mit dem Schlüssel "
+"'%2$s', nicht erstellen"
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+"Kann mobile Festlichkeit '%1$s' nicht erstellen: kann nur relativ zur "
+"Festlichkeit mit Schlüssel '%2$s' unter Verwendung der Schlüsselwörter %3$s "
+"sein"
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': 'strtotime' property must be "
+#| "either an object or a string! Currently it has type '%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+"Kann mobile Festlichkeit '%1$s' nicht erstellen: 'strtotime'-Eigenschaft "
+"muss entweder ein Objekt oder ein String sein! Derzeit hat es den Typ '%2$s'"
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -935,413 +1581,135 @@ msgstr ""
 "am %3$s gefeiert wird, fällt im Jahr %5$d mit dem Sonntag oder der "
 "Feierlichkeit '%4$s' zusammen! Muss hier etwas unternommen werden?"
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
-#, php-format
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s', proper to the calendar of the %3$s and usually "
+#| "celebrated on %4$s, is suppressed by the Sunday or Solemnity %5$s in the "
+#| "year %6$d"
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 "Der %1$s '%2$s', der dem Kalender des %3$s eigen ist und normalerweise am "
 "%4$s gefeiert wird, wird im Jahr %6$d durch den Sonntag oder die "
 "Feierlichkeit %5$s unterdrückt"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 "Fehler beim Empfangen oder Parsen von Informationen von GitHub über die "
 "neueste Version: %s."
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "JAHR"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr "Vigilmesse"
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-"Die Vigilmesse für den %1$s '%2$s' fällt im Jahr %5$d mit dem %3$s '%4$s' "
-"zusammen. Gemäß %6$s hat der erste Vorrang, daher wird die Vigilmesse sowie "
-"die I. Vesper bestätigt."
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-"Die Vigilmesse für das %1$s '%2$s' fällt im Jahr %5$d mit dem %3$s '%4$s' "
-"zusammen. Da die erste Feierlichkeit Vorrang hat, wird sie Vesper I und eine "
-"Vigilmesse haben, während die letzte Feierlichkeit weder Vesper II noch eine "
-"Abendmesse haben wird."
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-"Die Vigilmesse für das %1$s '%2$s' fällt im Jahr %5$d mit dem %3$s '%4$s' "
-"zusammen. Diese letzte Feierlichkeit hat Vorrang, daher wird sie Vesper II "
-"und eine Abendmesse beibehalten, während die erste Feierlichkeit keine "
-"Vigilmesse oder Vesper I haben wird."
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-"Die Vigilmesse für den %1$s '%2$s' fällt im Jahr %5$d mit dem %3$s '%4$s' "
-"zusammen. Wir sollten die Kongregation für den Gottesdienst fragen, was zu "
-"tun ist!"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "grün"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "violett"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "weiß"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "rot"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "rosa"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Eigen"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Kirchweihe"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Selige Jungfrau Maria"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Märtyrer"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Pastoren"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Kirchenlehrer"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Jungfrauen"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Heilige Männer und Frauen"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Für einen Märtyrer"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Für mehrere Märtyrer"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Für missionarische Märtyrer"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Für einen missionarischen Märtyrer"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Für mehrere missionarische Märtyrer"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Für eine jungfräuliche Märtyrerin"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Für eine heilige Märtyrerin"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Für einen Papst"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Für einen Bischof"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Für einen Pfarrer"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Für mehrere Hirten"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Für Gründer einer Kirche"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Für einen Gründer"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Für mehrere Gründer"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Für Missionare"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Für eine Jungfrau"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Für mehrere Jungfrauen"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Für mehrere Heilige"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Für einen Heiligen"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Für einen Abt"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Für einen Mönch"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Für eine Nonne"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Für Ordensleute"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Für diejenigen, die Werke der Barmherzigkeit praktizierten"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Für Erzieher"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Für heilige Frauen"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr "des"
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr "von"
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr "von"
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr "der"
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "Aus dem Gemeinsamen"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "Wochentag"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
 
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
+#~ msgid "The Diocesan calendar \"%s\" was not found in the index file."
+#~ msgstr "Der Diözesankalender \"%s\" wurde nicht in der Indexdatei gefunden."
+
+#~ msgid ""
+#~ "There was an error trying to decode localized JSON data for the "
+#~ "Temporale: %s"
+#~ msgstr ""
+#~ "Beim Versuch, lokalisierte JSON-Daten für das Temporale zu dekodieren, "
+#~ "ist ein Fehler aufgetreten: %s"
+
+#~ msgid ""
+#~ "There was an error trying to retrieve localized data for the Temporale."
+#~ msgstr ""
+#~ "Beim Versuch, lokalisierte Daten für das Temporale abzurufen, ist ein "
+#~ "Fehler aufgetreten."
+
+#~ msgid "There was an error trying to decode JSON data for the Temporale: %s"
+#~ msgstr ""
+#~ "Beim Versuch, JSON-Daten für das Temporale zu dekodieren, ist ein Fehler "
+#~ "aufgetreten: %s"
+
+#~ msgid "There was an error trying to retrieve data for the Temporale."
+#~ msgstr ""
+#~ "Beim Versuch, Daten für das Temporale abzurufen, ist ein Fehler "
+#~ "aufgetreten."
+
+#~ msgid "Translation data for the sanctorale from %s could not be found."
+#~ msgstr ""
+#~ "Übersetzungsdaten für das Sanctorale von %s konnten nicht gefunden werden."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON localization data for the "
+#~ "Sanctorale for the Missal %1$s: %2$s"
+#~ msgstr ""
+#~ "Beim Versuch, JSON-Lokalisierungsdaten für das Sanctorale des Messbuchs "
+#~ "%1$s zu dekodieren, ist ein Fehler aufgetreten: %2$s"
+
+#~ msgid "Data for the Sanctorale from %s could not be found."
+#~ msgstr "Daten für das Sanctorale von %s konnten nicht gefunden werden."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for the Sanctorale for the "
+#~ "Missal %1$s: %2$s."
+#~ msgstr ""
+#~ "Beim Versuch, JSON-Daten für das Sanctorale des Messbuchs %1$s zu "
+#~ "dekodieren, ist ein Fehler aufgetreten: %2$s."
+
+#~ msgid "Could not find the Sanctorale data"
+#~ msgstr "Konnte die Sanctorale-Daten nicht finden"
+
+#~ msgid ""
+#~ "There was an error trying to decode translation data for Memorials based "
+#~ "on Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Beim Versuch, Übersetzungsdaten für Gedenktage basierend auf Dekreten der "
+#~ "Kongregation für den Gottesdienst zu dekodieren, ist ein Fehler "
+#~ "aufgetreten: %s"
+
+#~ msgid ""
+#~ "Could not find translation data for Memorials based on Decrees of the "
+#~ "Congregation for Divine Worship"
+#~ msgstr ""
+#~ "Konnte keine Übersetzungsdaten für Gedenktage basierend auf Dekreten der "
+#~ "Kongregation für den Gottesdienst finden"
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for Memorials based on "
+#~ "Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Beim Versuch, JSON-Daten für Gedenktage basierend auf Dekreten der "
+#~ "Kongregation für den Gottesdienst zu dekodieren, ist ein Fehler "
+#~ "aufgetreten: %s"
+
+#~ msgid "before"
+#~ msgstr "vor"
+
+#~ msgid "after"
+#~ msgstr "nach"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s': when the 'strtotime' property is "
+#~ "an object, it must have properties %2$s"
+#~ msgstr ""
+#~ "Kann mobile Festlichkeit '%1$s' nicht erstellen: wenn die 'strtotime'-"
+#~ "Eigenschaft ein Objekt ist, muss sie Eigenschaften %2$s haben"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+#~ msgstr ""
+#~ "Kann mobile Festlichkeit '%1$s' ohne 'strtotime'-Eigenschaft nicht "
+#~ "erstellen!"
+
+#~ msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgstr ""
+#~ "Fehler beim Abrufen und Dekodieren der Daten der weiteren Region aus der "
+#~ "Datei %s."
+
 #, fuzzy
-#| msgid "Commemoration"
-msgid "commemoration"
-msgstr "Gedächtnis"
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-#, fuzzy
-#| msgid "Optional memorial"
-msgid "optional memorial"
-msgstr "Nichtgebotener Gedenktag"
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Gedenktag"
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "FEST"
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "FEST DES HERRN"
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "HOCHFEST"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "Feier mit Vorrang vor Hochfesten"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr "Advent"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr "Weihnachten"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr "Fastenzeit"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr "Österliches Triduum"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr "Osterzeit"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr "Gewöhnliche Zeit"
+#~| msgid "Error retrieving and decoding National data from file %s."
+#~ msgid "Error retrieving and decoding National Calendar data from file %s."
+#~ msgstr ""
+#~ "Fehler beim Abrufen und Dekodieren der nationalen Daten aus der Datei %s."

--- a/i18n/es/LC_MESSAGES/litcal.po
+++ b/i18n/es/LC_MESSAGES/litcal.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2025-04-08 00:58+0000\n"
 "Last-Translator: Miguel Galvez <miggalvez@gmail.com>\n"
 "Language-Team: Spanish <https://translate.johnromanodorazio.com/projects/"
@@ -24,7 +24,720 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "verde"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "morado"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "blanco"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "rojo"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "rosa"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Propio"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Dedicación de una Iglesia"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Santísima Virgen María"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Mártires"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Pastores"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Doctores"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Vírgenes"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Santos y Santas"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Por un mártir"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Para varios mártires"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Por Misioneros Mártires"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Por un Misionero Mártir"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Por Varios Misioneros Mártires"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Por una Virgen Mártir"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Por una Santa Mártir"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Para un Papa"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Por un Obispo"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Para un Pastor"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Para Varios Pastores"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Para Fundadores de una Iglesia"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Por un Fundador"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Por Varios Fundadores"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Para misioneros"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Por una Virgen"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Por Varias Vírgenes"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Por Varios Santos"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Por un Santo"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Por un Abad"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Para un monje"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Para una Monja"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Para Religiosos"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Para los que practicaron obras de misericordia"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Por Educadores"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Por Mujeres Santas"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr "del"
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr "de"
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr "de"
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr "del"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "día de la semana"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr "ds"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+msgid "commemoration"
+msgstr "conmemoración"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr "m*"
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+msgid "optional memorial"
+msgstr "memoria opcional"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr "m"
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Memoria obligatoria"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr "M"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "FIESTA"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr "F"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "FIESTA DEL SEÑOR"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr "F✝"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "SOLEMNIDAD"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr "S"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "celebración con precedencia sobre solemnidades"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr "S✝"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "y Doctor de la Iglesia"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Para un Papa"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Por un Obispo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Para Fundadores de una Iglesia"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Por un Santo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Para Religiosos"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "%s Día de la Octava de Navidad"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Para una Monja"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Por un mártir"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Por Educadores"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Por un mártir"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Por una Virgen"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Por un Santo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Por un Santo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr "Adviento"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr "Navidad"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr "Cuaresma"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr "Triduo Pascual"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr "Pascua"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr "Tiempo Ordinario"
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "Del Común"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "o"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "AÑO"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Misa de la Víspera"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+"La Misa de Vigilia para el %1$s '%2$s' coincide con el %3$s '%4$s' en el año "
+"%5$d. Según %6$s, el primero tiene precedencia, por lo tanto, se confirma la "
+"Misa de Vigilia así como las I Vísperas."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr "Decreto de la Congregación para el Culto Divino"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+"La Misa de Vigilia para el %1$s '%2$s' coincide con el %3$s '%4$s' en el año "
+"%5$d. Dado que la primera solemnidad tiene precedencia, tendrá Vísperas I y "
+"una Misa de vigilia, mientras que la última solemnidad no tendrá ni Vísperas "
+"II ni una Misa vespertina."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+"La Misa de Vigilia para el %1$s '%2$s' coincide con el %3$s '%4$s' en el año "
+"%5$d. Esta última solemnidad tiene precedencia, por lo tanto, mantendrá "
+"Vísperas II y una Misa vespertina, mientras que la primera solemnidad no "
+"tendrá Misa de Vigilia ni Vísperas I."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+"¡La Misa de Vigilia para el %1$s '%2$s' coincide con el %3$s '%4$s' en el "
+"año %5$d! ¡Deberíamos preguntar a la Congregación para el Culto Divino qué "
+"hacer al respecto!"
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
@@ -32,12 +745,7 @@ msgstr ""
 "No se pudo derivar el nombre de la diócesis a partir del ID de la diócesis "
 "\"%s\"."
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr "El calendario diocesano \"%s\" no se encontró en el archivo de índice."
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -45,133 +753,30 @@ msgid ""
 msgstr ""
 "Solo se admiten los años a partir de 1970. Intentaste solicitar el año %d."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-"Hubo un error al intentar decodificar datos JSON localizados para el "
-"Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-"Hubo un error al intentar recuperar datos localizados para el Temporale."
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr "Hubo un error al intentar decodificar datos JSON para el Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr "Hubo un error al intentar recuperar datos para el Temporale."
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr "No se pudieron encontrar datos de traducción para el sanctoral de %s."
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-"Hubo un error al intentar decodificar los datos de localización JSON para el "
-"Sanctorale del Misal %1$s: %2$s"
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr "No se pudieron encontrar datos para el Sanctorale de %s."
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-"Hubo un error al intentar decodificar datos JSON para el Sanctorale del "
-"Misal %1$s: %2$s."
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr "No se pudo encontrar la información del Sanctorale"
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-"Hubo un error al intentar decodificar datos de traducción para Memorias "
-"basadas en Decretos de la Congregación para el Culto Divino: %s"
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-"No se pudo encontrar datos de traducción para los Memoriales basados en los "
-"Decretos de la Congregación para el Culto Divino"
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-"Hubo un error al intentar decodificar datos JSON para Memorias basadas en "
-"Decretos de la Congregación para el Culto Divino: %s"
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Día de la Semana de Navidad"
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "o"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "domingo de la Misericordia divina"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -180,31 +785,20 @@ msgstr ""
 "La Solemnidad <i>'%1$s'</i> coincide con <b>%2$s</b> en el año %3$d, por "
 "tanto, la celebración ha sido trasladada a %4$s (%5$s) según el %6$s."
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr "Sábado anterior al Domingo de Ramos"
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr "Decreto de la Congregación para el Culto Divino"
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "el lunes siguiente al Segundo Domingo de Pascua"
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr "el siguiente lunes"
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -220,7 +814,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -230,7 +824,7 @@ msgstr ""
 "%3$d, se ha anticipado un día según %4$s."
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -240,12 +834,12 @@ msgstr ""
 "celebra el %4$s en lugar del domingo después de Navidad."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Nuestro Señor Jesucristo, El Sumo Sacerdote Eterno"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -259,59 +853,59 @@ msgstr ""
 "aplicable al calendario '%1$s' en el año '%2$d' (%3$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' es reemplazado por el %2$s '%3$s' en el año %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "de la %s Semana de Adviento"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Día de la Octava de Navidad"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "de la %s Semana de Cuaresma"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "después del Miércoles de Ceniza"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -320,7 +914,7 @@ msgstr ""
 "El %1$s '%2$s' se ha añadido el %3$s desde el año %4$d (%5$s), aplicable al "
 "año %6$d."
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -328,12 +922,7 @@ msgstr ""
 "Conferencia de prensa del Vaticano: Presentación de la Editio Typica Tertia "
 "del Misal Romano"
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -345,22 +934,33 @@ msgstr ""
 "el año %3$d, rango reducido a Conmemoración."
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "El %1$s '%2$s' es reemplazado por el %3$s '%4$s' en el año %5$d."
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Constitución Apostólica Missale Romanum"
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -372,16 +972,16 @@ msgstr ""
 "%9$d."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -396,7 +996,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -405,71 +1005,41 @@ msgstr ""
 "La Memoria '%1$s' coincide con otra Memoria '%2$s' en el año %3$d. Ambas se "
 "reducen en rango a memorias opcionales (%4$s)."
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr "antes"
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr "después"
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 "No se puede crear la festividad móvil '%1$s': solo puede ser relativa a la "
 "festividad con clave '%2$s' usando palabras clave %3$s"
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 "No se puede crear la festividad móvil '%1$s' relativa a la festividad con "
 "clave '%2$s'"
 
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-"No se puede crear la festividad móvil '%1$s': cuando la propiedad "
-"'strtotime' es un objeto, debe tener propiedades %2$s"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-"No se puede crear la festividad móvil '%1$s': la propiedad 'strtotime' debe "
-"ser un objeto o una cadena. Actualmente tiene el tipo '%2$s'"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
-msgstr ""
-"¡No se puede crear la festividad móvil '%1$s' sin una propiedad 'strtotime'!"
-
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -479,14 +1049,14 @@ msgstr ""
 "aplicable al año %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -496,14 +1066,14 @@ msgstr ""
 "al año %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -513,12 +1083,12 @@ msgstr ""
 "aplicable al año %5$d (%6$s)."
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -527,21 +1097,17 @@ msgstr ""
 "'%1$s' ha sido declarado Doctor de la Iglesia desde el año %2$d, aplicable "
 "al año %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "y Doctor de la Iglesia"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -552,15 +1118,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -570,7 +1136,7 @@ msgstr ""
 "el %6$s desde el año %7$d (%8$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -580,7 +1146,7 @@ msgstr ""
 "agosto desde el año 2002 (%2$s), aplicable al año %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -591,12 +1157,17 @@ msgstr ""
 "domingo o solemnidad si fuera el 12 de diciembre, ha sido transferida al 12 "
 "de agosto desde el año 2002 (%2$s), aplicable al año %3$d."
 
-#: src/Paths/Calendar.php:2981
-#, php-format
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
+#, fuzzy, php-format
+#| msgid ""
+#| "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
+#| "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
+#| "superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 "El memorial opcional '%1$s' ha sido transferido del 12 de diciembre al 12 de "
 "agosto desde el año 2002 (%2$s), aplicable al año %3$d. Sin embargo, es "
@@ -604,7 +1175,7 @@ msgstr ""
 "%3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -617,27 +1188,22 @@ msgstr ""
 "reinstaurada para que las iglesias locales puedan celebrar opcionalmente la "
 "memoria."
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "de la %s Semana de Pascua"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "de la %s Semana del Tiempo Ordinario"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memoria del sábado de la Bienaventurada Virgen María"
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-"Error al recuperar y decodificar datos de la Región Ampliada del archivo %s."
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -645,23 +1211,16 @@ msgstr ""
 "No se pudo encontrar una propiedad %1$s en el %2$s para el Calendario "
 "Nacional %3$s."
 
-#: src/Paths/Calendar.php:3245
-#, php-format
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-"Error al recuperar y decodificar los datos del Calendario Nacional desde el "
-"archivo %s."
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -673,15 +1232,15 @@ msgstr ""
 "para el Calendario %7$s, ha sido reinstaurada."
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -698,7 +1257,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -707,8 +1266,8 @@ msgstr ""
 "La Memoria '%1$s' coincide con otra Memoria '%2$s' en el año %3$d. Ambas se "
 "reducen en rango a memorias opcionales."
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -717,8 +1276,8 @@ msgstr ""
 "¡La Fiesta '%1$s', usualmente celebrada el %2$s, coincide con otra Fiesta "
 "'%3$s' en el año %4$d! ¿Hay que hacer algo al respecto?"
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -728,13 +1287,43 @@ msgstr ""
 "La solemnidad '%1$s', usualmente celebrada el %2$s, coincide con el domingo "
 "o solemnidad '%3$s' en el año %4$d! ¿Hay que hacer algo al respecto?"
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+#, fuzzy
+#| msgid ""
+#| "We should be creating a new festivity, however we do not seem to have the "
+#| "correct date information in order to proceed"
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
 msgstr ""
 "Deberíamos estar creando una nueva festividad, sin embargo, parece que no "
 "tenemos la información correcta sobre la fecha para proceder"
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
+#| "applicable to the year %5$d (%6$s)."
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
+msgstr ""
+"El %1$s '%2$s' ha sido elevado al rango de %3$s desde el año %4$d, aplicable "
+"al año %5$d (%6$s)."
 
 #. translators:
 #.  1. Liturgical grade
@@ -744,7 +1333,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -760,7 +1349,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -777,13 +1366,17 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
-#, php-format
+#: src/Paths/CalendarPath.php:3786
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
+#| "calendar '%4$s' since the year %5$d, applicable to the year %6$d."
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 "El grado de %1$s '%2$s' ha sido cambiado a '%3$s' en el calendario nacional "
 "'%4$s' desde el año %5$d, aplicable al año %6$d."
@@ -795,12 +1388,16 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
-#, php-format
+#: src/Paths/CalendarPath.php:3805
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
+#| "national calendar '%3$s' since the year %4$d, but could not be applied to "
+#| "the year %5$d because the celebration was not found."
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 "El grado de la celebración '%1$s' ha sido cambiado a '%2$s' en el calendario "
 "nacional '%3$s' desde el año %4$d, pero no se pudo aplicar al año %5$d "
@@ -815,7 +1412,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -831,7 +1428,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -844,26 +1441,38 @@ msgstr ""
 "del Misal Romano."
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
-#, php-format
+#: src/Paths/CalendarPath.php:3878
+#, fuzzy, php-format
+#| msgid ""
+#| "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
+#| "the national calendar '%4$s', but this could not take place in the year "
+#| "%5$d since the new date %2$s seems to be a Sunday or a festivity of "
+#| "greater rank."
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
 msgstr ""
 "El evento litúrgico '%1$s' se ha trasladado a %2$s desde el año %3$d en el "
 "calendario nacional '%4$s', pero esto no pudo tener lugar en el año %5$d ya "
 "que la nueva fecha %2$s parece ser un domingo o una festividad de mayor "
 "rango."
 
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
+msgstr ""
+
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Se encontró un archivo de datos del sanctoral para %s"
@@ -873,11 +1482,11 @@ msgstr "Se encontró un archivo de datos del sanctoral para %s"
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -887,13 +1496,13 @@ msgstr ""
 "reemplazado por el %5$s '%6$s' en el año %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "No se pudo encontrar un archivo de datos del sanctoral para %s"
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -902,8 +1511,8 @@ msgstr ""
 "El %1$s '%2$s' se transfiere de %5$s a %6$s según el %7$s, para hacer "
 "espacio para '%3$s': aplicable al año %4$d."
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -914,8 +1523,48 @@ msgstr ""
 "hacer espacio para '%6$s', sin embargo es suprimido por el %7$s '%8$s' en el "
 "año %9$d."
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+"No se puede crear la festividad móvil '%1$s' relativa a la festividad con "
+"clave '%2$s'"
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+"No se puede crear la festividad móvil '%1$s': solo puede ser relativa a la "
+"festividad con clave '%2$s' usando palabras clave %3$s"
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': 'strtotime' property must be "
+#| "either an object or a string! Currently it has type '%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+"No se puede crear la festividad móvil '%1$s': la propiedad 'strtotime' debe "
+"ser un objeto o una cadena. Actualmente tiene el tipo '%2$s'"
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -926,411 +1575,131 @@ msgstr ""
 "celebrada el %3$s, coincide con el Domingo o Solemnidad '%4$s' en el año "
 "%5$d! ¿Se necesita hacer algo al respecto?"
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
-#, php-format
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s', proper to the calendar of the %3$s and usually "
+#| "celebrated on %4$s, is suppressed by the Sunday or Solemnity %5$s in the "
+#| "year %6$d"
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 "El %1$s '%2$s', propio del calendario del %3$s y usualmente celebrado el "
 "%4$s, es suprimido por el domingo o solemnidad %5$s en el año %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 "Error al recibir o analizar información de github sobre la última versión: "
 "%s."
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "AÑO"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr "Misa de la Víspera"
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
-"La Misa de Vigilia para el %1$s '%2$s' coincide con el %3$s '%4$s' en el año "
-"%5$d. Según %6$s, el primero tiene precedencia, por lo tanto, se confirma la "
-"Misa de Vigilia así como las I Vísperas."
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-"La Misa de Vigilia para el %1$s '%2$s' coincide con el %3$s '%4$s' en el año "
-"%5$d. Dado que la primera solemnidad tiene precedencia, tendrá Vísperas I y "
-"una Misa de vigilia, mientras que la última solemnidad no tendrá ni Vísperas "
-"II ni una Misa vespertina."
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-"La Misa de Vigilia para el %1$s '%2$s' coincide con el %3$s '%4$s' en el año "
-"%5$d. Esta última solemnidad tiene precedencia, por lo tanto, mantendrá "
-"Vísperas II y una Misa vespertina, mientras que la primera solemnidad no "
-"tendrá Misa de Vigilia ni Vísperas I."
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-"¡La Misa de Vigilia para el %1$s '%2$s' coincide con el %3$s '%4$s' en el "
-"año %5$d! ¡Deberíamos preguntar a la Congregación para el Culto Divino qué "
-"hacer al respecto!"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "verde"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "morado"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "blanco"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "rojo"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "rosa"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Propio"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Dedicación de una Iglesia"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Santísima Virgen María"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Mártires"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Pastores"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Doctores"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Vírgenes"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Santos y Santas"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Por un mártir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Para varios mártires"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Por Misioneros Mártires"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Por un Misionero Mártir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Por Varios Misioneros Mártires"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Por una Virgen Mártir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Por una Santa Mártir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Para un Papa"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Por un Obispo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Para un Pastor"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Para Varios Pastores"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Para Fundadores de una Iglesia"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Por un Fundador"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Por Varios Fundadores"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Para misioneros"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Por una Virgen"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Por Varias Vírgenes"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Por Varios Santos"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Por un Santo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Por un Abad"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Para un monje"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Para una Monja"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Para Religiosos"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Para los que practicaron obras de misericordia"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Por Educadores"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Por Mujeres Santas"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr "del"
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr "de"
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr "de"
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr "del"
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "Del Común"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "día de la semana"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
-msgstr "ds"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
-msgid "commemoration"
-msgstr "conmemoración"
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr "m*"
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-msgid "optional memorial"
-msgstr "memoria opcional"
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr "m"
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Memoria obligatoria"
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr "M"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "FIESTA"
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr "F"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "FIESTA DEL SEÑOR"
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr "F✝"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "SOLEMNIDAD"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr "S"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "celebración con precedencia sobre solemnidades"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr "S✝"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr "Adviento"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr "Navidad"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr "Cuaresma"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr "Triduo Pascual"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr "Pascua"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr "Tiempo Ordinario"
+
+#~ msgid "The Diocesan calendar \"%s\" was not found in the index file."
+#~ msgstr ""
+#~ "El calendario diocesano \"%s\" no se encontró en el archivo de índice."
+
+#~ msgid ""
+#~ "There was an error trying to decode localized JSON data for the "
+#~ "Temporale: %s"
+#~ msgstr ""
+#~ "Hubo un error al intentar decodificar datos JSON localizados para el "
+#~ "Temporale: %s"
+
+#~ msgid ""
+#~ "There was an error trying to retrieve localized data for the Temporale."
+#~ msgstr ""
+#~ "Hubo un error al intentar recuperar datos localizados para el Temporale."
+
+#~ msgid "There was an error trying to decode JSON data for the Temporale: %s"
+#~ msgstr ""
+#~ "Hubo un error al intentar decodificar datos JSON para el Temporale: %s"
+
+#~ msgid "There was an error trying to retrieve data for the Temporale."
+#~ msgstr "Hubo un error al intentar recuperar datos para el Temporale."
+
+#~ msgid "Translation data for the sanctorale from %s could not be found."
+#~ msgstr ""
+#~ "No se pudieron encontrar datos de traducción para el sanctoral de %s."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON localization data for the "
+#~ "Sanctorale for the Missal %1$s: %2$s"
+#~ msgstr ""
+#~ "Hubo un error al intentar decodificar los datos de localización JSON para "
+#~ "el Sanctorale del Misal %1$s: %2$s"
+
+#~ msgid "Data for the Sanctorale from %s could not be found."
+#~ msgstr "No se pudieron encontrar datos para el Sanctorale de %s."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for the Sanctorale for the "
+#~ "Missal %1$s: %2$s."
+#~ msgstr ""
+#~ "Hubo un error al intentar decodificar datos JSON para el Sanctorale del "
+#~ "Misal %1$s: %2$s."
+
+#~ msgid "Could not find the Sanctorale data"
+#~ msgstr "No se pudo encontrar la información del Sanctorale"
+
+#~ msgid ""
+#~ "There was an error trying to decode translation data for Memorials based "
+#~ "on Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Hubo un error al intentar decodificar datos de traducción para Memorias "
+#~ "basadas en Decretos de la Congregación para el Culto Divino: %s"
+
+#~ msgid ""
+#~ "Could not find translation data for Memorials based on Decrees of the "
+#~ "Congregation for Divine Worship"
+#~ msgstr ""
+#~ "No se pudo encontrar datos de traducción para los Memoriales basados en "
+#~ "los Decretos de la Congregación para el Culto Divino"
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for Memorials based on "
+#~ "Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Hubo un error al intentar decodificar datos JSON para Memorias basadas en "
+#~ "Decretos de la Congregación para el Culto Divino: %s"
+
+#~ msgid "before"
+#~ msgstr "antes"
+
+#~ msgid "after"
+#~ msgstr "después"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s': when the 'strtotime' property is "
+#~ "an object, it must have properties %2$s"
+#~ msgstr ""
+#~ "No se puede crear la festividad móvil '%1$s': cuando la propiedad "
+#~ "'strtotime' es un objeto, debe tener propiedades %2$s"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+#~ msgstr ""
+#~ "¡No se puede crear la festividad móvil '%1$s' sin una propiedad "
+#~ "'strtotime'!"
+
+#~ msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgstr ""
+#~ "Error al recuperar y decodificar datos de la Región Ampliada del archivo "
+#~ "%s."
+
+#~ msgid "Error retrieving and decoding National Calendar data from file %s."
+#~ msgstr ""
+#~ "Error al recuperar y decodificar los datos del Calendario Nacional desde "
+#~ "el archivo %s."
 
 #~ msgid "%s day before Epiphany"
 #~ msgstr "%s día antes de la Epifanía"

--- a/i18n/fr/LC_MESSAGES/litcal.po
+++ b/i18n/fr/LC_MESSAGES/litcal.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: French <https://translate.johnromanodorazio.com/projects/"
@@ -23,19 +23,726 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "vert"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "violet"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "blanc"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "rouge"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "rose"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Propre"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Dédicace d'une église"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Bienheureuse Vierge Marie"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "martyrs"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "pasteurs"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "docteurs de l'Église"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "vierges"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "saints et saintes"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Pour un martyr"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Pour plusieurs martyrs"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Pour les missionnaires martyrs"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Pour un missionnaire martyr"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Pour plusieurs missionnaires martyrs"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Pour une vierge martyre"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Pour une sainte femme martyre"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Pour un Pape"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Pour un Évêque"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Pour un Pasteur"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Pour plusieurs pasteurs"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Pour des fondateurs d'église"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Pour un fondateur"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Pour plusieurs fondateurs"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Pour des missionnaires"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Pour une vierge"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Pour plusieurs vierges"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Pour plusieurs saints"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Pour un saint"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Pour un abbé"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Pour un moine"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Pour une moniale"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Pour les religieux et les religieuses"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Pour les saints ayant exercé une activité caritative"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Pour les éducateurs"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Pour les saintes femmes"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr "de la"
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr "des"
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr "des"
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr "du"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "jour de la semaine"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr "js"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+msgid "commemoration"
+msgstr "commémoration"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr "m*"
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+msgid "optional memorial"
+msgstr "mémoire facultative"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr "mf"
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Mémoire"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr "M"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "FÊTE"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr "F"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "FÊTE DU SEIGNEUR"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr "F✝"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "SOLENNITÉ"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr "S"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "célébration qui prime sur les solennités"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr "S✝"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "et docteur de l'Église"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Pour un Pape"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Pour un Évêque"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Pour des fondateurs d'église"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Pour un saint"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Pour les religieux et les religieuses"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "%s jour dans l'Octave de la Nativité"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Pour une moniale"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Pour un martyr"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Pour les éducateurs"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Pour un martyr"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Pour une vierge"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Pour un saint"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Pour un saint"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr "Avent"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr "Noël"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr "Carême"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr "Triduum pascal"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr "Pâques"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr "Temps ordinaire"
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "Du Commun"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "ou"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "ANNÉE"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Messe de la Veille"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+"La Messe de la Veillée pour le %1$s '%2$s' coïncide avec le %3$s '%4$s' en "
+"l'année %5$d. Selon %6$s, le premier a la préséance, donc la Messe de la "
+"Veillée est confirmée ainsi que les I Vêpres."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr "Décret de la Congrégation pour le Culte Divin"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+"La messe de vigile pour le %1$s '%2$s' coïncide avec le %3$s '%4$s' en "
+"l'année %5$d. Puisque la première solennité a la préséance, elle aura les "
+"Vêpres I et une messe de vigile, tandis que la dernière solennité n'aura ni "
+"Vêpres II ni messe du soir."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+"La Messe de la Veillée pour le %1$s '%2$s' coïncide avec le %3$s '%4$s' en "
+"l'année %5$d. Cette dernière Solennité a la priorité, donc elle maintiendra "
+"les Vêpres II et une messe du soir, tandis que la première Solennité n'aura "
+"pas de Messe de la Veillée ni de Vêpres I."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+"La Messe de la Veillée pour le %1$s '%2$s' coïncide avec le %3$s '%4$s' en "
+"l'année %5$d. Nous devrions demander à la Congrégation pour le Culte Divin "
+"quoi faire à ce sujet !"
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr "Le nom du diocèse n'a pas pu être dérivé de l'ID du diocèse \"%s\"."
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr ""
-"Le calendrier diocésain \"%s\" n'a pas été trouvé dans le fichier d'index."
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -44,141 +751,30 @@ msgstr ""
 "Seules les années à partir de 1970 sont prises en charge. Vous avez essayé "
 "de demander l'année %d."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-"Une erreur s'est produite lors de la tentative de décodage des données JSON "
-"localisées pour le Temporal : %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-"Une erreur s'est produite lors de la tentative de récupération des données "
-"localisées pour le Temporal."
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-"Une erreur s'est produite lors de la tentative de décodage des données JSON "
-"pour le Temporal : %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-"Une erreur s'est produite lors de la tentative de récupération des données "
-"pour le Temporal."
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr ""
-"Les données de traduction pour le sanctoral de %s n'ont pas pu être trouvées."
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-"Une erreur s'est produite lors de la tentative de décodage des données de "
-"localisation JSON pour le Sanctoral du Missel %1$s : %2$s"
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, fuzzy, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr "Les données pour le sanctoral de %s n'ont pas pu être trouvées."
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-"Une erreur s'est produite lors de la tentative de décodage des données JSON "
-"pour le Sanctoral du Missel %1$s : %2$s."
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-#, fuzzy
-msgid "Could not find the Sanctorale data"
-msgstr "Impossible de trouver un fichier de données sanctorale pour %s"
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-"Une erreur s'est produite lors de la tentative de décodage des données de "
-"traduction pour les Mémoires basés sur les Décrets de la Congrégation pour "
-"le Culte Divin : %s"
-
-#: src/Paths/Calendar.php:953
-#, fuzzy
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr "Décret de la Congrégation pour le Culte Divin"
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-"Une erreur s'est produite lors de la tentative de décodage des données JSON "
-"pour les Mémoires basés sur les Décrets de la Congrégation pour le Culte "
-"Divin : %s"
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Férie de Noël"
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "ou"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Dimanche de la divine Miséricorde"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -187,31 +783,20 @@ msgstr ""
 "La Solennité '%1$s' tombe le %2$s en l'année %3$d, la célébration a été "
 "transférée au %4$s (%5$s) selon le %6$s."
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr "le samedi précédant le dimanche des Rameaux"
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr "Décret de la Congrégation pour le Culte Divin"
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "le lundi suivant le deuxième dimanche de Pâques"
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr "le lundi suivant"
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -227,7 +812,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -237,7 +822,7 @@ msgstr ""
 "%3$d, elle a été anticipée d'un jour selon %4$s."
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -247,12 +832,12 @@ msgstr ""
 "%4$s plutôt que le dimanche après Noël."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Notre Seigneur Jésus-Christ, Éternel et Souverain Prêtre"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -266,59 +851,59 @@ msgstr ""
 "applicable au calendrier '%1$s' en l'année '%2$d' (%3$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' est supplanté par le %2$s '%3$s' en l'année %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "de la %s semaine de l'Avent"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s jour dans l'Octave de la Nativité"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "de la %s semaine de Carême"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "après le Mercredi des Cendres"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -327,7 +912,7 @@ msgstr ""
 "Le %1$s '%2$s' a été ajouté le %3$s depuis l'année %4$d (%5$s), applicable à "
 "l'année %6$d."
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -335,12 +920,7 @@ msgstr ""
 "Conférence de presse du Vatican : Présentation de l'Editio Typica Tertia du "
 "Missel Romain"
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -352,22 +932,33 @@ msgstr ""
 "en l'année %3$d, rang réduit à Commémoration."
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "Le %1$s '%2$s' est supplanté par le %3$s '%4$s' en l'année %5$d."
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Constitution apostolique Missale Romanum"
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -379,16 +970,16 @@ msgstr ""
 "l'année %9$d."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -403,7 +994,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -412,71 +1003,41 @@ msgstr ""
 "La Mémoire '%1$s' coïncide avec une autre Mémoire '%2$s' en l'année %3$d. "
 "Elles sont toutes deux réduites en rang à des mémoires facultatives (%4$s)."
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr "avant"
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr "après"
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 "Impossible de créer la fête mobile '%1$s' : ne peut être relative qu'à la "
 "fête avec la clé '%2$s' en utilisant les mots-clés %3$s"
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 "Impossible de créer la fête mobile '%1$s' relative à la fête avec la clé "
 "'%2$s'"
 
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-"Impossible de créer la fête mobile '%1$s' : lorsque la propriété 'strtotime' "
-"est un objet, elle doit avoir les propriétés %2$s"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-"Impossible de créer la fête mobile '%1$s' : la propriété 'strtotime' doit "
-"être soit un objet, soit une chaîne de caractères ! Actuellement, elle a le "
-"type '%2$s'"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
-msgstr "Impossible de créer la fête mobile '%1$s' sans propriété 'strtotime' !"
-
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -486,14 +1047,14 @@ msgstr ""
 "l'année %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -503,14 +1064,14 @@ msgstr ""
 "l'année %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -520,12 +1081,12 @@ msgstr ""
 "applicable à l'année %5$d (%6$s)."
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -534,21 +1095,17 @@ msgstr ""
 "'%1$s' a été déclaré Docteur de l'Église depuis l'année %2$d, applicable à "
 "l'année %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "et docteur de l'Église"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -559,15 +1116,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -577,7 +1134,7 @@ msgstr ""
 "%6$s depuis l'année %7$d (%8$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -587,7 +1144,7 @@ msgstr ""
 "l'année 2002 (%2$s), applicable à l'année %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -598,19 +1155,24 @@ msgstr ""
 "dimanche ou une solennité si elle avait eu lieu le 12 déc., a cependant été "
 "transférée au 12 août depuis l'année 2002 (%2$s), applicable à l'année %3$d."
 
-#: src/Paths/Calendar.php:2981
-#, php-format
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
+#, fuzzy, php-format
+#| msgid ""
+#| "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
+#| "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
+#| "superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 "Le mémorial facultatif '%1$s' a été transféré du 12 déc. au 12 août depuis "
 "l'année 2002 (%2$s), applicable à l'année %3$d. Cependant, il est supplanté "
 "par un dimanche, une solennité ou une fête '%4$s' en l'année %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -623,28 +1185,22 @@ msgstr ""
 "rétablie afin que les églises locales puissent célébrer facultativement la "
 "mémoire."
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "de la %s semaine de Pâques"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "de la %s Semaine du Temps Ordinaire"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Mémoire du samedi de la Bienheureuse Vierge Marie"
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-"Erreur lors de la récupération et du décodage des données de la région "
-"élargie à partir du fichier %s."
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -652,24 +1208,16 @@ msgstr ""
 "Impossible de trouver une propriété %1$s dans le %2$s pour le Calendrier "
 "National %3$s."
 
-#: src/Paths/Calendar.php:3245
-#, fuzzy, php-format
-#| msgid "Error retrieving and decoding National data from file %s."
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-"Erreur lors de la récupération et du décodage des données nationales à "
-"partir du fichier %s."
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -681,15 +1229,15 @@ msgstr ""
 "calendrier %7$s, elle a été rétablie."
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -706,7 +1254,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -715,8 +1263,8 @@ msgstr ""
 "La Mémoire '%1$s' coïncide avec une autre Mémoire '%2$s' en l'année %3$d. "
 "Elles sont toutes deux réduites au rang de mémoires facultatives."
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -725,8 +1273,8 @@ msgstr ""
 "La Fête '%1$s', habituellement célébrée le %2$s, coïncide avec une autre "
 "Fête '%3$s' en l'année %4$d ! Faut-il faire quelque chose à ce sujet ?"
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -737,13 +1285,43 @@ msgstr ""
 "dimanche ou la Solennité '%3$s' en l'année %4$d ! Faut-il faire quelque "
 "chose à ce sujet ?"
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+#, fuzzy
+#| msgid ""
+#| "We should be creating a new festivity, however we do not seem to have the "
+#| "correct date information in order to proceed"
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
 msgstr ""
 "Nous devrions créer une nouvelle fête, cependant nous ne semblons pas avoir "
 "les informations de date correctes pour procéder"
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
+#| "applicable to the year %5$d (%6$s)."
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
+msgstr ""
+"Le %1$s '%2$s' a été élevé au rang de %3$s depuis l'année %4$d, applicable à "
+"l'année %5$d (%6$s)."
 
 #. translators:
 #.  1. Liturgical grade
@@ -753,7 +1331,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -769,7 +1347,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -786,13 +1364,17 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
-#, php-format
+#: src/Paths/CalendarPath.php:3786
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
+#| "calendar '%4$s' since the year %5$d, applicable to the year %6$d."
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 "Le grade de %1$s '%2$s' a été changé en '%3$s' dans le calendrier national "
 "'%4$s' depuis l'année %5$d, applicable à l'année %6$d."
@@ -804,12 +1386,16 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
-#, php-format
+#: src/Paths/CalendarPath.php:3805
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
+#| "national calendar '%3$s' since the year %4$d, but could not be applied to "
+#| "the year %5$d because the celebration was not found."
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 "Le grade de la célébration '%1$s' a été changé en '%2$s' dans le calendrier "
 "national '%3$s' depuis l'année %4$d, mais n'a pas pu être appliqué à l'année "
@@ -824,7 +1410,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -840,7 +1426,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -853,26 +1439,38 @@ msgstr ""
 "dans les événements du Missel Romain."
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
-#, php-format
+#: src/Paths/CalendarPath.php:3878
+#, fuzzy, php-format
+#| msgid ""
+#| "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
+#| "the national calendar '%4$s', but this could not take place in the year "
+#| "%5$d since the new date %2$s seems to be a Sunday or a festivity of "
+#| "greater rank."
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
 msgstr ""
 "L'événement liturgique '%1$s' a été déplacé à %2$s depuis l'année %3$d dans "
 "le calendrier national '%4$s', mais cela n'a pas pu avoir lieu en l'année "
 "%5$d car la nouvelle date %2$s semble être un dimanche ou une fête de rang "
 "supérieur."
 
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
+msgstr ""
+
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Fichier de données sanctorale trouvé pour %s"
@@ -882,11 +1480,11 @@ msgstr "Fichier de données sanctorale trouvé pour %s"
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -896,13 +1494,13 @@ msgstr ""
 "par le %5$s '%6$s' en l'année %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Impossible de trouver un fichier de données sanctorale pour %s"
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -911,8 +1509,8 @@ msgstr ""
 "Le %1$s '%2$s' est transféré de %5$s à %6$s selon le %7$s, pour faire de la "
 "place à '%3$s' : applicable à l'année %4$d."
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -923,8 +1521,49 @@ msgstr ""
 "faire de la place pour '%6$s', cependant il est supprimé par le %7$s '%8$s' "
 "en l'année %9$d."
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+"Impossible de créer la fête mobile '%1$s' relative à la fête avec la clé "
+"'%2$s'"
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+"Impossible de créer la fête mobile '%1$s' : ne peut être relative qu'à la "
+"fête avec la clé '%2$s' en utilisant les mots-clés %3$s"
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': 'strtotime' property must be "
+#| "either an object or a string! Currently it has type '%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+"Impossible de créer la fête mobile '%1$s' : la propriété 'strtotime' doit "
+"être soit un objet, soit une chaîne de caractères ! Actuellement, elle a le "
+"type '%2$s'"
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -935,408 +1574,137 @@ msgstr ""
 "le %3$s, coïncide avec le dimanche ou la solennité '%4$s' en l'année %5$d ! "
 "Faut-il faire quelque chose à ce sujet ?"
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
-#, php-format
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s', proper to the calendar of the %3$s and usually "
+#| "celebrated on %4$s, is suppressed by the Sunday or Solemnity %5$s in the "
+#| "year %6$d"
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 "La %1$s '%2$s', propre au calendrier du %3$s et habituellement célébrée le "
 "%4$s, est supprimée par le dimanche ou la solennité %5$s en l'année %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 "Erreur lors de la réception ou de l'analyse des informations de github "
 "concernant la dernière version : %s."
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "ANNÉE"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr "Messe de la Veille"
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
-"La Messe de la Veillée pour le %1$s '%2$s' coïncide avec le %3$s '%4$s' en "
-"l'année %5$d. Selon %6$s, le premier a la préséance, donc la Messe de la "
-"Veillée est confirmée ainsi que les I Vêpres."
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-"La messe de vigile pour le %1$s '%2$s' coïncide avec le %3$s '%4$s' en "
-"l'année %5$d. Puisque la première solennité a la préséance, elle aura les "
-"Vêpres I et une messe de vigile, tandis que la dernière solennité n'aura ni "
-"Vêpres II ni messe du soir."
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-"La Messe de la Veillée pour le %1$s '%2$s' coïncide avec le %3$s '%4$s' en "
-"l'année %5$d. Cette dernière Solennité a la priorité, donc elle maintiendra "
-"les Vêpres II et une messe du soir, tandis que la première Solennité n'aura "
-"pas de Messe de la Veillée ni de Vêpres I."
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-"La Messe de la Veillée pour le %1$s '%2$s' coïncide avec le %3$s '%4$s' en "
-"l'année %5$d. Nous devrions demander à la Congrégation pour le Culte Divin "
-"quoi faire à ce sujet !"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "vert"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "violet"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "blanc"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "rouge"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "rose"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Propre"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Dédicace d'une église"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Bienheureuse Vierge Marie"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "martyrs"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "pasteurs"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "docteurs de l'Église"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "vierges"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "saints et saintes"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Pour un martyr"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Pour plusieurs martyrs"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Pour les missionnaires martyrs"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Pour un missionnaire martyr"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Pour plusieurs missionnaires martyrs"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Pour une vierge martyre"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Pour une sainte femme martyre"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Pour un Pape"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Pour un Évêque"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Pour un Pasteur"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Pour plusieurs pasteurs"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Pour des fondateurs d'église"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Pour un fondateur"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Pour plusieurs fondateurs"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Pour des missionnaires"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Pour une vierge"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Pour plusieurs vierges"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Pour plusieurs saints"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Pour un saint"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Pour un abbé"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Pour un moine"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Pour une moniale"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Pour les religieux et les religieuses"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Pour les saints ayant exercé une activité caritative"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Pour les éducateurs"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Pour les saintes femmes"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr "de la"
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr "des"
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr "des"
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr "du"
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "Du Commun"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "jour de la semaine"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
-msgstr "js"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
-msgid "commemoration"
-msgstr "commémoration"
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr "m*"
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-msgid "optional memorial"
-msgstr "mémoire facultative"
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr "mf"
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Mémoire"
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr "M"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "FÊTE"
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr "F"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "FÊTE DU SEIGNEUR"
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr "F✝"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "SOLENNITÉ"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr "S"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "célébration qui prime sur les solennités"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr "S✝"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr "Avent"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr "Noël"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr "Carême"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr "Triduum pascal"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr "Pâques"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr "Temps ordinaire"
+
+#~ msgid "The Diocesan calendar \"%s\" was not found in the index file."
+#~ msgstr ""
+#~ "Le calendrier diocésain \"%s\" n'a pas été trouvé dans le fichier d'index."
+
+#~ msgid ""
+#~ "There was an error trying to decode localized JSON data for the "
+#~ "Temporale: %s"
+#~ msgstr ""
+#~ "Une erreur s'est produite lors de la tentative de décodage des données "
+#~ "JSON localisées pour le Temporal : %s"
+
+#~ msgid ""
+#~ "There was an error trying to retrieve localized data for the Temporale."
+#~ msgstr ""
+#~ "Une erreur s'est produite lors de la tentative de récupération des "
+#~ "données localisées pour le Temporal."
+
+#~ msgid "There was an error trying to decode JSON data for the Temporale: %s"
+#~ msgstr ""
+#~ "Une erreur s'est produite lors de la tentative de décodage des données "
+#~ "JSON pour le Temporal : %s"
+
+#~ msgid "There was an error trying to retrieve data for the Temporale."
+#~ msgstr ""
+#~ "Une erreur s'est produite lors de la tentative de récupération des "
+#~ "données pour le Temporal."
+
+#~ msgid "Translation data for the sanctorale from %s could not be found."
+#~ msgstr ""
+#~ "Les données de traduction pour le sanctoral de %s n'ont pas pu être "
+#~ "trouvées."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON localization data for the "
+#~ "Sanctorale for the Missal %1$s: %2$s"
+#~ msgstr ""
+#~ "Une erreur s'est produite lors de la tentative de décodage des données de "
+#~ "localisation JSON pour le Sanctoral du Missel %1$s : %2$s"
+
+#, fuzzy
+#~ msgid "Data for the Sanctorale from %s could not be found."
+#~ msgstr "Les données pour le sanctoral de %s n'ont pas pu être trouvées."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for the Sanctorale for the "
+#~ "Missal %1$s: %2$s."
+#~ msgstr ""
+#~ "Une erreur s'est produite lors de la tentative de décodage des données "
+#~ "JSON pour le Sanctoral du Missel %1$s : %2$s."
+
+#, fuzzy
+#~ msgid "Could not find the Sanctorale data"
+#~ msgstr "Impossible de trouver un fichier de données sanctorale pour %s"
+
+#~ msgid ""
+#~ "There was an error trying to decode translation data for Memorials based "
+#~ "on Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Une erreur s'est produite lors de la tentative de décodage des données de "
+#~ "traduction pour les Mémoires basés sur les Décrets de la Congrégation "
+#~ "pour le Culte Divin : %s"
+
+#, fuzzy
+#~ msgid ""
+#~ "Could not find translation data for Memorials based on Decrees of the "
+#~ "Congregation for Divine Worship"
+#~ msgstr "Décret de la Congrégation pour le Culte Divin"
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for Memorials based on "
+#~ "Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Une erreur s'est produite lors de la tentative de décodage des données "
+#~ "JSON pour les Mémoires basés sur les Décrets de la Congrégation pour le "
+#~ "Culte Divin : %s"
+
+#~ msgid "before"
+#~ msgstr "avant"
+
+#~ msgid "after"
+#~ msgstr "après"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s': when the 'strtotime' property is "
+#~ "an object, it must have properties %2$s"
+#~ msgstr ""
+#~ "Impossible de créer la fête mobile '%1$s' : lorsque la propriété "
+#~ "'strtotime' est un objet, elle doit avoir les propriétés %2$s"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+#~ msgstr ""
+#~ "Impossible de créer la fête mobile '%1$s' sans propriété 'strtotime' !"
+
+#~ msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgstr ""
+#~ "Erreur lors de la récupération et du décodage des données de la région "
+#~ "élargie à partir du fichier %s."
+
+#, fuzzy
+#~| msgid "Error retrieving and decoding National data from file %s."
+#~ msgid "Error retrieving and decoding National Calendar data from file %s."
+#~ msgstr ""
+#~ "Erreur lors de la récupération et du décodage des données nationales à "
+#~ "partir du fichier %s."

--- a/i18n/hr/LC_MESSAGES/litcal.po
+++ b/i18n/hr/LC_MESSAGES/litcal.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2025-02-03 20:05+0000\n"
 "Last-Translator: Lovro <development.lovro@gmail.com>\n"
 "Language-Team: Croatian <https://translate.johnromanodorazio.com/projects/"
@@ -19,18 +19,686 @@ msgstr ""
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "zelena"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "ljubičasta"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "bijela"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "crvena"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "ružičasta"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr ""
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr ""
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr ""
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr ""
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr ""
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr ""
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr ""
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr ""
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "svagdan"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr "sv"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+msgid "commemoration"
+msgstr "spomendan"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr "sp*"
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+msgid "optional memorial"
+msgstr "neobvezatni spomendan"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr "sp"
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Spomendan"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr "Sp"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "BLAGDAN"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr "B"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "GOSPODNJI BLAGDAN"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr "B✝"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "SVETKOVINA"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr "S"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "slavlje s prednošću nad svetkovinom"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr "S✝"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+msgid "For the Church"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+msgid "For the Pope"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+msgid "For the Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+msgid "For Ministers of the Church"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+msgid "For the Laity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+msgid "For Reconciliation"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "%s dan u osmini Božića"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+msgid "For Rain"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+msgid "For Fine Weather"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+msgid "For an End to Storms"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+msgid "For Charity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+msgid "For Those in Prison"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+msgid "For the Sick"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+msgid "For the Dying"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr ""
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr ""
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "ili"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "GODINA"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr "Ime biskupije nije pronađeno koristeći ID biskupije \"%s\"."
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr "Dijecezanski kalendar \"%s\" nije pronađen u indeksnoj datoteci."
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, fuzzy, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -38,153 +706,50 @@ msgid ""
 msgstr ""
 "Podržane su samo godine od 1970. nadalje. Pokušali ste zatražiti godinu %d."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, fuzzy, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-"Došlo je do pogreške prilikom dekodiranja lokaliziranih JSON podataka za "
-"Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr ""
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr ""
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s u običnim danima poslije 2. siječnja"
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "ili"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Nedjelja Božjeg milosrđa"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -197,7 +762,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -205,7 +770,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -213,12 +778,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -228,77 +793,72 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "%s tjedna došašća"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s dan u osmini Božića"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "%s tjedna korizme"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "nakon Pepelnice"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
 msgstr ""
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -307,22 +867,33 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -331,16 +902,16 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -353,69 +924,38 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials (%4$s)."
 msgstr ""
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr ""
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr ""
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -423,14 +963,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -438,14 +978,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -453,33 +993,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr ""
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -488,15 +1024,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -504,7 +1040,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -512,7 +1048,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -520,16 +1056,17 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2981
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -538,46 +1075,37 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "%s vazmenog tjedna"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "%s tjedna kroz godinu"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3245
-#, php-format
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -586,15 +1114,15 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -608,23 +1136,23 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials."
 msgstr ""
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
 "'%3$s' in the year %4$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -632,10 +1160,31 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
+msgstr ""
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, php-format
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
 msgstr ""
 
 #. translators:
@@ -646,7 +1195,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -660,7 +1209,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -674,13 +1223,14 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
+#: src/Paths/CalendarPath.php:3786
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 
 #. translators:
@@ -690,12 +1240,12 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
+#: src/Paths/CalendarPath.php:3805
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 
 #. translators:
@@ -707,7 +1257,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -721,7 +1271,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -730,22 +1280,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
+#: src/Paths/CalendarPath.php:3878
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
+msgstr ""
+
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -755,11 +1312,11 @@ msgstr ""
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -767,21 +1324,21 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
 "room for '%3$s': applicable to the year %4$d."
 msgstr ""
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -789,8 +1346,33 @@ msgid ""
 "in the year %9$d."
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -798,390 +1380,34 @@ msgid ""
 "year %5$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "GODINA"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
 
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "zelena"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "ljubičasta"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "bijela"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "crvena"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "ružičasta"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr ""
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr ""
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr ""
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr ""
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr ""
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "svagdan"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
-msgstr "sv"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
-msgid "commemoration"
-msgstr "spomendan"
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr "sp*"
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-msgid "optional memorial"
-msgstr "neobvezatni spomendan"
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr "sp"
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Spomendan"
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr "Sp"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "BLAGDAN"
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr "B"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "GOSPODNJI BLAGDAN"
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr "B✝"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "SVETKOVINA"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr "S"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "slavlje s prednošću nad svetkovinom"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr "S✝"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr ""
+#~ msgid "The Diocesan calendar \"%s\" was not found in the index file."
+#~ msgstr "Dijecezanski kalendar \"%s\" nije pronađen u indeksnoj datoteci."
+
+#, fuzzy
+#~ msgid ""
+#~ "There was an error trying to decode localized JSON data for the "
+#~ "Temporale: %s"
+#~ msgstr ""
+#~ "Došlo je do pogreške prilikom dekodiranja lokaliziranih JSON podataka za "
+#~ "Temporale: %s"

--- a/i18n/hu/LC_MESSAGES/litcal.po
+++ b/i18n/hu/LC_MESSAGES/litcal.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: priest@johnromanodorazio.com\n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2025-04-21 09:40+0000\n"
 "Last-Translator: Gábor <pleineux@gmail.com>\n"
 "Language-Team: Hungarian <https://translate.johnromanodorazio.com/projects/"
@@ -18,169 +18,734 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.11\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "zöld"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "viola"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "fehér"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "piros"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "rózsaszín"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr ""
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr ""
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr ""
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr ""
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr ""
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr ""
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr ""
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr ""
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr ""
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+msgid "commemoration"
+msgstr ""
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+msgid "optional memorial"
+msgstr ""
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr ""
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr ""
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr ""
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr ""
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr ""
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+msgid "For the Church"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+msgid "For the Pope"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+msgid "For the Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+msgid "For Ministers of the Church"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+msgid "For the Laity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+msgid "For Reconciliation"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+msgid "For the Unity of Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+msgid "For Rain"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+msgid "For Fine Weather"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+msgid "For an End to Storms"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+msgid "For Charity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+msgid "For Those in Prison"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+msgid "For the Sick"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+msgid "For the Dying"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr ""
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr ""
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr ""
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr ""
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
 "%d."
 msgstr ""
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr ""
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr ""
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr ""
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -193,7 +758,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -201,7 +766,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -209,12 +774,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -224,77 +789,72 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr ""
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
 msgstr ""
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -303,22 +863,33 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -327,16 +898,16 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -349,69 +920,38 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials (%4$s)."
 msgstr ""
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr ""
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr ""
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -419,14 +959,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -434,14 +974,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -449,33 +989,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr ""
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -484,15 +1020,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -500,7 +1036,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -508,7 +1044,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -516,16 +1052,17 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2981
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -534,46 +1071,37 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr ""
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3245
-#, php-format
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -582,15 +1110,15 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -604,23 +1132,23 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials."
 msgstr ""
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
 "'%3$s' in the year %4$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -628,10 +1156,31 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
+msgstr ""
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, php-format
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
 msgstr ""
 
 #. translators:
@@ -642,7 +1191,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -656,7 +1205,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -670,13 +1219,14 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
+#: src/Paths/CalendarPath.php:3786
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 
 #. translators:
@@ -686,12 +1236,12 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
+#: src/Paths/CalendarPath.php:3805
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 
 #. translators:
@@ -703,7 +1253,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -717,7 +1267,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -726,22 +1276,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
+#: src/Paths/CalendarPath.php:3878
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
+msgstr ""
+
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -751,11 +1308,11 @@ msgstr ""
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -763,21 +1320,21 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
 "room for '%3$s': applicable to the year %4$d."
 msgstr ""
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -785,8 +1342,33 @@ msgid ""
 "in the year %9$d."
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -794,390 +1376,23 @@ msgid ""
 "year %5$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "zöld"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "viola"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "fehér"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "piros"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "rózsaszín"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr ""
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr ""
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr ""
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr ""
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr ""
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr ""
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
-msgid "commemoration"
-msgstr ""
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-msgid "optional memorial"
-msgstr ""
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr ""
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr ""
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr ""
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr ""
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr ""
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""

--- a/i18n/id/LC_MESSAGES/litcal.po
+++ b/i18n/id/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2024-08-20 15:40+0000\n"
 "Last-Translator: User_425 <user425.itsme@gmail.com>\n"
 "Language-Team: Indonesian <https://translate.johnromanodorazio.com/projects/"
@@ -19,18 +19,708 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr ""
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr ""
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr ""
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr ""
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "merah muda"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr ""
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Pemberkatan Gereja"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Santa Perawan Maria"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Martir"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Pastor"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Doktor"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Perawan"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Orang-orang Kudus"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Untuk Seorang Martir"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Untuk Beberapa Martir"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Untuk Martir Misionaris"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Untuk Seorang Martir Misionaris"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Untuk Beberapa Martir Misionaris"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Untuk Seorang Martir Perawan"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Untuk Seorang Paus"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Untuk Seorang Uskup"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Untuk Seorang Imam"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Untuk Beberapa Imam"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Untuk Para Pendiri Gereja"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Untuk Seorang Pendiri"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Untuk Beberapa Pendiri"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Untuk Para Misionaris"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Untuk Seorang Perawan"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Untuk Beberapa Perawan"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Untuk Beberapa Orang Kudus"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Untuk Seorang Kudus"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Untuk Seorang Abas"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Untuk Seorang Biarawan"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Untuk Seorang Biarawati"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr ""
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr ""
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr ""
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+msgid "commemoration"
+msgstr ""
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+msgid "optional memorial"
+msgstr ""
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr ""
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr ""
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr ""
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr ""
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr ""
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "dan Pujangga Gereja"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Untuk Seorang Paus"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Untuk Seorang Uskup"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Untuk Para Pendiri Gereja"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Untuk Seorang Kudus"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+msgid "For Reconciliation"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "Hari %s pada Oktaf Natal"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Untuk Seorang Biarawati"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Untuk Seorang Martir"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+msgid "For an End to Storms"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Untuk Seorang Martir"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Untuk Seorang Perawan"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Untuk Seorang Kudus"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Untuk Seorang Kudus"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr ""
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr ""
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "atau"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr ""
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -39,151 +729,50 @@ msgstr ""
 "Hanya mendukung dari tahun 1970 dan seterusnya. Kamu mencoba meminta tahun "
 "%d."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr ""
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr ""
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "atau"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Minggu Kerahiman Ilahi"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -196,7 +785,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -204,7 +793,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -212,12 +801,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -227,77 +816,72 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "Pekan %s Adven"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "Hari %s pada Oktaf Natal"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "Pekan %s Prapaskah"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "setelah Rabu Abu"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
 msgstr ""
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -306,22 +890,33 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -330,16 +925,16 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -352,69 +947,38 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials (%4$s)."
 msgstr ""
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr ""
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr ""
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -422,14 +986,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -437,14 +1001,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -452,33 +1016,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "dan Pujangga Gereja"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -487,15 +1047,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -503,7 +1063,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -511,7 +1071,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -519,16 +1079,17 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2981
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -537,46 +1098,37 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "Pekan %s Paskah"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "Pekan Biasa %s"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3245
-#, php-format
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -585,15 +1137,15 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -607,23 +1159,23 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials."
 msgstr ""
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
 "'%3$s' in the year %4$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -631,10 +1183,31 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
+msgstr ""
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, php-format
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
 msgstr ""
 
 #. translators:
@@ -645,7 +1218,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -659,7 +1232,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -673,13 +1246,14 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
+#: src/Paths/CalendarPath.php:3786
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 
 #. translators:
@@ -689,12 +1263,12 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
+#: src/Paths/CalendarPath.php:3805
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 
 #. translators:
@@ -706,7 +1280,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -720,7 +1294,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -729,22 +1303,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
+#: src/Paths/CalendarPath.php:3878
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
+msgstr ""
+
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -754,11 +1335,11 @@ msgstr ""
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -766,21 +1347,21 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
 "room for '%3$s': applicable to the year %4$d."
 msgstr ""
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -788,8 +1369,33 @@ msgid ""
 "in the year %9$d."
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -797,390 +1403,23 @@ msgid ""
 "year %5$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "merah muda"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Pemberkatan Gereja"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Santa Perawan Maria"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Martir"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Pastor"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Doktor"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Perawan"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Orang-orang Kudus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Untuk Seorang Martir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Untuk Beberapa Martir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Untuk Martir Misionaris"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Untuk Seorang Martir Misionaris"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Untuk Beberapa Martir Misionaris"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Untuk Seorang Martir Perawan"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Untuk Seorang Paus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Untuk Seorang Uskup"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Untuk Seorang Imam"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Untuk Beberapa Imam"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Untuk Para Pendiri Gereja"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Untuk Seorang Pendiri"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Untuk Beberapa Pendiri"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Untuk Para Misionaris"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Untuk Seorang Perawan"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Untuk Beberapa Perawan"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Untuk Beberapa Orang Kudus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Untuk Seorang Kudus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Untuk Seorang Abas"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Untuk Seorang Biarawan"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Untuk Seorang Biarawati"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr ""
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr ""
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr ""
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr ""
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr ""
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr ""
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
-msgid "commemoration"
-msgstr ""
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-msgid "optional memorial"
-msgstr ""
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr ""
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr ""
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr ""
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr ""
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr ""
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""

--- a/i18n/it/LC_MESSAGES/litcal.po
+++ b/i18n/it/LC_MESSAGES/litcal.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Italian <https://translate.johnromanodorazio.com/projects/"
@@ -22,19 +22,727 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "verde"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "viola"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "bianco"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "rosso"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "rosa"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Proprio"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Dedicazione di una Chiesa"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Beata Vergine Maria"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Martiri"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Pastori"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Dottori della Chiesa"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Vergini"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Santi e delle Sante"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Per un martire"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Per più martiri"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Per i martiri missionari"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Per un martire missionario"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Per più martiri missionari"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Per una vergine martire"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Per una santa martire"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Per un papa"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Per un vescovo"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Per un pastore"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Per più pastori"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Per i fondatori delle chiese"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Per un fondatore"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Per più fondatori"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Per i missionari"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Per una vergine"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Per più vergini"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Per più santi"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Per un santo"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Per un abate"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Per un monaco"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Per una monaca"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Per i religiosi"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Per gli operatori di misericordia"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Per gli educatori"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Per le sante"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr "della"
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr "delle"
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr "dei"
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr "del"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "feria"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr "f"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+msgid "commemoration"
+msgstr "commemorazione"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr "mf*"
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+msgid "optional memorial"
+msgstr "memoria facoltativa"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr "mf"
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Memoria"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr "M"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "FESTA"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr "F"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "FESTA DEL SIGNORE"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr "F✝"
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "SOLENNITÀ"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr "S"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "celebrazione con precedenza sulle solennità"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr "S✝"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "e Dottore della Chiesa"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Per un papa"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Per un vescovo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Per i fondatori delle chiese"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Per un santo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Per i religiosi"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "%s Giorno dell'Ottava di Natale"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Per una monaca"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Per un martire"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Per gli educatori"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Per un martire"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Per una vergine"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Per un santo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Per un santo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr "Avvento"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr "Natale"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr "Quaresima"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr "Triduo Pasquale"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr "Pasqua"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr "Tempo Ordinario"
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "Dal Comune"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "oppure"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "ANNO"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Messa della vigilia"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+"La Messa nella Vigilia per la %1$s '%2$s' coincide con la %3$s '%4$s' "
+"nell'anno %5$d. Secondo il %6$s, la prima ha la precedenza, pertanto la "
+"Messa nella Vigilia è confermata come anche i Primi Vespri."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr "Decreto della Congregazione per il Culto Divino"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+"La Messa nella Vigilia per la %1$s '%2$s' coincide con la %3$s '%4$s' "
+"nell'anno %5$d. Visto che la prima Solennità ha la precedenza, avrà i Primi "
+"Vespri e una Messa di Vigilia, mentre l'ultima Solennità non avrà né i "
+"Secondi Vespri né una Messa serale."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+"La Messa nella Vigilia per la %1$s '%2$s' coincide con la %3$s '%4$s' "
+"nell'anno %5$d. Quest'ultima Solennità ha la precedenza, pertanto manterrà i "
+"Secondi Vespri e una Messa serale, mentre la prima Solennità non avrà né una "
+"Messa di Vigilia né i Primi Vespri."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+"La Messa nella Vigilia per la %1$s '%2$s' coincide con la %3$s '%4$s' "
+"nell'anno %5$d. Dovremmo chiedere alla Congregazione del Culto Divino cosa "
+"fare a riguardo!"
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 "Il nome della diocesi non può essere derivato dall'ID della diocesi \"%s\"."
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr "Il calendario diocesano \"%s\" non è stato trovato nel file indice."
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -43,138 +751,30 @@ msgstr ""
 "Sono supportati anni dal 1970 in poi soltanto. Tu invece hai provato a "
 "richiedere l'anno %d."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-"Si è verificato un errore nel tentativo di decodificare i dati JSON "
-"localizzati per il Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-"Si è verificato un errore nel tentativo di recuperare i dati localizzati per "
-"il Temporale."
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-"Si è verificato un errore nel tentativo di decodificare i dati JSON per il "
-"Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-"Si è verificato un errore nel tentativo di recuperare i dati per il "
-"Temporale."
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr "Non sono stati trovati dati per la traduzione del santorale di: %s."
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-"Si è verificato un errore nel tentativo di decodificare i dati di "
-"localizzazione JSON per il Sanctorale del Messale %1$s: %2$s"
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr "Non sono stati trovati dati per il Santorale da %s."
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-"Si è verificato un errore nel tentativo di decodificare i dati JSON per il "
-"Sanctorale del Messale %1$s: %2$s."
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr "Non è stato trovato un file con i dati del Santorale"
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-"Si è verificato un errore nel tentativo di decodificare i dati di traduzione "
-"per le Memorie basate sui Decreti della Congregazione per il Culto Divino: %s"
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-"Impossibile trovare dati di traduzione per le Memorie basate sui Decreti "
-"della Congregazione per il Culto Divino"
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-"Si è verificato un errore nel tentativo di decodificare i dati JSON per le "
-"Memorie basate sui Decreti della Congregazione per il Culto Divino: %s"
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Giorno feriale di Natale"
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "oppure"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Domenica della Divina Misericordia"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -183,31 +783,20 @@ msgstr ""
 "La Solennità <i>'%1$s'</i> cade di %2$s nell'anno %3$d, pertanto la "
 "celebrazione è stata trasferita al %4$s (%5$s) in accordo con il %6$s."
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr "sabato che precede la Domenica delle Palme"
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr "Decreto della Congregazione per il Culto Divino"
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "lunedì che segue la Seconda Domenica di Pasqua"
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr "lunedì seguente"
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -223,7 +812,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -233,7 +822,7 @@ msgstr ""
 "nell'anno %3$d, la prima è stata anticipata di un giorno come da %4$s."
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -243,12 +832,12 @@ msgstr ""
 "<i>'%3$s'</i> viene celebrata il %4$s anziché la Domenica dopo Natale."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Nostro Signore Gesù Cristo, Sommo ed Eterno Sacerdote"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -262,59 +851,59 @@ msgstr ""
 "calendario '%1$s' nell'anno '%2$d' (%3$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "<i>'%1$s'</i> è soppiantata dalla %2$s <i>'%3$s'</i> nell'anno %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "della %s Settimana dell'Avvento"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Giorno dell'Ottava di Natale"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "della %s Settimana di Quaresima"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "dopo il Mercoledì delle Ceneri"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -323,7 +912,7 @@ msgstr ""
 "La %1$s '%2$s' è stata inserita il giorno %3$s a partire dall'anno %4$d "
 "(%5$s), applicabile pertanto all'anno %6$d."
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -331,12 +920,7 @@ msgstr ""
 "Conferenza Stampa Vaticana: Presentazione della Editio Typica Tertia del "
 "Messale Romano"
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -348,22 +932,33 @@ msgstr ""
 "stato ridotto a Commemorazione."
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "La %1$s '%2$s' è soppiantata dalla %3$s '%4$s' nell'anno %5$d."
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Costituzione Apostolica Missale Romanum"
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -375,16 +970,16 @@ msgstr ""
 "nell'anno %9$d."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -399,7 +994,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -408,71 +1003,41 @@ msgstr ""
 "La Memoria '%1$s' coincide con un'altra Memoria '%2$s' nell'anno %3$d. Tutte "
 "e due sono ridotte al grado di memorie facoltative (%4$s)."
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr "prima di"
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr "dopo"
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 "Impossibile creare la festività mobile '%1$s': può solo essere relativa alla "
 "festività con chiave '%2$s' utilizzando le parole chiave %3$s"
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 "Impossibile creare la festività mobile '%1$s' relativa alla festività con "
 "chiave '%2$s'"
 
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-"Impossibile creare la festività mobile '%1$s': quando la proprietà "
-"'strtotime' è un oggetto, deve avere le proprietà %2$s"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-"Impossibile creare la festività mobile '%1$s': la proprietà 'strtotime' deve "
-"essere un oggetto oppure una stringa! Attualmente è di tipo '%2$s'"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
-msgstr ""
-"Impossibile creare la festività mobile '%1$s' senza la proprietà 'strtotime'!"
-
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -482,14 +1047,14 @@ msgstr ""
 "pertanto all'anno %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -499,14 +1064,14 @@ msgstr ""
 "pertanto all'anno %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -516,12 +1081,12 @@ msgstr ""
 "pertanto all'anno %5$d (%6$s)."
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -530,21 +1095,17 @@ msgstr ""
 "'%1$s' è stato dichiarato Dottore della Chiesa sin dal %2$d, applicabile "
 "pertanto all'anno %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "e Dottore della Chiesa"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -555,15 +1116,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -573,7 +1134,7 @@ msgstr ""
 "il giorno %6$s sin dal %7$d (%8$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -583,7 +1144,7 @@ msgstr ""
 "sin dal 2002 (%2$s), applicabile pertanto all'anno %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -595,19 +1156,24 @@ msgstr ""
 "trasferita al 12 Agosto sin dal 2002 (%2$s), applicabile pertanto all'anno "
 "%3$d."
 
-#: src/Paths/Calendar.php:2981
-#, php-format
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
+#, fuzzy, php-format
+#| msgid ""
+#| "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
+#| "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
+#| "superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 "La memoria facoltativa '%1$s' è stata trasferita dal 12 Dic. al 12 Agosto "
 "sin dal 2002 (%2$s), applicabile pertanto all'anno %3$d. Tuttavia, è "
 "soppressa da una Domenica, una Solennità o una Festa '%4$s' nell'anno %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -620,28 +1186,22 @@ msgstr ""
 "restituita secondo il %2$s in modo che le chiese locali abbiano facoltà di "
 "mantenere la memoria."
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "della %s Settimana di Pasqua"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "della %s Settimana del Tempo Ordinario"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memoria di Santa Maria in sabato"
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-"Errore nella lettura o nella decodifica dei dati per la Regione più ampia "
-"dal file %s."
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -649,23 +1209,16 @@ msgstr ""
 "Impossibile trovare una proprietà %1$s nel %2$s per il Calendario Nazionale "
 "%3$s."
 
-#: src/Paths/Calendar.php:3245
-#, php-format
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-"Errore nella lettura o nella decodifica dei dati del Calendario Nazionale "
-"dal file %s."
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -677,15 +1230,15 @@ msgstr ""
 "Calendario %7$s, è stata reintegrata."
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -702,7 +1255,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -711,8 +1264,8 @@ msgstr ""
 "La Memoria '%1$s' coincide con un'altra Memoria '%2$s' nell'anno %3$d. Tutte "
 "e due sono ridotte al grado di memorie facoltative."
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -721,8 +1274,8 @@ msgstr ""
 "La Festa '%1$s', celebrata solitamente il giorno %2$s, è soppressa dalla "
 "Festa '%3$s' nell'anno %4$d. Dobbiamo rimediare?"
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -732,13 +1285,43 @@ msgstr ""
 "La Solennità '%1$s', solitamente celebrate il %2$s, coincide con la Domenica "
 "o Solennità '%3$s' nell'anno %4$d. Dobbiamo rimediare in qualche modo?"
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+#, fuzzy
+#| msgid ""
+#| "We should be creating a new festivity, however we do not seem to have the "
+#| "correct date information in order to proceed"
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
 msgstr ""
 "Dovremmo creare una nuova festività, tuttavia sembra che non ci sono le "
 "corrette informazioni sulla data per poter procedere"
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
+#| "applicable to the year %5$d (%6$s)."
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
+msgstr ""
+"La %1$s '%2$s' è stata promossa al grado di %3$s sin dal %4$d, applicabile "
+"pertanto all'anno %5$d (%6$s)."
 
 #. translators:
 #.  1. Liturgical grade
@@ -748,7 +1331,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -764,7 +1347,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -781,13 +1364,17 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
-#, php-format
+#: src/Paths/CalendarPath.php:3786
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
+#| "calendar '%4$s' since the year %5$d, applicable to the year %6$d."
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 "Il grado di %1$s '%2$s' è stato cambiato in '%3$s' nel calendario nazionale "
 "'%4$s' dall'anno %5$d, applicabile all'anno %6$d."
@@ -799,12 +1386,16 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
-#, php-format
+#: src/Paths/CalendarPath.php:3805
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
+#| "national calendar '%3$s' since the year %4$d, but could not be applied to "
+#| "the year %5$d because the celebration was not found."
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 "Il grado della celebrazione '%1$s' è stato cambiato in '%2$s' nel calendario "
 "nazionale '%3$s' dall'anno %4$d, ma non è stato possibile applicarlo "
@@ -819,7 +1410,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -835,7 +1426,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -848,26 +1439,38 @@ msgstr ""
 "eventi del Messale Romano."
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
-#, php-format
+#: src/Paths/CalendarPath.php:3878
+#, fuzzy, php-format
+#| msgid ""
+#| "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
+#| "the national calendar '%4$s', but this could not take place in the year "
+#| "%5$d since the new date %2$s seems to be a Sunday or a festivity of "
+#| "greater rank."
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
 msgstr ""
 "L'evento liturgico '%1$s' è stato spostato a %2$s dall'anno %3$d nel "
 "calendario nazionale '%4$s', ma non ha potuto aver luogo nell'anno %5$d "
 "poiché la nuova data %2$s sembra essere una domenica o una festività di "
 "rango superiore."
 
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
+msgstr ""
+
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Trovato un file con dati per il santorale di: %s"
@@ -877,11 +1480,11 @@ msgstr "Trovato un file con dati per il santorale di: %s"
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -891,13 +1494,13 @@ msgstr ""
 "superata dalla %5$s '%6$s' nell'anno %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Non è stato trovato un file con i dati del santorale di: %s"
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -906,8 +1509,8 @@ msgstr ""
 "La %1$s '%2$s' è stata trasferita da %5$s a %6$s secondo il %7$s, per "
 "lasciare luogo a '%3$s': applicabile pertanto all'anno %4$d."
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -918,8 +1521,48 @@ msgstr ""
 "lasciare luogo a '%6$s', tuttavia è soppressa dalla %7$s '%8$s' nell'anno "
 "%9$d."
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+"Impossibile creare la festività mobile '%1$s' relativa alla festività con "
+"chiave '%2$s'"
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+"Impossibile creare la festività mobile '%1$s': può solo essere relativa alla "
+"festività con chiave '%2$s' utilizzando le parole chiave %3$s"
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': 'strtotime' property must be "
+#| "either an object or a string! Currently it has type '%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+"Impossibile creare la festività mobile '%1$s': la proprietà 'strtotime' deve "
+"essere un oggetto oppure una stringa! Attualmente è di tipo '%2$s'"
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -930,411 +1573,134 @@ msgstr ""
 "il %3$s, coincide con la Domenica o Solennità '%4$s' nell'anno %5$d! Bisogna "
 "fare qualcosa a riguardo?"
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
-#, php-format
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s', proper to the calendar of the %3$s and usually "
+#| "celebrated on %4$s, is suppressed by the Sunday or Solemnity %5$s in the "
+#| "year %6$d"
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 "La %1$s '%2$s', propria del calendario %3$s e solitamente celebrate il "
 "giorno %4$s, è soppressa dalla Domenica o Solennità '%5$s' nell'anno %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 "Errore nel ricevere o nel fare il parsing delle informazioni da github "
 "sull'ultima release: %s."
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "ANNO"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr "Messa della vigilia"
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
-"La Messa nella Vigilia per la %1$s '%2$s' coincide con la %3$s '%4$s' "
-"nell'anno %5$d. Secondo il %6$s, la prima ha la precedenza, pertanto la "
-"Messa nella Vigilia è confermata come anche i Primi Vespri."
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-"La Messa nella Vigilia per la %1$s '%2$s' coincide con la %3$s '%4$s' "
-"nell'anno %5$d. Visto che la prima Solennità ha la precedenza, avrà i Primi "
-"Vespri e una Messa di Vigilia, mentre l'ultima Solennità non avrà né i "
-"Secondi Vespri né una Messa serale."
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-"La Messa nella Vigilia per la %1$s '%2$s' coincide con la %3$s '%4$s' "
-"nell'anno %5$d. Quest'ultima Solennità ha la precedenza, pertanto manterrà i "
-"Secondi Vespri e una Messa serale, mentre la prima Solennità non avrà né una "
-"Messa di Vigilia né i Primi Vespri."
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-"La Messa nella Vigilia per la %1$s '%2$s' coincide con la %3$s '%4$s' "
-"nell'anno %5$d. Dovremmo chiedere alla Congregazione del Culto Divino cosa "
-"fare a riguardo!"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "verde"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "viola"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "bianco"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "rosso"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "rosa"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Proprio"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Dedicazione di una Chiesa"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Beata Vergine Maria"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Martiri"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Pastori"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Dottori della Chiesa"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Vergini"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Santi e delle Sante"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Per un martire"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Per più martiri"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Per i martiri missionari"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Per un martire missionario"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Per più martiri missionari"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Per una vergine martire"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Per una santa martire"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Per un papa"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Per un vescovo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Per un pastore"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Per più pastori"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Per i fondatori delle chiese"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Per un fondatore"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Per più fondatori"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Per i missionari"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Per una vergine"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Per più vergini"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Per più santi"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Per un santo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Per un abate"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Per un monaco"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Per una monaca"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Per i religiosi"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Per gli operatori di misericordia"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Per gli educatori"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Per le sante"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr "della"
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr "delle"
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr "dei"
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr "del"
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "Dal Comune"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "feria"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
-msgstr "f"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
-msgid "commemoration"
-msgstr "commemorazione"
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr "mf*"
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-msgid "optional memorial"
-msgstr "memoria facoltativa"
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr "mf"
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Memoria"
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr "M"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "FESTA"
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr "F"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "FESTA DEL SIGNORE"
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr "F✝"
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "SOLENNITÀ"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr "S"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "celebrazione con precedenza sulle solennità"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr "S✝"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr "Avvento"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr "Natale"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr "Quaresima"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr "Triduo Pasquale"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr "Pasqua"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr "Tempo Ordinario"
+
+#~ msgid "The Diocesan calendar \"%s\" was not found in the index file."
+#~ msgstr "Il calendario diocesano \"%s\" non è stato trovato nel file indice."
+
+#~ msgid ""
+#~ "There was an error trying to decode localized JSON data for the "
+#~ "Temporale: %s"
+#~ msgstr ""
+#~ "Si è verificato un errore nel tentativo di decodificare i dati JSON "
+#~ "localizzati per il Temporale: %s"
+
+#~ msgid ""
+#~ "There was an error trying to retrieve localized data for the Temporale."
+#~ msgstr ""
+#~ "Si è verificato un errore nel tentativo di recuperare i dati localizzati "
+#~ "per il Temporale."
+
+#~ msgid "There was an error trying to decode JSON data for the Temporale: %s"
+#~ msgstr ""
+#~ "Si è verificato un errore nel tentativo di decodificare i dati JSON per "
+#~ "il Temporale: %s"
+
+#~ msgid "There was an error trying to retrieve data for the Temporale."
+#~ msgstr ""
+#~ "Si è verificato un errore nel tentativo di recuperare i dati per il "
+#~ "Temporale."
+
+#~ msgid "Translation data for the sanctorale from %s could not be found."
+#~ msgstr "Non sono stati trovati dati per la traduzione del santorale di: %s."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON localization data for the "
+#~ "Sanctorale for the Missal %1$s: %2$s"
+#~ msgstr ""
+#~ "Si è verificato un errore nel tentativo di decodificare i dati di "
+#~ "localizzazione JSON per il Sanctorale del Messale %1$s: %2$s"
+
+#~ msgid "Data for the Sanctorale from %s could not be found."
+#~ msgstr "Non sono stati trovati dati per il Santorale da %s."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for the Sanctorale for the "
+#~ "Missal %1$s: %2$s."
+#~ msgstr ""
+#~ "Si è verificato un errore nel tentativo di decodificare i dati JSON per "
+#~ "il Sanctorale del Messale %1$s: %2$s."
+
+#~ msgid "Could not find the Sanctorale data"
+#~ msgstr "Non è stato trovato un file con i dati del Santorale"
+
+#~ msgid ""
+#~ "There was an error trying to decode translation data for Memorials based "
+#~ "on Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Si è verificato un errore nel tentativo di decodificare i dati di "
+#~ "traduzione per le Memorie basate sui Decreti della Congregazione per il "
+#~ "Culto Divino: %s"
+
+#~ msgid ""
+#~ "Could not find translation data for Memorials based on Decrees of the "
+#~ "Congregation for Divine Worship"
+#~ msgstr ""
+#~ "Impossibile trovare dati di traduzione per le Memorie basate sui Decreti "
+#~ "della Congregazione per il Culto Divino"
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for Memorials based on "
+#~ "Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Si è verificato un errore nel tentativo di decodificare i dati JSON per "
+#~ "le Memorie basate sui Decreti della Congregazione per il Culto Divino: %s"
+
+#~ msgid "before"
+#~ msgstr "prima di"
+
+#~ msgid "after"
+#~ msgstr "dopo"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s': when the 'strtotime' property is "
+#~ "an object, it must have properties %2$s"
+#~ msgstr ""
+#~ "Impossibile creare la festività mobile '%1$s': quando la proprietà "
+#~ "'strtotime' è un oggetto, deve avere le proprietà %2$s"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+#~ msgstr ""
+#~ "Impossibile creare la festività mobile '%1$s' senza la proprietà "
+#~ "'strtotime'!"
+
+#~ msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgstr ""
+#~ "Errore nella lettura o nella decodifica dei dati per la Regione più ampia "
+#~ "dal file %s."
+
+#~ msgid "Error retrieving and decoding National Calendar data from file %s."
+#~ msgstr ""
+#~ "Errore nella lettura o nella decodifica dei dati del Calendario Nazionale "
+#~ "dal file %s."
 
 #~ msgctxt "(SING_FEMM)"
 #~ msgid "of"

--- a/i18n/la/LC_MESSAGES/litcal.po
+++ b/i18n/la/LC_MESSAGES/litcal.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2024-11-03 10:52+0000\n"
 "Last-Translator: Weblate Admin <admin@example.com>\n"
 "Language-Team: Latin <https://translate.johnromanodorazio.com/projects/"
@@ -20,18 +20,729 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "viridis"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "purpura"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "albus"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "ruber"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "rosea"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Proprium"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Dedicationis ecclesiæ"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Beatæ Mariæ Virginis"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Martyrum"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Pastorum"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Doctorum Ecclesiæ"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Virginum"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Sanctorum et Sanctarum"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Pro uno martyre"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Pro pluribus martyribus"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Pro missionariis martyribus"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Pro uno missionario martyre"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Pro pluribus missionariis martyribus"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Pro virgine martyre"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Pro sancta muliere martyre"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Pro papa"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Pro episcopo"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Pro uno pastore"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Pro pluribus pastoribus"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Pro fundatoribus ecclesiarum"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Pro uno fundatore"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Pro pluribus fundatoribus"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Pro missionariis"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Pro una virgine"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Pro pluribus virginibus"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Pro pluribus sanctis"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Pro uno sancto"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Pro abbate"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Pro monacho"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Pro moniali"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Pro religiosis"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Pro iis qui opera misericordiæ exercuerunt"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Pro educatoribus"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Pro sanctis mulieribus"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr ""
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "feria"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+#, fuzzy
+#| msgid "Commemoration"
+msgid "commemoration"
+msgstr "Commemoratio"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+#, fuzzy
+#| msgid "Optional memorial"
+msgid "optional memorial"
+msgstr "Memoria ad libitum"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Memoria obligatoria"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "FESTUM"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "FESTUM DOMINI"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "SOLLEMNITAS"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "celebratio altioris ordinis quam sollemnitatis"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "et Ecclesiæ doctoris"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Pro papa"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Pro episcopo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Pro fundatoribus ecclesiarum"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Pro uno sancto"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Pro religiosis"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "Dies %s Octavæ Nativitatis"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Pro moniali"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Pro uno martyre"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Pro educatoribus"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Pro uno martyre"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Pro una virgine"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Pro uno sancto"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Pro uno sancto"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr "Tempus Adventus"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr "Tempus Nativitatis"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr "Tempus Quadragesimæ"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr "Sacrum Triduum paschale"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr "Tempus paschale"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr "Tempus per annum"
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "De Commune"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "vel"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "ANNUM"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Missa in Vigilia"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+"Missa in Vigilia %1$s '%2$s' coincidet cum %3$s'%4$s' in anno %5$d. Secundum "
+"%6$s, prima praecedentia habet, ergo Missa vesperum et Missa in Vigilia "
+"servabuntur."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr "Decretum Congregationis pro Cultu Divino"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+"Missa in Vigilia %1$s '%2$s' coincidet cum %3$s'%4$s' in anno %5$d. "
+"Sollemnitas prima praecedentia habet, ergo servabit Secundis Vesperis atque "
+"Missa vesperum, cum Sollemnitas ultima neque Missa in Vigilia neque Primis "
+"Vesperis servabit."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+"Missa in Vigilia %1$s '%2$s' coincidet cum %3$s'%4$s' in anno %5$d. "
+"Sollemnitas ultima praecedentia habet, ergo servabit Secundis Vesperis atque "
+"Missa vesperum, cum Sollemnitas prima neque Missa in Vigilia neque Primis "
+"Vesperis servabit."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+"Missa in Vigilia %1$s '%2$s' coincidet cum %3$s'%4$s' in anno %5$d. Oportet "
+"quaerere a Congregatione Cultu Divino quid facere!"
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr ""
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -39,122 +750,30 @@ msgid ""
 msgstr ""
 "Petere potes nisi ab annis MCMLXX et ultra. Tu anno %d conatus est petere."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr "Translationem datarum pro sanctorali ex %s inveniri non potuit."
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, fuzzy, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr "Data pro sanctorale ex %s reperiri non potuit."
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-#, fuzzy
-msgid "Could not find the Sanctorale data"
-msgstr "Archivum datarum de Sanctorale pro %s non inventa est"
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-
-#: src/Paths/Calendar.php:953
-#, fuzzy
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr "Decretum Congregationis pro Cultu Divino"
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "vel"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Dominica de divina Misericordia"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -163,31 +782,20 @@ msgstr ""
 "Coincidet enim Sollemnitas <i>'%1$s'</i> cum <b>%2$s</b> in anno %3$d, ergo "
 "traslata est celebratio ad %4$s (%5$s) secundum %6$s."
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr "sabbatum ante Dominicam in Palmis"
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr "Decretum Congregationis pro Cultu Divino"
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "diem Lunæ post Dominicam Secundam Paschæ"
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr "diem Lunæ proximum"
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -202,7 +810,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -212,7 +820,7 @@ msgstr ""
 "in anno %3$d, anticipata est ab uno die secundum %4$s."
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -222,12 +830,12 @@ msgstr ""
 "celebrentur die %4$s quam Dominica post Nativitate."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Dómini nostri Iesu Christi, Summi et Aetérni Sacerdótis"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -241,59 +849,59 @@ msgstr ""
 "applicabile ad calendarium '%1$s' anno '%2$d' (%3$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "<i>'%1$s'</i> subplantata est ab %2$s <i>'%3$s'</i> in anno %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "Hebdomadæ %s Adventus"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "Dies %s Octavæ Nativitatis"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "Hebdomadæ %s Quadragesimæ"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "post Feria IV Cinerum"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -302,7 +910,7 @@ msgstr ""
 "%1$s <i>'%2$s'</i> aggregata est igitur in die %3$s ab anno %4$d (%5$s), "
 "ergo viget in anno %6$d."
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -310,12 +918,7 @@ msgstr ""
 "Conferentia Vaticanensis: Praesentatio Editionis Typicae Tertiae Missalis "
 "Romani"
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -327,22 +930,33 @@ msgstr ""
 "gradus ad Commemorationem."
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "%1$s '%2$s' subplantata est ab %3$s '%4$s' in anno %5$d."
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apostolica Constitutio Missale Romanum"
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -353,16 +967,16 @@ msgstr ""
 "plerumque celebrata in die %6$s subplantata est ab %7$s '%8$s' in anno %9$d."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -377,7 +991,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -386,71 +1000,41 @@ msgstr ""
 "Memoria '%1$s' coincidet cum alia Memoria '%2$s' in anno %3$d. Ergo ambo "
 "simul redunctur in gradu Memoriæ ad libitum (%4$s)."
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr "ante"
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr "postquam"
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 "Festivitas mobilia '%1$s' creari non potest: tantum ad festivitatem cum "
 "clave '%2$s' relativa esse potest, utentem verbis clavum %3$s"
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 "Festivitas mobilia '%1$s' in comparatione cum festivitate clavigeri '%2$s' "
 "creari non potest"
 
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-"Mobile festivitas '%1$s' creare non possum: cum proprietas 'strtotime' sit "
-"obiectum, oportet eam habere proprietates %2$s"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-"Festivitas mobilia '%1$s' creari non potest: proprietas 'strtotime' aut "
-"obiectum esse debet aut stringere! Nunc autem habet typum '%2$s'"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
-msgstr ""
-"Festivitas mobilia '%1$s' non potest creari sine proprietate 'strtotime'!"
-
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -460,14 +1044,14 @@ msgstr ""
 "%5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -477,14 +1061,14 @@ msgstr ""
 "%5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -494,12 +1078,12 @@ msgstr ""
 "%5$d (%6$s)."
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -508,21 +1092,17 @@ msgstr ""
 "'%1$s' declarato/a est Doctor Ecclesiæ ab anno %2$d, ergo applicatur ad anno "
 "%3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "et Ecclesiæ doctoris"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -533,15 +1113,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -551,7 +1131,7 @@ msgstr ""
 "%6$s ab anno %7$d (%8$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -561,7 +1141,7 @@ msgstr ""
 "2002 (%2$s), ergo viget in anno %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -572,19 +1152,24 @@ msgstr ""
 "Sollemnitate si celebrata fuisset in die 12 Dec., nihilominus traslata est "
 "ad 12 Aug. ab anno 2002 (%2$s), ergo viget in anno %3$d."
 
-#: src/Paths/Calendar.php:2981
-#, php-format
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
+#, fuzzy, php-format
+#| msgid ""
+#| "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
+#| "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
+#| "superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 "Memoria ad libitum <i>\\'%1$s\\'</i> traslata est de 12 Dec. ad 12 Aug. ab "
 "anno 2002 (%2$s), ergo viget in anno %3$d. Nihilominus subplantata est ab "
 "Dominica, aut Sollemnitate, aut Festu <i>\\'%4$s\\'</i> in anno %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -596,51 +1181,37 @@ msgstr ""
 "tamen quamvis sit Annus Pauli Apostoli, restituta est secundum %2$s ut "
 "permittant ecclesias locales ad memoriam celebrandam."
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "Hebdomadæ %s Temporis Paschali"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "Hebdomadæ %s Temporis Ordinarii"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memoria Sanctæ Mariæ in Sabbato"
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-"Errorem ad recuperandam et interpretandam datam Regionis Latiorem ex archivo "
-"%s."
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3245
-#, fuzzy, php-format
-#| msgid "Error retrieving and decoding Wider Region data from file %s."
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-"Errorem ad recuperandam et interpretandam datam Regionis Latiorem ex archivo "
-"%s."
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -654,15 +1225,15 @@ msgstr ""
 "in anno %6$d."
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -681,7 +1252,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -690,8 +1261,8 @@ msgstr ""
 "Memoria '%1$s' coincidet cum alia Memoria '%2$s' in anno %3$d. Ergo ambo "
 "simul redunctur in gradu Memoriæ ad libitum."
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -700,8 +1271,8 @@ msgstr ""
 "Festum '%1$s', sollemniter celebratum die %2$s, coincidet cum alio Festum "
 "'%3$s' anno %4$d! Opus est aliquid de hoc agere?"
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -711,13 +1282,43 @@ msgstr ""
 "Solemnitas '%1$s', quae plerumque celebratur die %2$s, coincidet cum "
 "Dominica vel Solemnitate '%3$s' anno %4$d! Opus est aliquid de hoc agere?"
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+#, fuzzy
+#| msgid ""
+#| "We should be creating a new festivity, however we do not seem to have the "
+#| "correct date information in order to proceed"
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
 msgstr ""
 "Novam festivitatem creare debemus, sed videtur nos non habere rectam "
 "informationem de die quo procedere"
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
+#| "applicable to the year %5$d (%6$s)."
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
+msgstr ""
+"%1$s '%2$s' elevata est in gradu %3$s ab anno %4$d, ergo applicatur ad anno "
+"%5$d (%6$s)."
 
 #. translators:
 #.  1. Liturgical grade
@@ -727,7 +1328,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -746,7 +1347,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -765,16 +1366,17 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
+#: src/Paths/CalendarPath.php:3786
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
 #| "applicable to the year %5$d (%6$s)."
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 "%1$s '%2$s' elevata est in gradu %3$s ab anno %4$d, ergo applicatur ad anno "
 "%5$d (%6$s)."
@@ -786,15 +1388,15 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
+#: src/Paths/CalendarPath.php:3805
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
 #| "applicable to the year %5$d (%6$s)."
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 "%1$s '%2$s' elevata est in gradu %3$s ab anno %4$d, ergo applicatur ad anno "
 "%5$d (%6$s)."
@@ -808,7 +1410,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -827,7 +1429,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -836,22 +1438,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
+#: src/Paths/CalendarPath.php:3878
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
+msgstr ""
+
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Inveni codicem datarum sanctoralium pro %s"
@@ -861,11 +1470,11 @@ msgstr "Inveni codicem datarum sanctoralium pro %s"
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -875,13 +1484,13 @@ msgstr ""
 "ab %5$s '%6$s' in anno %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Archivum datarum de Sanctorale pro %s non inventa est"
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -890,8 +1499,8 @@ msgstr ""
 "%1$s <i>'%2$s'</i> traslata est de die %5$s ad diem %6$s secundum %7$s, cum "
 "spatium facere in gratiam '%3$s': ergo viget in anno %4$d."
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -902,8 +1511,48 @@ msgstr ""
 "spatium facere in gratiam '%6$s', sed subplantata est ab %7$s '%8$s' in anno "
 "%9$d."
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+"Festivitas mobilia '%1$s' in comparatione cum festivitate clavigeri '%2$s' "
+"creari non potest"
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+"Festivitas mobilia '%1$s' creari non potest: tantum ad festivitatem cum "
+"clave '%2$s' relativa esse potest, utentem verbis clavum %3$s"
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': 'strtotime' property must be "
+#| "either an object or a string! Currently it has type '%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+"Festivitas mobilia '%1$s' creari non potest: proprietas 'strtotime' aut "
+"obiectum esse debet aut stringere! Nunc autem habet typum '%2$s'"
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -911,412 +1560,79 @@ msgid ""
 "year %5$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
-#, php-format
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s', proper to the calendar of the %3$s and usually "
+#| "celebrated on %4$s, is suppressed by the Sunday or Solemnity %5$s in the "
+#| "year %6$d"
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 "%1$s '%2$s', proprio calendario %3$s et plerumque celebratur die %4$s, "
 "supprimatur a Dominica vel Sollemnitate %5$s anno %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "ANNUM"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr "Missa in Vigilia"
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-"Missa in Vigilia %1$s '%2$s' coincidet cum %3$s'%4$s' in anno %5$d. Secundum "
-"%6$s, prima praecedentia habet, ergo Missa vesperum et Missa in Vigilia "
-"servabuntur."
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-"Missa in Vigilia %1$s '%2$s' coincidet cum %3$s'%4$s' in anno %5$d. "
-"Sollemnitas prima praecedentia habet, ergo servabit Secundis Vesperis atque "
-"Missa vesperum, cum Sollemnitas ultima neque Missa in Vigilia neque Primis "
-"Vesperis servabit."
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-"Missa in Vigilia %1$s '%2$s' coincidet cum %3$s'%4$s' in anno %5$d. "
-"Sollemnitas ultima praecedentia habet, ergo servabit Secundis Vesperis atque "
-"Missa vesperum, cum Sollemnitas prima neque Missa in Vigilia neque Primis "
-"Vesperis servabit."
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-"Missa in Vigilia %1$s '%2$s' coincidet cum %3$s'%4$s' in anno %5$d. Oportet "
-"quaerere a Congregatione Cultu Divino quid facere!"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "viridis"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "purpura"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "albus"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "ruber"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "rosea"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Proprium"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Dedicationis ecclesiæ"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Beatæ Mariæ Virginis"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Martyrum"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Pastorum"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Doctorum Ecclesiæ"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Virginum"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Sanctorum et Sanctarum"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Pro uno martyre"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Pro pluribus martyribus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Pro missionariis martyribus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Pro uno missionario martyre"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Pro pluribus missionariis martyribus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Pro virgine martyre"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Pro sancta muliere martyre"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Pro papa"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Pro episcopo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Pro uno pastore"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Pro pluribus pastoribus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Pro fundatoribus ecclesiarum"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Pro uno fundatore"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Pro pluribus fundatoribus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Pro missionariis"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Pro una virgine"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Pro pluribus virginibus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Pro pluribus sanctis"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Pro uno sancto"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Pro abbate"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Pro monacho"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Pro moniali"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Pro religiosis"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Pro iis qui opera misericordiæ exercuerunt"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Pro educatoribus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Pro sanctis mulieribus"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
 
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr ""
+#~ msgid "Translation data for the sanctorale from %s could not be found."
+#~ msgstr "Translationem datarum pro sanctorali ex %s inveniri non potuit."
 
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr ""
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr ""
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "De Commune"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "feria"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
 #, fuzzy
-#| msgid "Commemoration"
-msgid "commemoration"
-msgstr "Commemoratio"
+#~ msgid "Data for the Sanctorale from %s could not be found."
+#~ msgstr "Data pro sanctorale ex %s reperiri non potuit."
 
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
 #, fuzzy
-#| msgid "Optional memorial"
-msgid "optional memorial"
-msgstr "Memoria ad libitum"
+#~ msgid "Could not find the Sanctorale data"
+#~ msgstr "Archivum datarum de Sanctorale pro %s non inventa est"
 
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
+#, fuzzy
+#~ msgid ""
+#~ "Could not find translation data for Memorials based on Decrees of the "
+#~ "Congregation for Divine Worship"
+#~ msgstr "Decretum Congregationis pro Cultu Divino"
 
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Memoria obligatoria"
+#~ msgid "before"
+#~ msgstr "ante"
 
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
+#~ msgid "after"
+#~ msgstr "postquam"
 
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "FESTUM"
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s': when the 'strtotime' property is "
+#~ "an object, it must have properties %2$s"
+#~ msgstr ""
+#~ "Mobile festivitas '%1$s' creare non possum: cum proprietas 'strtotime' "
+#~ "sit obiectum, oportet eam habere proprietates %2$s"
 
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+#~ msgstr ""
+#~ "Festivitas mobilia '%1$s' non potest creari sine proprietate 'strtotime'!"
 
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "FESTUM DOMINI"
+#~ msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgstr ""
+#~ "Errorem ad recuperandam et interpretandam datam Regionis Latiorem ex "
+#~ "archivo %s."
 
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "SOLLEMNITAS"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "celebratio altioris ordinis quam sollemnitatis"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr "Tempus Adventus"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr "Tempus Nativitatis"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr "Tempus Quadragesimæ"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr "Sacrum Triduum paschale"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr "Tempus paschale"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr "Tempus per annum"
+#, fuzzy
+#~| msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgid "Error retrieving and decoding National Calendar data from file %s."
+#~ msgstr ""
+#~ "Errorem ad recuperandam et interpretandam datam Regionis Latiorem ex "
+#~ "archivo %s."
 
 #~ msgid "%s day before Epiphany"
 #~ msgstr "Dies %s ante Epiphaniam"

--- a/i18n/nl/LC_MESSAGES/litcal.po
+++ b/i18n/nl/LC_MESSAGES/litcal.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2024-12-06 23:24+0000\n"
 "Last-Translator: \"John R. D'Orazio\" <priest@johnromanodorazio.com>\n"
 "Language-Team: Dutch <https://translate.johnromanodorazio.com/projects/"
@@ -21,19 +21,730 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "groen"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "paars"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "wit"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "rood"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "roze"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Eigen"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Kerkwijding"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "H. Maagd Maria"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Martelaren"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Herders"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Kerkleraren"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Maagden"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Heilige mannen en vrouwen"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Voor een martelaar"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Voor meer martelaren"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Voor missionarissen-martelaren"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Voor een missionaire martelaar"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Voor meer missionarissen-martelaren"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Voor een maagd-martelares"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Voor een heilige martelares"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Voor een Paus"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Voor een bisschop"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Voor één priester"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Voor meerdere priesters"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Voor stichters van een plaatselijke kerk"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Voor één stichter"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Voor meerdere stichters"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Voor missionarissen"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Voor één maagd"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Voor meerdere maagden"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Voor meerdere heiligen"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Voor één heilige"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Voor een abt"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Voor een monnik"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Voor een non"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Voor kloosterlingen"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Voor hen die werken van barmhartigheid hebben verricht"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Voor opvoeders"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Voor heilige vrouwen"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr "voor de"
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr "voor"
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr "voor"
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr "voor de"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "weekdag"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+#, fuzzy
+#| msgid "Commemoration"
+msgid "commemoration"
+msgstr "Vrije gedachtenis"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+#, fuzzy
+#| msgid "Optional memorial"
+msgid "optional memorial"
+msgstr "Vrije gedachtenis"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Gedachtenis"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "FEEST"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "FEEST VAN DE HEER"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "HOOGFEEST"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "viering met voorrang op hoogfesten"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "en kerkleraar"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Voor een Paus"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Voor een bisschop"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Voor stichters van een plaatselijke kerk"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Voor één heilige"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Voor kloosterlingen"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "%s dag onder het octaaf van Kerstmis"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Voor een non"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Voor een martelaar"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Voor opvoeders"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Voor een martelaar"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Voor één maagd"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Voor één heilige"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Voor één heilige"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr "Adventstijd"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr "Kersttijd"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr "Vastentijd"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr "Paastriduüm"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr "Paasseizoen"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr "Gewone tijd"
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "Gemeenschappelijke"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "of"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "JAAR"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Vigiliemis"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+"De vigiliemis voor de %1$s '%2$s' valt samen met de %3$s '%4$s' in het jaar "
+"%5$d. Overeenkomstig %6$s heeft de eerste voorrang, waardoor de vigiliemis "
+"en het avondgebed op de vooravond zijn vastgesteld."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr "Decreet van de Congregatie voor de Goddelijke Eredienst"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+"De vigiliemis van de %1$s '%2$s' valt samen met de %3$s '%4$s' in het jaar "
+"%5$d. Omdat het eerste hoogfeest voorrang heeft, heeft het een avondgebed op "
+"de vooravond en een vigiliemis, terwijl het tweede hoogfeest geen avondgebed "
+"of een avondmis heeft."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+"De vigiliemis voor de %1$s '%2$s' valt samen met de %3$s '%4$s' in het jaar "
+"%5$d. Het tweede hoogfeest heeft voorrang, waardoor het een avondgebed op de "
+"vooravond en een avondmis behoudt, terwijl het eerste hoogfeest geen "
+"vigiliemis of avondgebed heeft."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+"De vigiliemis voor de %1$s '%2$s' valt samen met de %3$s '%4$s' in het jaar "
+"%5$d. Het Dicasterie van de Goddelijke Eredienst moet aangeven wat te doen!"
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 "De naam van het bisdom kon niet worden afgeleid van het bisdom-ID \"%s\"."
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr "De diocesane kalender \"%s\" werd niet gevonden in het indexbestand."
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -41,142 +752,30 @@ msgid ""
 msgstr ""
 "Alleen jaren na 1970 worden ondersteund. U probeert het jaar %d op te vragen."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-"Er is een fout opgetreden bij het decoderen van gelokaliseerde JSON-gegevens "
-"voor de Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-"Er is een fout opgetreden bij het ophalen van gelokaliseerde gegevens voor "
-"de Temporale."
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-"Er is een fout opgetreden bij het decoderen van JSON-gegevens voor de "
-"Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-"Er is een fout opgetreden bij het ophalen van gegevens voor de Temporale."
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr ""
-"Vertaalgegevens voor het eigen van de heiligen van %s kon niet worden "
-"gevonden."
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-"Er is een fout opgetreden bij het decoderen van JSON-lokalisatiegegevens "
-"voor het Sanctorale voor het Missaal %1$s: %2$s"
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, fuzzy, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr ""
-"Gegevens voor het eigen van de heiligen van %s kon niet worden gevonden."
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-"Er is een fout opgetreden bij het decoderen van JSON-gegevens voor het "
-"Sanctorale voor het Missaal %1$s: %2$s."
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-#, fuzzy
-msgid "Could not find the Sanctorale data"
-msgstr "Een sanctorale data bestand voor %s is niet gevonden"
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-"Er is een fout opgetreden bij het decoderen van vertaalgegevens voor "
-"Herdenkingen op basis van Decreten van de Congregatie voor de Goddelijke "
-"Eredienst: %s"
-
-#: src/Paths/Calendar.php:953
-#, fuzzy
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr "Decreet van de Congregatie voor de Goddelijke Eredienst"
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-"Er is een fout opgetreden bij het decoderen van JSON-gegevens voor "
-"Herdenkingen op basis van Decreten van de Congregatie voor de Goddelijke "
-"Eredienst: %s"
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s van de kersttijd"
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "of"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Barmhartige zondag"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -185,31 +784,20 @@ msgstr ""
 "Het hoogfeest van '%1$s' valt op %2$s in het jaar %3$d, de viering is "
 "verplaatst naar %4$s (%5$s) overeenkomstig %6$s."
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr "de zaterdag voorafgaand aan Palmzondag"
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr "Decreet van de Congregatie voor de Goddelijke Eredienst"
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "maandag na de tweede zondag van pasen"
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr "de volgende maandag"
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -225,7 +813,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -235,7 +823,7 @@ msgstr ""
 "jaar %3$d, wordt het een dag eerder gevierd overeenkomstig %4$s."
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -245,12 +833,12 @@ msgstr ""
 "'%3$s' gevierd op %4$s in plaats van op de zondag na Kerstmis."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Onze Heer Christus Eeuwige Hogepriester"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -265,59 +853,59 @@ msgstr ""
 "'%2$d' (%3$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' wordt vervangen door het %2$s van '%3$s' in het jaar %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "in de %s week van de advent"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s dag onder het octaaf van Kerstmis"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "in de %s week van de veertigdagentijd"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "na Aswoensdag"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -326,7 +914,7 @@ msgstr ""
 "De %1$s '%2$s' is toegevoegd op %3$s vanaf %4$d (%5$s), van toepassing in "
 "het jaar %6$d."
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -334,12 +922,7 @@ msgstr ""
 "Persconferentie van het Vaticaan: presentatie van de derde standaarduitgave "
 "van het Romeins Missaal"
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -351,22 +934,33 @@ msgstr ""
 "teruggebracht naar vrije gedachtenis."
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "De %1$s '%2$s' heeft voorrang boven de %3$s '%4$s' in het jaar %5$d."
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apostolische Constitutie Missale Romanum"
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -378,16 +972,16 @@ msgstr ""
 "het jaar %9$d."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -402,7 +996,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -412,72 +1006,41 @@ msgstr ""
 "jaar %3$d. Zij worden beide in rang teruggebracht tot vrije gedachtenis "
 "(%4$s)."
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr "voor"
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr "na"
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 "Kan het verplaatsbare feest '%1$s' niet genereren: is alleen verbonden met "
 "het feest met sleutel '%2$s' met sleutelwoorden %3$s"
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 "Kan het verplaatsbare feest '%1$s' niet genereren dat verbonden is met het "
 "feest met sleutel '%2$s'"
 
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-"Kan het verplaatsbare feest '%1$s' niet genereren: indien de eigenschap "
-"'strtotime' een object is, moet het de eigenschappen '%2$s' hebben"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-"Kan het verplaatsbare feest '%1$s' niet genereren: de eigenschap 'strtotime' "
-"moet ofwel een object of een string zijn! Nu heeft hij type '%2$s'"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
-msgstr ""
-"Kan het verplaatsbare feest '%1$s' niet genereren zonder de eigenschap "
-"'strtotime'!"
-
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -487,14 +1050,14 @@ msgstr ""
 "toepassing in het jaar %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -504,14 +1067,14 @@ msgstr ""
 "toepassing in het jaar %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -521,12 +1084,12 @@ msgstr ""
 "toepassing in het jaar %5$d (%6$s)."
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -535,21 +1098,17 @@ msgstr ""
 "'%1$s' is tot Kerkleraar uitgeroepen vanaf het jaar %2$d, van toepassing in "
 "het jaar %3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "en kerkleraar"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -560,15 +1119,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -578,7 +1137,7 @@ msgstr ""
 "toegevoegd op %6$s vanaf het jaar %7$d (%8$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -588,7 +1147,7 @@ msgstr ""
 "vanaf het jaar 2002 (%2$s), van toepassing in het jaar %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -600,19 +1159,24 @@ msgstr ""
 "vanaf het jaar 2002 verplaatst naar 12 augustus (%2$s), van toepassing in "
 "het jaar %3$d."
 
-#: src/Paths/Calendar.php:2981
-#, php-format
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
+#, fuzzy, php-format
+#| msgid ""
+#| "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
+#| "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
+#| "superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 "De vrije gedachtenis '%1$s' is verplaatst van 12 december naar 12 augustus "
 "vanaf het jaar 2002 (%2$s), van toepassing in het jaar %3$d. Echter, hij "
 "wordt vervangen door een zondag, hoogfeest of feest '%4$s' in het jaar %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -624,27 +1188,22 @@ msgstr ""
 "zondag valt, maar vanwege het Paulusjaar is het, overeenkomstig %2$s "
 "hersteld, zodat lokale kerken de gedachtenis naar keuze kunnen vieren."
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "na de %s zondag van pasen"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "in de %s week door het jaar"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Maria op zaterdag"
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-"Fout bij het ophalen en decoderen van Wider Region data uit bestand %s."
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -652,22 +1211,16 @@ msgstr ""
 "Kon de %1$s eigenschap niet vinden in de %2$s voor de Nationale Kalender "
 "%3$s."
 
-#: src/Paths/Calendar.php:3245
-#, fuzzy, php-format
-#| msgid "Error retrieving and decoding National data from file %s."
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr "Fout bij het ophalen en decoderen van National data uit bestand %s."
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -681,15 +1234,15 @@ msgstr ""
 "'%5$s' in het jaar %6$d."
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -708,7 +1261,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -717,8 +1270,8 @@ msgstr ""
 "De gedachtenis '%1$s' valt samen met een andere gedachtenis '%2$s' in het "
 "jaar %3$d. Ze zijn beide teruggebracht naar de rang van vrije gedachtenis."
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -727,8 +1280,8 @@ msgstr ""
 "De Feest '%1$s', gewoonlijk gevierd op %2$s, wordt vervangen door de Feest "
 "'%3$s' in het jaar %4$d. Moet hier iets aan gedaan worden?"
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -739,13 +1292,43 @@ msgstr ""
 "Zondag of hoogfeest van '%3$s' in het jaar %4$d. Moet hier iets aan gedaan "
 "worden?"
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+#, fuzzy
+#| msgid ""
+#| "We should be creating a new festivity, however we do not seem to have the "
+#| "correct date information in order to proceed"
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
 msgstr ""
 "Er zou een nieuw feest moeten worden aangemaakt, maar de juiste gegevens om "
 "verder te gaan lijken niet beschikbaar"
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
+#| "applicable to the year %5$d (%6$s)."
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
+msgstr ""
+"De %1$s '%2$s' is verhoogd tot de rang van %3$s vanaf het jaar %4$d, van "
+"toepassing in het jaar %5$d (%6$s)."
 
 #. translators:
 #.  1. Liturgical grade
@@ -755,7 +1338,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -774,7 +1357,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -793,16 +1376,17 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
+#: src/Paths/CalendarPath.php:3786
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
 #| "applicable to the year %5$d (%6$s)."
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 "De naam van de %1$s '%2$s' is veranderd in %3$s vanaf het jaar %4$d, van "
 "toepassing in het jaar %5$d (%6$s)."
@@ -814,15 +1398,15 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
+#: src/Paths/CalendarPath.php:3805
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
 #| "applicable to the year %5$d (%6$s)."
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 "De naam van de %1$s '%2$s' is veranderd in %3$s vanaf het jaar %4$d, van "
 "toepassing in het jaar %5$d (%6$s)."
@@ -836,7 +1420,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -855,7 +1439,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -868,26 +1452,38 @@ msgstr ""
 "gebeurtenissen van het Romeins Missaal."
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
-#, php-format
+#: src/Paths/CalendarPath.php:3878
+#, fuzzy, php-format
+#| msgid ""
+#| "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
+#| "the national calendar '%4$s', but this could not take place in the year "
+#| "%5$d since the new date %2$s seems to be a Sunday or a festivity of "
+#| "greater rank."
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
 msgstr ""
 "De liturgische gebeurtenis '%1$s' is sinds het jaar %3$d verplaatst naar "
 "%2$s in de nationale kalender '%4$s', maar dit kon niet plaatsvinden in het "
 "jaar %5$d omdat de nieuwe datum %2$s op een zondag of een feestdag van "
 "hogere rang lijkt te vallen."
 
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
+msgstr ""
+
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Er is een sanctorale data bestand gevonden voor %s"
@@ -897,11 +1493,11 @@ msgstr "Er is een sanctorale data bestand gevonden voor %s"
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -911,13 +1507,13 @@ msgstr ""
 "wordt vervangen door de %5$s '%6$s' in het jaar %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Een sanctorale data bestand voor %s is niet gevonden"
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -926,8 +1522,8 @@ msgstr ""
 "De %1$s '%2$s' wordt verplaatst van %5$s naar %6$s overeenkomstig de %7$s, "
 "om plaats te maken voor '%3$s': van toepassing in het jaar %4$d."
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -938,8 +1534,48 @@ msgstr ""
 "%5$s, om plaats te maken voor '%6$s', maar wordt vervangen door %7$s '%8$s' "
 "in het jaar %9$d."
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+"Kan het verplaatsbare feest '%1$s' niet genereren dat verbonden is met het "
+"feest met sleutel '%2$s'"
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+"Kan het verplaatsbare feest '%1$s' niet genereren: is alleen verbonden met "
+"het feest met sleutel '%2$s' met sleutelwoorden %3$s"
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': 'strtotime' property must be "
+#| "either an object or a string! Currently it has type '%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+"Kan het verplaatsbare feest '%1$s' niet genereren: de eigenschap 'strtotime' "
+"moet ofwel een object of een string zijn! Nu heeft hij type '%2$s'"
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -950,414 +1586,138 @@ msgstr ""
 "op %3$s, valt samen met de zondag of plechtigheid '%4$s' in het jaar %5$d! "
 "Moet hier iets aan gedaan worden?"
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
-#, php-format
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s', proper to the calendar of the %3$s and usually "
+#| "celebrated on %4$s, is suppressed by the Sunday or Solemnity %5$s in the "
+#| "year %6$d"
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 "De %1$s '%2$s', eigen aan de kalender van de %3$s en gewoonlijk gevierd op "
 "%4$s, wordt vervangen door de Zondag of hoogfeest '%5$s' in het jaar %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 "Fout bij het ontvangen of verwerken van informatie van GitHub over de "
 "laatste release: %s."
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "JAAR"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr "Vigiliemis"
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-"De vigiliemis voor de %1$s '%2$s' valt samen met de %3$s '%4$s' in het jaar "
-"%5$d. Overeenkomstig %6$s heeft de eerste voorrang, waardoor de vigiliemis "
-"en het avondgebed op de vooravond zijn vastgesteld."
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-"De vigiliemis van de %1$s '%2$s' valt samen met de %3$s '%4$s' in het jaar "
-"%5$d. Omdat het eerste hoogfeest voorrang heeft, heeft het een avondgebed op "
-"de vooravond en een vigiliemis, terwijl het tweede hoogfeest geen avondgebed "
-"of een avondmis heeft."
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-"De vigiliemis voor de %1$s '%2$s' valt samen met de %3$s '%4$s' in het jaar "
-"%5$d. Het tweede hoogfeest heeft voorrang, waardoor het een avondgebed op de "
-"vooravond en een avondmis behoudt, terwijl het eerste hoogfeest geen "
-"vigiliemis of avondgebed heeft."
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-"De vigiliemis voor de %1$s '%2$s' valt samen met de %3$s '%4$s' in het jaar "
-"%5$d. Het Dicasterie van de Goddelijke Eredienst moet aangeven wat te doen!"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "groen"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "paars"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "wit"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "rood"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "roze"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Eigen"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Kerkwijding"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "H. Maagd Maria"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Martelaren"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Herders"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Kerkleraren"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Maagden"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Heilige mannen en vrouwen"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Voor een martelaar"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Voor meer martelaren"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Voor missionarissen-martelaren"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Voor een missionaire martelaar"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Voor meer missionarissen-martelaren"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Voor een maagd-martelares"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Voor een heilige martelares"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Voor een Paus"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Voor een bisschop"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Voor één priester"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Voor meerdere priesters"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Voor stichters van een plaatselijke kerk"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Voor één stichter"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Voor meerdere stichters"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Voor missionarissen"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Voor één maagd"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Voor meerdere maagden"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Voor meerdere heiligen"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Voor één heilige"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Voor een abt"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Voor een monnik"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Voor een non"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Voor kloosterlingen"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Voor hen die werken van barmhartigheid hebben verricht"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Voor opvoeders"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Voor heilige vrouwen"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr "voor de"
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr "voor"
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr "voor"
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr "voor de"
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "Gemeenschappelijke"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "weekdag"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
 
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
+#~ msgid "The Diocesan calendar \"%s\" was not found in the index file."
+#~ msgstr ""
+#~ "De diocesane kalender \"%s\" werd niet gevonden in het indexbestand."
+
+#~ msgid ""
+#~ "There was an error trying to decode localized JSON data for the "
+#~ "Temporale: %s"
+#~ msgstr ""
+#~ "Er is een fout opgetreden bij het decoderen van gelokaliseerde JSON-"
+#~ "gegevens voor de Temporale: %s"
+
+#~ msgid ""
+#~ "There was an error trying to retrieve localized data for the Temporale."
+#~ msgstr ""
+#~ "Er is een fout opgetreden bij het ophalen van gelokaliseerde gegevens "
+#~ "voor de Temporale."
+
+#~ msgid "There was an error trying to decode JSON data for the Temporale: %s"
+#~ msgstr ""
+#~ "Er is een fout opgetreden bij het decoderen van JSON-gegevens voor de "
+#~ "Temporale: %s"
+
+#~ msgid "There was an error trying to retrieve data for the Temporale."
+#~ msgstr ""
+#~ "Er is een fout opgetreden bij het ophalen van gegevens voor de Temporale."
+
+#~ msgid "Translation data for the sanctorale from %s could not be found."
+#~ msgstr ""
+#~ "Vertaalgegevens voor het eigen van de heiligen van %s kon niet worden "
+#~ "gevonden."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON localization data for the "
+#~ "Sanctorale for the Missal %1$s: %2$s"
+#~ msgstr ""
+#~ "Er is een fout opgetreden bij het decoderen van JSON-lokalisatiegegevens "
+#~ "voor het Sanctorale voor het Missaal %1$s: %2$s"
+
 #, fuzzy
-#| msgid "Commemoration"
-msgid "commemoration"
-msgstr "Vrije gedachtenis"
+#~ msgid "Data for the Sanctorale from %s could not be found."
+#~ msgstr ""
+#~ "Gegevens voor het eigen van de heiligen van %s kon niet worden gevonden."
 
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for the Sanctorale for the "
+#~ "Missal %1$s: %2$s."
+#~ msgstr ""
+#~ "Er is een fout opgetreden bij het decoderen van JSON-gegevens voor het "
+#~ "Sanctorale voor het Missaal %1$s: %2$s."
 
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
 #, fuzzy
-#| msgid "Optional memorial"
-msgid "optional memorial"
-msgstr "Vrije gedachtenis"
+#~ msgid "Could not find the Sanctorale data"
+#~ msgstr "Een sanctorale data bestand voor %s is niet gevonden"
 
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
+#~ msgid ""
+#~ "There was an error trying to decode translation data for Memorials based "
+#~ "on Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Er is een fout opgetreden bij het decoderen van vertaalgegevens voor "
+#~ "Herdenkingen op basis van Decreten van de Congregatie voor de Goddelijke "
+#~ "Eredienst: %s"
 
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Gedachtenis"
+#, fuzzy
+#~ msgid ""
+#~ "Could not find translation data for Memorials based on Decrees of the "
+#~ "Congregation for Divine Worship"
+#~ msgstr "Decreet van de Congregatie voor de Goddelijke Eredienst"
 
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for Memorials based on "
+#~ "Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Er is een fout opgetreden bij het decoderen van JSON-gegevens voor "
+#~ "Herdenkingen op basis van Decreten van de Congregatie voor de Goddelijke "
+#~ "Eredienst: %s"
 
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "FEEST"
+#~ msgid "before"
+#~ msgstr "voor"
 
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
+#~ msgid "after"
+#~ msgstr "na"
 
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "FEEST VAN DE HEER"
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s': when the 'strtotime' property is "
+#~ "an object, it must have properties %2$s"
+#~ msgstr ""
+#~ "Kan het verplaatsbare feest '%1$s' niet genereren: indien de eigenschap "
+#~ "'strtotime' een object is, moet het de eigenschappen '%2$s' hebben"
 
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+#~ msgstr ""
+#~ "Kan het verplaatsbare feest '%1$s' niet genereren zonder de eigenschap "
+#~ "'strtotime'!"
 
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "HOOGFEEST"
+#~ msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgstr ""
+#~ "Fout bij het ophalen en decoderen van Wider Region data uit bestand %s."
 
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "viering met voorrang op hoogfesten"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr "Adventstijd"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr "Kersttijd"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr "Vastentijd"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr "Paastriduüm"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr "Paasseizoen"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr "Gewone tijd"
+#, fuzzy
+#~| msgid "Error retrieving and decoding National data from file %s."
+#~ msgid "Error retrieving and decoding National Calendar data from file %s."
+#~ msgstr "Fout bij het ophalen en decoderen van National data uit bestand %s."
 
 #~ msgctxt "(SING_FEMM)"
 #~ msgid "of"

--- a/i18n/pl/LC_MESSAGES/litcal.po
+++ b/i18n/pl/LC_MESSAGES/litcal.po
@@ -5,8 +5,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: priest@johnromanodorazio.com\n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2025-04-25 20:30+0000\n"
 "Last-Translator: Jarek Niewiadomski <jarekn2008@gmail.com>\n"
 "Language-Team: Polish <https://translate.johnromanodorazio.com/projects/"
@@ -19,169 +19,760 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 5.11\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "zielony"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "fioletowy"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "biały"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "czerwony"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "różowy"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Właściwy"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Poświęcenie kościoła"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Najświętsza Maryja Panna"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Męczennicy"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Pastorzy"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Doktorzy"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Dziewice"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Święci mężczyźni i kobiety"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Dla jednego męczennika"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Dla kilku męczenników"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Za misjonarzy męczenników"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Dla jednego misjonarza męczennika"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Dla kilku misjonarzy męczenników"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Dla Dziewicy Męczennicy"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Dla świętej kobiety męczennicy"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Za papieża"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Dla biskupa"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Dla jednego pastora"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Dla kilku pastorów"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Dla założycieli kościoła"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Dla jednego założyciela"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Dla kilku założycieli"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Dla misjonarzy"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Dla jednej dziewicy"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Dla kilku dziewic"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Dla kilku świętych"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Dla jednego świętego"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Dla opata"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Dla mnicha"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Dla zakonnicy"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Dla religijnych"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Dla tych, którzy praktykowali uczynki miłosierdzia"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Dla nauczycieli"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Dla świętych kobiet"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr "z"
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr "z"
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr "z"
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr "z"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "dzień powszedni"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+msgid "commemoration"
+msgstr ""
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+msgid "optional memorial"
+msgstr ""
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Upamiętnienie"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "ŚWIĘTO"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "ŚWIĘTO PAŃSKIE"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "NAMASZCZENE"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "obchody z pierwszeństwem przed uroczystościami"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For the Church"
+msgstr "Dla założycieli kościoła"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Za papieża"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Dla biskupa"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Dla założycieli kościoła"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Dla jednego świętego"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Dla religijnych"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+msgid "For the Unity of Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Dla zakonnicy"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Dla jednego męczennika"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Dla nauczycieli"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Dla jednego męczennika"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Dla jednej dziewicy"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Dla jednego świętego"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Dla jednego świętego"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr ""
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "Ze wspólnego"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "lub"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Msza czuwania"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr ""
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
 "%d."
 msgstr ""
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr ""
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr ""
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "lub"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr ""
 
-#. translators: 1: Festivity name, 2: Festivity date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: Festivity name, 2: Festivity date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: Festivity name,
-#.  2: Festivity date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/FestivityCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr ""
 
-#. translators: 1: Festivity name, 2: Coinciding Festivity name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -189,20 +780,20 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1: Festivity name,
-#.  2: Coinciding Festivity name,
+#.  1: LiturgicalEvent name,
+#.  2: Coinciding LiturgicalEvent name,
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
 "year %3$d, it has been anticipated by one day as per %4$s."
 msgstr ""
 
-#. translators: 1: Festivity name (Christmas), 2: Requested calendar year, 3: Festivity name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -210,12 +801,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -224,78 +815,73 @@ msgid ""
 "calendar '%1$s' in the year '%2$d' (%3$s)."
 msgstr ""
 
-#. translators: 1: Festivity name, 2: Superseding Festivity grade, 3: Superseding Festivity name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr ""
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
 msgstr ""
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -304,22 +890,33 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -328,16 +925,16 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -350,69 +947,38 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials (%4$s)."
 msgstr ""
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr ""
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr ""
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -420,14 +986,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -435,14 +1001,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -450,33 +1016,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr ""
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -485,31 +1047,31 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
 "added on %6$s since the year %7$d (%8$s)."
 msgstr ""
 
-#. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#. translators: 1: Festivity name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -517,16 +1079,17 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2981
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 
-#. translators: 1: Festivity name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#. translators: 1: LiturgicalEvent name, 2: Source of the information
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -535,46 +1098,37 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr ""
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3245
-#, php-format
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -583,15 +1137,15 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -605,23 +1159,23 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials."
 msgstr ""
 
-#. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
 "'%3$s' in the year %4$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1. Festivity name, 2. Festivity date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -629,10 +1183,31 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
+msgstr ""
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, php-format
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
 msgstr ""
 
 #. translators:
@@ -643,7 +1218,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -657,7 +1232,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -671,13 +1246,14 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
+#: src/Paths/CalendarPath.php:3786
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 
 #. translators:
@@ -687,12 +1263,12 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
+#: src/Paths/CalendarPath.php:3805
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 
 #. translators:
@@ -704,7 +1280,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -718,7 +1294,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -727,36 +1303,43 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
+#: src/Paths/CalendarPath.php:3878
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
+msgstr ""
+
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
 
 #. translators:
-#.  1. Festivity grade
-#.  2. Festivity name
-#.  3. Festivity date
+#.  1. LiturgicalEvent grade
+#.  2. LiturgicalEvent name
+#.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -764,21 +1347,21 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
-#. translators: 1. Festivity grade, 2. Festivity name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
 "room for '%3$s': applicable to the year %4$d."
 msgstr ""
 
-#. translators: 1. Festivity grade, 2. Festivity name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -786,8 +1369,33 @@ msgid ""
 "in the year %9$d."
 msgstr ""
 
-#. translators: 1: Festivity name, 2: Name of the diocese, 3: Festivity date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -795,390 +1403,23 @@ msgid ""
 "year %5$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1: Festivity grade, 2: Festivity name, 3: Name of the diocese, 4: Festivity date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/FestivityCollection.php:60
-msgid "YEAR"
-msgstr ""
-
-#: src/FestivityCollection.php:61
-msgid "Vigil Mass"
-msgstr "Msza czuwania"
-
-#: src/FestivityCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-
-#: src/FestivityCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-
-#: src/FestivityCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-
-#: src/FestivityCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "zielony"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "fioletowy"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "biały"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "czerwony"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "różowy"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Właściwy"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Poświęcenie kościoła"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Najświętsza Maryja Panna"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Męczennicy"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Pastorzy"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Doktorzy"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Dziewice"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Święci mężczyźni i kobiety"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Dla jednego męczennika"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Dla kilku męczenników"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Za misjonarzy męczenników"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Dla jednego misjonarza męczennika"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Dla kilku misjonarzy męczenników"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Dla Dziewicy Męczennicy"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Dla świętej kobiety męczennicy"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Za papieża"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Dla biskupa"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Dla jednego pastora"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Dla kilku pastorów"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Dla założycieli kościoła"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Dla jednego założyciela"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Dla kilku założycieli"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Dla misjonarzy"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Dla jednej dziewicy"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Dla kilku dziewic"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Dla kilku świętych"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Dla jednego świętego"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Dla opata"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Dla mnicha"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Dla zakonnicy"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Dla religijnych"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Dla tych, którzy praktykowali uczynki miłosierdzia"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Dla nauczycieli"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Dla świętych kobiet"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr "z"
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr "z"
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr "z"
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr "z"
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "Ze wspólnego"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "dzień powszedni"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
-msgid "commemoration"
-msgstr ""
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-msgid "optional memorial"
-msgstr ""
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Upamiętnienie"
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "ŚWIĘTO"
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "ŚWIĘTO PAŃSKIE"
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "NAMASZCZENE"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "obchody z pierwszeństwem przed uroczystościami"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""

--- a/i18n/pt/LC_MESSAGES/litcal.po
+++ b/i18n/pt/LC_MESSAGES/litcal.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2025-04-08 21:01+0000\n"
 "Last-Translator: Ronaldo Soares Couto <ronaldocouto@gmail.com>\n"
 "Language-Team: Portuguese <https://translate.johnromanodorazio.com/projects/"
@@ -23,18 +23,730 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Weblate 5.8.4\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "verde"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "roxo"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "branco"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "vermelho"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "rosa"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Próprio"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Dedicação de uma Igreja"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Bem-Aventurada Virgem Maria"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Mártires"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Pastores"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Doutores"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Virgens"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Homens e Mulheres Santos"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Para um Mártir"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Para Vários Mártires"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Para Mártires Missionários"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Para Um Missionário Mártir"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Para Vários Mártires Missionários"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Para uma Virgem Mártir"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Para uma Santa Mártir"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Para um Papa"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Para um Bispo"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Para um Pastor"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Para Vários Pastores"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Para Fundadores de uma Igreja"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Para um Fundador"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Para Vários Fundadores"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Para Missionários"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Para Uma Virgem"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Para Várias Virgens"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Para Vários Santos"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Para Um Santo"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Para um Abade"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Para um Monge"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Para uma Freira"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Para Religiosos"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Para Aqueles que Praticaram Obras de Misericórdia"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Para Educadores"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Para Mulheres Santas"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr "do"
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr "de"
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr "de"
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr "do"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "dia de semana"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+#, fuzzy
+#| msgid "Commemoration"
+msgid "commemoration"
+msgstr "Comemoração"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+#, fuzzy
+#| msgid "Optional memorial"
+msgid "optional memorial"
+msgstr "Memória opcional"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Memória"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "FESTA"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "FESTA DO SENHOR"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "SOLENIDADE"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "celebração com precedência sobre solenidades"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "e Doutor da Igreja"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Para um Papa"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Para um Bispo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Para Fundadores de uma Igreja"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Para Um Santo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Para Religiosos"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "%s Dia da Oitava de Natal"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Para uma Freira"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Para um Mártir"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Para Educadores"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Para um Mártir"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Para Uma Virgem"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Para Um Santo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Para Um Santo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr "Advento"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr "Natal"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr "Quaresma"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr "Tríduo Pascal"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr "Páscoa"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr "Tempo Comum"
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "Do Comum"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "ou"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "ANO"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Missa da Vigília"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+"A Missa da Vigília para o %1$s '%2$s' coincide com o %3$s '%4$s' no ano "
+"%5$d. Conforme %6$s, o primeiro tem precedência, portanto a Missa da Vigília "
+"é confirmada assim como as I Vésperas."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr "Decreto da Congregação para o Culto Divino"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+"A Missa da Vigília para o %1$s '%2$s' coincide com o %3$s '%4$s' no ano "
+"%5$d. Como a primeira solenidade tem precedência, terá Vésperas I e uma "
+"Missa de vigília, enquanto a última solenidade não terá nem Vésperas II nem "
+"uma Missa vespertina."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+"A Missa da Vigília para o %1$s '%2$s' coincide com o %3$s '%4$s' no ano "
+"%5$d. Esta última solenidade tem precedência, portanto, manterá Vésperas II "
+"e uma Missa vespertina, enquanto a primeira solenidade não terá Missa de "
+"vigília nem Vésperas I."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+"A Missa da Vigília para o %1$s '%2$s' coincide com o %3$s '%4$s' no ano "
+"%5$d. Devemos perguntar à Congregação para o Culto Divino o que fazer sobre "
+"isso!"
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr "O nome da diocese não pôde ser derivado do ID da diocese \"%s\"."
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr "O calendário diocesano \"%s\" não foi encontrado no arquivo de índice."
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -42,133 +754,30 @@ msgid ""
 msgstr ""
 "Apenas anos a partir de 1970 são suportados. Você tentou solicitar o ano %d."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-"Houve um erro ao tentar decodificar os dados JSON localizados para o "
-"Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-"Houve um erro ao tentar recuperar os dados localizados para o Temporale."
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr "Houve um erro ao tentar decodificar os dados JSON para o Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr "Houve um erro ao tentar recuperar os dados para o Temporale."
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr "Dados de tradução para o sanctorale de %s não foram encontrados."
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-"Houve um erro ao tentar decodificar os dados de localização JSON para o "
-"Sanctorale do Missal %1$s: %2$s"
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr "Não foi possível encontrar os dados para o Sanctorale de %s."
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-"Houve um erro ao tentar decodificar os dados JSON para o Sanctorale do "
-"Missal %1$s: %2$s."
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr "Não foi possível encontrar os dados do Sanctorale"
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-"Houve um erro ao tentar decodificar os dados de tradução para Memoriais com "
-"base nos Decretos da Congregação para o Culto Divino: %s"
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-"Não foi possível encontrar dados de tradução para Memoriais baseados em "
-"Decretos da Congregação para o Culto Divino"
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-"Houve um erro ao tentar decodificar os dados JSON para Memoriais baseados em "
-"Decretos da Congregação para o Culto Divino: %s"
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Dia de Semana do Natal"
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "ou"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Domingo da Divina Misericórdia"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -177,31 +786,20 @@ msgstr ""
 "A Solenidade '%1$s' cai em %2$s no ano %3$d, a celebração foi transferida "
 "para %4$s (%5$s) conforme o %6$s."
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr "o sábado anterior ao Domingo de Ramos"
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr "Decreto da Congregação para o Culto Divino"
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "a segunda-feira após o Segundo Domingo de Páscoa"
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr "a próxima segunda-feira"
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -216,7 +814,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -226,7 +824,7 @@ msgstr ""
 "ela foi antecipada em um dia conforme %4$s."
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -236,12 +834,12 @@ msgstr ""
 "%4$s em vez do domingo após o Natal."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Nosso Senhor Jesus Cristo, O Eterno Sumo Sacerdote"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -255,59 +853,59 @@ msgstr ""
 "aplicável ao calendário '%1$s' no ano '%2$d' (%3$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' é substituído pelo %2$s '%3$s' no ano %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "da %s Semana do Advento"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s Dia da Oitava de Natal"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "da %s Semana da Quaresma"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "após a Quarta-feira de Cinzas"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -316,7 +914,7 @@ msgstr ""
 "O %1$s '%2$s' foi adicionado em %3$s desde o ano %4$d (%5$s), aplicável ao "
 "ano %6$d."
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -324,12 +922,7 @@ msgstr ""
 "Conferência de imprensa do Vaticano: Apresentação da Editio Typica Tertia do "
 "Missal Romano"
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -341,22 +934,33 @@ msgstr ""
 "a Comemoração."
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "O %1$s '%2$s' é suplantado pelo %3$s '%4$s' no ano %5$d."
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Constituição Apostólica Missale Romanum"
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -367,16 +971,16 @@ msgstr ""
 "geralmente celebrado em %6$s, é suprimido pelo %7$s '%8$s' no ano %9$d."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -391,7 +995,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -400,72 +1004,41 @@ msgstr ""
 "A Memória '%1$s' coincide com outra Memória '%2$s' no ano %3$d. Ambas são "
 "reduzidas a memórias opcionais (%4$s)."
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr "antes"
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr "após"
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 "Não é possível criar a festividade móvel '%1$s': só pode ser relativa à "
 "festividade com a chave '%2$s' usando as palavras-chave %3$s"
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 "Não é possível criar a festividade móvel '%1$s' relativa à festividade com a "
 "chave '%2$s'"
 
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-"Não é possível criar festividade móvel '%1$s': quando a propriedade "
-"'strtotime' é um objeto, deve ter propriedades %2$s"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-"Não é possível criar a festividade móvel '%1$s': a propriedade 'strtotime' "
-"deve ser um objeto ou uma string! Atualmente tem o tipo '%2$s'"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
-msgstr ""
-"Não é possível criar a festividade móvel '%1$s' sem uma propriedade "
-"'strtotime'!"
-
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -475,14 +1048,14 @@ msgstr ""
 "ano %5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -492,14 +1065,14 @@ msgstr ""
 "%5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -509,12 +1082,12 @@ msgstr ""
 "ano %5$d (%6$s)."
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -523,21 +1096,17 @@ msgstr ""
 "'%1$s' foi declarado Doutor da Igreja desde o ano %2$d, aplicável ao ano "
 "%3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "e Doutor da Igreja"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -548,15 +1117,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -566,7 +1135,7 @@ msgstr ""
 "%6$s desde o ano %7$d (%8$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -576,7 +1145,7 @@ msgstr ""
 "agosto desde o ano de 2002 (%2$s), aplicável ao ano %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -587,19 +1156,24 @@ msgstr ""
 "ou solenidade se fosse em 12 de dezembro, foi transferida para 12 de agosto "
 "desde o ano de 2002 (%2$s), aplicável ao ano %3$d."
 
-#: src/Paths/Calendar.php:2981
-#, php-format
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
+#, fuzzy, php-format
+#| msgid ""
+#| "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
+#| "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
+#| "superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 "A memória opcional '%1$s' foi transferida de 12 de dezembro para 12 de "
 "agosto desde o ano de 2002 (%2$s), aplicável ao ano %3$d. No entanto, é "
 "substituída por um domingo, uma solenidade ou uma festa '%4$s' no ano %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -611,26 +1185,22 @@ msgstr ""
 "mas sendo o Ano do Apóstolo Paulo, conforme o %2$s, foi restabelecida para "
 "que as igrejas locais possam opcionalmente celebrar a memória."
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "da %s Semana da Páscoa"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "da %s Semana do Tempo Comum"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Memória de Sábado da Bem-Aventurada Virgem Maria"
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr "Erro ao recuperar e decodificar dados da Região Ampla do arquivo %s."
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
@@ -638,22 +1208,16 @@ msgstr ""
 "Não foi possível encontrar uma propriedade %1$s no %2$s para o Calendário "
 "Nacional %3$s."
 
-#: src/Paths/Calendar.php:3245
-#, fuzzy, php-format
-#| msgid "Error retrieving and decoding National data from file %s."
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr "Erro ao recuperar e decodificar dados Nacionais do arquivo %s."
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -665,15 +1229,15 @@ msgstr ""
 "Calendário %7$s, foi reinstaurada."
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -690,7 +1254,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -699,8 +1263,8 @@ msgstr ""
 "A Memória '%1$s' coincide com outra Memória '%2$s' no ano %3$d. Ambas são "
 "reduzidas a memórias opcionais."
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -709,8 +1273,8 @@ msgstr ""
 "A Festa '%1$s', geralmente celebrada em %2$s, coincide com outra Festa "
 "'%3$s' no ano %4$d! Algo precisa ser feito sobre isso?"
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -720,13 +1284,43 @@ msgstr ""
 "A Solenidade '%1$s', geralmente celebrada em %2$s, coincide com o Domingo ou "
 "Solenidade '%3$s' no ano %4$d! Algo precisa ser feito sobre isso?"
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+#, fuzzy
+#| msgid ""
+#| "We should be creating a new festivity, however we do not seem to have the "
+#| "correct date information in order to proceed"
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
 msgstr ""
 "Deveríamos criar uma nova festividade, mas parece que não temos a informação "
 "correta da data para prosseguir"
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
+#| "applicable to the year %5$d (%6$s)."
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
+msgstr ""
+"O %1$s '%2$s' foi elevado ao grau de %3$s desde o ano %4$d, aplicável ao ano "
+"%5$d (%6$s)."
 
 #. translators:
 #.  1. Liturgical grade
@@ -736,7 +1330,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -752,7 +1346,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -769,13 +1363,17 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
-#, php-format
+#: src/Paths/CalendarPath.php:3786
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
+#| "calendar '%4$s' since the year %5$d, applicable to the year %6$d."
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 "O grau do %1$s '%2$s' foi alterado para '%3$s' no calendário nacional '%4$s' "
 "desde o ano %5$d, aplicável ao ano %6$d."
@@ -787,12 +1385,16 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
-#, php-format
+#: src/Paths/CalendarPath.php:3805
+#, fuzzy, php-format
+#| msgid ""
+#| "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
+#| "national calendar '%3$s' since the year %4$d, but could not be applied to "
+#| "the year %5$d because the celebration was not found."
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 "O grau da celebração '%1$s' foi alterado para '%2$s' no calendário nacional "
 "'%3$s' desde o ano %4$d, mas não pôde ser aplicado ao ano %5$d porque a "
@@ -807,7 +1409,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -823,7 +1425,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -836,25 +1438,37 @@ msgstr ""
 "do Missal Romano."
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
-#, php-format
+#: src/Paths/CalendarPath.php:3878
+#, fuzzy, php-format
+#| msgid ""
+#| "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
+#| "the national calendar '%4$s', but this could not take place in the year "
+#| "%5$d since the new date %2$s seems to be a Sunday or a festivity of "
+#| "greater rank."
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
 msgstr ""
 "O evento litúrgico '%1$s' foi transferido para %2$s desde o ano %3$d no "
 "calendário nacional '%4$s', mas isso não pôde ocorrer no ano %5$d já que a "
 "nova data %2$s parece ser um domingo ou uma festividade de maior importância."
 
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
+msgstr ""
+
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Arquivo de dados do sanctorale encontrado para %s"
@@ -864,11 +1478,11 @@ msgstr "Arquivo de dados do sanctorale encontrado para %s"
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -878,13 +1492,13 @@ msgstr ""
 "suplantada pela %5$s '%6$s' no ano %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Não foi possível encontrar um arquivo de dados sanctorale para %s"
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -893,8 +1507,8 @@ msgstr ""
 "O %1$s '%2$s' é transferido de %5$s para %6$s conforme o %7$s, para dar "
 "lugar a '%3$s': aplicável ao ano %4$d."
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -904,8 +1518,48 @@ msgstr ""
 "O %1$s '%2$s' teria sido transferido de %3$s para %4$s conforme o %5$s, para "
 "dar lugar a '%6$s', no entanto é suprimido pelo %7$s '%8$s' no ano %9$d."
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+"Não é possível criar a festividade móvel '%1$s' relativa à festividade com a "
+"chave '%2$s'"
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+"Não é possível criar a festividade móvel '%1$s': só pode ser relativa à "
+"festividade com a chave '%2$s' usando as palavras-chave %3$s"
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': 'strtotime' property must be "
+#| "either an object or a string! Currently it has type '%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+"Não é possível criar a festividade móvel '%1$s': a propriedade 'strtotime' "
+"deve ser um objeto ou uma string! Atualmente tem o tipo '%2$s'"
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -916,411 +1570,125 @@ msgstr ""
 "%3$s, coincide com o Domingo ou Solenidade '%4$s' no ano %5$d! Precisa ser "
 "feito algo sobre isso?"
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
-#, php-format
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s', proper to the calendar of the %3$s and usually "
+#| "celebrated on %4$s, is suppressed by the Sunday or Solemnity %5$s in the "
+#| "year %6$d"
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 "A %1$s '%2$s', própria do calendário do %3$s e geralmente celebrada em %4$s, "
 "é suprimida pelo Domingo ou Solenidade %5$s no ano %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 "Erro ao receber ou analisar informações do GitHub sobre a última versão: %s."
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "ANO"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr "Missa da Vigília"
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-"A Missa da Vigília para o %1$s '%2$s' coincide com o %3$s '%4$s' no ano "
-"%5$d. Conforme %6$s, o primeiro tem precedência, portanto a Missa da Vigília "
-"é confirmada assim como as I Vésperas."
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-"A Missa da Vigília para o %1$s '%2$s' coincide com o %3$s '%4$s' no ano "
-"%5$d. Como a primeira solenidade tem precedência, terá Vésperas I e uma "
-"Missa de vigília, enquanto a última solenidade não terá nem Vésperas II nem "
-"uma Missa vespertina."
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-"A Missa da Vigília para o %1$s '%2$s' coincide com o %3$s '%4$s' no ano "
-"%5$d. Esta última solenidade tem precedência, portanto, manterá Vésperas II "
-"e uma Missa vespertina, enquanto a primeira solenidade não terá Missa de "
-"vigília nem Vésperas I."
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-"A Missa da Vigília para o %1$s '%2$s' coincide com o %3$s '%4$s' no ano "
-"%5$d. Devemos perguntar à Congregação para o Culto Divino o que fazer sobre "
-"isso!"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "verde"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "roxo"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "branco"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "vermelho"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "rosa"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Próprio"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Dedicação de uma Igreja"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Bem-Aventurada Virgem Maria"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Mártires"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Pastores"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Doutores"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Virgens"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Homens e Mulheres Santos"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Para um Mártir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Para Vários Mártires"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Para Mártires Missionários"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Para Um Missionário Mártir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Para Vários Mártires Missionários"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Para uma Virgem Mártir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Para uma Santa Mártir"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Para um Papa"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Para um Bispo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Para um Pastor"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Para Vários Pastores"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Para Fundadores de uma Igreja"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Para um Fundador"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Para Vários Fundadores"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Para Missionários"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Para Uma Virgem"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Para Várias Virgens"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Para Vários Santos"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Para Um Santo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Para um Abade"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Para um Monge"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Para uma Freira"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Para Religiosos"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Para Aqueles que Praticaram Obras de Misericórdia"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Para Educadores"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Para Mulheres Santas"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr "do"
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr "de"
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr "de"
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr "do"
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "Do Comum"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "dia de semana"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
 
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
+#~ msgid "The Diocesan calendar \"%s\" was not found in the index file."
+#~ msgstr ""
+#~ "O calendário diocesano \"%s\" não foi encontrado no arquivo de índice."
+
+#~ msgid ""
+#~ "There was an error trying to decode localized JSON data for the "
+#~ "Temporale: %s"
+#~ msgstr ""
+#~ "Houve um erro ao tentar decodificar os dados JSON localizados para o "
+#~ "Temporale: %s"
+
+#~ msgid ""
+#~ "There was an error trying to retrieve localized data for the Temporale."
+#~ msgstr ""
+#~ "Houve um erro ao tentar recuperar os dados localizados para o Temporale."
+
+#~ msgid "There was an error trying to decode JSON data for the Temporale: %s"
+#~ msgstr ""
+#~ "Houve um erro ao tentar decodificar os dados JSON para o Temporale: %s"
+
+#~ msgid "There was an error trying to retrieve data for the Temporale."
+#~ msgstr "Houve um erro ao tentar recuperar os dados para o Temporale."
+
+#~ msgid "Translation data for the sanctorale from %s could not be found."
+#~ msgstr "Dados de tradução para o sanctorale de %s não foram encontrados."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON localization data for the "
+#~ "Sanctorale for the Missal %1$s: %2$s"
+#~ msgstr ""
+#~ "Houve um erro ao tentar decodificar os dados de localização JSON para o "
+#~ "Sanctorale do Missal %1$s: %2$s"
+
+#~ msgid "Data for the Sanctorale from %s could not be found."
+#~ msgstr "Não foi possível encontrar os dados para o Sanctorale de %s."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for the Sanctorale for the "
+#~ "Missal %1$s: %2$s."
+#~ msgstr ""
+#~ "Houve um erro ao tentar decodificar os dados JSON para o Sanctorale do "
+#~ "Missal %1$s: %2$s."
+
+#~ msgid "Could not find the Sanctorale data"
+#~ msgstr "Não foi possível encontrar os dados do Sanctorale"
+
+#~ msgid ""
+#~ "There was an error trying to decode translation data for Memorials based "
+#~ "on Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Houve um erro ao tentar decodificar os dados de tradução para Memoriais "
+#~ "com base nos Decretos da Congregação para o Culto Divino: %s"
+
+#~ msgid ""
+#~ "Could not find translation data for Memorials based on Decrees of the "
+#~ "Congregation for Divine Worship"
+#~ msgstr ""
+#~ "Não foi possível encontrar dados de tradução para Memoriais baseados em "
+#~ "Decretos da Congregação para o Culto Divino"
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for Memorials based on "
+#~ "Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Houve um erro ao tentar decodificar os dados JSON para Memoriais baseados "
+#~ "em Decretos da Congregação para o Culto Divino: %s"
+
+#~ msgid "before"
+#~ msgstr "antes"
+
+#~ msgid "after"
+#~ msgstr "após"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s': when the 'strtotime' property is "
+#~ "an object, it must have properties %2$s"
+#~ msgstr ""
+#~ "Não é possível criar festividade móvel '%1$s': quando a propriedade "
+#~ "'strtotime' é um objeto, deve ter propriedades %2$s"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+#~ msgstr ""
+#~ "Não é possível criar a festividade móvel '%1$s' sem uma propriedade "
+#~ "'strtotime'!"
+
+#~ msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgstr ""
+#~ "Erro ao recuperar e decodificar dados da Região Ampla do arquivo %s."
+
 #, fuzzy
-#| msgid "Commemoration"
-msgid "commemoration"
-msgstr "Comemoração"
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-#, fuzzy
-#| msgid "Optional memorial"
-msgid "optional memorial"
-msgstr "Memória opcional"
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Memória"
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "FESTA"
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "FESTA DO SENHOR"
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "SOLENIDADE"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "celebração com precedência sobre solenidades"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr "Advento"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr "Natal"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr "Quaresma"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr "Tríduo Pascal"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr "Páscoa"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr "Tempo Comum"
+#~| msgid "Error retrieving and decoding National data from file %s."
+#~ msgid "Error retrieving and decoding National Calendar data from file %s."
+#~ msgstr "Erro ao recuperar e decodificar dados Nacionais do arquivo %s."

--- a/i18n/pt_BR/LC_MESSAGES/litcal.po
+++ b/i18n/pt_BR/LC_MESSAGES/litcal.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,169 +15,734 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr ""
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr ""
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr ""
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr ""
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr ""
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr ""
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr ""
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr ""
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr ""
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr ""
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr ""
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr ""
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr ""
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr ""
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr ""
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr ""
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr ""
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+msgid "commemoration"
+msgstr ""
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+msgid "optional memorial"
+msgstr ""
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr ""
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr ""
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr ""
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr ""
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr ""
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+msgid "For the Church"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+msgid "For the Pope"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+msgid "For the Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+msgid "For Ministers of the Church"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+msgid "For the Laity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+msgid "For Reconciliation"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+msgid "For the Unity of Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+msgid "For Rain"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+msgid "For Fine Weather"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+msgid "For an End to Storms"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+msgid "For Charity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+msgid "For Those in Prison"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+msgid "For the Sick"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+msgid "For the Dying"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr ""
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr ""
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr ""
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr ""
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
 "%d."
 msgstr ""
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr ""
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr ""
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr ""
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr ""
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr ""
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr ""
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr ""
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr ""
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -190,7 +755,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -198,7 +763,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -206,12 +771,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -221,77 +786,72 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr ""
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr ""
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
 msgstr ""
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -300,22 +860,33 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -324,16 +895,16 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -346,69 +917,38 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials (%4$s)."
 msgstr ""
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr ""
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr ""
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
 #, php-format
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -416,14 +956,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -431,14 +971,14 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -446,33 +986,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
 "applicable to the year %3$d (%4$s)."
 msgstr ""
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr ""
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -481,15 +1017,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -497,7 +1033,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -505,7 +1041,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -513,16 +1049,17 @@ msgid ""
 "Aug. 12 since the year 2002 (%2$s), applicable to the year %3$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:2981
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -531,46 +1068,37 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr ""
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr ""
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3245
-#, php-format
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr ""
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -579,15 +1107,15 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -601,23 +1129,23 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
 "They are both reduced in rank to optional memorials."
 msgstr ""
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
 "'%3$s' in the year %4$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -625,10 +1153,31 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
+msgstr ""
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, php-format
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
 msgstr ""
 
 #. translators:
@@ -639,7 +1188,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -653,7 +1202,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -667,13 +1216,14 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
+#: src/Paths/CalendarPath.php:3786
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 
 #. translators:
@@ -683,12 +1233,12 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
+#: src/Paths/CalendarPath.php:3805
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 
 #. translators:
@@ -700,7 +1250,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -714,7 +1264,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -723,22 +1273,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
+#: src/Paths/CalendarPath.php:3878
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
+msgstr ""
+
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -748,11 +1305,11 @@ msgstr ""
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -760,21 +1317,21 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
 "room for '%3$s': applicable to the year %4$d."
 msgstr ""
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -782,8 +1339,33 @@ msgid ""
 "in the year %9$d."
 msgstr ""
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, php-format
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -791,390 +1373,23 @@ msgid ""
 "year %5$d! Does something need to be done about this?"
 msgstr ""
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr ""
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr ""
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr ""
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr ""
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr ""
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr ""
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr ""
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr ""
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr ""
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr ""
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
-msgid "commemoration"
-msgstr ""
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-msgid "optional memorial"
-msgstr ""
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr ""
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr ""
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr ""
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr ""
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr ""
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""

--- a/i18n/sk/LC_MESSAGES/litcal.po
+++ b/i18n/sk/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2024-10-03 11:32+0000\n"
 "Last-Translator: Milan Šalka <salka.milan@googlemail.com>\n"
 "Language-Team: Slovak <https://translate.johnromanodorazio.com/projects/"
@@ -19,18 +19,727 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "zelená"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "fialová"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "biela"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "červená"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "ružová"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Správne"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Posviacka kostola"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Blahoslavená Panna Mária"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Mučeníci"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Pastori"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Lekári"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Panny"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Svätí muži a ženy"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Pre jedného mučeníka"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Pre niekoľkých mučeníkov"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Za misionárskych mučeníkov"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Za jedného misionárskeho mučeníka"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Za niekoľkých misionárskych mučeníkov"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Pre Pannu Martýrku"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Pre svätú ženu mučeníčku"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Pre pápeža"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Pre biskupa"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Pre jedného pastora"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Pre niekoľkých pastierov"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Pre zakladateľov Cirkvi"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Pre jedného zakladateľa"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Za viacerých zakladateľov"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Pre misionárov"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Pre jednu Pannu"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Pre niekoľko panien"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Pre niekoľkých svätých"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Pre jedného svätého"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Za opáta"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Pre mnícha"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Pre mníšku"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Pre náboženské účely"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Pre tých, ktorí vykonávali skutky milosrdenstva"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Pre pedagógov"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Za sväté ženy"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr "z"
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr "z"
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr "z"
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr "z"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "pracovný deň"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+#, fuzzy
+#| msgid "Commemoration"
+msgid "commemoration"
+msgstr "Spomienka"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+#, fuzzy
+#| msgid "Optional memorial"
+msgid "optional memorial"
+msgstr "Ľubovoľná spomienka"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Pamätník"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "SVIATOK"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "SVIATOK PÁNA"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "SLÁVNOSŤ"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "slávenie s prednosťou pred slávnosťami"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "a učiteľ Cirkvi"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Pre pápeža"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Pre biskupa"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Pre zakladateľov Cirkvi"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Pre jedného svätého"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Pre náboženské účely"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "%s deň oktávy Vianoc"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Pre mníšku"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Pre jedného mučeníka"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Pre pedagógov"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Pre jedného mučeníka"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Pre jednu Pannu"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Pre jedného svätého"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Pre jedného svätého"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr "Advent"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr "Vianoce"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr "Pôst"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr "Veľkonočné trojdnie"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr "Veľká noc"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr "Obdobie cez rok"
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "Z bežného"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "alebo"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "ROK"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Omšová vigília"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+"Vigília omša pre %1$s '%2$s' sa zhoduje s %3$s '%4$s' v roku %5$d. Podľa "
+"%6$s má prvá prednosť, preto je Vigília omša potvrdená rovnako ako I. "
+"vešpery."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr "Dekrét Kongregácie pre Boží kult"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+"Vigilná omša pre %1$s '%2$s' sa zhoduje s %3$s '%4$s' v roku %5$d. Keďže "
+"prvá slávnosť má prednosť, bude mať prvé vešpery a vigilnú omšu, zatiaľ čo "
+"posledná slávnosť nebude mať ani druhé vešpery, ani večernú omšu."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+"Vigilná omša pre %1$s '%2$s' sa zhoduje s %3$s '%4$s' v roku %5$d. Táto "
+"posledná slávnosť má prednosť, preto si zachová Vešpery II a večernú omšu, "
+"zatiaľ čo prvá slávnosť nebude mať vigilnú omšu ani Vešpery I."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+"Vigília omša pre %1$s '%2$s' sa zhoduje s %3$s '%4$s' v roku %5$d. Mali by "
+"sme sa opýtať Kongregácie pre Boží kult, čo s tým robiť!"
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr ""
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
@@ -38,133 +747,30 @@ msgid ""
 msgstr ""
 "Podporované sú len roky od roku 1970 a neskôr. Skúsili ste požiadať o rok %d."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-"Vyskytla sa chyba pri pokuse dekódovať lokalizované údaje JSON pre "
-"Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr ""
-"Vyskytla sa chyba pri pokuse o načítanie lokalizovaných údajov pre Temporale."
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr "Vyskytla sa chyba pri pokuse dekódovať údaje JSON pre Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr "Vyskytla sa chyba pri pokuse o načítanie údajov pre Temporale."
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr "Údaje o sanctorale z %s sa nenašli."
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-"Vyskytla sa chyba pri pokuse dekódovať údaje JSON lokalizácie pre Sanctorale "
-"pre Misál %1$s: %2$s"
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr "Údaje pre Sanctorale z %s sa nenašli."
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-"Vyskytla sa chyba pri pokuse dekódovať údaje JSON pre Sanctorale pre Misál "
-"%1$s: %2$s."
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr "Nepodarilo sa nájsť údaje Sanctorale"
-
-#: src/Paths/Calendar.php:947
-#, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-"Vyskytla sa chyba pri pokuse dekódovať prekladové údaje pre Pamätné dni na "
-"základe dekrétov Kongregácie pre Boží kult: %s"
-
-#: src/Paths/Calendar.php:953
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-"Nepodarilo sa nájsť prekladové údaje pre Pamätné dni založené na dekrétoch "
-"Kongregácie pre Boží kult"
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-"Vyskytla sa chyba pri pokuse dekódovať údaje JSON pre Pamätné dni na základe "
-"dekrétov Kongregácie pre Boží kult: %s"
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Vianočný všedný deň"
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "alebo"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Nedeľa Božieho milosrdenstva"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -173,31 +779,20 @@ msgstr ""
 "Slávnosť '%1$s' pripadá na %2$s v roku %3$d, oslava bola presunutá na %4$s "
 "(%5$s) podľa %6$s."
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr "sobota pred Kvetnou nedeľou"
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr "Dekrét Kongregácie pre Boží kult"
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "pondelok po Druhej veľkonočnej nedeli"
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr "nasledujúci pondelok"
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -212,7 +807,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -222,7 +817,7 @@ msgstr ""
 "podľa %4$s presunutá o jeden deň dopredu."
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -232,12 +827,12 @@ msgstr ""
 "%4$s namiesto nedele po Vianociach."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Náš Pán Ježiš Kristus, Večný Veľkňaz"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -251,59 +846,59 @@ msgstr ""
 "'%2$d' (%3$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' je nahradený %2$s '%3$s' v roku %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "týždňa adventu %s"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "%s deň oktávy Vianoc"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "týždňa pôstu %s"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "po Popolcovej strede"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -311,7 +906,7 @@ msgid ""
 msgstr ""
 "%1$s '%2$s' bol pridaný dňa %3$s od roku %4$d (%5$s), platný pre rok %6$d."
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
@@ -319,12 +914,7 @@ msgstr ""
 "Tlačová konferencia vo Vatikáne: Predstavenie Editio Typica Tertia Rímskeho "
 "misála"
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -336,22 +926,33 @@ msgstr ""
 "znížená na Spomienku."
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "%1$s '%2$s' je nahradený %3$s '%4$s' v roku %5$d."
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Apoštolská konštitúcia Missale Romanum"
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -362,16 +963,16 @@ msgstr ""
 "slávený %6$s, je zrušený %7$s '%8$s' v roku %9$d."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -386,7 +987,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -395,70 +996,40 @@ msgstr ""
 "Pamätný deň '%1$s' sa zhoduje s iným pamätným dňom '%2$s' v roku %3$d. Oba "
 "sú znížené na ľubovoľné spomienky (%4$s)."
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr "predtým"
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr "po"
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 "Nie je možné vytvoriť mobilnú slávnosť '%1$s': môže byť relatívna len k "
 "slávnosti s kľúčom '%2$s' pomocou kľúčových slov %3$s"
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr ""
 "Nemožno vytvoriť mobilnú slávnosť '%1$s' vzhľadom na slávnosť s kľúčom '%2$s'"
 
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-"Nie je možné vytvoriť mobilnú slávnosť '%1$s': keď je vlastnosť 'strtotime' "
-"objektom, musí mať vlastnosti %2$s"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-"Nemožno vytvoriť mobilnú slávnosť '%1$s': vlastnosť 'strtotime' musí byť buď "
-"objekt alebo reťazec! Momentálne má typ '%2$s'"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
-msgstr ""
-"Nie je možné vytvoriť mobilnú slávnosť '%1$s' bez vlastnosti 'strtotime'!"
-
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -468,14 +1039,14 @@ msgstr ""
 "(%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -485,14 +1056,14 @@ msgstr ""
 "(%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -502,12 +1073,12 @@ msgstr ""
 "(%6$s)."
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -516,21 +1087,17 @@ msgstr ""
 "'%1$s' bol vyhlásený za učiteľa Cirkvi od roku %2$d, platné pre rok %3$d "
 "(%4$s)."
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "a učiteľ Cirkvi"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -541,15 +1108,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -559,7 +1126,7 @@ msgstr ""
 "%7$d (%8$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -569,7 +1136,7 @@ msgstr ""
 "roku 2002 (%2$s), platná pre rok %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -580,19 +1147,24 @@ msgstr ""
 "slávnosťou, keby bola 12. decembra, bola však od roku 2002 (%2$s) presunutá "
 "na 12. augusta, platná pre rok %3$d."
 
-#: src/Paths/Calendar.php:2981
-#, php-format
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
+#, fuzzy, php-format
+#| msgid ""
+#| "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
+#| "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
+#| "superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 "Voliteľná spomienka '%1$s' bola presunutá z 12. decembra na 12. augusta od "
 "roku 2002 (%2$s), platná pre rok %3$d. Avšak, v roku %3$d je nahradená "
 "nedeľou, slávnosťou alebo sviatkom '%4$s'."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -604,48 +1176,37 @@ msgstr ""
 "avšak keďže je Rok apoštola Pavla, podľa %2$s bol obnovený, aby miestne "
 "cirkvi mohli voliteľne sláviť pamätný deň."
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "týždňa Veľkej noci %s"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "týždňa v období cez rok %s"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Sobotná pamiatka Preblahoslavenej Panny Márie"
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr ""
-"Chyba pri načítaní a dekódovaní údajov z širšieho regiónu zo súboru %s."
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3245
-#, fuzzy, php-format
-#| msgid "Error retrieving and decoding National data from file %s."
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr "Chyba pri načítaní a dekódovaní národných údajov zo súboru %s."
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -658,15 +1219,15 @@ msgstr ""
 "%1$s '%2$s', zvyčajne oslavovaný %3$s, je v roku %6$d potlačený %4$s '%5$s'."
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -684,7 +1245,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -693,8 +1254,8 @@ msgstr ""
 "Pamätný deň '%1$s' sa zhoduje s iným pamätným dňom '%2$s' v roku %3$d. Oba "
 "sú znížené na ľubovoľné spomienky."
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -703,8 +1264,8 @@ msgstr ""
 "Sviatok '%1$s', zvyčajne oslavovaný %2$s, sa v roku %4$d zhoduje s iným "
 "sviatkom '%3$s'! Treba s tým niečo urobiť?"
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -714,13 +1275,43 @@ msgstr ""
 "Slávnosť '%1$s', zvyčajne slávená %2$s, sa v roku %4$d zhoduje s nedeľou "
 "alebo slávnosťou '%3$s'! Treba s tým niečo urobiť?"
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+#, fuzzy
+#| msgid ""
+#| "We should be creating a new festivity, however we do not seem to have the "
+#| "correct date information in order to proceed"
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
 msgstr ""
 "Mali by sme vytvoriť nový sviatok, ale zdá sa, že nemáme správne informácie "
 "o dátume, aby sme mohli pokračovať"
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
+#| "applicable to the year %5$d (%6$s)."
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
+msgstr ""
+"%1$s '%2$s' bol povýšený na hodnosť %3$s od roku %4$d, platné pre rok %5$d "
+"(%6$s)."
 
 #. translators:
 #.  1. Liturgical grade
@@ -730,7 +1321,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -749,7 +1340,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -768,16 +1359,17 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
+#: src/Paths/CalendarPath.php:3786
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
 #| "applicable to the year %5$d (%6$s)."
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 "Názov %1$s '%2$s' bol zmenený na %3$s od roku %4$d, platný pre rok %5$d "
 "(%6$s)."
@@ -789,15 +1381,15 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
+#: src/Paths/CalendarPath.php:3805
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
 #| "applicable to the year %5$d (%6$s)."
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 "Názov %1$s '%2$s' bol zmenený na %3$s od roku %4$d, platný pre rok %5$d "
 "(%6$s)."
@@ -811,7 +1403,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -829,7 +1421,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -838,22 +1430,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
+#: src/Paths/CalendarPath.php:3878
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
+msgstr ""
+
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Našiel som súbor sanctorale pre %s"
@@ -863,11 +1462,11 @@ msgstr "Našiel som súbor sanctorale pre %s"
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -877,13 +1476,13 @@ msgstr ""
 "'%6$s' v roku %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Nepodarilo sa nájsť súbor sanctorale pre %s"
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -892,8 +1491,8 @@ msgstr ""
 "%1$s '%2$s' je presunutý z %5$s do %6$s podľa %7$s, aby sa uvoľnilo miesto "
 "pre '%3$s': platné pre rok %4$d."
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -903,8 +1502,47 @@ msgstr ""
 "%1$s '%2$s' by bol presunutý z %3$s do %4$s podľa %5$s, aby sa uvoľnilo "
 "miesto pre '%6$s', avšak je potlačený %7$s '%8$s' v roku %9$d."
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr ""
+"Nemožno vytvoriť mobilnú slávnosť '%1$s' vzhľadom na slávnosť s kľúčom '%2$s'"
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+"Nie je možné vytvoriť mobilnú slávnosť '%1$s': môže byť relatívna len k "
+"slávnosti s kľúčom '%2$s' pomocou kľúčových slov %3$s"
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': 'strtotime' property must be "
+#| "either an object or a string! Currently it has type '%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+"Nemožno vytvoriť mobilnú slávnosť '%1$s': vlastnosť 'strtotime' musí byť buď "
+"objekt alebo reťazec! Momentálne má typ '%2$s'"
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -914,409 +1552,121 @@ msgstr ""
 "Slávnosť '%1$s', vlastná kalendáru %2$s a zvyčajne slávená %3$s, sa v roku "
 "%5$d zhoduje s nedeľou alebo slávnosťou '%4$s'! Treba s tým niečo urobiť?"
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
-#, php-format
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s', proper to the calendar of the %3$s and usually "
+#| "celebrated on %4$s, is suppressed by the Sunday or Solemnity %5$s in the "
+#| "year %6$d"
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 "Slávnosť %1$s '%2$s', vlastná kalendáru %3$s a zvyčajne slávená %4$s, je v "
 "roku %6$d potlačená nedeľou alebo slávnosťou %5$s"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 "Chyba pri prijímaní alebo spracovaní informácií z GitHubu o najnovšom "
 "vydaní: %s."
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "ROK"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr "Omšová vigília"
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-"Vigília omša pre %1$s '%2$s' sa zhoduje s %3$s '%4$s' v roku %5$d. Podľa "
-"%6$s má prvá prednosť, preto je Vigília omša potvrdená rovnako ako I. "
-"vešpery."
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-"Vigilná omša pre %1$s '%2$s' sa zhoduje s %3$s '%4$s' v roku %5$d. Keďže "
-"prvá slávnosť má prednosť, bude mať prvé vešpery a vigilnú omšu, zatiaľ čo "
-"posledná slávnosť nebude mať ani druhé vešpery, ani večernú omšu."
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-"Vigilná omša pre %1$s '%2$s' sa zhoduje s %3$s '%4$s' v roku %5$d. Táto "
-"posledná slávnosť má prednosť, preto si zachová Vešpery II a večernú omšu, "
-"zatiaľ čo prvá slávnosť nebude mať vigilnú omšu ani Vešpery I."
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-"Vigília omša pre %1$s '%2$s' sa zhoduje s %3$s '%4$s' v roku %5$d. Mali by "
-"sme sa opýtať Kongregácie pre Boží kult, čo s tým robiť!"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "zelená"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "fialová"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "biela"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "červená"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "ružová"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Správne"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Posviacka kostola"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Blahoslavená Panna Mária"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Mučeníci"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Pastori"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Lekári"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Panny"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Svätí muži a ženy"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Pre jedného mučeníka"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Pre niekoľkých mučeníkov"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Za misionárskych mučeníkov"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Za jedného misionárskeho mučeníka"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Za niekoľkých misionárskych mučeníkov"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Pre Pannu Martýrku"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Pre svätú ženu mučeníčku"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Pre pápeža"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Pre biskupa"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Pre jedného pastora"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Pre niekoľkých pastierov"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Pre zakladateľov Cirkvi"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Pre jedného zakladateľa"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Za viacerých zakladateľov"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Pre misionárov"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Pre jednu Pannu"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Pre niekoľko panien"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Pre niekoľkých svätých"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Pre jedného svätého"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Za opáta"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Pre mnícha"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Pre mníšku"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Pre náboženské účely"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Pre tých, ktorí vykonávali skutky milosrdenstva"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Pre pedagógov"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Za sväté ženy"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr "z"
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr "z"
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr "z"
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr "z"
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "Z bežného"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "pracovný deň"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
 
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
+#~ msgid ""
+#~ "There was an error trying to decode localized JSON data for the "
+#~ "Temporale: %s"
+#~ msgstr ""
+#~ "Vyskytla sa chyba pri pokuse dekódovať lokalizované údaje JSON pre "
+#~ "Temporale: %s"
+
+#~ msgid ""
+#~ "There was an error trying to retrieve localized data for the Temporale."
+#~ msgstr ""
+#~ "Vyskytla sa chyba pri pokuse o načítanie lokalizovaných údajov pre "
+#~ "Temporale."
+
+#~ msgid "There was an error trying to decode JSON data for the Temporale: %s"
+#~ msgstr "Vyskytla sa chyba pri pokuse dekódovať údaje JSON pre Temporale: %s"
+
+#~ msgid "There was an error trying to retrieve data for the Temporale."
+#~ msgstr "Vyskytla sa chyba pri pokuse o načítanie údajov pre Temporale."
+
+#~ msgid "Translation data for the sanctorale from %s could not be found."
+#~ msgstr "Údaje o sanctorale z %s sa nenašli."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON localization data for the "
+#~ "Sanctorale for the Missal %1$s: %2$s"
+#~ msgstr ""
+#~ "Vyskytla sa chyba pri pokuse dekódovať údaje JSON lokalizácie pre "
+#~ "Sanctorale pre Misál %1$s: %2$s"
+
+#~ msgid "Data for the Sanctorale from %s could not be found."
+#~ msgstr "Údaje pre Sanctorale z %s sa nenašli."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for the Sanctorale for the "
+#~ "Missal %1$s: %2$s."
+#~ msgstr ""
+#~ "Vyskytla sa chyba pri pokuse dekódovať údaje JSON pre Sanctorale pre "
+#~ "Misál %1$s: %2$s."
+
+#~ msgid "Could not find the Sanctorale data"
+#~ msgstr "Nepodarilo sa nájsť údaje Sanctorale"
+
+#~ msgid ""
+#~ "There was an error trying to decode translation data for Memorials based "
+#~ "on Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Vyskytla sa chyba pri pokuse dekódovať prekladové údaje pre Pamätné dni "
+#~ "na základe dekrétov Kongregácie pre Boží kult: %s"
+
+#~ msgid ""
+#~ "Could not find translation data for Memorials based on Decrees of the "
+#~ "Congregation for Divine Worship"
+#~ msgstr ""
+#~ "Nepodarilo sa nájsť prekladové údaje pre Pamätné dni založené na "
+#~ "dekrétoch Kongregácie pre Boží kult"
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for Memorials based on "
+#~ "Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Vyskytla sa chyba pri pokuse dekódovať údaje JSON pre Pamätné dni na "
+#~ "základe dekrétov Kongregácie pre Boží kult: %s"
+
+#~ msgid "before"
+#~ msgstr "predtým"
+
+#~ msgid "after"
+#~ msgstr "po"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s': when the 'strtotime' property is "
+#~ "an object, it must have properties %2$s"
+#~ msgstr ""
+#~ "Nie je možné vytvoriť mobilnú slávnosť '%1$s': keď je vlastnosť "
+#~ "'strtotime' objektom, musí mať vlastnosti %2$s"
+
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+#~ msgstr ""
+#~ "Nie je možné vytvoriť mobilnú slávnosť '%1$s' bez vlastnosti 'strtotime'!"
+
+#~ msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgstr ""
+#~ "Chyba pri načítaní a dekódovaní údajov z širšieho regiónu zo súboru %s."
+
 #, fuzzy
-#| msgid "Commemoration"
-msgid "commemoration"
-msgstr "Spomienka"
-
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
-#, fuzzy
-#| msgid "Optional memorial"
-msgid "optional memorial"
-msgstr "Ľubovoľná spomienka"
-
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
-
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Pamätník"
-
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "SVIATOK"
-
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "SVIATOK PÁNA"
-
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
-
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "SLÁVNOSŤ"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "slávenie s prednosťou pred slávnosťami"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr "Advent"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr "Vianoce"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr "Pôst"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr "Veľkonočné trojdnie"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr "Veľká noc"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr "Obdobie cez rok"
+#~| msgid "Error retrieving and decoding National data from file %s."
+#~ msgid "Error retrieving and decoding National Calendar data from file %s."
+#~ msgstr "Chyba pri načítaní a dekódovaní národných údajov zo súboru %s."

--- a/i18n/vi/LC_MESSAGES/litcal.po
+++ b/i18n/vi/LC_MESSAGES/litcal.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-22 13:48+0000\n"
+"POT-Creation-Date: 2025-08-10 03:13+0000\n"
 "PO-Revision-Date: 2024-10-03 13:34+0000\n"
 "Last-Translator: OpenAI <noreply-mt-openai@weblate.org>\n"
 "Language-Team: Vietnamese <https://translate.johnromanodorazio.com/projects/"
@@ -19,151 +19,757 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 5.6.1\n"
 
-#: src/Paths/Calendar.php:623
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:32
+msgid "green"
+msgstr "màu xanh lá cây"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:35
+msgid "purple"
+msgstr "màu tím"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:38
+msgid "white"
+msgstr "trắng"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:41
+msgid "red"
+msgstr "đỏ"
+
+#. translators: context = liturgical color
+#: src/Enum/LitColor.php:44
+msgid "pink"
+msgstr "hồng"
+
+#. translators: context = liturgical color: unsupported value
+#: src/Enum/LitColor.php:47
+msgid "unknown"
+msgstr ""
+
+#. translators: context = from the Proper of the festivity (as opposed to a Common)
+#: src/Enum/LitCommon.php:166
+msgid "Proper"
+msgstr "Riêng"
+
+#. translators: context = from the Common of the Dedication of a Church
+#: src/Enum/LitCommon.php:168
+msgid "Dedication of a Church"
+msgstr "Cung hiến Nhà thờ"
+
+#. translators: context = from the Common of the Blessed Virgin Mary
+#: src/Enum/LitCommon.php:170
+msgid "Blessed Virgin Mary"
+msgstr "Đức Trinh Nữ Maria"
+
+#. translators: context = from the Common of Martyrs
+#: src/Enum/LitCommon.php:172
+msgid "Martyrs"
+msgstr "Tử đạo"
+
+#. translators: context = from the Common of Pastors
+#: src/Enum/LitCommon.php:174
+msgid "Pastors"
+msgstr "Mục tử"
+
+#. translators: context = from the Common of Doctors
+#: src/Enum/LitCommon.php:176
+msgid "Doctors"
+msgstr "Tiến sĩ"
+
+#. translators: context = from the Common of Virgins
+#: src/Enum/LitCommon.php:178
+msgid "Virgins"
+msgstr "Trinh nữ"
+
+#. translators: context = from the Common of Holy Men and Women
+#: src/Enum/LitCommon.php:180
+msgid "Holy Men and Women"
+msgstr "Các Thánh Nam Nữ"
+
+#. translators: context = from the Common of Martyrs: For One Martyr
+#: src/Enum/LitCommon.php:182
+msgid "For One Martyr"
+msgstr "Dành cho một Thánh Tử đạo"
+
+#. translators: context = from the Common of Martyrs: For Several Martyrs
+#: src/Enum/LitCommon.php:184
+msgid "For Several Martyrs"
+msgstr "Cho Nhiều Vị Tử Đạo"
+
+#. translators: context = from the Common of Martyrs: For Missionary Martyrs
+#: src/Enum/LitCommon.php:186
+msgid "For Missionary Martyrs"
+msgstr "Dành cho các Thánh Tử đạo Truyền giáo"
+
+#. translators: context = from the Common of Martyrs: For One Missionary Martyr
+#: src/Enum/LitCommon.php:188
+msgid "For One Missionary Martyr"
+msgstr "Cho Một Tử đạo Truyền giáo"
+
+#. translators: context = from the Common of Martyrs: For Several Missionary Martyrs
+#: src/Enum/LitCommon.php:190
+msgid "For Several Missionary Martyrs"
+msgstr "Cho Nhiều Vị Tử Đạo Truyền Giáo"
+
+#. translators: context = from the Common of Martyrs: For a Virgin Martyr
+#: src/Enum/LitCommon.php:192
+msgid "For a Virgin Martyr"
+msgstr "Cho một Trinh Nữ Tử Đạo"
+
+#. translators: context = from the Common of Martyrs: For a Holy Woman Martyr
+#: src/Enum/LitCommon.php:194
+msgid "For a Holy Woman Martyr"
+msgstr "Dành cho một Nữ thánh Tử đạo"
+
+#. translators: context = from the Common of Pastors: For a Pope
+#: src/Enum/LitCommon.php:196
+msgid "For a Pope"
+msgstr "Cho Một Giáo Hoàng"
+
+#. translators: context = from the Common of Pastors: For a Bishop
+#: src/Enum/LitCommon.php:198
+msgid "For a Bishop"
+msgstr "Dành cho một Giám mục"
+
+#. translators: context = from the Common of Pastors: For One Pastor
+#: src/Enum/LitCommon.php:200
+msgid "For One Pastor"
+msgstr "Cho Một Mục Tử"
+
+#. translators: context = from the Common of Pastors: For Several Pastors
+#: src/Enum/LitCommon.php:202
+msgid "For Several Pastors"
+msgstr "Cho Nhiều Mục Tử"
+
+#. translators: context = from the Common of Pastors: For Founders of a Church
+#: src/Enum/LitCommon.php:204
+msgid "For Founders of a Church"
+msgstr "Cho Các Nhà Sáng Lập Giáo Hội"
+
+#. translators: context = from the Common of Pastors: For One Founder
+#: src/Enum/LitCommon.php:206
+msgid "For One Founder"
+msgstr "Dành cho một Đấng sáng lập"
+
+#. translators: context = from the Common of Pastors: For Several Founders
+#: src/Enum/LitCommon.php:208
+msgid "For Several Founders"
+msgstr "Cho Nhiều Đấng Sáng Lập"
+
+#. translators: context = from the Common of Pastors: For Missionaries
+#: src/Enum/LitCommon.php:210
+msgid "For Missionaries"
+msgstr "Cho Các Nhà Truyền Giáo"
+
+#. translators: context = from the Common of Virgins: For One Virgin
+#: src/Enum/LitCommon.php:212
+msgid "For One Virgin"
+msgstr "Cho Một Trinh nữ"
+
+#. translators: context = from the Common of Virgins: For Several Virgins
+#: src/Enum/LitCommon.php:214
+msgid "For Several Virgins"
+msgstr "Dành cho nhiều Trinh nữ"
+
+#. translators: context = from the Common of Holy Men and Women: For Several Saints
+#: src/Enum/LitCommon.php:216
+msgid "For Several Saints"
+msgstr "Dành cho nhiều Thánh"
+
+#. translators: context = from the Common of Holy Men and Women: For One Saint
+#: src/Enum/LitCommon.php:218
+msgid "For One Saint"
+msgstr "Cho Một Thánh"
+
+#. translators: context = from the Common of Holy Men and Women: For an Abbot
+#: src/Enum/LitCommon.php:220
+msgid "For an Abbot"
+msgstr "Cho một Viện Phụ"
+
+#. translators: context = from the Common of Holy Men and Women: For a Monk
+#: src/Enum/LitCommon.php:222
+msgid "For a Monk"
+msgstr "Cho Một Tu Sĩ"
+
+#. translators: context = from the Common of Holy Men and Women: For a Nun
+#: src/Enum/LitCommon.php:224
+msgid "For a Nun"
+msgstr "Cho Một Nữ Tu"
+
+#. translators: context = from the Common of Holy Men and Women: For Religious
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitCommon.php:226 src/Enum/LitMassVariousNeeds.php:236
+msgid "For Religious"
+msgstr "Cho Tu Sĩ"
+
+#. translators: context = from the Common of Holy Men and Women: For Those Who Practiced Works of Mercy
+#: src/Enum/LitCommon.php:228
+msgid "For Those Who Practiced Works of Mercy"
+msgstr "Cho Những Người Thực Hành Các Công Việc Từ Thiện"
+
+#. translators: context = from the Common of Holy Men and Women: For Educators
+#: src/Enum/LitCommon.php:230
+msgid "For Educators"
+msgstr "Cho Các Nhà Giáo Dục"
+
+#. translators: context = from the Common of Holy Men and Women: For Holy Women
+#: src/Enum/LitCommon.php:232
+msgid "For Holy Women"
+msgstr "Cho Các Thánh Nữ"
+
+#. translators: "From the Common [of the] Blessed Virgin Mary|Dedication of a Church" (singular feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:261
+msgctxt "(SING_FEMM)"
+msgid "of the"
+msgstr "của"
+
+#. translators: "From the Common [of] Virgins" (plural feminine). Latin: leave empty!
+#: src/Enum/LitCommon.php:263
+msgctxt "(PLUR_FEMM)"
+msgid "of"
+msgstr "của"
+
+#. translators: "From the Common [of] Martyrs|Pastors|Doctors|Holy Men and Women" (plural masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:265
+msgctxt "(PLUR_MASC)"
+msgid "of"
+msgstr "của"
+
+#. translators: "From the Common [of the] (no current cases)" (singular masculine). Latin: leave empty!
+#: src/Enum/LitCommon.php:267
+msgctxt "(SING_MASC)"
+msgid "of the"
+msgstr "của"
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:132 src/Enum/LitGrade.php:188
+msgid "weekday"
+msgstr "ngày trong tuần"
+
+#. translators: liturgical rank 'WEEKDAY' in abbreviated form
+#: src/Enum/LitGrade.php:134 src/Enum/LitGrade.php:190
+msgid "w"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:139
+#, fuzzy
+#| msgid "Commemoration"
+msgid "commemoration"
+msgstr "Kỷ Niệm"
+
+#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
+#: src/Enum/LitGrade.php:141
+msgid "m*"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercsase
+#: src/Enum/LitGrade.php:146
+#, fuzzy
+#| msgid "Optional memorial"
+msgid "optional memorial"
+msgstr "Lễ nhớ tùy chọn"
+
+#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:148
+msgid "m"
+msgstr ""
+
+#. translators: liturgical rank. Keep Capitalized
+#: src/Enum/LitGrade.php:153
+msgid "Memorial"
+msgstr "Lễ nhớ"
+
+#. translators: liturgical rank 'MEMORIAL' in abbreviated form
+#: src/Enum/LitGrade.php:155
+msgid "M"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:160
+msgid "FEAST"
+msgstr "LỄ"
+
+#. translators: liturgical rank 'FEAST' in abbreviated form
+#: src/Enum/LitGrade.php:162
+msgid "F"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:167
+msgid "FEAST OF THE LORD"
+msgstr "LỄ CHÚA"
+
+#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
+#: src/Enum/LitGrade.php:169
+msgid "F✝"
+msgstr ""
+
+#. translators: liturgical rank. Keep UPPERCASE
+#: src/Enum/LitGrade.php:174
+msgid "SOLEMNITY"
+msgstr "LỄ TRỌNG"
+
+#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:176
+msgid "S"
+msgstr ""
+
+#. translators: liturgical rank. Keep lowercase
+#: src/Enum/LitGrade.php:181
+msgid "celebration with precedence over solemnities"
+msgstr "lễ kỷ niệm có ưu tiên hơn các lễ trọng"
+
+#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
+#: src/Enum/LitGrade.php:183
+msgid "S✝"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:206
+#, fuzzy
+#| msgid "and Doctor of the Church"
+msgid "For the Church"
+msgstr "và Tiến sĩ Hội Thánh"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:208
+#, fuzzy
+#| msgid "For a Pope"
+msgid "For the Pope"
+msgstr "Cho Một Giáo Hoàng"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:210
+#, fuzzy
+#| msgid "For a Bishop"
+msgid "For the Bishop"
+msgstr "Dành cho một Giám mục"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:212
+msgid "For the Election of a Pope or a Bishop"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:214
+msgid "For a Council or a Synod"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:216
+msgid "For Priests"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:218
+msgid "For the Priest Himself"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:220
+msgid "On the Anniversary of His Ordination"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:222
+#, fuzzy
+#| msgid "For Founders of a Church"
+msgid "For Ministers of the Church"
+msgstr "Cho Các Nhà Sáng Lập Giáo Hội"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:224
+msgid "For Vocations to Holy Orders"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:226
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Laity"
+msgstr "Cho Một Thánh"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:228
+msgid "On the Anniversaries of Marriage: On Any Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:230
+msgid "On the Anniversaries of Marriage: On the Twenty-Fifth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:232
+msgid "On the Anniversaries of Marriage: On the Fiftieth Anniversary"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:234
+msgid "For the Family"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:238
+msgid "On the Twenty-Fifth or Fiftieth Anniversary of Religious Profession"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:240
+msgid "For Vocations to Religious Life"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:242
+msgid "For Promoting Harmony"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:244
+#, fuzzy
+#| msgid "For Religious"
+msgid "For Reconciliation"
+msgstr "Cho Tu Sĩ"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:246
+#, fuzzy
+#| msgid "%s Day of the Octave of Christmas"
+msgid "For the Unity of Christians"
+msgstr "Ngày %s trong Tuần Bát Nhật Giáng Sinh"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:248
+msgid "For the Evangelization of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:250
+msgid "For Persecuted Christians"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:252
+msgid "For a Spiritual or Pastoral Gathering"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:254
+msgid "For the Nation or State"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:256
+msgid "For Those in Public Office"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:258
+msgid "For a Governing Assembly"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:260
+msgid "For the Head of State or Ruler"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:262
+msgid "At the Beginning of the Civil Year"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:264
+msgid "For the Sanctification of Human Labor"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:266
+msgid "At Seedtime"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:268
+msgid "After the Harvest"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:270
+msgid "For the Progress of Peoples"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:272
+msgid "For the Preservation of Peace and Justice"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:274
+msgid "In Time of War or Civil Disturbance"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:276
+msgid "For Refugees and Exiles"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:278
+msgid "In Time of Famine or for Those Suffering Hunger"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:280
+msgid "In Time of Earthquake"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:282
+#, fuzzy
+#| msgid "For a Nun"
+msgid "For Rain"
+msgstr "Cho Một Nữ Tu"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:284
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Fine Weather"
+msgstr "Dành cho một Thánh Tử đạo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:286
+#, fuzzy
+#| msgid "For Educators"
+msgid "For an End to Storms"
+msgstr "Cho Các Nhà Giáo Dục"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:288
+msgid "For the Forgiveness of Sins"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:290
+msgid "For Chastity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:292
+#, fuzzy
+#| msgid "For One Martyr"
+msgid "For Charity"
+msgstr "Dành cho một Thánh Tử đạo"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:294
+msgid "For Relatives and Friends"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:296
+msgid "For Our Oppressors"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:298
+msgid "For Those Held in Captivity"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:300
+#, fuzzy
+#| msgid "For One Virgin"
+msgid "For Those in Prison"
+msgstr "Cho Một Trinh nữ"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:302
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Sick"
+msgstr "Cho Một Thánh"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:304
+#, fuzzy
+#| msgid "For One Saint"
+msgid "For the Dying"
+msgstr "Cho Một Thánh"
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:306
+msgid "For the Grace of a Happy Death"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:308
+msgid "In Any Need"
+msgstr ""
+
+#. translators: context = Masses and Prayers for Various Needs and Occasions
+#: src/Enum/LitMassVariousNeeds.php:310
+msgid "For Giving Thanks to God"
+msgstr ""
+
+#: src/Enum/LitMassVariousNeeds.php:326
+msgid "Masses and Prayers for Various Needs and Occasions"
+msgstr ""
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:28
+msgid "Advent"
+msgstr "Mùa Vọng"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:31
+msgid "Christmas"
+msgstr "Giáng Sinh"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:34
+msgid "Lent"
+msgstr "Mùa Chay"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:37
+msgid "Easter Triduum"
+msgstr "Tam Nhật Vượt Qua"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:40
+msgid "Easter"
+msgstr "Phục Sinh"
+
+#. translators: context = liturgical season
+#: src/Enum/LitSeason.php:43
+msgid "Ordinary Time"
+msgstr "Thường Niên"
+
+#. translators: context = liturgical season: unsupported value
+#: src/Enum/LitSeason.php:46
+msgid "Unknown Season"
+msgstr ""
+
+#: src/Models/Calendar/LitCommons.php:195
+msgid "From the Common"
+msgstr "Từ Phổ thông"
+
+#. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
+#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
+#: src/Models/Calendar/LitCommons.php:223
+#: src/Models/Calendar/LiturgicalEvent.php:118
+#: src/Models/EventsPath/LiturgicalEventAbstract.php:93
+#: src/Paths/CalendarPath.php:1289 src/Utilities.php:456 src/Utilities.php:461
+msgid "or"
+msgstr "hoặc"
+
+#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
+#: src/Models/Calendar/LiturgicalEventCollection.php:170
+msgid "YEAR"
+msgstr "NĂM"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:171
+msgid "Vigil Mass"
+msgstr "Thánh lễ vọng"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1430
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
+"is confirmed as are I Vespers."
+msgstr ""
+"Thánh lễ vọng cho %1$s '%2$s' trùng với %3$s '%4$s' trong năm %5$d. Theo "
+"%6$s, cái đầu tiên được ưu tiên, do đó Thánh lễ vọng được xác nhận cũng như "
+"Kinh Chiều I."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1436
+#: src/Models/Decrees/DecreeEventMetadata.php:54
+#: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:49
+#: src/Paths/CalendarPath.php:1488 src/Paths/CalendarPath.php:1513
+#: src/Paths/CalendarPath.php:1568 src/Paths/CalendarPath.php:1606
+#: src/Paths/CalendarPath.php:2199 src/Paths/CalendarPath.php:2505
+#: src/Paths/CalendarPath.php:2987 src/Paths/CalendarPath.php:3003
+#: src/Paths/CalendarPath.php:3021 src/Paths/CalendarPath.php:3060
+msgid "Decree of the Congregation for Divine Worship"
+msgstr "Sắc lệnh của Bộ Phụng tự và Kỷ luật Bí tích"
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1445
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
+"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
+"or an evening Mass."
+msgstr ""
+"Thánh lễ Vọng cho %1$s '%2$s' trùng với %3$s '%4$s' trong năm %5$d. Vì Lễ "
+"trọng đầu tiên có ưu tiên, nó sẽ có Kinh Chiều I và Thánh lễ vọng, trong khi "
+"Lễ trọng cuối cùng sẽ không có Kinh Chiều II hoặc Thánh lễ buổi tối."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1455
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
+"Vespers II and an evening Mass, while the first Solemnity will not have a "
+"Vigil Mass or Vespers I."
+msgstr ""
+"Thánh lễ Vọng cho %1$s '%2$s' trùng với %3$s '%4$s' trong năm %5$d. Lễ trọng "
+"cuối cùng này được ưu tiên, do đó sẽ giữ Vespers II và một Thánh lễ buổi "
+"tối, trong khi Lễ trọng đầu tiên sẽ không có Thánh lễ Vọng hoặc Vespers I."
+
+#: src/Models/Calendar/LiturgicalEventCollection.php:1540
+#, php-format
+msgid ""
+"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
+"year %5$d. We should ask the Congregation for Divine Worship what to do "
+"about this!"
+msgstr ""
+"Thánh Lễ Vọng cho %1$s '%2$s' trùng với %3$s '%4$s' trong năm %5$d. Chúng ta "
+"nên hỏi Bộ Phụng Tự về việc này!"
+
+#: src/Paths/CalendarPath.php:663
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Paths/Calendar.php:658
-#, php-format
-msgid "The Diocesan calendar \"%s\" was not found in the index file."
-msgstr ""
-
-#: src/Paths/Calendar.php:754
+#: src/Paths/CalendarPath.php:801
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
 "%d."
 msgstr "Chỉ hỗ trợ từ năm 1970 trở về sau. Bạn đã yêu cầu năm %d."
 
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:786
-#, php-format
-msgid ""
-"There was an error trying to decode localized JSON data for the Temporale: %s"
-msgstr ""
-"Đã xảy ra lỗi khi cố gắng giải mã dữ liệu JSON được bản địa hóa cho "
-"Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:793
-msgid "There was an error trying to retrieve localized data for the Temporale."
-msgstr "Đã xảy ra lỗi khi cố gắng truy xuất dữ liệu bản địa hóa cho Temporale."
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:826
-#, php-format
-msgid "There was an error trying to decode JSON data for the Temporale: %s"
-msgstr "Đã xảy ra lỗi khi cố gắng giải mã dữ liệu JSON cho Temporale: %s"
-
-#. translators: Temporale refers to the Proprium de Tempore
-#: src/Paths/Calendar.php:833
-msgid "There was an error trying to retrieve data for the Temporale."
-msgstr "Đã xảy ra lỗi khi cố gắng truy xuất dữ liệu cho Temporale."
-
-#. translators: name of the Roman Missal
-#: src/Paths/Calendar.php:861
-#, fuzzy, php-format
-msgid "Translation data for the sanctorale from %s could not be found."
-msgstr "Không tìm thấy dữ liệu dịch cho sanctorale từ %s."
-
-#. translators:
-#.   do not translate 'JSON';
-#.  'Sanctorale' refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:880
-#, php-format
-msgid ""
-"There was an error trying to decode JSON localization data for the "
-"Sanctorale for the Missal %1$s: %2$s"
-msgstr ""
-"Đã xảy ra lỗi khi giải mã dữ liệu bản địa hóa JSON cho Sanctorale của Sách "
-"lễ %1$s: %2$s"
-
-#. translators: Sanctorale refers to the Proprium de Sanctis; %s = name of the Roman Missal
-#: src/Paths/Calendar.php:889
-#, php-format
-msgid "Data for the Sanctorale from %s could not be found."
-msgstr "Không tìm thấy dữ liệu cho Sanctorale từ %s."
-
-#. translators: Sanctorale refers to the Proprium de Sanctis;
-#.  1: name of the Roman Missal
-#.  2: error message
-#.
-#: src/Paths/Calendar.php:913
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for the Sanctorale for the "
-"Missal %1$s: %2$s."
-msgstr ""
-"Có lỗi xảy ra khi cố gắng giải mã dữ liệu JSON cho Sanctorale của sách lễ "
-"%1$s: %2$s."
-
-#. translators: Sanctorale refers to Proprium de Sanctis
-#: src/Paths/Calendar.php:921
-msgid "Could not find the Sanctorale data"
-msgstr "Không thể tìm thấy dữ liệu Sanctorale"
-
-#: src/Paths/Calendar.php:947
-#, fuzzy, php-format
-msgid ""
-"There was an error trying to decode translation data for Memorials based on "
-"Decrees of the Congregation for Divine Worship: %s"
-msgstr ""
-"Đã xảy ra lỗi khi cố gắng giải mã dữ liệu dịch thuật cho Lễ nhớ dựa trên Sắc "
-"lệnh của Thánh bộ Phụng tự: %s"
-
-#: src/Paths/Calendar.php:953
-#, fuzzy
-msgid ""
-"Could not find translation data for Memorials based on Decrees of the "
-"Congregation for Divine Worship"
-msgstr ""
-"Không tìm thấy dữ liệu dịch thuật cho Lễ nhớ dựa trên Sắc lệnh của Thánh bộ "
-"Phụng tự"
-
-#: src/Paths/Calendar.php:962
-#, php-format
-msgid ""
-"There was an error trying to decode JSON data for Memorials based on Decrees "
-"of the Congregation for Divine Worship: %s"
-msgstr ""
-"Đã xảy ra lỗi khi cố gắng giải mã dữ liệu JSON cho các Lễ Kỷ Niệm dựa trên "
-"Sắc lệnh của Bộ Phụng Tự: %s"
-
 #. translators: days before Epiphany (not useful in Italian!)
 #. translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!)
-#: src/Paths/Calendar.php:1111 src/Paths/Calendar.php:1162
+#: src/Paths/CalendarPath.php:1089 src/Paths/CalendarPath.php:1147
 #, php-format
 msgid "%s - Christmas Weekday"
 msgstr "%s - Ngày trong tuần Giáng Sinh"
 
-#. translators: context alternate name for a liturgical event, e.g. Second Sunday of Easter `or` Divine Mercy Sunday
-#. translators: when there are multiple possible commons, this will be the glue "or from the common of..."
-#: src/Paths/Calendar.php:1285 src/Enum/LitCommon.php:424
-msgid "or"
-msgstr "hoặc"
-
 #. translators: as instituted on the day of the canonization of St Faustina Kowalska by Pope John Paul II in the year 2000
-#: src/Paths/Calendar.php:1289
+#: src/Paths/CalendarPath.php:1293
 msgid "Divine Mercy Sunday"
 msgstr "Chúa Nhật Lòng Thương Xót Chúa"
 
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
-#. translators: 1: LiturgicalEvent name, 2: LiturgicalEvent date, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Congregation for Divine Worship
 #. translators:
-#.  1: LiturgicalEvent name,
-#.  2: LiturgicalEvent date,
+#.  1: Solemnity name,
+#.  2: Coinciding Solemnity name,
 #.  3: Requested calendar year,
 #.  4: Explicatory string for the transferral,
 #.  5: actual date for the transferral,
 #.  6: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1458 src/Paths/Calendar.php:1478
-#: src/Paths/Calendar.php:1528
+#: src/Paths/CalendarPath.php:1476 src/Paths/CalendarPath.php:1501
+#: src/Paths/CalendarPath.php:1557
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
@@ -172,31 +778,20 @@ msgstr ""
 "Lễ Trọng '%1$s' rơi vào ngày %2$s trong năm %3$d, lễ kỷ niệm đã được chuyển "
 "sang ngày %4$s (%5$s) theo %6$s."
 
-#: src/Paths/Calendar.php:1462
+#: src/Paths/CalendarPath.php:1480
 msgid "the Saturday preceding Palm Sunday"
 msgstr "thứ Bảy trước Chúa Nhật Lễ Lá"
 
-#: src/Paths/Calendar.php:1470 src/Paths/Calendar.php:1490
-#: src/Paths/Calendar.php:1539 src/Paths/Calendar.php:1568
-#: src/Paths/Calendar.php:2083 src/Paths/Calendar.php:2297
-#: src/Paths/Calendar.php:2365 src/Paths/Calendar.php:2710
-#: src/Paths/Calendar.php:2781 src/Paths/Calendar.php:2820
-#: src/Paths/Calendar.php:2952 src/Paths/Calendar.php:2967
-#: src/Paths/Calendar.php:2984 src/Paths/Calendar.php:3025
-#: src/LiturgicalEventCollection.php:923
-msgid "Decree of the Congregation for Divine Worship"
-msgstr "Sắc lệnh của Bộ Phụng tự và Kỷ luật Bí tích"
-
-#: src/Paths/Calendar.php:1482
+#: src/Paths/CalendarPath.php:1505
 msgid "the Monday following the Second Sunday of Easter"
 msgstr "thứ Hai sau Chúa nhật thứ Hai Phục Sinh"
 
-#: src/Paths/Calendar.php:1532
+#: src/Paths/CalendarPath.php:1561
 msgid "the following Monday"
 msgstr "thứ Hai tiếp theo"
 
-#. translators: 1: LiturgicalEvent name, 2: Coinciding LiturgicalEvent name, 3: Requested calendar year
-#: src/Paths/Calendar.php:1546
+#. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
+#: src/Paths/CalendarPath.php:1580
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -211,7 +806,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Congregation for Divine Worship
 #.
-#: src/Paths/Calendar.php:1579
+#: src/Paths/CalendarPath.php:1618
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -221,7 +816,7 @@ msgstr ""
 "lên một ngày theo %4$s."
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Paths/Calendar.php:1683
+#: src/Paths/CalendarPath.php:1704
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -231,12 +826,12 @@ msgstr ""
 "%4$s thay vì vào Chủ nhật sau Giáng Sinh."
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Paths/Calendar.php:1714
+#: src/Paths/CalendarPath.php:1735
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr "Chúa Giêsu Kitô, Thượng Tế Vĩnh Cửu"
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Paths/Calendar.php:1719
+#: src/Paths/CalendarPath.php:1747
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -250,59 +845,59 @@ msgstr ""
 "'%2$d' (%3$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Paths/Calendar.php:1771 src/Paths/Calendar.php:1812
+#: src/Paths/CalendarPath.php:1806 src/Paths/CalendarPath.php:1850
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr "'%1$s' bị thay thế bởi %2$s '%3$s' trong năm %4$d."
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1899
+#: src/Paths/CalendarPath.php:1953
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr "của Tuần %s Mùa Vọng"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1938
+#: src/Paths/CalendarPath.php:2013
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr "Ngày %s trong Tuần Bát Nhật Giáng Sinh"
 
 #. translators: %s is an ordinal number (first, second...)
-#: src/Paths/Calendar.php:1981
+#: src/Paths/CalendarPath.php:2071
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr "của Tuần %s Mùa Chay"
 
-#: src/Paths/Calendar.php:1991
+#: src/Paths/CalendarPath.php:2092
 msgid "after Ash Wednesday"
 msgstr "sau Lễ Tro"
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2022 src/Paths/Calendar.php:2506
-#: src/Paths/Calendar.php:2792 src/Paths/Calendar.php:3537
+#: src/Paths/CalendarPath.php:2129 src/Paths/CalendarPath.php:2600
+#: src/Paths/CalendarPath.php:2830 src/Paths/CalendarPath.php:3645
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -311,18 +906,13 @@ msgstr ""
 "%1$s '%2$s' đã được thêm vào ngày %3$s kể từ năm %4$d (%5$s), áp dụng cho "
 "năm %6$d."
 
-#: src/Paths/Calendar.php:2068 src/Paths/Calendar.php:2230
+#: src/Paths/CalendarPath.php:2181 src/Paths/CalendarPath.php:2371
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
 msgstr "Họp báo Vatican: Trình bày Editio Typica Tertia của Sách lễ Rôma"
 
-#. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Requested calendar year
-#.
-#: src/Paths/Calendar.php:2124
+#: src/Paths/CalendarPath.php:2246
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -334,22 +924,33 @@ msgstr ""
 "trong năm %3$d, cấp bậc giảm xuống thành Lễ tưởng niệm."
 
 #. translators:
-#.  1. Grade or rank of the festivity that has been superseded
-#.  2. Name of the festivity that has been superseded
-#.  3. Grade or rank of the festivity that is superseding
-#.  4. Name of the festivity that is superseding
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Grade or rank of the liturgical event that is superseding
+#.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2152 src/Paths/Calendar.php:2194
+#: src/Paths/CalendarPath.php:2284 src/Paths/CalendarPath.php:2332
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr "%1$s '%2$s' bị thay thế bởi %3$s '%4$s' trong năm %5$d."
 
-#: src/Paths/Calendar.php:2224
+#: src/Paths/CalendarPath.php:2365
 msgid "Apostolic Constitution Missale Romanum"
 msgstr "Hiến chế Tông đồ Missale Romanum"
 
-#: src/Paths/Calendar.php:2250
+#. translators:
+#.  1. Grade or rank of the liturgical event that has been superseded
+#.  2. Name of the liturgical event that has been superseded
+#.  3. Edition of the Roman Missal
+#.  4. Year in which the Edition of the Roman Missal was published
+#.  5. Any possible decrees or sources about the edition of the Roman Missal
+#.  6. Date in which the superseded liturgical event is usually celebrated
+#.  7. Grade or rank of the liturgical event that is superseding
+#.  8. Name of the liturgical event that is superseding
+#.  9. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:2394
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -360,16 +961,16 @@ msgstr ""
 "thường được cử hành vào ngày %6$s, bị loại bỏ bởi %7$s '%8$s' trong năm %9$d."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. Day of the festivity
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day of the liturgical event
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of the superseding festivity
-#.  7. Name of the superseding festivity
+#.  6. Grade or rank of the superseding liturgical event
+#.  7. Name of the superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2311
+#: src/Paths/CalendarPath.php:2447
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -384,7 +985,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2360
+#: src/Paths/CalendarPath.php:2500
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -393,68 +994,39 @@ msgstr ""
 "Lễ nhớ '%1$s' trùng với một Lễ nhớ khác '%2$s' trong năm %3$d. Cả hai đều bị "
 "giảm cấp xuống thành lễ nhớ tùy chọn (%4$s)."
 
-#. translators: e.g. 'Monday before Palm Sunday'
-#: src/Paths/Calendar.php:2402
-msgid "before"
-msgstr "trước"
-
-#. translators: e.g. 'Monday after Pentecost'
-#: src/Paths/Calendar.php:2407
-msgid "after"
-msgstr "sau"
-
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2412 src/Paths/Calendar.php:4185
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2549
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
 msgid ""
-"Cannot create mobile festivity '%1$s': can only be relative to festivity "
-"with key '%2$s' using keywords %3$s"
+"Cannot create mobile liturgical event '%1$s': can only be relative to "
+"liturgical event with key '%2$s' using keywords %3$s"
 msgstr ""
 "Không thể tạo lễ di động '%1$s': chỉ có thể liên quan đến lễ có khóa '%2$s' "
 "bằng cách sử dụng từ khóa %3$s"
 
-#. translators: 1. Name of the mobile festivity being created, 2. Name of the festivity that it is relative to
-#: src/Paths/Calendar.php:2429 src/Paths/Calendar.php:4169
-#, php-format
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:2563
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
 msgid ""
-"Cannot create mobile festivity '%1$s' relative to festivity with key '%2$s'"
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s'"
 msgstr "Không thể tạo lễ di động '%1$s' liên quan đến lễ có khóa '%2$s'"
 
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created 2. list of properties
-#: src/Paths/Calendar.php:2437 src/Paths/Calendar.php:4158
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': when the 'strtotime' property is an "
-"object, it must have properties %2$s"
-msgstr ""
-"Không thể tạo lễ di động '%1$s': khi thuộc tính 'strtotime' là một đối "
-"tượng, nó phải có các thuộc tính %2$s"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2457 src/Paths/Calendar.php:4289
-#, php-format
-msgid ""
-"Cannot create mobile festivity '%1$s': 'strtotime' property must be either "
-"an object or a string! Currently it has type '%2$s'"
-msgstr ""
-"Không thể tạo lễ di động '%1$s': thuộc tính 'strtotime' phải là một đối "
-"tượng hoặc một chuỗi! Hiện tại nó có kiểu '%2$s'"
-
-#. translators: Do not translate 'strtotime'! 1. Name of the mobile festivity being created
-#: src/Paths/Calendar.php:2465
-#, php-format
-msgid "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
-msgstr "Không thể tạo lễ di động '%1$s' mà không có thuộc tính 'strtotime'!"
-
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New name of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New name of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2565
+#: src/Paths/CalendarPath.php:2660
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -464,14 +1036,14 @@ msgstr ""
 "%5$d (%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2587
+#: src/Paths/CalendarPath.php:2682
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -481,14 +1053,14 @@ msgstr ""
 "(%6$s)."
 
 #. translators:
-#.  1. Grade or rank of the festivity
-#.  2. Name of the festivity
-#.  3. New grade of the festivity
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. New grade of the liturgical event
 #.  4. Year from which the grade has been changed
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Paths/Calendar.php:2597
+#: src/Paths/CalendarPath.php:2692
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -498,12 +1070,12 @@ msgstr ""
 "(%6$s)."
 
 #. translators:
-#.  1. Name of the festivity
+#.  1. Name of the liturgical event
 #.  2. Year in which was declared Doctor
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:2647
+#: src/Paths/CalendarPath.php:2745
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -512,21 +1084,17 @@ msgstr ""
 "'%1$s' đã được tuyên bố là Tiến sĩ Hội Thánh từ năm %2$d, áp dụng cho năm "
 "%3$d (%4$s)."
 
-#: src/Paths/Calendar.php:2655
-msgid "and Doctor of the Church"
-msgstr "và Tiến sĩ Hội Thánh"
-
 #. translators:
-#.  1. Grade or rank of the festivity being created
-#.  2. Name of the festivity being created
-#.  3. Indication of the mobile date for the festivity being created
-#.  4. Year from which the festivity has been added
+#.  1. Grade or rank of the liturgical event being created
+#.  2. Name of the liturgical event being created
+#.  3. Indication of the mobile date for the liturgical event being created
+#.  4. Year from which the liturgical event has been added
 #.  5. Source of the information
-#.  6. Grade or rank of superseding festivity
-#.  7. Name of superseding festivity
+#.  6. Grade or rank of superseding liturgical event
+#.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Paths/Calendar.php:2841
+#: src/Paths/CalendarPath.php:2885
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -537,15 +1105,15 @@ msgstr ""
 
 #. translators:
 #.  1. Requested calendar year
-#.  2. Grade or rank of suppressed festivity
-#.  3. Name of suppressed festivity
-#.  4. Grade or rank of the festivity being created
-#.  5. Name of the festivity being created
-#.  6. Indication of the mobile date for the festivity being created
-#.  7. Year from which the festivity has been added
+#.  2. Grade or rank of suppressed liturgical event
+#.  3. Name of suppressed liturgical event
+#.  4. Grade or rank of the liturgical event being created
+#.  5. Name of the liturgical event being created
+#.  6. Indication of the mobile date for the liturgical event being created
+#.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Paths/Calendar.php:2868
+#: src/Paths/CalendarPath.php:2912
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -555,7 +1123,7 @@ msgstr ""
 "kể từ năm %7$d (%8$s)."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2949
+#: src/Paths/CalendarPath.php:2984
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -565,7 +1133,7 @@ msgstr ""
 "tháng 8 kể từ năm 2002 (%2$s), áp dụng cho năm %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Paths/Calendar.php:2964
+#: src/Paths/CalendarPath.php:3000
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -576,19 +1144,24 @@ msgstr ""
 "Lễ trọng nếu nó vào ngày 12 tháng 12, tuy nhiên đã được chuyển sang ngày 12 "
 "tháng 8 kể từ năm 2002 (%2$s), áp dụng cho năm %3$d."
 
-#: src/Paths/Calendar.php:2981
-#, php-format
+#. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
+#: src/Paths/CalendarPath.php:3018
+#, fuzzy, php-format
+#| msgid ""
+#| "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
+#| "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
+#| "superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
 "since the year 2002 (%2$s), applicable to the year %3$d. However, it is "
-"superseded by a Sunday, a Solemnity, or a Feast '%4$s' in the year %3$d."
+"superseded by the %4$s '%5$s' in the year %3$d."
 msgstr ""
 "Lễ nhớ tùy chọn '%1$s' đã được chuyển từ ngày 12 tháng 12 sang ngày 12 tháng "
 "8 từ năm 2002 (%2$s), áp dụng cho năm %3$d. Tuy nhiên, nó bị thay thế bởi "
 "một Chúa Nhật, một Lễ Trọng, hoặc một Lễ Kính '%4$s' vào năm %3$d."
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Paths/Calendar.php:3022
+#: src/Paths/CalendarPath.php:3057
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -600,47 +1173,37 @@ msgstr ""
 "do là Năm của Tông đồ Phaolô, theo %2$s nó đã được khôi phục để các nhà thờ "
 "địa phương có thể tùy chọn cử hành lễ nhớ."
 
-#: src/Paths/Calendar.php:3057
+#: src/Paths/CalendarPath.php:3109
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr "của Tuần %s Phục Sinh"
 
-#: src/Paths/Calendar.php:3102 src/Paths/Calendar.php:3143
+#: src/Paths/CalendarPath.php:3181 src/Paths/CalendarPath.php:3229
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr "của Tuần %s Thường Niên"
 
-#: src/Paths/Calendar.php:3169
+#: src/Paths/CalendarPath.php:3272
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr "Lễ nhớ Thứ Bảy Đức Mẹ"
 
-#: src/Paths/Calendar.php:3192
-#, php-format
-msgid "Error retrieving and decoding Wider Region data from file %s."
-msgstr "Lỗi khi truy xuất và giải mã dữ liệu Vùng Rộng từ tệp %s."
-
-#: src/Paths/Calendar.php:3237
+#. translators: 1: wider_region, 2: metadata, 3: calendar_id
+#: src/Paths/CalendarPath.php:3347
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
-#: src/Paths/Calendar.php:3245
-#, fuzzy, php-format
-#| msgid "Error retrieving and decoding National data from file %s."
-msgid "Error retrieving and decoding National Calendar data from file %s."
-msgstr "Lỗi khi truy xuất và giải mã dữ liệu Quốc gia từ tệp %s."
-
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3295
+#: src/Paths/CalendarPath.php:3404
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -654,15 +1217,15 @@ msgstr ""
 "vào năm %6$d."
 
 #. translators:
-#.  1. Grade of the festivity
-#.  2. Name of the festivity
-#.  3. Date on which the festivity is usually celebrated
-#.  4. Grade of the superseding festivity
-#.  5. Name of the superseding festivity
+#.  1. Grade of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Date on which the liturgical event is usually celebrated
+#.  4. Grade of the superseding liturgical event
+#.  5. Name of the superseding liturgical event
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Paths/Calendar.php:3315
+#: src/Paths/CalendarPath.php:3424
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s', usually celebrated on %3$s, is suppressed by the %4$s "
@@ -681,7 +1244,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Paths/Calendar.php:3411
+#: src/Paths/CalendarPath.php:3508
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -690,8 +1253,8 @@ msgstr ""
 "Lễ Kỷ Niệm '%1$s' trùng với Lễ Kỷ Niệm khác '%2$s' trong năm %3$d. Cả hai "
 "đều bị giảm cấp xuống thành lễ kỷ niệm tùy chọn."
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3433
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3531
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -700,8 +1263,8 @@ msgstr ""
 "Lễ '%1$s', thường được cử hành vào ngày %2$s, trùng với Lễ khác '%3$s' trong "
 "năm %4$d! Có cần làm gì về điều này không?"
 
-#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding festivity name, 4. Requested calendar year
-#: src/Paths/Calendar.php:3447
+#. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
+#: src/Paths/CalendarPath.php:3551
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -711,13 +1274,43 @@ msgstr ""
 "Lễ trọng '%1$s', thường được cử hành vào %2$s, trùng với Chủ nhật hoặc Lễ "
 "trọng '%3$s' trong năm %4$d! Có cần làm gì về điều này không?"
 
-#: src/Paths/Calendar.php:3491
+#: src/Paths/CalendarPath.php:3588
+#, php-format
 msgid ""
-"We should be creating a new festivity, however we do not seem to have the "
-"correct date information in order to proceed"
+"Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
+"liturgical event is greater than the number of days (%3$d) in the month "
+"(%4$d) of the liturgical event year (%5$d)."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:3602
+#, fuzzy
+#| msgid ""
+#| "We should be creating a new festivity, however we do not seem to have the "
+#| "correct date information in order to proceed"
+msgid ""
+"We should be creating a new liturgical event, however we do not seem to have "
+"the correct date information in order to proceed"
 msgstr ""
 "Chúng ta nên tạo ra một lễ hội mới, tuy nhiên dường như chúng ta không có "
 "thông tin ngày tháng chính xác để tiến hành"
+
+#. translators:
+#.  1. Grade or rank of the liturgical event
+#.  2. Name of the liturgical event
+#.  3. Day and month of the liturgical event
+#.  4. Requested calendar year
+#.
+#: src/Paths/CalendarPath.php:3672
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
+#| "applicable to the year %5$d (%6$s)."
+msgid ""
+"The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
+"with an existing liturgical event in the year %4$d."
+msgstr ""
+"%1$s '%2$s' đã được nâng lên bậc %3$s kể từ năm %4$d, áp dụng cho năm %5$d "
+"(%6$s)."
 
 #. translators:
 #.  1. Liturgical grade
@@ -727,7 +1320,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3604
+#: src/Paths/CalendarPath.php:3741
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -746,7 +1339,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3622
+#: src/Paths/CalendarPath.php:3759
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -765,16 +1358,17 @@ msgstr ""
 #.  3. New liturgical grade
 #.  4. ID of the national calendar
 #.  5. Year from which the grade has been changed
-#.  6. Requested calendar year
+#.  6. Source of the information
+#.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3643
+#: src/Paths/CalendarPath.php:3786
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
 #| "applicable to the year %5$d (%6$s)."
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
-"calendar '%4$s' since the year %5$d, applicable to the year %6$d."
+"calendar '%4$s' since the year %5$d (%6$s), applicable to the year %7$d."
 msgstr ""
 "Tên của %1$s '%2$s' đã được đổi thành %3$s kể từ năm %4$d, áp dụng cho năm "
 "%5$d (%6$s)."
@@ -786,15 +1380,15 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3661
+#: src/Paths/CalendarPath.php:3805
 #, fuzzy, php-format
 #| msgid ""
 #| "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
 #| "applicable to the year %5$d (%6$s)."
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
-"national calendar '%3$s' since the year %4$d, but could not be applied to "
-"the year %5$d because the celebration was not found."
+"national calendar '%3$s' since the year %4$d (%5$s), but could not be "
+"applied to the year %6$d because the celebration was not found."
 msgstr ""
 "Tên của %1$s '%2$s' đã được đổi thành %3$s kể từ năm %4$d, áp dụng cho năm "
 "%5$d (%6$s)."
@@ -808,7 +1402,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3693
+#: src/Paths/CalendarPath.php:3840
 #, fuzzy, php-format
 #| msgid ""
 #| "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
@@ -827,7 +1421,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3712
+#: src/Paths/CalendarPath.php:3859
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -836,22 +1430,29 @@ msgid ""
 msgstr ""
 
 #. translators:
-#.  1. ID of the liturgical event
+#.  1. event_key of the liturgical event
 #.  2. New date of the liturgical event
 #.  3. Year from which the date has been changed
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3731
+#: src/Paths/CalendarPath.php:3878
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
 "the national calendar '%4$s', but this could not take place in the year %5$d "
-"since the new date %2$s seems to be a Sunday or a festivity of greater rank."
+"since the new date %2$s seems to be a Sunday or a liturgical event of "
+"greater rank."
+msgstr ""
+
+#. translators: 1. Country name, 2. List of missals
+#: src/Paths/CalendarPath.php:3917
+#, php-format
+msgid "Found Missals for region %1$s: %2$s."
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3766
+#: src/Paths/CalendarPath.php:3944
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr "Tìm thấy tệp dữ liệu sanctorale cho %s"
@@ -861,11 +1462,11 @@ msgstr "Tìm thấy tệp dữ liệu sanctorale cho %s"
 #.  2. LiturgicalEvent name
 #.  3. LiturgicalEvent date
 #.  4. Edition of the Roman Missal
-#.  5. Superseding festivity grade
-#.  6. Superseding festivity name
+#.  5. Superseding liturgical event grade
+#.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Paths/Calendar.php:3815
+#: src/Paths/CalendarPath.php:3991
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -875,13 +1476,13 @@ msgstr ""
 "bởi %5$s '%6$s' trong năm %7$d"
 
 #. translators: Name of the Roman Missal
-#: src/Paths/Calendar.php:3830
+#: src/Paths/CalendarPath.php:4006
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr "Không thể tìm thấy tệp dữ liệu sanctorale cho %s"
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New festivity name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Paths/Calendar.php:3926
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
+#: src/Paths/CalendarPath.php:4096
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -890,8 +1491,8 @@ msgstr ""
 "%1$s '%2$s' được chuyển từ %5$s sang %6$s theo %7$s, để nhường chỗ cho "
 "'%3$s': áp dụng cho năm %4$d."
 
-#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New festivity name, 7. Superseding festivity grade, 8. Superseding festivity name, 9: Requested calendar year
-#: src/Paths/Calendar.php:3949
+#. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
+#: src/Paths/CalendarPath.php:4120
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -901,8 +1502,46 @@ msgstr ""
 "%1$s '%2$s' sẽ được chuyển từ %3$s sang %4$s theo %5$s, để nhường chỗ cho "
 "'%6$s', tuy nhiên nó bị thay thế bởi %7$s '%8$s' vào năm %9$d."
 
-#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding festivity name, 5: Requested calendar year
-#: src/Paths/Calendar.php:4349
+#. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
+#: src/Paths/CalendarPath.php:4309
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s' relative to festivity with key "
+#| "'%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s' relative to liturgical event "
+"with key '%2$s', liturgical event does not exist."
+msgstr "Không thể tạo lễ di động '%1$s' liên quan đến lễ có khóa '%2$s'"
+
+#. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
+#: src/Paths/CalendarPath.php:4325
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': can only be relative to festivity "
+#| "with key '%2$s' using keywords %3$s"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
+"property can only express relativity to the liturgical event with key '%2$s' "
+"using keywords %3$s."
+msgstr ""
+"Không thể tạo lễ di động '%1$s': chỉ có thể liên quan đến lễ có khóa '%2$s' "
+"bằng cách sử dụng từ khóa %3$s"
+
+#. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
+#: src/Paths/CalendarPath.php:4403
+#, fuzzy, php-format
+#| msgid ""
+#| "Cannot create mobile festivity '%1$s': 'strtotime' property must be "
+#| "either an object or a string! Currently it has type '%2$s'"
+msgid ""
+"Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
+"either an object or a string, instead it is of type '%2$s'."
+msgstr ""
+"Không thể tạo lễ di động '%1$s': thuộc tính 'strtotime' phải là một đối "
+"tượng hoặc một chuỗi! Hiện tại nó có kiểu '%2$s'"
+
+#. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
+#: src/Paths/CalendarPath.php:4471
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -913,409 +1552,121 @@ msgstr ""
 "với Chủ nhật hoặc Lễ trọng '%4$s' trong năm %5$d! Có cần làm gì về việc này "
 "không?"
 
-#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding festivity name, 6: Requested calendar year
-#: src/Paths/Calendar.php:4383
-#, php-format
+#. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
+#: src/Paths/CalendarPath.php:4496
+#, fuzzy, php-format
+#| msgid ""
+#| "The %1$s '%2$s', proper to the calendar of the %3$s and usually "
+#| "celebrated on %4$s, is suppressed by the Sunday or Solemnity %5$s in the "
+#| "year %6$d"
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
-"on %4$s, is suppressed by the Sunday or Solemnity %5$s in the year %6$d"
+"on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 "Lễ %1$s '%2$s', thuộc lịch của %3$s và thường được cử hành vào %4$s, bị thay "
 "thế bởi Chủ nhật hoặc Lễ trọng %5$s trong năm %6$d"
 
-#: src/Paths/Calendar.php:4650
+#: src/Paths/CalendarPath.php:4806
+msgid "Error converting Liturgical Calendar to XML."
+msgstr ""
+
+#: src/Paths/CalendarPath.php:4834
 #, php-format
 msgid "Error receiving or parsing info from github about latest release: %s."
 msgstr ""
 "Lỗi khi nhận hoặc phân tích thông tin từ github về bản phát hành mới nhất: "
 "%s."
 
-#. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/LiturgicalEventCollection.php:60
-msgid "YEAR"
-msgstr "NĂM"
-
-#: src/LiturgicalEventCollection.php:61
-msgid "Vigil Mass"
-msgstr "Thánh lễ vọng"
-
-#: src/LiturgicalEventCollection.php:917
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. As per %6$s, the first has precedence, therefore the Vigil Mass "
-"is confirmed as are I Vespers."
-msgstr ""
-"Thánh lễ vọng cho %1$s '%2$s' trùng với %3$s '%4$s' trong năm %5$d. Theo "
-"%6$s, cái đầu tiên được ưu tiên, do đó Thánh lễ vọng được xác nhận cũng như "
-"Kinh Chiều I."
-
-#: src/LiturgicalEventCollection.php:931
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. Since the first Solemnity has precedence, it will have Vespers I "
-"and a vigil Mass, whereas the last Solemnity will not have either Vespers II "
-"or an evening Mass."
-msgstr ""
-"Thánh lễ Vọng cho %1$s '%2$s' trùng với %3$s '%4$s' trong năm %5$d. Vì Lễ "
-"trọng đầu tiên có ưu tiên, nó sẽ có Kinh Chiều I và Thánh lễ vọng, trong khi "
-"Lễ trọng cuối cùng sẽ không có Kinh Chiều II hoặc Thánh lễ buổi tối."
-
-#: src/LiturgicalEventCollection.php:941
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. This last Solemnity takes precedence, therefore it will maintain "
-"Vespers II and an evening Mass, while the first Solemnity will not have a "
-"Vigil Mass or Vespers I."
-msgstr ""
-"Thánh lễ Vọng cho %1$s '%2$s' trùng với %3$s '%4$s' trong năm %5$d. Lễ trọng "
-"cuối cùng này được ưu tiên, do đó sẽ giữ Vespers II và một Thánh lễ buổi "
-"tối, trong khi Lễ trọng đầu tiên sẽ không có Thánh lễ Vọng hoặc Vespers I."
-
-#: src/LiturgicalEventCollection.php:1006
-#, php-format
-msgid ""
-"The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
-"year %5$d. We should ask the Congregation for Divine Worship what to do "
-"about this!"
-msgstr ""
-"Thánh Lễ Vọng cho %1$s '%2$s' trùng với %3$s '%4$s' trong năm %5$d. Chúng ta "
-"nên hỏi Bộ Phụng Tự về việc này!"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:34
-msgid "green"
-msgstr "màu xanh lá cây"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:39
-msgid "purple"
-msgstr "màu tím"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:44
-msgid "white"
-msgstr "trắng"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:49
-msgid "red"
-msgstr "đỏ"
-
-#. translators: context = liturgical color
-#: src/Enum/LitColor.php:54
-msgid "pink"
-msgstr "hồng"
-
-#: src/Enum/LitCommon.php:71
-msgid "Proper"
-msgstr "Riêng"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:73
-msgid "Dedication of a Church"
-msgstr "Cung hiến Nhà thờ"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:75
-msgid "Blessed Virgin Mary"
-msgstr "Đức Trinh Nữ Maria"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:77
-msgid "Martyrs"
-msgstr "Tử đạo"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:79
-msgid "Pastors"
-msgstr "Mục tử"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:81
-msgid "Doctors"
-msgstr "Tiến sĩ"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:83
-msgid "Virgins"
-msgstr "Trinh nữ"
-
-#. translators: context = from the Common of nn
-#: src/Enum/LitCommon.php:85
-msgid "Holy Men and Women"
-msgstr "Các Thánh Nam Nữ"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:88
-msgid "For One Martyr"
-msgstr "Dành cho một Thánh Tử đạo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:90
-msgid "For Several Martyrs"
-msgstr "Cho Nhiều Vị Tử Đạo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:92
-msgid "For Missionary Martyrs"
-msgstr "Dành cho các Thánh Tử đạo Truyền giáo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:94
-msgid "For One Missionary Martyr"
-msgstr "Cho Một Tử đạo Truyền giáo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:96
-msgid "For Several Missionary Martyrs"
-msgstr "Cho Nhiều Vị Tử Đạo Truyền Giáo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:98
-msgid "For a Virgin Martyr"
-msgstr "Cho một Trinh Nữ Tử Đạo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:100
-msgid "For a Holy Woman Martyr"
-msgstr "Dành cho một Nữ thánh Tử đạo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:102
-msgid "For a Pope"
-msgstr "Cho Một Giáo Hoàng"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:104
-msgid "For a Bishop"
-msgstr "Dành cho một Giám mục"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:106
-msgid "For One Pastor"
-msgstr "Cho Một Mục Tử"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:108
-msgid "For Several Pastors"
-msgstr "Cho Nhiều Mục Tử"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:110
-msgid "For Founders of a Church"
-msgstr "Cho Các Nhà Sáng Lập Giáo Hội"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:112
-msgid "For One Founder"
-msgstr "Dành cho một Đấng sáng lập"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:114
-msgid "For Several Founders"
-msgstr "Cho Nhiều Đấng Sáng Lập"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:116
-msgid "For Missionaries"
-msgstr "Cho Các Nhà Truyền Giáo"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:118
-msgid "For One Virgin"
-msgstr "Cho Một Trinh nữ"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:120
-msgid "For Several Virgins"
-msgstr "Dành cho nhiều Trinh nữ"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:122
-msgid "For Several Saints"
-msgstr "Dành cho nhiều Thánh"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:124
-msgid "For One Saint"
-msgstr "Cho Một Thánh"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:126
-msgid "For an Abbot"
-msgstr "Cho một Viện Phụ"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:128
-msgid "For a Monk"
-msgstr "Cho Một Tu Sĩ"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:130
-msgid "For a Nun"
-msgstr "Cho Một Nữ Tu"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:132
-msgid "For Religious"
-msgstr "Cho Tu Sĩ"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:134
-msgid "For Those Who Practiced Works of Mercy"
-msgstr "Cho Những Người Thực Hành Các Công Việc Từ Thiện"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:136
-msgid "For Educators"
-msgstr "Cho Các Nhà Giáo Dục"
-
-#. translators: context = from the Common of nn: nn
-#: src/Enum/LitCommon.php:138
-msgid "For Holy Women"
-msgstr "Cho Các Thánh Nữ"
-
-#. translators: (singular feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:202 src/Enum/LitCommon.php:214
-msgctxt "(SING_FEMM)"
-msgid "of the"
-msgstr "của"
-
-#. translators: (plural feminine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:205
-msgctxt "(PLUR_FEMM)"
-msgid "of"
-msgstr "của"
-
-#. translators: (plural masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:211
-msgctxt "(PLUR_MASC)"
-msgid "of"
-msgstr "của"
-
-#. translators: (singular masculine) glue between "From the Common" and the actual common. Latin: leave empty!
-#: src/Enum/LitCommon.php:217
-msgctxt "(SING_MASC)"
-msgid "of the"
-msgstr "của"
-
-#: src/Enum/LitCommon.php:407
-msgid "From the Common"
-msgstr "Từ Phổ thông"
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:150 src/Enum/LitGrade.php:205
-msgid "weekday"
-msgstr "ngày trong tuần"
-
-#. translators: liturgical rank 'WEEKDAY' in abbreviated form
-#: src/Enum/LitGrade.php:152
-msgid "w"
+#: src/Paths/CalendarPath.php:4846
+msgid "Error serializing Liturgical Calendar."
 msgstr ""
 
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:157
+#~ msgid ""
+#~ "There was an error trying to decode localized JSON data for the "
+#~ "Temporale: %s"
+#~ msgstr ""
+#~ "Đã xảy ra lỗi khi cố gắng giải mã dữ liệu JSON được bản địa hóa cho "
+#~ "Temporale: %s"
+
+#~ msgid ""
+#~ "There was an error trying to retrieve localized data for the Temporale."
+#~ msgstr ""
+#~ "Đã xảy ra lỗi khi cố gắng truy xuất dữ liệu bản địa hóa cho Temporale."
+
+#~ msgid "There was an error trying to decode JSON data for the Temporale: %s"
+#~ msgstr "Đã xảy ra lỗi khi cố gắng giải mã dữ liệu JSON cho Temporale: %s"
+
+#~ msgid "There was an error trying to retrieve data for the Temporale."
+#~ msgstr "Đã xảy ra lỗi khi cố gắng truy xuất dữ liệu cho Temporale."
+
 #, fuzzy
-#| msgid "Commemoration"
-msgid "commemoration"
-msgstr "Kỷ Niệm"
+#~ msgid "Translation data for the sanctorale from %s could not be found."
+#~ msgstr "Không tìm thấy dữ liệu dịch cho sanctorale từ %s."
 
-#. translators: liturgical rank 'COMMEMORATION' in abbreviated form
-#: src/Enum/LitGrade.php:159
-msgid "m*"
-msgstr ""
+#~ msgid ""
+#~ "There was an error trying to decode JSON localization data for the "
+#~ "Sanctorale for the Missal %1$s: %2$s"
+#~ msgstr ""
+#~ "Đã xảy ra lỗi khi giải mã dữ liệu bản địa hóa JSON cho Sanctorale của "
+#~ "Sách lễ %1$s: %2$s"
 
-#. translators: liturgical rank. Keep lowercsase
-#: src/Enum/LitGrade.php:164
+#~ msgid "Data for the Sanctorale from %s could not be found."
+#~ msgstr "Không tìm thấy dữ liệu cho Sanctorale từ %s."
+
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for the Sanctorale for the "
+#~ "Missal %1$s: %2$s."
+#~ msgstr ""
+#~ "Có lỗi xảy ra khi cố gắng giải mã dữ liệu JSON cho Sanctorale của sách lễ "
+#~ "%1$s: %2$s."
+
+#~ msgid "Could not find the Sanctorale data"
+#~ msgstr "Không thể tìm thấy dữ liệu Sanctorale"
+
 #, fuzzy
-#| msgid "Optional memorial"
-msgid "optional memorial"
-msgstr "Lễ nhớ tùy chọn"
+#~ msgid ""
+#~ "There was an error trying to decode translation data for Memorials based "
+#~ "on Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Đã xảy ra lỗi khi cố gắng giải mã dữ liệu dịch thuật cho Lễ nhớ dựa trên "
+#~ "Sắc lệnh của Thánh bộ Phụng tự: %s"
 
-#. translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:166
-msgid "m"
-msgstr ""
+#, fuzzy
+#~ msgid ""
+#~ "Could not find translation data for Memorials based on Decrees of the "
+#~ "Congregation for Divine Worship"
+#~ msgstr ""
+#~ "Không tìm thấy dữ liệu dịch thuật cho Lễ nhớ dựa trên Sắc lệnh của Thánh "
+#~ "bộ Phụng tự"
 
-#. translators: liturgical rank. Keep Capitalized
-#: src/Enum/LitGrade.php:171
-msgid "Memorial"
-msgstr "Lễ nhớ"
+#~ msgid ""
+#~ "There was an error trying to decode JSON data for Memorials based on "
+#~ "Decrees of the Congregation for Divine Worship: %s"
+#~ msgstr ""
+#~ "Đã xảy ra lỗi khi cố gắng giải mã dữ liệu JSON cho các Lễ Kỷ Niệm dựa "
+#~ "trên Sắc lệnh của Bộ Phụng Tự: %s"
 
-#. translators: liturgical rank 'MEMORIAL' in abbreviated form
-#: src/Enum/LitGrade.php:173
-msgid "M"
-msgstr ""
+#~ msgid "before"
+#~ msgstr "trước"
 
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:178
-msgid "FEAST"
-msgstr "LỄ"
+#~ msgid "after"
+#~ msgstr "sau"
 
-#. translators: liturgical rank 'FEAST' in abbreviated form
-#: src/Enum/LitGrade.php:180
-msgid "F"
-msgstr ""
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s': when the 'strtotime' property is "
+#~ "an object, it must have properties %2$s"
+#~ msgstr ""
+#~ "Không thể tạo lễ di động '%1$s': khi thuộc tính 'strtotime' là một đối "
+#~ "tượng, nó phải có các thuộc tính %2$s"
 
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:185
-msgid "FEAST OF THE LORD"
-msgstr "LỄ CHÚA"
+#~ msgid ""
+#~ "Cannot create mobile festivity '%1$s' without a 'strtotime' property!"
+#~ msgstr "Không thể tạo lễ di động '%1$s' mà không có thuộc tính 'strtotime'!"
 
-#. translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form
-#: src/Enum/LitGrade.php:187
-msgid "F✝"
-msgstr ""
+#~ msgid "Error retrieving and decoding Wider Region data from file %s."
+#~ msgstr "Lỗi khi truy xuất và giải mã dữ liệu Vùng Rộng từ tệp %s."
 
-#. translators: liturgical rank. Keep UPPERCASE
-#: src/Enum/LitGrade.php:192
-msgid "SOLEMNITY"
-msgstr "LỄ TRỌNG"
-
-#. translators: liturgical rank 'SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:194
-msgid "S"
-msgstr ""
-
-#. translators: liturgical rank. Keep lowercase
-#: src/Enum/LitGrade.php:199
-msgid "celebration with precedence over solemnities"
-msgstr "lễ kỷ niệm có ưu tiên hơn các lễ trọng"
-
-#. translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form
-#: src/Enum/LitGrade.php:201
-msgid "S✝"
-msgstr ""
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:25
-msgid "Advent"
-msgstr "Mùa Vọng"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:28
-msgid "Christmas"
-msgstr "Giáng Sinh"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:31
-msgid "Lent"
-msgstr "Mùa Chay"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:34
-msgid "Easter Triduum"
-msgstr "Tam Nhật Vượt Qua"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:37
-msgid "Easter"
-msgstr "Phục Sinh"
-
-#. translators: context = liturgical season
-#: src/Enum/LitSeason.php:40
-msgid "Ordinary Time"
-msgstr "Thường Niên"
+#, fuzzy
+#~| msgid "Error retrieving and decoding National data from file %s."
+#~ msgid "Error retrieving and decoding National Calendar data from file %s."
+#~ msgstr "Lỗi khi truy xuất và giải mã dữ liệu Quốc gia từ tệp %s."


### PR DESCRIPTION
Translations update from [JohnRDOrazio Weblate](https://translate.johnromanodorazio.com) for [Liturgical Calendar/Proprium de Tempore](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-tempore/).


It also includes following components:

* [Liturgical Calendar/Memorials from Decrees](https://translate.johnromanodorazio.com/projects/liturgical-calendar/memorials-from-decrees/)

* [Liturgical Calendar/Proprium de Sanctis 2008](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-2008/)

* [Liturgical Calendar/API strings](https://translate.johnromanodorazio.com/projects/liturgical-calendar/api-strings/)

* [Liturgical Calendar/Proprium de Sanctis 2002](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-2002/)

* [Liturgical Calendar/Proprium de Sanctis 1970](https://translate.johnromanodorazio.com/projects/liturgical-calendar/proprium-de-sanctis-1970/)

* [Liturgical Calendar/Patron saints of Europe](https://translate.johnromanodorazio.com/projects/liturgical-calendar/patron-saints-of-europe/)



Current translation status:

![Weblate translation status](https://translate.johnromanodorazio.com/widget/liturgical-calendar/proprium-de-tempore/horizontal-auto.svg)