### PR TITLE
realign XML schema with new Lectionary Readings schemas

### DIFF
--- a/jsondata/schemas/LiturgicalCalendar.xsd
+++ b/jsondata/schemas/LiturgicalCalendar.xsd
@@ -97,6 +97,7 @@
                     <xs:element name="GradeAbbr" type="xs:string" />
                     <xs:element name="GradeDisplay" type="xs:string" />
                     <xs:element name="GradeLcl" type="xs:string" />
+                    <xs:element name="Readings" type="cl:ReadingsType" />
                     <xs:element name="HasVesperI" minOccurs="0" type="xs:boolean" />
                     <xs:element name="HasVesperII" minOccurs="0" type="xs:boolean" />
                     <xs:element name="HasVigilMass" minOccurs="0" type="xs:boolean" />
@@ -383,5 +384,128 @@
         <xs:attribute type="xs:short" name="idx" use="required" />
       </xs:extension>
     </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="ReadingsType" abstract="true" mixed="true" />
+  <xs:complexType name="ReadingsFerialType" mixed="true">
+    <xs:complexContent>
+      <xs:extension base="cl:ReadingsType">
+        <xs:sequence>
+          <xs:element name="FirstReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="AlleluiaVerse" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="Gospel" type="xs:string" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="readingsType" type="xs:string" use="required" fixed="ferial"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ReadingsFestiveType" mixed="true">
+    <xs:complexContent>
+      <xs:extension base="cl:ReadingsType">
+        <xs:sequence>
+          <xs:element name="FirstReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="SecondReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="AlleluiaVerse" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="Gospel" type="xs:string" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="readingsType" type="xs:string" use="required" fixed="festive" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ReadingsPalmSundayType" mixed="true">
+    <xs:complexContent>
+      <xs:extension base="cl:ReadingsType">
+        <xs:sequence>
+          <xs:element name="PalmGospel" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="FirstReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="SecondReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="AlleluiaVerse" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="Gospel" type="xs:string" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="readingsType" type="xs:string" use="required" fixed="palmSunday" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ReadingsEasterVigilType" mixed="true">
+    <xs:complexContent>
+      <xs:extension base="cl:ReadingsType">
+        <xs:sequence>
+          <xs:element name="FirstReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="SecondReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm2" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ThirdReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm3" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="FourthReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm4" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="FifthReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm5" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="SixthReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm6" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="SeventhReading" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalm7" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="Epistle" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="ResponsorialPsalmEpistle" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="AlleluiaVerse" type="xs:string" minOccurs="1" maxOccurs="1" />
+          <xs:element name="Gospel" type="xs:string" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="readingsType" type="xs:string" use="required" fixed="easterVigil" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ReadingsChristmasType" mixed="true">
+    <xs:complexContent>
+      <xs:extension base="cl:ReadingsType">
+        <xs:sequence>
+          <xs:element name="Night" type="cl:ReadingsFestiveType" minOccurs="1" maxOccurs="1" />
+          <xs:element name="Dawn" type="cl:ReadingsFestiveType" minOccurs="1" maxOccurs="1" />
+          <xs:element name="Day" type="cl:ReadingsFestiveType" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="readingsType" type="xs:string" use="required" fixed="christmas" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ReadingsMultipleSchemasType" mixed="true"><!-- e.g. All Souls Day or Commemoration of the Faithful Departed -->
+    <xs:complexContent>
+      <xs:extension base="cl:ReadingsType">
+        <xs:sequence>
+          <xs:element name="SchemaOne" type="cl:ReadingsFestiveType" minOccurs="1" maxOccurs="1" />
+          <xs:element name="SchemaTwo" type="cl:ReadingsFestiveType" minOccurs="1" maxOccurs="1" />
+          <xs:element name="SchemaThree" type="cl:ReadingsFestiveType" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="readingsType" type="xs:string" use="required" fixed="multipleSchemas" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ReadingsSeasonalType" mixed="true">
+    <xs:complexContent>
+      <xs:extension base="cl:ReadingsType">
+        <xs:sequence>
+          <xs:element name="OutsideEasterSeasonType" type="cl:ReadingsFerialType" minOccurs="1" maxOccurs="1" />
+          <xs:element name="EasterSeason" type="cl:ReadingsFerialType" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="readingsType" type="xs:string" use="required" fixed="seasonal" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ReadingsWithEveningMassType" mixed="true"><!-- e.g. Easter Sunday -->
+    <xs:complexContent>
+      <xs:extension base="cl:ReadingsType">
+        <xs:sequence>
+          <xs:element name="Day" type="cl:ReadingsFestiveType" minOccurs="1" maxOccurs="1" />
+          <xs:element name="Evening" type="cl:ReadingsFestiveType" minOccurs="1" maxOccurs="1" />
+        </xs:sequence>
+        <xs:attribute name="readingsType" type="xs:string" use="required" fixed="withEveningMass" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ReadingsCommonsType" mixed="true">
+    <xs:complexContent>
+      <xs:extension base="cl:ReadingsType">
+        <xs:attribute name="readingsType" type="xs:string" use="required" fixed="fromCommons" />
+      </xs:extension>
+    </xs:complexContent>
   </xs:complexType>
 </xs:schema>

--- a/src/Models/Lectionary/ReadingsGeneralRoman.php
+++ b/src/Models/Lectionary/ReadingsGeneralRoman.php
@@ -63,12 +63,12 @@ final class ReadingsGeneralRoman
                 JsonData::LECTIONARY_WEEKDAYS_CHRISTMAS_FILE,
                 [ '{locale}' => $locale ]
             ),
-            'weekdaysEaster'           => strtr(
-                JsonData::LECTIONARY_WEEKDAYS_EASTER_FILE,
-                [ '{locale}' => $locale ]
-            ),
             'weekdaysLent'             => strtr(
                 JsonData::LECTIONARY_WEEKDAYS_LENT_FILE,
+                [ '{locale}' => $locale ]
+            ),
+            'weekdaysEaster'           => strtr(
+                JsonData::LECTIONARY_WEEKDAYS_EASTER_FILE,
                 [ '{locale}' => $locale ]
             ),
             'decreeReadings'           => strtr(

--- a/src/Models/Lectionary/ReadingsMap.php
+++ b/src/Models/Lectionary/ReadingsMap.php
@@ -89,7 +89,7 @@ final class ReadingsMap implements \ArrayAccess
     /**
      * @var array{0:'first_reading',1:'responsorial_psalm',2:'second_reading',3:'responsorial_psalm_2',4:'third_reading',5:'responsorial_psalm_3',6:'fourth_reading',7:'responsorial_psalm_4',8:'fifth_reading',9:'responsorial_psalm_5',10:'sixth_reading',11:'responsorial_psalm_6',12:'seventh_reading',13:'responsorial_psalm_7',14:'epistle',15:'responsorial_psalm_epistle',16:'alleluia_verse',17:'gospel'}
      */
-    private const EASTER_VIGIL_KEYS = [
+    public const EASTER_VIGIL_KEYS = [
         'first_reading',
         'responsorial_psalm',
         'second_reading',
@@ -113,7 +113,7 @@ final class ReadingsMap implements \ArrayAccess
     /**
      * @var array{0:'first_reading',1:'responsorial_psalm',2:'alleluia_verse',3:'gospel'}
      */
-    private const FERIAL_KEYS = [
+    public const FERIAL_KEYS = [
         'first_reading',
         'responsorial_psalm',
         'alleluia_verse',
@@ -123,7 +123,7 @@ final class ReadingsMap implements \ArrayAccess
     /**
      * @var array{0:'first_reading',1:'responsorial_psalm',2:'alleluia_verse',3:'gospel',4:'second_reading'}
      */
-    private const FESTIVE_KEYS = [
+    public const FESTIVE_KEYS = [
         ...self::FERIAL_KEYS,
         'second_reading'
     ];
@@ -131,7 +131,7 @@ final class ReadingsMap implements \ArrayAccess
     /**
      * @var array{0:'first_reading',1:'responsorial_psalm',2:'alleluia_verse',3:'gospel',4:'second_reading',5:'palm_gospel'}
      */
-    private const PALM_SUNDAY_KEYS = [
+    public const PALM_SUNDAY_KEYS = [
         ...self::FESTIVE_KEYS,
         'palm_gospel'
     ];
@@ -139,7 +139,7 @@ final class ReadingsMap implements \ArrayAccess
     /**
      * @var array{0:'vigil',1:'day'}
      */
-    private const READINGS_WITH_VIGIL_KEYS = [
+    public const READINGS_WITH_VIGIL_KEYS = [
         'vigil',
         'day'
     ];
@@ -147,7 +147,7 @@ final class ReadingsMap implements \ArrayAccess
     /**
      * @var array{0:'vigil',1:'night',2:'dawn',3:'day'}
      */
-    private const READINGS_CHRISTMAS_KEYS = [
+    public const READINGS_CHRISTMAS_KEYS = [
         'vigil',
         'night',
         'dawn',
@@ -157,7 +157,7 @@ final class ReadingsMap implements \ArrayAccess
     /**
      * @var array{0:'schema_one',1:'schema_two',2:'schema_three'}
      */
-    private const READINGS_MULTIPLE_SCHEMAS_KEYS = [
+    public const READINGS_MULTIPLE_SCHEMAS_KEYS = [
         'schema_one',
         'schema_two',
         'schema_three'
@@ -166,7 +166,7 @@ final class ReadingsMap implements \ArrayAccess
     /**
      * @var array{0:'day',1:'evening'}
      */
-    private const READINGS_WITH_EVENING_MASS_KEYS = [
+    public const READINGS_WITH_EVENING_MASS_KEYS = [
         'day',
         'evening'
     ];
@@ -174,7 +174,7 @@ final class ReadingsMap implements \ArrayAccess
     /**
      * @var array{0:'easter_season',1:'outside_easter_season'}
      */
-    private const READINGS_SEASONAL_KEYS = [
+    public const READINGS_SEASONAL_KEYS = [
         'easter_season',
         'outside_easter_season'
     ];

--- a/src/Models/Lectionary/ReadingsPalmSunday.php
+++ b/src/Models/Lectionary/ReadingsPalmSunday.php
@@ -9,7 +9,7 @@ final class ReadingsPalmSunday extends ReadingsAbstract
     public readonly string $second_reading;
     public readonly string $palm_gospel;
 
-    private function __construct(string $first_reading, string $second_reading, string $responsorial_psalm, string $alleluia_verse, string $gospel, string $palm_gospel)
+    private function __construct(string $first_reading, string $responsorial_psalm, string $second_reading, string $alleluia_verse, string $gospel, string $palm_gospel)
     {
         parent::__construct($first_reading, $responsorial_psalm, $alleluia_verse, $gospel);
         $this->second_reading = $second_reading;
@@ -26,8 +26,8 @@ final class ReadingsPalmSunday extends ReadingsAbstract
 
         return new static(
             $data->first_reading,
-            $data->second_reading,
             $data->responsorial_psalm,
+            $data->second_reading,
             $data->alleluia_verse,
             $data->gospel,
             $data->palm_gospel
@@ -45,7 +45,7 @@ final class ReadingsPalmSunday extends ReadingsAbstract
      * - gospel (string): The gospel for Palm Sunday
      * - palm_gospel (string): The gospel for the procession of the palms
      *
-     * @param array{first_reading:string,second_reading:string,responsorial_psalm:string,alleluia_verse:string,gospel:string,palm_gospel:string} $data
+     * @param array{first_reading:string,responsorial_psalm:string,second_reading:string,alleluia_verse:string,gospel:string,palm_gospel:string} $data
      * @return static
      */
     protected static function fromArrayInternal(array $data): static
@@ -58,8 +58,8 @@ final class ReadingsPalmSunday extends ReadingsAbstract
 
         return new static(
             $data['first_reading'],
-            $data['second_reading'],
             $data['responsorial_psalm'],
+            $data['second_reading'],
             $data['alleluia_verse'],
             $data['gospel'],
             $data['palm_gospel']
@@ -84,8 +84,8 @@ final class ReadingsPalmSunday extends ReadingsAbstract
         return [
             'palm_gospel'        => $this->palm_gospel,
             'first_reading'      => $this->first_reading,
-            'second_reading'     => $this->second_reading,
             'responsorial_psalm' => $this->responsorial_psalm,
+            'second_reading'     => $this->second_reading,
             'alleluia_verse'     => $this->alleluia_verse,
             'gospel'             => $this->gospel
         ];

--- a/src/Paths/CalendarPath.php
+++ b/src/Paths/CalendarPath.php
@@ -4620,7 +4620,9 @@ final class CalendarPath
                 $xml            = new \SimpleXMLElement(
                     '<?xml version="1.0" encoding="UTF-8"?' . '><LiturgicalCalendar xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
                     . " xsi:schemaLocation=\"$ns $schemaLocation\""
-                    . " xmlns=\"$ns\"/>"
+                    . " xmlns=\"$ns\""
+                    . " xmlns:cl=\"$ns\""
+                    . '/>'
                 );
 
                 $jsonArr = Utilities::objectToArray($SerializeableLitCal);


### PR DESCRIPTION
Fixes #328

# Summary of changes
 * created abstract Readings type in XSD schema, with derived types for the various types of lectionary Readings
 * updated `Utilities::convertArray2XML` to deal with <Readings> elements with all of their complexities and types, which required setting the `xsi:type` on each `<Readings>` element, and on child elements when in turn they were parents of `Ferial` or `Festive` readings
 * updated `CalendarPath::generateResponse` >> `case ReturnType::XML` to also declare the `xmlns:cl` namespace

All tests finally passing!