### PR TITLE
reduce feast of the lord readings to ferial when falls during the week

### DIFF
--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -1161,7 +1161,8 @@ final class LiturgicalEventCollection
                                 $readings = $readings->outside_easter_season;
                             }
                         }
-                        elseif (self::dateIsNotSunday($litEvent->date) && $litEvent->grade === LitGrade::FEAST_LORD && $readings instanceof ReadingsFestive) {
+
+                        if (self::dateIsNotSunday($litEvent->date) && $litEvent->grade === LitGrade::FEAST_LORD && $readings instanceof ReadingsFestive) {
                             // When Feasts of the Lord fall on weekdays, the Festive readings are reduced to Ferial readings
                             // (the second reading is appended as a second option for the first reading).
                             /** @var ReadingsFerial */
@@ -1195,9 +1196,9 @@ final class LiturgicalEventCollection
                                 $commonsReadings = new ReadingsCommons($litEvent->common);
                                 $litEvent->setReadings($commonsReadings);
                             } else {
-                                // N.B. Diocesan calendar events will have the diocese id prepended to them, we should remove it
-                                //      since the lectionary event_key does not have the diocese id preprended.
-                                //      All diocesan calendar events' lectionary readings are pushed to the Sanctorale map,
+                                // N.B. Diocesan calendar events have the diocese id prepended to the event_key; remove it
+                                //      since lectionary event_keys do not include the diocese id.
+                                //      All diocesan events' lectionary readings are pushed to the Sanctorale map,
                                 //      so we retrieve the readings from there.
                                 if (preg_match('/^[a-z]{6}_[a-z]{2}_/', $litEvent->event_key)) {
                                     $event_key = substr($litEvent->event_key, 10);

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -29,6 +29,7 @@ use LiturgicalCalendar\Api\Map\SuppressedEventsMap;
 use LiturgicalCalendar\Api\Map\ReinstatedEventsMap;
 use LiturgicalCalendar\Api\Models\Lectionary\ReadingsChristmas;
 use LiturgicalCalendar\Api\Models\Lectionary\ReadingsCommons;
+use LiturgicalCalendar\Api\Models\Lectionary\ReadingsFerial;
 use LiturgicalCalendar\Api\Models\Lectionary\ReadingsFestive;
 use LiturgicalCalendar\Api\Models\Lectionary\ReadingsFestiveWithVigil;
 use LiturgicalCalendar\Api\Models\Lectionary\ReadingsGeneralRoman;

--- a/src/Models/Lectionary/ReadingsFestive.php
+++ b/src/Models/Lectionary/ReadingsFestive.php
@@ -61,6 +61,27 @@ final class ReadingsFestive extends ReadingsAbstract
     }
 
     /**
+     * Reduces the current festive readings to ferial readings.
+     *
+     * This method creates a new `ReadingsFerial` object using the properties
+     * of the current festive readings, excluding the second reading,
+     * which is however appended as a second option for the first reading.
+     *
+     * This is useful for Feasts of the Lord that fall on weekdays.
+     *
+     * @return ReadingsFerial An instance containing ferial readings.
+     */
+    public function reduceToFerial(): ReadingsFerial
+    {
+        return new ReadingsFerial(
+            $this->first_reading . '|' . $this->second_reading,
+            $this->responsorial_psalm,
+            $this->alleluia_verse,
+            $this->gospel
+        );
+    }
+
+    /**
      * {@inheritDoc}
      *
      * Returns an associative array containing the properties of this object,


### PR DESCRIPTION
Fixes #324

# Issue being addressed
When a Feast of the Lord falls on a Sunday, the readings are festive = there is a second reading other than the first reading. However when a Feast of the Lord falls during the week, the readings are reduced to ferial: only the first reading, though the second reading can be used as an option for the first reading.

# Summary of changes
 * add a `reduceToFerial` method to `ReadingsFestive`, which will return an instance of `ReadingsFerial` where the second reading is appended as an option on top of the first reading
 * add a check in `LiturgicalEventCollection::setCyclesVigilsSeasons` for when the date is not a Sunday, and the readings are of type `ReadingsFestive`, and in that case set the readings to ferial using the newly introduced `->reduceToFerial` method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Weekday Feasts of the Lord now display simplified lectionary readings, merging the first and second readings into a single reading for these occasions.

* **Documentation**
  * Clarified handling of diocesan calendar event keys in comments for improved understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->