### PR TITLE
calculate readings for events that have easter season readings

### DIFF
--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -1093,7 +1093,7 @@ final class LiturgicalEventCollection
                     $litEvent->date < $this->liturgicalEvents->getEvent('HolyThurs')->date
                     || $litEvent->date >= $this->liturgicalEvents->getEvent('Easter2')->date
                 ) {
-                    if (in_array($litEvent->event_key, self::$lectionary->getSanctoraleKeys())) {
+                    if (self::$lectionary->hasSanctoraleReadings($litEvent->event_key)) {
                         // If the event is from the Sanctorale (this includes national and diocesan created events),
                         // we get the readings from the Sanctorale
                         $readings = self::$lectionary->getSanctoraleReadings($litEvent->event_key);
@@ -1136,7 +1136,11 @@ final class LiturgicalEventCollection
                                 //      since the lectionary event_key does not have the diocese id preprended
                                 if (preg_match('/^[a-z]{6}_[a-z]{2}_/', $litEvent->event_key)) {
                                     $event_key = substr($litEvent->event_key, 10);
-                                    $litEvent->setReadings(self::$lectionary->getSanctoraleReadings($event_key));
+                                    if (self::$lectionary->hasSanctoraleReadings($event_key)) {
+                                        $litEvent->setReadings(self::$lectionary->getSanctoraleReadings($event_key));
+                                    } else {
+                                        throw new \InvalidArgumentException('event_key: ' . $litEvent->event_key . ' not found in Sanctorale, valid keys are: ' . implode(', ', self::$lectionary->getSanctoraleKeys()));
+                                    }
                                 } else {
                                     $litEvent->setReadings(self::$lectionary->getCycle($festiveCycle)->getReadings($litEvent->event_key));
                                 }
@@ -1163,7 +1167,7 @@ final class LiturgicalEventCollection
                         $litEvent->setReadings(self::$lectionary->getCycle($festiveCycle)->getReadings($litEvent->event_key));
                     }
                 }
-            } elseif (in_array($litEvent->event_key, self::$lectionary->getSanctoraleKeys())) {
+            } elseif (self::$lectionary->hasSanctoraleReadings($litEvent->event_key)) {
                 // STEP 3: If it's not a weekday or a Sunday or a Feast or the Lord or a Solemnity,
                 //         then it's probably a Sanctorale event; if so we retrieve the lectionary readings
                 //         from the Lectionary for the Sanctorale

--- a/src/Models/Lectionary/ReadingsGeneralRoman.php
+++ b/src/Models/Lectionary/ReadingsGeneralRoman.php
@@ -198,21 +198,36 @@ final class ReadingsGeneralRoman
      * and is of type ReadingsMultipleSchemas.
      *
      * @param string $offset The offset to retrieve the readings for.
-     * @return ReadingsAbstract|ReadingsMultipleSchemas The readings for the specified sanctorale offset.
+     * @return ReadingsAbstract|ReadingsSeasonal|ReadingsMultipleSchemas The readings for the specified sanctorale offset.
      */
-    public function getSanctoraleReadings(string $offset): ReadingsAbstract|ReadingsMultipleSchemas
+    public function getSanctoraleReadings(string $offset): ReadingsAbstract|ReadingsSeasonal|ReadingsMultipleSchemas
     {
         $readings = $this->sanctorale->getReadings($offset);
 
-        if (false === $readings instanceof ReadingsAbstract && false === $readings instanceof ReadingsMultipleSchemas) {
-            throw new \UnexpectedValueException('The readings for the sanctorale are expected to be an instance that extends ReadingsAbstract or ReadingsMultipleSchemas');
+        if (
+            false === $readings instanceof ReadingsAbstract
+            && false === $readings instanceof ReadingsSeasonal
+            && false === $readings instanceof ReadingsMultipleSchemas
+        ) {
+            throw new \UnexpectedValueException('The readings for the sanctorale are expected to be an instance of ReadingsSeasonal, of ReadingsMultipleSchemas, or an instance that extends ReadingsAbstract');
         }
 
         return $readings;
     }
 
     /**
-     * @param array<string,ReadingsFerialArray|ReadingsFestiveArray|ReadingsFestiveWithVigilArray|ReadingsMultipleSchemasArray> $readings
+     * Checks if the sanctorale readings contain the specified offset.
+     *
+     * @param string $offset The offset to check for.
+     * @return bool True if the sanctorale readings contain the specified offset, false otherwise.
+     */
+    public function hasSanctoraleReadings(string $offset): bool
+    {
+        return $this->sanctorale->offsetExists($offset);
+    }
+
+    /**
+     * @param array<string,ReadingsFerialArray|ReadingsFestiveArray|ReadingsFestiveWithVigilArray|ReadingsSeasonalArray|ReadingsMultipleSchemasArray> $readings
      */
     public function addSanctoraleReadings(array $readings): void
     {


### PR DESCRIPTION
Fixes #332

# Issue being addressed
For events that have seasonal readings, which change based on whether they fall during Easter season or not, we should produce the readings based on the season in which they fall.

# Summary of changes
 * add a method to ReadingsGeneralRoman `hasSancoraleReadings` to check whether there are readings in the Sanctorale (which includes even for national or diocesan calendar events) for the `event_key`
 * update the signature of the `ReadingsGeneralRoman::getSanctoraleReadings` method and add `ReadingsSeasonal` as a possible return type
 * add checks in `LiturgicalEventCollection::setCyclesVigilsSeasons` whether we have an instance of `ReadingsSeasonal`, and if so apply the appropriate lectionary readings based on the liturgical season