### PR TITLE
JohnRDOrazio/issue345

### DIFF
--- a/src/Enum/LitColor.php
+++ b/src/Enum/LitColor.php
@@ -18,24 +18,24 @@ enum LitColor: string
      * This method returns the translation of a given liturgical color based on
      * the specified locale. If the locale is Latin, it returns the Latin
      * translation; otherwise, it returns the translation in the current locale.
-     * If the color value is not supported, a default "unknown" value is returned.
      *
      * @param string $locale The locale for the translation.
      * @return string The translated liturgical color.
      */
     public function i18n(string $locale): string
     {
+        $isLatin = in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true);
         return match ($this) {
             /**translators: context = liturgical color */
-            LitColor::GREEN  => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'viridis' : _('green') ),
+            LitColor::GREEN  => ( $isLatin ? 'viridis' : _('green') ),
             /**translators: context = liturgical color */
-            LitColor::PURPLE => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'purpura' : _('purple') ),
+            LitColor::PURPLE => ( $isLatin ? 'purpura' : _('purple') ),
             /**translators: context = liturgical color */
-            LitColor::WHITE  => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'albus'   : _('white') ),
+            LitColor::WHITE  => ( $isLatin ? 'albus'   : _('white') ),
             /**translators: context = liturgical color */
-            LitColor::RED    => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'ruber'   : _('red') ),
+            LitColor::RED    => ( $isLatin ? 'ruber'   : _('red') ),
             /**translators: context = liturgical color */
-            LitColor::PINK   => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'rosea'   : _('pink') )
+            LitColor::PINK   => ( $isLatin ? 'rosea'   : _('pink') )
         };
     }
 }

--- a/src/Enum/LitColor.php
+++ b/src/Enum/LitColor.php
@@ -20,31 +20,22 @@ enum LitColor: string
      * translation; otherwise, it returns the translation in the current locale.
      * If the color value is not supported, a default "unknown" value is returned.
      *
-     * @param LitColor $color The liturgical color to translate.
      * @param string $locale The locale for the translation.
      * @return string The translated liturgical color.
      */
-    public static function i18n(LitColor $color, string $locale): string
+    public function i18n(string $locale): string
     {
-        switch ($color) {
-            case self::GREEN:
-                /**translators: context = liturgical color */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'viridis'     : _('green');
-            case self::PURPLE:
-                /**translators: context = liturgical color */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'purpura'     : _('purple');
-            case self::WHITE:
-                /**translators: context = liturgical color */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'albus'       : _('white');
-            case self::RED:
-                /**translators: context = liturgical color */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'ruber'       : _('red');
-            case self::PINK:
-                /**translators: context = liturgical color */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'rosea'       : _('pink');
-            default:
-                /**translators: context = liturgical color: unsupported value */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'ignotus'     : _('unknown');
-        }
+        return match ($this) {
+            /**translators: context = liturgical color */
+            LitColor::GREEN  => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'viridis' : _('green') ),
+            /**translators: context = liturgical color */
+            LitColor::PURPLE => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'purpura' : _('purple') ),
+            /**translators: context = liturgical color */
+            LitColor::WHITE  => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'albus'   : _('white') ),
+            /**translators: context = liturgical color */
+            LitColor::RED    => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'ruber'   : _('red') ),
+            /**translators: context = liturgical color */
+            LitColor::PINK   => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'rosea'   : _('pink') )
+        };
     }
 }

--- a/src/Enum/LitCommon.php
+++ b/src/Enum/LitCommon.php
@@ -238,15 +238,10 @@ enum LitCommon: string
      * Returns glue string for use between "From the Common" and the actual common.
      *
      * If the LitCommon case is not one of the General Commons, an exception will be thrown.
-     *
      * For LitCommon::BEATAE_MARIAE_VIRGINIS, returns the singular feminine form "of the".
-     *
      * For LitCommon::VIRGINUM, returns the plural feminine form "of".
-     *
      * For LitCommon::MARTYRUM, LitCommon::PASTORUM, LitCommon::DOCTORUM, LitCommon::SANCTORUM_ET_SANCTARUM, returns the plural maculine form "of".
-     *
      * For LitCommon::DEDICATIONIS_ECCLESIAE, returns the singular feminine form "of the".
-     *
      * For all other cases (?), returns the singular masculine form "of the".
      * @return string
      */

--- a/src/Enum/LitGrade.php
+++ b/src/Enum/LitGrade.php
@@ -125,6 +125,8 @@ enum LitGrade: int
      */
     public function i18n(string $locale, bool $html = true, bool $abbreviate = false): string
     {
+        $isLatin = in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true);
+
         [
             'grade'     => $grade,
             'gradeAbbr' => $gradeAbbr,
@@ -132,65 +134,65 @@ enum LitGrade: int
         ] = match ($this) {
             LitGrade::WEEKDAY => [
                 /**translators: liturgical rank. Keep lowercase  */
-                'grade'     => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'feria'             : _('weekday') ),
+                'grade'     => ( $isLatin ? 'feria'             : _('weekday') ),
                 /**translators: liturgical rank 'WEEKDAY' in abbreviated form */
-                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'f'                 : _('w') ),
+                'gradeAbbr' => ( $isLatin ? 'f'                 : _('w') ),
                 'tags'      => ['<I>','</I>']
             ],
             LitGrade::COMMEMORATION => [
                 /**translators: liturgical rank. Keep lowercase  */
-                'grade'     => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'commemoratio'      : _('commemoration') ),
+                'grade'     => ( $isLatin ? 'commemoratio'      : _('commemoration') ),
                 /**translators: liturgical rank 'COMMEMORATION' in abbreviated form */
-                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'm*'                : _('m*') ),
+                'gradeAbbr' => ( $isLatin ? 'm*'                : _('m*') ),
                 'tags'      => ['<I>','</I>']
             ],
             LitGrade::MEMORIAL_OPT => [
-                /**translators: liturgical rank. Keep lowercsase  */
-                'grade'     => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'memoria ad libitum' : _('optional memorial') ),
+                /**translators: liturgical rank. Keep lowercase  */
+                'grade'     => ( $isLatin ? 'memoria ad libitum' : _('optional memorial') ),
                 /**translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form */
-                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'm'                  : _('m') ),
+                'gradeAbbr' => ( $isLatin ? 'm'                  : _('m') ),
                 'tags'      => ['','']
             ],
             LitGrade::MEMORIAL => [
                 /**translators: liturgical rank. Keep Capitalized  */
-                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Memoria obligatoria' : _('Memorial') ),
+                'grade'     => ( $isLatin ? 'Memoria obligatoria' : _('Memorial') ),
                 /**translators: liturgical rank 'MEMORIAL' in abbreviated form */
-                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'M'                   : _('M') ),
+                'gradeAbbr' => ( $isLatin ? 'M'                   : _('M') ),
                 'tags'      => ['','']
             ],
             LitGrade::FEAST => [
                 /**translators: liturgical rank. Keep UPPERCASE  */
-                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'FESTUM'            : _('FEAST') ),
+                'grade'     => ( $isLatin ? 'FESTUM'            : _('FEAST') ),
                 /**translators: liturgical rank 'FEAST' in abbreviated form */
-                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'F'                 : _('F') ),
+                'gradeAbbr' => ( $isLatin ? 'F'                 : _('F') ),
                 'tags'      => ['','']
             ],
             LitGrade::FEAST_LORD => [
                 /**translators: liturgical rank. Keep UPPERCASE  */
-                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'FESTUM DOMINI'     : _('FEAST OF THE LORD') ),
+                'grade'     => ( $isLatin ? 'FESTUM DOMINI'     : _('FEAST OF THE LORD') ),
                 /**translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form */
-                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'F✝'                : _('F✝') ),
+                'gradeAbbr' => ( $isLatin ? 'F✝'                : _('F✝') ),
                 'tags'      => ['<B>','</B>']
             ],
             LitGrade::SOLEMNITY => [
                 /**translators: liturgical rank. Keep UPPERCASE  */
-                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'SOLLEMNITAS'       : _('SOLEMNITY') ),
+                'grade'     => ( $isLatin ? 'SOLLEMNITAS'       : _('SOLEMNITY') ),
                 /**translators: liturgical rank 'SOLEMNITY' in abbreviated form */
-                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'S'                 : _('S') ),
+                'gradeAbbr' => ( $isLatin ? 'S'                 : _('S') ),
                 'tags'      => ['<B>','</B>']
             ],
             LitGrade::HIGHER_SOLEMNITY => [
                 /**translators: liturgical rank. Keep lowercase  */
-                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'celebratio altioris ordinis quam sollemnitatis' : _('celebration with precedence over solemnities') ),
+                'grade'     => ( $isLatin ? 'celebratio altioris ordinis quam sollemnitatis' : _('celebration with precedence over solemnities') ),
                 /**translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form */
-                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'S✝'                : _('S✝') ),
+                'gradeAbbr' => ( $isLatin ? 'S✝'                : _('S✝') ),
                 'tags'      => ['<B><I>','</I></B>']
             ],
             LitGrade::INVALID => [
                 /**translators: liturgical rank. Keep lowercase  */
-                'grade'     => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'ignotus'         : 'invalid value' ),
+                'grade'     => ( $isLatin ? 'ignotus'         : 'invalid value' ),
                 /**translators: liturgical rank 'INVALID' in abbreviated form */
-                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'ign'               : '???' ),
+                'gradeAbbr' => ( $isLatin ? 'ign'               : '???' ),
                 'tags'      => ['','']
             ],
         };

--- a/src/Enum/LitGrade.php
+++ b/src/Enum/LitGrade.php
@@ -185,7 +185,14 @@ enum LitGrade: int
                 /**translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form */
                 'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'S✝'                : _('S✝') ),
                 'tags'      => ['<B><I>','</I></B>']
-            ]
+            ],
+            LitGrade::INVALID => [
+                /**translators: liturgical rank. Keep lowercase  */
+                'grade'     => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'ignotus'         : 'invalid value' ),
+                /**translators: liturgical rank 'INVALID' in abbreviated form */
+                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'ign'               : '???' ),
+                'tags'      => ['','']
+            ],
         };
         if ($abbreviate) {
             return $html ? $tags[0] . $gradeAbbr . $tags[1] : $gradeAbbr;

--- a/src/Enum/LitGrade.php
+++ b/src/Enum/LitGrade.php
@@ -116,7 +116,6 @@ enum LitGrade: int
     /**
      * Translates a liturgical grade value into a localized string, optionally wrapped in HTML tags.
      *
-     * @param LitGrade $value The liturgical grade value to be translated.
      * @param string $locale The locale to use for the translation.
      * @param bool $html Optional parameter to determine if the output should be wrapped in HTML tags.
      *                   Defaults to true.
@@ -124,72 +123,70 @@ enum LitGrade: int
      *                         Defaults to false.
      * @return string The localized string representing the liturgical grade, potentially wrapped in HTML.
      */
-    public static function i18n(LitGrade $value, string $locale, bool $html = true, bool $abbreviate = false): string
+    public function i18n(string $locale, bool $html = true, bool $abbreviate = false): string
     {
-        switch ($value) {
-            case self::WEEKDAY:
+        [
+            'grade'     => $grade,
+            'gradeAbbr' => $gradeAbbr,
+            'tags'      => $tags
+        ] = match ($this) {
+            LitGrade::WEEKDAY => [
                 /**translators: liturgical rank. Keep lowercase  */
-                $grade = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'feria'                 : _('weekday');
+                'grade'     => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'feria'             : _('weekday') ),
                 /**translators: liturgical rank 'WEEKDAY' in abbreviated form */
-                $gradeAbbr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'f'                 : _('w');
-                $tags      = ['<I>','</I>'];
-                break;
-            case self::COMMEMORATION:
+                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'f'                 : _('w') ),
+                'tags'      => ['<I>','</I>']
+            ],
+            LitGrade::COMMEMORATION => [
                 /**translators: liturgical rank. Keep lowercase  */
-                $grade = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'commemoratio'          : _('commemoration');
+                'grade'     => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'commemoratio'      : _('commemoration') ),
                 /**translators: liturgical rank 'COMMEMORATION' in abbreviated form */
-                $gradeAbbr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'm*'                : _('m*');
-                $tags      = ['<I>','</I>'];
-                break;
-            case self::MEMORIAL_OPT:
+                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'm*'                : _('m*') ),
+                'tags'      => ['<I>','</I>']
+            ],
+            LitGrade::MEMORIAL_OPT => [
                 /**translators: liturgical rank. Keep lowercsase  */
-                $grade = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'memoria ad libitum'    : _('optional memorial');
+                'grade'     => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'memoria ad libitum' : _('optional memorial') ),
                 /**translators: liturgical rank 'OPTIONAL MEMORIAL' in abbreviated form */
-                $gradeAbbr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'm'                 : _('m');
-                $tags      = ['',''];
-                break;
-            case self::MEMORIAL:
+                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'm'                  : _('m') ),
+                'tags'      => ['','']
+            ],
+            LitGrade::MEMORIAL => [
                 /**translators: liturgical rank. Keep Capitalized  */
-                $grade = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'Memoria obligatoria'   : _('Memorial');
+                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Memoria obligatoria' : _('Memorial') ),
                 /**translators: liturgical rank 'MEMORIAL' in abbreviated form */
-                $gradeAbbr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'M'                 : _('M');
-                $tags      = ['',''];
-                break;
-            case self::FEAST:
+                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'M'                   : _('M') ),
+                'tags'      => ['','']
+            ],
+            LitGrade::FEAST => [
                 /**translators: liturgical rank. Keep UPPERCASE  */
-                $grade = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'FESTUM'                : _('FEAST');
+                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'FESTUM'            : _('FEAST') ),
                 /**translators: liturgical rank 'FEAST' in abbreviated form */
-                $gradeAbbr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'F'                 : _('F');
-                $tags      = ['',''];
-                break;
-            case self::FEAST_LORD:
+                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'F'                 : _('F') ),
+                'tags'      => ['','']
+            ],
+            LitGrade::FEAST_LORD => [
                 /**translators: liturgical rank. Keep UPPERCASE  */
-                $grade = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'FESTUM DOMINI'         : _('FEAST OF THE LORD');
+                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'FESTUM DOMINI'     : _('FEAST OF THE LORD') ),
                 /**translators: liturgical rank 'FEAST OF THE LORD' in abbreviated form */
-                $gradeAbbr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'F✝'                : _('F✝');
-                $tags      = ['<B>','</B>'];
-                break;
-            case self::SOLEMNITY:
+                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'F✝'                : _('F✝') ),
+                'tags'      => ['<B>','</B>']
+            ],
+            LitGrade::SOLEMNITY => [
                 /**translators: liturgical rank. Keep UPPERCASE  */
-                $grade = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'SOLLEMNITAS'           : _('SOLEMNITY');
+                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'SOLLEMNITAS'       : _('SOLEMNITY') ),
                 /**translators: liturgical rank 'SOLEMNITY' in abbreviated form */
-                $gradeAbbr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'S'                 : _('S');
-                $tags      = ['<B>','</B>'];
-                break;
-            case self::HIGHER_SOLEMNITY:
+                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'S'                 : _('S') ),
+                'tags'      => ['<B>','</B>']
+            ],
+            LitGrade::HIGHER_SOLEMNITY => [
                 /**translators: liturgical rank. Keep lowercase  */
-                $grade = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'celebratio altioris ordinis quam sollemnitatis' : _('celebration with precedence over solemnities');
+                'grade'     => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'celebratio altioris ordinis quam sollemnitatis' : _('celebration with precedence over solemnities') ),
                 /**translators: liturgical rank 'HIGHER SOLEMNITY' in abbreviated form */
-                $gradeAbbr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'S✝'                : _('S✝');
-                $tags      = ['<B><I>','</I></B>'];
-                break;
-            default:
-                /**translators: liturgical rank. Keep lowercase  */
-                $grade = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'feria'                 : _('weekday');
-                /**translators: liturgical rank 'WEEKDAY' in abbreviated form */
-                $gradeAbbr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'f'                 : _('w');
-                $tags      = ['',''];
-        }
+                'gradeAbbr' => ( in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'S✝'                : _('S✝') ),
+                'tags'      => ['<B><I>','</I></B>']
+            ]
+        };
         if ($abbreviate) {
             return $html ? $tags[0] . $gradeAbbr . $tags[1] : $gradeAbbr;
         }

--- a/src/Enum/LitLocale.php
+++ b/src/Enum/LitLocale.php
@@ -7,6 +7,7 @@ class LitLocale
     public const LATIN                     = 'la_VA';
     public const LATIN_PRIMARY_LANGUAGE    = 'la';
     public static string $PRIMARY_LANGUAGE = 'la';
+    public static string $RUNTIME_LOCALE   = 'en_US';
 
     /** @var string[] */
     public static array $values = [ 'la', 'la_VA' ];

--- a/src/Enum/LitSeason.php
+++ b/src/Enum/LitSeason.php
@@ -2,8 +2,6 @@
 
 namespace LiturgicalCalendar\Api\Enum;
 
-use LiturgicalCalendar\Api\Router;
-
 enum LitSeason: string
 {
     use EnumToArrayTrait;
@@ -23,19 +21,20 @@ enum LitSeason: string
      */
     public function i18n(string $locale): string
     {
+        $isLatin = in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true);
         return match ($this) {
             /**translators: context = liturgical season */
-            LitSeason::ADVENT         => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus Adventus'     : _('Advent'),
+            LitSeason::ADVENT         => $isLatin ? 'Tempus Adventus'     : _('Advent'),
             /**translators: context = liturgical season */
-            LitSeason::CHRISTMAS      => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus Nativitatis'  : _('Christmas'),
+            LitSeason::CHRISTMAS      => $isLatin ? 'Tempus Nativitatis'  : _('Christmas'),
             /**translators: context = liturgical season */
-            LitSeason::LENT           => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus Quadragesima' : _('Lent'),
+            LitSeason::LENT           => $isLatin ? 'Tempus Quadragesima' : _('Lent'),
             /**translators: context = liturgical season */
-            LitSeason::EASTER_TRIDUUM => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Triduum Paschale'    : _('Easter Triduum'),
+            LitSeason::EASTER_TRIDUUM => $isLatin ? 'Triduum Paschale'    : _('Easter Triduum'),
             /**translators: context = liturgical season */
-            LitSeason::EASTER         => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus Paschale'     : _('Easter'),
+            LitSeason::EASTER         => $isLatin ? 'Tempus Paschale'     : _('Easter'),
             /**translators: context = liturgical season */
-            LitSeason::ORDINARY_TIME  => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus per Annum'    : _('Ordinary Time')
+            LitSeason::ORDINARY_TIME  => $isLatin ? 'Tempus per Annum'    : _('Ordinary Time')
         };
     }
 }

--- a/src/Enum/LitSeason.php
+++ b/src/Enum/LitSeason.php
@@ -2,6 +2,8 @@
 
 namespace LiturgicalCalendar\Api\Enum;
 
+use LiturgicalCalendar\Api\Router;
+
 enum LitSeason: string
 {
     use EnumToArrayTrait;
@@ -16,34 +18,24 @@ enum LitSeason: string
     /**
      * Translate a liturgical season value into the specified locale.
      *
-     * @param LitSeason $value The liturgical season value to translate.
      * @param string $locale The locale for the translation.
      * @return string The translated liturgical season value.
      */
-    public static function i18n(LitSeason $value, string $locale): string
+    public function i18n(string $locale): string
     {
-        switch ($value) {
-            case self::ADVENT:
-                /**translators: context = liturgical season */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'Tempus Adventus'     : _('Advent');
-            case self::CHRISTMAS:
-                /**translators: context = liturgical season */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'Tempus Nativitatis'  : _('Christmas');
-            case self::LENT:
-                /**translators: context = liturgical season */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'Tempus Quadragesima' : _('Lent');
-            case self::EASTER_TRIDUUM:
-                /**translators: context = liturgical season */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'Triduum Paschale'    : _('Easter Triduum');
-            case self::EASTER:
-                /**translators: context = liturgical season */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'Tempus Paschale'     : _('Easter');
-            case self::ORDINARY_TIME:
-                /**translators: context = liturgical season */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'Tempus per Annum'    : _('Ordinary Time');
-            default:
-                /**translators: context = liturgical season: unsupported value */
-                return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'Tempus Ignotum'      : _('Unknown Season');
-        }
+        return match ($this) {
+            /**translators: context = liturgical season */
+            LitSeason::ADVENT         => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus Adventus'     : _('Advent'),
+            /**translators: context = liturgical season */
+            LitSeason::CHRISTMAS      => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus Nativitatis'  : _('Christmas'),
+            /**translators: context = liturgical season */
+            LitSeason::LENT           => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus Quadragesima' : _('Lent'),
+            /**translators: context = liturgical season */
+            LitSeason::EASTER_TRIDUUM => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Triduum Paschale'    : _('Easter Triduum'),
+            /**translators: context = liturgical season */
+            LitSeason::EASTER         => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus Paschale'     : _('Easter'),
+            /**translators: context = liturgical season */
+            LitSeason::ORDINARY_TIME  => in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE]) ? 'Tempus per Annum'    : _('Ordinary Time')
+        };
     }
 }

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4585,7 +4585,7 @@ final class CalendarHandler extends AbstractHandler
         }
 
         // Example: "it_IT.UTF-8" → "it_IT"
-        $normalizedLocale = strtok($runtimeLocale, '.');
+        $normalizedLocale = strtok($runtimeLocale, '.') ?: $runtimeLocale;
 
         $languageEnv = implode(':', array_unique([
             $runtimeLocale,
@@ -4606,7 +4606,6 @@ final class CalendarHandler extends AbstractHandler
             throw new ServiceUnavailableException('The i18n folder does not exist at path: ' . Router::$apiFilePath . 'i18n' . '.');
         }
 
-        $textDomain = null;
         if (false === bindtextdomain('litcal', Router::$apiFilePath . 'i18n')) {
             throw new ServiceUnavailableException('Could not bind text domain for translations to path: ' . Router::$apiFilePath . 'i18n' . '.');
         } else {
@@ -4614,7 +4613,7 @@ final class CalendarHandler extends AbstractHandler
             $textDomain = textdomain('litcal');
         }
 
-        if (null === $textDomain || $textDomain !== 'litcal') {
+        if ($textDomain !== 'litcal') {
             throw new ServiceUnavailableException('Could not set text domain for translations to \'litcal\'.');
         }
     }

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -343,7 +343,7 @@ final class CalendarHandler extends AbstractHandler
             $this->CalendarParams->EternalHighPriest = false;
         } else {
             if ($this->NationalData === null) {
-                throw new \RuntimeException(
+                throw new ServiceUnavailableException(
                     '“Leave behind the senses and the operations of the intellect, and all things sensible and intelligible, and all things in the realm of being and non-being, and be raised up to the divine ray of the darkness that surpasses being.”'
                     . ' — Pseudo-Dionysius the Areopagite, Mystical Theology, Chapter 1'
                 );
@@ -514,7 +514,7 @@ final class CalendarHandler extends AbstractHandler
             || null === $dayOfTheWeek
             || null === $dayOfTheWeekEnglish
         ) {
-            throw new \RuntimeException(
+            throw new ServiceUnavailableException(
                 '"Time is like a river made up of the events which happen, and a violent stream;'
                 . ' for as soon as a thing has been seen, it is carried away, and another comes in its place, and this will be carried away too."'
                 . ' — Marcus Aurelius, Meditations 4.43'
@@ -829,7 +829,7 @@ final class CalendarHandler extends AbstractHandler
         $nth      = 0;
         $Epiphany = $this->Cal->getLiturgicalEvent('Epiphany');
         if (null === $Epiphany) {
-            throw new \RuntimeException('The liturgical event "Epiphany" is missing');
+            throw new ServiceUnavailableException('The liturgical event "Epiphany" is missing');
         }
 
         $DayOfEpiphany = (int) $Epiphany->date->format('j');
@@ -884,7 +884,7 @@ final class CalendarHandler extends AbstractHandler
         $Epiphany    = $this->Cal->getLiturgicalEvent('Epiphany');
         $BaptismLord = $this->Cal->getLiturgicalEvent('BaptismLord');
         if (null === $Epiphany || null === $BaptismLord) {
-            throw new \RuntimeException('The liturgical events "Epiphany" and/or the liturgical event "Baptism of the Lord" is/are missing');
+            throw new ServiceUnavailableException('The liturgical events "Epiphany" and/or the liturgical event "Baptism of the Lord" is/are missing');
         }
 
         $DayOfEpiphany    = (int) $Epiphany->date->format('j');
@@ -1232,7 +1232,7 @@ final class CalendarHandler extends AbstractHandler
                     $tempLiturgicalEvent->date = Utilities::calcGregEaster($this->CalendarParams->Year)->sub(new \DateInterval('P8D'));
                     $coincidingSolemnity       = $this->Cal->solemnityFromDate($currentLitEventDate);
                     if (null === $coincidingSolemnity) {
-                        throw new \RuntimeException('No coinciding Solemnity found for ' . $currentLitEventDate->format('Y-m-d'));
+                        throw new ServiceUnavailableException('No coinciding Solemnity found for ' . $currentLitEventDate->format('Y-m-d'));
                     }
 
                     $this->Messages[] = sprintf(
@@ -1257,7 +1257,7 @@ final class CalendarHandler extends AbstractHandler
                     $tempLiturgicalEvent->date = Utilities::calcGregEaster($this->CalendarParams->Year)->add(new \DateInterval('P8D'));
                     $coincidingSolemnity       = $this->Cal->solemnityFromDate($currentLitEventDate);
                     if (null === $coincidingSolemnity) {
-                        throw new \RuntimeException('No coinciding Solemnity found for ' . $currentLitEventDate->format('Y-m-d'));
+                        throw new ServiceUnavailableException('No coinciding Solemnity found for ' . $currentLitEventDate->format('Y-m-d'));
                     }
 
                     $this->Messages[] = sprintf(
@@ -1306,7 +1306,7 @@ final class CalendarHandler extends AbstractHandler
                         $tempLiturgicalEvent->date->add(new \DateInterval('P1D'));
                         $coincidingSolemnity = $this->Cal->solemnityFromDate($currentLitEventDate);
                         if (null === $coincidingSolemnity) {
-                            throw new \RuntimeException('No Solemnity found for ' . $currentLitEventDate->format('Y-m-d'));
+                            throw new ServiceUnavailableException('No Solemnity found for ' . $currentLitEventDate->format('Y-m-d'));
                         }
 
                         $this->Messages[] = sprintf(
@@ -1336,7 +1336,7 @@ final class CalendarHandler extends AbstractHandler
                     //In all other cases, let's make a note of what's happening and ask the Congegation for Divine Worship
                     $coincidingSolemnity = $this->Cal->solemnityFromDate($currentLitEventDate);
                     if (null === $coincidingSolemnity) {
-                        throw new \RuntimeException('No Solemnity found for ' . $currentLitEventDate->format('Y-m-d'));
+                        throw new ServiceUnavailableException('No Solemnity found for ' . $currentLitEventDate->format('Y-m-d'));
                     }
 
                     $this->Messages[] = '<span style="padding:3px 6px; font-weight: bold; background-color: #FFC;color:Red;border-radius:6px;">IMPORTANT</span> ' . sprintf(
@@ -1358,7 +1358,7 @@ final class CalendarHandler extends AbstractHandler
                 if ($propriumDeSanctisEvent->event_key === 'NativityJohnBaptist' && $this->Cal->solemnityKeyFromDate($currentLitEventDate) === 'SacredHeart') {
                     $SacredHeart = $this->Cal->getLiturgicalEvent('SacredHeart');
                     if (null === $SacredHeart) {
-                        throw new \RuntimeException('The Solemnity of the Sacred Heart was not found');
+                        throw new ServiceUnavailableException('The Solemnity of the Sacred Heart was not found');
                     }
 
                     $NativityJohnBaptistNewDate = clone( $SacredHeart->date );
@@ -1446,8 +1446,8 @@ final class CalendarHandler extends AbstractHandler
             // $propriumDeSanctisEvent->type = LitEventType::FIXED;
             $litEvent = LiturgicalEvent::fromObject($propriumDeSanctisEvent);
             if ($propriumDeSanctisEvent->event_key === 'DedicationLateran') {
-                $litEvent->grade_display = LitGrade::i18n(LitGrade::FEAST, $this->CalendarParams->Locale, false);
-                $litEvent->setGradeAbbreviation(LitGrade::i18n(LitGrade::FEAST, $this->CalendarParams->Locale, false, true));
+                $litEvent->grade_display = LitGrade::FEAST->i18n($this->CalendarParams->Locale, false);
+                $litEvent->setGradeAbbreviation(LitGrade::FEAST->i18n($this->CalendarParams->Locale, false, true));
             }
             $this->Cal->addLiturgicalEvent($propriumDeSanctisEvent->event_key, $litEvent);
         }
@@ -1456,7 +1456,7 @@ final class CalendarHandler extends AbstractHandler
         $locale    = LitLocale::$PRIMARY_LANGUAGE;
         $Christmas = $this->Cal->getLiturgicalEvent('Christmas');
         if (null === $Christmas) {
-            throw new \RuntimeException('Christmas was not found among the LiturgicalEvents');
+            throw new ServiceUnavailableException('Christmas was not found among the LiturgicalEvents');
         }
 
         if (self::dateIsSunday($Christmas->date)) {
@@ -1488,7 +1488,7 @@ final class CalendarHandler extends AbstractHandler
         if ($this->CalendarParams->Year >= 2012 && true === $this->CalendarParams->EternalHighPriest) {
             $Pentecost = $this->Cal->getLiturgicalEvent('Pentecost');
             if (null === $Pentecost) {
-                throw new \RuntimeException('Pentecost was not found among the LiturgicalEvents');
+                throw new ServiceUnavailableException('Pentecost was not found among the LiturgicalEvents');
             }
 
             $EternalHighPriestDate = clone( $Pentecost->date );
@@ -1543,7 +1543,7 @@ final class CalendarHandler extends AbstractHandler
         $ordSun             = 1;
         $BaptismLord        = $this->Cal->getLiturgicalEvent('BaptismLord');
         if (null === $BaptismLord) {
-            throw new \RuntimeException('Baptism of the Lord was not found among the LiturgicalEvents');
+            throw new ServiceUnavailableException('Baptism of the Lord was not found among the LiturgicalEvents');
         }
 
         while ($firstOrdinaryDate >= $BaptismLord->date && $firstOrdinaryDate < $firstOrdinaryLimit) {
@@ -1562,7 +1562,7 @@ final class CalendarHandler extends AbstractHandler
             } else {
                 $litEvent = $this->Cal->solemnityFromDate($firstOrdinaryDate) ?? $this->Cal->feastLordFromDate($firstOrdinaryDate);
                 if (null === $litEvent) {
-                    throw new \RuntimeException('We were expecting to find either a Solemnity or a Feast of the Lord on ' . $firstOrdinaryDate->format('Y-m-d') . ' but no LiturgicalEvent was not found');
+                    throw new ServiceUnavailableException('We were expecting to find either a Solemnity or a Feast of the Lord on ' . $firstOrdinaryDate->format('Y-m-d') . ' but no LiturgicalEvent was not found');
                 }
 
                 $this->Messages[] = sprintf(
@@ -1570,8 +1570,8 @@ final class CalendarHandler extends AbstractHandler
                     _('\'%1$s\' is superseded by the %2$s \'%3$s\' in the year %4$d.'),
                     $this->PropriumDeTempore['OrdSunday' . $ordSun]->name,
                     $litEvent->grade->value > LitGrade::SOLEMNITY->value
-                        ? '<i>' . LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale, false) . '</i>'
-                        : LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale, false),
+                        ? '<i>' . $litEvent->grade->i18n($this->CalendarParams->Locale, false) . '</i>'
+                        : $litEvent->grade->i18n($this->CalendarParams->Locale, false),
                     $litEvent->name,
                     $this->CalendarParams->Year
                 );
@@ -1587,7 +1587,7 @@ final class CalendarHandler extends AbstractHandler
         $ordSunCycle            = 4;
         $ChristKing             = $this->Cal->getLiturgicalEvent('ChristKing');
         if (null === $ChristKing) {
-            throw new \RuntimeException('Christ the King was not found among the LiturgicalEvents');
+            throw new ServiceUnavailableException('Christ the King was not found among the LiturgicalEvents');
         }
 
         while ($lastOrdinary <= $ChristKing->date && $lastOrdinary > $lastOrdinaryLowerLimit) {
@@ -1606,7 +1606,7 @@ final class CalendarHandler extends AbstractHandler
             } else {
                 $litEvent = $this->Cal->solemnityFromDate($firstOrdinaryDate) ?? $this->Cal->feastLordFromDate($firstOrdinaryDate);
                 if (null === $litEvent) {
-                    throw new \RuntimeException('We were expecting to find either a Solemnity or a Feast of the Lord on ' . $lastOrdinary->format('Y-m-d') . ' but no LiturgicalEvent was not found');
+                    throw new ServiceUnavailableException('We were expecting to find either a Solemnity or a Feast of the Lord on ' . $lastOrdinary->format('Y-m-d') . ' but no LiturgicalEvent was not found');
                 }
 
                 $this->Messages[] = sprintf(
@@ -1614,8 +1614,8 @@ final class CalendarHandler extends AbstractHandler
                     _('\'%1$s\' is superseded by the %2$s \'%3$s\' in the year %4$d.'),
                     $this->PropriumDeTempore['OrdSunday' . $ordSun]->name,
                     $litEvent->grade->value > LitGrade::SOLEMNITY->value
-                        ? '<i>' . LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale, false) . '</i>'
-                        : LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale, false),
+                        ? '<i>' . $litEvent->grade->i18n($this->CalendarParams->Locale, false) . '</i>'
+                        : $litEvent->grade->i18n($this->CalendarParams->Locale, false),
                     $litEvent->name,
                     $this->CalendarParams->Year
                 );
@@ -1680,7 +1680,7 @@ final class CalendarHandler extends AbstractHandler
         $Advent1   = $this->Cal->getLiturgicalEvent('Advent1');
         $Christmas = $this->Cal->getLiturgicalEvent('Christmas');
         if (null === $Advent1 || null === $Christmas) {
-            throw new \RuntimeException('The First Sunday of Advent and/or Christmas were not found among the Liturgical Events');
+            throw new ServiceUnavailableException('The First Sunday of Advent and/or Christmas were not found among the Liturgical Events');
         }
 
         $DoMAdvent1       = $Advent1->date->format('j'); // j = Day of the Month (DoM) on which the first Sunday of Advent falls
@@ -1893,7 +1893,7 @@ final class CalendarHandler extends AbstractHandler
         $message          = _('The %1$s \'%2$s\' has been added on %3$s since the year %4$d (%5$s), applicable to the year %6$d.');
         $this->Messages[] = sprintf(
             $message,
-            LitGrade::i18n($propriumDeSanctisEvent->grade, $this->CalendarParams->Locale, false),
+            $propriumDeSanctisEvent->grade->i18n($this->CalendarParams->Locale, false),
             $propriumDeSanctisEvent->name,
             $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
                 ? ( $propriumDeSanctisEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $propriumDeSanctisEvent->date->format('n')] )
@@ -2011,7 +2011,7 @@ final class CalendarHandler extends AbstractHandler
             );
             $this->Messages[] = sprintf(
                 $message,
-                LitGrade::i18n($propriumDeSanctisEvent->grade, $this->CalendarParams->Locale, false),
+                $propriumDeSanctisEvent->grade->i18n($this->CalendarParams->Locale, false),
                 $propriumDeSanctisEvent->name,
                 $this->CalendarParams->Year
             );
@@ -2035,7 +2035,7 @@ final class CalendarHandler extends AbstractHandler
             if (null !== $key) {
                 $weekdayEpiphany = $this->Cal->getLiturgicalEvent($key);
                 if (null === $weekdayEpiphany) {
-                    throw new \RuntimeException('The weekday of Epihany ' . $key . ' has been lost; as long as Paradise has not we will survive');
+                    throw new ServiceUnavailableException('The weekday of Epihany ' . $key . ' has been lost; as long as Paradise has not we will survive');
                 }
 
                 /**translators:
@@ -2048,9 +2048,9 @@ final class CalendarHandler extends AbstractHandler
                 $message          = _('The %1$s \'%2$s\' is superseded by the %3$s \'%4$s\' in the year %5$d.');
                 $this->Messages[] = sprintf(
                     $message,
-                    LitGrade::i18n($weekdayEpiphany->grade, $this->CalendarParams->Locale),
+                    $weekdayEpiphany->grade->i18n($this->CalendarParams->Locale),
                     $weekdayEpiphany->name,
-                    LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale, false),
+                    $litEvent->grade->i18n($this->CalendarParams->Locale, false),
                     $litEvent->name,
                     $this->CalendarParams->Year
                 );
@@ -2083,7 +2083,7 @@ final class CalendarHandler extends AbstractHandler
             if (null !== $key) {
                 $weekdayAdvent = $this->Cal->getLiturgicalEvent($key);
                 if (null === $weekdayAdvent) {
-                    throw new \RuntimeException('The weekday of Advent ' . $key . ' was nowhere to be found; perhaps it ascended like Elijah.');
+                    throw new ServiceUnavailableException('The weekday of Advent ' . $key . ' was nowhere to be found; perhaps it ascended like Elijah.');
                 }
 
                 /**translators:
@@ -2096,15 +2096,15 @@ final class CalendarHandler extends AbstractHandler
                 $message          = _('The %1$s \'%2$s\' is superseded by the %3$s \'%4$s\' in the year %5$d.');
                 $this->Messages[] = sprintf(
                     $message,
-                    LitGrade::i18n($weekdayAdvent->grade, $this->CalendarParams->Locale),
+                    $weekdayAdvent->grade->i18n($this->CalendarParams->Locale),
                     $weekdayAdvent->name,
-                    LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale, false),
+                    $litEvent->grade->i18n($this->CalendarParams->Locale, false),
                     $litEvent->name,
                     $this->CalendarParams->Year
                 );
                 $psalter_week     = $weekdayAdvent->psalter_week;
                 if (null === $psalter_week) {
-                    throw new \RuntimeException('No psalter week for the weekday of Advent ' . $key . ', you will just have to figure out for yourself which breviary to use.');
+                    throw new ServiceUnavailableException('No psalter week for the weekday of Advent ' . $key . ', you will just have to figure out for yourself which breviary to use.');
                 }
                 $this->Cal->setProperty($event_key, 'psalter_week', $psalter_week);
                 $this->Cal->removeLiturgicalEvent($key);
@@ -2157,7 +2157,7 @@ final class CalendarHandler extends AbstractHandler
          */
         $message          = _('The %1$s \'%2$s\', added in the %3$s of the Roman Missal since the year %4$d (%5$s) and usually celebrated on %6$s, is suppressed by the %7$s \'%8$s\' in the year %9$d.');
         $locale           = LitLocale::$PRIMARY_LANGUAGE;
-        $grade_str        = LitGrade::i18n($potentialEvent->grade, $this->CalendarParams->Locale, false);
+        $grade_str        = $potentialEvent->grade->i18n($this->CalendarParams->Locale, false);
         $this->Messages[] = sprintf(
             $message,
             $grade_str,
@@ -2209,7 +2209,7 @@ final class CalendarHandler extends AbstractHandler
              * 8. Requested calendar year
              */
             _('The %1$s \'%2$s\', added on %3$s since the year %4$d (%5$s), is however superseded by a %6$s \'%7$s\' in the year %8$d.'),
-            LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale),
+            $liturgicalEvent->grade->i18n($this->CalendarParams->Locale),
             $liturgicalEvent->name,
             $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
                 ? ( $liturgicalEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $liturgicalEvent->date->format('n')] )
@@ -2362,7 +2362,7 @@ final class CalendarHandler extends AbstractHandler
                      * 6. Requested calendar year
                      */
                     _('The %1$s \'%2$s\' has been added on %3$s since the year %4$d (%5$s), applicable to the year %6$d.'),
-                    LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                    $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                     $liturgicalEvent->name,
                     $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
                         ? ( $date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $date->format('n')] )
@@ -2424,7 +2424,7 @@ final class CalendarHandler extends AbstractHandler
                 $message          = _('The name of the %1$s \'%2$s\' has been changed to %3$s since the year %4$d, applicable to the year %5$d (%6$s).');
                 $this->Messages[] = sprintf(
                     $message,
-                    LitGrade::i18n($existingLiturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                    $existingLiturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                     '<i>' . $existingLiturgicalEvent->name . '</i>',
                     '<i>' . $decreeLiturgicalEvent->name . '</i>',
                     $decreeMetadata->since_year,
@@ -2457,9 +2457,9 @@ final class CalendarHandler extends AbstractHandler
                 }
                 $this->Messages[] = sprintf(
                     $message,
-                    LitGrade::i18n($existingLiturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                    $existingLiturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                     $existingLiturgicalEvent->name,
-                    LitGrade::i18n($decreeLiturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                    $decreeLiturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                     $decreeMetadata->since_year,
                     $this->CalendarParams->Year,
                     $decreeMetadata->getUrl()
@@ -2538,13 +2538,13 @@ final class CalendarHandler extends AbstractHandler
     private function applyDecrees(LitGrade $grade = LitGrade::MEMORIAL): void
     {
         if (count($this->decreeItems) === 0) {
-            throw new \RuntimeException('We seem to be missing data for Decrees of the Congregation for Divine Worship: no data found!');
+            throw new ServiceUnavailableException('We seem to be missing data for Decrees of the Congregation for Divine Worship: no data found!');
         }
 
         // filterByGrade excludes Doctors of the Church through the `makeDoctor` action
         $decreeItems = $this->decreeItems->filterByGrade($grade);
         if (count($decreeItems) === 0) {
-            throw new \RuntimeException('We seem to be missing data for Decrees that handle liturgical events of grade ' . $grade->value);
+            throw new ServiceUnavailableException('We seem to be missing data for Decrees that handle liturgical events of grade ' . $grade->value);
         }
         foreach ($decreeItems as $decreeItem) {
             if ($this->CalendarParams->Year >= $decreeItem->metadata->since_year) {
@@ -2591,7 +2591,7 @@ final class CalendarHandler extends AbstractHandler
              * 6. Requested calendar year
              */
             _('The %1$s \'%2$s\' has been added on %3$s since the year %4$d (%5$s), applicable to the year %6$d.'),
-            LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, false),
+            $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
             $liturgicalEvent->name,
             $liturgicalEvent->strtotime,
             $decreeItem->metadata->since_year,
@@ -2646,12 +2646,12 @@ final class CalendarHandler extends AbstractHandler
                      * 8. Requested calendar year
                      */
                     _('The %1$s \'%2$s\', added on %3$s since the year %4$d (%5$s), is however superseded by the %6$s \'%7$s\' in the year %8$d.'),
-                    LitGrade::i18n($decreeItemLiturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                    $decreeItemLiturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                     '<i>' . $decreeItemLiturgicalEvent->name . '</i>',
                     $decreeItemLiturgicalEvent->strtotime,
                     $decreeItem->metadata->since_year,
                     $decreeItem->metadata->getUrl(),
-                    LitGrade::i18n($coincidingLiturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                    $coincidingLiturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                     '<i>' . $coincidingLiturgicalEvent->name . '</i>',
                     $this->CalendarParams->Year
                 );
@@ -2674,9 +2674,9 @@ final class CalendarHandler extends AbstractHandler
                                  */
                                 _('In the year %1$d, the %2$s \'%3$s\' has been suppressed by the %4$s \'%5$s\', added on %6$s since the year %7$d (%8$s).'),
                                 $this->CalendarParams->Year,
-                                LitGrade::i18n($coincidingLiturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                                $coincidingLiturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                                 '<i>' . $coincidingLiturgicalEvent->name . '</i>',
-                                LitGrade::i18n($decreeItemLiturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                                $decreeItemLiturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                                 '<i>' . $decreeItemLiturgicalEvent->name . '</i>',
                                 $decreeItemLiturgicalEvent->strtotime,
                                 $decreeItem->metadata->since_year,
@@ -2848,7 +2848,7 @@ final class CalendarHandler extends AbstractHandler
         $Easter    = $this->Cal->getLiturgicalEvent('Easter');
         $Pentecost = $this->Cal->getLiturgicalEvent('Pentecost');
         if (null === $Easter || null === $Pentecost) {
-            throw new \RuntimeException('For had He not died, He would not have risen again; and had He not risen again, no one would have believed in Him; and had no one believed in Him, no one would have been redeemed. (St. Augustine, Sermon 213)');
+            throw new ServiceUnavailableException('For had He not died, He would not have risen again; and had He not risen again, no one would have believed in Him; and had no one believed in Him, no one would have been redeemed. (St. Augustine, Sermon 213)');
         }
 
         $DoMEaster   = $Easter->date->format('j');    // day of the month of Easter
@@ -2911,7 +2911,7 @@ final class CalendarHandler extends AbstractHandler
         $BaptismLord  = $this->Cal->getLiturgicalEvent('BaptismLord');
         $AshWednesday = $this->Cal->getLiturgicalEvent('AshWednesday');
         if (null === $BaptismLord || null === $AshWednesday) {
-            throw new \RuntimeException('The Lord was baptized, not to be cleansed Himself, but to cleanse the waters, so that those waters, cleansed by the flesh of Christ who knew no sin, might have the power of baptism. (St. Ambrose of Milan - On the Mysteries, 4.20)');
+            throw new ServiceUnavailableException('The Lord was baptized, not to be cleansed Himself, but to cleanse the waters, so that those waters, cleansed by the flesh of Christ who knew no sin, might have the power of baptism. (St. Ambrose of Milan - On the Mysteries, 4.20)');
         }
         // In the first part of the year, weekdays of ordinary time begin the day after the Baptism of the Lord
         $FirstWeekdaysLowerLimit = $BaptismLord->date;
@@ -2962,7 +2962,7 @@ final class CalendarHandler extends AbstractHandler
 
         $Pentecost = $this->Cal->getLiturgicalEvent('Pentecost');
         if (null === $Pentecost) {
-            throw new \RuntimeException('Where the Church is, there is the Spirit of God; and where the Spirit of God is, there is the Church and every kind of grace. (St. Irenaeus of Lyons - Against Heresies III.17.2)');
+            throw new ServiceUnavailableException('Where the Church is, there is the Spirit of God; and where the Spirit of God is, there is the Church and every kind of grace. (St. Irenaeus of Lyons - Against Heresies III.17.2)');
         }
 
         // In the second part of the year, weekdays of ordinary time begin the day after Pentecost
@@ -3055,7 +3055,7 @@ final class CalendarHandler extends AbstractHandler
     private function loadWiderRegionData(): void
     {
         if (null === $this->NationalData) {
-            throw new \RuntimeException('loadNationalCalendarData() seems to not have produces results?');
+            throw new ServiceUnavailableException('loadNationalCalendarData() seems to not have produces results?');
         }
 
         $widerRegionDataFile = strtr(
@@ -3131,7 +3131,7 @@ final class CalendarHandler extends AbstractHandler
         if ($this->Cal->isSuppressed($litCalItem->liturgical_event->event_key)) {
             $suppressedEvent = $this->Cal->getSuppressedEventByKey($litCalItem->liturgical_event->event_key);
             if (null === $suppressedEvent) {
-                throw new \RuntimeException('Suppressed event not found, we expected to find it by its key ' . $litCalItem->liturgical_event->event_key . '.');
+                throw new ServiceUnavailableException('Suppressed event not found, we expected to find it by its key ' . $litCalItem->liturgical_event->event_key . '.');
             }
 
             // Let's check if it was suppressed by a Solemnity, Feast, Memorial or Sunday,
@@ -3165,7 +3165,7 @@ final class CalendarHandler extends AbstractHandler
                          * 7. National or wider region calendar
                          */
                         _('The %1$s \'%2$s\', usually celebrated on %3$s, was suppressed by the %4$s \'%5$s\' in the year %6$d, however being elevated to a Patronal festivity for the Calendar %7$s, it has been reinstated.'),
-                        LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                        $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                         $liturgicalEvent->name,
                         $this->dayAndMonth->format($suppressedEvent->date->format('U')),
                         $coincidingLiturgicalEvent->grade_lcl,
@@ -3185,7 +3185,7 @@ final class CalendarHandler extends AbstractHandler
                          * 7. National or wider region calendar
                          */
                         _('The %1$s \'%2$s\', usually celebrated on %3$s, was suppressed by the %4$s \'%5$s\' in the year %6$d, and though it would be elevated to a Patronal festivity for the Calendar %7$s, it has not been reinstated.'),
-                        LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                        $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                         $liturgicalEvent->name,
                         $this->dayAndMonth->format($suppressedEvent->date->format('U')),
                         $coincidingLiturgicalEvent->grade_lcl,
@@ -3304,7 +3304,7 @@ final class CalendarHandler extends AbstractHandler
                 //should we attempt to move to the next open slot?
                 $coincidingEvent = $this->Cal->solemnityFromDate($liturgicalEvent->date);
                 if (null === $coincidingEvent) {
-                    throw new \RuntimeException('No Solemnity found for ' . $liturgicalEvent->date->format('Y-m-d') . '; this was not expected, where did it go?');
+                    throw new ServiceUnavailableException('No Solemnity found for ' . $liturgicalEvent->date->format('Y-m-d') . '; this was not expected, where did it go?');
                 }
 
                 $this->Messages[] = '<span style="padding:3px 6px; font-weight: bold; background-color: #FFC;color:Red;border-radius:6px;">IMPORTANT</span> '
@@ -3406,7 +3406,7 @@ final class CalendarHandler extends AbstractHandler
                  * 6. Requested calendar year
                  */
                 _('The %1$s \'%2$s\' has been added on %3$s since the year %4$d (%5$s), applicable to the year %6$d.'),
-                LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                 $liturgicalEvent->name,
                 $dateStr,
                 $litEvent->metadata->since_year,
@@ -3433,7 +3433,7 @@ final class CalendarHandler extends AbstractHandler
                  * 4. Requested calendar year
                  */
                 _('The %1$s \'%2$s\' was not added to the calendar on %3$s because it conflicts with an existing liturgical event in the year %4$d.'),
-                LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                 $liturgicalEvent->name,
                 $dateStr,
                 $this->CalendarParams->Year
@@ -3502,7 +3502,7 @@ final class CalendarHandler extends AbstractHandler
                                          * 6. Requested calendar year
                                          */
                                         _('The name of the %1$s \'%2$s\' has been changed to \'%3$s\' in the national calendar \'%4$s\' since the year %5$d, applicable to the year %6$d.'),
-                                        LitGrade::i18n($existingLiturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                                        $existingLiturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                                         $existingLiturgicalEvent->name,
                                         $liturgicalEvent->name,
                                         $this->CalendarParams->NationalCalendar,
@@ -3547,9 +3547,9 @@ final class CalendarHandler extends AbstractHandler
                                          * 7. Requested calendar year
                                          */
                                         _('The grade of the %1$s \'%2$s\' has been changed to \'%3$s\' in the national calendar \'%4$s\' since the year %5$d (%6$s), applicable to the year %7$d.'),
-                                        LitGrade::i18n($existingLiturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                                        $existingLiturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                                         $existingLiturgicalEvent->name,
-                                        LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                                        $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                                         $this->CalendarParams->NationalCalendar,
                                         $litEventItem->metadata->since_year,
                                         $url,
@@ -3567,7 +3567,7 @@ final class CalendarHandler extends AbstractHandler
                                          */
                                         _('The grade of the celebration \'%1$s\' has been changed to \'%2$s\' in the national calendar \'%3$s\' since the year %4$d (%5$s), but could not be applied to the year %6$d because the celebration was not found.'),
                                         $liturgicalEvent->event_key,
-                                        LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                                        $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                                         $this->CalendarParams->NationalCalendar,
                                         $litEventItem->metadata->since_year,
                                         $url,
@@ -3588,7 +3588,7 @@ final class CalendarHandler extends AbstractHandler
                                 if ($this->Cal->isSuppressed($liturgicalEvent->event_key)) {
                                     $existingLitEvent = $this->Cal->getSuppressedEventByKey($liturgicalEvent->event_key);
                                     if (null === $existingLitEvent) {
-                                        throw new \RuntimeException('eh daje. Hemo provato a recuperare l\'evento dal calendario, e non c\'era. Hemo provato a recuperarlo dagli eventi soppressi, e non c\'era. Ma \'ndo è andato a fini\'?');
+                                        throw new ServiceUnavailableException('eh daje. Hemo provato a recuperare l\'evento dal calendario, e non c\'era. Hemo provato a recuperarlo dagli eventi soppressi, e non c\'era. Ma \'ndo è andato a fini\'?');
                                     }
                                     $this->Messages[] = sprintf(
                                         /**translators:
@@ -3601,7 +3601,7 @@ final class CalendarHandler extends AbstractHandler
                                          * 7. Requested calendar year
                                          */
                                         _('The %1$s \'%2$s\' has been moved from %3$s to %4$s since the year %5$d in the national calendar \'%6$s\', applicable to the year %7$d.'),
-                                        LitGrade::i18n($existingLitEvent->grade, $this->CalendarParams->Locale, false),
+                                        $existingLitEvent->grade->i18n($this->CalendarParams->Locale, false),
                                         $existingLitEvent->name,
                                         $this->dayAndMonth->format($existingLitEvent->date->format('U')),
                                         $this->dayAndMonth->format($litEventNewDate->format('U')),
@@ -3711,7 +3711,7 @@ final class CalendarHandler extends AbstractHandler
                             $keys        = array_keys(get_object_vars($propriumDeSanctisEvent));
                             $missingKeys = array_diff($requiredProps, $keys);
                             if (count($missingKeys) > 0) {
-                                throw new \RuntimeException(sprintf(
+                                throw new ServiceUnavailableException(sprintf(
                                     'The sanctorale data file for the %1$s does not contain the required fields to create a liturgical event: missing keys %2$s in event %3$s.',
                                     RomanMissal::getName($missal),
                                     implode(', ', $missingKeys),
@@ -3749,7 +3749,7 @@ final class CalendarHandler extends AbstractHandler
                                          * 7. Requested calendar year
                                          */
                                         $Nation . ': ' . _('The %1$s \'%2$s\' (%3$s), added to the national calendar in the %4$s, is superseded by the %5$s \'%6$s\' in the year %7$d'),
-                                        LitGrade::i18n($propriumDeSanctisEvent->grade, $this->CalendarParams->Locale, false),
+                                        $propriumDeSanctisEvent->grade->i18n($this->CalendarParams->Locale, false),
                                         '<i>' . $propriumDeSanctisEvent->name . '</i>',
                                         $this->dayAndMonth->format($currentLitEventDate->format('U')),
                                         RomanMissal::getName($missal),
@@ -3827,7 +3827,7 @@ final class CalendarHandler extends AbstractHandler
                     if ($this->Cal->isSuppressed($event_key)) {
                         $suppressedEvent = $this->Cal->getSuppressedEventByKey($event_key);
                         if (null === $suppressedEvent) {
-                            throw new \RuntimeException('Would you please make up your mind? First you tell me that the liturgical event ' . $event_key . ' is suppressed, ' .
+                            throw new ServiceUnavailableException('Would you please make up your mind? First you tell me that the liturgical event ' . $event_key . ' is suppressed, ' .
                                 'then you go on to tell me that it is nowhere to be found among the suppressed events?');
                         }
 
@@ -3854,7 +3854,7 @@ final class CalendarHandler extends AbstractHandler
                 $this->Messages[] = sprintf(
                     /**translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date */
                     _('The %1$s \'%2$s\' is transferred from %5$s to %6$s as per the %7$s, to make room for \'%3$s\': applicable to the year %4$d.'),
-                    LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale),
+                    $litEvent->grade->i18n($this->CalendarParams->Locale),
                     '<i>' . $litEvent->name . '</i>',
                     '<i>' . $inFavorOf . '</i>',
                     $this->CalendarParams->Year,
@@ -3878,7 +3878,7 @@ final class CalendarHandler extends AbstractHandler
                 $this->Messages[] = sprintf(
                     /**translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year */
                     _('The %1$s \'%2$s\' would have been transferred from %3$s to %4$s as per the %5$s, to make room for \'%6$s\', however it is suppressed by the %7$s \'%8$s\' in the year %9$d.'),
-                    LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale),
+                    $litEvent->grade->i18n($this->CalendarParams->Locale),
                     '<i>' . $litEvent->name . '</i>',
                     $oldDateStr,
                     $newDateStr,
@@ -4186,7 +4186,7 @@ final class CalendarHandler extends AbstractHandler
     private function applyDiocesanCalendar(): void
     {
         if ($this->DiocesanData === null) {
-            throw new \RuntimeException('Don\'t go asking me to apply a diocesan calendar if I don\'t have one!');
+            throw new ServiceUnavailableException('Don\'t go asking me to apply a diocesan calendar if I don\'t have one!');
         }
 
         foreach ($this->DiocesanData->litcal as $litCalItem) {
@@ -4222,7 +4222,7 @@ final class CalendarHandler extends AbstractHandler
                             // Should we attempt to move to the next open slot?
                             $coincidingSolemnity = $this->Cal->solemnityFromDate($currentLitEventDate);
                             if (null === $coincidingSolemnity) {
-                                throw new \RuntimeException('You tell me there\'s a solemnity on ' . $currentLitEventDate->format('Y-m-d') . ', but alas, no solemnity to be found! “What we see is merely a shadow of what is hidden.” (Plato, The Republic)');
+                                throw new ServiceUnavailableException('You tell me there\'s a solemnity on ' . $currentLitEventDate->format('Y-m-d') . ', but alas, no solemnity to be found! “What we see is merely a shadow of what is hidden.” (Plato, The Republic)');
                             }
                             $this->Messages[] = '<span style="padding:3px 6px; font-weight: bold; background-color: #FFC;color:Red;border-radius:6px;">IMPORTANT</span> '
                                 . $this->CalendarParams->DiocesanCalendar . ': '
@@ -4254,7 +4254,7 @@ final class CalendarHandler extends AbstractHandler
                         $this->Messages[] = $this->CalendarParams->DiocesanCalendar . ': ' . sprintf(
                             /**translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year */
                             _('The %1$s \'%2$s\', proper to the calendar of the %3$s and usually celebrated on %4$s, is suppressed by the %5$s %6$s in the year %7$d.'),
-                            LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, false),
+                            $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                             '<i>' . $liturgicalEvent->name . '</i>',
                             $this->DioceseName,
                             '<b>' . $this->dayAndMonth->format($currentLitEventDate->format('U')) . '</b>',
@@ -4552,16 +4552,19 @@ final class CalendarHandler extends AbstractHandler
      * internationalization functions. Also sets up the formatters for the
      * dates and ordinals, and loads the translation files for the
      * requested locale.
-     *
-     * @return string|false The locale set by this function, or false
-     *                      if the locale could not be set.
      */
-    private function prepareL10N(): string|false
+    private function prepareL10N(): void
     {
         $baseLocale = \Locale::getPrimaryLanguage($this->CalendarParams->Locale);
         if (null === $baseLocale) {
-            throw new \RuntimeException('“Pride was the reason for the division of tongues, humility the reason they were reunited.” - St. Augustine, The City of God, Book XVI, Chapter 4');
+            throw new ServiceUnavailableException('“Pride was the reason for the division of tongues, humility the reason they were reunited.” - St. Augustine, The City of God, Book XVI, Chapter 4');
         }
+
+        LiturgicalEvent::setLocale(
+            $this->CalendarParams->Locale === LitLocale::LATIN
+                ? LitLocale::LATIN_PRIMARY_LANGUAGE
+                : $this->CalendarParams->Locale
+        );
 
         LitLocale::$PRIMARY_LANGUAGE = $baseLocale;
         $localeArray                 = [
@@ -4576,14 +4579,44 @@ final class CalendarHandler extends AbstractHandler
             $baseLocale
         ];
 
-        $localeThatWasSet = setlocale(LC_ALL, $localeArray);
+        $runtimeLocale = setlocale(LC_ALL, $localeArray);
+        if (false === $runtimeLocale) {
+            throw new ServiceUnavailableException('Could not set locale to ' . $this->CalendarParams->Locale . '.');
+        }
+
+        // Example: "it_IT.UTF-8" → "it_IT"
+        $normalizedLocale = strtok($runtimeLocale, '.');
+
+        $languageEnv = implode(':', array_unique([
+            $runtimeLocale,
+            $normalizedLocale,
+            $baseLocale,
+            'en'
+        ]));
+        putenv("LANGUAGE={$languageEnv}");
+
+        LitLocale::$RUNTIME_LOCALE = $normalizedLocale;
+
+        // also update ICU’s default locale
+        \Locale::setDefault($normalizedLocale);
 
         $this->createFormatters();
-        bindtextdomain('litcal', Router::$apiFilePath . 'i18n');
-        textdomain('litcal');
 
-        $this->Cal = new LiturgicalEventCollection($this->CalendarParams);
-        return $localeThatWasSet;
+        if (false === is_dir(Router::$apiFilePath . 'i18n')) {
+            throw new ServiceUnavailableException('The i18n folder does not exist at path: ' . Router::$apiFilePath . 'i18n' . '.');
+        }
+
+        $textDomain = null;
+        if (false === bindtextdomain('litcal', Router::$apiFilePath . 'i18n')) {
+            throw new ServiceUnavailableException('Could not bind text domain for translations to path: ' . Router::$apiFilePath . 'i18n' . '.');
+        } else {
+            bind_textdomain_codeset('litcal', 'UTF-8');
+            $textDomain = textdomain('litcal');
+        }
+
+        if (null === $textDomain || $textDomain !== 'litcal') {
+            throw new ServiceUnavailableException('Could not set text domain for translations to \'litcal\'.');
+        }
     }
 
     /**
@@ -4791,9 +4824,9 @@ final class CalendarHandler extends AbstractHandler
             }
 
             if ($liturgicalEvent->event_key === 'DedicationLateran' || $liturgicalEvent->event_key === 'DedicationLateran_vigil') {
-                $displayGradeHTML = LitGrade::i18n(LitGrade::FEAST, $this->CalendarParams->Locale, true);
+                $displayGradeHTML = LitGrade::FEAST->i18n($this->CalendarParams->Locale, true);
             } elseif ($liturgicalEvent->grade_display === null) {
-                $displayGradeHTML = LitGrade::i18n($liturgicalEvent->grade, $this->CalendarParams->Locale, true);
+                $displayGradeHTML = $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, true);
             } else {
                 if ($liturgicalEvent->grade_display === '') {
                     $displayGradeHTML = '';
@@ -5006,8 +5039,9 @@ final class CalendarHandler extends AbstractHandler
         } else {
             $this->validateMinMaxYear();
 
-            $this->prepareL10N(); // the result could be stored in a variable $localeThatWasSet if it were to prove useful
-            LiturgicalEvent::setLocale($this->CalendarParams->Locale === LitLocale::LATIN ? LitLocale::LATIN_PRIMARY_LANGUAGE : $this->CalendarParams->Locale);
+            $this->prepareL10N();
+
+            $this->Cal = new LiturgicalEventCollection($this->CalendarParams);
 
             $this->calculateUniversalCalendar();
 

--- a/src/Models/Calendar/LitCommons.php
+++ b/src/Models/Calendar/LitCommons.php
@@ -195,7 +195,7 @@ final class LitCommons implements \JsonSerializable
         $fromTheCommon = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'De Commune' : _('From the Common');
 
         /** @var string[] $commonsLcl */
-        $commonsLcl = array_map(function ($litCommonItem) use ($locale, $fromTheCommon): string {
+        $commonsLcl = array_map(function (LitCommonItem $litCommonItem) use ($locale, $fromTheCommon): string {
             $commonGeneralStringParts = [ $fromTheCommon ];
 
             $possessive = self::getPossessive($litCommonItem->commonGeneral, $locale);
@@ -249,7 +249,7 @@ final class LitCommons implements \JsonSerializable
      */
     public static function i18n(LitCommon $litCommon, string $locale): string
     {
-        return $locale === LitLocale::LATIN || $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
+        return in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE])
             ? LitCommon::LATIN[$litCommon->name]
             : $litCommon->translate();
     }

--- a/src/Models/Calendar/LitCommons.php
+++ b/src/Models/Calendar/LitCommons.php
@@ -249,7 +249,7 @@ final class LitCommons implements \JsonSerializable
      */
     public static function i18n(LitCommon $litCommon, string $locale): string
     {
-        return in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE])
+        return in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true)
             ? LitCommon::LATIN[$litCommon->name]
             : $litCommon->translate();
     }
@@ -265,9 +265,9 @@ final class LitCommons implements \JsonSerializable
      * @param string $locale the locale in which to get the possessive form
      * @return string the possessive form for the given liturgical common
      */
-    private static function getPossessive(LitCommon $litCommon, $locale): string
+    private static function getPossessive(LitCommon $litCommon, string $locale): string
     {
-        return $locale === LitLocale::LATIN || $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
+        return in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true)
             ? ''
             : $litCommon->possessive();
     }

--- a/src/Models/Calendar/LiturgicalEvent.php
+++ b/src/Models/Calendar/LiturgicalEvent.php
@@ -97,11 +97,11 @@ final class LiturgicalEvent implements \JsonSerializable
         $this->name          = $name;
         $this->date          = $date; //DateTime object
         $this->color         = is_array($color) ? $color : [$color];
-        $this->color_lcl     = array_map(fn($item) => LitColor::i18n($item, self::$locale), $this->color);
+        $this->color_lcl     = array_map(fn(LitColor $item): string => $item->i18n(self::$locale), $this->color);
         $this->type          = $type;
         $this->grade         = $grade;
-        $this->grade_lcl     = LitGrade::i18n($this->grade, self::$locale, false, false);
-        $this->grade_abbr    = LitGrade::i18n($this->grade, self::$locale, false, true);
+        $this->grade_lcl     = $this->grade->i18n(self::$locale, false, false);
+        $this->grade_abbr    = $this->grade->i18n(self::$locale, false, true);
         $this->grade_display = $this->grade === LitGrade::HIGHER_SOLEMNITY ? '' : $displayGrade;
         $commons             = $common instanceof LitCommons || $common instanceof LitMassVariousNeeds || $litMassVariousNeedsArray
                                 ? $common
@@ -297,7 +297,7 @@ final class LiturgicalEvent implements \JsonSerializable
 
         if ($this->liturgical_season !== null) {
             $returnArr['liturgical_season']     = $this->liturgical_season->value;
-            $returnArr['liturgical_season_lcl'] = LitSeason::i18n($this->liturgical_season, self::$locale);
+            $returnArr['liturgical_season_lcl'] = $this->liturgical_season->i18n(self::$locale);
         }
 
         return $returnArr;
@@ -330,6 +330,8 @@ final class LiturgicalEvent implements \JsonSerializable
             self::$dayOfTheWeekLong  = $dowLongFormat;
             self::$monthShort        = $monthShortFormat;
             self::$monthLong         = $monthLongFormat;
+        } else {
+            throw new \InvalidArgumentException('The provided locale is not valid: ' . $locale . '.');
         }
     }
 

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -330,7 +330,7 @@ final class LiturgicalEventCollection
             if ($litEvent->grade === LitGrade::FEAST_LORD) {
                 $this->feastsLord->addEvent($litEvent);
             } else {
-                throw new \InvalidArgumentException('Trying to add a non feast: ' . $key . ' to Feasts of the Lord, liturgical event has grade: ' . LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale, false, false));
+                throw new \InvalidArgumentException('Trying to add a non feast: ' . $key . ' to Feasts of the Lord, liturgical event has grade: ' . $litEvent->grade->i18n($this->CalendarParams->Locale, false, false));
             }
         }
     }
@@ -783,8 +783,8 @@ final class LiturgicalEventCollection
             throw new \InvalidArgumentException('Invalid key: ' . $key . ' for LiturgicalEvents, valid keys are: ' . implode(', ', $this->liturgicalEvents->getKeys()));
         }
         // Update the grade_lcl and grade_abbr properties
-        $litEvent->setGradeLocalization(LitGrade::i18n($newGradeValue, $this->CalendarParams->Locale, false, false));
-        $litEvent->setGradeAbbreviation(LitGrade::i18n($newGradeValue, $this->CalendarParams->Locale, false, true));
+        $litEvent->setGradeLocalization($newGradeValue->i18n($this->CalendarParams->Locale, false, false));
+        $litEvent->setGradeAbbreviation($newGradeValue->i18n($this->CalendarParams->Locale, false, true));
 
         if ($newGradeValue->value >= LitGrade::FEAST_LORD->value) {
             $this->solemnities->addEvent($litEvent);
@@ -1493,9 +1493,9 @@ final class LiturgicalEventCollection
             $litEventGradeLcl = $this->CalendarParams->Locale === LitLocale::LATIN ? 'Die Domini' : ucfirst($dayOfTheWeek);
         } else {
             if ($litEvent->grade->value > LitGrade::SOLEMNITY->value) {
-                $litEventGradeLcl = '<i>' . LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale, false) . '</i>';
+                $litEventGradeLcl = '<i>' . $litEvent->grade->i18n($this->CalendarParams->Locale, false) . '</i>';
             } else {
-                $litEventGradeLcl = LitGrade::i18n($litEvent->grade, $this->CalendarParams->Locale, false);
+                $litEventGradeLcl = $litEvent->grade->i18n($this->CalendarParams->Locale, false);
             }
         }
 
@@ -1533,8 +1533,8 @@ final class LiturgicalEventCollection
                         //it's a Feast of the Lord or a Solemnity
                         $coincidingEvent->grade_lcl = (
                             $coincidingEvent->event->grade->value > LitGrade::SOLEMNITY->value
-                                ? '<i>' . LitGrade::i18n($coincidingEvent->event->grade, $this->CalendarParams->Locale, false) . '</i>'
-                                : LitGrade::i18n($coincidingEvent->event->grade, $this->CalendarParams->Locale, false)
+                                ? '<i>' . $coincidingEvent->event->grade->i18n($this->CalendarParams->Locale, false) . '</i>'
+                                : $coincidingEvent->event->grade->i18n($this->CalendarParams->Locale, false)
                         );
                     }
 
@@ -1744,15 +1744,15 @@ final class LiturgicalEventCollection
             }
             $coincidingEvent->event     = $liturgicalEvent;
             $coincidingEvent->grade_lcl = ( $coincidingEvent->event->grade->value > LitGrade::SOLEMNITY->value
-                ? '<i>' . LitGrade::i18n($coincidingEvent->event->grade, $this->CalendarParams->Locale, false) . '</i>'
-                : LitGrade::i18n($coincidingEvent->event->grade, $this->CalendarParams->Locale, false) );
+                ? '<i>' . $coincidingEvent->event->grade->i18n($this->CalendarParams->Locale, false) . '</i>'
+                : $coincidingEvent->event->grade->i18n($this->CalendarParams->Locale, false) );
         } elseif ($this->inFeastsOrMemorials($currentLitEventDate)) {
             $liturgicalEvent = $this->feastOrMemorialFromDate($currentLitEventDate);
             if (null === $liturgicalEvent) {
                 throw new \RuntimeException('No Feast or Memorial found for ' . $currentLitEventDate->format('Y-m-d'));
             }
             $coincidingEvent->event     = $liturgicalEvent;
-            $coincidingEvent->grade_lcl = LitGrade::i18n($coincidingEvent->event->grade, $this->CalendarParams->Locale, false);
+            $coincidingEvent->grade_lcl = $coincidingEvent->event->grade->i18n($this->CalendarParams->Locale, false);
         } else {
             // DEBUG START
             $isSunday = self::dateIsSunday($currentLitEventDate);

--- a/src/Models/EventsPath/LiturgicalEventAbstract.php
+++ b/src/Models/EventsPath/LiturgicalEventAbstract.php
@@ -69,11 +69,11 @@ abstract class LiturgicalEventAbstract implements \JsonSerializable
         $this->event_key     = $event_key;
         $this->name          = $name;
         $this->color         = is_array($color) ? $color : [$color];
-        $this->color_lcl     = array_map(fn($item) => LitColor::i18n($item, self::$locale), $this->color);
+        $this->color_lcl     = array_map(fn(LitColor $item): string => $item->i18n(self::$locale), $this->color);
         $this->type          = $type;
         $this->grade         = $grade;
-        $this->grade_lcl     = LitGrade::i18n($this->grade, self::$locale, false, false);
-        $this->grade_abbr    = LitGrade::i18n($this->grade, self::$locale, false, true);
+        $this->grade_lcl     = $this->grade->i18n(self::$locale, false, false);
+        $this->grade_abbr    = $this->grade->i18n(self::$locale, false, true);
         $this->grade_display = $this->grade === LitGrade::HIGHER_SOLEMNITY ? '' : $displayGrade;
         $commons             = $common instanceof LitCommons || $common instanceof LitMassVariousNeeds || $litMassVariousNeedsArray
                                 ? $common

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -453,13 +453,13 @@ class Utilities
         if ($html === true) {
             $colorStrings = array_map(function (LitColor $litColor) use ($locale) {
                 return '<B><I><SPAN LANG=' . strtolower($locale) . '><FONT FACE="Calibri" COLOR="' . self::colorToHex($litColor->value) . '">'
-                    . LitColor::i18n($litColor, $locale)
+                    . $litColor->i18n($locale)
                     . '</FONT></SPAN></I></B>';
             }, $colors);
             return implode(' <I><FONT FACE="Calibri">' . _('or') . '</FONT></I> ', $colorStrings);
         } else {
             $colorStrings = array_map(function (LitColor $txt) use ($locale) {
-                return LitColor::i18n($txt, $locale);
+                return $txt->i18n($locale);
             }, $colors);
 
             $or = $locale === LitLocale::LATIN || $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'vel' : _('or');

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -452,7 +452,8 @@ class Utilities
     {
         if ($html === true) {
             $colorStrings = array_map(function (LitColor $litColor) use ($locale) {
-                return '<B><I><SPAN LANG=' . strtolower($locale) . '><FONT FACE="Calibri" COLOR="' . self::colorToHex($litColor->value) . '">'
+                $langAttr = htmlspecialchars(strtolower($locale), ENT_QUOTES, 'UTF-8');
+                return '<B><I><SPAN LANG=' . $langAttr . '><FONT FACE="Calibri" COLOR="' . self::colorToHex($litColor->value) . '">'
                     . $litColor->i18n($locale)
                     . '</FONT></SPAN></I></B>';
             }, $colors);


### PR DESCRIPTION
# Issue being addressed
addresses issue #345

# Summary of changes
* refactor Enum static i18n methods to instance methods
* ensure correct locale environment is set (`LANGUAGE` environment variable should be set)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Broader Latin localization and more consistent translations for colors, grades, and seasons.
  - Default runtime locale (en_US) is applied automatically.
  - Improved grade labels/abbreviations; invalid grades now display user-friendly text.

- Bug Fixes
  - Locale is initialized earlier to ensure correct, locale-aware calendar output.
  - Stricter validation prevents misconfigured locales and missing translation resources.
  - Clearer, more informative error messages when data or translations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->