### PR TITLE
Catch PHP warnings as exceptions and implement logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
         "guzzlehttp/guzzle": "^7.10",
         "symfony/semaphore": "^7.3",
         "symfony/lock": "^7.3",
-        "react/filesystem": "0.2.x-dev"
+        "react/filesystem": "0.2.x-dev",
+        "psr/log": "^3.0",
+        "monolog/monolog": "^3.9"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c9f6df2d22c3cddec0fb0a5c7f029cd",
+    "content-hash": "18b9f8bb18fd98bf985f57a2dca7c704",
     "packages": [
         {
             "name": "cboden/ratchet",
@@ -569,6 +569,109 @@
                 }
             ],
             "time": "2025-05-13T21:21:16+00:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "3.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
+            },
+            "provide": {
+                "psr/log-implementation": "3.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "^3.0",
+                "doctrine/couchdb": "~1.0@dev",
+                "elasticsearch/elasticsearch": "^7 || ^8",
+                "ext-json": "*",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.2",
+                "mongodb/mongodb": "^1.8",
+                "php-amqplib/php-amqplib": "~2.4 || ^3",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
+                "symfony/mailer": "^5.4 || ^6",
+                "symfony/mime": "^5.4 || ^6"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "elasticsearch/elasticsearch": "Allow sending log messages to an Elasticsearch server via official client",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-curl": "Required to send log messages using the IFTTTHandler, the LogglyHandler, the SendGridHandler, the SlackWebhookHandler or the TelegramBotHandler",
+                "ext-mbstring": "Allow to work properly with unicode symbols",
+                "ext-mongodb": "Allow sending log messages to a MongoDB server (via driver)",
+                "ext-openssl": "Required to send log messages using SSL",
+                "ext-sockets": "Allow sending log messages to a Syslog server (via UDP driver)",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "mongodb/mongodb": "Allow sending log messages to a MongoDB server (via library)",
+                "php-amqplib/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "https://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "https://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/monolog/issues",
+                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/monolog/monolog",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-03-24T10:02:05+00:00"
         },
         {
             "name": "nyholm/psr7",

--- a/public/index.php
+++ b/public/index.php
@@ -81,11 +81,9 @@ if (
     ini_set('log_errors', 1);
     ini_set('error_log', $logFile);
     error_reporting(E_ALL);
-    // Get microtime as string "msec sec"
-    list($msec, $sec) = explode(' ', microtime(false));
-    // Create DateTime with microseconds
-    $usec = substr($msec, 2, 6);
-    $dt   = DateTimeImmutable::createFromFormat('U.u', $sec . '.' . $usec);
+    // Get current time with microseconds
+    $microtime = microtime(true);
+    $dt        = DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $microtime));
     // Check for errors
     if ($dt === false) {
         $errors = DateTimeImmutable::getLastErrors();

--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -541,13 +541,10 @@ abstract class AbstractHandler implements RequestHandlerInterface
                     throw new ImplementationException('YAML extension not loaded');
                 }
 
-                set_error_handler([self::class, 'warningHandler'], E_WARNING);
                 try {
                     $parsedBody = yaml_parse($rawBodyContents);
                 } catch (\ErrorException $e) {
                     throw new YamlException($e->getMessage(), StatusCode::UNPROCESSABLE_CONTENT->value, $e);
-                } finally {
-                    restore_error_handler();
                 }
                 break;
             case RequestContentType::FORMDATA:
@@ -628,7 +625,6 @@ abstract class AbstractHandler implements RequestHandlerInterface
                     throw new ImplementationException('YAML extension not loaded');
                 }
 
-                set_error_handler([self::class, 'warningHandler'], E_WARNING);
                 try {
                     $parsedBody = yaml_parse($rawBodyContents);
                     if (false === is_array($parsedBody) || empty($parsedBody)) {
@@ -650,8 +646,6 @@ abstract class AbstractHandler implements RequestHandlerInterface
                     }
                 } catch (\ErrorException $e) {
                     throw new YamlException($e->getMessage(), StatusCode::UNPROCESSABLE_CONTENT->value, $e);
-                } finally {
-                    restore_error_handler();
                 }
                 break;
             default:
@@ -689,13 +683,10 @@ abstract class AbstractHandler implements RequestHandlerInterface
                 $recodedResponse     = json_decode($jsonEncodedResponse, true, 512, JSON_THROW_ON_ERROR);
 
                 // Then we attempt to encode the array as YAML
-                set_error_handler([static::class, 'warningHandler'], E_WARNING);
                 try {
                     $encodedResponse = yaml_emit($recodedResponse, YAML_UTF8_ENCODING);
                 } catch (\ErrorException $e) {
                     throw new YamlException($e->getMessage(), StatusCode::UNPROCESSABLE_CONTENT->value, $e);
-                } finally {
-                    restore_error_handler();
                 }
                 break;
             default:

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4486,13 +4486,10 @@ final class CalendarHandler extends AbstractHandler
                     throw new ImplementationException('YAML extension not loaded');
                 }
                 $jsonArr = Utilities::objectToArray($SerializeableLitCal);
-                set_error_handler([static::class, 'warningHandler'], E_WARNING);
                 try {
                     $responseBody = yaml_emit($jsonArr, YAML_UTF8_ENCODING);
                 } catch (\ErrorException $e) {
                     throw new YamlException($e->getMessage(), StatusCode::UNPROCESSABLE_CONTENT->value, $e);
-                } finally {
-                    restore_error_handler();
                 }
                 break;
             case ReturnTypeParam::ICS:

--- a/src/Handlers/MetadataHandler.php
+++ b/src/Handlers/MetadataHandler.php
@@ -302,13 +302,10 @@ final class MetadataHandler extends AbstractHandler
                     }
                     $responseBodyObj = json_decode($responseBody, true, 512, JSON_THROW_ON_ERROR);
 
-                    set_error_handler([static::class, 'warningHandler'], E_WARNING);
                     try {
                         $yamlEncodedResponse = yaml_emit($responseBodyObj, YAML_UTF8_ENCODING);
                     } catch (\ErrorException $e) {
                         throw new YamlException($e->getMessage(), StatusCode::UNPROCESSABLE_CONTENT->value, $e);
-                    } finally {
-                        restore_error_handler();
                     }
                     return $response->withStatus(StatusCode::OK->value, StatusCode::OK->reason())->withBody(Stream::create($yamlEncodedResponse));
                     // no break needed

--- a/src/Http/Logs/LoggerFactory.php
+++ b/src/Http/Logs/LoggerFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Http\Logs;
+
+use LiturgicalCalendar\Api\Http\Logs\PrettyLineFormatter;
+use Monolog\Level;
+use Monolog\Logger;
+use Monolog\Handler\RotatingFileHandler;
+use Monolog\Formatter\JsonFormatter;
+use Monolog\Processor\WebProcessor;
+
+class LoggerFactory
+{
+    public static function createApiLogger(string $logsFolder, bool $debug = false, ?RequestResponseProcessor $processor = null): Logger
+    {
+        $logger = new Logger('litcalapi');
+
+        // --- Plain text rotating file ---
+        $plainHandler   = new RotatingFileHandler($logsFolder . '/api.log', 30, $debug ? Level::Debug : Level::Info);
+        $plainFormatter = new PrettyLineFormatter(
+            "[%datetime%] %level_name%: %message%\n",
+            'Y-m-d H:i:s',
+            true,
+            true,
+            false
+        );
+        $plainHandler->setFormatter($plainFormatter);
+        $logger->pushHandler($plainHandler);
+
+        // --- JSON rotating file (for aggregation) ---
+        $jsonHandler   = new RotatingFileHandler($logsFolder . '/api.json.log', 30, $debug ? Level::Debug : Level::Info);
+        $jsonFormatter = new JsonFormatter(JsonFormatter::BATCH_MODE_JSON, true);
+        $jsonHandler->setFormatter($jsonFormatter);
+        $logger->pushHandler($jsonHandler);
+
+        // --- WebProcessor adds request info automatically ---
+        $logger->pushProcessor(new WebProcessor()); // adds url, method, server params, etc.
+
+        if ($processor !== null) {
+            $logger->pushProcessor($processor);
+        }
+
+        return $logger;
+    }
+}

--- a/src/Http/Logs/PrettyLineFormatter.php
+++ b/src/Http/Logs/PrettyLineFormatter.php
@@ -69,7 +69,6 @@ class PrettyLineFormatter extends LineFormatter
             Level::Critical  => "\033[1;31m", // Bright Red
             Level::Alert     => "\033[1;33m", // Bright Yellow
             Level::Emergency => "\033[1;41m", // Red background
-            default          => self::NC      // No color
         };
     }
 

--- a/src/Http/Logs/PrettyLineFormatter.php
+++ b/src/Http/Logs/PrettyLineFormatter.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Http\Logs;
+
+use Monolog\Formatter\LineFormatter;
+use Monolog\LogRecord;
+
+class PrettyLineFormatter extends LineFormatter
+{
+    private const COLORS = [
+        'DEBUG'     => "\033[0;34m", // Blue
+        'INFO'      => "\033[0;32m", // Green
+        'NOTICE'    => "\033[0;36m", // Cyan
+        'WARNING'   => "\033[0;33m", // Yellow
+        'ERROR'     => "\033[0;31m", // Red
+        'CRITICAL'  => "\033[1;31m", // Bright Red
+        'ALERT'     => "\033[1;33m", // Bright Yellow
+        'EMERGENCY' => "\033[1;41m", // Red background
+    ];
+
+    private const NC = "\033[0m"; // Reset
+
+    public function format(LogRecord $record): string
+    {
+        $levelName = strtoupper($record->level->name);
+
+        $color          = self::COLORS[$levelName] ?? self::NC;
+        $coloredMessage = $color . $record->message . self::NC;
+        $record         = $record->with(message: $coloredMessage);
+
+        // Format main message + stack trace
+        $output = parent::format($record);
+
+        // Append extra fields in pretty-printed form
+        if (!empty($record->extra)) {
+            $output .= "Extra:\n" . $this->prettyPrint($record->extra, 1) . "\n";
+        }
+
+        return $output;
+    }
+
+    private function prettyPrint(mixed $value, int $level = 0): string
+    {
+        $indent = str_repeat('    ', $level);
+
+        if (is_scalar($value) || $value === null) {
+            return $indent . (string) $value;
+        }
+
+        if (is_array($value)) {
+            $lines = [];
+            foreach ($value as $k => $v) {
+                $prefix = $indent . $k . ': ';
+                if (is_array($v) || is_object($v)) {
+                    $lines[] = $indent . $k . ':';
+                    $lines[] = $this->prettyPrint($v, $level + 1);
+                } else {
+                    $lines[] = $prefix . $this->prettyPrint($v, 0);
+                }
+            }
+            return implode("\n", $lines);
+        }
+
+        if (is_object($value)) {
+            // convert to array for logging
+            return $this->prettyPrint(get_object_vars($value), $level);
+        }
+
+        return $indent . '[unserializable]';
+    }
+}

--- a/src/Http/Logs/PrettyLineFormatter.php
+++ b/src/Http/Logs/PrettyLineFormatter.php
@@ -3,30 +3,16 @@
 namespace LiturgicalCalendar\Api\Http\Logs;
 
 use Monolog\Formatter\LineFormatter;
+use Monolog\Level;
 use Monolog\LogRecord;
 
 class PrettyLineFormatter extends LineFormatter
 {
-    private const COLORS = [
-        'DEBUG'     => "\033[0;34m", // Blue
-        'INFO'      => "\033[0;32m", // Green
-        'NOTICE'    => "\033[0;36m", // Cyan
-        'WARNING'   => "\033[0;33m", // Yellow
-        'ERROR'     => "\033[0;31m", // Red
-        'CRITICAL'  => "\033[1;31m", // Bright Red
-        'ALERT'     => "\033[1;33m", // Bright Yellow
-        'EMERGENCY' => "\033[1;41m", // Red background
-    ];
-
     private const NC = "\033[0m"; // Reset
 
     public function format(LogRecord $record): string
     {
-        $levelName = strtoupper($record->level->name);
-
-        $color          = self::COLORS[$levelName] ?? self::NC;
-        $coloredMessage = $color . $record->message . self::NC;
-        $record         = $record->with(message: $coloredMessage);
+        $record = $this->applyColorToMessage($record);
 
         // Format main message + stack trace
         $output = parent::format($record);
@@ -39,8 +25,11 @@ class PrettyLineFormatter extends LineFormatter
         return $output;
     }
 
-    private function prettyPrint(mixed $value, int $level = 0): string
+    private function prettyPrint(mixed $value, int $level = 0, int $maxDepth = 10): string
     {
+        if ($level > $maxDepth) {
+            return str_repeat('    ', $level) . '[max depth reached]';
+        }
         $indent = str_repeat('    ', $level);
 
         if (is_scalar($value) || $value === null) {
@@ -53,9 +42,9 @@ class PrettyLineFormatter extends LineFormatter
                 $prefix = $indent . $k . ': ';
                 if (is_array($v) || is_object($v)) {
                     $lines[] = $indent . $k . ':';
-                    $lines[] = $this->prettyPrint($v, $level + 1);
+                    $lines[] = $this->prettyPrint($v, $level + 1, $maxDepth);
                 } else {
-                    $lines[] = $prefix . $this->prettyPrint($v, 0);
+                    $lines[] = $prefix . $this->prettyPrint($v, 0, $maxDepth);
                 }
             }
             return implode("\n", $lines);
@@ -63,9 +52,31 @@ class PrettyLineFormatter extends LineFormatter
 
         if (is_object($value)) {
             // convert to array for logging
-            return $this->prettyPrint(get_object_vars($value), $level);
+            return $this->prettyPrint(get_object_vars($value), $level, $maxDepth);
         }
 
         return $indent . '[unserializable]';
+    }
+
+    private static function logLevelToColor(Level $level): string
+    {
+        return match ($level) {
+            Level::Debug     => "\033[0;34m", // Blue
+            Level::Info      => "\033[0;32m", // Green
+            Level::Notice    => "\033[0;36m", // Cyan
+            Level::Warning   => "\033[0;33m", // Yellow
+            Level::Error     => "\033[0;31m", // Red
+            Level::Critical  => "\033[1;31m", // Bright Red
+            Level::Alert     => "\033[1;33m", // Bright Yellow
+            Level::Emergency => "\033[1;41m", // Red background
+            default          => self::NC      // No color
+        };
+    }
+
+    private static function applyColorToMessage(LogRecord $record): LogRecord
+    {
+        $color          = self::logLevelToColor($record->level);
+        $coloredMessage = $color . $record->message . self::NC;
+        return $record->with(message: $coloredMessage);
     }
 }

--- a/src/Http/Logs/RequestResponseProcessor.php
+++ b/src/Http/Logs/RequestResponseProcessor.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Http\Logs;
+
+use Monolog\LogRecord;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class RequestResponseProcessor
+{
+    private ?ServerRequestInterface $request = null;
+    private ?ResponseInterface $response     = null;
+    private const RED                        = "\033[0;31m";
+    private const GREEN                      = "\033[0;32m";
+    private const YELLOW                     = "\033[0;33m";
+    private const BLUE                       = "\033[0;34m";
+    private const NC                         = "\033[0m"; // No Color
+
+    public function setRequest(ServerRequestInterface $request): void
+    {
+        $this->request = $request;
+    }
+
+    public function setResponse(ResponseInterface $response): void
+    {
+        $this->response = $response;
+    }
+
+    public function __invoke(LogRecord $record): LogRecord
+    {
+        if (( $record->context['type'] ?? null ) === 'request' && $this->request) {
+            $protocol = $this->request->getProtocolVersion();
+
+            // add extra fields
+            $record = $record->with(extra: array_merge($record->extra, [
+                'request_id' => $this->request->getAttribute('request_id'),
+                'protocol'   => "HTTP/{$protocol}",
+                'headers'    => $this->request->getHeaders(),
+                'pid'        => getmypid(),
+            ]));
+
+            $coloredMessage = self::BLUE . $record->message . self::NC;
+            $record         = $record->with(message: $coloredMessage);
+        }
+
+        if (( $record->context['type'] ?? null ) === 'response') {
+            if ($this->response) {
+                $status   = $this->response->getStatusCode();
+                $protocol = $this->response->getProtocolVersion();
+
+                // add extra fields
+                $record = $record->with(extra: array_merge($record->extra, [
+                    'response_id' => $this->request->getAttribute('request_id'),
+                    'status_code' => $status,
+                    'protocol'    => "HTTP/{$protocol}",
+                    'pid'         => getmypid(),
+                ]));
+
+                // Change color depending on status
+                $coloredMessage = $record->message;
+                if ($status >= 500) {
+                    $coloredMessage = self::RED . $record->message . self::NC;
+                } elseif ($status >= 400) {
+                    $coloredMessage = self::YELLOW . $record->message . self::NC;
+                } else {
+                    $coloredMessage = self::GREEN . $record->message . self::NC;
+                }
+                $record = $record->with(message: $coloredMessage);
+            } else {
+                // No response yet → just skip modification
+                return $record;
+            }
+        }
+
+        return $record;
+    }
+}

--- a/src/Http/Logs/RequestResponseProcessor.php
+++ b/src/Http/Logs/RequestResponseProcessor.php
@@ -33,10 +33,10 @@ class RequestResponseProcessor
 
             // add extra fields
             $record = $record->with(extra: array_merge($record->extra, [
-                'request_id' => $this->request->getAttribute('request_id'),
-                'protocol'   => "HTTP/{$protocol}",
-                'headers'    => $this->request->getHeaders(),
                 'pid'        => getmypid(),
+                'protocol'   => "HTTP/{$protocol}",
+                //'headers'    => $this->request->getHeaders(),
+                'request_id' => $this->request->getAttribute('request_id'),
             ]));
 
             $coloredMessage = self::BLUE . $record->message . self::NC;
@@ -49,12 +49,16 @@ class RequestResponseProcessor
                 $protocol = $this->response->getProtocolVersion();
 
                 // add extra fields
-                $record = $record->with(extra: array_merge($record->extra, [
-                    'response_id' => $this->request->getAttribute('request_id'),
+                $extraFields = [
                     'status_code' => $status,
-                    'protocol'    => "HTTP/{$protocol}",
                     'pid'         => getmypid(),
-                ]));
+                    'protocol'    => "HTTP/{$protocol}",
+                    'headers'     => $this->response->getHeaders(),
+                ];
+                if ($this->request !== null) {
+                    $extraFields['response_id'] = $this->request->getAttribute('request_id');
+                }
+                $record = $record->with(extra: array_merge($record->extra, $extraFields));
 
                 // Change color depending on status
                 $coloredMessage = $record->message;

--- a/src/Http/Middleware/LoggingMiddleware.php
+++ b/src/Http/Middleware/LoggingMiddleware.php
@@ -2,6 +2,10 @@
 
 namespace LiturgicalCalendar\Api\Http\Middleware;
 
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use LiturgicalCalendar\Api\Http\Logs\RequestResponseProcessor;
+use LiturgicalCalendar\Api\Router;
+use Monolog\Logger;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Server\MiddlewareInterface;
@@ -9,13 +13,49 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class LoggingMiddleware implements MiddlewareInterface
 {
+    private static string $logsFolder;
+    private Logger $logger;
+    private RequestResponseProcessor $processor;
+
+    public function __construct(bool $debug = false)
+    {
+        if (false === isset(self::$logsFolder)) {
+            self::$logsFolder = Router::$apiFilePath . 'logs';
+            if (!file_exists(self::$logsFolder)) {
+                mkdir(self::$logsFolder);
+            }
+        }
+
+        $this->processor = new RequestResponseProcessor();
+        $this->logger    = LoggerFactory::createApiLogger(self::$logsFolder, $debug, $this->processor);
+    }
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        error_log('Incoming request: ' . $request->getMethod() . ' ' . $request->getUri());
+        $requestId = $request->getAttribute('request_id');
+
+        $this->processor->setRequest($request);
+        $this->logger->debug('Incoming request', [
+            'request_id' => $requestId,
+            'headers'    => $request->getHeaders(),
+            'query'      => $request->getQueryParams(),
+            'body'       => (string) $request->getBody(),
+            'type'       => 'request',
+            'pid'        => getmypid(),
+        ]);
 
         $response = $handler->handle($request);
 
-        error_log('Outgoing response: ' . $response->getStatusCode());
+        // Add response context to log entries
+        $this->processor->setResponse($response);
+        $this->logger->debug('Outgoing response', [
+            'request_id' => $requestId,
+            'status'     => $response->getStatusCode(),
+            'headers'    => $response->getHeaders(),
+            'body'       => (string) $response->getBody(),
+            'type'       => 'response',
+            'pid'        => getmypid(),
+        ]);
 
         return $response;
     }

--- a/src/Router.php
+++ b/src/Router.php
@@ -87,6 +87,7 @@ class Router
             case E_USER_NOTICE:
             case E_DEPRECATED:
             case E_USER_DEPRECATED:
+            case E_RECOVERABLE_ERROR:
                 throw new \ErrorException($errstr, 0, $errno, $errfile, $errline);
 
             default:


### PR DESCRIPTION
Escalate PHP warnings to exceptions to ensure they are processed by the ErrorHandlingMiddleware. Introduce PSR-3 compliant logging using Monolog and a custom LoggingMiddleware for better error tracking. Additionally, remove unnecessary default cases in enum matches and implement suggestions from CodeRabbit.

Fixes #360