### PR TITLE
Feature/conditional rules issue 206

### DIFF
--- a/jsondata/schemas/CommonDef.json
+++ b/jsondata/schemas/CommonDef.json
@@ -8138,42 +8138,62 @@
             "properties": {
                 "condition": {
                     "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "if_weekday": {
-                            "type": "string",
-                            "enum": [
-                                "sunday",
-                                "monday",
-                                "tuesday",
-                                "wednesday",
-                                "thursday",
-                                "friday",
-                                "saturday"
-                            ]
+                    "oneOf": [
+                        {
+                            "required": ["if_weekday"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "if_weekday": {
+                                    "type": "string",
+                                    "enum": [
+                                        "sunday",
+                                        "monday",
+                                        "tuesday",
+                                        "wednesday",
+                                        "thursday",
+                                        "friday",
+                                        "saturday"
+                                    ]
+                                }
+                            }
                         },
-                        "if_grade": {
-                            "type": "integer",
-                            "minimum": 0,
-                            "maximum": 7
+                        {
+                            "required": ["if_grade"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "if_grade": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 7
+                                }
+                            }
                         }
-                    },
-                    "minProperties": 1
+                    ]
                 },
                 "then": {
                     "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "move": {
-                            "type": "string",
-                            "pattern": "^\\-?P\\d+D$"
+                    "oneOf": [
+                        {
+                            "required": ["move"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "move": {
+                                    "type": "string",
+                                    "pattern": "^\\-?P\\d+D$"
+                                }
+                            }
                         },
-                        "move_to": {
-                            "type": "string",
-                            "pattern": "^(next|previous) (monday|tuesday|wednesday|thursday|friday|saturday|sunday)$"
+                        {
+                            "required": ["move_to"],
+                            "additionalProperties": false,
+                            "properties": {
+                                "move_to": {
+                                    "type": "string",
+                                    "pattern": "^(next|previous) (monday|tuesday|wednesday|thursday|friday|saturday|sunday)$"
+                                }
+                            }
                         }
-                    },
-                    "minProperties": 1
+                    ]
                 }
             },
             "required": [

--- a/jsondata/schemas/CommonDef.json
+++ b/jsondata/schemas/CommonDef.json
@@ -8131,6 +8131,53 @@
                 "Pacific/Wake",
                 "Pacific/Wallis"
             ]
+        },
+        "ConditionalRule": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "condition": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "if_weekday": {
+                            "type": "string",
+                            "enum": [
+                                "sunday",
+                                "monday",
+                                "tuesday",
+                                "wednesday",
+                                "thursday",
+                                "friday",
+                                "saturday"
+                            ]
+                        },
+                        "if_grade": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 7
+                        }
+                    }
+                },
+                "then": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "move": {
+                            "type": "string",
+                            "pattern": "^[PM]\\d+[DWMY]$"
+                        },
+                        "move_to": {
+                            "type": "string",
+                            "pattern": "^(next|previous) (monday|tuesday|wednesday|thursday|friday|saturday|sunday)$"
+                        }
+                    }
+                }
+            },
+            "required": [
+                "condition",
+                "then"
+            ]
         }
     }
 }

--- a/jsondata/schemas/CommonDef.json
+++ b/jsondata/schemas/CommonDef.json
@@ -8157,7 +8157,8 @@
                             "minimum": 0,
                             "maximum": 7
                         }
-                    }
+                    },
+                    "minProperties": 1
                 },
                 "then": {
                     "type": "object",
@@ -8165,13 +8166,14 @@
                     "properties": {
                         "move": {
                             "type": "string",
-                            "pattern": "^[PM]\\d+[DWMY]$"
+                            "pattern": "^\\-?P\\d+D$"
                         },
                         "move_to": {
                             "type": "string",
                             "pattern": "^(next|previous) (monday|tuesday|wednesday|thursday|friday|saturday|sunday)$"
                         }
-                    }
+                    },
+                    "minProperties": 1
                 }
             },
             "required": [

--- a/jsondata/schemas/NationalCalendar.json
+++ b/jsondata/schemas/NationalCalendar.json
@@ -63,6 +63,12 @@
                         "grade": {
                             "$ref": "./CommonDef.json#/definitions/LitGrade"
                         },
+                        "grade_display": {
+                            "type": [
+                                "string",
+                                "null"
+                            ]
+                        },
                         "day": {
                             "$ref": "./CommonDef.json#/definitions/Day"
                         },
@@ -159,6 +165,13 @@
                 },
                 "until_year": {
                     "type": "integer"
+                },
+                "rules": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "./CommonDef.json#/definitions/ConditionalRule"
+                    },
+                    "description": "An array of conditional rules that apply to this event, for example moving the date if it falls on a Sunday."
                 }
             },
             "required": [

--- a/jsondata/sourcedata/calendars/nations/US/US.json
+++ b/jsondata/sourcedata/calendars/nations/US/US.json
@@ -87,6 +87,37 @@
                 "reason": "Independence Day",
                 "since_year": 1970
             }
+        },
+        {
+            "liturgical_event": {
+                "event_key": "PrayerUnborn",
+                "day": 22,
+                "month": 1,
+                "grade": 3,
+                "grade_display": "National Day of Prayer",
+                "common": [
+                    "For Giving Thanks to God for the Gift of Human Life [USA]",
+                    "For the Preservation of Peace and Justice"
+                ],
+                "color": [
+                    "purple",
+                    "white"
+                ]
+            },
+            "metadata": {
+                "action": "createNew",
+                "since_year": 2011,
+                "rules": [
+                    {
+                        "condition": {
+                            "if_weekday": "sunday"
+                        },
+                        "then": {
+                            "move": "P1D"
+                        }
+                    }
+                ]
+            }
         }
     ],
     "settings": {

--- a/jsondata/sourcedata/calendars/nations/US/i18n/en_US.json
+++ b/jsondata/sourcedata/calendars/nations/US/i18n/en_US.json
@@ -5,5 +5,6 @@
     "StsJeanBrebeuf": "[ USA ] Saints John de Brébeuf and Isaac Jogues, Priests, and Companions, Martyrs",
     "ThanksgivingDay": "[ USA ] Thanksgiving",
     "StCamillusDeLellis": "[ USA ] Saint Camillus de Lellis, Priest",
-    "StElizabethPortugal": "[ USA ] Saint Elizabeth of Portugal"
+    "StElizabethPortugal": "[ USA ] Saint Elizabeth of Portugal",
+    "PrayerUnborn": "[ USA ] Day of Prayer for the Legal Protection of Unborn Children"
 }

--- a/jsondata/sourcedata/calendars/nations/US/lectionary/en_US.json
+++ b/jsondata/sourcedata/calendars/nations/US/lectionary/en_US.json
@@ -1,0 +1,8 @@
+{
+    "PrayerUnborn": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    }
+}

--- a/jsondata/sourcedata/calendars/nations/US/lectionary/es_US.json
+++ b/jsondata/sourcedata/calendars/nations/US/lectionary/es_US.json
@@ -1,0 +1,8 @@
+{
+    "PrayerUnborn": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    }
+}

--- a/jsondata/sourcedata/missals/propriumdesanctis_US_2011/i18n/en_US.json
+++ b/jsondata/sourcedata/missals/propriumdesanctis_US_2011/i18n/en_US.json
@@ -2,7 +2,6 @@
     "StElizabethSeton": "Saint Elizabeth Ann Seton, Religious",
     "StJohnNeumann": "Saint John Neumann, Bishop",
     "StAndreBessette": "Saint André Bessette, Religious",
-    "PrayerUnborn": "Day of Prayer for the Legal Protection of Unborn Children",
     "StKatharineDrexel": "Saint Katharine Drexel, Virgin",
     "StDamienVeuster": "Saint Damien de Veuster, Priest",
     "StIsidore": "Saint Isidore",

--- a/jsondata/sourcedata/missals/propriumdesanctis_US_2011/lectionary/en_US.json
+++ b/jsondata/sourcedata/missals/propriumdesanctis_US_2011/lectionary/en_US.json
@@ -17,12 +17,6 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "PrayerUnborn": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
     "StKatharineDrexel": {
         "first_reading": "",
         "responsorial_psalm": "",

--- a/jsondata/sourcedata/missals/propriumdesanctis_US_2011/lectionary/es_US.json
+++ b/jsondata/sourcedata/missals/propriumdesanctis_US_2011/lectionary/es_US.json
@@ -17,12 +17,6 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "PrayerUnborn": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
     "StKatharineDrexel": {
         "first_reading": "",
         "responsorial_psalm": "",

--- a/jsondata/sourcedata/missals/propriumdesanctis_US_2011/propriumdesanctis_US_2011.json
+++ b/jsondata/sourcedata/missals/propriumdesanctis_US_2011/propriumdesanctis_US_2011.json
@@ -42,22 +42,6 @@
         ]
     },
     {
-        "month": 1,
-        "day": 22,
-        "event_key": "PrayerUnborn",
-        "grade": 3,
-        "grade_display": "National Day of Prayer",
-        "common": [
-            "For Giving Thanks to God for the Gift of Human Life [USA]",
-            "For the Preservation of Peace and Justice"
-        ],
-        "calendar": "US",
-        "color": [
-            "purple",
-            "white"
-        ]
-    },
-    {
         "month": 3,
         "day": 3,
         "event_key": "StKatharineDrexel",

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -3135,15 +3135,16 @@ final class CalendarHandler extends AbstractHandler
 
         foreach ($rules as $rule) {
             if ($rule->condition->matches($currentDate, $this->Cal)) {
-                $newDate = $rule->then->apply($currentDate);
+                $previousDate = clone $currentDate;
+                $newDate      = $rule->then->apply($currentDate);
 
                 // Add a message about the rule application
                 $locale          = LitLocale::$PRIMARY_LANGUAGE;
-                $originalDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? ( $originalDate->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $originalDate->format('n')] )
+                $previousDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
+                    ? ( $previousDate->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $previousDate->format('n')] )
                     : ( $locale === 'en'
-                        ? $originalDate->format('F jS')
-                        : $this->dayAndMonth->format($originalDate->format('U'))
+                        ? $previousDate->format('F jS')
+                        : $this->dayAndMonth->format($previousDate->format('U'))
                     );
                 $newDateStr      = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
                     ? ( $newDate->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $newDate->format('n')] )
@@ -3156,7 +3157,7 @@ final class CalendarHandler extends AbstractHandler
                     /**translators: 1: Event key, 2: Original date, 3: New date, 4: Requested calendar year */
                     _('The liturgical event \'%1$s\' has been moved from %2$s to %3$s due to conditional rules in the year %4$d.'),
                     $eventKey,
-                    $originalDateStr,
+                    $previousDateStr,
                     $newDateStr,
                     $this->CalendarParams->Year
                 );

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -3162,7 +3162,6 @@ final class CalendarHandler extends AbstractHandler
                 );
 
                 $currentDate = $newDate;
-                break; // Apply only the first matching rule
             }
         }
 
@@ -3420,7 +3419,10 @@ final class CalendarHandler extends AbstractHandler
             // Apply any conditional rules to the date
             if (!empty($liturgicalEventMetadata->rules)) {
                 $newDate = $this->applyConditionalRules($liturgicalEvent->date, $liturgicalEventMetadata->rules, $liturgicalEvent->event_key);
-                $liturgicalEvent->setDate($newDate);
+                if ($newDate != $liturgicalEvent->date) {
+                    // If the date has changed, we need to update the date in the liturgical event
+                    $liturgicalEvent->setDate($newDate);
+                }
             }
         } else {
             ob_start();

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -50,6 +50,7 @@ use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyGradeMetadata;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyName;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyNameMetadata;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarSettings;
+use LiturgicalCalendar\Api\Models\ConditionalRule;
 use LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanData;
 use LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanLitCalItemCreateNewFixed;
 use LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanLitCalItemCreateNewMobile;
@@ -3121,6 +3122,54 @@ final class CalendarHandler extends AbstractHandler
     }
 
     /**
+     * Applies conditional rules to a liturgical event date
+     *
+     * @param DateTime $originalDate The original date of the liturgical event
+     * @param ConditionalRule[] $rules The conditional rules to apply
+     * @param string $eventKey The event key for logging purposes
+     * @return DateTime The potentially modified date
+     */
+    private function applyConditionalRules(DateTime $originalDate, array $rules, string $eventKey): DateTime
+    {
+        $currentDate = clone $originalDate;
+        
+        foreach ($rules as $rule) {
+            if ($rule->condition->matches($currentDate, $this->Cal)) {
+                $newDate = $rule->then->apply($currentDate);
+                
+                // Add a message about the rule application
+                $locale = LitLocale::$PRIMARY_LANGUAGE;
+                $originalDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
+                    ? ($originalDate->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $originalDate->format('n')])
+                    : ($locale === 'en'
+                        ? $originalDate->format('F jS')
+                        : $this->dayAndMonth->format($originalDate->format('U'))
+                    );
+                $newDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
+                    ? ($newDate->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $newDate->format('n')])
+                    : ($locale === 'en'
+                        ? $newDate->format('F jS')
+                        : $this->dayAndMonth->format($newDate->format('U'))
+                    );
+                
+                $this->Messages[] = sprintf(
+                    /**translators: 1: Event key, 2: Original date, 3: New date, 4: Requested calendar year */
+                    _('The liturgical event \'%1$s\' has been moved from %2$s to %3$s due to conditional rules in the year %4$d.'),
+                    $eventKey,
+                    $originalDateStr,
+                    $newDateStr,
+                    $this->CalendarParams->Year
+                );
+                
+                $currentDate = $newDate;
+                break; // Apply only the first matching rule
+            }
+        }
+        
+        return $currentDate;
+    }
+
+    /**
      * Handles a liturgical event for a National calendar that is missing from the calendar.
      * If the liturgical event is suppressed by a Sunday or a Solemnity,
      * a message is added to the Messages array, indicating what has happened.
@@ -4229,6 +4278,11 @@ final class CalendarHandler extends AbstractHandler
                     /** @var DiocesanLitCalItemCreateNewFixed $liturgicalEvent */
                     $liturgicalEvent     = $litCalItem->liturgical_event;
                     $currentLitEventDate = DateTime::fromFormat($liturgicalEvent->day . '-' . $liturgicalEvent->month . '-' . $this->CalendarParams->Year);
+                        
+                    // Apply conditional rules if they exist
+                    if (!empty($liturgicalEvent->rules)) {
+                        $currentLitEventDate = $this->applyConditionalRules($currentLitEventDate, $liturgicalEvent->rules, $liturgicalEvent->event_key);
+                    }
                 }
                 if ($currentLitEventDate !== false) {
                     $liturgicalEvent->setDate($currentLitEventDate);

--- a/src/Models/ConditionalRule.php
+++ b/src/Models/ConditionalRule.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Models;
+
+/**
+ * Represents a conditional rule for liturgical events
+ */
+final class ConditionalRule
+{
+    public function __construct(
+        public readonly ConditionalRuleCondition $condition,
+        public readonly ConditionalRuleAction $then
+    ) {}
+
+    public static function fromObject(\stdClass $data): self
+    {
+        if (!property_exists($data, 'condition') || !property_exists($data, 'then')) {
+            throw new \InvalidArgumentException('ConditionalRule must have both condition and then properties');
+        }
+
+        return new self(
+            ConditionalRuleCondition::fromObject($data->condition),
+            ConditionalRuleAction::fromObject($data->then)
+        );
+    }
+}

--- a/src/Models/ConditionalRule.php
+++ b/src/Models/ConditionalRule.php
@@ -4,23 +4,53 @@ namespace LiturgicalCalendar\Api\Models;
 
 /**
  * Represents a conditional rule for liturgical events
+ * @phpstan-type ConditionalRuleConditionObject \stdClass&object{if_weekday?:string,if_grade?:int}
+ * @phpstan-type ConditionalRuleConditionArray array{if_weekday?:string,if_grade?:int}
+ * @phpstan-type ConditionalRuleActionObject \stdClass&object{move?:string,move_to?:string}
+ * @phpstan-type ConditionalRuleActionArray array{move?:string,move_to?:string}
+ * @phpstan-type ConditionalRuleObject \stdClass&object{condition:ConditionalRuleConditionObject,then:ConditionalRuleActionObject}
+ * @phpstan-type ConditionalRuleArray array{condition:ConditionalRuleConditionArray,then:ConditionalRuleActionArray}
  */
-final class ConditionalRule
+final class ConditionalRule extends AbstractJsonSrcData
 {
-    public function __construct(
-        public readonly ConditionalRuleCondition $condition,
-        public readonly ConditionalRuleAction $then
-    ) {}
+    public readonly ConditionalRuleCondition $condition;
+    public readonly ConditionalRuleAction $then;
 
-    public static function fromObject(\stdClass $data): self
+    private function __construct(ConditionalRuleCondition $condition, ConditionalRuleAction $then)
+    {
+        $this->condition = $condition;
+        $this->then      = $then;
+    }
+
+    /**
+     * @param ConditionalRuleObject $data
+     * @return static
+     */
+    protected static function fromObjectInternal(\stdClass $data): static
     {
         if (!property_exists($data, 'condition') || !property_exists($data, 'then')) {
-            throw new \InvalidArgumentException('ConditionalRule must have both condition and then properties');
+            throw new \InvalidArgumentException('ConditionalRule must have both `condition` and `then` properties');
         }
 
-        return new self(
+        return new static(
             ConditionalRuleCondition::fromObject($data->condition),
             ConditionalRuleAction::fromObject($data->then)
+        );
+    }
+
+    /**
+     * @param ConditionalRuleArray $data
+     * @return static
+     */
+    protected static function fromArrayInternal(array $data): static
+    {
+        if (!array_key_exists('condition', $data) || !array_key_exists('then', $data)) {
+            throw new \InvalidArgumentException('ConditionalRule must have both `condition` and `then` properties');
+        }
+
+        return new static(
+            ConditionalRuleCondition::fromArray($data['condition']),
+            ConditionalRuleAction::fromArray($data['then'])
         );
     }
 }

--- a/src/Models/ConditionalRule.php
+++ b/src/Models/ConditionalRule.php
@@ -4,10 +4,10 @@ namespace LiturgicalCalendar\Api\Models;
 
 /**
  * Represents a conditional rule for liturgical events
- * @phpstan-type ConditionalRuleConditionObject \stdClass&object{if_weekday?:string,if_grade?:int}
- * @phpstan-type ConditionalRuleConditionArray array{if_weekday?:string,if_grade?:int}
- * @phpstan-type ConditionalRuleActionObject \stdClass&object{move?:string,move_to?:string}
- * @phpstan-type ConditionalRuleActionArray array{move?:string,move_to?:string}
+ * @phpstan-type ConditionalRuleConditionObject \stdClass&object{if_weekday?:?string,if_grade?:?int}
+ * @phpstan-type ConditionalRuleConditionArray array{if_weekday?:?string,if_grade?:?int}
+ * @phpstan-type ConditionalRuleActionObject \stdClass&object{move?:?string,move_to?:?string}
+ * @phpstan-type ConditionalRuleActionArray array{move?:?string,move_to?:?string}
  * @phpstan-type ConditionalRuleObject \stdClass&object{condition:ConditionalRuleConditionObject,then:ConditionalRuleActionObject}
  * @phpstan-type ConditionalRuleArray array{condition:ConditionalRuleConditionArray,then:ConditionalRuleActionArray}
  */

--- a/src/Models/ConditionalRuleAction.php
+++ b/src/Models/ConditionalRuleAction.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Models;
+
+/**
+ * Represents an action for a conditional rule
+ */
+final class ConditionalRuleAction
+{
+    public function __construct(
+        public readonly ?string $move = null,
+        public readonly ?string $move_to = null
+    ) {}
+
+    public static function fromObject(\stdClass $data): self
+    {
+        $move = property_exists($data, 'move') ? $data->move : null;
+        $moveTo = property_exists($data, 'move_to') ? $data->move_to : null;
+
+        return new self($move, $moveTo);
+    }
+
+    public function apply(\DateTime $date): \DateTime
+    {
+        $newDate = clone $date;
+
+        if ($this->move !== null) {
+            // Handle DateInterval format (P1D, P7D, etc.)
+            if (preg_match('/^P\d+[DWMY]$/', $this->move)) {
+                $newDate->add(new \DateInterval($this->move));
+            }
+            // Handle negative intervals
+            elseif (preg_match('/^-P\d+[DWMY]$/', $this->move)) {
+                $interval = substr($this->move, 1); // Remove the minus sign
+                $newDate->sub(new \DateInterval($interval));
+            }
+        }
+
+        if ($this->move_to !== null) {
+            // Handle relative date strings like "next monday", "previous friday"
+            $newDate->modify($this->move_to);
+        }
+
+        return $newDate;
+    }
+}

--- a/src/Models/ConditionalRuleAction.php
+++ b/src/Models/ConditionalRuleAction.php
@@ -102,11 +102,13 @@ final class ConditionalRuleAction extends AbstractJsonSrcData
                 $interval = substr($this->move, 1); // Remove the minus sign
                 $newDate->sub(new \DateInterval($interval));
             } else {
-                throw new \ValueError('Invalid move interval "' . $this->move . '"');
+                throw new \ValueError('Invalid `move` interval "' . $this->move . '"');
             }
         } elseif ($this->move_to !== null) {
             // Handle relative date strings like "next monday", "previous friday"
-            $newDate->modify($this->move_to);
+            if ($newDate->modify($this->move_to) === false) {
+                throw new \ValueError('Invalid `move_to` specification "' . $this->move_to . '"');
+            }
         }
 
         return $newDate;

--- a/src/Models/ConditionalRuleAction.php
+++ b/src/Models/ConditionalRuleAction.php
@@ -39,14 +39,14 @@ final class ConditionalRuleAction extends AbstractJsonSrcData
 
         if (property_exists($data, 'move')) {
             if (!is_string($data->move)) {
-                throw new \InvalidArgumentException('`move` property must have a value of type string or null, received ' . gettype($data->move));
+                throw new \InvalidArgumentException('`move` property must have a value of type string, received ' . gettype($data->move));
             }
             $move = $data->move;
         }
 
         if (property_exists($data, 'move_to')) {
             if (!is_string($data->move_to)) {
-                throw new \InvalidArgumentException('`move_to` property must have a value of type string or null, received ' . gettype($data->move_to));
+                throw new \InvalidArgumentException('`move_to` property must have a value of type string, received ' . gettype($data->move_to));
             }
             $moveTo = $data->move_to;
         }
@@ -73,14 +73,14 @@ final class ConditionalRuleAction extends AbstractJsonSrcData
 
         if (array_key_exists('move', $data)) {
             if (!is_string($data['move'])) {
-                throw new \InvalidArgumentException('`move` property must have a value of type string or null, received ' . gettype($data['move']));
+                throw new \InvalidArgumentException('`move` property must have a value of type string, received ' . gettype($data['move']));
             }
             $move = $data['move'];
         }
 
         if (array_key_exists('move_to', $data)) {
             if (!is_string($data['move_to'])) {
-                throw new \InvalidArgumentException('`move_to` property must have a value of type string or null, received ' . gettype($data['move_to']));
+                throw new \InvalidArgumentException('`move_to` property must have a value of type string, received ' . gettype($data['move_to']));
             }
             $moveTo = $data['move_to'];
         }

--- a/src/Models/ConditionalRuleAction.php
+++ b/src/Models/ConditionalRuleAction.php
@@ -27,7 +27,11 @@ final class ConditionalRuleAction extends AbstractJsonSrcData
     protected static function fromObjectInternal(\stdClass $data): static
     {
         if (!property_exists($data, 'move') && !property_exists($data, 'move_to')) {
-            throw new \InvalidArgumentException('ConditionalRuleAction must have either move or move_to properties');
+            throw new \InvalidArgumentException('ConditionalRuleAction must have either `move` or `move_to` properties');
+        }
+
+        if (property_exists($data, 'move') && property_exists($data, 'move_to')) {
+            throw new \InvalidArgumentException('ConditionalRuleAction cannot have both `move` and `move_to` properties at the same time');
         }
 
         $move   = null;
@@ -35,14 +39,14 @@ final class ConditionalRuleAction extends AbstractJsonSrcData
 
         if (property_exists($data, 'move')) {
             if (!is_string($data->move)) {
-                throw new \InvalidArgumentException('move must be a string or null');
+                throw new \InvalidArgumentException('`move` property must have a value of type string or null, received ' . gettype($data->move));
             }
             $move = $data->move;
         }
 
         if (property_exists($data, 'move_to')) {
             if (!is_string($data->move_to)) {
-                throw new \InvalidArgumentException('move_to must be a string or null');
+                throw new \InvalidArgumentException('`move_to` property must have a value of type string or null, received ' . gettype($data->move_to));
             }
             $moveTo = $data->move_to;
         }
@@ -57,7 +61,11 @@ final class ConditionalRuleAction extends AbstractJsonSrcData
     protected static function fromArrayInternal(array $data): static
     {
         if (!array_key_exists('move', $data) && !array_key_exists('move_to', $data)) {
-            throw new \InvalidArgumentException('ConditionalRuleAction must have either move or move_to properties');
+            throw new \InvalidArgumentException('ConditionalRuleAction must have either `move` or `move_to` properties');
+        }
+
+        if (array_key_exists('move', $data) && array_key_exists('move_to', $data)) {
+            throw new \InvalidArgumentException('ConditionalRuleAction cannot have both `move` and `move_to` properties at the same time');
         }
 
         $move   = null;
@@ -65,14 +73,14 @@ final class ConditionalRuleAction extends AbstractJsonSrcData
 
         if (array_key_exists('move', $data)) {
             if (!is_string($data['move'])) {
-                throw new \InvalidArgumentException('move must be a string or null');
+                throw new \InvalidArgumentException('`move` property must have a value of type string or null, received ' . gettype($data['move']));
             }
             $move = $data['move'];
         }
 
         if (array_key_exists('move_to', $data)) {
             if (!is_string($data['move_to'])) {
-                throw new \InvalidArgumentException('move_to must be a string or null');
+                throw new \InvalidArgumentException('`move_to` property must have a value of type string or null, received ' . gettype($data['move_to']));
             }
             $moveTo = $data['move_to'];
         }
@@ -93,10 +101,10 @@ final class ConditionalRuleAction extends AbstractJsonSrcData
             elseif (preg_match('/^-P\d+D$/', $this->move)) {
                 $interval = substr($this->move, 1); // Remove the minus sign
                 $newDate->sub(new \DateInterval($interval));
+            } else {
+                throw new \ValueError('Invalid move interval "' . $this->move . '"');
             }
-        }
-
-        if ($this->move_to !== null) {
+        } elseif ($this->move_to !== null) {
             // Handle relative date strings like "next monday", "previous friday"
             $newDate->modify($this->move_to);
         }

--- a/src/Models/ConditionalRuleCondition.php
+++ b/src/Models/ConditionalRuleCondition.php
@@ -21,13 +21,13 @@ final class ConditionalRuleCondition
 
         if (property_exists($data, 'coincides_with')) {
             $coincidesWith = [];
-            if (property_exists($data->coincides_with, 'lit_grade')) {
-                if (is_array($data->coincides_with->lit_grade)) {
-                    foreach ($data->coincides_with->lit_grade as $grade) {
-                        $coincidesWith['lit_grade'][] = LitGrade::from($grade);
+            if (property_exists($data->coincides_with, 'grade')) {
+                if (is_array($data->coincides_with->grade)) {
+                    foreach ($data->coincides_with->grade as $grade) {
+                        $coincidesWith['grade'][] = LitGrade::from($grade);
                     }
                 } else {
-                    $coincidesWith['lit_grade'] = [LitGrade::from($data->coincides_with->lit_grade)];
+                    $coincidesWith['grade'] = [LitGrade::from($data->coincides_with->grade)];
                 }
             }
             if (property_exists($data->coincides_with, 'day_of_week')) {
@@ -54,9 +54,9 @@ final class ConditionalRuleCondition
 
         // Check coincides with condition
         if ($this->coincides_with !== null) {
-            if (isset($this->coincides_with['lit_grade'])) {
+            if (isset($this->coincides_with['grade'])) {
                 $hasCoincidence = false;
-                foreach ($this->coincides_with['lit_grade'] as $grade) {
+                foreach ($this->coincides_with['grade'] as $grade) {
                     switch ($grade) {
                         case LitGrade::SOLEMNITY:
                             if ($calendar->inSolemnities($date)) {

--- a/src/Models/ConditionalRuleCondition.php
+++ b/src/Models/ConditionalRuleCondition.php
@@ -41,17 +41,20 @@ final class ConditionalRuleCondition extends AbstractJsonSrcData
 
         if (property_exists($data, 'if_weekday')) {
             if (!is_string($data->if_weekday)) {
-                throw new \InvalidArgumentException('if_weekday must be a string');
+                throw new \InvalidArgumentException('`if_weekday` property must have a value of type string, received ' . gettype($data->if_weekday));
             }
             if (!in_array(strtolower($data->if_weekday), ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'], true)) {
-                throw new \InvalidArgumentException('if_weekday must be a valid weekday name');
+                throw new \InvalidArgumentException('`if_weekday` property must have a value that is a valid weekday name, received ' . $data->if_weekday);
             }
             $if_weekday = strtolower($data->if_weekday);
         }
 
         if (property_exists($data, 'if_grade')) {
             if (!is_int($data->if_grade)) {
-                throw new \InvalidArgumentException('if_grade must be an integer');
+                throw new \InvalidArgumentException('`if_grade` property must have a value of type int, received ' . gettype($data->if_grade));
+            }
+            if (!in_array($data->if_grade, LitGrade::values(), true)) {
+                throw new \InvalidArgumentException('`if_grade` property must have a value that is a valid LitGrade enum value, received ' . $data->if_grade);
             }
             $if_grade = LitGrade::from($data->if_grade);
         }
@@ -78,15 +81,21 @@ final class ConditionalRuleCondition extends AbstractJsonSrcData
 
         if (array_key_exists('if_weekday', $data)) {
             if (!is_string($data['if_weekday'])) {
-                throw new \InvalidArgumentException('if_weekday must be a string');
+                throw new \InvalidArgumentException('`if_weekday` property must have a value of type string, received ' . gettype($data['if_weekday']));
             }
             if (!in_array(strtolower($data['if_weekday']), ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'], true)) {
-                throw new \InvalidArgumentException('if_weekday must be a valid weekday name');
+                throw new \InvalidArgumentException('`if_weekday` property must have a value that is a valid weekday name, received ' . $data['if_weekday']);
             }
             $if_weekday = strtolower($data['if_weekday']);
         }
 
         if (array_key_exists('if_grade', $data)) {
+            if (!is_int($data['if_grade'])) {
+                throw new \InvalidArgumentException('`if_grade` property must have a value of type int, received ' . gettype($data['if_grade']));
+            }
+            if (!in_array($data['if_grade'], LitGrade::values(), true)) {
+                throw new \InvalidArgumentException('`if_grade` property must have a value that is a valid LitGrade enum value, received ' . $data['if_grade']);
+            }
             $if_grade = LitGrade::from($data['if_grade']);
         }
 

--- a/src/Models/ConditionalRuleCondition.php
+++ b/src/Models/ConditionalRuleCondition.php
@@ -107,7 +107,7 @@ final class ConditionalRuleCondition extends AbstractJsonSrcData
         if ($this->if_weekday !== null) {
             // Check day of week condition
             $dayName = strtolower($date->format('l'));
-            if ($dayName === strtolower($this->if_weekday)) {
+            if ($dayName === $this->if_weekday) {
                 return true;
             }
         } elseif ($this->if_grade !== null) {
@@ -130,6 +130,8 @@ final class ConditionalRuleCondition extends AbstractJsonSrcData
                         $hasCoincidence = true;
                     }
                     break;
+                default:
+                    // No check for other grades (COMMEMORATION, FERIA, etc.)
             }
             return $hasCoincidence;
         }

--- a/src/Models/ConditionalRuleCondition.php
+++ b/src/Models/ConditionalRuleCondition.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Models;
+
+use LiturgicalCalendar\Api\Enum\LitGrade;
+
+/**
+ * Represents a condition for a conditional rule
+ */
+final class ConditionalRuleCondition
+{
+    public function __construct(
+        public readonly ?array $coincides_with = null,
+        public readonly ?string $day_of_week = null
+    ) {}
+
+    public static function fromObject(\stdClass $data): self
+    {
+        $coincidesWith = null;
+        $dayOfWeek = null;
+
+        if (property_exists($data, 'coincides_with')) {
+            $coincidesWith = [];
+            if (property_exists($data->coincides_with, 'lit_grade')) {
+                if (is_array($data->coincides_with->lit_grade)) {
+                    foreach ($data->coincides_with->lit_grade as $grade) {
+                        $coincidesWith['lit_grade'][] = LitGrade::from($grade);
+                    }
+                } else {
+                    $coincidesWith['lit_grade'] = [LitGrade::from($data->coincides_with->lit_grade)];
+                }
+            }
+            if (property_exists($data->coincides_with, 'day_of_week')) {
+                $coincidesWith['day_of_week'] = $data->coincides_with->day_of_week;
+            }
+        }
+
+        if (property_exists($data, 'day_of_week')) {
+            $dayOfWeek = $data->day_of_week;
+        }
+
+        return new self($coincidesWith, $dayOfWeek);
+    }
+
+    public function matches(\DateTime $date, $calendar): bool
+    {
+        // Check day of week condition
+        if ($this->day_of_week !== null) {
+            $dayName = strtolower($date->format('l'));
+            if ($dayName !== strtolower($this->day_of_week)) {
+                return false;
+            }
+        }
+
+        // Check coincides with condition
+        if ($this->coincides_with !== null) {
+            if (isset($this->coincides_with['lit_grade'])) {
+                $hasCoincidence = false;
+                foreach ($this->coincides_with['lit_grade'] as $grade) {
+                    switch ($grade) {
+                        case LitGrade::SOLEMNITY:
+                            if ($calendar->inSolemnities($date)) {
+                                $hasCoincidence = true;
+                                break 2;
+                            }
+                            break;
+                        case LitGrade::FEAST:
+                        case LitGrade::FEAST_LORD:
+                            if ($calendar->inFeasts($date) || $calendar->inFeastsLord($date)) {
+                                $hasCoincidence = true;
+                                break 2;
+                            }
+                            break;
+                        case LitGrade::MEMORIAL:
+                            if ($calendar->inMemorials($date)) {
+                                $hasCoincidence = true;
+                                break 2;
+                            }
+                            break;
+                    }
+                }
+                if (!$hasCoincidence && isset($this->coincides_with['day_of_week'])) {
+                    $dayName = strtolower($date->format('l'));
+                    $hasCoincidence = ($dayName === strtolower($this->coincides_with['day_of_week']));
+                }
+                return $hasCoincidence;
+            }
+            
+            if (isset($this->coincides_with['day_of_week'])) {
+                $dayName = strtolower($date->format('l'));
+                return ($dayName === strtolower($this->coincides_with['day_of_week']));
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Models/ConditionalRuleCondition.php
+++ b/src/Models/ConditionalRuleCondition.php
@@ -32,6 +32,10 @@ final class ConditionalRuleCondition extends AbstractJsonSrcData
             throw new \InvalidArgumentException('ConditionalRuleCondition must have at least one of `if_weekday` or `if_grade` properties');
         }
 
+        if (property_exists($data, 'if_weekday') && property_exists($data, 'if_grade')) {
+            throw new \InvalidArgumentException('ConditionalRuleCondition cannot have both `if_weekday` and `if_grade` properties at the same time');
+        }
+
         $if_weekday = null;
         $if_grade   = null;
 
@@ -65,6 +69,10 @@ final class ConditionalRuleCondition extends AbstractJsonSrcData
             throw new \InvalidArgumentException('ConditionalRuleCondition must have at least one of `if_weekday` or `if_grade` properties');
         }
 
+        if (array_key_exists('if_weekday', $data) && array_key_exists('if_grade', $data)) {
+            throw new \InvalidArgumentException('ConditionalRuleCondition cannot have both `if_weekday` and `if_grade` properties at the same time');
+        }
+
         $if_weekday = null;
         $if_grade   = null;
 
@@ -87,16 +95,14 @@ final class ConditionalRuleCondition extends AbstractJsonSrcData
 
     public function matches(DateTime $date, LiturgicalEventCollection $calendar): bool
     {
-        // Check day of week condition
         if ($this->if_weekday !== null) {
+            // Check day of week condition
             $dayName = strtolower($date->format('l'));
             if ($dayName === strtolower($this->if_weekday)) {
                 return true;
             }
-        }
-
-        // Check liturgical grade condition
-        if ($this->if_grade !== null) {
+        } elseif ($this->if_grade !== null) {
+            // Check liturgical grade condition
             $hasCoincidence = false;
             switch ($this->if_grade) {
                 case LitGrade::SOLEMNITY:

--- a/src/Models/LitCalItem.php
+++ b/src/Models/LitCalItem.php
@@ -20,13 +20,33 @@ use LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemSetPropert
  * @phpstan-import-type LitCalItemCreateNewFixedArray from \LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemCreateNewFixed
  * @phpstan-import-type LitCalItemCreateNewMobileObject from \LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemCreateNewMobile
  * @phpstan-import-type LitCalItemCreateNewMobileArray from \LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemCreateNewMobile
+ * @phpstan-import-type ConditionalRuleObject from \LiturgicalCalendar\Api\Models\ConditionalRule
+ * @phpstan-import-type ConditionalRuleArray from \LiturgicalCalendar\Api\Models\ConditionalRule
  * @phpstan-type LitCalItemObject \stdClass&object{
  *      liturgical_event:LitCalItemCreateNewFixedObject|LitCalItemCreateNewMobileObject,
- *      metadata:\stdClass&object{action:string,since_year:int|null,until_year?:int|null,url?:string|null,reason?:string|null,property?:string|null,url_lang_map?:\stdClass&object<string,string>}
+ *      metadata:\stdClass&object{
+ *          action:string,
+ *          since_year:int|null,
+ *          until_year?:int|null,
+ *          url?:string|null,
+ *          reason?:string|null,
+ *          property?:string|null,
+ *          url_lang_map?:\stdClass&object<string,string>,
+ *          rules?:list<ConditionalRuleObject>
+ *    }
  * }
  * @phpstan-type LitCalItemArray array{
  *      liturgical_event:LitCalItemCreateNewFixedArray|LitCalItemCreateNewMobileArray,
- *      metadata:array{action:string,since_year:int|null,until_year?:int|null,url?:string|null,reason?:string|null,property?:string|null,url_lang_map?:array<string,string>}
+ *      metadata:array{
+ *          action:string,
+ *          since_year:int|null,
+ *          until_year?:int|null,
+ *          url?:string|null,
+ *          reason?:string|null,
+ *          property?:string|null,
+ *          url_lang_map?:array<string,string>,
+ *          rules?:list<ConditionalRuleArray>
+ *     }
  * }
  */
 final class LitCalItem extends AbstractJsonSrcData
@@ -142,6 +162,8 @@ final class LitCalItem extends AbstractJsonSrcData
      *                                  -> `until_year`: The year until when the liturgical event was added.
      *                                  -> `url`: The URL of the document that introduces the liturgical event.
      *                                  -> `reason`: The reason why the liturgical event was introduced.
+     *                                  -> `rules`: An array of conditional rules.
+     *
      * @return static A new instance.
      */
     protected static function fromArrayInternal(array $data): static

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
@@ -6,13 +6,28 @@ use LiturgicalCalendar\Api\DateTime;
 use LiturgicalCalendar\Api\Enum\LitColor;
 use LiturgicalCalendar\Api\Enum\LitEventType;
 use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Enum\LitMassVariousNeeds;
 use LiturgicalCalendar\Api\Models\Calendar\LitCommons;
 use LiturgicalCalendar\Api\Models\ConditionalRule;
 use LiturgicalCalendar\Api\Models\LiturgicalEventData;
 
 /**
- * @phpstan-type LitCalItemCreateNewFixedObject \stdClass&object{event_key:string,day:int,month:int,color:string[],grade:int,common:string[],rules?:\stdClass[]}
- * @phpstan-type LitCalItemCreateNewFixedArray array{event_key:string,day:int,month:int,color:string[],grade:int,common:string[],rules?:array[]}
+ * @phpstan-type LitCalItemCreateNewFixedObject \stdClass&object{
+ *      event_key:string,
+ *      day:int,
+ *      month:int,
+ *      color:string[],
+ *      grade:int,
+ *      common:string[]
+ * }
+ * @phpstan-type LitCalItemCreateNewFixedArray array{
+ *      event_key:string,
+ *      day:int,
+ *      month:int,
+ *      color:string[],
+ *      grade:int,
+ *      common:string[]
+ * }
  */
 final class LitCalItemCreateNewFixed extends LiturgicalEventData
 {
@@ -25,14 +40,15 @@ final class LitCalItemCreateNewFixed extends LiturgicalEventData
 
     public private(set) LitGrade $grade;
 
-    public readonly LitCommons $common;
+    public readonly ?string $grade_display;
+
+    /** @var LitCommons|LitMassVariousNeeds[] $common */
+    public readonly LitCommons|array $common;
 
     public readonly LitEventType $type;
 
     public private(set) DateTime $date;
 
-    /** @var ConditionalRule[] */
-    public readonly array $rules;
 
     /**
      * Creates a new LitCalItemCreateNewFixed object.
@@ -44,11 +60,11 @@ final class LitCalItemCreateNewFixed extends LiturgicalEventData
      * @param int $month The month of the event.
      * @param LitColor[] $color The liturgical color(s) of the event.
      * @param LitGrade $grade The liturgical grade of the event.
-     * @param LitCommons $common The liturgical common of the event.
+     * @param LitCommons|LitMassVariousNeeds[] $common The liturgical common for the event.
      *
      * @throws \ValueError If the provided arguments are invalid.
      */
-    private function __construct(string $event_key, int $day, int $month, array $color, LitGrade $grade, LitCommons $common, array $rules = [])
+    private function __construct(string $event_key, int $day, int $month, array $color, LitGrade $grade, ?string $grade_display, LitCommons|array $common)
     {
         if (false === static::isValidMonthValue($month)) {
             throw new \ValueError('`$month` must be an integer between 1 and 12');
@@ -68,20 +84,15 @@ final class LitCalItemCreateNewFixed extends LiturgicalEventData
             }
         }
 
-        foreach ($rules as $rule) {
-            if (false === $rule instanceof ConditionalRule) {
-                throw new \ValueError('`$rules` must be an array of ConditionalRule instances');
-            }
-        }
 
         parent::__construct($event_key);
-        $this->day    = $day;
-        $this->month  = $month;
-        $this->color  = $color;
-        $this->grade  = $grade;
-        $this->common = $common;
-        $this->type   = LitEventType::FIXED;
-        $this->rules  = $rules;
+        $this->day           = $day;
+        $this->month         = $month;
+        $this->color         = $color;
+        $this->grade         = $grade;
+        $this->grade_display = $grade_display;
+        $this->common        = $common;
+        $this->type          = LitEventType::FIXED;
     }
 
     /**
@@ -127,32 +138,38 @@ final class LitCalItemCreateNewFixed extends LiturgicalEventData
      */
     protected static function fromObjectInternal(\stdClass $data): static
     {
-        $commons = LitCommons::create($data->common);
+        $commons = LitCommons::create($data->common) ?? array_values(array_map(
+            function (string $value): LitMassVariousNeeds {
+                return LitMassVariousNeeds::from($value);
+            },
+            $data->common
+        ));
 
         if (null === $commons) {
             throw new \ValueError('invalid common: expected an array of LitCommon enum cases, LitCommon enum values, or LitMassVariousNeeds instances');
         }
 
-        $rules = [];
-        if (property_exists($data, 'rules') && is_array($data->rules)) {
-            foreach ($data->rules as $ruleData) {
-                $rules[] = ConditionalRule::fromObject($ruleData);
+        $grade_display = null;
+        if (property_exists($data, 'grade_display')) {
+            if (!is_string($data->grade_display) && null !== $data->grade_display) {
+                throw new \ValueError('invalid grade_display: expected a string or null');
             }
+            $grade_display = $data->grade_display;
         }
 
         return new static(
             $data->event_key,
             $data->day,
             $data->month,
-            array_map(
+            array_values(array_map(
                 function (string $color) {
                     return LitColor::from($color);
                 },
                 $data->color
-            ),
+            )),
             LitGrade::from($data->grade),
+            $grade_display,
             $commons,
-            $rules
         );
     }
 
@@ -173,32 +190,38 @@ final class LitCalItemCreateNewFixed extends LiturgicalEventData
      */
     protected static function fromArrayInternal(array $data): static
     {
-        $commons = LitCommons::create($data['common']);
+        $commons = LitCommons::create($data['common']) ?? array_values(array_map(
+            function (string $value): LitMassVariousNeeds {
+                return LitMassVariousNeeds::from($value);
+            },
+            $data['common']
+        ));
 
         if (null === $commons) {
             throw new \ValueError('invalid common: expected an array of LitCommon enum cases, LitCommon enum values, or LitMassVariousNeeds instances');
         }
 
-        $rules = [];
-        if (array_key_exists('rules', $data) && is_array($data['rules'])) {
-            foreach ($data['rules'] as $ruleData) {
-                $rules[] = ConditionalRule::fromObject((object) $ruleData);
+        $grade_display = null;
+        if (array_key_exists('grade_display', $data)) {
+            if (!is_string($data['grade_display']) && null !== $data['grade_display']) {
+                throw new \ValueError('invalid grade_display: expected a string or null');
             }
+            $grade_display = $data['grade_display'];
         }
 
         return new static(
             $data['event_key'],
             $data['day'],
             $data['month'],
-            array_map(
+            array_values(array_map(
                 function (string $color): LitColor {
                     return LitColor::from($color);
                 },
                 $data['color']
-            ),
+            )),
             LitGrade::from($data['grade']),
-            $commons,
-            $rules
+            $grade_display,
+            $commons
         );
     }
 }

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
@@ -145,10 +145,6 @@ final class LitCalItemCreateNewFixed extends LiturgicalEventData
             $data->common
         ));
 
-        if (null === $commons) {
-            throw new \ValueError('invalid common: expected an array of LitCommon enum cases, LitCommon enum values, or LitMassVariousNeeds instances');
-        }
-
         $grade_display = null;
         if (property_exists($data, 'grade_display')) {
             if (!is_string($data->grade_display) && null !== $data->grade_display) {
@@ -196,10 +192,6 @@ final class LitCalItemCreateNewFixed extends LiturgicalEventData
             },
             $data['common']
         ));
-
-        if (null === $commons) {
-            throw new \ValueError('invalid common: expected an array of LitCommon enum cases, LitCommon enum values, or LitMassVariousNeeds instances');
-        }
 
         $grade_display = null;
         if (array_key_exists('grade_display', $data)) {

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
@@ -8,7 +8,6 @@ use LiturgicalCalendar\Api\Enum\LitEventType;
 use LiturgicalCalendar\Api\Enum\LitGrade;
 use LiturgicalCalendar\Api\Enum\LitMassVariousNeeds;
 use LiturgicalCalendar\Api\Models\Calendar\LitCommons;
-use LiturgicalCalendar\Api\Models\ConditionalRule;
 use LiturgicalCalendar\Api\Models\LiturgicalEventData;
 
 /**
@@ -18,7 +17,7 @@ use LiturgicalCalendar\Api\Models\LiturgicalEventData;
  *      month:int,
  *      color:string[],
  *      grade:int,
- *      grade_display?:?string,
+ *      grade_display?:string|null,
  *      common:string[]
  * }
  * @phpstan-type LitCalItemCreateNewFixedArray array{
@@ -27,7 +26,7 @@ use LiturgicalCalendar\Api\Models\LiturgicalEventData;
  *      month:int,
  *      color:string[],
  *      grade:int,
- *      grade_display?:?string,
+ *      grade_display?:string|null,
  *      common:string[]
  * }
  */
@@ -44,7 +43,7 @@ final class LitCalItemCreateNewFixed extends LiturgicalEventData
 
     public readonly ?string $grade_display;
 
-    /** @var LitCommons|LitMassVariousNeeds[] $common */
+    /** @var LitCommons|LitMassVariousNeeds[] */
     public readonly LitCommons|array $common;
 
     public readonly LitEventType $type;

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
@@ -87,7 +87,6 @@ final class LitCalItemCreateNewFixed extends LiturgicalEventData
             }
         }
 
-
         parent::__construct($event_key);
         $this->day           = $day;
         $this->month         = $month;

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
@@ -18,6 +18,7 @@ use LiturgicalCalendar\Api\Models\LiturgicalEventData;
  *      month:int,
  *      color:string[],
  *      grade:int,
+ *      grade_display?:?string,
  *      common:string[]
  * }
  * @phpstan-type LitCalItemCreateNewFixedArray array{
@@ -26,6 +27,7 @@ use LiturgicalCalendar\Api\Models\LiturgicalEventData;
  *      month:int,
  *      color:string[],
  *      grade:int,
+ *      grade_display?:?string,
  *      common:string[]
  * }
  */

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewFixed.php
@@ -29,6 +29,8 @@ use LiturgicalCalendar\Api\Models\LiturgicalEventData;
  *      grade_display?:string|null,
  *      common:string[]
  * }
+ * N.B. `common` is a string array input, but will be converted to a LitCommons object or to an array of LitMassVariousNeeds enum cases upon deserialization;
+ *      similarly `color` is a string array input, but will be converted to an array of LitColor enum cases upon deserialization.
  */
 final class LitCalItemCreateNewFixed extends LiturgicalEventData
 {

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewMetadata.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewMetadata.php
@@ -34,10 +34,13 @@ final class LitCalItemCreateNewMetadata extends LiturgicalEventMetadata
     /**
      * Creates an instance from a StdClass object.
      *
-     * @param \stdClass&object{since_year:int,until_year?:int,rules:ConditionalRuleObject[]} $data The StdClass object to create an instance from.
-     * It must have the following properties:
-     * - since_year (int): The year since when the liturgical event was added.
-     * - until_year (int|null): The year until when the liturgical event was added.
+     * @param \stdClass&object{since_year:int,until_year?:int,rules?:ConditionalRuleObject[]} $data The StdClass object to create an instance from.
+     * It must have the following property:
+     * - since_year (int): The year from which the liturgical event is celebrated.
+     *
+     * Optional properties:
+     * - until_year (int|null): The year until which the liturgical event is celebrated.
+     * - rules (ConditionalRuleObject[]): An array of ConditionalRule objects defining conditions for the event.
      *
      * @return static A new instance created from the given data.
      */
@@ -66,8 +69,9 @@ final class LitCalItemCreateNewMetadata extends LiturgicalEventMetadata
      *
      * Optional keys:
      * - until_year (int|null): The year until when the liturgical event was added.
+     * - rules (ConditionalRuleArray[]): An array of ConditionalRule associative arrays defining conditions for the event.
      *
-     * @param array{since_year:int,until_year?:int,rules:ConditionalRuleArray[]} $data The associative array containing the properties of the class.
+     * @param array{since_year:int,until_year?:int,rules?:ConditionalRuleArray[]} $data The associative array containing the properties of the class.
      * @return static A new instance of the class.
      */
     protected static function fromArrayInternal(array $data): static

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewMetadata.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewMetadata.php
@@ -3,22 +3,38 @@
 namespace LiturgicalCalendar\Api\Models\RegionalData\NationalData;
 
 use LiturgicalCalendar\Api\Enum\CalEventAction;
+use LiturgicalCalendar\Api\Models\ConditionalRule;
 use LiturgicalCalendar\Api\Models\LiturgicalEventMetadata;
 
+/**
+ * @phpstan-import-type ConditionalRuleObject from \LiturgicalCalendar\Api\Models\ConditionalRule
+ * @phpstan-import-type ConditionalRuleArray from \LiturgicalCalendar\Api\Models\ConditionalRule
+ */
 final class LitCalItemCreateNewMetadata extends LiturgicalEventMetadata
 {
     public readonly CalEventAction $action;
 
-    private function __construct(int $since_year, ?int $until_year = null)
+    /** @var ConditionalRule[] */
+    public readonly array $rules;
+
+    /**
+     * Creates a new LitCalItemCreateNewMetadata object.
+     *
+     * @param int $since_year The year from which the liturgical event is celebrated.
+     * @param int|null $until_year The year until which the liturgical event is celebrated, or null if there is no end year.
+     * @param ConditionalRule[] $rules An array of ConditionalRule instances that define conditions for the event.
+     */
+    private function __construct(int $since_year, ?int $until_year = null, array $rules = [])
     {
         parent::__construct($since_year, $until_year ?? null);
         $this->action = CalEventAction::CreateNew;
+        $this->rules  = $rules;
     }
 
     /**
      * Creates an instance from a StdClass object.
      *
-     * @param \stdClass&object{since_year:int,until_year?:int} $data The StdClass object to create an instance from.
+     * @param \stdClass&object{since_year:int,until_year?:int,rules:ConditionalRuleObject[]} $data The StdClass object to create an instance from.
      * It must have the following properties:
      * - since_year (int): The year since when the liturgical event was added.
      * - until_year (int|null): The year until when the liturgical event was added.
@@ -27,9 +43,18 @@ final class LitCalItemCreateNewMetadata extends LiturgicalEventMetadata
      */
     protected static function fromObjectInternal(\stdClass $data): static
     {
+
+        $rules = [];
+        if (property_exists($data, 'rules') && is_array($data->rules)) {
+            foreach ($data->rules as $ruleData) {
+                $rules[] = ConditionalRule::fromObject($ruleData);
+            }
+        }
+
         return new static(
             $data->since_year,
-            $data->until_year ?? null
+            $data->until_year ?? null,
+            $rules
         );
     }
 
@@ -42,14 +67,22 @@ final class LitCalItemCreateNewMetadata extends LiturgicalEventMetadata
      * Optional keys:
      * - until_year (int|null): The year until when the liturgical event was added.
      *
-     * @param array{since_year:int,until_year?:int} $data The associative array containing the properties of the class.
+     * @param array{since_year:int,until_year?:int,rules:ConditionalRuleArray[]} $data The associative array containing the properties of the class.
      * @return static A new instance of the class.
      */
     protected static function fromArrayInternal(array $data): static
     {
+        $rules = [];
+        if (array_key_exists('rules', $data) && is_array($data['rules'])) {
+            foreach ($data['rules'] as $ruleData) {
+                $rules[] = ConditionalRule::fromArray($ruleData);
+            }
+        }
+
         return new static(
             $data['since_year'],
-            $data['until_year'] ?? null
+            $data['until_year'] ?? null,
+            $rules
         );
     }
 }

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewMetadata.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewMetadata.php
@@ -46,7 +46,6 @@ final class LitCalItemCreateNewMetadata extends LiturgicalEventMetadata
      */
     protected static function fromObjectInternal(\stdClass $data): static
     {
-
         $rules = [];
         if (property_exists($data, 'rules')) {
             if (!is_array($data->rules)) {

--- a/src/Models/RegionalData/NationalData/LitCalItemCreateNewMetadata.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemCreateNewMetadata.php
@@ -48,8 +48,14 @@ final class LitCalItemCreateNewMetadata extends LiturgicalEventMetadata
     {
 
         $rules = [];
-        if (property_exists($data, 'rules') && is_array($data->rules)) {
+        if (property_exists($data, 'rules')) {
+            if (!is_array($data->rules)) {
+                throw new \InvalidArgumentException('`rules` property must be an array if provided, received ' . gettype($data->rules));
+            }
             foreach ($data->rules as $ruleData) {
+                if (!( $ruleData instanceof \stdClass )) {
+                    throw new \InvalidArgumentException('Each item in `rules` property must be an object, received ' . gettype($ruleData));
+                }
                 $rules[] = ConditionalRule::fromObject($ruleData);
             }
         }
@@ -77,7 +83,10 @@ final class LitCalItemCreateNewMetadata extends LiturgicalEventMetadata
     protected static function fromArrayInternal(array $data): static
     {
         $rules = [];
-        if (array_key_exists('rules', $data) && is_array($data['rules'])) {
+        if (array_key_exists('rules', $data)) {
+            if (!is_array($data['rules'])) {
+                throw new \InvalidArgumentException('`rules` property must be an array if provided, received ' . gettype($data['rules']));
+            }
             foreach ($data['rules'] as $ruleData) {
                 $rules[] = ConditionalRule::fromArray($ruleData);
             }


### PR DESCRIPTION
Initial implementation started with the help of `aider`. Although this was a fairly good start, it did however need some fixing and adaptation to make it work as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conditional-rule support and schema to allow conditional date adjustments.
  * Metadata enhancements: until_year, rules array, and grade_display for events.
  * US calendar: added "PrayerUnborn" (National Day of Prayer) with a rule to move when on Sunday.
  * Added lectionary placeholders for "PrayerUnborn" in en_US and es_US.

* **Chores**
  * Removed legacy "PrayerUnborn" entries from the 2011 missal data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->