### PR TITLE
Added decree-based liturgical event readings from the USCCB website.

### DIFF
--- a/jsondata/sourcedata/decrees/lectionary/en.json
+++ b/jsondata/sourcedata/decrees/lectionary/en.json
@@ -39,7 +39,7 @@
         "first_reading": "Wisdom 7: 7-10, 15-16",
         "responsorial_psalm": "Psalm 37: 3-4, 5-6, 30-31",
         "gospel_acclamation": "John 6: 63c, 68c",
-        "gospel": ""Matthew 7: 21-29
+        "gospel": "Matthew 7: 21-29"
     },
     "StJohnAvila": {
         "first_reading": "Acts 13: 46-49",

--- a/jsondata/sourcedata/decrees/lectionary/en.json
+++ b/jsondata/sourcedata/decrees/lectionary/en.json
@@ -1,57 +1,57 @@
 {
     "MaryMotherChurch": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Genesis 3: 9-15, 20|Acts 1: 12-14",
+        "responsorial_psalm": "Psalm 87: 1-2, 3; 5, 6-7",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "John 19: 25-34"
     },
     "StJohnXXIII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Ezekiel 34: 11-16",
+        "responsorial_psalm": "Psalm 23: 1-3a, 4, 5, 6",
+        "gospel_acclamation": "John 10: 14",
+        "gospel": "John 21: 15-17"
     },
     "StJohnPaulII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 52: 7-10",
+        "responsorial_psalm": "Psalm 96: 1-2a, 2b-3, 7-8a, 10",
+        "gospel_acclamation": "John 10: 14",
+        "gospel": "John 21: 15-17"
     },
     "LadyLoreto": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 7: 10-14; 8: 10",
+        "responsorial_psalm": "Luke 1: 46-47, 48-49, 50-51, 52-53, 54-55",
+        "gospel_acclamation": "Luke 1: 28",
+        "gospel": "Luke 1: 26-38"
     },
     "StPaulVI": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "1 Corinthians 9: 16-19, 22-23",
+        "responsorial_psalm": "Psalm 96: 1-2a, 2b-3, 7-8a, 10",
+        "gospel_acclamation": "Mark 1: 17",
+        "gospel": "Matthew 16: 13-19"
     },
     "StFaustinaKowalska": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Ephesians 3: 14-19",
+        "responsorial_psalm": "Psalm 103 (102): 1-2, 3-4, 8-9, 13-14, 17-18a",
+        "gospel_acclamation": "Matthew 11: 28",
+        "gospel": "Matthew 11: 25-30"
     },
     "StGregoryNarek": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Wisdom 7: 7-10, 15-16",
+        "responsorial_psalm": "Psalm 37: 3-4, 5-6, 30-31",
+        "gospel_acclamation": "John 6: 63c, 68c",
+        "gospel": ""Matthew 7: 21-29
     },
     "StJohnAvila": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Acts 13: 46-49",
+        "responsorial_psalm": "Psalm 23: 1-3a, 4, 5, 6",
+        "gospel_acclamation": "Matthew 5: 16",
+        "gospel": "Matthew 5: 13-19"
     },
     "StHildegardBingen": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Song of Songs 8: 6-7",
+        "responsorial_psalm": "Psalm 45: 11-12, 14-15, 16-17",
+        "gospel_acclamation": "Matthew 5: 8",
+        "gospel": "Matthew 25: 1-13"
     },
     "StMotherTeresa": {
         "first_reading": "Isaiah 58: 6-11",


### PR DESCRIPTION
Adds readings specifically for decree-based liturgical events, all sourced from the USCCB website.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Populated lectionary entries for multiple feast days with complete scripture readings — first readings, responsorial psalms, gospel acclamations, and gospel selections — replacing prior placeholders so these celebrations now show full canonical texts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->