### PR TITLE
Added Advent Weekday and Sunday Readings, Week 34 OT Readings in English

### DIFF
--- a/jsondata/sourcedata/lectionary/dominicale_et_festivum_A/en.json
+++ b/jsondata/sourcedata/lectionary/dominicale_et_festivum_A/en.json
@@ -1,31 +1,31 @@
 {
     "Advent1": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "second_reading": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 2:1-5",
+        "responsorial_psalm": "Psalm 122: 1-2, 3-4, 4-5, 6-7, 8-9",
+        "second_reading": "Romans 13:11-14",
+        "gospel_acclamation": "Cf. Psalm 85:8",
+        "gospel": "Matthew 24:37-44"
     },
     "Advent2": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "second_reading": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 11:1-10",
+        "responsorial_psalm": "Psalm 72:1-2, 7-8, 12-13, 17",
+        "second_reading": "Romans 15:4-9",
+        "gospel_acclamation": "Luke 3:4, 6",
+        "gospel": "Matthew 3:1-12"
     },
     "Advent3": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "second_reading": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 35:1-6a, 10",
+        "responsorial_psalm": "Psalm 146:6-7, 8-9, 9-10",
+        "second_reading": "James 5:7-10",
+        "gospel_acclamation": "Isaiah 61:1",
+        "gospel": "Matthew 11:2-11"
     },
     "Advent4": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "second_reading": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 7:10-14",
+        "responsorial_psalm": "Psalm 24:1-2, 3-4, 5-6",
+        "second_reading": "Romans 1:1-7",
+        "gospel_acclamation": "Matthew 1:23",
+        "gospel": "Matthew 1:18-24"
     },
     "Christmas": {
         "vigil": {

--- a/jsondata/sourcedata/lectionary/dominicale_et_festivum_C/en.json
+++ b/jsondata/sourcedata/lectionary/dominicale_et_festivum_C/en.json
@@ -503,11 +503,11 @@
         "gospel": ""
     },
     "ChristKing": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "second_reading": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "2 Samuel 5:1-3",
+        "responsorial_psalm": "Psalm 122:1-3, 3-4, 4-5",
+        "second_reading": "Colossians 1:12-20",
+        "gospel_acclamation": "Mark 11:9, 10",
+        "gospel": "Luke 23:35-43"
     },
     "JesusChristEternalHighPriest": {
         "first_reading": "Isaiah 6:1-4,8",

--- a/jsondata/sourcedata/lectionary/feriale_per_annum_I/en.json
+++ b/jsondata/sourcedata/lectionary/feriale_per_annum_I/en.json
@@ -1188,39 +1188,39 @@
         "gospel": ""
     },
     "OrdWeekday34Monday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Daniel 1:1-6, 8-20",
+        "responsorial_psalm": "Daniel 3:52, 53, 54, 55, 56",
+        "gospel_acclamation": "Matthew 24:42a, 44",
+        "gospel": "Luke 21:1-4"
     },
     "OrdWeekday34Tuesday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Daniel 2:31-45",
+        "responsorial_psalm": "Daniel 3:57, 58, 59, 60, 61",
+        "gospel_acclamation": "Revelation 2:10c",
+        "gospel": "Luke 21:5-11"
     },
     "OrdWeekday34Wednesday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Daniel 5:1-6, 13-14, 16-17, 23-28",
+        "responsorial_psalm": "Daniel 3:62, 63, 64, 65, 66, 67",
+        "gospel_acclamation": "Revelation 2:10c",
+        "gospel": "Luke 21:12-19"
     },
     "OrdWeekday34Thursday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Daniel 6:12-28",
+        "responsorial_psalm": "Daniel 3:68, 69, 70, 71, 72, 73, 74",
+        "gospel_acclamation": "Luke 21:28",
+        "gospel": "Luke 21:20-28"
     },
     "OrdWeekday34Friday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Daniel 7:2-14",
+        "responsorial_psalm": "Daniel 3:75, 76, 77, 78, 79, 80, 81",
+        "gospel_acclamation": "Luke 21:28",
+        "gospel": "Luke 21:29-33"
     },
     "OrdWeekday34Saturday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Daniel 7:15-27",
+        "responsorial_psalm": "Daniel 3:82, 83, 84, 85, 86, 87",
+        "gospel_acclamation": "Luke 21:36",
+        "gospel": "Luke 21:34-36"
     }
 }

--- a/jsondata/sourcedata/lectionary/feriale_tempus_adventus/en.json
+++ b/jsondata/sourcedata/lectionary/feriale_tempus_adventus/en.json
@@ -1,152 +1,152 @@
 {
     "AdventWeekday1Monday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 4:2-6",
+        "responsorial_psalm": "Psalm 122:1-2, 3-4b, 4cd-5, 6-7, 8-9",
+        "gospel_acclamation": "Psalm 80:4",
+        "gospel": "Matthew 8:5-11"
     },
     "AdventWeekday1Tuesday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Isaiah 11:1-10",
+        "responsorial_psalm": "Psalm 72:1-2, 7-8, 12-13, 17",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Luke 10:21-24"
     },
     "AdventWeekday1Wednesday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Isaiah 25:6-10a",
+        "responsorial_psalm": "Psalm 23:1-3a, 3b-4, 5, 6",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 15:29-37"
     },
     "AdventWeekday1Thursday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 26:1-6",
+        "responsorial_psalm": "Psalm 118:1, 8-9, 19-21, 25-27a",
+        "gospel_acclamation": "Isaiah 55:6",
+        "gospel": "Matthew 7:21, 24-27"
     },
     "AdventWeekday1Friday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Isaiah 29:17-24",
+        "responsorial_psalm": "Psalm 27:1, 4, 13-14",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 9:27-31"
     },
     "AdventWeekday1Saturday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 30:19-21, 23-26",
+        "responsorial_psalm": "Psalm 147:1-2, 3-4, 5-6",
+        "gospel_acclamation": "Isaiah 33:22",
+        "gospel": "Matthew 9:35-9:38;10:1, 5a, 6-8"
     },
     "AdventWeekday2Monday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Isaiah 35:1-10",
+        "responsorial_psalm": "Psalm 85:9ab, 10, 11-12, 13-14",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Luke 5:17-26"
     },
     "AdventWeekday2Tuesday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Isaiah 40:1-11",
+        "responsorial_psalm": "Psalm 96:1-2, 3, 10ac, 11-12, 13",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 18:12-14"
     },
     "AdventWeekday2Wednesday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Isaiah 40:25-31",
+        "responsorial_psalm": "Psalm 103:1-2, 3-4, 8, 10",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 11:28-30"
     },
     "AdventWeekday2Thursday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 41:13-20",
+        "responsorial_psalm": "Psalm 145:1, 9, 10-11, 12-13ab",
+        "gospel_acclamation": "Isaiah 45:8",
+        "gospel": "Matthew 11:11-15"
     },
     "AdventWeekday2Friday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Isaiah 48:17-19",
+        "responsorial_psalm": "Psalm 1:1-2, 3, 4, 6",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 11:16-19"
     },
     "AdventWeekday2Saturday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Sirach 48:1-4, 9-11",
+        "responsorial_psalm": "Psalm 80:2ac, 3b, 15-16, 18-19",
+        "gospel_acclamation": "Luke 3:4, 6",
+        "gospel": "Matthew 17:9a, 10-13"
     },
     "AdventWeekday3Monday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Numbers 24:2-7, 15-17a",
+        "responsorial_psalm": "Psalm 25:4-5ab, 6, 7bc, 8-9",
+        "gospel_acclamation": "Psalm 85:8",
+        "gospel": "Matthew 21:23-27"
     },
     "AdventWeekday3Tuesday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Zephaniah 3:1-2, 9-13",
+        "responsorial_psalm": "Psalm 34:2-3, 6-7, 17-18, 19, 23",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 21:28-32"
     },
     "AdventWeekday3Wednesday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 45:6c-8, 18, 21c-25",
+        "responsorial_psalm": "Psalm 85:9ab, 10, 11-12, 13-14",
+        "gospel_acclamation": "Isaiah 40:9-10",
+        "gospel": "Luke 7:18b-23"
     },
     "AdventWeekday3Thursday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 54:1-10",
+        "responsorial_psalm": "Psalm 30:2, 4, 5-6, 11-12a, 13b",
+        "gospel_acclamation": "Luke 3:4, 6",
+        "gospel": "Luke 7:24-30"
     },
     "AdventWeekday3Friday": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Isaiah 56:1-3a, 6-8",
+        "responsorial_psalm": "Psalm 67:2-3, 5, 7-8",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "John 5:33-36"
     },
     "AdventWeekdayDec17": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Genesis 49:2, 8-10",
+        "responsorial_psalm": "Psalm 72:1-2, 3-4ab, 7-8, 17",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 1:1-17"
     },
     "AdventWeekdayDec18": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Jeremiah 23:5-8",
+        "responsorial_psalm": "Psalm 72:1-2, 12-13, 18-19",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 1:18-25"
     },
     "AdventWeekdayDec19": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Judges 13:2-7, 24-25a",
+        "responsorial_psalm": "Psalm 71:3-4a, 5-6ab, 16-17",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Luke 1:5-25"
     },
     "AdventWeekdayDec20": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Isaiah 7:10-14",
+        "responsorial_psalm": "Psalm 24:1-2, 3-4ab, 5-6",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Luke 1:26-38"
     },
     "AdventWeekdayDec21": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Song of Songs 2:8-14|Zephaniah 3:14-18a",
+        "responsorial_psalm": "Psalm 33:2-3, 11-12, 20-21",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Luke 1:39-45"
     },
     "AdventWeekdayDec22": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "1 Samuel 1:24-28",
+        "responsorial_psalm": "1 Samuel 2:1, 4-5, 6-7, 8abcd",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Luke 1:46-56"
     },
     "AdventWeekdayDec23": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Malachi 3:1-4, 23-24",
+        "responsorial_psalm": "Psalm 25:4-5ab, 8-9, 10, 14",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Luke 1:57-66"
     },
     "AdventWeekdayDec24": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "2 Samuel 7:1-5, 8b-12, 14a, 16",
+        "responsorial_psalm": "Psalm 89:2-3, 4-5, 27, 29",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Luke 1:67-79"
     }
 }

--- a/jsondata/sourcedata/lectionary/feriale_tempus_adventus/en.json
+++ b/jsondata/sourcedata/lectionary/feriale_tempus_adventus/en.json
@@ -33,7 +33,7 @@
         "first_reading": "Isaiah 30:19-21, 23-26",
         "responsorial_psalm": "Psalm 147:1-2, 3-4, 5-6",
         "gospel_acclamation": "Isaiah 33:22",
-        "gospel": "Matthew 9:35-9:38;10:1, 5a, 6-8"
+        "gospel": "Matthew 9:35-38;10:1, 5a, 6-8"
     },
     "AdventWeekday2Monday": {
         "first_reading": "Isaiah 35:1-10",


### PR DESCRIPTION
Added readings for
-  Advent (Year A Sundays, weekdays)
- Weekdays of Week 34 in Ordinary Time (Year I)
- Christ the King (Year C)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completed liturgical readings and gospels for all Advent Sundays (Weeks 1-4)
  * Added full lectionary entries for Christ the King Sunday
  * Populated all Ordinary Weekday entries for Week 34
  * Filled in Advent weekday readings throughout the season

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->