### PR TITLE
Added readings for saints whose feast days are coming up through Advent 2025 in English.

### DIFF
--- a/jsondata/sourcedata/lectionary/sanctorum/en.json
+++ b/jsondata/sourcedata/lectionary/sanctorum/en.json
@@ -106,11 +106,11 @@
         "gospel": "John 2:13-22"
     },
     "ImmaculateConception": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "second_reading": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Genesis 3:9-15, 20",
+        "responsorial_psalm": "Psalm 98:1, 2-3ab, 3cd-4",
+        "second_reading": "Ephesians 1:3-6, 11-12",
+        "gospel_acclamation": "Luke 1:28",
+        "gospel": "Luke 1:26-38"
     },
     "ImmaculateHeart": {
         "first_reading": "",
@@ -1099,22 +1099,22 @@
         "gospel": ""
     },
     "StFrancisXavier": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "1 Corinthians 9:16-19, 22-23",
+        "responsorial_psalm": "Psalm 117:1bc, 2",
+        "gospel_acclamation": "Matthew 28:19a, 20b",
+        "gospel": "Mark 16:15-20"
     },
     "StJohnDamascene": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "2 Timothy 1:13-14, 2:1-3",
+        "responsorial_psalm": "Psalm 19:8, 9, 10, 11",
+        "gospel_acclamation": "John 14:23",
+        "gospel": "Matthew 25:14-30"
     },
     "StNicholas": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Isaiah 6:1-8",
+        "responsorial_psalm": "Psalm 40:2, 4, 7-8a, 8b-9, 10, 11",
+        "gospel_acclamation": "Luke 4:18",
+        "gospel": "Luke 10:1-9"
     },
     "StAmbrose": {
         "first_reading": "",
@@ -1123,16 +1123,16 @@
         "gospel": ""
     },
     "StDamasusIPope": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Acts 20:17-18a, 28-32, 36",
+        "responsorial_psalm": "Psalm 110:1, 2, 3, 4",
+        "gospel_acclamation": "John 15:15b",
+        "gospel": "John 15:9-17"
     },
     "StLucySyracuse": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "2 Corinthians 10:17b-18; 11:1-2",
+        "responsorial_psalm": "Psalm 31:3cd-4, 6, 8ab, 16bc, 17",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 25:1-13"
     },
     "StJohnCross": {
         "first_reading": "",
@@ -1147,10 +1147,10 @@
         "gospel": ""
     },
     "StJohnKanty": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "James 2:14-17",
+        "responsorial_psalm": "Psalm 112:1bc-2, 3-4, 5-7, 6-8, 9",
+        "gospel_acclamation": "John 3:34",
+        "gospel": "Luke 6:27-38"
     },
     "StStephenProtomartyr": {
         "first_reading": "",
@@ -1285,16 +1285,16 @@
         "gospel": ""
     },
     "StAndrewDungLac": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "Wisdom 3:1-9",
+        "responsorial_psalm": "Psalm 126:1-2ab, 2cd-3, 4-5, 6",
+        "gospel_acclamation": "1 Peter 4:14",
+        "gospel": "Matthew 10:17-22"
     },
     "StCatherineAlexandria": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Revelation 21:5-7",
+        "responsorial_psalm": "Psalm 124:2-3, 4-5, 7cd-8",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Matthew 10:28-33"
     },
     "StPioPietrelcina": {
         "first_reading": "",
@@ -1303,15 +1303,15 @@
         "gospel": ""
     },
     "OurLadyOfGuadalupe": {
-        "first_reading": "",
-        "responsorial_psalm": "",
+        "first_reading": "Zechariah 2:14-17|Revelation 11:19a; 12:1-6a, 10ab",
+        "responsorial_psalm": "Judith 13:18bcde, 19",
         "gospel_acclamation": "",
-        "gospel": ""
+        "gospel": "Luke 1:26-38|Luke 1:39-47"
     },
     "JuanDiego": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
+        "first_reading": "1 Corinthians 1:26-31",
+        "responsorial_psalm": "Psalm 131:1bcde, 2, 3",
+        "gospel_acclamation": "Matthew 11:25",
+        "gospel": "Matthew 11:25-30"
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the liturgical calendar by adding complete readings data for multiple saints' feast days throughout the year. Populated previously empty fields including first readings, responsorial psalms, gospel acclamations, and gospels with precise biblical references, with several entries now featuring combined readings for special celebrations, significantly improving data consistency and completeness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->