### PR TITLE
[Bug]: schemas not enforcing minItems: 1 for litcal payloads

### DIFF
--- a/jsondata/schemas/DiocesanCalendar.json
+++ b/jsondata/schemas/DiocesanCalendar.json
@@ -25,6 +25,7 @@
     "definitions": {
         "LitCal": {
             "type": "array",
+            "minItems": 1,
             "items": {
                 "type": "object",
                 "additionalProperties": false,

--- a/jsondata/schemas/NationalCalendar.json
+++ b/jsondata/schemas/NationalCalendar.json
@@ -6,6 +6,7 @@
     "properties": {
         "litcal": {
             "type": "array",
+            "minItems": 1,
             "items": {
                 "oneOf": [
                     {

--- a/phpunit_tests/Schemas/PayloadValidationTest.php
+++ b/phpunit_tests/Schemas/PayloadValidationTest.php
@@ -143,12 +143,15 @@ class PayloadValidationTest extends TestCase
             // Diocesan invalid payloads
             'diocesan: wrapped litcal (broken serialization)'    => ['invalid_litcal_wrapped.json', LitSchema::DIOCESAN],
             'diocesan: missing metadata'                         => ['invalid_missing_metadata.json', LitSchema::DIOCESAN],
+            'diocesan: empty litcal array'                       => ['invalid_diocesan_empty_litcal.json', LitSchema::DIOCESAN],
             // National invalid payloads
             'national: wrapped litcal (broken serialization)'    => ['invalid_national_litcal_wrapped.json', LitSchema::NATIONAL],
             'national: missing metadata'                         => ['invalid_national_missing_metadata.json', LitSchema::NATIONAL],
+            'national: empty litcal array'                       => ['invalid_national_empty_litcal.json', LitSchema::NATIONAL],
             // Wider region invalid payloads
             'widerregion: wrapped litcal (broken serialization)' => ['invalid_widerregion_litcal_wrapped.json', LitSchema::WIDERREGION],
             'widerregion: missing metadata'                      => ['invalid_widerregion_missing_metadata.json', LitSchema::WIDERREGION],
+            'widerregion: empty litcal array'                    => ['invalid_widerregion_empty_litcal.json', LitSchema::WIDERREGION],
         ];
     }
 

--- a/phpunit_tests/fixtures/payloads/invalid_diocesan_empty_litcal.json
+++ b/phpunit_tests/fixtures/payloads/invalid_diocesan_empty_litcal.json
@@ -1,0 +1,13 @@
+{
+    "litcal": [],
+    "metadata": {
+        "diocese_id": "TEST_DIOCESE",
+        "diocese_name": "Test Diocese",
+        "nation": "US",
+        "locales": ["en_US"],
+        "timezone": "America/New_York"
+    },
+    "i18n": {
+        "en_US": {}
+    }
+}

--- a/phpunit_tests/fixtures/payloads/invalid_national_empty_litcal.json
+++ b/phpunit_tests/fixtures/payloads/invalid_national_empty_litcal.json
@@ -1,0 +1,17 @@
+{
+    "litcal": [],
+    "metadata": {
+        "nation": "XX",
+        "locales": ["en_US"],
+        "wider_region": "Americas"
+    },
+    "settings": {
+        "epiphany": "SUNDAY_JAN2_JAN8",
+        "ascension": "SUNDAY",
+        "corpus_christi": "SUNDAY",
+        "eternal_high_priest": false
+    },
+    "i18n": {
+        "en_US": {}
+    }
+}

--- a/phpunit_tests/fixtures/payloads/invalid_national_empty_litcal.json
+++ b/phpunit_tests/fixtures/payloads/invalid_national_empty_litcal.json
@@ -3,7 +3,8 @@
     "metadata": {
         "nation": "XX",
         "locales": ["en_US"],
-        "wider_region": "Americas"
+        "wider_region": "Americas",
+        "missals": ["EDITIO_TYPICA_1970"]
     },
     "settings": {
         "epiphany": "SUNDAY_JAN2_JAN8",

--- a/phpunit_tests/fixtures/payloads/invalid_widerregion_empty_litcal.json
+++ b/phpunit_tests/fixtures/payloads/invalid_widerregion_empty_litcal.json
@@ -1,0 +1,11 @@
+{
+    "litcal": [],
+    "national_calendars": ["US", "CA"],
+    "metadata": {
+        "wider_region": "TestRegion",
+        "locales": ["en_US"]
+    },
+    "i18n": {
+        "en_US": {}
+    }
+}

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -1568,6 +1568,10 @@ final class RegionalDataHandler extends AbstractHandler
                         if (!property_exists($payload, 'i18n')) {
                             throw new UnprocessableContentException('The i18n property is required for PUT/PATCH operations');
                         }
+                        // A calendar must have at least one liturgical event
+                        if (empty($payload->litcal)) {
+                            throw new UnprocessableContentException('The litcal array must contain at least one liturgical event');
+                        }
                         $params['rawPayload'] = $payload;  // Store raw for writing to disk
                         $params['payload']    = DiocesanData::fromObject($payload);  // DTO for property access
                         $key                  = $params['payload']->metadata->diocese_id;
@@ -1579,6 +1583,10 @@ final class RegionalDataHandler extends AbstractHandler
                         if (!property_exists($payload, 'i18n')) {
                             throw new UnprocessableContentException('The i18n property is required for PUT/PATCH operations');
                         }
+                        // A calendar must have at least one liturgical event
+                        if (empty($payload->litcal)) {
+                            throw new UnprocessableContentException('The litcal array must contain at least one liturgical event');
+                        }
                         $params['rawPayload'] = $payload;  // Store raw for writing to disk
                         $params['payload']    = NationalData::fromObject($payload);  // DTO for property access
                         $key                  = $params['payload']->metadata->nation;
@@ -1589,6 +1597,10 @@ final class RegionalDataHandler extends AbstractHandler
                         // Schema marks i18n as optional (for stored files), but it's required for PUT/PATCH
                         if (!property_exists($payload, 'i18n')) {
                             throw new UnprocessableContentException('The i18n property is required for PUT/PATCH operations');
+                        }
+                        // A calendar must have at least one liturgical event
+                        if (empty($payload->litcal)) {
+                            throw new UnprocessableContentException('The litcal array must contain at least one liturgical event');
                         }
                         $params['rawPayload'] = $payload;  // Store raw for writing to disk
                         $params['payload']    = WiderRegionData::fromObject($payload);  // DTO for property access


### PR DESCRIPTION
## Summary

- Add `minItems: 1` to DiocesanCalendar.json and NationalCalendar.json schemas (WiderRegionCalendar.json already had this constraint)
- Add explicit empty litcal validation in RegionalDataHandler for all calendar types with clear error message
- Add test fixtures and test cases for empty litcal validation

## Test plan

- [x] PHPUnit tests pass (111 tests, 144719 assertions)
- [x] PHPStan analysis passes
- [x] OpenAPI schema validation passes
- [x] Verify empty litcal payloads are rejected via API request

Fixes #414

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Validation Updates**
  * Liturgical calendars must include at least one liturgical event; empty calendars for diocesan, national, and wider-region submissions are now rejected.

* **Tests**
  * Added test coverage and fixtures verifying rejection of empty calendar payloads across diocesan, national, and wider-region cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->