### PR TITLE
feat: CORS and OpenAPI updates for Phase 2.5 cookie authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,3 +53,10 @@ JWT_SECRET=change-this-to-a-secure-random-string-in-production-minimum-32-chars
 # In staging/production, a valid ADMIN_PASSWORD_HASH is required.
 ADMIN_PASSWORD_HASH=CHANGE_ME_GENERATE_WITH_password_hash
 ADMIN_USERNAME=admin
+
+# CORS Allowed Origins for Authentication Endpoints
+# Comma-separated list of allowed origins for credentialed CORS requests (auth endpoints)
+# Use '*' to allow all origins (not recommended for production with cookie-based auth)
+# Example: CORS_ALLOWED_ORIGINS=https://example.com,https://admin.example.com
+# For development, you typically want to allow the frontend origin
+CORS_ALLOWED_ORIGINS=*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,13 @@ The API supports full cookie-only authentication where:
 - `RefreshHandler` reads refresh token from cookie, no request body needed
 - Frontend uses `credentials: 'include'` to send cookies automatically
 
+**CORS Configuration:**
+
+- `CORS_ALLOWED_ORIGINS` - Comma-separated list of allowed origins for credentialed CORS requests
+  - Default: `*` (all origins allowed - not recommended for production with cookies)
+  - Example: `CORS_ALLOWED_ORIGINS=https://example.com,https://admin.example.com`
+  - Auth endpoint errors only reflect validated origins (security measure)
+
 See [Authentication Roadmap](docs/enhancements/AUTHENTICATION_ROADMAP.md) for implementation details.
 
 ### Testing

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -893,7 +893,7 @@
         ],
         "summary": "Authenticate user and obtain JWT tokens",
         "operationId": "authLogin",
-        "description": "Authenticate with username and password to obtain access and refresh tokens. The access token should be included in the Authorization header for protected endpoints.",
+        "description": "Authenticate with username and password to obtain access and refresh tokens. Tokens are returned in the response body AND set as HttpOnly cookies (litcal_access_token, litcal_refresh_token). Browser clients should use the cookie-based authentication (preferred for XSS protection), while server-to-server clients can use the Bearer token in the Authorization header.",
         "requestBody": {
           "required": true,
           "content": {
@@ -906,7 +906,7 @@
         },
         "responses": {
           "200": {
-            "description": "OK: Authentication successful, tokens returned",
+            "description": "OK: Authentication successful. Tokens returned in response body and set as HttpOnly cookies.",
             "content": {
               "application/json": {
                 "schema": {
@@ -4307,14 +4307,15 @@
       },
       "LoginResponse": {
         "type": "object",
+        "description": "Authentication response containing JWT tokens. Note: These tokens are also set as HttpOnly cookies (litcal_access_token, litcal_refresh_token) for browser-based clients. Browser clients should rely on cookies for authentication rather than storing tokens in localStorage/sessionStorage.",
         "properties": {
           "access_token": {
             "type": "string",
-            "description": "JWT access token valid for 1 hour (configurable via JWT_EXPIRY)"
+            "description": "JWT access token valid for 1 hour (configurable via JWT_EXPIRY). Also set as HttpOnly cookie 'litcal_access_token'."
           },
           "refresh_token": {
             "type": "string",
-            "description": "JWT refresh token valid for 7 days (configurable via JWT_REFRESH_EXPIRY)"
+            "description": "JWT refresh token valid for 7 days (configurable via JWT_REFRESH_EXPIRY). Also set as HttpOnly cookie 'litcal_refresh_token'."
           },
           "token_type": {
             "type": "string",
@@ -5173,7 +5174,13 @@
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "JWT",
-        "description": "JWT access token obtained from /auth/login or /auth/refresh endpoint. Include in Authorization header as: `Authorization: Bearer <token>`"
+        "description": "JWT access token obtained from /auth/login or /auth/refresh endpoint. Include in Authorization header as: `Authorization: Bearer <token>`. This method is suitable for server-to-server communication or non-browser clients."
+      },
+      "CookieAuth": {
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "litcal_access_token",
+        "description": "HttpOnly cookie containing JWT access token, automatically set by /auth/login endpoint. This is the preferred authentication method for browser-based clients as it protects tokens from XSS attacks. Requires `credentials: 'include'` in fetch requests for cross-origin scenarios."
       }
     }
   }

--- a/public/index.php
+++ b/public/index.php
@@ -67,6 +67,7 @@ $dotenv->ifPresent(['API_PROTOCOL', 'API_HOST', 'API_BASE_PATH'])->notEmpty();
 $dotenv->ifPresent(['API_PROTOCOL'])->allowedValues(['http', 'https']);
 $dotenv->ifPresent(['API_PORT'])->isInteger();
 $dotenv->ifPresent(['APP_ENV'])->notEmpty()->allowedValues(['development', 'test', 'staging', 'production']);
+$dotenv->ifPresent(['CORS_ALLOWED_ORIGINS'])->notEmpty();
 
 $logsFolder = $projectFolder . DIRECTORY_SEPARATOR . 'logs';
 if (!file_exists($logsFolder)) {

--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -80,59 +80,6 @@ abstract class AbstractHandler implements RequestHandlerInterface
     }
 
     /**
-     * @param string $originsFile The path to the file that defines the allowed origins.
-     */
-    public function setAllowedOriginsFromFile(string $originsFile): static
-    {
-        if (!file_exists($originsFile)) {
-            $projectFolder = __DIR__;
-            $level         = 0;
-            while (true) {
-                if (file_exists($projectFolder . DIRECTORY_SEPARATOR . $originsFile)) {
-                    $originsFile = $projectFolder . DIRECTORY_SEPARATOR . $originsFile;
-                    break;
-                }
-
-                // Don't look more than 4 levels up
-                if ($level > 4) {
-                    $originsFile = '';
-                    break;
-                }
-
-                $parentDir = dirname($projectFolder);
-                if ($parentDir === $projectFolder) { // reached the system root!
-                    $originsFile = '';
-                    break;
-                }
-
-                $projectFolder = $parentDir;
-                ++$level;
-            }
-        }
-
-        if ('' === $originsFile) {
-            throw new \RuntimeException("Allowed origins file '{$originsFile}' not found.");
-        }
-
-        $originsFileContents = file($originsFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
-        if (false === $originsFileContents) {
-            throw new \RuntimeException("Allowed origins file '{$originsFile}' could not be read.");
-        }
-
-        /** @var string[] $trimmedOriginsFileContents */
-        $trimmedOriginsFileContents = array_map(
-            function (string $v): string {
-                return trim($v);
-            },
-            $originsFileContents
-        );
-
-        $this->setAllowedOrigins($trimmedOriginsFileContents);
-
-        return $this;
-    }
-
-    /**
      * Sets the allowed referers for Cross-Origin Resource Sharing (CORS).
      *
      * This function updates the list of referers that are permitted to access

--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -335,12 +335,14 @@ abstract class AbstractHandler implements RequestHandlerInterface
      * Checks if the request Origin is allowed based on the list of allowed Origins.
      *
      * This function returns true if the request Origin is allowed, false otherwise.
+     * Note: Wildcard ('*') handling is done in setAccessControlAllowOriginHeader()
+     * before this method is called.
      *
      * @return bool True if the request Origin is allowed, false otherwise.
      */
     protected function isAllowedOrigin(string $origin): bool
     {
-        return $origin !== '' && in_array($origin, $this->allowedOrigins);
+        return $origin !== '' && in_array($origin, $this->allowedOrigins, true);
     }
 
     /**

--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -354,7 +354,8 @@ abstract class AbstractHandler implements RequestHandlerInterface
      */
     protected function isAllowedReferer(): bool
     {
-        return in_array($_SERVER['HTTP_REFERER'], $this->allowedReferers);
+        $referer = $_SERVER['HTTP_REFERER'] ?? '';
+        return $referer !== '' && in_array($referer, $this->allowedReferers, true);
     }
 
 

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -66,6 +66,8 @@ final class RegionalDataHandler extends AbstractHandler
     public function __construct(array $requestPathParams = [])
     {
         parent::__construct($requestPathParams);
+        // Allow credentials for cross-origin cookie requests (required for authenticated PUT/PATCH/DELETE)
+        $this->allowCredentials = true;
         /** @var \stdClass&object{litcal_metadata:MetadataCalendarsObject} $metadataObj */
         $metadataObj             = Utilities::jsonUrlToObject(Route::CALENDARS->path());
         $this->CalendarsMetadata = MetadataCalendars::fromObject($metadataObj->litcal_metadata);

--- a/src/Http/Middleware/ErrorHandlingMiddleware.php
+++ b/src/Http/Middleware/ErrorHandlingMiddleware.php
@@ -24,17 +24,46 @@ class ErrorHandlingMiddleware implements MiddlewareInterface
     private ?ServerRequestInterface $currentRequest = null;
 
     /**
+     * List of allowed origins for CORS.
+     * If ['*'] (default), all origins are allowed for non-credentialed requests.
+     * For credentialed requests (cookies), specific origins must be listed.
+     *
+     * @var string[]
+     */
+    private array $allowedOrigins;
+
+    /**
+     * Optional callable to validate origins dynamically.
+     * When set, takes precedence over the $allowedOrigins array.
+     * Signature: fn(string $origin): bool
+     *
+     * This allows for future extensibility where applications can define
+     * their own allowed origins (e.g., per-API-key origin restrictions).
+     *
+     * @var callable(string): bool|null
+     */
+    private $originValidator;
+
+    /**
      * Constructor for the ErrorHandlingMiddleware.
      *
      * @param ResponseFactoryInterface $responseFactory The PSR-7 response factory.
      * @param bool $debug Whether to enable debug level logging.
+     * @param string[] $allowedOrigins List of allowed origins for CORS (default: ['*']).
+     * @param callable(string): bool|null $originValidator Optional callable to validate origins dynamically.
      *
      * @throws \RuntimeException If unable to open php://stderr for writing.
      */
-    public function __construct(ResponseFactoryInterface $responseFactory, bool $debug = false)
-    {
+    public function __construct(
+        ResponseFactoryInterface $responseFactory,
+        bool $debug = false,
+        array $allowedOrigins = ['*'],
+        ?callable $originValidator = null
+    ) {
         $this->responseFactory = $responseFactory;
         $this->debug           = $debug;
+        $this->allowedOrigins  = $allowedOrigins;
+        $this->originValidator = $originValidator;
         $debugLogger           = LoggerFactory::create('api', null, 30, $debug, true, true);
         $this->debugLogger     = $debugLogger;
         $errorLogger           = LoggerFactory::create('api-error', null, 30, $debug, true, true);
@@ -54,6 +83,35 @@ class ErrorHandlingMiddleware implements MiddlewareInterface
 
         // Escalate PHP warnings/notices to exceptions
         set_error_handler([$this, 'handlePhpWarning']);
+    }
+
+    /**
+     * Check if an origin is allowed for CORS.
+     *
+     * First checks the custom originValidator callable if set.
+     * Falls back to checking the allowedOrigins array.
+     *
+     * @param string $origin The origin to validate.
+     * @return bool True if the origin is allowed, false otherwise.
+     */
+    private function isAllowedOrigin(string $origin): bool
+    {
+        if ($origin === '') {
+            return false;
+        }
+
+        // Use custom validator if provided
+        if ($this->originValidator !== null) {
+            return ( $this->originValidator )($origin);
+        }
+
+        // Check if wildcard is allowed (allows all origins)
+        if (count($this->allowedOrigins) === 1 && $this->allowedOrigins[0] === '*') {
+            return true;
+        }
+
+        // Check against explicit list
+        return in_array($origin, $this->allowedOrigins, true);
     }
 
     /**
@@ -115,22 +173,29 @@ class ErrorHandlingMiddleware implements MiddlewareInterface
                 ->getBody()
                 ->write($responseBody);
 
-            // For auth endpoints that use credentials, return specific origin (not wildcard)
-            // This is required for CORS when credentials: 'include' is used
+            // Handle CORS headers for error responses
             $path           = $request->getUri()->getPath();
             $origin         = $request->getHeaderLine('Origin');
             $isAuthEndpoint = str_starts_with($path, '/auth/') || $path === '/auth';
 
+            $response = $response->withHeader('Content-Type', 'application/problem+json');
+
+            // For auth endpoints that use credentials, validate origin before reflecting
+            // This is required for CORS when credentials: 'include' is used
             if ($isAuthEndpoint && $origin !== '') {
-                return $response
-                    ->withHeader('Content-Type', 'application/problem+json')
-                    ->withHeader('Access-Control-Allow-Origin', $origin)
-                    ->withHeader('Access-Control-Allow-Credentials', 'true');
+                // Only reflect the origin if it passes validation
+                if ($this->isAllowedOrigin($origin)) {
+                    return $response
+                        ->withHeader('Access-Control-Allow-Origin', $origin)
+                        ->withHeader('Access-Control-Allow-Credentials', 'true');
+                }
+                // Origin not allowed - don't add CORS headers (browser will block the request)
+                // This prevents unauthorized origins from receiving credentialed responses
+                return $response;
             }
 
-            return $response
-                ->withHeader('Content-Type', 'application/problem+json')
-                ->withHeader('Access-Control-Allow-Origin', '*');
+            // For non-auth endpoints or requests without Origin header, use wildcard
+            return $response->withHeader('Access-Control-Allow-Origin', '*');
         }
     }
 

--- a/src/Http/Middleware/ErrorHandlingMiddleware.php
+++ b/src/Http/Middleware/ErrorHandlingMiddleware.php
@@ -115,6 +115,19 @@ class ErrorHandlingMiddleware implements MiddlewareInterface
                 ->getBody()
                 ->write($responseBody);
 
+            // For auth endpoints that use credentials, return specific origin (not wildcard)
+            // This is required for CORS when credentials: 'include' is used
+            $path           = $request->getUri()->getPath();
+            $origin         = $request->getHeaderLine('Origin');
+            $isAuthEndpoint = str_starts_with($path, '/auth/') || $path === '/auth';
+
+            if ($isAuthEndpoint && $origin !== '') {
+                return $response
+                    ->withHeader('Content-Type', 'application/problem+json')
+                    ->withHeader('Access-Control-Allow-Origin', $origin)
+                    ->withHeader('Access-Control-Allow-Credentials', 'true');
+            }
+
             return $response
                 ->withHeader('Content-Type', 'application/problem+json')
                 ->withHeader('Access-Control-Allow-Origin', '*');

--- a/src/Router.php
+++ b/src/Router.php
@@ -95,10 +95,8 @@ class Router
         // This is used for both handler-level CORS and error response CORS
         $allowedOriginsEnv = isset($_ENV['CORS_ALLOWED_ORIGINS']) && is_string($_ENV['CORS_ALLOWED_ORIGINS'])
             ? $_ENV['CORS_ALLOWED_ORIGINS']
-            : '*';
-        $allowedOrigins    = $allowedOriginsEnv === '*'
-            ? ['*']
-            : array_filter(array_map('trim', explode(',', $allowedOriginsEnv)));
+            : null;
+        $allowedOrigins    = Utilities::parseCorsAllowedOrigins($allowedOriginsEnv);
 
         // The very first response that will need to be submitted by the API,
         // is the response to pre-flight requests.

--- a/src/Router.php
+++ b/src/Router.php
@@ -387,7 +387,16 @@ class Router
         }
 
         $pipeline = new MiddlewarePipeline($this->handler);
-        $pipeline->pipe(new ErrorHandlingMiddleware($this->psr17Factory, self::$debug)); // outermost middleware
+
+        // Parse allowed origins from environment (comma-separated list, or '*' for all)
+        $allowedOriginsEnv = isset($_ENV['CORS_ALLOWED_ORIGINS']) && is_string($_ENV['CORS_ALLOWED_ORIGINS'])
+            ? $_ENV['CORS_ALLOWED_ORIGINS']
+            : '*';
+        $allowedOrigins    = $allowedOriginsEnv === '*'
+            ? ['*']
+            : array_filter(array_map('trim', explode(',', $allowedOriginsEnv)));
+
+        $pipeline->pipe(new ErrorHandlingMiddleware($this->psr17Factory, self::$debug, $allowedOrigins)); // outermost middleware
         $pipeline->pipe(new LoggingMiddleware(self::$debug));
 
         // Apply JWT authentication middleware for protected routes

--- a/src/Router.php
+++ b/src/Router.php
@@ -360,6 +360,12 @@ class Router
                     AcceptHeader::JSON,
                     AcceptHeader::YAML
                 ]);
+                if (
+                    in_array($this->request->getMethod(), [ RequestMethod::PUT->value, RequestMethod::PATCH->value, RequestMethod::DELETE->value ], true)
+                    && false === Router::isLocalhost()
+                ) {
+                    $regionalDataHandler->setAllowedOrigins($allowedOrigins);
+                }
                 $this->handler = $regionalDataHandler;
                 break;
             case 'tests':

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -738,6 +738,41 @@ class Utilities
     }
 
     /**
+     * Parse CORS_ALLOWED_ORIGINS environment variable into an array of allowed origins.
+     *
+     * This method provides consistent parsing across all entry points (Router, CLI servers, workers).
+     *
+     * @param string|null $envValue The value from $_ENV['CORS_ALLOWED_ORIGINS'] or null if not set.
+     * @param bool $throwOnEmpty If true, throws exception when value is set but results in empty array.
+     * @return string[] Array of allowed origins, or ['*'] if not configured or wildcard.
+     * @throws \InvalidArgumentException If $throwOnEmpty is true and parsed result is empty.
+     */
+    public static function parseCorsAllowedOrigins(?string $envValue, bool $throwOnEmpty = false): array
+    {
+        // Not set or explicit wildcard - allow all origins
+        if ($envValue === null || $envValue === '*') {
+            return ['*'];
+        }
+
+        // Parse comma-separated list, trim whitespace, filter empty values
+        $origins = array_filter(array_map('trim', explode(',', $envValue)));
+
+        // Handle empty result (e.g., whitespace-only value)
+        if (count($origins) === 0) {
+            if ($throwOnEmpty) {
+                throw new \InvalidArgumentException(
+                    'CORS_ALLOWED_ORIGINS is set but contains no valid origins. '
+                    . 'Use "*" to allow all origins or provide a comma-separated list of origins.'
+                );
+            }
+            // Default to wildcard if not throwing
+            return ['*'];
+        }
+
+        return $origins;
+    }
+
+    /**
      * Function called after a successful installation of the Catholic Liturgical Calendar API.
      *
      * It prints the typical motto of the Jesuits (see {@link https://it.cathopedia.org/wiki/Ad_Maiorem_Dei_Gloriam})


### PR DESCRIPTION
## Summary

Additional updates to support Phase 2.5 cookie-only authentication (follow-up to #424):

- **CORS origin validation** - Validate origins before reflecting them in error responses (security improvement)
- **CORS config centralization** - Move CORS allowed origins to environment variable, remove file-based config
- **OpenAPI documentation updates** - Add `CookieAuth` security scheme and update auth endpoint documentation
- **RegionalDataHandler CORS** - Enable `allowCredentials` for cookie-based authentication on protected routes

## Changes

### `src/Http/Middleware/ErrorHandlingMiddleware.php`
- Add `allowedOrigins` array and optional `originValidator` callable via constructor
- Add `isAllowedOrigin()` method to validate origins before reflecting
- Only reflect validated origins with `Access-Control-Allow-Credentials` for auth endpoints
- Reject unknown origins by omitting CORS headers (browser blocks request)

### `src/Router.php`
- Parse `CORS_ALLOWED_ORIGINS` once at route start
- Use `setAllowedOrigins($allowedOrigins)` for handlers instead of file-based config
- Remove duplicate parsing in middleware setup

### `src/Handlers/AbstractHandler.php`
- Remove `setAllowedOriginsFromFile()` method (no longer needed)

### `public/index.php`
- Add `CORS_ALLOWED_ORIGINS` validation to DotEnv loader

### `.env.example`
- Add `CORS_ALLOWED_ORIGINS` environment variable documentation

### `CLAUDE.md`
- Document `CORS_ALLOWED_ORIGINS` configuration

### `jsondata/schemas/openapi.json`
- Add `CookieAuth` security scheme for HttpOnly cookie authentication
- Update `BearerAuth` description to note it's for server-to-server clients
- Update `/auth/login` description to mention HttpOnly cookies are set
- Update `LoginResponse` schema to document cookie behavior

### `src/Handlers/RegionalDataHandler.php`
- Enable `allowCredentials` for CORS with cookies

## Security Notes

- The `originValidator` callable allows future extensibility for per-application origin restrictions (e.g., when apps register their own allowed origins via API keys)
- Origins are validated before being reflected in CORS headers, preventing unauthorized origins from receiving credentialed responses

## Test plan

- [x] PHPStan analysis passes (level 10)
- [x] PHP parallel-lint passes
- [x] All PHPUnit tests pass
- [ ] Manual testing of cookie-based authentication flow

## Related

- Closes the remaining work from #423
- Follow-up to #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HttpOnly cookie-based authentication for browser clients, complementing existing Bearer token support
  * Token expiration time now included in authentication responses

* **Security Improvements**
  * Enhanced CORS configuration with environment-based allowed origins
  * Stricter origin validation for authenticated endpoints and cross-origin requests

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->