### PR TITLE
Fix CORS headers on error responses for credentialed requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,3 +60,15 @@ ADMIN_USERNAME=admin
 # Example: CORS_ALLOWED_ORIGINS=https://example.com,https://admin.example.com
 # For development, you typically want to allow the frontend origin
 CORS_ALLOWED_ORIGINS=*
+
+# Redis Configuration (for WebSocket server caching)
+# The WebSocket test server uses Redis (or APCu fallback) for caching.
+# Configure either Unix socket OR TCP connection (socket takes precedence).
+# If not configured, defaults to TCP 127.0.0.1:6379
+#
+# Unix socket connection (recommended for local Redis):
+# REDIS_SOCKET=/var/run/redis/redis.sock
+#
+# TCP connection:
+# REDIS_HOST=127.0.0.1
+# REDIS_PORT=6379

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ composer stop
 
 The API supports full cookie-only authentication where:
 
-- Tokens are stored in HttpOnly cookies (not accessible to JavaScript, XSS-proof)
+- Tokens are stored in HttpOnly cookies (not accessible to JavaScript, mitigating token theft via XSS)
 - `JwtAuthMiddleware` reads token from cookie first, falls back to Authorization header
 - `RefreshHandler` reads refresh token from cookie, no request body needed
 - Frontend uses `credentials: 'include'` to send cookies automatically

--- a/docs/enhancements/AUTHENTICATION_ROADMAP.md
+++ b/docs/enhancements/AUTHENTICATION_ROADMAP.md
@@ -491,13 +491,11 @@ This allows frontends to use HttpOnly cookies exclusively, without needing to st
 **Backend Support Already Implemented:**
 
 1. **RefreshHandler** (`src/Handlers/Auth/RefreshHandler.php`)
-   - ✅ Reads refresh token from HttpOnly cookie first (lines 124-128)
-   - ✅ Falls back to request body for backwards compatibility (lines 130-134)
+   - ✅ Reads refresh token from HttpOnly cookie first, falling back to request body
    - ✅ No request body required when refresh token cookie is present
 
 2. **JwtAuthMiddleware** (`src/Http/Middleware/JwtAuthMiddleware.php`)
-   - ✅ Reads access token from HttpOnly cookie first (lines 62-64)
-   - ✅ Falls back to Authorization header for backwards compatibility (lines 67-78)
+   - ✅ Reads access token from HttpOnly cookie first, falling back to Authorization header
    - ✅ Automatic token validation from cookies
 
 3. **CookieHelper** (`src/Http/CookieHelper.php`)

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -973,6 +973,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Logout user session",
@@ -1009,6 +1012,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Get current authenticated user information",
@@ -1687,6 +1693,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Create a national calendar data resource",
@@ -1758,6 +1767,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Create a wider region data resource",
@@ -1829,6 +1841,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Create a diocesan calendar data resource",
@@ -1976,6 +1991,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Update a national calendar data resource",
@@ -2051,6 +2069,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Delete a national calendar data resource",
@@ -2169,6 +2190,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Update a diocesan calendar data resource",
@@ -2243,6 +2267,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Delete a diocesan calendar data resource",
@@ -2360,6 +2387,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Update a wider region calendar data resource",
@@ -2434,6 +2464,9 @@
         "security": [
           {
             "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
           }
         ],
         "summary": "Delete a wider region calendar data resource",

--- a/public/LitCalTestServer.php
+++ b/public/LitCalTestServer.php
@@ -48,6 +48,9 @@ $dotenv->ifPresent(['API_PORT'])->isInteger();
 $dotenv->ifPresent(['APP_ENV'])->notEmpty()->allowedValues(['development', 'test', 'staging', 'production']);
 $dotenv->ifPresent(['WS_PROTOCOL', 'WS_HOST'])->notEmpty();
 $dotenv->ifPresent(['WS_PORT'])->isInteger();
+// Redis configuration for caching (socket takes precedence over TCP)
+$dotenv->ifPresent(['REDIS_SOCKET', 'REDIS_HOST'])->notEmpty();
+$dotenv->ifPresent(['REDIS_PORT'])->isInteger();
 
 $logsFolder = $projectFolder . DIRECTORY_SEPARATOR . 'logs';
 if (!file_exists($logsFolder)) {

--- a/src/Handlers/AbstractHandler.php
+++ b/src/Handlers/AbstractHandler.php
@@ -349,11 +349,21 @@ abstract class AbstractHandler implements RequestHandlerInterface
      * Checks if the request Referer is allowed based on the list of allowed Referers.
      *
      * This function returns true if the request Referer is allowed, false otherwise.
+     * Unlike isAllowedOrigin(), this method handles wildcard ('*') internally since
+     * referer validation is strict-matching-only by design (no CORS header echoing).
+     *
+     * Note: This method is currently unused but provided for future use cases
+     * where referer validation may be needed (e.g., API key restrictions).
      *
      * @return bool True if the request Referer is allowed, false otherwise.
      */
     protected function isAllowedReferer(): bool
     {
+        // If wildcard is set, all referers are allowed
+        if (count($this->allowedReferers) === 1 && $this->allowedReferers[0] === '*') {
+            return true;
+        }
+
         $referer = $_SERVER['HTTP_REFERER'] ?? '';
         return $referer !== '' && in_array($referer, $this->allowedReferers, true);
     }

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -754,8 +754,12 @@ class Utilities
             return ['*'];
         }
 
-        // Parse comma-separated list, trim whitespace, filter empty values
-        $origins = array_filter(array_map('trim', explode(',', $envValue)));
+        // Parse comma-separated list, trim whitespace, filter empty strings only
+        // Using explicit callback to avoid filtering falsy values like "0"
+        $origins = array_filter(
+            array_map('trim', explode(',', $envValue)),
+            static fn(string $origin): bool => $origin !== ''
+        );
 
         // Handle empty result (e.g., whitespace-only value)
         if (count($origins) === 0) {


### PR DESCRIPTION
## Summary

- Include proper CORS headers on ALL error responses when Origin header is present
- Previously, only `/auth/` endpoints got proper CORS headers on errors
- Now all endpoints get `Access-Control-Allow-Origin: <specific-origin>` and `Access-Control-Allow-Credentials: true`

## Problem

When using credentialed requests (`credentials: 'include'` for HttpOnly cookies), browsers require:
1. `Access-Control-Allow-Origin` to be a specific origin (not `*`)
2. `Access-Control-Allow-Credentials: true`

Error responses (e.g., 401 Unauthorized) were returning `Access-Control-Allow-Origin: *` which caused browsers to block the response with "Failed to fetch".

## Test plan

- [x] Verified 401 response now includes proper CORS headers:
  ```
  Access-Control-Allow-Origin: http://localhost:3000
  Access-Control-Allow-Credentials: true
  ```
- [x] Frontend e2e tests pass (diocesan empty litcal test no longer skips)
- [x] PHPStan analysis passes
- [x] PHP linting passes

Fixes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added HttpOnly cookie-based authentication as the primary method, with fallback to Authorization header support.
  * Introduced new `/auth/me` endpoint for checking authentication state via cookies.
  * CORS configuration now managed via environment variables for flexible cross-origin setup.

* **Bug Fixes**
  * Improved serialization validation with stricter JSON error handling.
  * Fixed inconsistent naming across liturgical event references for data consistency.

* **Documentation**
  * Updated authentication and CORS configuration guidance.
  * Enhanced serialization and validation documentation with examples.

* **Tests**
  * Added validation tests for payloads with empty liturgical calendars.

* **Chores**
  * Updated internationalization translations and metadata.
  * Refined environment configuration for development and test environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->