### PR TITLE
Refactor: Extract duplicated code into helper methods

### DIFF
--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -650,7 +650,7 @@ final class CalendarHandler extends AbstractHandler
                 throw new ServiceUnavailableException($description);
             }
 
-            if (false === mkdir($this->CachePath, 0755, true)) {
+            if (false === mkdir($this->CachePath, 0755, true) && false === is_dir($this->CachePath)) {
                 $description = sprintf(
                     'Could not create cache folder: %s. Please ensure the path is writable.',
                     $this->CachePath

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -569,13 +569,18 @@ final class CalendarHandler extends AbstractHandler
     }
 
     /**
-     * Get the localized day of the week string for a given date.
+     * Get the localized date identifier for Christmas weekday naming.
      *
-     * Handles Latin (using LatinUtils::LATIN_DAYOFTHEWEEK), Italian (using dayAndMonth formatter),
-     * and other locales (using dayOfTheWeek formatter).
+     * Returns different formats based on locale, tailored for use in Christmas weekday names:
+     * - Latin: Day of the week (e.g., "Feria II") from LatinUtils::LATIN_DAYOFTHEWEEK
+     * - Italian: Day and month (e.g., "3 gennaio") using dayAndMonth formatter
+     * - Other locales: Day of the week using dayOfTheWeek formatter
      *
-     * @param DateTime $dateTime The date to get the day of the week for
-     * @return string The localized day of the week string
+     * Note: This is specifically designed for formatChristmasWeekdayName() usage,
+     * where Italian uses day+month format ("Feria propria del 3 gennaio").
+     *
+     * @param DateTime $dateTime The date to format
+     * @return string The localized date identifier for Christmas weekday naming
      */
     private function getLocalizedDayOfTheWeek(DateTime $dateTime): string
     {
@@ -597,20 +602,21 @@ final class CalendarHandler extends AbstractHandler
      * Handles Latin ("X temporis Nativitatis"), Italian ("Feria propria del X"),
      * and other locales using gettext translation.
      *
-     * @param string $dayOfTheWeek The localized day of the week string
+     * @param string $dateIdentifier The localized date identifier from getLocalizedDayOfTheWeek().
+     *                               For Latin/other locales: day of week. For Italian: day+month.
      * @return string The formatted Christmas weekday name
      */
-    private function formatChristmasWeekdayName(string $dayOfTheWeek): string
+    private function formatChristmasWeekdayName(string $dateIdentifier): string
     {
         $locale = LitLocale::$PRIMARY_LANGUAGE;
         return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-            ? sprintf('%s temporis Nativitatis', $dayOfTheWeek)
+            ? sprintf('%s temporis Nativitatis', $dateIdentifier)
             : ( $locale === 'it'
-                ? sprintf('Feria propria del %s', $dayOfTheWeek)
+                ? sprintf('Feria propria del %s', $dateIdentifier)
                 : sprintf(
                     /**translators: Christmas weekday name pattern */
                     _('%s - Christmas Weekday'),
-                    $dayOfTheWeek
+                    $dateIdentifier
                 )
             );
     }

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -639,9 +639,15 @@ final class CalendarHandler extends AbstractHandler
      */
     private function ensureCachePathExists(): void
     {
-        if (false === realpath($this->CachePath)) {
+        // Normalize and validate the cache path
+        $cachePath = rtrim($this->CachePath, DIRECTORY_SEPARATOR);
+        if ($cachePath === '') {
+            throw new ServiceUnavailableException('Cache path has not been initialized.');
+        }
+
+        if (false === realpath($cachePath)) {
             // Walk up from the target directory to find the nearest existing ancestor
-            $existingAncestor = dirname($this->CachePath);
+            $existingAncestor = dirname($cachePath);
             while ($existingAncestor !== '' && $existingAncestor !== '.' && false === is_dir($existingAncestor)) {
                 $existingAncestor = dirname($existingAncestor);
             }
@@ -653,16 +659,16 @@ final class CalendarHandler extends AbstractHandler
             if (false === is_writable($existingAncestor)) {
                 $description = sprintf(
                     'The cache folder %s does not exist, but we cannot create it because the parent folder %s is not writable.',
-                    $this->CachePath,
+                    $cachePath,
                     $existingAncestor
                 );
                 throw new ServiceUnavailableException($description);
             }
 
-            if (false === mkdir($this->CachePath, 0755, true) && false === is_dir($this->CachePath)) {
+            if (false === mkdir($cachePath, 0755, true) && false === is_dir($cachePath)) {
                 $description = sprintf(
                     'Could not create cache folder: %s. Please ensure the path is writable.',
-                    $this->CachePath
+                    $cachePath
                 );
                 throw new ServiceUnavailableException($description);
             }

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -1521,7 +1521,6 @@ final class CalendarHandler extends AbstractHandler
         }
 
         //Holy Family is celebrated the Sunday after Christmas, unless Christmas falls on a Sunday, in which case it is celebrated Dec. 30
-        $locale    = LitLocale::$PRIMARY_LANGUAGE;
         $Christmas = $this->Cal->getLiturgicalEvent('Christmas');
         if (null === $Christmas) {
             throw new ServiceUnavailableException('Christmas was not found among the LiturgicalEvents');
@@ -1537,12 +1536,7 @@ final class CalendarHandler extends AbstractHandler
                 $Christmas->name,
                 $this->CalendarParams->Year,
                 $HolyFamily->name,
-                $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? ( $HolyFamily->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $HolyFamily->date->format('n')] )
-                    : ( $locale === 'en'
-                        ? $HolyFamily->date->format('F jS')
-                        : $this->dayAndMonth->format($HolyFamily->date->format('U'))
-                    )
+                $this->formatLocalizedDate($HolyFamily->date)
             );
         } else {
             $this->PropriumDeTempore['HolyFamily']->setDate(DateTime::fromFormat('25-12-' . $this->CalendarParams->Year)->modify('next Sunday'));
@@ -1952,8 +1946,6 @@ final class CalendarHandler extends AbstractHandler
      */
     private function addMissalMemorialMessage(PropriumDeSanctisEvent $propriumDeSanctisEvent): void
     {
-        $locale = LitLocale::$PRIMARY_LANGUAGE;
-
         /**translators:
          * 1. Grade or rank of the liturgical event
          * 2. Name of the liturgical event
@@ -1967,12 +1959,7 @@ final class CalendarHandler extends AbstractHandler
             $message,
             $propriumDeSanctisEvent->grade->i18n($this->CalendarParams->Locale, false),
             $propriumDeSanctisEvent->name,
-            $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                ? ( $propriumDeSanctisEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $propriumDeSanctisEvent->date->format('n')] )
-                : ( $locale === 'en'
-                    ? $propriumDeSanctisEvent->date->format('F jS')
-                    : $this->dayAndMonth->format($propriumDeSanctisEvent->date->format('U'))
-                ),
+            $this->formatLocalizedDate($propriumDeSanctisEvent->date),
             $propriumDeSanctisEvent->since_year,
             $propriumDeSanctisEvent->decree,
             $this->CalendarParams->Year
@@ -2226,7 +2213,6 @@ final class CalendarHandler extends AbstractHandler
          * 9. Requested calendar year
          */
         $message          = _('The %1$s \'%2$s\', added in the %3$s of the Roman Missal since the year %4$d (%5$s) and usually celebrated on %6$s, is suppressed by the %7$s \'%8$s\' in the year %9$d.');
-        $locale           = LitLocale::$PRIMARY_LANGUAGE;
         $grade_str        = $potentialEvent->grade->i18n($this->CalendarParams->Locale, false);
         $this->Messages[] = sprintf(
             $message,
@@ -2235,12 +2221,7 @@ final class CalendarHandler extends AbstractHandler
             RomanMissal::getName($missal),
             $year,
             $decree,
-            $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                ? ( $potentialEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $potentialEvent->date->format('n')] )
-                : ( $locale === 'en'
-                    ? $potentialEvent->date->format('F jS')
-                    : $this->dayAndMonth->format($potentialEvent->date->format('U'))
-                ),
+            $this->formatLocalizedDate($potentialEvent->date),
             $coincidingLiturgicalEvent->grade_lcl,
             $coincidingLiturgicalEvent->event->name,
             $this->CalendarParams->Year
@@ -2266,7 +2247,6 @@ final class CalendarHandler extends AbstractHandler
         /** @var DecreeItemCreateNewFixed $liturgicalEvent */
         $liturgicalEvent           = $decreeItem->liturgical_event;
         $coincidingLiturgicalEvent = $this->Cal->determineSundaySolemnityOrFeast($liturgicalEvent->date, $liturgicalEvent->event_key);
-        $locale                    = LitLocale::$PRIMARY_LANGUAGE;
         $this->Messages[]          = sprintf(
             /**translators:
              * 1. Grade or rank of the liturgical event
@@ -2281,12 +2261,7 @@ final class CalendarHandler extends AbstractHandler
             _('The %1$s \'%2$s\', added on %3$s since the year %4$d (%5$s), is however superseded by the %6$s \'%7$s\' in the year %8$d.'),
             $liturgicalEvent->grade->i18n($this->CalendarParams->Locale),
             $liturgicalEvent->name,
-            $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                ? ( $liturgicalEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $liturgicalEvent->date->format('n')] )
-                : ( $locale === 'en'
-                    ? $liturgicalEvent->date->format('F jS')
-                    : $this->dayAndMonth->format($liturgicalEvent->date->format('U'))
-                ),
+            $this->formatLocalizedDate($liturgicalEvent->date),
             $decreeItem->metadata->since_year,
             $decreeItem->metadata->getUrl(),
             $coincidingLiturgicalEvent->grade_lcl,
@@ -2415,8 +2390,6 @@ final class CalendarHandler extends AbstractHandler
         $date            = DateTime::fromFormat("{$liturgicalEvent->day}-{$liturgicalEvent->month}-{$this->CalendarParams->Year}");
         $liturgicalEvent->setDate($date);
 
-        $locale = LitLocale::$PRIMARY_LANGUAGE;
-
         if ($liturgicalEvent->grade === LitGrade::MEMORIAL_OPT) {
             if ($this->Cal->notInSolemnitiesFeastsOrMemorials($date)) {
                 $litEvent = LiturgicalEvent::fromObject($liturgicalEvent);
@@ -2434,11 +2407,7 @@ final class CalendarHandler extends AbstractHandler
                     _('The %1$s \'%2$s\' has been added on %3$s since the year %4$d (%5$s), applicable to the year %6$d.'),
                     $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false),
                     $liturgicalEvent->name,
-                    $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                        ? ( $date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $date->format('n')] )
-                        : ( $locale === 'en' ? $date->format('F jS') :
-                            $this->dayAndMonth->format($date->format('U'))
-                        ),
+                    $this->formatLocalizedDate($date),
                     $decreeItem->metadata->since_year,
                     $decreeItem->metadata->getUrl(),
                     $this->CalendarParams->Year
@@ -3203,20 +3172,8 @@ final class CalendarHandler extends AbstractHandler
                 $newDate      = $rule->then->apply($currentDate);
 
                 // Add a message about the rule application
-                $locale          = LitLocale::$PRIMARY_LANGUAGE;
-                $previousDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? ( $previousDate->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $previousDate->format('n')] )
-                    : ( $locale === 'en'
-                        ? $previousDate->format('F jS')
-                        : $this->dayAndMonth->format($previousDate->format('U'))
-                    );
-                $newDateStr      = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? ( $newDate->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $newDate->format('n')] )
-                    : ( $locale === 'en'
-                        ? $newDate->format('F jS')
-                        : $this->dayAndMonth->format($newDate->format('U'))
-                    );
-
+                $previousDateStr  = $this->formatLocalizedDate($previousDate);
+                $newDateStr       = $this->formatLocalizedDate($newDate);
                 $this->Messages[] = sprintf(
                     /**translators: 1: Event key, 2: Original date, 3: New date, 4: Requested calendar year */
                     _('The liturgical event \'%1$s\' has been moved from %2$s to %3$s due to conditional rules in the year %4$d.'),
@@ -3904,25 +3861,14 @@ final class CalendarHandler extends AbstractHandler
     private function moveLiturgicalEventDate(string $event_key, DateTime $newDate, string $inFavorOf, $missal): void
     {
         $litEvent   = $this->Cal->getLiturgicalEvent($event_key);
-        $locale     = LitLocale::$PRIMARY_LANGUAGE;
-        $newDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-            ? ( $newDate->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $newDate->format('n')] )
-            : ( $locale === 'en'
-                ? $newDate->format('F jS')
-                : $this->dayAndMonth->format($newDate->format('U'))
-            );
+        $newDateStr = $this->formatLocalizedDate($newDate);
 
         if (!$this->Cal->inSolemnitiesFeastsOrMemorials($newDate)) {
             $oldDateStr = '';
             // If the liturgical event exists, we can simply move it to the new date
             // If it does not exist, we should recreate it on the new date
             if ($litEvent !== null) {
-                $oldDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? ( $litEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $litEvent->date->format('n')] )
-                    : ( $locale === 'en'
-                        ? $litEvent->date->format('F jS')
-                        : $this->dayAndMonth->format($litEvent->date->format('U'))
-                    );
+                $oldDateStr = $this->formatLocalizedDate($litEvent->date);
                 $this->Cal->moveLiturgicalEventDate($event_key, $newDate);
             } else {
                 // If it was suppressed on the original date because of a higher ranking celebration,
@@ -3947,12 +3893,7 @@ final class CalendarHandler extends AbstractHandler
                         $this->Cal->addLiturgicalEvent($event_key, $suppressedEvent);
                         // if it was suppressed previously (which it should have been), we should remove from the suppressed events collection
                         $this->Cal->reinstateEvent($event_key);
-                        $oldDateStr = in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true)
-                            ? ( $oldDate->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $oldDate->format('n')] )
-                            : ( $locale === 'en'
-                                ? $oldDate->format('F jS')
-                                : $this->dayAndMonth->format($oldDate->format('U'))
-                            );
+                        $oldDateStr = $this->formatLocalizedDate($oldDate);
                     } else {
                         throw new ServiceUnavailableException("This is strange, {$event_key} is not suppressed? Where is it?");
                     }
@@ -3976,13 +3917,7 @@ final class CalendarHandler extends AbstractHandler
             }
         } else {
             if ($litEvent !== null) {
-                $oldDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? ( $litEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $litEvent->date->format('n')] )
-                    : ( $locale === 'en'
-                        ? $litEvent->date->format('F jS')
-                        : $this->dayAndMonth->format($litEvent->date->format('U'))
-                    );
-
+                $oldDateStr                = $this->formatLocalizedDate($litEvent->date);
                 $coincidingLiturgicalEvent = $this->Cal->determineSundaySolemnityOrFeast($newDate, $event_key);
                 //If the new date is already covered by a Solemnity, Feast or Memorial, then we can't move the celebration, so we simply suppress it
                 $this->Messages[] = sprintf(

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -3494,6 +3494,11 @@ final class CalendarHandler extends AbstractHandler
             && is_string($liturgicalEvent->strtotime)
             && $liturgicalEvent->strtotime !== '';
 
+        $formattedDateStr = $this->formatLocalizedDate($liturgicalEvent->date);
+        $dateStr          = ( $liturgicalEvent instanceof LitCalItemCreateNewMobile ) && $hasStrToTime
+            ? '<i>' . $liturgicalEvent->strtotime . '</i>'
+            : $formattedDateStr;
+
         if ($this->liturgicalEventCanBeCreated($liturgicalEvent)) {
             if ($this->liturgicalEventDoesNotCoincide($liturgicalEvent)) {
                 $newLitEvent = LiturgicalEvent::fromObject($liturgicalEvent);
@@ -3514,10 +3519,6 @@ final class CalendarHandler extends AbstractHandler
                 $infoSource = RomanMissal::getName($litEvent->metadata->missal) . ' #createNewRegionalOrNationalLiturgicalEvent';
             }
 
-            $formattedDateStr = $this->formatLocalizedDate($liturgicalEvent->date);
-            $dateStr          = ( $liturgicalEvent instanceof LitCalItemCreateNewMobile ) && $hasStrToTime
-                ? '<i>' . $liturgicalEvent->strtotime . '</i>'
-                : $formattedDateStr;
             $this->Messages[] = sprintf(
                 /**translators:
                  * 1. Grade or rank of the liturgical event
@@ -3536,11 +3537,6 @@ final class CalendarHandler extends AbstractHandler
                 $this->CalendarParams->Year
             );
         } else {
-            $formattedDateStr = $this->formatLocalizedDate($liturgicalEvent->date);
-            $dateStr          = ( $liturgicalEvent instanceof LitCalItemCreateNewMobile ) && $hasStrToTime
-                ? '<i>' . $liturgicalEvent->strtotime . '</i>'
-                : $formattedDateStr;
-
             $this->Messages[] = sprintf(
                 /**translators:
                  * 1. Grade or rank of the liturgical event

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -114,7 +114,12 @@ final class CalendarHandler extends AbstractHandler
     private string $BaptismLordFmt;
     private string $BaptismLordMod;
 
-    public const API_VERSION                  = '5.6';
+    public const API_VERSION = '5.6';
+
+    /**
+     * Path to the cache directory. Initialized by handle() before any cache operations.
+     * Must be set before calling ensureCachePathExists() or prepareResponseBody().
+     */
     private string $CachePath                 = '';
     private string $CacheFile                 = '';
     private string $CacheDuration             = '';
@@ -625,6 +630,9 @@ final class CalendarHandler extends AbstractHandler
      * Ensure the cache directory exists and is writable.
      *
      * Creates the cache directory if it doesn't exist.
+     *
+     * Note: $this->CachePath must be initialized by handle() before calling this method.
+     * This is used by both fetchGitHubReleaseInfo() and prepareResponseBody().
      *
      * @throws ServiceUnavailableException If the cache directory cannot be created
      * @return void

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -3488,7 +3488,7 @@ final class CalendarHandler extends AbstractHandler
                 /**translators:
                  * 1. Grade or rank of the liturgical event
                  * 2. Name of the liturgical event
-                 * 3. Day and month of the liturgical event
+                 * 3. Date of the liturgical event (day/month for fixed events, or mobile date expression for mobile events)
                  * 4. Year from which the liturgical event has been added
                  * 5. Source of the information
                  * 6. Requested calendar year
@@ -3506,7 +3506,7 @@ final class CalendarHandler extends AbstractHandler
                 /**translators:
                  * 1. Grade or rank of the liturgical event
                  * 2. Name of the liturgical event
-                 * 3. Day and month of the liturgical event
+                 * 3. Date of the liturgical event (day/month for fixed events, or mobile date expression for mobile events)
                  * 4. Requested calendar year
                  */
                 _('The %1$s \'%2$s\' was not added to the calendar on %3$s because it conflicts with an existing liturgical event in the year %4$d.'),

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -547,6 +547,106 @@ final class CalendarHandler extends AbstractHandler
     }
 
     /**
+     * Format a date according to the current locale.
+     *
+     * Handles Latin (using LatinUtils::LATIN_MONTHS), English (F jS format),
+     * and other locales (using dayAndMonth IntlDateFormatter).
+     *
+     * @param DateTime $date The date to format
+     * @return string The formatted date string
+     */
+    private function formatLocalizedDate(DateTime $date): string
+    {
+        $locale = LitLocale::$PRIMARY_LANGUAGE;
+        if ($locale === LitLocale::LATIN_PRIMARY_LANGUAGE) {
+            return $date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $date->format('n')];
+        }
+        if ($locale === 'en') {
+            return $date->format('F jS');
+        }
+        $formatted = $this->dayAndMonth->format($date->format('U'));
+        return $formatted !== false ? $formatted : $date->format('j/n');
+    }
+
+    /**
+     * Get the localized day of the week string for a given date.
+     *
+     * Handles Latin (using LatinUtils::LATIN_DAYOFTHEWEEK), Italian (using dayAndMonth formatter),
+     * and other locales (using dayOfTheWeek formatter).
+     *
+     * @param DateTime $dateTime The date to get the day of the week for
+     * @return string The localized day of the week string
+     */
+    private function getLocalizedDayOfTheWeek(DateTime $dateTime): string
+    {
+        $locale = LitLocale::$PRIMARY_LANGUAGE;
+        if ($locale === LitLocale::LATIN_PRIMARY_LANGUAGE) {
+            return LatinUtils::LATIN_DAYOFTHEWEEK[$dateTime->format('w')];
+        }
+        if ($locale === 'it') {
+            $formatted = $this->dayAndMonth->format($dateTime->format('U'));
+            return Utilities::ucfirst($formatted !== false ? $formatted : $dateTime->format('l'));
+        }
+        $formatted = $this->dayOfTheWeek->format($dateTime->format('U'));
+        return Utilities::ucfirst($formatted !== false ? $formatted : $dateTime->format('l'));
+    }
+
+    /**
+     * Format the name of a Christmas weekday according to the current locale.
+     *
+     * Handles Latin ("X temporis Nativitatis"), Italian ("Feria propria del X"),
+     * and other locales using gettext translation.
+     *
+     * @param string $dayOfTheWeek The localized day of the week string
+     * @return string The formatted Christmas weekday name
+     */
+    private function formatChristmasWeekdayName(string $dayOfTheWeek): string
+    {
+        $locale = LitLocale::$PRIMARY_LANGUAGE;
+        return $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
+            ? sprintf('%s temporis Nativitatis', $dayOfTheWeek)
+            : ( $locale === 'it'
+                ? sprintf('Feria propria del %s', $dayOfTheWeek)
+                : sprintf(
+                    /**translators: Christmas weekday name pattern */
+                    _('%s - Christmas Weekday'),
+                    $dayOfTheWeek
+                )
+            );
+    }
+
+    /**
+     * Ensure the cache directory exists and is writable.
+     *
+     * Creates the cache directory if it doesn't exist.
+     *
+     * @throws ServiceUnavailableException If the cache directory cannot be created
+     * @return void
+     */
+    private function ensureCachePathExists(): void
+    {
+        if (false === realpath($this->CachePath)) {
+            $cwd = getcwd() ?: './';
+            if (false === is_writable($cwd)) {
+                $description = sprintf(
+                    'The cache folder %s does not exist, but we cannot create it because the parent folder %s is not writable.',
+                    dirname($this->CachePath),
+                    $cwd
+                );
+                throw new ServiceUnavailableException($description);
+            }
+
+            if (false === mkdir($this->CachePath, 0755, true)) {
+                $description = sprintf(
+                    'Could not create cache folder: %s. Please ensure the path is writable.',
+                    $this->CachePath
+                );
+                throw new ServiceUnavailableException($description);
+            }
+        }
+    }
+
+    /**
      * Validate whether the year requested is earlier than 1970
      *
      * 1970 is the year in which the Prima Editio Typica of the Roman Missal was published
@@ -837,23 +937,8 @@ final class CalendarHandler extends AbstractHandler
             $dateTime = DateTime::fromFormat($i . '-1-' . $this->CalendarParams->Year);
             if (false === self::dateIsSunday($dateTime) && $this->Cal->notInSolemnitiesFeastsOrMemorials($dateTime)) {
                 $nth++;
-                $locale       = LitLocale::$PRIMARY_LANGUAGE;
-                $dayOfTheWeek = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? LatinUtils::LATIN_DAYOFTHEWEEK[$dateTime->format('w')]
-                    : ( $locale === 'it'
-                        ? Utilities::ucfirst($this->dayAndMonth->format($dateTime->format('U')))
-                        : Utilities::ucfirst($this->dayOfTheWeek->format($dateTime->format('U')))
-                    );
-                $name         = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? sprintf('%s temporis Nativitatis', $dayOfTheWeek)
-                    : ( $locale === 'it'
-                        ? sprintf('Feria propria del %s', $dayOfTheWeek)
-                        : sprintf(
-                            /**translators: days before Epiphany (not useful in Italian!) */
-                            _('%s - Christmas Weekday'),
-                            $dayOfTheWeek
-                        )
-                    );
+                $dayOfTheWeek  = $this->getLocalizedDayOfTheWeek($dateTime);
+                $name          = $this->formatChristmasWeekdayName($dayOfTheWeek);
                 $dayOfTheMonth = $dateTime->format('j');
                 $event_key     = 'ChristmasWeekdayJan' . $dayOfTheMonth;
                 $litEvent      = new LiturgicalEvent(
@@ -894,27 +979,12 @@ final class CalendarHandler extends AbstractHandler
             $nth++;
             $dateTime = DateTime::fromFormat($i . '-1-' . $this->CalendarParams->Year);
             if ($this->Cal->notInSolemnitiesFeastsOrMemorials($dateTime)) {
-                $locale         = LitLocale::$PRIMARY_LANGUAGE;
-                $dayOfTheWeek   = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? LatinUtils::LATIN_DAYOFTHEWEEK[$dateTime->format('w')]
-                    : ( $locale === 'it'
-                        ? Utilities::ucfirst($this->dayAndMonth->format($dateTime->format('U')))
-                        : Utilities::ucfirst($this->dayOfTheWeek->format($dateTime->format('U')))
-                    );
+                $dayOfTheWeek   = $this->getLocalizedDayOfTheWeek($dateTime);
                 $dayOfTheWeekEn = $this->dayOfTheWeekEnglish->format($dateTime->format('U'));
-                $name           = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                    ? sprintf('%s temporis Nativitatis', $dayOfTheWeek)
-                    : ( $locale === 'it'
-                        ? sprintf('Feria propria del %s', $dayOfTheWeek)
-                        : sprintf(
-                            /**translators: days after Epiphany when Epiphany falls on Jan 6 (not useful in Italian!) */
-                            _('%s - Christmas Weekday'),
-                            $dayOfTheWeek
-                        )
-                    );
-                $dayOfTheMonth = $dateTime->format('j');
-                $event_key     = $this->CalendarParams->Epiphany === Epiphany::SUNDAY_JAN2_JAN8 ? 'DayAfterEpiphany' . $dayOfTheWeekEn : 'DayAfterEpiphanyJan' . $dayOfTheMonth;
-                $litEvent      = new LiturgicalEvent(
+                $name           = $this->formatChristmasWeekdayName($dayOfTheWeek);
+                $dayOfTheMonth  = $dateTime->format('j');
+                $event_key      = $this->CalendarParams->Epiphany === Epiphany::SUNDAY_JAN2_JAN8 ? 'DayAfterEpiphany' . $dayOfTheWeekEn : 'DayAfterEpiphanyJan' . $dayOfTheMonth;
+                $litEvent       = new LiturgicalEvent(
                     $name,
                     $dateTime,
                     LitColor::WHITE,
@@ -1216,7 +1286,6 @@ final class CalendarHandler extends AbstractHandler
                  * http://www.cultodivino.va/content/cultodivino/it/rivista-notitiae/indici-annate/2006/475-476.html
                  * https://www.cultodivino.va/content/dam/cultodivino/rivista-notitiae/2000/notitiae-42-(2006)/Notitiae-475-476-2006.pdf
                  */
-                $locale  = LitLocale::$PRIMARY_LANGUAGE;
                 $PalmSun = $this->Cal->getLiturgicalEvent('PalmSun');
                 $Easter  = $this->Cal->getLiturgicalEvent('Easter');
                 $Easter2 = $this->Cal->getLiturgicalEvent('Easter2');
@@ -1242,12 +1311,7 @@ final class CalendarHandler extends AbstractHandler
                         $coincidingSolemnity->name,
                         $this->CalendarParams->Year,
                         _('the Saturday preceding Palm Sunday'),
-                        $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                            ? ( $tempLiturgicalEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $tempLiturgicalEvent->date->format('n')] )
-                            : ( $locale === 'en'
-                                ? $tempLiturgicalEvent->date->format('F jS')
-                                : $this->dayAndMonth->format($tempLiturgicalEvent->date->format('U'))
-                            ),
+                        $this->formatLocalizedDate($tempLiturgicalEvent->date),
                         '<a href="https://www.cultodivino.va/content/dam/cultodivino/rivista-notitiae/2000/notitiae-42-(2006)/Notitiae-475-476-2006.pdf" target="_blank">'
                             . _('Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments')
                         . '</a>'
@@ -1267,12 +1331,7 @@ final class CalendarHandler extends AbstractHandler
                         $coincidingSolemnity->name,
                         $this->CalendarParams->Year,
                         _('the Monday following the Second Sunday of Easter'),
-                        $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                            ? ( $tempLiturgicalEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $tempLiturgicalEvent->date->format('n')] )
-                            : ( $locale === 'en'
-                                ? $tempLiturgicalEvent->date->format('F jS')
-                                : $this->dayAndMonth->format($tempLiturgicalEvent->date->format('U'))
-                            ),
+                        $this->formatLocalizedDate($tempLiturgicalEvent->date),
                         '<a href="https://www.cultodivino.va/content/dam/cultodivino/rivista-notitiae/2000/notitiae-42-(2006)/Notitiae-475-476-2006.pdf" target="_blank">'
                             . _('Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments')
                         . '</a>'
@@ -1323,12 +1382,7 @@ final class CalendarHandler extends AbstractHandler
                             $coincidingSolemnity->name,
                             $this->CalendarParams->Year,
                             _('the following Monday'),
-                            $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                                ? ( $tempLiturgicalEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $tempLiturgicalEvent->date->format('n')] )
-                                : ( $locale === 'en'
-                                        ? $tempLiturgicalEvent->date->format('F jS')
-                                        : $this->dayAndMonth->format($tempLiturgicalEvent->date->format('U'))
-                            ),
+                            $this->formatLocalizedDate($tempLiturgicalEvent->date),
                             '<a href="https://www.cultodivino.va/content/dam/cultodivino/rivista-notitiae/1990/notitiae-26-(1990)/Notitiae-284-285-1990.pdf" target="_blank">' . _('Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments') . '</a>'
                         );
                     }
@@ -3454,13 +3508,7 @@ final class CalendarHandler extends AbstractHandler
                 $infoSource = RomanMissal::getName($litEvent->metadata->missal) . ' #createNewRegionalOrNationalLiturgicalEvent';
             }
 
-            $locale           = LitLocale::$PRIMARY_LANGUAGE;
-            $formattedDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                ? ( $liturgicalEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $liturgicalEvent->date->format('n')] )
-                : ( $locale === 'en'
-                    ? $liturgicalEvent->date->format('F jS')
-                    : $this->dayAndMonth->format($liturgicalEvent->date->format('U'))
-                );
+            $formattedDateStr = $this->formatLocalizedDate($liturgicalEvent->date);
             $dateStr          = ( $liturgicalEvent instanceof LitCalItemCreateNewMobile ) && $hasStrToTime
                 ? '<i>' . $liturgicalEvent->strtotime . '</i>'
                 : $formattedDateStr;
@@ -3482,13 +3530,7 @@ final class CalendarHandler extends AbstractHandler
                 $this->CalendarParams->Year
             );
         } else {
-            $locale           = LitLocale::$PRIMARY_LANGUAGE;
-            $formattedDateStr = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE
-                ? ( $liturgicalEvent->date->format('j') . ' ' . LatinUtils::LATIN_MONTHS[(int) $liturgicalEvent->date->format('n')] )
-                : ( $locale === 'en'
-                    ? $liturgicalEvent->date->format('F jS')
-                    : $this->dayAndMonth->format($liturgicalEvent->date->format('U'))
-                );
+            $formattedDateStr = $this->formatLocalizedDate($liturgicalEvent->date);
             $dateStr          = ( $liturgicalEvent instanceof LitCalItemCreateNewMobile ) && $hasStrToTime
                 ? '<i>' . $liturgicalEvent->strtotime . '</i>'
                 : $formattedDateStr;
@@ -4364,25 +4406,7 @@ final class CalendarHandler extends AbstractHandler
         } else {
             // We always create a cache of the Github Release, even for localhost development,
             // to avoid sending too many requests
-            if (false === realpath($this->CachePath)) {
-                $cwd = getcwd() ?: './';
-                if (false === is_writable($cwd)) {
-                    $description = sprintf(
-                        'The cache folder %s does not exist, but we cannot create it because the parent folder %s is not writable.',
-                        dirname($this->CachePath),
-                        $cwd
-                    );
-                    throw new ServiceUnavailableException($description);
-                }
-
-                if (false === mkdir($this->CachePath, 0755, true)) {
-                    $description = sprintf(
-                        'Could not create cache folder: %s. Please ensure the path is writable.',
-                        $this->CachePath
-                    );
-                    throw new ServiceUnavailableException($description);
-                }
-            }
+            $this->ensureCachePathExists();
 
             $GithubReleasesAPI = 'https://api.github.com/repos/Liturgical-Calendar/LiturgicalCalendarAPI/releases/latest';
 
@@ -4487,25 +4511,7 @@ final class CalendarHandler extends AbstractHandler
 
         // Ensure cache folder exists, except for localhost
         if (false === Router::isLocalhost()) {
-            if (false === realpath($this->CachePath)) {
-                $cwd = getcwd() ?: './';
-                if (false === is_writable($cwd)) {
-                    $description = sprintf(
-                        'The cache folder %s does not exist, but we cannot create it because the parent folder %s is not writable.',
-                        dirname($this->CachePath),
-                        $cwd
-                    );
-                    throw new ServiceUnavailableException($description);
-                }
-
-                if (false === mkdir($this->CachePath, 0755, true)) {
-                    $message = sprintf(
-                        'Could not create cache folder: %s.',
-                        $this->CachePath
-                    );
-                    throw new ServiceUnavailableException($message);
-                }
-            }
+            $this->ensureCachePathExists();
         }
 
         $responseBody = null;

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -640,12 +640,21 @@ final class CalendarHandler extends AbstractHandler
     private function ensureCachePathExists(): void
     {
         if (false === realpath($this->CachePath)) {
-            $parentDir = dirname($this->CachePath) ?: '.';
-            if (false === is_writable($parentDir)) {
+            // Walk up from the target directory to find the nearest existing ancestor
+            $existingAncestor = dirname($this->CachePath);
+            while ($existingAncestor !== '' && $existingAncestor !== '.' && false === is_dir($existingAncestor)) {
+                $existingAncestor = dirname($existingAncestor);
+            }
+            // Fall back to current directory if we walked all the way up
+            if ($existingAncestor === '' || false === is_dir($existingAncestor)) {
+                $existingAncestor = '.';
+            }
+
+            if (false === is_writable($existingAncestor)) {
                 $description = sprintf(
                     'The cache folder %s does not exist, but we cannot create it because the parent folder %s is not writable.',
                     $this->CachePath,
-                    $parentDir
+                    $existingAncestor
                 );
                 throw new ServiceUnavailableException($description);
             }

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -632,7 +632,7 @@ final class CalendarHandler extends AbstractHandler
      * Creates the cache directory if it doesn't exist.
      *
      * Note: $this->CachePath must be initialized by handle() before calling this method.
-     * This is used by both fetchGitHubReleaseInfo() and prepareResponseBody().
+     * This is used by both getGithubReleaseInfo() and prepareResponseBody().
      *
      * @throws ServiceUnavailableException If the cache directory cannot be created
      * @return void
@@ -640,12 +640,12 @@ final class CalendarHandler extends AbstractHandler
     private function ensureCachePathExists(): void
     {
         if (false === realpath($this->CachePath)) {
-            $cwd = getcwd() ?: './';
-            if (false === is_writable($cwd)) {
+            $parentDir = dirname($this->CachePath) ?: '.';
+            if (false === is_writable($parentDir)) {
                 $description = sprintf(
                     'The cache folder %s does not exist, but we cannot create it because the parent folder %s is not writable.',
-                    dirname($this->CachePath),
-                    $cwd
+                    $this->CachePath,
+                    $parentDir
                 );
                 throw new ServiceUnavailableException($description);
             }

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -1324,22 +1324,7 @@ final class RegionalDataHandler extends AbstractHandler
         // we don't care about locale for DELETE or PUT requests
         if (false === in_array($method, [RequestMethod::DELETE, RequestMethod::PUT], true)) {
             /** @var MetadataNationalCalendarItem $currentNation */
-            $validLangs = $currentNation->locales;
-            if (isset($params->locale)) {
-                if (
-                    null === $this->params->i18nRequest // short circuit for i18n requests
-                    && false === in_array($params->locale, $validLangs, true)
-                ) {
-                    $message = "Invalid value {$params->locale} for param `locale`, valid values for nation {$params->key} are: "
-                                . implode(', ', $validLangs);
-                    throw new UnprocessableContentException($message);
-                }
-            } else {
-                if (null !== $this->params->i18nRequest) {
-                    $description = 'Missing param `locale`';
-                    throw new UnprocessableContentException($description);
-                }
-            }
+            $this->validateLocaleForCalendar($params, $currentNation->locales);
         }
     }
 
@@ -1383,22 +1368,7 @@ final class RegionalDataHandler extends AbstractHandler
         // we don't care about locale for DELETE or PUT requests
         if (false === in_array($method, [RequestMethod::DELETE, RequestMethod::PUT], true)) {
             /** @var MetadataDiocesanCalendarItem $currentDiocese */
-            $validLangs = $currentDiocese->locales;
-            if (isset($params->locale)) {
-                if (
-                    null === $this->params->i18nRequest // short circuit for i18n requests
-                    && false === in_array($params->locale, $validLangs, true)
-                ) {
-                    $message = "Invalid value {$params->locale} for param `locale`, valid values for nation {$params->key} are: "
-                                . implode(', ', $validLangs);
-                    throw new UnprocessableContentException($message);
-                }
-            } else {
-                if (null !== $this->params->i18nRequest) {
-                    $description = 'Missing param `locale`';
-                    throw new UnprocessableContentException($description);
-                }
-            }
+            $this->validateLocaleForCalendar($params, $currentDiocese->locales);
         }
     }
 
@@ -1455,26 +1425,38 @@ final class RegionalDataHandler extends AbstractHandler
         // we don't care about locale for DELETE or PUT requests
         if (false === in_array($method, [RequestMethod::DELETE, RequestMethod::PUT], true)) {
             /** @var MetadataWiderRegionItem $currentWiderRegion */
-            $validLangs = $currentWiderRegion->locales;
-            if (isset($params->locale)) {
-                if (
-                    null === $this->params->i18nRequest // short circuit for i18n requests
-                    && false === in_array($params->locale, $validLangs, true)
-                ) {
-                    $message = "Invalid value {$params->locale} for param `locale`, valid values for nation {$params->key} are: "
-                                . implode(', ', $validLangs);
-                    throw new UnprocessableContentException($message);
-                }
-            } else {
-                if (null !== $this->params->i18nRequest) {
-                    $description = 'Missing param `locale`';
-                    throw new UnprocessableContentException($description);
-                }
-            }
+            $this->validateLocaleForCalendar($params, $currentWiderRegion->locales);
         }
     }
 
-
+    /**
+     * Validate the locale parameter for a regional calendar request.
+     *
+     * Checks that the locale is valid for the given calendar, unless this is an i18n request.
+     * Also validates that locale is present when required for i18n requests.
+     *
+     * @param RegionalDataParams $params The request parameters containing locale and key.
+     * @param string[] $validLangs The valid locales for the calendar.
+     * @throws UnprocessableContentException If locale validation fails.
+     */
+    private function validateLocaleForCalendar(RegionalDataParams $params, array $validLangs): void
+    {
+        if (isset($params->locale)) {
+            if (
+                null === $this->params->i18nRequest // short circuit for i18n requests
+                && false === in_array($params->locale, $validLangs, true)
+            ) {
+                $message = "Invalid value {$params->locale} for param `locale`, valid values for calendar {$params->key} are: "
+                            . implode(', ', $validLangs);
+                throw new UnprocessableContentException($message);
+            }
+        } else {
+            if (null !== $this->params->i18nRequest) {
+                $description = 'Missing param `locale`';
+                throw new UnprocessableContentException($description);
+            }
+        }
+    }
 
     /**
      * Initializes the RegionalData class.

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -1443,7 +1443,7 @@ final class RegionalDataHandler extends AbstractHandler
     {
         if (isset($params->locale)) {
             if (
-                null === $this->params->i18nRequest // short circuit for i18n requests
+                null === $params->i18nRequest // short circuit for i18n requests
                 && false === in_array($params->locale, $validLangs, true)
             ) {
                 $message = "Invalid value {$params->locale} for param `locale`, valid values for calendar {$params->key} are: "
@@ -1451,7 +1451,7 @@ final class RegionalDataHandler extends AbstractHandler
                 throw new UnprocessableContentException($message);
             }
         } else {
-            if (null !== $this->params->i18nRequest) {
+            if (null !== $params->i18nRequest) {
                 $description = 'Missing param `locale`';
                 throw new UnprocessableContentException($description);
             }

--- a/src/Health.php
+++ b/src/Health.php
@@ -380,6 +380,31 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * Find diocese metadata by calendar ID.
+     *
+     * @param string $calendarId The diocese calendar ID to look up.
+     * @return MetadataDiocesanCalendarItem The diocese metadata.
+     * @throws \RuntimeException If metadata is not loaded yet.
+     * @throws \Exception If no diocese is found for the given calendar ID.
+     */
+    private function findDioceseMetadata(string $calendarId): MetadataDiocesanCalendarItem
+    {
+        if (false === isset(self::$metadata)) {
+            throw new \RuntimeException('Metadata not loaded yet; retry shortly');
+        }
+        $dioceseMetadata = array_find(
+            self::$metadata->diocesan_calendars,
+            function (MetadataDiocesanCalendarItem $el) use ($calendarId): bool {
+                return $el->calendar_id === $calendarId;
+            }
+        );
+        if ($dioceseMetadata === null) {
+            throw new \Exception("No diocese found for calendar id: {$calendarId}");
+        }
+        return $dioceseMetadata;
+    }
+
+    /**
      * Validate a data file by checking that it exists and that it is valid JSON that conforms to a specific schema.
      *
      * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource $validation The validation object. It should have the following properties:
@@ -429,24 +454,12 @@ class Health implements MessageComponentInterface
                             );
                             break;
                         case 'diocesan-calendar':
-                            if (false === isset(self::$metadata)) {
-                                throw new \RuntimeException('Metadata not loaded yet; retry shortly');
-                            }
-                            $dioceseMetadata = array_find(
-                                self::$metadata->diocesan_calendars,
-                                function (MetadataDiocesanCalendarItem $el) use ($matches): bool {
-                                    return $el->calendar_id === $matches[2];
-                                }
-                            );
-                            if ($dioceseMetadata === null) {
-                                throw new \Exception("No diocese found for calendar id: {$matches[2]}");
-                            }
-                            $nation   = $dioceseMetadata->nation;
-                            $dataPath = strtr(
+                            $dioceseMetadata = $this->findDioceseMetadata($matches[2]);
+                            $dataPath        = strtr(
                                 JsonData::DIOCESAN_CALENDAR_I18N_FOLDER->path(),
                                 [
                                     '{diocese}' => $matches[2],
-                                    '{nation}'  => $nation
+                                    '{nation}'  => $dioceseMetadata->nation
                                 ]
                             );
                             break;
@@ -481,26 +494,13 @@ class Health implements MessageComponentInterface
                                 );
                                 break;
                             case 'diocesan-calendar':
-                                if (false === isset(self::$metadata)) {
-                                    throw new \RuntimeException('Metadata not loaded yet; retry shortly');
-                                }
-                                $dioceseMetadata = array_find(
-                                    self::$metadata->diocesan_calendars,
-                                    function (MetadataDiocesanCalendarItem $el) use ($matches): bool {
-                                        return $el->calendar_id === $matches[2];
-                                    }
-                                );
-                                if ($dioceseMetadata === null) {
-                                    throw new \Exception("No diocese found for calendar id: {$matches[2]}");
-                                }
-                                $nation      = (string) $dioceseMetadata->nation;
-                                $dioceseName = (string) $dioceseMetadata->diocese;
-                                $dataPath    = strtr(
+                                $dioceseMetadata = $this->findDioceseMetadata($matches[2]);
+                                $dataPath        = strtr(
                                     JsonData::DIOCESAN_CALENDAR_FILE->path(),
                                     [
                                         '{diocese}'      => $matches[2],
-                                        '{nation}'       => $nation,
-                                        '{diocese_name}' => $dioceseName
+                                        '{nation}'       => $dioceseMetadata->nation,
+                                        '{diocese_name}' => $dioceseMetadata->diocese
                                     ]
                                 );
                                 break;
@@ -804,6 +804,26 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * Build the calendar API request path based on calendar ID, year, and category.
+     *
+     * @param string $calendar The calendar identifier (e.g., 'VA' for Vatican, 'USA' for national).
+     * @param int $year The year for the calendar request.
+     * @param string $category The type of calendar ('nationalcalendar' or 'diocesancalendar').
+     * @return string The constructed request path.
+     */
+    private function buildCalendarRequestPath(string $calendar, int $year, string $category): string
+    {
+        if ($calendar === 'VA') {
+            return "/$year?year_type=CIVIL";
+        }
+        return match ($category) {
+            'nationalcalendar'  => "/nation/$calendar/$year?year_type=CIVIL",
+            'diocesancalendar'  => "/diocese/$calendar/$year?year_type=CIVIL",
+            default             => '/unknown'
+        };
+    }
+
+    /**
      * Validates the specified liturgical calendar for a given year and category,
      * and sends the validation results to the specified connection.
      *
@@ -828,22 +848,7 @@ class Health implements MessageComponentInterface
             'stream'  => true
         ];
 
-        if ($calendar === 'VA') {
-            $req = "/$year?year_type=CIVIL";
-        } else {
-            switch ($category) {
-                case 'nationalcalendar':
-                    $req = "/nation/$calendar/$year?year_type=CIVIL";
-                    break;
-                case 'diocesancalendar':
-                    $req = "/diocese/$calendar/$year?year_type=CIVIL";
-                    break;
-                default:
-                    //we shouldn't ever get any other categories
-                    $req = '/unknown';
-            }
-        }
-
+        $req     = $this->buildCalendarRequestPath($calendar, $year, $category);
         $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts);
         $promise->then(
             function (array $result) use ($to, $calendar, $year, $category, $req, $responseType) {
@@ -1127,21 +1132,7 @@ class Health implements MessageComponentInterface
             'stream'  => true
         ];
 
-        if ($calendar === 'VA') {
-            $req = "/$year?year_type=CIVIL";
-        } else {
-            switch ($category) {
-                case 'nationalcalendar':
-                    $req = "/nation/$calendar/$year?year_type=CIVIL";
-                    break;
-                case 'diocesancalendar':
-                    $req = "/diocese/$calendar/$year?year_type=CIVIL";
-                    break;
-                default:
-                    //we shouldn't ever get any other categories
-                    $req = '/unknown';
-            }
-        }
+        $req     = $this->buildCalendarRequestPath($calendar, $year, $category);
         $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts);
         $promise->then(
             function (array $result) use ($to, $test, $year) {

--- a/src/Health.php
+++ b/src/Health.php
@@ -657,23 +657,11 @@ class Health implements MessageComponentInterface
             // If the 'sourceFolder' property is not set, then we are validating a single source file or API path
             $matches = null;
             if (preg_match('/^diocesan-calendar-([a-z]{6}_[a-z]{2})$/', $pathForSchema, $matches)) {
-                $dioceseId = $matches[1];
-                if (false === isset(self::$metadata)) {
-                    throw new \RuntimeException('Metadata not loaded yet; retry shortly');
-                }
-
-                $dioceseMetadata = array_find(
-                    self::$metadata->diocesan_calendars,
-                    function (MetadataDiocesanCalendarItem $diocesan_calendar) use ($dioceseId): bool {
-                        return $diocesan_calendar->calendar_id === $dioceseId;
-                    }
-                );
-                if (null === $dioceseMetadata) {
-                    throw new \InvalidArgumentException("Invalid diocese ID $dioceseId");
-                }
-                $nation      = $dioceseMetadata->nation;
-                $dioceseName = $dioceseMetadata->diocese;
-                $dataPath    = strtr(JsonData::DIOCESAN_CALENDAR_FILE->path(), [
+                $dioceseId       = $matches[1];
+                $dioceseMetadata = $this->findDioceseMetadata($dioceseId);
+                $nation          = $dioceseMetadata->nation;
+                $dioceseName     = $dioceseMetadata->diocese;
+                $dataPath        = strtr(JsonData::DIOCESAN_CALENDAR_FILE->path(), [
                     '{nation}'       => $nation,
                     '{diocese}'      => $dioceseId,
                     '{diocese_name}' => $dioceseName

--- a/src/Health.php
+++ b/src/Health.php
@@ -20,6 +20,7 @@ use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
 use LiturgicalCalendar\Api\Test\LitTestRunner;
@@ -385,7 +386,7 @@ class Health implements MessageComponentInterface
      * @param string $calendarId The diocese calendar ID to look up.
      * @return MetadataDiocesanCalendarItem The diocese metadata.
      * @throws \RuntimeException If metadata is not loaded yet.
-     * @throws \Exception If no diocese is found for the given calendar ID.
+     * @throws NotFoundException If no diocese is found for the given calendar ID.
      */
     private function findDioceseMetadata(string $calendarId): MetadataDiocesanCalendarItem
     {
@@ -399,7 +400,7 @@ class Health implements MessageComponentInterface
             }
         );
         if ($dioceseMetadata === null) {
-            throw new \Exception("No diocese found for calendar id: {$calendarId}");
+            throw new NotFoundException("No diocese found for calendar id: {$calendarId}");
         }
         return $dioceseMetadata;
     }
@@ -819,7 +820,7 @@ class Health implements MessageComponentInterface
         return match ($category) {
             'nationalcalendar'  => "/nation/$calendar/$year?year_type=CIVIL",
             'diocesancalendar'  => "/diocese/$calendar/$year?year_type=CIVIL",
-            default             => '/unknown'
+            default             => throw new \InvalidArgumentException("Unknown calendar category: {$category}")
         };
     }
 

--- a/src/Health.php
+++ b/src/Health.php
@@ -42,7 +42,7 @@ use Psr\Http\Message\ResponseInterface;
  * @phpstan-type ExecuteValidationSourceFolder \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFolder:string}
  * @phpstan-type ExecuteValidationSourceFile \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFile:string}
  * @phpstan-type ExecuteValidationResource \stdClass&object{action:'executeValidation',category:'resourceDataCheck',validate:string,sourceFile:string}
- * @phpstan-type ValidateCalendar \stdClass&object{action:'validateCalendar',calendar:string,year:int,category:'nationalcalendar'|'diocesanCalendar',responsetype:'JSON'|'XML'|'ICS'|'YML'}
+ * @phpstan-type ValidateCalendar \stdClass&object{action:'validateCalendar',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar',responsetype:'JSON'|'XML'|'ICS'|'YML'}
  * @phpstan-type ExecuteUnitTest \stdClass&object{action:'executeUnitTest',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar',test:string}
  *
  * @phpstan-import-type LiturgicalEvent from \LiturgicalCalendar\Api\Test\LitTestRunner

--- a/src/Health.php
+++ b/src/Health.php
@@ -391,7 +391,7 @@ class Health implements MessageComponentInterface
     private function findDioceseMetadata(string $calendarId): MetadataDiocesanCalendarItem
     {
         if (false === isset(self::$metadata)) {
-            throw new \RuntimeException('Metadata not loaded yet; retry shortly');
+            throw new \RuntimeException('Metadata not loaded yet; it is fetched asynchronously on WebSocket connection');
         }
         $dioceseMetadata = array_find(
             self::$metadata->diocesan_calendars,


### PR DESCRIPTION
## Summary

- Extract duplicated code patterns into reusable helper methods to address CodeFactor warnings
- **CalendarHandler.php**: 4 helper methods for date formatting and cache path handling
- **Health.php**: 2 helper methods for request path building and diocese metadata lookup
- **RegionalDataHandler.php**: 1 helper method for locale validation

## Changes

| File | Helper Methods Added |
|------|---------------------|
| `CalendarHandler.php` | `formatLocalizedDate()`, `getLocalizedDayOfTheWeek()`, `formatChristmasWeekdayName()`, `ensureCachePathExists()` |
| `Health.php` | `buildCalendarRequestPath()`, `findDioceseMetadata()` |
| `RegionalDataHandler.php` | `validateLocaleForCalendar()` |

## Test plan

- [x] PHPStan level 10 passes
- [x] All PHPUnit tests pass (128 tests, 144751 assertions)
- [x] Code style (phpcs) passes

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated locale-aware date and weekday formatting for consistent, localized display across calendars and events.
  * Centralized locale validation for calendar requests to standardize behavior and error wording.

* **Chores**
  * Centralized cache path handling and initialization to improve reliability when generating calendar responses.
  * Centralized calendar request path construction for consistent request handling.

* **Bug Fixes**
  * Clearer error messages and more robust lookup for diocesan/national calendar data to reduce failures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->