### PR TITLE
feat: implement Remember Me functionality for login

### DIFF
--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -4334,6 +4334,11 @@
             "type": "string",
             "format": "password",
             "description": "Password for authentication"
+          },
+          "remember_me": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, the refresh token cookie persists beyond the browser session (with Max-Age/Expires). When false (default), the refresh token is stored as a session cookie that is deleted when the browser closes."
           }
         },
         "required": [

--- a/src/Handlers/Auth/LoginHandler.php
+++ b/src/Handlers/Auth/LoginHandler.php
@@ -29,6 +29,7 @@ use Psr\Http\Message\ServerRequestInterface;
  * Accepts:
  * - username (string)
  * - password (string)
+ * - remember_me (boolean, optional) - When true, refresh token cookie persists beyond browser session
  *
  * Returns:
  * - access_token (string) - JWT access token
@@ -151,13 +152,17 @@ final class LoginHandler extends AbstractHandler
         // Parse request body (required=true handles Content-Type and empty body validation)
         $parsedBodyParams = $this->parseBodyParams($request, true);
 
-        // Extract username and password
-        $username = $parsedBodyParams['username'] ?? null;
-        $password = $parsedBodyParams['password'] ?? null;
+        // Extract username, password, and remember_me option
+        $username   = $parsedBodyParams['username'] ?? null;
+        $password   = $parsedBodyParams['password'] ?? null;
+        $rememberMe = $parsedBodyParams['remember_me'] ?? false;
 
         if (!is_string($username) || !is_string($password) || trim($username) === '' || trim($password) === '') {
             throw new ValidationException('Username and password are required and must be non-empty strings');
         }
+
+        // Ensure remember_me is a boolean
+        $rememberMe = filter_var($rememberMe, FILTER_VALIDATE_BOOLEAN);
 
         // Authenticate user
         $user = User::authenticate($username, $password);
@@ -192,8 +197,10 @@ final class LoginHandler extends AbstractHandler
         ]);
 
         // Set HttpOnly cookies for secure token storage
+        // Access token always has Max-Age set (short-lived, refreshed automatically)
+        // Refresh token is a session cookie unless "remember me" is checked
         $response = CookieHelper::setAccessTokenCookie($response, $token, $jwtService->getExpiry());
-        $response = CookieHelper::setRefreshTokenCookie($response, $refreshToken, $jwtService->getRefreshExpiry());
+        $response = CookieHelper::setRefreshTokenCookie($response, $refreshToken, $jwtService->getRefreshExpiry(), $rememberMe);
 
         // Prepare response data (tokens still included for backwards compatibility)
         $responseData = [

--- a/src/Handlers/Auth/LoginHandler.php
+++ b/src/Handlers/Auth/LoginHandler.php
@@ -197,8 +197,8 @@ final class LoginHandler extends AbstractHandler
         ]);
 
         // Set HttpOnly cookies for secure token storage
-        // Access token always has Max-Age set (short-lived, refreshed automatically)
-        // Refresh token is a session cookie unless "remember me" is checked
+        // Access token: persistent cookie with short TTL (e.g., 15-60 min), refreshed automatically
+        // Refresh token: session cookie (deleted on browser close) unless remember_me=true
         $response = CookieHelper::setAccessTokenCookie($response, $token, $jwtService->getExpiry());
         $response = CookieHelper::setRefreshTokenCookie($response, $refreshToken, $jwtService->getRefreshExpiry(), $rememberMe);
 

--- a/src/Http/CookieHelper.php
+++ b/src/Http/CookieHelper.php
@@ -137,20 +137,30 @@ class CookieHelper
     /**
      * Set refresh token cookie on response
      *
+     * When rememberMe is false, the cookie is set as a session cookie (no Max-Age/Expires),
+     * which means the browser will delete it when closed. When rememberMe is true,
+     * the cookie persists for the specified expiry duration.
+     *
      * @param ResponseInterface $response The response to add cookie to
      * @param string $token The refresh token
-     * @param int $expiry Token expiry in seconds
+     * @param int $expiry Token expiry in seconds (used only when rememberMe is true)
+     * @param bool $rememberMe Whether to persist the cookie beyond the browser session
      * @return ResponseInterface Response with Set-Cookie header
      */
     public static function setRefreshTokenCookie(
         ResponseInterface $response,
         string $token,
-        int $expiry
+        int $expiry,
+        bool $rememberMe = false
     ): ResponseInterface {
+        // When rememberMe is false, pass 0 for maxAge to create a session cookie
+        // When rememberMe is true, use the provided expiry for a persistent cookie
+        $maxAge = $rememberMe ? $expiry : 0;
+
         $cookie = self::buildCookieHeader(
             self::REFRESH_TOKEN_COOKIE,
             $token,
-            $expiry,
+            $maxAge,
             '/auth', // Refresh token only needs to be sent to /auth endpoints
             'Strict' // Strict for refresh token - extra security
         );


### PR DESCRIPTION
## Summary

- Add `$rememberMe` parameter to `CookieHelper::setRefreshTokenCookie()`
- When `rememberMe` is false (default), refresh token is stored as a session cookie (deleted on browser close)
- When `rememberMe` is true, refresh token persists with `Max-Age`/`Expires` headers
- Read `remember_me` from login request body in `LoginHandler`
- Document `remember_me` parameter in OpenAPI schema

## Behavior

| Remember Me | Access Token Cookie | Refresh Token Cookie |
|-------------|--------------------|--------------------|
| Unchecked (default) | Persistent (short TTL) | Session cookie (deleted on browser close) |
| Checked | Persistent (short TTL) | Persistent (long TTL) |

## Test plan

- [ ] Login without "Remember Me" checked, close browser, reopen - should require login again
- [ ] Login with "Remember Me" checked, close browser, reopen - should remain logged in
- [ ] Verify access token cookie always has Max-Age set
- [ ] Verify refresh token cookie has no Max-Age when remember_me=false
- [ ] Verify refresh token cookie has Max-Age when remember_me=true

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional "Remember Me" login functionality. When enabled, users remain logged in across browser sessions. When disabled, sessions automatically end upon browser closure for enhanced security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->