### PR TITLE
Add integration tests for login rate limiting

### DIFF
--- a/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
+++ b/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
@@ -1,0 +1,334 @@
+<?php
+
+namespace LiturgicalCalendar\Tests\Routes\Auth;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+/**
+ * Integration tests for login endpoint rate limiting
+ *
+ * These tests verify that the /auth/login endpoint properly enforces rate limiting
+ * to protect against brute-force attacks.
+ *
+ * Note: These tests are marked @group slow because they make multiple HTTP requests
+ * and may take longer to complete.
+ *
+ * @group slow
+ */
+class LoginRateLimitTest extends ApiTestCase
+{
+    /**
+     * Clear rate limit state before each test by removing rate limit files.
+     *
+     * This ensures that rate limit state doesn't carry over from previous tests.
+     * We clear the files directly because if we're rate limited, we can't make
+     * a successful login to clear the rate limit (the check happens before auth).
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Clear rate limit files directly
+        $this->clearRateLimitFiles();
+    }
+
+    /**
+     * Clear all rate limit files from the storage directory.
+     */
+    private function clearRateLimitFiles(): void
+    {
+        // Get the storage path (default is system temp dir)
+        $storagePath  = $_ENV['RATE_LIMIT_STORAGE_PATH'] ?? sys_get_temp_dir();
+        $rateLimitDir = rtrim($storagePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'litcal_rate_limits';
+
+        if (!is_dir($rateLimitDir)) {
+            return;
+        }
+
+        $files = glob($rateLimitDir . DIRECTORY_SEPARATOR . '*.json');
+        if ($files === false) {
+            return;
+        }
+
+        foreach ($files as $file) {
+            unlink($file);
+        }
+    }
+
+    /**
+     * Test that login fails with invalid credentials.
+     *
+     * This is a basic test to ensure the login endpoint returns 401 for wrong passwords.
+     */
+    public function testLoginFailsWithInvalidCredentials(): void
+    {
+        $response = self::$http->post('/auth/login', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept'       => 'application/json'
+            ],
+            'json'    => [
+                'username' => 'admin',
+                'password' => 'wrong-password-' . uniqid()
+            ]
+        ]);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    /**
+     * Test that rate limiting is triggered after multiple failed login attempts.
+     *
+     * The API is configured with RATE_LIMIT_LOGIN_ATTEMPTS (default: 5) and
+     * RATE_LIMIT_LOGIN_WINDOW (default: 900 seconds). This test makes more
+     * failed attempts than the limit to trigger rate limiting.
+     *
+     * Important: This test uses a unique "identifier" to avoid affecting other tests.
+     * Since rate limiting is IP-based, we rely on the test environment configuration.
+     */
+    public function testRateLimitingTriggeredAfterMaxAttempts(): void
+    {
+        // Get the configured rate limit (default is 5)
+        $maxAttempts = (int) ( $_ENV['RATE_LIMIT_LOGIN_ATTEMPTS'] ?? 5 );
+
+        // Make failed login attempts up to the limit
+        for ($i = 0; $i < $maxAttempts; $i++) {
+            $response = self::$http->post('/auth/login', [
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                    'Accept'       => 'application/json'
+                ],
+                'json'    => [
+                    'username' => 'admin',
+                    'password' => 'wrong-password-attempt-' . $i
+                ]
+            ]);
+
+            // Each failed attempt should return 401 until we hit the limit
+            $this->assertEquals(
+                401,
+                $response->getStatusCode(),
+                'Expected 401 on attempt ' . ( $i + 1 ) . ' of ' . $maxAttempts
+            );
+        }
+
+        // The next attempt should be rate limited (429)
+        $response = self::$http->post('/auth/login', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept'       => 'application/json'
+            ],
+            'json'    => [
+                'username' => 'admin',
+                'password' => 'wrong-password-final'
+            ]
+        ]);
+
+        $this->assertEquals(
+            429,
+            $response->getStatusCode(),
+            'Expected 429 Too Many Requests after ' . $maxAttempts . ' failed attempts'
+        );
+
+        // Verify Retry-After header is present
+        $this->assertTrue(
+            $response->hasHeader('Retry-After'),
+            'Expected Retry-After header in 429 response'
+        );
+
+        $retryAfter = $response->getHeaderLine('Retry-After');
+        $this->assertGreaterThan(0, (int) $retryAfter, 'Retry-After should be a positive integer');
+    }
+
+    /**
+     * Test that the 429 response body contains expected error details.
+     *
+     * The response should follow RFC 7807 Problem Details format.
+     */
+    public function testRateLimitResponseFormat(): void
+    {
+        // Get the configured rate limit (default is 5)
+        $maxAttempts = (int) ( $_ENV['RATE_LIMIT_LOGIN_ATTEMPTS'] ?? 5 );
+
+        // Exhaust rate limit
+        for ($i = 0; $i < $maxAttempts; $i++) {
+            self::$http->post('/auth/login', [
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                    'Accept'       => 'application/json'
+                ],
+                'json'    => [
+                    'username' => 'admin',
+                    'password' => 'wrong-password-format-test-' . $i
+                ]
+            ]);
+        }
+
+        // Get rate limited response
+        $response = self::$http->post('/auth/login', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept'       => 'application/json'
+            ],
+            'json'    => [
+                'username' => 'admin',
+                'password' => 'wrong-password-format-final'
+            ]
+        ]);
+
+        $this->assertEquals(429, $response->getStatusCode());
+
+        // Parse response body
+        $body = (string) $response->getBody();
+        $data = json_decode($body, true);
+
+        $this->assertIsArray($data, 'Response body should be valid JSON');
+
+        // Check RFC 7807 Problem Details fields
+        $this->assertArrayHasKey('status', $data, 'Response should have status field');
+        $this->assertEquals(429, $data['status']);
+
+        $this->assertArrayHasKey('title', $data, 'Response should have title field');
+        $this->assertArrayHasKey('detail', $data, 'Response should have detail field');
+
+        // Check for retryAfter in body (custom field)
+        $this->assertArrayHasKey('retryAfter', $data, 'Response should have retryAfter field');
+        $this->assertIsInt($data['retryAfter']);
+        $this->assertGreaterThan(0, $data['retryAfter']);
+    }
+
+    /**
+     * Test that successful login clears the rate limit.
+     *
+     * After a user successfully authenticates, their rate limit counter should
+     * be cleared, allowing subsequent attempts.
+     */
+    public function testSuccessfulLoginClearsRateLimit(): void
+    {
+        // Get the configured rate limit (default is 5)
+        $maxAttempts = (int) ( $_ENV['RATE_LIMIT_LOGIN_ATTEMPTS'] ?? 5 );
+
+        // Make some failed attempts (but not enough to trigger rate limiting)
+        $failedAttempts = max(1, $maxAttempts - 2);
+        for ($i = 0; $i < $failedAttempts; $i++) {
+            $response = self::$http->post('/auth/login', [
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                    'Accept'       => 'application/json'
+                ],
+                'json'    => [
+                    'username' => 'admin',
+                    'password' => 'wrong-password-clear-test-' . $i
+                ]
+            ]);
+            $this->assertEquals(401, $response->getStatusCode());
+        }
+
+        // Now login successfully
+        $response = self::$http->post('/auth/login', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept'       => 'application/json'
+            ],
+            'json'    => [
+                'username' => $_ENV['ADMIN_USERNAME'] ?? 'admin',
+                'password' => $_ENV['ADMIN_PASSWORD'] ?? 'password'
+            ]
+        ]);
+
+        $this->assertEquals(
+            200,
+            $response->getStatusCode(),
+            'Successful login should return 200'
+        );
+
+        // Now we should be able to make failed attempts again without being rate limited
+        // Make the same number of failed attempts as before
+        for ($i = 0; $i < $failedAttempts; $i++) {
+            $response = self::$http->post('/auth/login', [
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                    'Accept'       => 'application/json'
+                ],
+                'json'    => [
+                    'username' => 'admin',
+                    'password' => 'wrong-password-after-clear-' . $i
+                ]
+            ]);
+
+            // Should get 401 (not 429) because rate limit was cleared
+            $this->assertEquals(
+                401,
+                $response->getStatusCode(),
+                'Expected 401 (not 429) on attempt ' . ( $i + 1 ) . ' after rate limit cleared'
+            );
+        }
+    }
+
+    /**
+     * Test that rate limiting returns proper Content-Type header.
+     */
+    public function testRateLimitResponseContentType(): void
+    {
+        // Get the configured rate limit (default is 5)
+        $maxAttempts = (int) ( $_ENV['RATE_LIMIT_LOGIN_ATTEMPTS'] ?? 5 );
+
+        // Exhaust rate limit
+        for ($i = 0; $i < $maxAttempts; $i++) {
+            self::$http->post('/auth/login', [
+                'headers' => [
+                    'Content-Type' => 'application/json',
+                    'Accept'       => 'application/json'
+                ],
+                'json'    => [
+                    'username' => 'admin',
+                    'password' => 'wrong-password-content-type-' . $i
+                ]
+            ]);
+        }
+
+        // Get rate limited response
+        $response = self::$http->post('/auth/login', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept'       => 'application/json'
+            ],
+            'json'    => [
+                'username' => 'admin',
+                'password' => 'wrong-password-content-type-final'
+            ]
+        ]);
+
+        $this->assertEquals(429, $response->getStatusCode());
+
+        // Check Content-Type header - should be application/problem+json for RFC 7807 compliance
+        $contentType = $response->getHeaderLine('Content-Type');
+        $this->assertStringContainsString(
+            'application/problem+json',
+            $contentType,
+            'Rate limit response should use application/problem+json content type'
+        );
+    }
+
+    /**
+     * Clean up rate limit data after each test by making a successful login.
+     *
+     * This ensures that rate limit state doesn't carry over between tests.
+     */
+    protected function tearDown(): void
+    {
+        // Make a successful login to clear any rate limiting state
+        self::$http->post('/auth/login', [
+            'headers' => [
+                'Content-Type' => 'application/json',
+                'Accept'       => 'application/json'
+            ],
+            'json'    => [
+                'username' => $_ENV['ADMIN_USERNAME'] ?? 'admin',
+                'password' => $_ENV['ADMIN_PASSWORD'] ?? 'password'
+            ]
+        ]);
+
+        parent::tearDown();
+    }
+}


### PR DESCRIPTION
## Summary

- Add comprehensive integration tests for the `/auth/login` endpoint's rate limiting functionality
- Tests verify brute-force protection works correctly by testing 429 responses after max attempts
- Completes the final remaining item in issue #428

## Test Coverage

The new `LoginRateLimitTest` class includes 5 tests:

1. **testLoginFailsWithInvalidCredentials** - Verifies 401 response for wrong passwords
2. **testRateLimitingTriggeredAfterMaxAttempts** - Verifies 429 response after exceeding rate limit
3. **testRateLimitResponseFormat** - Verifies RFC 7807 Problem Details format in response body
4. **testSuccessfulLoginClearsRateLimit** - Verifies successful login clears the rate limit counter
5. **testRateLimitResponseContentType** - Verifies `application/problem+json` content type

## Test plan

- [x] All new tests pass locally (`vendor/bin/phpunit phpunit_tests/Routes/Auth/LoginRateLimitTest.php`)
- [x] PHPStan analysis passes
- [x] Code style (phpcs) passes
- [x] Pre-commit hooks pass

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive integration test suite for login endpoint rate-limiting, validating rate-limit enforcement, response formats, and clearing behavior upon successful authentication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->