### PR TITLE
Fix rate limit test cleanup to prevent CI failures

### DIFF
--- a/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
+++ b/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
@@ -310,13 +310,18 @@ class LoginRateLimitTest extends ApiTestCase
     }
 
     /**
-     * Clean up rate limit data after each test by making a successful login.
+     * Clean up rate limit data after each test.
      *
-     * This ensures that rate limit state doesn't carry over between tests.
+     * This ensures that rate limit state doesn't carry over to other test classes.
+     * We clear files directly first (essential when tests end in rate-limited state),
+     * then attempt a successful login as a fallback for containerized environments.
      */
     protected function tearDown(): void
     {
-        // Make a successful login to clear any rate limiting state
+        // Clear rate limit files directly first (essential when rate-limited)
+        $this->clearRateLimitFiles();
+
+        // Also attempt a successful login as a fallback for containerized environments
         self::$http->post('/auth/login', [
             'headers' => [
                 'Content-Type' => 'application/json',


### PR DESCRIPTION
## Summary

- Fix rate limit tests leaving the API in a rate-limited state after tests complete
- Add `clearRateLimitFiles()` call in `tearDown()` to ensure cleanup happens even when rate-limited

## Problem

The rate limit integration tests were causing subsequent test classes (like `RegionalDataTest`) to fail in CI because:

1. Tests like `testRateLimitingTriggeredAfterMaxAttempts` intentionally exhaust the rate limit
2. `tearDown()` only attempted a successful login to clear the rate limit
3. But when rate-limited (429), that login attempt also fails, leaving the state persisted
4. `RegionalDataTest::getJwtToken()` then fails because login returns 429 instead of 200

## Solution

Now `tearDown()` clears rate limit files directly first (essential when tests end in rate-limited state), then attempts successful login as fallback for containerized environments where file access may differ.

## Test plan

- [x] Run rate limit tests followed by regional data tests locally - all pass
- [x] PHPStan analysis passes
- [x] Code style passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Consolidated and improved cleanup for login rate‑limit tests via a new helper, making test teardown and setup more reliable and consistent.
  * Updated test documentation/comments to reflect the revised two‑step cleanup approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->