### PR TITLE
fix: preserve duplicate event_keys when merging liturgical years

### DIFF
--- a/src/Map/AbstractLiturgicalEventMap.php
+++ b/src/Map/AbstractLiturgicalEventMap.php
@@ -296,9 +296,12 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      */
     public function mergeCollections(AbstractLiturgicalEventMap $litEvents): void
     {
-        // Get both as indexed arrays (collections) and merge them
+        // Always merge from raw eventMap arrays to avoid recursion/duplication on repeated calls
         // array_merge on indexed arrays appends rather than overwrites
-        $this->mergedCollection = array_merge($this->toCollection(), $litEvents->toCollection());
+        $this->mergedCollection = array_merge(
+            array_values($this->eventMap),
+            array_values($litEvents->getEvents())
+        );
     }
 
     /**

--- a/src/Map/AbstractLiturgicalEventMap.php
+++ b/src/Map/AbstractLiturgicalEventMap.php
@@ -55,9 +55,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      *
      * @param string $key The key of the event to retrieve.
      * @return LiturgicalEvent|null The event if found, null otherwise.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function getEvent(string $key): ?LiturgicalEvent
     {
+        $this->assertNotMerged(__METHOD__);
         return $this->eventMap[$key] ?? null;
     }
 
@@ -66,9 +68,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      *
      * @param DateTime $date The date of the event to retrieve.
      * @return LiturgicalEvent|null The event if found, null otherwise.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function getEventByDate(DateTime $date): ?LiturgicalEvent
     {
+        $this->assertNotMerged(__METHOD__);
         return array_find($this->eventMap, fn ($el) => $el->date == $date);
     }
 
@@ -104,9 +108,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      * Returns the number of events in the map.
      *
      * @return int The number of events.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function countEvents(): int
     {
+        $this->assertNotMerged(__METHOD__);
         return count($this->eventMap);
     }
 
@@ -114,9 +120,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      * Checks if the event map is empty.
      *
      * @return bool True if the map is empty, false otherwise.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function isEmpty(): bool
     {
+        $this->assertNotMerged(__METHOD__);
         return empty($this->eventMap);
     }
 
@@ -125,9 +133,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      *
      * @param string $key The key of the event to check.
      * @return bool True if the event exists, false otherwise.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function hasEvent(string $key): bool
     {
+        $this->assertNotMerged(__METHOD__);
         return isset($this->eventMap[$key]);
     }
 
@@ -136,9 +146,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      *
      * @param DateTime $date The date to check for events.
      * @return bool True if an event occurs on the given date, false otherwise.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function hasDate(DateTime $date): bool
     {
+        $this->assertNotMerged(__METHOD__);
         // important: DateTime objects cannot use strict comparison!
         return array_find($this->eventMap, fn ($el) => $el->date == $date) !== null;
     }
@@ -148,9 +160,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      *
      * @param string $key The key to check.
      * @return bool True if the key exists, false otherwise.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function hasKey(string $key): bool
     {
+        $this->assertNotMerged(__METHOD__);
         return array_key_exists($key, $this->eventMap);
     }
 
@@ -158,9 +172,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      * Retrieves all LiturgicalEvent objects in the map.
      *
      * @return array<string,LiturgicalEvent> An array of LiturgicalEvent objects.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function getEvents(): array
     {
+        $this->assertNotMerged(__METHOD__);
         return $this->eventMap;
     }
 
@@ -172,9 +188,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      *
      * @param DateTime $date The date for which to retrieve events.
      * @return array<string,LiturgicalEvent> An array of events occurring on the specified date.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function getEventsByDate(DateTime $date): array
     {
+        $this->assertNotMerged(__METHOD__);
         // important: DateTime objects cannot use strict comparison!
         return array_filter($this->eventMap, fn ($el) => $el->date == $date);
     }
@@ -197,9 +215,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      *
      * @param DateTime $date The date for which to find the event key.
      * @return string|null The key of the event at the given date, or null if no event exists.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function getEventKeyByDate(DateTime $date): ?string
     {
+        $this->assertNotMerged(__METHOD__);
         // important: DateTime objects cannot use strict comparison!
         return array_find_key($this->eventMap, fn ($el) => $el->date == $date);
     }
@@ -227,9 +247,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      * Returns an array of keys for the events in the map.
      *
      * @return string[] An array of event keys.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function getKeys(): array
     {
+        $this->assertNotMerged(__METHOD__);
         return array_keys($this->eventMap);
     }
 
@@ -328,9 +350,11 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      * Returns an iterator for the events in the map.
      *
      * @return \Traversable<string,LiturgicalEvent> An iterator for the events in the map.
+     * @throws \LogicException If called after mergeCollections().
      */
     public function getIterator(): \Traversable
     {
+        $this->assertNotMerged(__METHOD__);
         return new \ArrayIterator($this->eventMap);
     }
 

--- a/src/Map/AbstractLiturgicalEventMap.php
+++ b/src/Map/AbstractLiturgicalEventMap.php
@@ -9,6 +9,11 @@ use LiturgicalCalendar\Api\DateTime;
  * Abstract class for liturgical event maps.
  *
  * Maps event keys to LiturgicalEvent objects.
+ *
+ * Lifecycle: After calling mergeCollections(), the map enters a merged state.
+ * In this state, toCollection() returns the merged collection and the map
+ * should not be modified further (addEvent, removeEvent, etc.).
+ *
  * @implements \IteratorAggregate<string,LiturgicalEvent>
  */
 abstract class AbstractLiturgicalEventMap implements \IteratorAggregate

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -1965,6 +1965,10 @@ final class LiturgicalEventCollection
      * Christmas and Lent, weekdays of Epiphany, solemnities of Lord and BVM,
      * Sundays of Advent, Lent, and Easter.
      *
+     * For the main liturgicalEvents map, this uses mergeCollections() to preserve events with
+     * the same event_key but different dates (e.g., St. Andrew Apostle on Nov 30 appearing
+     * twice when a liturgical year spans two civil years).
+     *
      * @param LiturgicalEventCollection $litEvents The LiturgicalEventCollection to merge with the current one.
      * @return void
      */
@@ -1985,7 +1989,8 @@ final class LiturgicalEventCollection
         $this->weekdaysLent->merge($litEvents->weekdaysLent);
         $this->weekdaysEpiphany->merge($litEvents->weekdaysEpiphany);
         $this->weekdaysOrdinary->merge($litEvents->weekdaysOrdinary);
-        $this->liturgicalEvents->merge($litEvents->liturgicalEvents);
+        // Use mergeCollections() to preserve duplicate event_keys with different dates
+        $this->liturgicalEvents->mergeCollections($litEvents->liturgicalEvents);
         $this->suppressedEvents->merge($litEvents->suppressedEvents);
         $this->reinstatedEvents->merge($litEvents->reinstatedEvents);
     }


### PR DESCRIPTION
## Summary

- Fixes issue where events with the same `event_key` but different dates were being overwritten when merging civil year calendars into a liturgical year
- Added `mergeCollections()` method that merges events as indexed arrays instead of associative arrays
- Preserves both occurrences of events like St. Andrew Apostle (Nov 30) that appear twice in a liturgical year spanning two civil years

## Root Cause

When merging two civil year calendars into a single liturgical year, the `merge()` method used `array_merge()` on associative arrays keyed by `event_key`. This caused the second event to overwrite the first when they shared the same key.

## Solution

- Added `$mergedCollection` property to store merged events as an indexed array
- Added `mergeCollections()` method that converts maps to indexed arrays before merging
- Updated `toCollection()` to return the merged collection when available
- Updated `sort()` to also sort the merged collection

## Test Plan

- [x] PHPStan analysis passes (level 10)
- [x] All 168 PHPUnit tests pass
- [x] Code style check passes
- [x] Manual verification: `curl "http://localhost:8000/calendar/2028" | jq '[.litcal[] | select(.event_key == "StAndrewAp")]'` now returns both events (2027-11-30 and 2028-11-30)

Fixes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a merged-collection mode to combine calendars while preserving duplicate events on different dates; merged calendars become read-only and sorting respects the merged state.

* **Bug Fixes**
  * Fixed calendar merging so duplicate liturgical events with different dates are retained when calendars are combined.

* **Documentation**
  * Clarified lifecycle guidance: after merging the collection is in a merged state and should no longer be mutated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->