### PR TITLE
fix: remove OrdSunday34 from temporale

### DIFF
--- a/.claude/commands/merge.md
+++ b/.claude/commands/merge.md
@@ -2,6 +2,6 @@
 
 1. Merge the PR using `gh pr merge <pr-number> --merge --delete-branch`, handling any conflicts if needed.
 2. Confirm the merge was successful by checking the PR status: `gh pr view <pr-number>`.
-3. Checkout the target branch (the branch the PR was merged into, e.g., `master` or `development`).
+3. Checkout the target branch (the branch the PR was merged into, e.g., `stable` or `development`).
 4. Pull the changes: `git pull origin <target-branch>`.
 5. Delete the local branch if it wasn't already deleted: `git branch -d <branch-name>`.

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -47,10 +47,10 @@ Add a new entry at the top of the changelog (after any commented unreleased sect
 
 ## Step 4: Open Pull Request
 
-Create a PR from `development` to `master`:
+Create a PR from `development` to `stable`:
 
 ```bash
-gh pr create --base master --head development --title "Release vX.Y" --body "$(cat <<'EOF'
+gh pr create --base stable --head development --title "Release vX.Y" --body "$(cat <<'EOF'
 ## Release vX.Y
 
 [Summary of changes from the changelog]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,11 +374,11 @@ data validation via WebSocket backend.
 
 ## Git Workflow
 
-- **Main branch:** `master` (stable releases)
-- **Development branch:** `development` (active development and testing)
-- **Feature branches:** Always branch off `development`, not `master`
-- **Pull requests:** Always target `development` branch, never `master` directly
-- **Release flow:** Changes merge from feature branches → `development` → `master` after community testing
+- **Stable branch:** `stable` (stable releases)
+- **Development branch:** `development` (active development and testing, default branch)
+- **Feature branches:** Always branch off `development`, not `stable`
+- **Pull requests:** Always target `development` branch, never `stable` directly
+- **Release flow:** Changes merge from feature branches → `development` → `stable` after community testing
 - Test locally before submitting PR
 
 **Creating a feature branch:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,8 @@ How you can contribute to this project:
 * PRs should be small, simple, direct and to the point, addressing a specific issue and offering a concrete solution
 * the fix contained in a PR should first be tested locally by the issuer, before being issued against the repo `development` branch
 * pull requests should generally be made against the `development` branch, to ensure they can be tested by the community
-  before being pulled into the `master` branch
-* the `master` branch should be clean, only tested PRs should be pulled into the `master` branch (usually passing through the `development`
-  branch first and then pulled from there). Version releases are created from the `master` branch directly.
+  before being pulled into the `stable` branch
+* the `stable` branch should be clean, only tested PRs should be pulled into the `stable` branch (usually passing through the `development`
+  branch first and then pulled from there). Version releases are created from the `stable` branch directly.
 * if a PR is more complex and is directed at adding a significant feature, a specific feature branch will first be created, then the PR should
-  be issued against the feature branch, that way the feature can be fully tested by the community before being pulled into the `master` branch
+  be issued against the feature branch, that way the feature can be fully tested by the community before being pulled into the `stable` branch

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@
     <tbody>
         <tr>
             <th style="text-align: center; background-color: lightgray; color: black;" scope="row">
-                <a href="https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/tree/master">stable branch</a>
+                <a href="https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/tree/stable">stable branch</a>
             </th>
             <td style="text-align:center; background-color: whitesmoke;">
-                <a href="https://www.codefactor.io/repository/github/liturgical-calendar/liturgicalcalendarapi/overview/master">
-                    <img src="https://www.codefactor.io/repository/github/liturgical-calendar/liturgicalcalendarapi/badge/master" title="CodeFactor" alt="CodeFactor" />
+                <a href="https://www.codefactor.io/repository/github/liturgical-calendar/liturgicalcalendarapi/overview/stable">
+                    <img src="https://www.codefactor.io/repository/github/liturgical-calendar/liturgicalcalendarapi/badge/stable" title="CodeFactor" alt="CodeFactor" />
                 </a>
             </td>
             <td rowspan="2" style="text-align:center; background-color: whitesmoke;">
@@ -22,8 +22,8 @@
                 </a>
             </td>
             <td style="text-align:center; background-color: whitesmoke;">
-                <a href="https://validator.swagger.io/validator?url=https://raw.githubusercontent.com/Liturgical-Calendar/LiturgicalCalendarAPI/master/jsondata/schemas/openapi.json">
-                    <img src="https://validator.swagger.io/validator?url=https://raw.githubusercontent.com/Liturgical-Calendar/LiturgicalCalendarAPI/master/jsondata/schemas/openapi.json"
+                <a href="https://validator.swagger.io/validator?url=https://raw.githubusercontent.com/Liturgical-Calendar/LiturgicalCalendarAPI/stable/jsondata/schemas/openapi.json">
+                    <img src="https://validator.swagger.io/validator?url=https://raw.githubusercontent.com/Liturgical-Calendar/LiturgicalCalendarAPI/stable/jsondata/schemas/openapi.json"
                          alt="OpenAPI validation result" />
                 </a>
             </td>

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/de.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/de.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "",
     "OrdSunday32": "",
     "OrdSunday33": "",
-    "OrdSunday34": "",
     "ImmaculateHeart": ""
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/en.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/en.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "31st Sunday of Ordinary Time",
     "OrdSunday32": "32nd Sunday of Ordinary Time",
     "OrdSunday33": "33rd Sunday of Ordinary Time",
-    "OrdSunday34": "34th Sunday of Ordinary Time",
     "ImmaculateHeart": "The Immaculate Heart of the Blessed Virgin Mary"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/es.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/es.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "",
     "OrdSunday32": "",
     "OrdSunday33": "",
-    "OrdSunday34": "",
     "ImmaculateHeart": ""
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/fr.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/fr.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "31ème dimanche du temps ordinaire",
     "OrdSunday32": "32ème dimanche du temps ordinaire",
     "OrdSunday33": "33ème dimanche du temps ordinaire",
-    "OrdSunday34": "34ème dimanche du temps ordinaire",
     "ImmaculateHeart": "Cœur Immaculé de la bienheureuse Vierge Marie"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/hr.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/hr.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "Trideset prva nedjelja «kroz godinu»",
     "OrdSunday32": "Trideset druga nedjelja «kroz godinu»",
     "OrdSunday33": "Trideset treća nedjelja «kroz godinu»",
-    "OrdSunday34": "Trideset četvrta nedjelja «kroz godinu»",
     "ImmaculateHeart": "Bezgrešno Srce Marijino"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/hu.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/hu.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "",
     "OrdSunday32": "",
     "OrdSunday33": "",
-    "OrdSunday34": "",
     "ImmaculateHeart": ""
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/id.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/id.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "Hari Minggu Biasa XXXI",
     "OrdSunday32": "Hari Minggu Biasa XXXII",
     "OrdSunday33": "Hari Minggu Biasa XXXIII",
-    "OrdSunday34": "Hari Minggu Biasa XXXIV",
     "ImmaculateHeart": "Hati Tak Bernoda SP Maria"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/it.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/it.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "XXXI Domenica del Tempo Ordinario",
     "OrdSunday32": "XXXII Domenica del Tempo Ordinario",
     "OrdSunday33": "XXXIII Domenica del Tempo Ordinario",
-    "OrdSunday34": "XXXIV Domenica del Tempo Ordinario",
     "ImmaculateHeart": "Cuore Immacolato della Beata Vergine Maria"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/la.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/la.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "Dominica XXXI «Per Annum»",
     "OrdSunday32": "Dominica XXXII «Per Annum»",
     "OrdSunday33": "Dominica XXXIII «Per Annum»",
-    "OrdSunday34": "Dominica XXXIV «Per Annum»",
     "ImmaculateHeart": "Immaculati Cordis Beatæ Mariæ Virginis"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/nl.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/nl.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "Eenendertigste zondag door het jaar",
     "OrdSunday32": "Tweeëndertigste zondag door het jaar",
     "OrdSunday33": "Drieëndertigste zondag door het jaar",
-    "OrdSunday34": "Vierendertigste zondag door het jaar",
     "ImmaculateHeart": "Onbevlekt Hart van de H. Maagd Maria"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/pl.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/pl.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "XXXI Niedziela Zwykła",
     "OrdSunday32": "XXXII Niedziela Zwykła",
     "OrdSunday33": "XXXIII Niedziela Zwykła",
-    "OrdSunday34": "XXXIV Niedziela Zwykła",
     "ImmaculateHeart": "Niepokalanego Serca Najświętszej Maryi Panny"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/pt.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/pt.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "",
     "OrdSunday32": "",
     "OrdSunday33": "",
-    "OrdSunday34": "",
     "ImmaculateHeart": ""
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/sk.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/sk.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "XXXI. nedeľa v období cez rok",
     "OrdSunday32": "XXXII. nedeľa v cezročnom období",
     "OrdSunday33": "Tridsiata tretia nedeľa v cezročnom období",
-    "OrdSunday34": "XXXIV. nedeľa v cezročnom období",
     "ImmaculateHeart": "Nepoškvrneného Srdca Panny Márie"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/vi.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/vi.json
@@ -73,6 +73,5 @@
     "OrdSunday31": "Chúa Nhật XXXI Mùa Thường Niên",
     "OrdSunday32": "Chúa Nhật XXXII Mùa Thường Niên",
     "OrdSunday33": "Chúa Nhật XXXIII Mùa Thường Niên",
-    "OrdSunday34": "Chúa Nhật XXXIV Mùa Thường Niên",
     "ImmaculateHeart": "Trái Tim Vô Nhiễm Nguyên Tội Đức Trinh Nữ Maria"
 }

--- a/jsondata/sourcedata/missals/propriumdetempore/propriumdetempore.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/propriumdetempore.json
@@ -444,12 +444,6 @@
         "color": [ "green" ]
     },
     {
-        "event_key": "OrdSunday34",
-        "grade": 5,
-        "type": "mobile",
-        "color": [ "green" ]
-    },
-    {
         "event_key": "ImmaculateHeart",
         "grade": 3,
         "type": "mobile",


### PR DESCRIPTION
## Summary

- Removes the unnecessary `OrdSunday34` event key from the temporale data
- The 34th Sunday of Ordinary Time IS Christ the King, so no separate event is needed
- No lectionary readings exist for `OrdSunday34`, only for `ChristKing`

## Changes

- Removed `OrdSunday34` entry from `propriumdetempore.json`
- Removed `OrdSunday34` translations from all 14 i18n files (de, en, es, fr, hr, hu, id, it, la, nl, pl, pt, sk, vi)

## Test plan

- [x] All 168 PHPUnit tests pass
- [x] PHPStan analysis passes (level 10)
- [x] No references to `OrdSunday34` remain in the codebase

Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced event merging capabilities for improved calendar data handling

* **Content Updates**
  * Added lectionary readings for Christmas, Epiphany, and related liturgical celebrations
  * Expanded translations across multiple languages
  * Corrected Latin spelling errors in saint titles

* **Improvements**
  * Added automatic PHP code quality tool integration for development

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->