### PR TITLE
feat: expose temporale data via /temporale API endpoint

### DIFF
--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -3242,6 +3242,45 @@
           }
         }
       },
+      "post": {
+        "tags": [
+          "Temporale"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all Proprium de Tempore (temporale) events (POST alias)",
+        "operationId": "temporalePOST",
+        "description": "Read-only alias of GET. Returns all temporale events with translated names based on the Accept-Language header. Temporale events are liturgical events that don't have fixed dates (Easter, Pentecost, etc.).",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: array of temporale events with translated names",
+            "headers": {
+              "X-Litcal-Temporale-Locale": {
+                "description": "The locale used for translating event names",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./PropriumDeTempore.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      },
       "put": {
         "tags": [
           "Temporale"

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -59,6 +59,10 @@
     {
       "name": "Unit Tests",
       "description": "Retrieve / create / update / delete unit tests"
+    },
+    {
+      "name": "Temporale",
+      "description": "Retrieve / create / update / delete Proprium de Tempore (temporale) events"
     }
   ],
   "paths": {
@@ -3188,6 +3192,224 @@
         "responses": {
           "204": {
             "description": "204 No Content. The unit test was deleted successfully."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      }
+    },
+    "/temporale": {
+      "get": {
+        "tags": [
+          "Temporale"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all Proprium de Tempore (temporale) events",
+        "operationId": "temporaleGET",
+        "description": "Returns all temporale events with translated names based on the Accept-Language header. Temporale events are liturgical events that don't have fixed dates (Easter, Pentecost, etc.).",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: array of temporale events with translated names",
+            "headers": {
+              "X-Litcal-Temporale-Locale": {
+                "description": "The locale used for translating event names",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./PropriumDeTempore.json"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Temporale"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Replace all Proprium de Tempore (temporale) events",
+        "operationId": "temporalePUT",
+        "description": "Replaces the entire temporale data with the provided array of events. Requires authentication.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./PropriumDeTempore.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK: temporale data replaced successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "events": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Temporale"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Update specific Proprium de Tempore (temporale) events",
+        "operationId": "temporalePATCH",
+        "description": "Updates or adds specific temporale events. Events are matched by event_key. Requires authentication.",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./PropriumDeTempore.json"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK: temporale data updated successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "updated": {
+                      "type": "integer"
+                    },
+                    "added": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      }
+    },
+    "/temporale/{event_key}": {
+      "delete": {
+        "tags": [
+          "Temporale"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete a specific Proprium de Tempore (temporale) event",
+        "operationId": "temporaleDELETE",
+        "description": "Deletes a specific temporale event by its event_key. Requires authentication.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "The event_key of the temporale event to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: temporale event deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "event_key": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized401"

--- a/phpunit_tests/Routes/ReadWrite/TemporaleTest.php
+++ b/phpunit_tests/Routes/ReadWrite/TemporaleTest.php
@@ -17,6 +17,53 @@ use LiturgicalCalendar\Tests\ApiTestCase;
 final class TemporaleTest extends ApiTestCase
 {
     /**
+     * Test that unauthenticated DELETE returns 401.
+     */
+    public function testDeleteTemporaleWithoutAuthReturns401(): void
+    {
+        $response = self::$http->delete('/temporale/Easter', [
+            'http_errors' => false
+        ]);
+        $this->assertSame(
+            401,
+            $response->getStatusCode(),
+            'DELETE without authentication should return 401 Unauthorized'
+        );
+    }
+
+    /**
+     * Test that unauthenticated PUT returns 401.
+     */
+    public function testPutTemporaleWithoutAuthReturns401(): void
+    {
+        $response = self::$http->put('/temporale', [
+            'http_errors' => false,
+            'json'        => []
+        ]);
+        $this->assertSame(
+            401,
+            $response->getStatusCode(),
+            'PUT without authentication should return 401 Unauthorized'
+        );
+    }
+
+    /**
+     * Test that unauthenticated PATCH returns 401.
+     */
+    public function testPatchTemporaleWithoutAuthReturns401(): void
+    {
+        $response = self::$http->patch('/temporale', [
+            'http_errors' => false,
+            'json'        => []
+        ]);
+        $this->assertSame(
+            401,
+            $response->getStatusCode(),
+            'PATCH without authentication should return 401 Unauthorized'
+        );
+    }
+
+    /**
      * Test that authenticated PUT with invalid payload (not an array) returns 400.
      */
     public function testAuthenticatedPutWithInvalidPayloadReturns400(): void

--- a/phpunit_tests/Routes/ReadWrite/TemporaleTest.php
+++ b/phpunit_tests/Routes/ReadWrite/TemporaleTest.php
@@ -41,6 +41,39 @@ final class TemporaleTest extends ApiTestCase
     }
 
     /**
+     * Test that authenticated PUT with empty event_key returns 400.
+     */
+    public function testAuthenticatedPutWithEmptyEventKeyReturns400(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        $invalidPayload = [
+            [
+                'event_key' => '',
+                'grade'     => 3,
+                'type'      => 'mobile',
+                'color'     => ['white']
+            ]
+        ];
+
+        $response = self::$http->put('/temporale', [
+            'headers'     => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'        => json_encode($invalidPayload),
+            'http_errors' => false
+        ]);
+
+        $this->assertSame(
+            400,
+            $response->getStatusCode(),
+            'PUT with empty event_key should return 400'
+        );
+    }
+
+    /**
      * Test that authenticated PUT with invalid event structure returns 400.
      */
     public function testAuthenticatedPutWithInvalidEventReturns400(): void

--- a/phpunit_tests/Routes/ReadWrite/TemporaleTest.php
+++ b/phpunit_tests/Routes/ReadWrite/TemporaleTest.php
@@ -1,0 +1,289 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\ReadWrite;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+/**
+ * Integration tests for authenticated write operations on the /temporale API endpoint.
+ *
+ * These tests verify JWT authentication and validation for PUT, PATCH, and DELETE operations.
+ * To avoid modifying production data, tests focus on validation errors and non-existent resources.
+ *
+ * @group slow
+ */
+final class TemporaleTest extends ApiTestCase
+{
+    /**
+     * Test that authenticated PUT with invalid payload (not an array) returns 400.
+     */
+    public function testAuthenticatedPutWithInvalidPayloadReturns400(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        $response = self::$http->put('/temporale', [
+            'headers'     => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'        => json_encode(['not' => 'an array of events']),
+            'http_errors' => false
+        ]);
+
+        $this->assertSame(
+            400,
+            $response->getStatusCode(),
+            'PUT with object instead of array should return 400'
+        );
+    }
+
+    /**
+     * Test that authenticated PUT with invalid event structure returns 400.
+     */
+    public function testAuthenticatedPutWithInvalidEventReturns400(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        // Missing required properties
+        $response = self::$http->put('/temporale', [
+            'headers'     => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'        => json_encode([['event_key' => 'Test']]),
+            'http_errors' => false
+        ]);
+
+        $this->assertSame(
+            400,
+            $response->getStatusCode(),
+            'PUT with incomplete event should return 400'
+        );
+    }
+
+    /**
+     * Test that authenticated PUT with duplicate event_keys returns 400.
+     */
+    public function testAuthenticatedPutWithDuplicateEventKeysReturns400(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        $duplicatePayload = [
+            [
+                'event_key' => 'DuplicateTest',
+                'grade'     => 3,
+                'type'      => 'mobile',
+                'color'     => ['white']
+            ],
+            [
+                'event_key' => 'DuplicateTest',
+                'grade'     => 4,
+                'type'      => 'fixed',
+                'color'     => ['red']
+            ]
+        ];
+
+        $response = self::$http->put('/temporale', [
+            'headers'     => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'        => json_encode($duplicatePayload),
+            'http_errors' => false
+        ]);
+
+        $this->assertSame(
+            400,
+            $response->getStatusCode(),
+            'PUT with duplicate event_keys should return 400'
+        );
+    }
+
+    /**
+     * Test that authenticated PUT with invalid grade (out of range) returns 400.
+     */
+    public function testAuthenticatedPutWithInvalidGradeReturns400(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        $invalidPayload = [
+            [
+                'event_key' => 'TestEvent',
+                'grade'     => 99,  // Invalid: should be 0-7
+                'type'      => 'mobile',
+                'color'     => ['white']
+            ]
+        ];
+
+        $response = self::$http->put('/temporale', [
+            'headers'     => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'        => json_encode($invalidPayload),
+            'http_errors' => false
+        ]);
+
+        $this->assertSame(
+            400,
+            $response->getStatusCode(),
+            'PUT with invalid grade should return 400'
+        );
+    }
+
+    /**
+     * Test that authenticated PUT with invalid color returns 400.
+     */
+    public function testAuthenticatedPutWithInvalidColorReturns400(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        $invalidPayload = [
+            [
+                'event_key' => 'TestEvent',
+                'grade'     => 3,
+                'type'      => 'mobile',
+                'color'     => ['invalid_color']
+            ]
+        ];
+
+        $response = self::$http->put('/temporale', [
+            'headers'     => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'        => json_encode($invalidPayload),
+            'http_errors' => false
+        ]);
+
+        $this->assertSame(
+            400,
+            $response->getStatusCode(),
+            'PUT with invalid color should return 400'
+        );
+    }
+
+    /**
+     * Test that authenticated PATCH with invalid event structure returns 400.
+     */
+    public function testAuthenticatedPatchWithInvalidEventReturns400(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        // Event without event_key
+        $response = self::$http->patch('/temporale', [
+            'headers'     => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'        => json_encode([['grade' => 3, 'type' => 'mobile', 'color' => ['white']]]),
+            'http_errors' => false
+        ]);
+
+        $this->assertSame(
+            400,
+            $response->getStatusCode(),
+            'PATCH with event missing event_key should return 400'
+        );
+    }
+
+    /**
+     * Test that authenticated PATCH with duplicate event_keys returns 400.
+     */
+    public function testAuthenticatedPatchWithDuplicateEventKeysReturns400(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        $duplicatePayload = [
+            [
+                'event_key' => 'DuplicateTest',
+                'grade'     => 3,
+                'type'      => 'mobile',
+                'color'     => ['white']
+            ],
+            [
+                'event_key' => 'DuplicateTest',
+                'grade'     => 4,
+                'type'      => 'fixed',
+                'color'     => ['red']
+            ]
+        ];
+
+        $response = self::$http->patch('/temporale', [
+            'headers'     => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'        => json_encode($duplicatePayload),
+            'http_errors' => false
+        ]);
+
+        $this->assertSame(
+            400,
+            $response->getStatusCode(),
+            'PATCH with duplicate event_keys should return 400'
+        );
+    }
+
+    /**
+     * Test that authenticated DELETE for non-existent event returns 404.
+     */
+    public function testAuthenticatedDeleteNonExistentEventReturns404(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        $response = self::$http->delete('/temporale/NonExistentEventKey12345', [
+            'headers'     => self::authHeaders($token),
+            'http_errors' => false
+        ]);
+
+        $this->assertSame(
+            404,
+            $response->getStatusCode(),
+            'DELETE for non-existent event_key should return 404'
+        );
+    }
+
+    /**
+     * Test that authenticated PUT/PATCH without Content-Type returns 415.
+     */
+    public function testAuthenticatedWriteWithoutContentTypeReturns415(): void
+    {
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        // PUT without Content-Type
+        $putResponse = self::$http->put('/temporale', [
+            'headers'     => self::authHeaders($token),
+            'body'        => '[]',
+            'http_errors' => false
+        ]);
+        $this->assertSame(
+            415,
+            $putResponse->getStatusCode(),
+            'PUT without Content-Type should return 415'
+        );
+
+        // PATCH without Content-Type
+        $patchResponse = self::$http->patch('/temporale', [
+            'headers'     => self::authHeaders($token),
+            'body'        => '[]',
+            'http_errors' => false
+        ]);
+        $this->assertSame(
+            415,
+            $patchResponse->getStatusCode(),
+            'PATCH without Content-Type should return 415'
+        );
+    }
+}

--- a/phpunit_tests/Routes/Readonly/TemporaleTest.php
+++ b/phpunit_tests/Routes/Readonly/TemporaleTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Readonly;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+final class TemporaleTest extends ApiTestCase
+{
+    public function testGetTemporaleReturnsJson(): void
+    {
+        $response = self::$http->get('/temporale', []);
+        $this->assertSame(
+            200,
+            $response->getStatusCode(),
+            'Expected HTTP 200 OK, got ' . $response->getStatusCode() . ': ' . $response->getBody()
+        );
+        $this->assertStringStartsWith(
+            'application/json',
+            $response->getHeaderLine('Content-Type'),
+            'Expected Content-Type application/json, got ' . $response->getHeaderLine('Content-Type')
+        );
+    }
+
+    public function testGetTemporaleReturnsArrayOfEvents(): void
+    {
+        $response = self::$http->get('/temporale', []);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), 'Invalid JSON: ' . json_last_error_msg());
+        $this->assertIsArray($data, 'Response should be a JSON array');
+        $this->assertNotEmpty($data, 'Response array should not be empty');
+    }
+
+    public function testGetTemporaleEventStructure(): void
+    {
+        $response = self::$http->get('/temporale', []);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsArray($data);
+
+        // Check at least one event has the expected structure
+        $event = $data[0];
+        $this->assertIsObject($event, 'Each event should be an object');
+        $this->assertObjectHasProperty('event_key', $event, 'Event should have event_key property');
+        $this->assertIsString($event->event_key, 'event_key should be a string');
+        $this->assertObjectHasProperty('grade', $event, 'Event should have grade property');
+        $this->assertIsInt($event->grade, 'grade should be an integer');
+        $this->assertObjectHasProperty('type', $event, 'Event should have type property');
+        $this->assertIsString($event->type, 'type should be a string');
+        $this->assertContains($event->type, ['mobile', 'fixed'], 'type should be either "mobile" or "fixed"');
+        $this->assertObjectHasProperty('color', $event, 'Event should have color property');
+        $this->assertIsArray($event->color, 'color should be an array');
+    }
+
+    public function testGetTemporaleReturnsLocaleHeader(): void
+    {
+        $response = self::$http->get('/temporale', []);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertTrue(
+            $response->hasHeader('X-Litcal-Temporale-Locale'),
+            'Response should have X-Litcal-Temporale-Locale header'
+        );
+    }
+
+    public function testGetTemporaleWithEnglishLocale(): void
+    {
+        $response = self::$http->get('/temporale', [
+            'headers' => ['Accept-Language' => 'en']
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsArray($data);
+
+        // Find Easter event and check it has a translated name
+        $easter = array_find($data, fn($event) => $event->event_key === 'Easter');
+        $this->assertNotNull($easter, 'Easter event should exist');
+        $this->assertObjectHasProperty('name', $easter, 'Event should have translated name');
+        $this->assertIsString($easter->name, 'name should be a string');
+    }
+
+    public function testGetTemporaleWithLatinLocale(): void
+    {
+        $response = self::$http->get('/temporale', [
+            'headers' => ['Accept-Language' => 'la']
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $localeHeader = $response->getHeaderLine('X-Litcal-Temporale-Locale');
+        $this->assertSame('la', $localeHeader, 'Locale header should be "la"');
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsArray($data);
+    }
+
+    public function testGetTemporaleWithItalianLocale(): void
+    {
+        $response = self::$http->get('/temporale', [
+            'headers' => ['Accept-Language' => 'it']
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $localeHeader = $response->getHeaderLine('X-Litcal-Temporale-Locale');
+        $this->assertSame('it', $localeHeader, 'Locale header should be "it"');
+    }
+
+    public function testGetTemporaleContainsKnownEvents(): void
+    {
+        $response = self::$http->get('/temporale', []);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsArray($data);
+
+        // Extract event keys
+        $eventKeys = array_map(fn($event) => $event->event_key, $data);
+
+        // Check for known temporale events
+        $knownEvents = ['Easter', 'Christmas', 'Pentecost', 'Advent1', 'Lent1', 'HolyThurs', 'GoodFri'];
+        foreach ($knownEvents as $knownEvent) {
+            $this->assertContains(
+                $knownEvent,
+                $eventKeys,
+                "Temporale should contain the event '{$knownEvent}'"
+            );
+        }
+    }
+
+    public function testGetTemporaleWithUnsupportedAcceptDefaultsToJson(): void
+    {
+        // LAX acceptability level allows unsupported Accept headers and defaults to JSON
+        $response = self::$http->get('/temporale', [
+            'headers' => ['Accept' => 'text/plain']
+        ]);
+        $this->assertSame(
+            200,
+            $response->getStatusCode(),
+            'Expected HTTP 200 OK even with unsupported Accept header (LAX mode)'
+        );
+        $this->assertStringStartsWith(
+            'application/json',
+            $response->getHeaderLine('Content-Type'),
+            'Should default to JSON when Accept header is unsupported'
+        );
+    }
+
+    public function testGetTemporalePostMethodWorks(): void
+    {
+        $response = self::$http->post('/temporale', []);
+        $this->assertSame(
+            200,
+            $response->getStatusCode(),
+            'POST method should work the same as GET'
+        );
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsArray($data, 'Response should be a JSON array');
+    }
+}

--- a/phpunit_tests/Routes/Readonly/TemporaleTest.php
+++ b/phpunit_tests/Routes/Readonly/TemporaleTest.php
@@ -181,47 +181,6 @@ final class TemporaleTest extends ApiTestCase
         $this->assertIsArray($data, 'Response should be a JSON array');
     }
 
-    public function testDeleteTemporaleWithoutAuthReturns401(): void
-    {
-        // DELETE requires JWT authentication
-        $response = self::$http->delete('/temporale/Easter', [
-            'http_errors' => false
-        ]);
-        $this->assertSame(
-            401,
-            $response->getStatusCode(),
-            'DELETE without authentication should return 401 Unauthorized'
-        );
-    }
-
-    public function testPutTemporaleWithoutAuthReturns401(): void
-    {
-        // PUT requires JWT authentication
-        $response = self::$http->put('/temporale', [
-            'http_errors' => false,
-            'json'        => []
-        ]);
-        $this->assertSame(
-            401,
-            $response->getStatusCode(),
-            'PUT without authentication should return 401 Unauthorized'
-        );
-    }
-
-    public function testPatchTemporaleWithoutAuthReturns401(): void
-    {
-        // PATCH requires JWT authentication
-        $response = self::$http->patch('/temporale', [
-            'http_errors' => false,
-            'json'        => []
-        ]);
-        $this->assertSame(
-            401,
-            $response->getStatusCode(),
-            'PATCH without authentication should return 401 Unauthorized'
-        );
-    }
-
     public function testGetTemporaleWithUnsupportedLocaleDefaultsToLatin(): void
     {
         // Unsupported locale should default to Latin (la)

--- a/phpunit_tests/Routes/Readonly/TemporaleTest.php
+++ b/phpunit_tests/Routes/Readonly/TemporaleTest.php
@@ -100,6 +100,12 @@ final class TemporaleTest extends ApiTestCase
 
         $data = json_decode((string) $response->getBody());
         $this->assertIsArray($data);
+
+        // Validate translated content
+        $easter = array_find($data, fn($event) => $event->event_key === 'Easter');
+        $this->assertNotNull($easter, 'Easter event should exist');
+        $this->assertObjectHasProperty('name', $easter, 'Event should have translated name');
+        $this->assertIsString($easter->name, 'name should be a string');
     }
 
     public function testGetTemporaleWithItalianLocale(): void
@@ -111,6 +117,15 @@ final class TemporaleTest extends ApiTestCase
 
         $localeHeader = $response->getHeaderLine('X-Litcal-Temporale-Locale');
         $this->assertSame('it', $localeHeader, 'Locale header should be "it"');
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsArray($data);
+
+        // Validate translated content
+        $easter = array_find($data, fn($event) => $event->event_key === 'Easter');
+        $this->assertNotNull($easter, 'Easter event should exist');
+        $this->assertObjectHasProperty('name', $easter, 'Event should have translated name');
+        $this->assertIsString($easter->name, 'name should be a string');
     }
 
     public function testGetTemporaleContainsKnownEvents(): void

--- a/phpunit_tests/Routes/Readonly/TemporaleTest.php
+++ b/phpunit_tests/Routes/Readonly/TemporaleTest.php
@@ -46,6 +46,7 @@ final class TemporaleTest extends ApiTestCase
 
         $data = json_decode((string) $response->getBody());
         $this->assertIsArray($data);
+        $this->assertNotEmpty($data, 'Expected at least one event in response');
 
         // Check at least one event has the expected structure
         $event = $data[0];

--- a/phpunit_tests/Routes/Readonly/TemporaleTest.php
+++ b/phpunit_tests/Routes/Readonly/TemporaleTest.php
@@ -6,6 +6,11 @@ namespace LiturgicalCalendar\Tests\Routes\Readonly;
 
 use LiturgicalCalendar\Tests\ApiTestCase;
 
+/**
+ * Integration tests for the /temporale API endpoint.
+ *
+ * @group slow
+ */
 final class TemporaleTest extends ApiTestCase
 {
     public function testGetTemporaleReturnsJson(): void

--- a/phpunit_tests/Routes/Readonly/TemporaleTest.php
+++ b/phpunit_tests/Routes/Readonly/TemporaleTest.php
@@ -180,4 +180,57 @@ final class TemporaleTest extends ApiTestCase
         $data = json_decode((string) $response->getBody());
         $this->assertIsArray($data, 'Response should be a JSON array');
     }
+
+    public function testDeleteTemporaleWithoutAuthReturns401(): void
+    {
+        // DELETE requires JWT authentication
+        $response = self::$http->delete('/temporale/Easter', [
+            'http_errors' => false
+        ]);
+        $this->assertSame(
+            401,
+            $response->getStatusCode(),
+            'DELETE without authentication should return 401 Unauthorized'
+        );
+    }
+
+    public function testPutTemporaleWithoutAuthReturns401(): void
+    {
+        // PUT requires JWT authentication
+        $response = self::$http->put('/temporale', [
+            'http_errors' => false,
+            'json'        => []
+        ]);
+        $this->assertSame(
+            401,
+            $response->getStatusCode(),
+            'PUT without authentication should return 401 Unauthorized'
+        );
+    }
+
+    public function testPatchTemporaleWithoutAuthReturns401(): void
+    {
+        // PATCH requires JWT authentication
+        $response = self::$http->patch('/temporale', [
+            'http_errors' => false,
+            'json'        => []
+        ]);
+        $this->assertSame(
+            401,
+            $response->getStatusCode(),
+            'PATCH without authentication should return 401 Unauthorized'
+        );
+    }
+
+    public function testGetTemporaleWithUnsupportedLocaleDefaultsToLatin(): void
+    {
+        // Unsupported locale should default to Latin (la)
+        $response = self::$http->get('/temporale', [
+            'headers' => ['Accept-Language' => 'xyz']
+        ]);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $localeHeader = $response->getHeaderLine('X-Litcal-Temporale-Locale');
+        $this->assertSame('la', $localeHeader, 'Unsupported locale should default to Latin (la)');
+    }
 }

--- a/src/Enum/JsonData.php
+++ b/src/Enum/JsonData.php
@@ -94,6 +94,31 @@ enum JsonData: string
     case MISSAL_LECTIONARY_FILE = JsonDataConstants::MISSAL_LECTIONARY_FILE;
 
     /**
+     * The folder containing Proprium de Tempore (temporale) data.
+     * Evaluates to 'jsondata/sourcedata/missals/propriumdetempore'.
+     */
+    case TEMPORALE_FOLDER = JsonDataConstants::TEMPORALE_FOLDER;
+
+    /**
+     * The file containing the Proprium de Tempore (temporale) data.
+     * Evaluates to 'jsondata/sourcedata/missals/propriumdetempore/propriumdetempore.json'.
+     */
+    case TEMPORALE_FILE = JsonDataConstants::TEMPORALE_FILE;
+
+    /**
+     * The folder containing i18n files for Proprium de Tempore (temporale).
+     * Evaluates to 'jsondata/sourcedata/missals/propriumdetempore/i18n'.
+     */
+    case TEMPORALE_I18N_FOLDER = JsonDataConstants::TEMPORALE_I18N_FOLDER;
+
+    /**
+     * The file containing the i18n data for Proprium de Tempore (temporale),
+     * with a placeholder for the locale.
+     * Evaluates to 'jsondata/sourcedata/missals/propriumdetempore/i18n/{locale}.json'.
+     */
+    case TEMPORALE_I18N_FILE = JsonDataConstants::TEMPORALE_I18N_FILE;
+
+    /**
      * The folder containing readings from the lectionary for every possible liturgical event in the General Roman Calendar.
      * Evaluates to 'jsondata/sourcedata/lectionarium'.
      */

--- a/src/Enum/JsonDataConstants.php
+++ b/src/Enum/JsonDataConstants.php
@@ -92,6 +92,31 @@ class JsonDataConstants
     public const MISSAL_LECTIONARY_FILE = JsonDataConstants::MISSAL_LECTIONARY_FOLDER . '/{locale}.json';
 
     /**
+     * The folder containing Proprium de Tempore (temporale) data.
+     * Evaluates to 'jsondata/sourcedata/missals/propriumdetempore'.
+     */
+    public const TEMPORALE_FOLDER = JsonDataConstants::MISSALS_FOLDER . '/propriumdetempore';
+
+    /**
+     * The file containing the Proprium de Tempore (temporale) data.
+     * Evaluates to 'jsondata/sourcedata/missals/propriumdetempore/propriumdetempore.json'.
+     */
+    public const TEMPORALE_FILE = JsonDataConstants::TEMPORALE_FOLDER . '/propriumdetempore.json';
+
+    /**
+     * The folder containing i18n files for Proprium de Tempore (temporale).
+     * Evaluates to 'jsondata/sourcedata/missals/propriumdetempore/i18n'.
+     */
+    public const TEMPORALE_I18N_FOLDER = JsonDataConstants::TEMPORALE_FOLDER . '/i18n';
+
+    /**
+     * The file containing the i18n data for Proprium de Tempore (temporale),
+     * with a placeholder for the locale.
+     * Evaluates to 'jsondata/sourcedata/missals/propriumdetempore/i18n/{locale}.json'.
+     */
+    public const TEMPORALE_I18N_FILE = JsonDataConstants::TEMPORALE_I18N_FOLDER . '/{locale}.json';
+
+    /**
      * The folder containing readings from the lectionary for every possible liturgical event in the General Roman Calendar.
      * Evaluates to 'jsondata/sourcedata/lectionarium'.
      */

--- a/src/Handlers/TemporaleHandler.php
+++ b/src/Handlers/TemporaleHandler.php
@@ -255,6 +255,18 @@ final class TemporaleHandler extends AbstractHandler
 
         $existingData = Utilities::jsonFileToObjectArray($temporaleFile);
 
+        // Check for duplicate event_keys in the payload
+        /** @var array<string,bool> $seenEventKeys */
+        $seenEventKeys = [];
+        foreach ($payload as $event) {
+            if ($event instanceof \stdClass && property_exists($event, 'event_key') && is_string($event->event_key)) {
+                if (isset($seenEventKeys[$event->event_key])) {
+                    throw new ValidationException("Duplicate event_key '{$event->event_key}' in payload");
+                }
+                $seenEventKeys[$event->event_key] = true;
+            }
+        }
+
         // Build a map of existing events by event_key
         /** @var array<string,int> $eventKeyToIndex */
         $eventKeyToIndex = [];

--- a/src/Handlers/TemporaleHandler.php
+++ b/src/Handlers/TemporaleHandler.php
@@ -410,6 +410,11 @@ final class TemporaleHandler extends AbstractHandler
             throw new ValidationException('Event must have an integer grade property');
         }
 
+        // Validate grade is within canonical range (0=WEEKDAY to 7=HIGHER_SOLEMNITY)
+        if ($event->grade < 0 || $event->grade > 7) {
+            throw new ValidationException("Event grade must be between 0 and 7, got {$event->grade}");
+        }
+
         if (!property_exists($event, 'type') || !is_string($event->type)) {
             throw new ValidationException('Event must have a string type property');
         }

--- a/src/Handlers/TemporaleHandler.php
+++ b/src/Handlers/TemporaleHandler.php
@@ -405,6 +405,9 @@ final class TemporaleHandler extends AbstractHandler
         if (!property_exists($event, 'event_key') || !is_string($event->event_key)) {
             throw new ValidationException('Event must have a string event_key property');
         }
+        if ($event->event_key === '') {
+            throw new ValidationException('Event event_key cannot be empty');
+        }
 
         if (!property_exists($event, 'grade') || !is_int($event->grade)) {
             throw new ValidationException('Event must have an integer grade property');

--- a/src/Handlers/TemporaleHandler.php
+++ b/src/Handlers/TemporaleHandler.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Handlers\Auth\ClientIpTrait;
 use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
 use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
 use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use LiturgicalCalendar\Api\Http\Exception\InternalServerErrorException;
 use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
@@ -216,7 +217,7 @@ final class TemporaleHandler extends AbstractHandler
 
         $result = file_put_contents($temporaleFile, $jsonContent, LOCK_EX);
         if ($result === false) {
-            throw new ValidationException('Failed to write temporale data to file');
+            throw new InternalServerErrorException('Failed to write temporale data to file');
         }
 
         // Log the operation
@@ -310,7 +311,7 @@ final class TemporaleHandler extends AbstractHandler
 
         $result = file_put_contents($temporaleFile, $jsonContent, LOCK_EX);
         if ($result === false) {
-            throw new ValidationException('Failed to write temporale data to file');
+            throw new InternalServerErrorException('Failed to write temporale data to file');
         }
 
         // Log the operation
@@ -376,7 +377,7 @@ final class TemporaleHandler extends AbstractHandler
 
         $result = file_put_contents($temporaleFile, $jsonContent, LOCK_EX);
         if ($result === false) {
-            throw new ValidationException('Failed to write temporale data to file');
+            throw new InternalServerErrorException('Failed to write temporale data to file');
         }
 
         // Log the operation

--- a/src/Handlers/TemporaleHandler.php
+++ b/src/Handlers/TemporaleHandler.php
@@ -1,0 +1,408 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Handlers;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Handlers\Auth\ClientIpTrait;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use LiturgicalCalendar\Api\Http\Negotiator;
+use LiturgicalCalendar\Api\Utilities;
+use Monolog\Logger;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Handles the `/temporale` path of the API.
+ *
+ * This is the path that handles the Proprium de Tempore (Temporale) data.
+ * The source data can be retrieved (GET), created (PUT), updated (PATCH), or deleted (DELETE).
+ *
+ * GET/POST: Returns the temporale events with translated names based on Accept-Language header.
+ * PUT: Replace the entire temporale data (authenticated).
+ * PATCH: Update specific temporale events (authenticated).
+ * DELETE: Remove a specific temporale event by event_key (authenticated).
+ */
+final class TemporaleHandler extends AbstractHandler
+{
+    use ClientIpTrait;
+
+    private string $locale;
+    private Logger $auditLogger;
+    private string $clientIp = 'unknown';
+
+    /** @var string[] Available locale files in the temporale i18n folder */
+    private array $availableLocales = [];
+
+    /** @param string[] $requestPathParams */
+    public function __construct(array $requestPathParams = [])
+    {
+        parent::__construct($requestPathParams);
+        // Allow credentials for cross-origin cookie requests (required for authenticated PUT/PATCH/DELETE)
+        $this->allowCredentials = true;
+        // Initialize the list of available locales
+        LitLocale::init();
+        // Initialize audit logger for write operations
+        $this->auditLogger = LoggerFactory::create('audit', null, 90, false, true, false);
+        // Build available locales list from i18n folder
+        $this->buildAvailableLocales();
+    }
+
+    /**
+     * Builds the list of available locales from the i18n folder.
+     */
+    private function buildAvailableLocales(): void
+    {
+        $i18nFolder = JsonData::TEMPORALE_I18N_FOLDER->path();
+        if (is_dir($i18nFolder)) {
+            $files = glob($i18nFolder . '/*.json');
+            if ($files !== false) {
+                foreach ($files as $file) {
+                    $locale                   = basename($file, '.json');
+                    $this->availableLocales[] = $locale;
+                }
+            }
+        }
+    }
+
+    /**
+     * Handles the request for the /temporale endpoint.
+     *
+     * If the request method is GET or POST, it will return the temporale events with translated names.
+     * If the request method is PUT, it will replace the entire temporale data.
+     * If the request method is PATCH, it will update specific temporale events.
+     * If the request method is DELETE, it will remove a specific temporale event by event_key.
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        // We instantiate a Response object with minimum state
+        $response = static::initResponse($request);
+
+        $method = RequestMethod::from($request->getMethod());
+
+        // OPTIONS method for CORS preflight requests is always allowed
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        } else {
+            $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        }
+
+        // First of all we validate that the Content-Type requested in the Accept header is supported by the endpoint
+        switch ($method) {
+            case RequestMethod::GET:
+                $mime = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+                break;
+            default:
+                $mime = $this->validateAcceptHeader($request, AcceptabilityLevel::INTERMEDIATE);
+        }
+
+        $response = $response->withHeader('Content-Type', $mime);
+
+        // Check Accept-Language header for locale
+        $locale = Negotiator::pickLanguage($request, [], LitLocale::LATIN);
+        if ($locale && LitLocale::isValid($locale)) {
+            // Check if we have a translation file for this locale
+            $baseLocale = explode('_', $locale)[0];
+            if (in_array($locale, $this->availableLocales, true)) {
+                $this->locale = $locale;
+            } elseif (in_array($baseLocale, $this->availableLocales, true)) {
+                $this->locale = $baseLocale;
+            } else {
+                $this->locale = LitLocale::LATIN_PRIMARY_LANGUAGE;
+            }
+        } else {
+            $this->locale = LitLocale::LATIN_PRIMARY_LANGUAGE;
+        }
+
+        // Capture client IP for audit logging
+        /** @var array<string,mixed> $serverParams */
+        $serverParams   = $request->getServerParams();
+        $this->clientIp = $this->getClientIp($request, $serverParams);
+
+        // Validate request method
+        $this->validateRequestMethod($request);
+
+        switch ($method) {
+            case RequestMethod::GET:
+                // no break (intentional fallthrough)
+            case RequestMethod::POST:
+                return $this->handleGetRequest($response);
+            case RequestMethod::PUT:
+                return $this->handlePutRequest($request, $response);
+            case RequestMethod::PATCH:
+                return $this->handlePatchRequest($request, $response);
+            case RequestMethod::DELETE:
+                return $this->handleDeleteRequest($response);
+            default:
+                throw new MethodNotAllowedException();
+        }
+    }
+
+    /**
+     * Handle GET and POST requests to retrieve temporale data.
+     *
+     * Returns the temporale events with translated names based on the locale.
+     */
+    private function handleGetRequest(ResponseInterface $response): ResponseInterface
+    {
+        $temporaleFile = JsonData::TEMPORALE_FILE->path();
+        if (!file_exists($temporaleFile)) {
+            throw new NotFoundException('Temporale data file not found');
+        }
+
+        $temporaleRows = Utilities::jsonFileToObjectArray($temporaleFile);
+
+        // Load translations
+        $i18nFile = strtr(JsonData::TEMPORALE_I18N_FILE->path(), ['{locale}' => $this->locale]);
+        if (file_exists($i18nFile)) {
+            $i18nObj = Utilities::jsonFileToObject($i18nFile);
+
+            /** @var array<int,\stdClass&object{event_key:string,grade:int,type:string,color:string[]}> $temporaleRows */
+            foreach ($temporaleRows as $idx => $row) {
+                $key = $row->event_key;
+                if (property_exists($i18nObj, $key)) {
+                    $temporaleRows[$idx]->name = $i18nObj->{$key};
+                }
+            }
+        }
+
+        $response = $response->withHeader('X-Litcal-Temporale-Locale', $this->locale);
+        return $this->encodeResponseBody($response, $temporaleRows);
+    }
+
+    /**
+     * Handle PUT requests to replace the entire temporale data.
+     *
+     * Requires JWT authentication (handled by middleware).
+     */
+    private function handlePutRequest(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $payload = $this->parseBodyPayload($request, false);
+
+        if (!is_array($payload)) {
+            throw new ValidationException('Request body must be an array of temporale events');
+        }
+
+        // Validate each event in the payload
+        foreach ($payload as $event) {
+            if (!( $event instanceof \stdClass )) {
+                throw new ValidationException('Each event must be an object');
+            }
+            $this->validateTemporaleEvent($event);
+        }
+
+        $temporaleFile = JsonData::TEMPORALE_FILE->path();
+        $jsonContent   = json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        if ($jsonContent === false) {
+            throw new ValidationException('Failed to encode temporale data as JSON');
+        }
+
+        $result = file_put_contents($temporaleFile, $jsonContent);
+        if ($result === false) {
+            throw new ValidationException('Failed to write temporale data to file');
+        }
+
+        // Log the operation
+        $this->auditLogger->info('Temporale data replaced', [
+            'operation' => 'PUT',
+            'client_ip' => $this->clientIp,
+            'file'      => $temporaleFile,
+            'events'    => count($payload)
+        ]);
+
+        return $this->encodeResponseBody($response, [
+            'success' => true,
+            'message' => 'Temporale data replaced successfully',
+            'events'  => count($payload)
+        ], StatusCode::OK);
+    }
+
+    /**
+     * Handle PATCH requests to update specific temporale events.
+     *
+     * Requires JWT authentication (handled by middleware).
+     */
+    private function handlePatchRequest(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $payload = $this->parseBodyPayload($request, false);
+
+        if (!is_array($payload)) {
+            throw new ValidationException('Request body must be an array of temporale events to update');
+        }
+
+        // Load existing data
+        $temporaleFile = JsonData::TEMPORALE_FILE->path();
+        if (!file_exists($temporaleFile)) {
+            throw new NotFoundException('Temporale data file not found');
+        }
+
+        $existingData = Utilities::jsonFileToObjectArray($temporaleFile);
+
+        // Build a map of existing events by event_key
+        /** @var array<string,int> $eventKeyToIndex */
+        $eventKeyToIndex = [];
+        foreach ($existingData as $idx => $event) {
+            if (property_exists($event, 'event_key') && is_string($event->event_key)) {
+                $eventKeyToIndex[$event->event_key] = (int) $idx;
+            }
+        }
+
+        $updatedCount = 0;
+        $addedCount   = 0;
+
+        // Process each event in the payload
+        foreach ($payload as $event) {
+            if (!( $event instanceof \stdClass )) {
+                throw new ValidationException('Each event must be an object');
+            }
+            if (!property_exists($event, 'event_key') || !is_string($event->event_key)) {
+                throw new ValidationException('Each event must have an event_key property');
+            }
+
+            $this->validateTemporaleEvent($event);
+
+            /** @var string $eventKey */
+            $eventKey = $event->event_key;
+            if (isset($eventKeyToIndex[$eventKey])) {
+                // Update existing event
+                $existingData[$eventKeyToIndex[$eventKey]] = $event;
+                $updatedCount++;
+            } else {
+                // Add new event
+                $existingData[] = $event;
+                $addedCount++;
+            }
+        }
+
+        $jsonContent = json_encode(array_values($existingData), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        if ($jsonContent === false) {
+            throw new ValidationException('Failed to encode temporale data as JSON');
+        }
+
+        $result = file_put_contents($temporaleFile, $jsonContent);
+        if ($result === false) {
+            throw new ValidationException('Failed to write temporale data to file');
+        }
+
+        // Log the operation
+        $this->auditLogger->info('Temporale data updated', [
+            'operation' => 'PATCH',
+            'client_ip' => $this->clientIp,
+            'file'      => $temporaleFile,
+            'updated'   => $updatedCount,
+            'added'     => $addedCount
+        ]);
+
+        return $this->encodeResponseBody($response, [
+            'success' => true,
+            'message' => 'Temporale data updated successfully',
+            'updated' => $updatedCount,
+            'added'   => $addedCount
+        ], StatusCode::OK);
+    }
+
+    /**
+     * Handle DELETE requests to remove a specific temporale event.
+     *
+     * Requires JWT authentication (handled by middleware).
+     * The event_key is expected as a path parameter: DELETE /temporale/{event_key}
+     */
+    private function handleDeleteRequest(ResponseInterface $response): ResponseInterface
+    {
+        if (count($this->requestPathParams) !== 1) {
+            throw new ValidationException('DELETE requires exactly one path parameter: the event_key');
+        }
+
+        $eventKey = $this->requestPathParams[0];
+
+        // Load existing data
+        $temporaleFile = JsonData::TEMPORALE_FILE->path();
+        if (!file_exists($temporaleFile)) {
+            throw new NotFoundException('Temporale data file not found');
+        }
+
+        $existingData = Utilities::jsonFileToObjectArray($temporaleFile);
+
+        // Find and remove the event
+        /** @var int|null $foundIndex */
+        $foundIndex = null;
+        foreach ($existingData as $idx => $event) {
+            if (property_exists($event, 'event_key') && $event->event_key === $eventKey) {
+                $foundIndex = (int) $idx;
+                break;
+            }
+        }
+
+        if ($foundIndex === null) {
+            throw new NotFoundException("Temporale event with key '{$eventKey}' not found");
+        }
+
+        // Remove the event
+        array_splice($existingData, $foundIndex, 1);
+
+        $jsonContent = json_encode(array_values($existingData), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE);
+        if ($jsonContent === false) {
+            throw new ValidationException('Failed to encode temporale data as JSON');
+        }
+
+        $result = file_put_contents($temporaleFile, $jsonContent);
+        if ($result === false) {
+            throw new ValidationException('Failed to write temporale data to file');
+        }
+
+        // Log the operation
+        $this->auditLogger->info('Temporale event deleted', [
+            'operation' => 'DELETE',
+            'client_ip' => $this->clientIp,
+            'file'      => $temporaleFile,
+            'event_key' => $eventKey
+        ]);
+
+        return $this->encodeResponseBody($response, [
+            'success'   => true,
+            'message'   => "Temporale event '{$eventKey}' deleted successfully",
+            'event_key' => $eventKey
+        ], StatusCode::OK);
+    }
+
+    /**
+     * Validates a temporale event object.
+     *
+     * @param \stdClass $event The event object to validate
+     * @throws ValidationException if the event is invalid
+     */
+    private function validateTemporaleEvent(\stdClass $event): void
+    {
+        if (!property_exists($event, 'event_key') || !is_string($event->event_key)) {
+            throw new ValidationException('Event must have a string event_key property');
+        }
+
+        if (!property_exists($event, 'grade') || !is_int($event->grade)) {
+            throw new ValidationException('Event must have an integer grade property');
+        }
+
+        if (!property_exists($event, 'type') || !is_string($event->type)) {
+            throw new ValidationException('Event must have a string type property');
+        }
+
+        if (!in_array($event->type, ['mobile', 'fixed'], true)) {
+            throw new ValidationException('Event type must be either "mobile" or "fixed"');
+        }
+
+        if (!property_exists($event, 'color') || !is_array($event->color)) {
+            throw new ValidationException('Event must have an array color property');
+        }
+
+        foreach ($event->color as $color) {
+            if (!is_string($color)) {
+                throw new ValidationException('Each color must be a string');
+            }
+        }
+    }
+}

--- a/src/Handlers/TemporaleHandler.php
+++ b/src/Handlers/TemporaleHandler.php
@@ -214,7 +214,7 @@ final class TemporaleHandler extends AbstractHandler
             throw new ValidationException('Failed to encode temporale data as JSON');
         }
 
-        $result = file_put_contents($temporaleFile, $jsonContent);
+        $result = file_put_contents($temporaleFile, $jsonContent, LOCK_EX);
         if ($result === false) {
             throw new ValidationException('Failed to write temporale data to file');
         }
@@ -308,7 +308,7 @@ final class TemporaleHandler extends AbstractHandler
             throw new ValidationException('Failed to encode temporale data as JSON');
         }
 
-        $result = file_put_contents($temporaleFile, $jsonContent);
+        $result = file_put_contents($temporaleFile, $jsonContent, LOCK_EX);
         if ($result === false) {
             throw new ValidationException('Failed to write temporale data to file');
         }
@@ -374,7 +374,7 @@ final class TemporaleHandler extends AbstractHandler
             throw new ValidationException('Failed to encode temporale data as JSON');
         }
 
-        $result = file_put_contents($temporaleFile, $jsonContent);
+        $result = file_put_contents($temporaleFile, $jsonContent, LOCK_EX);
         if ($result === false) {
             throw new ValidationException('Failed to write temporale data to file');
         }

--- a/src/Http/Exception/InternalServerErrorException.php
+++ b/src/Http/Exception/InternalServerErrorException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Http\Exception;
+
+/**
+ * Exception thrown when an internal server error occurs.
+ *
+ * This exception should be used for server-side failures such as
+ * file system errors, database errors, or other infrastructure issues.
+ * Maps to HTTP 500 Internal Server Error.
+ */
+class InternalServerErrorException extends ApiException
+{
+    public function __construct(string $message = 'Internal Server Error', ?\Throwable $previous = null)
+    {
+        parent::__construct(
+            $message,
+            500,
+            'https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500',
+            'Internal Server Error',
+            $previous
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Implements new `/temporale` REST API endpoint for Proprium de Tempore data (Issue #464)
- Adds full CRUD operations with JWT authentication for write operations
- Includes Accept-Language header support for 14 locales (en, de, es, fr, it, la, pl, pt, vi, nl, hu, id, sk, hr)

## New Endpoint Routes

| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/temporale` | No | Retrieve all temporale events with translations |
| POST | `/temporale` | No | Same as GET |
| PUT | `/temporale` | JWT | Replace entire temporale data |
| PATCH | `/temporale` | JWT | Update specific events |
| DELETE | `/temporale/{event_key}` | JWT | Remove event by key |

## Files Changed

**New files:**
- `src/Handlers/TemporaleHandler.php` - Handler for temporale endpoint
- `phpunit_tests/Routes/Readonly/TemporaleTest.php` - Test coverage (10 tests)

**Modified files:**
- `src/Enum/JsonData.php` - Added temporale constants
- `src/Enum/JsonDataConstants.php` - Added temporale file paths
- `src/Router.php` - Added temporale route and JWT middleware
- `jsondata/schemas/openapi.json` - Added OpenAPI documentation

## Test plan

- [x] PHPStan static analysis passes (level 10)
- [x] Code style checks pass (phpcs)
- [x] OpenAPI schema validates (Redocly)
- [x] All 10 temporale tests pass
- [x] All 34 readonly route tests pass
- [ ] Manual testing of GET endpoint with different locales
- [ ] Manual testing of authenticated write operations

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Temporale API to list, replace, update, and delete Proprium de Tempore events (per-event delete supported). POST mirrors GET for read-only access.
  * Locale-aware responses with a locale response header and translated names; write endpoints require authentication and support CORS/credentials with preflight handling.

* **Tests**
  * Added extensive integration tests for read and write flows covering locales/translations, validation, authentication, and error cases.

* **Chores**
  * Added a dedicated internal-server-error exception for standardized 500 responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->