### PR TITLE
fix: remove event_key from i18n files on temporale DELETE

### DIFF
--- a/src/Handlers/TemporaleHandler.php
+++ b/src/Handlers/TemporaleHandler.php
@@ -425,7 +425,7 @@ final class TemporaleHandler extends AbstractHandler
 
         foreach ($this->availableLocales as $locale) {
             $i18nFile = strtr(JsonData::TEMPORALE_I18N_FILE->path(), ['{locale}' => $locale]);
-            if (!file_exists($i18nFile)) {
+            if (!file_exists($i18nFile) || !is_file($i18nFile)) {
                 continue;
             }
 

--- a/src/Handlers/TemporaleHandler.php
+++ b/src/Handlers/TemporaleHandler.php
@@ -66,6 +66,9 @@ final class TemporaleHandler extends AbstractHandler
             $files = glob($i18nFolder . '/*.json');
             if ($files !== false) {
                 foreach ($files as $file) {
+                    if (!is_readable($file)) {
+                        continue;
+                    }
                     $locale                   = basename($file, '.json');
                     $this->availableLocales[] = $locale;
                 }
@@ -220,6 +223,9 @@ final class TemporaleHandler extends AbstractHandler
             throw new InternalServerErrorException('Failed to write temporale data to file');
         }
 
+        // Invalidate APCu cache for the temporale file
+        Utilities::invalidateJsonFileCache($temporaleFile);
+
         // Log the operation
         $this->auditLogger->info('Temporale data replaced', [
             'operation' => 'PUT',
@@ -314,6 +320,9 @@ final class TemporaleHandler extends AbstractHandler
             throw new InternalServerErrorException('Failed to write temporale data to file');
         }
 
+        // Invalidate APCu cache for the temporale file
+        Utilities::invalidateJsonFileCache($temporaleFile);
+
         // Log the operation
         $this->auditLogger->info('Temporale data updated', [
             'operation' => 'PATCH',
@@ -380,6 +389,9 @@ final class TemporaleHandler extends AbstractHandler
             throw new InternalServerErrorException('Failed to write temporale data to file');
         }
 
+        // Invalidate APCu cache for the temporale file
+        Utilities::invalidateJsonFileCache($temporaleFile);
+
         // Remove from all i18n files
         $this->removeEventKeyFromI18nFiles($eventKey);
 
@@ -439,6 +451,9 @@ final class TemporaleHandler extends AbstractHandler
                     'locale'    => $locale,
                     'file'      => $i18nFile
                 ]);
+            } else {
+                // Invalidate APCu cache for this file
+                Utilities::invalidateJsonFileCache($i18nFile);
             }
         }
     }

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -629,6 +629,27 @@ class Utilities
     }
 
     /**
+     * Invalidate APCu cache entries for a JSON file.
+     *
+     * Removes both object and object-array cache entries for the given file
+     * to ensure subsequent reads fetch fresh data from disk.
+     *
+     * @param string $filename The path to the JSON file whose cache should be invalidated.
+     */
+    public static function invalidateJsonFileCache(string $filename): void
+    {
+        if (!extension_loaded('apcu') || !function_exists('apcu_delete')) {
+            return;
+        }
+
+        $objectCacheKey      = 'jsoncache_object_' . md5($filename);
+        $objectArrayCacheKey = 'jsoncache_objectarray_' . md5($filename);
+
+        apcu_delete($objectCacheKey);
+        apcu_delete($objectArrayCacheKey);
+    }
+
+    /**
      * Reads a JSON file and converts its contents to an array of objects.
      *
      * @param string $filename The path to the JSON file.

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -599,7 +599,8 @@ class Utilities
      *
      * @param string $filename The path to the JSON file.
      * @return \stdClass The decoded JSON data as an object.
-     * @throws \JsonException If the file does not exist, is not readable, contains invalid JSON, or does not contain an object.
+     * @throws ServiceUnavailableException If the file does not exist or is not readable.
+     * @throws \JsonException If the file contains invalid JSON or does not contain an object.
      */
     public static function jsonFileToObject(string $filename): \stdClass
     {
@@ -642,11 +643,14 @@ class Utilities
             return;
         }
 
-        $objectCacheKey      = 'jsoncache_object_' . md5($filename);
-        $objectArrayCacheKey = 'jsoncache_objectarray_' . md5($filename);
+        $fileHash            = md5($filename);
+        $objectCacheKey      = 'jsoncache_object_' . $fileHash;
+        $objectArrayCacheKey = 'jsoncache_objectarray_' . $fileHash;
+        $arrayCacheKey       = 'jsoncache_array_' . $fileHash;
 
         apcu_delete($objectCacheKey);
         apcu_delete($objectArrayCacheKey);
+        apcu_delete($arrayCacheKey);
     }
 
     /**


### PR DESCRIPTION
## Summary

- When deleting a temporale event via `DELETE /temporale/{event_key}`, also remove the corresponding translation entry from all i18n locale files

## Changes

Added `removeEventKeyFromI18nFiles()` method that:
- Iterates through all available locale files in the i18n folder
- Removes the event_key property from each translation file
- Logs warnings (but doesn't fail) if i18n file updates fail

## Test plan
- [x] PHPStan static analysis passes
- [x] phpcs code style check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Keeps translations in sync when events are deleted: removed keys are propagated across all locales and related caches are invalidated so updates are immediately visible.
  * Skips unreadable locale files during processing to prevent failures.

* **Chores**
  * Enhances JSON cache invalidation so changes to data and translation files are reliably picked up after write operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->