### PR TITLE
Add HolyThursChrism (Chrism Mass) to temporale and calendar

### DIFF
--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/de.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/de.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "",
     "HolyThurs": "",
     "GoodFri": "",
     "EasterVigil": "",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/en.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/en.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Chrism Mass",
     "HolyThurs": "Holy Thursday",
     "GoodFri": "Good Friday",
     "EasterVigil": "Easter Vigil",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/es.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/es.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Misa Crismal",
     "HolyThurs": "Jueves Santo",
     "GoodFri": "Viernes Santo",
     "EasterVigil": "Vigilia Pascual",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/fr.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/fr.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Messe Chrismale",
     "HolyThurs": "Jeudi Saint",
     "GoodFri": "Vendredi Saint",
     "EasterVigil": "Vigile pascale",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/hr.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/hr.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Misa posvete ulja",
     "HolyThurs": "Veliki četvrtak",
     "GoodFri": "Veliki petak",
     "EasterVigil": "Vazmeno bdjenje",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/hu.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/hu.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "",
     "HolyThurs": "",
     "GoodFri": "",
     "EasterVigil": "",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/id.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/id.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Misa Krisma",
     "HolyThurs": "Hari Kamis Dalam Pekan Suci/Kamis Putih",
     "GoodFri": "Hari Jumat Agung",
     "EasterVigil": "Hari Sabtu Suci",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/it.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/it.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Messa del Crisma",
     "HolyThurs": "Giovedì Santo",
     "GoodFri": "Venerdì Santo",
     "EasterVigil": "Vigilia Pasquale",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/la.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/la.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Missa Chrismatis",
     "HolyThurs": "Feria V Hebdomadæ Sanctæ",
     "GoodFri": "Feria VI in Passione Domini",
     "EasterVigil": "Vigilia Paschalis",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/nl.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/nl.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Chrismamis",
     "HolyThurs": "Avondmis van Witte Donderdag",
     "GoodFri": "Goede Vrijdag Herdenking van het lijden en sterven van de Heer",
     "EasterVigil": "Paaswake",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/pl.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/pl.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Msza Krzyżma",
     "HolyThurs": "Wielki Czwartek",
     "GoodFri": "Wielki Piątek",
     "EasterVigil": "Wielka Sobota",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/pt.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/pt.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "",
     "HolyThurs": "",
     "GoodFri": "",
     "EasterVigil": "",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/sk.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/sk.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Svätá omša svätenia olejov",
     "HolyThurs": "Féria V Veľkého týždňa",
     "GoodFri": "Féria VI v Utrpení Pána",
     "EasterVigil": "Veľkonočná vigília",

--- a/jsondata/sourcedata/missals/propriumdetempore/i18n/vi.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/i18n/vi.json
@@ -1,4 +1,5 @@
 {
+    "HolyThursChrism": "Thánh Lễ Làm Phép Dầu",
     "HolyThurs": "Thứ Năm Tuần Thánh",
     "GoodFri": "Thứ Sáu Tuần Thánh Tưởng Niệm Cuộc Thương Khó của Chúa",
     "EasterVigil": "Canh Thức Vượt Qua",

--- a/jsondata/sourcedata/missals/propriumdetempore/propriumdetempore.json
+++ b/jsondata/sourcedata/missals/propriumdetempore/propriumdetempore.json
@@ -1,5 +1,11 @@
 [
     {
+        "event_key": "HolyThursChrism",
+        "grade": 7,
+        "type": "mobile",
+        "color": [ "white" ]
+    },
+    {
         "event_key": "HolyThurs",
         "grade": 7,
         "type": "mobile",

--- a/src/Enum/LectionaryCategory.php
+++ b/src/Enum/LectionaryCategory.php
@@ -21,6 +21,7 @@ enum LectionaryCategory: string
      * - Easter Sundays (Easter, Easter2-7)
      * - Ordinary Time Sundays (OrdSunday2-33)
      * - Major celebrations (Christmas, Epiphany, Ascension, Pentecost, etc.)
+     * - Holy Week (HolyThursChrism)
      * - Triduum (HolyThurs, GoodFri, EasterVigil)
      */
     case SUNDAYS_SOLEMNITIES = 'dominicale_et_festivum';

--- a/src/Enum/LitSeason.php
+++ b/src/Enum/LitSeason.php
@@ -29,7 +29,7 @@ enum LitSeason: string
         '/^HolyFamily$/',
         '/^Epiphany/',
         '/^BaptismLord$/',
-        '/^MaryMotherGod$/',
+        '/^MaryMotherOfGod$/',
         '/^DayAfterEpiphany/',
     ];
 
@@ -43,6 +43,7 @@ enum LitSeason: string
         '/^LentWeekday\d/',
         '/^PalmSun$/',
         '/^(Mon|Tue|Wed)HolyWeek$/',
+        '/^HolyThursChrism$/',
     ];
 
     /**

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -1127,9 +1127,12 @@ final class CalendarHandler extends AbstractHandler
             ->sub(new \DateInterval('P5D')));
         $this->PropriumDeTempore['WedHolyWeek']->setDate(Utilities::calcGregEaster($this->CalendarParams->Year)
             ->sub(new \DateInterval('P4D')));
+        $this->PropriumDeTempore['HolyThursChrism']->setDate(Utilities::calcGregEaster($this->CalendarParams->Year)
+            ->sub(new \DateInterval('P3D')));
         $this->createPropriumDeTemporeLiturgicalEventByKey('MonHolyWeek');
         $this->createPropriumDeTemporeLiturgicalEventByKey('TueHolyWeek');
         $this->createPropriumDeTemporeLiturgicalEventByKey('WedHolyWeek');
+        $this->createPropriumDeTemporeLiturgicalEventByKey('HolyThursChrism');
     }
 
     /**

--- a/src/Map/AbstractLiturgicalEventMap.php
+++ b/src/Map/AbstractLiturgicalEventMap.php
@@ -2,8 +2,9 @@
 
 namespace LiturgicalCalendar\Api\Map;
 
-use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
 use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\LitSeason;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
 
 /**
  * Abstract class for liturgical event maps.
@@ -323,14 +324,15 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      */
     private static function compareSeasons(LiturgicalEvent $a, LiturgicalEvent $b): int
     {
-        // Define season order (lower = earlier in liturgical year)
+        // Define season order using enum cases directly for maintainability
+        // (lower = earlier in liturgical year)
         $seasonOrder = [
-            'ADVENT'         => 0,
-            'CHRISTMAS'      => 1,
-            'LENT'           => 2,
-            'EASTER_TRIDUUM' => 3,
-            'EASTER'         => 4,
-            'ORDINARY_TIME'  => 5,
+            LitSeason::ADVENT->value         => 0,
+            LitSeason::CHRISTMAS->value      => 1,
+            LitSeason::LENT->value           => 2,
+            LitSeason::EASTER_TRIDUUM->value => 3,
+            LitSeason::EASTER->value         => 4,
+            LitSeason::ORDINARY_TIME->value  => 5,
         ];
 
         $seasonA = $a->liturgical_season?->value;

--- a/src/Map/AbstractLiturgicalEventMap.php
+++ b/src/Map/AbstractLiturgicalEventMap.php
@@ -275,7 +275,8 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
      * If the two LiturgicalEvent objects have different dates, the comparison is based on their date.
      * If the two LiturgicalEvent objects have different dates, the object with the later date is considered higher (i.e. it will come after the earlier date).
      * If the two LiturgicalEvent objects have the same date, the comparison is based on their grade.
-     * If the two LiturgicalEvent objects have the same grade, the comparison result is 0 and no sorting will take place.
+     * If the two LiturgicalEvent objects have the same grade, the comparison is based on their liturgical season.
+     * If the two LiturgicalEvent objects have the same liturgical season, the comparison result is 0 and no sorting will take place.
      * If the two LiturgicalEvent objects have different grades, the object with the higher grade is considered higher (i.e. it will come after the lower grade):
      *   this may seem counterintuitive, it would seem that a higher grade should come before a lower grade, but the most common case is for commemorations on weekdays,
      *   where the commemoration actually has a higher logical grade but is still optional so it should come after the weekday celebration.
@@ -299,11 +300,51 @@ abstract class AbstractLiturgicalEventMap implements \IteratorAggregate
                 return -1;
             }
             if ($a->grade->value === $b->grade->value) {
-                return 0;
+                // When date and grade are equal, sort by liturgical season order.
+                // This ensures events like HolyThursChrism (LENT) come before HolyThurs (EASTER_TRIDUUM).
+                // Season order: ADVENT < CHRISTMAS < LENT < EASTER_TRIDUUM < EASTER < ORDINARY_TIME
+                return self::compareSeasons($a, $b);
             }
             return ( $a->grade->value > $b->grade->value ) ? +1 : -1;
         }
         return ( $a->date > $b->date ) ? +1 : -1;
+    }
+
+    /**
+     * Compares two LiturgicalEvent objects based on their liturgical season.
+     *
+     * The season order follows the liturgical year: ADVENT, CHRISTMAS, LENT, EASTER_TRIDUUM, EASTER, ORDINARY_TIME.
+     * This is used as a tiebreaker when events have the same date and grade (e.g., HolyThursChrism vs HolyThurs).
+     *
+     * @param LiturgicalEvent $a The first LiturgicalEvent object to compare.
+     * @param LiturgicalEvent $b The second LiturgicalEvent object to compare.
+     *
+     * @return int A value indicating the result of the comparison.
+     */
+    private static function compareSeasons(LiturgicalEvent $a, LiturgicalEvent $b): int
+    {
+        // Define season order (lower = earlier in liturgical year)
+        $seasonOrder = [
+            'ADVENT'         => 0,
+            'CHRISTMAS'      => 1,
+            'LENT'           => 2,
+            'EASTER_TRIDUUM' => 3,
+            'EASTER'         => 4,
+            'ORDINARY_TIME'  => 5,
+        ];
+
+        $seasonA = $a->liturgical_season?->value;
+        $seasonB = $b->liturgical_season?->value;
+
+        // If either season is null, treat as equal
+        if ($seasonA === null || $seasonB === null) {
+            return 0;
+        }
+
+        $orderA = $seasonOrder[$seasonA] ?? 99;
+        $orderB = $seasonOrder[$seasonB] ?? 99;
+
+        return $orderA <=> $orderB;
     }
 
     /**

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -1079,7 +1079,13 @@ final class LiturgicalEventCollection
             } elseif ($litEvent->date >= $AshWednesday->date && $litEvent->date < $HolyThurs->date) {
                 $litEvent->liturgical_season = LitSeason::LENT;
             } elseif ($litEvent->date >= $HolyThurs->date && $litEvent->date < $Easter->date) {
-                $litEvent->liturgical_season = LitSeason::EASTER_TRIDUUM;
+                // The Chrism Mass is celebrated on Holy Thursday morning, before the Triduum begins
+                // (the Triduum starts with the Evening Mass of the Lord's Supper)
+                if ($litEvent->event_key === 'HolyThursChrism') {
+                    $litEvent->liturgical_season = LitSeason::LENT;
+                } else {
+                    $litEvent->liturgical_season = LitSeason::EASTER_TRIDUUM;
+                }
             } elseif ($litEvent->date >= $Easter->date && $litEvent->date <= $Pentecost->date) {
                 $litEvent->liturgical_season = LitSeason::EASTER;
             } else {


### PR DESCRIPTION
## Summary

- Add `HolyThursChrism` (Chrism Mass) event to the `/temporale` and `/calendar` endpoints
- Fix `MaryMotherOfGod` pattern in `LitSeason` (was missing "Of")
- Ensure `HolyThursChrism` is correctly classified as `LENT` season (not `EASTER_TRIDUUM`)
- Sort events by liturgical season when date and grade match, ensuring `HolyThursChrism` appears before `HolyThurs`

## Changes

### Temporale Data
- Added `HolyThursChrism` to `propriumdetempore.json` (grade 7, mobile, white)
- Added translations to all 14 i18n files

### Calendar Calculation
- Added `HolyThursChrism` calculation in `CalendarHandler::calculateWeekdaysHolyWeek()`
- Added special case in `LiturgicalEventCollection` to classify `HolyThursChrism` as `LENT` (since the Chrism Mass is celebrated on Holy Thursday morning, before the Triduum begins)

### Sorting
- Updated `AbstractLiturgicalEventMap::compDateAndGrade()` to use liturgical season as a tiebreaker when date and grade are equal
- Added `compareSeasons()` method with season order: ADVENT < CHRISTMAS < LENT < EASTER_TRIDUUM < EASTER < ORDINARY_TIME
- This ensures `HolyThursChrism` (LENT) is sorted before `HolyThurs` (EASTER_TRIDUUM)

### Season/Category Classification
- Added pattern to `LitSeason::LENT_PATTERNS`
- Updated `LectionaryCategory` documentation to show `HolyThursChrism` under Holy Week
- Fixed `MaryMotherOfGod` pattern (was `/^MaryMotherGod$/`, now `/^MaryMotherOfGod$/`)

## Translations Added

| Language | Translation |
|----------|-------------|
| English | Chrism Mass |
| Latin | Missa Chrismatis |
| Italian | Messa del Crisma |
| French | Messe Chrismale |
| Spanish | Misa Crismal |
| Dutch | Chrismamis |
| Polish | Msza Krzyżma |
| Croatian | Misa posvete ulja |
| Slovak | Svätá omša svätenia olejov |
| Vietnamese | Thánh Lễ Làm Phép Dầu |
| Indonesian | Misa Krisma |
| German | *(pending)* |
| Portuguese | *(pending)* |
| Hungarian | *(pending)* |

## Test plan

- [x] Verify `HolyThursChrism` appears in `/temporale` output
- [x] Verify `HolyThursChrism` appears in `/calendar` output
- [x] Verify `liturgical_season` is `LENT` for `HolyThursChrism`
- [x] Verify `HolyThursChrism` is sorted before `HolyThurs` in calendar output
- [x] Verify `MaryMotherOfGod` is correctly classified as `CHRISTMAS` season
- [x] Run test suite

Closes #473

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Holy Thursday Chrism Mass as a new liturgical event with multi-language support and correct placement within the liturgical calendar.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->