### PR TITLE
Stagger cached WebSocket responses for gradual streaming

### DIFF
--- a/src/Health.php
+++ b/src/Health.php
@@ -92,7 +92,8 @@ class Health implements MessageComponentInterface
     private static bool $cacheEnabled     = false;
     private static string $cacheBackend   = 'none';
     private static ?\Redis $redis         = null;
-    private int $cacheHitCounter          = 0;
+    /** @var array<int, int> Per-connection cache hit counters, keyed by resourceId */
+    private array $cacheHitCounters = [];
     //private static PromiseInterface $metadataPromise;
 
     /**
@@ -254,7 +255,7 @@ class Health implements MessageComponentInterface
             ];
 
             /** @var PromiseInterface<array{data: string, fromCache: bool}> $metadataPromise */
-            $metadataPromise = $this->cachedGet(Route::CALENDARS->path(), $opts);
+            $metadataPromise = $this->cachedGet(Route::CALENDARS->path(), $opts, 300, $conn);
             //self::$metadataPromise = $metadataPromise;
 
             $metadataPromise->then(
@@ -389,7 +390,7 @@ class Health implements MessageComponentInterface
         $resourceId = $conn->resourceId;
         // The connection is closed, remove it, as we can no longer send it messages
         unset($this->clients[$conn]);
-        $this->cacheHitCounter = 0;
+        unset($this->cacheHitCounters[$resourceId]);
         echo "Connection {$resourceId} has disconnected\n";
     }
 
@@ -746,7 +747,7 @@ class Health implements MessageComponentInterface
                 // $dataPath is an API path in this case
                 echo 'Retrieving data from URL ' . $dataPath . "\n";
                 /** @var PromiseInterface<array{data: string, fromCache: bool}> $httpPromise */
-                $httpPromise = $this->cachedGet($dataPath);
+                $httpPromise = $this->cachedGet($dataPath, [], 300, $to);
                 $httpPromise->then(
                     function (array $result) use ($to, $validation, $dataPath, $schema, $pathForSchema) {
                         /** @var array{data: string, fromCache: bool} $result */
@@ -954,7 +955,7 @@ class Health implements MessageComponentInterface
         ];
 
         $req     = $this->buildCalendarRequestPath($calendar, $year, $category);
-        $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts);
+        $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
         $promise->then(
             function (array $result) use ($to, $calendar, $year, $category, $req, $responseType) {
                 /** @var array{data: string, fromCache: bool} $result */
@@ -1204,7 +1205,7 @@ class Health implements MessageComponentInterface
         ];
 
         $req     = $this->buildCalendarRequestPath($calendar, $year, $category);
-        $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts);
+        $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
         $promise->then(
             function (array $result) use ($to, $test, $year) {
                 /** @var array{data: string, fromCache: bool} $result */
@@ -1476,7 +1477,7 @@ class Health implements MessageComponentInterface
      *
      * @return PromiseInterface<array{data: string, fromCache: bool}>
      */
-    private function cachedGet(string $url, array $options = [], int $ttl = 300): PromiseInterface
+    private function cachedGet(string $url, array $options = [], int $ttl = 300, ?ConnectionInterface $conn = null): PromiseInterface
     {
         $key      = 'http_' . md5($url . serialize($options));
         $deferred = new Deferred();
@@ -1488,8 +1489,10 @@ class Health implements MessageComponentInterface
             if ($success && is_string($data)) {
                 // Stagger cached responses: resolve in small batches using incremental delays
                 // This prevents all cache hits from resolving in a single tick
-                $delay = floor($this->cacheHitCounter / $this->maxConcurrency) * 0.05;
-                ++$this->cacheHitCounter;
+                $connId                          = $conn !== null && is_int($conn->resourceId) ? $conn->resourceId : 0;
+                $counter                         = $this->cacheHitCounters[$connId] ?? 0;
+                $delay                           = floor($counter / max(1, $this->maxConcurrency)) * 0.05;
+                $this->cacheHitCounters[$connId] = $counter + 1;
                 if ($delay > 0) {
                     Loop::addTimer($delay, function () use ($deferred, $data) {
                         $deferred->resolve(['data' => $data, 'fromCache' => true]);

--- a/src/Health.php
+++ b/src/Health.php
@@ -313,6 +313,8 @@ class Health implements MessageComponentInterface
     {
         /** @var int $resourceId */
         $resourceId = $from->resourceId;
+        // Reset per-connection cache hit counter for each new message (test run)
+        $this->cacheHitCounters[$resourceId] = 0;
         echo sprintf('Receiving message from connection %d: %s', $resourceId, $msg . "\n");
         /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest $messageReceived */
         $messageReceived = json_decode($msg);

--- a/src/Health.php
+++ b/src/Health.php
@@ -121,7 +121,7 @@ class Health implements MessageComponentInterface
         ]);
 
         if (isset($_ENV['WS_MAX_CONCURRENCY']) && is_numeric($_ENV['WS_MAX_CONCURRENCY'])) {
-            $this->maxConcurrency = (int) $_ENV['WS_MAX_CONCURRENCY'];
+            $this->maxConcurrency = max(1, (int) $_ENV['WS_MAX_CONCURRENCY']);
         } elseif (Router::isLocalhost() || ( isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'development' )) {
             $this->maxConcurrency = 4;
         } else {

--- a/src/Health.php
+++ b/src/Health.php
@@ -1504,14 +1504,17 @@ class Health implements MessageComponentInterface
                 $counter                         = $this->cacheHitCounters[$connId] ?? 0;
                 $delay                           = floor($counter / max(1, $this->maxConcurrency)) * $this->staggerInterval;
                 $this->cacheHitCounters[$connId] = $counter + 1;
+                $resolveIfOpen                   = function () use ($deferred, $data, $conn) {
+                    // Skip resolving if the client has disconnected while waiting
+                    if ($conn !== null && !$this->clients->contains($conn)) {
+                        return;
+                    }
+                    $deferred->resolve(['data' => $data, 'fromCache' => true]);
+                };
                 if ($delay > 0) {
-                    Loop::addTimer($delay, function () use ($deferred, $data) {
-                        $deferred->resolve(['data' => $data, 'fromCache' => true]);
-                    });
+                    Loop::addTimer($delay, $resolveIfOpen);
                 } else {
-                    Loop::futureTick(function () use ($deferred, $data) {
-                        $deferred->resolve(['data' => $data, 'fromCache' => true]);
-                    });
+                    Loop::futureTick($resolveIfOpen);
                 }
             } else {
                 $deferred->reject(new \RuntimeException("Cache fetch for URL $url failed or returned non-string data"));

--- a/src/Health.php
+++ b/src/Health.php
@@ -92,6 +92,7 @@ class Health implements MessageComponentInterface
     private static bool $cacheEnabled     = false;
     private static string $cacheBackend   = 'none';
     private static ?\Redis $redis         = null;
+    private int $cacheHitCounter          = 0;
     //private static PromiseInterface $metadataPromise;
 
     /**
@@ -388,6 +389,7 @@ class Health implements MessageComponentInterface
         $resourceId = $conn->resourceId;
         // The connection is closed, remove it, as we can no longer send it messages
         unset($this->clients[$conn]);
+        $this->cacheHitCounter = 0;
         echo "Connection {$resourceId} has disconnected\n";
     }
 
@@ -1479,15 +1481,24 @@ class Health implements MessageComponentInterface
         $key      = 'http_' . md5($url . serialize($options));
         $deferred = new Deferred();
 
-        // Return from cache if available - use futureTick to allow event loop to process other events
+        // Return from cache if available - stagger resolutions to stream results back gradually
         if (self::$cacheEnabled && self::cacheExists($key)) {
             echo "Cache hit for $url\n";
             [$success, $data] = self::cacheGet($key);
             if ($success && is_string($data)) {
-                // Schedule resolution via event loop to prevent blocking
-                Loop::futureTick(function () use ($deferred, $data) {
-                    $deferred->resolve(['data' => $data, 'fromCache' => true]);
-                });
+                // Stagger cached responses: resolve in small batches using incremental delays
+                // This prevents all cache hits from resolving in a single tick
+                $delay = floor($this->cacheHitCounter / $this->maxConcurrency) * 0.05;
+                ++$this->cacheHitCounter;
+                if ($delay > 0) {
+                    Loop::addTimer($delay, function () use ($deferred, $data) {
+                        $deferred->resolve(['data' => $data, 'fromCache' => true]);
+                    });
+                } else {
+                    Loop::futureTick(function () use ($deferred, $data) {
+                        $deferred->resolve(['data' => $data, 'fromCache' => true]);
+                    });
+                }
             } else {
                 $deferred->reject(new \RuntimeException("Cache fetch for URL $url failed or returned non-string data"));
             }

--- a/src/Health.php
+++ b/src/Health.php
@@ -82,6 +82,11 @@ class Health implements MessageComponentInterface
 
     private CurlMultiHandler $multiHandler;
 
+    /**
+     * Delay in seconds between batches of staggered cache responses.
+     * Override via WS_STAGGER_INTERVAL env var.
+     */
+    private float $staggerInterval;
     private int $maxConcurrency;
     private int $inFlight = 0;
     /** @var list<array{url:string,options:array{headers?:array{Accept:string}},resolve:\Closure(ResponseInterface):void,reject:\Closure(\Throwable):void}> */
@@ -127,6 +132,10 @@ class Health implements MessageComponentInterface
         } else {
             $this->maxConcurrency = 10; // Conservative default for production
         }
+
+        $this->staggerInterval = isset($_ENV['WS_STAGGER_INTERVAL']) && is_numeric($_ENV['WS_STAGGER_INTERVAL'])
+            ? max(0.01, (float) $_ENV['WS_STAGGER_INTERVAL'])
+            : 0.05;
     }
 
     /**
@@ -1493,7 +1502,7 @@ class Health implements MessageComponentInterface
                 // This prevents all cache hits from resolving in a single tick
                 $connId                          = $conn !== null && is_int($conn->resourceId) ? $conn->resourceId : 0;
                 $counter                         = $this->cacheHitCounters[$connId] ?? 0;
-                $delay                           = floor($counter / max(1, $this->maxConcurrency)) * 0.05;
+                $delay                           = floor($counter / max(1, $this->maxConcurrency)) * $this->staggerInterval;
                 $this->cacheHitCounters[$connId] = $counter + 1;
                 if ($delay > 0) {
                     Loop::addTimer($delay, function () use ($deferred, $data) {


### PR DESCRIPTION
## Summary

- Adds incremental delays to cached response resolutions in `Health::cachedGet()` so results stream back in batches of `maxConcurrency` with 50ms spacing, instead of all resolving in a single event loop tick
- Resets the stagger counter on connection close

Fixes #513

## Test plan

- [ ] Run the test interface with a warm Redis cache and verify results stream back gradually
- [ ] Verify first run (cache misses) still works normally
- [ ] Confirm the 50ms delay feels natural — adjust if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cached response delivery now staggers replies per connection based on current request load, reducing bursts under high concurrency.
  * Concurrency handling tightened to enforce a sensible minimum, preventing zero/invalid concurrency settings.

* **Bug Fixes / Cleanup**
  * Per-connection cache counters are initialized/reset on new messages and removed on disconnect to avoid lingering state.

---

Note: Cached response timing adjusted to improve load distribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->