### PR TITLE
Echo optional runToken in WebSocket responses

### DIFF
--- a/src/Health.php
+++ b/src/Health.php
@@ -330,7 +330,12 @@ class Health implements MessageComponentInterface
         /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest $messageReceived */
         $messageReceived = json_decode($msg);
         // Store optional run token for response correlation
-        if ($messageReceived instanceof \stdClass && property_exists($messageReceived, 'runToken') && is_string($messageReceived->runToken)) {
+        if (
+            $messageReceived instanceof \stdClass
+            && property_exists($messageReceived, 'runToken')
+            && is_string($messageReceived->runToken)
+            && preg_match('/^[A-Za-z0-9_\-]{1,64}$/', $messageReceived->runToken)
+        ) {
             $this->runTokens[$resourceId] = $messageReceived->runToken;
         }
         if (

--- a/src/Health.php
+++ b/src/Health.php
@@ -99,6 +99,8 @@ class Health implements MessageComponentInterface
     private static ?\Redis $redis         = null;
     /** @var array<int, int> Per-connection cache hit counters, keyed by resourceId */
     private array $cacheHitCounters = [];
+    /** @var array<int, string> Per-connection run tokens, keyed by resourceId */
+    private array $runTokens = [];
     //private static PromiseInterface $metadataPromise;
 
     /**
@@ -327,6 +329,10 @@ class Health implements MessageComponentInterface
         echo sprintf('Receiving message from connection %d: %s', $resourceId, $msg . "\n");
         /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest $messageReceived */
         $messageReceived = json_decode($msg);
+        // Store optional run token for response correlation
+        if ($messageReceived instanceof \stdClass && property_exists($messageReceived, 'runToken') && is_string($messageReceived->runToken)) {
+            $this->runTokens[$resourceId] = $messageReceived->runToken;
+        }
         if (
             json_last_error() === JSON_ERROR_NONE
             && $messageReceived instanceof \stdClass
@@ -402,6 +408,7 @@ class Health implements MessageComponentInterface
         // The connection is closed, remove it, as we can no longer send it messages
         unset($this->clients[$conn]);
         unset($this->cacheHitCounters[$resourceId]);
+        unset($this->runTokens[$resourceId]);
         echo "Connection {$resourceId} has disconnected\n";
     }
 
@@ -429,6 +436,11 @@ class Health implements MessageComponentInterface
      */
     private function sendMessage(ConnectionInterface $from, string|\stdClass $msg): void
     {
+        /** @var int $resourceId */
+        $resourceId = $from->resourceId;
+        if ($msg instanceof \stdClass && isset($this->runTokens[$resourceId])) {
+            $msg->runToken = $this->runTokens[$resourceId];
+        }
         if (gettype($msg) !== 'string') {
             $msg = json_encode($msg, JSON_PRETTY_PRINT);
         }


### PR DESCRIPTION
## Summary

- Store an optional `runToken` from incoming WebSocket messages per-connection (keyed by `resourceId`, like `cacheHitCounters`)
- Attach the stored `runToken` to every outgoing response in `sendMessage()`
- Clean up stored token on connection close
- Fully backward compatible — clients that don't send `runToken` are unaffected

This enables the UnitTestInterface to generate a unique token per test run and discard stale responses from previous runs.

## Test plan

- [ ] Verify existing tests pass (no behavior change for clients not sending `runToken`)
- [ ] Verify PHPStan level 10 passes (`composer analyse` — confirmed locally)
- [ ] Verify phpcs passes (`composer lint` — confirmed locally)
- [ ] Test with UnitTestInterface client sending `runToken` and confirm it is echoed in responses

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced run token management for WebSocket connections with improved state tracking and persistence across message exchanges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->