### PR TITLE
Add ZITADEL_INTERNAL_URL support for Docker networking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,10 @@ HTTPS_ENFORCEMENT=true
 # ZITADEL_ISSUER=http://localhost:8080
 # ZITADEL_CLIENT_ID=your-api-client-id
 # ZITADEL_PROJECT_ID=your-project-id
+# Internal URL for Docker networking (when API and Zitadel run in the same compose stack)
+# Set to the Docker service name so server-side requests route through the Docker network
+# Leave unset when the API runs on the host (default: uses ZITADEL_ISSUER for all requests)
+# ZITADEL_INTERNAL_URL=http://zitadel:8080
 
 ##
 # PostgreSQL Configuration (for app-specific data: permissions, API keys, audit log)

--- a/src/Http/Logs/PrettyLineFormatter.php
+++ b/src/Http/Logs/PrettyLineFormatter.php
@@ -95,8 +95,7 @@ class PrettyLineFormatter extends LineFormatter
             return $record;
         }
         if (
-            isset($record->context)
-            && isset($record->context['type'])
+            isset($record->context['type'])
             && $record->context['type'] === 'response'
             && isset($record->context['response'])
             && $record->context['response'] instanceof ResponseInterface

--- a/src/Http/Logs/RequestResponseProcessor.php
+++ b/src/Http/Logs/RequestResponseProcessor.php
@@ -10,7 +10,7 @@ class RequestResponseProcessor
 {
     public function __invoke(LogRecord $record): LogRecord
     {
-        $ctx = $record->context ?? [];
+        $ctx = $record->context;
         if (isset($ctx['type'])) {
             switch ($ctx['type']) {
                 case 'request':

--- a/src/Http/Middleware/OidcAuthMiddleware.php
+++ b/src/Http/Middleware/OidcAuthMiddleware.php
@@ -240,9 +240,12 @@ class OidcAuthMiddleware implements MiddlewareInterface
             // default headers. Use middleware to inject the Host header so Zitadel
             // accepts requests sent to the Docker service name.
             $parsedIssuer = parse_url($this->issuer);
-            $hostHeader   = ( $parsedIssuer['host'] ?? 'localhost' )
+            if (!is_array($parsedIssuer)) {
+                throw new \RuntimeException('Invalid ZITADEL_ISSUER URL: ' . $this->issuer);
+            }
+            $hostHeader = ( $parsedIssuer['host'] ?? 'localhost' )
                 . ( isset($parsedIssuer['port']) ? ':' . $parsedIssuer['port'] : '' );
-            $stack        = HandlerStack::create();
+            $stack      = HandlerStack::create();
             $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($hostHeader) {
                 return $request->withHeader('Host', $hostHeader);
             }));

--- a/src/Http/Middleware/OidcAuthMiddleware.php
+++ b/src/Http/Middleware/OidcAuthMiddleware.php
@@ -7,7 +7,10 @@ namespace LiturgicalCalendar\Api\Http\Middleware;
 use Firebase\JWT\CachedKeySet;
 use Firebase\JWT\JWT;
 use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\HttpFactory;
+use Psr\Http\Message\RequestInterface;
 use LiturgicalCalendar\Api\Http\CookieHelper;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
@@ -32,6 +35,7 @@ class OidcAuthMiddleware implements MiddlewareInterface
 {
     private string $issuer;
     private string $clientId;
+    private ?string $internalUrl;
     private int $cacheTtl;
     private LoggerInterface $logger;
 
@@ -45,21 +49,24 @@ class OidcAuthMiddleware implements MiddlewareInterface
     /**
      * Create the OIDC authentication middleware.
      *
-     * @param string $issuer Zitadel issuer URL (e.g., http://localhost:8081)
+     * @param string $issuer Zitadel issuer URL (e.g., http://localhost:8080)
      * @param string $clientId Zitadel client ID for audience validation
+     * @param string|null $internalUrl Internal URL for server-side requests (e.g., http://zitadel:8080)
      * @param int $cacheTtl JWKS cache TTL in seconds (default: 3600)
      * @param LoggerInterface|null $logger PSR-3 logger instance (optional)
      */
     public function __construct(
         string $issuer,
         string $clientId,
+        ?string $internalUrl = null,
         int $cacheTtl = 3600,
         ?LoggerInterface $logger = null
     ) {
-        $this->issuer   = rtrim($issuer, '/');
-        $this->clientId = $clientId;
-        $this->cacheTtl = $cacheTtl;
-        $this->logger   = $logger ?? LoggerFactory::create('auth', null, 30, false, true, false);
+        $this->issuer      = rtrim($issuer, '/');
+        $this->clientId    = $clientId;
+        $this->internalUrl = $internalUrl !== null ? rtrim($internalUrl, '/') : null;
+        $this->cacheTtl    = $cacheTtl;
+        $this->logger      = $logger ?? LoggerFactory::create('auth', null, 30, false, true, false);
     }
 
     /**
@@ -89,11 +96,13 @@ class OidcAuthMiddleware implements MiddlewareInterface
     public static function fromEnv(): self
     {
         // Check both getenv() and $_ENV since Dotenv may not always populate putenv()
-        $issuerEnv   = getenv('ZITADEL_ISSUER') ?: ( $_ENV['ZITADEL_ISSUER'] ?? '' );
-        $clientIdEnv = getenv('ZITADEL_CLIENT_ID') ?: ( $_ENV['ZITADEL_CLIENT_ID'] ?? '' );
+        $issuerEnv      = getenv('ZITADEL_ISSUER') ?: ( $_ENV['ZITADEL_ISSUER'] ?? '' );
+        $clientIdEnv    = getenv('ZITADEL_CLIENT_ID') ?: ( $_ENV['ZITADEL_CLIENT_ID'] ?? '' );
+        $internalUrlEnv = getenv('ZITADEL_INTERNAL_URL') ?: ( $_ENV['ZITADEL_INTERNAL_URL'] ?? '' );
 
-        $issuer   = is_string($issuerEnv) ? $issuerEnv : '';
-        $clientId = is_string($clientIdEnv) ? $clientIdEnv : '';
+        $issuer      = is_string($issuerEnv) ? $issuerEnv : '';
+        $clientId    = is_string($clientIdEnv) ? $clientIdEnv : '';
+        $internalUrl = is_string($internalUrlEnv) && !empty($internalUrlEnv) ? $internalUrlEnv : null;
 
         if (empty($issuer) || empty($clientId)) {
             throw new \RuntimeException(
@@ -101,7 +110,7 @@ class OidcAuthMiddleware implements MiddlewareInterface
             );
         }
 
-        return new self($issuer, $clientId);
+        return new self($issuer, $clientId, $internalUrl);
     }
 
     /**
@@ -223,7 +232,24 @@ class OidcAuthMiddleware implements MiddlewareInterface
 
         $jwksUri = $this->issuer . '/oauth/v2/keys';
 
-        $httpClient  = new Client();
+        if ($this->internalUrl !== null) {
+            // Rewrite JWKS URI to use internal URL for Docker networking
+            $jwksUri = $this->internalUrl . '/oauth/v2/keys';
+
+            // CachedKeySet uses PSR-18 sendRequest() which doesn't apply Guzzle's
+            // default headers. Use middleware to inject the Host header so Zitadel
+            // accepts requests sent to the Docker service name.
+            $parsedIssuer = parse_url($this->issuer);
+            $hostHeader   = ( $parsedIssuer['host'] ?? 'localhost' )
+                . ( isset($parsedIssuer['port']) ? ':' . $parsedIssuer['port'] : '' );
+            $stack        = HandlerStack::create();
+            $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($hostHeader) {
+                return $request->withHeader('Host', $hostHeader);
+            }));
+            $httpClient = new Client(['handler' => $stack]);
+        } else {
+            $httpClient = new Client();
+        }
         $httpFactory = new HttpFactory();
 
         // Use filesystem cache for JWKS (PSR-6 compatible)

--- a/src/Http/Middleware/OidcAuthMiddleware.php
+++ b/src/Http/Middleware/OidcAuthMiddleware.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Psr7\HttpFactory;
 use Psr\Http\Message\RequestInterface;
 use LiturgicalCalendar\Api\Http\CookieHelper;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Services\ZitadelHostHeader;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -239,12 +240,7 @@ class OidcAuthMiddleware implements MiddlewareInterface
             // CachedKeySet uses PSR-18 sendRequest() which doesn't apply Guzzle's
             // default headers. Use middleware to inject the Host header so Zitadel
             // accepts requests sent to the Docker service name.
-            $parsedIssuer = parse_url($this->issuer);
-            if (!is_array($parsedIssuer)) {
-                throw new \RuntimeException('Invalid ZITADEL_ISSUER URL: ' . $this->issuer);
-            }
-            $hostHeader = ( $parsedIssuer['host'] ?? 'localhost' )
-                . ( isset($parsedIssuer['port']) ? ':' . $parsedIssuer['port'] : '' );
+            $hostHeader = ZitadelHostHeader::deriveFromIssuer($this->issuer);
             $stack      = HandlerStack::create();
             $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($hostHeader) {
                 return $request->withHeader('Host', $hostHeader);

--- a/src/Services/ZitadelHostHeader.php
+++ b/src/Services/ZitadelHostHeader.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+/**
+ * Utility for deriving the Host header value from a Zitadel issuer URL.
+ *
+ * When running in Docker, server-side requests to Zitadel are routed
+ * via the Docker service name (e.g., http://zitadel:8080) but Zitadel
+ * requires the Host header to match its configured external domain
+ * (e.g., localhost:8080). This helper extracts the host[:port] from the
+ * public issuer URL for use as a Host header value.
+ */
+class ZitadelHostHeader
+{
+    /**
+     * Derive the Host header value from a Zitadel issuer URL.
+     *
+     * Returns the host and optional port (e.g., "localhost:8080") extracted
+     * from the given URL. Defaults to "localhost" if the host cannot be parsed.
+     *
+     * @param string $issuer The public Zitadel issuer URL
+     * @return string Host header value (host[:port])
+     * @throws \RuntimeException If the URL is malformed and cannot be parsed
+     */
+    public static function deriveFromIssuer(string $issuer): string
+    {
+        $parsed = parse_url($issuer);
+        if (!is_array($parsed)) {
+            throw new \RuntimeException('Invalid ZITADEL_ISSUER URL: ' . $issuer);
+        }
+        return ( $parsed['host'] ?? 'localhost' )
+            . ( isset($parsed['port']) ? ':' . $parsed['port'] : '' );
+    }
+}

--- a/src/Services/ZitadelHostHeader.php
+++ b/src/Services/ZitadelHostHeader.php
@@ -19,19 +19,19 @@ class ZitadelHostHeader
      * Derive the Host header value from a Zitadel issuer URL.
      *
      * Returns the host and optional port (e.g., "localhost:8080") extracted
-     * from the given URL. Defaults to "localhost" if the host cannot be parsed.
+     * from the given URL.
      *
      * @param string $issuer The public Zitadel issuer URL
      * @return string Host header value (host[:port])
-     * @throws \RuntimeException If the URL is malformed and cannot be parsed
+     * @throws \RuntimeException If the URL is malformed or missing a host component
      */
     public static function deriveFromIssuer(string $issuer): string
     {
         $parsed = parse_url($issuer);
-        if (!is_array($parsed)) {
-            throw new \RuntimeException('Invalid ZITADEL_ISSUER URL: ' . $issuer);
+        if (!is_array($parsed) || empty($parsed['host'])) {
+            throw new \RuntimeException('Invalid ZITADEL_ISSUER URL (missing host): ' . $issuer);
         }
-        return ( $parsed['host'] ?? 'localhost' )
+        return $parsed['host']
             . ( isset($parsed['port']) ? ':' . $parsed['port'] : '' );
     }
 }

--- a/src/Services/ZitadelService.php
+++ b/src/Services/ZitadelService.php
@@ -6,6 +6,9 @@ namespace LiturgicalCalendar\Api\Services;
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -61,23 +64,23 @@ class ZitadelService
         $this->logger       = $logger;
 
         // Use internal URL for HTTP requests if configured (Docker networking)
-        $baseUri = $this->internalUrl ?? $this->issuer;
-        $headers = [];
-        if ($this->internalUrl !== null) {
-            // Add Host header matching the public issuer for Zitadel's domain validation
-            $parsedIssuer = parse_url($this->issuer);
-            if (!is_array($parsedIssuer)) {
-                throw new \RuntimeException('Invalid ZITADEL_ISSUER URL: ' . $this->issuer);
-            }
-            $host            = ( $parsedIssuer['host'] ?? 'localhost' )
-                . ( isset($parsedIssuer['port']) ? ':' . $parsedIssuer['port'] : '' );
-            $headers['Host'] = $host;
-        }
-        $this->httpClient = new Client([
+        $baseUri       = $this->internalUrl ?? $this->issuer;
+        $clientOptions = [
             'base_uri' => $baseUri,
             'timeout'  => 30,
-            'headers'  => $headers,
-        ]);
+        ];
+        if ($this->internalUrl !== null) {
+            // Use middleware to force the Host header matching the public issuer.
+            // Client-level default headers can be overridden by the PSR-7 request URI,
+            // so middleware is needed to reliably inject the Host header.
+            $hostHeader = ZitadelHostHeader::deriveFromIssuer($this->issuer);
+            $stack      = HandlerStack::create();
+            $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($hostHeader) {
+                return $request->withHeader('Host', $hostHeader);
+            }));
+            $clientOptions['handler'] = $stack;
+        }
+        $this->httpClient = new Client($clientOptions);
     }
 
     /**

--- a/src/Services/ZitadelService.php
+++ b/src/Services/ZitadelService.php
@@ -65,7 +65,10 @@ class ZitadelService
         $headers = [];
         if ($this->internalUrl !== null) {
             // Add Host header matching the public issuer for Zitadel's domain validation
-            $parsedIssuer    = parse_url($this->issuer);
+            $parsedIssuer = parse_url($this->issuer);
+            if (!is_array($parsedIssuer)) {
+                throw new \RuntimeException('Invalid ZITADEL_ISSUER URL: ' . $this->issuer);
+            }
             $host            = ( $parsedIssuer['host'] ?? 'localhost' )
                 . ( isset($parsedIssuer['port']) ? ':' . $parsedIssuer['port'] : '' );
             $headers['Host'] = $host;

--- a/src/Services/ZitadelService.php
+++ b/src/Services/ZitadelService.php
@@ -20,6 +20,7 @@ class ZitadelService
 {
     private Client $httpClient;
     private string $issuer;
+    private ?string $internalUrl;
     private string $projectId;
     private ?string $machineToken;
     private ?LoggerInterface $logger;
@@ -40,24 +41,39 @@ class ZitadelService
     /**
      * Create Zitadel service.
      *
-     * @param string $issuer Zitadel issuer URL
+     * @param string $issuer Zitadel issuer URL (public URL for token validation)
      * @param string $projectId Zitadel project ID
      * @param string|null $machineToken Service account token for management API
+     * @param string|null $internalUrl Internal URL for Docker networking (e.g., http://zitadel:8080)
      * @param LoggerInterface|null $logger Optional logger for error logging
      */
     public function __construct(
         string $issuer,
         string $projectId,
         ?string $machineToken = null,
+        ?string $internalUrl = null,
         ?LoggerInterface $logger = null
     ) {
         $this->issuer       = rtrim($issuer, '/');
+        $this->internalUrl  = $internalUrl !== null ? rtrim($internalUrl, '/') : null;
         $this->projectId    = $projectId;
         $this->machineToken = $machineToken;
         $this->logger       = $logger;
-        $this->httpClient   = new Client([
-            'base_uri' => $this->issuer,
+
+        // Use internal URL for HTTP requests if configured (Docker networking)
+        $baseUri = $this->internalUrl ?? $this->issuer;
+        $headers = [];
+        if ($this->internalUrl !== null) {
+            // Add Host header matching the public issuer for Zitadel's domain validation
+            $parsedIssuer    = parse_url($this->issuer);
+            $host            = ( $parsedIssuer['host'] ?? 'localhost' )
+                . ( isset($parsedIssuer['port']) ? ':' . $parsedIssuer['port'] : '' );
+            $headers['Host'] = $host;
+        }
+        $this->httpClient = new Client([
+            'base_uri' => $baseUri,
             'timeout'  => 30,
+            'headers'  => $headers,
         ]);
     }
 
@@ -89,10 +105,12 @@ class ZitadelService
         $issuerEnv       = getenv('ZITADEL_ISSUER') ?: ( $_ENV['ZITADEL_ISSUER'] ?? '' );
         $projectIdEnv    = getenv('ZITADEL_PROJECT_ID') ?: ( $_ENV['ZITADEL_PROJECT_ID'] ?? '' );
         $machineTokenEnv = getenv('ZITADEL_MACHINE_TOKEN') ?: ( $_ENV['ZITADEL_MACHINE_TOKEN'] ?? null );
+        $internalUrlEnv  = getenv('ZITADEL_INTERNAL_URL') ?: ( $_ENV['ZITADEL_INTERNAL_URL'] ?? '' );
 
         $issuer       = is_string($issuerEnv) ? $issuerEnv : '';
         $projectId    = is_string($projectIdEnv) ? $projectIdEnv : '';
         $machineToken = is_string($machineTokenEnv) ? $machineTokenEnv : null;
+        $internalUrl  = is_string($internalUrlEnv) && !empty($internalUrlEnv) ? $internalUrlEnv : null;
 
         if (empty($issuer) || empty($projectId)) {
             throw new \RuntimeException(
@@ -100,7 +118,7 @@ class ZitadelService
             );
         }
 
-        return new self($issuer, $projectId, $machineToken, $logger);
+        return new self($issuer, $projectId, $machineToken, $internalUrl, $logger);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add optional `ZITADEL_INTERNAL_URL` env var to `OidcAuthMiddleware` and `ZitadelService` for routing server-side requests through the Docker network
- When set (e.g., `http://zitadel:8080`), all HTTP requests to Zitadel use the internal URL with a `Host` header matching the public issuer for domain validation
- When not set, behavior is unchanged — uses `ZITADEL_ISSUER` for all requests (preserving compatibility with host-based setups)
- Fix pre-existing PHPStan errors in log formatters (redundant isset/null-coalesce on non-nullable `LogRecord::$context`)

## Why

When the API runs inside a Docker container alongside Zitadel (in the unified stack from LiturgicalCalendarFrontend), `localhost:8080` is unreachable because it refers to the container itself. Previously this wasn't an issue because the API's docker-compose only containerized infrastructure while the API ran on the host.

## Test plan

- [ ] Verify `composer analyse` passes (PHPStan level 10)
- [ ] Verify `composer lint` passes
- [ ] Host-based setup (no `ZITADEL_INTERNAL_URL`): API reaches Zitadel at `ZITADEL_ISSUER` as before
- [ ] Docker setup (`ZITADEL_INTERNAL_URL=http://zitadel:8080`): API reaches Zitadel via Docker service name

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for using an internal OIDC server URL so the API can retrieve JWKS when running alongside the identity provider in the same Docker stack.

* **Configuration**
  * Added a commented ZITADEL_INTERNAL_URL entry to the example environment file to document optional internal routing.

* **Refactor**
  * Streamlined token/key retrieval and logging/context handling for the internal-JWKS mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->