### PR TITLE
Add CHECK constraint on role_requests.requested_role

### DIFF
--- a/infrastructure/init-db.sql
+++ b/infrastructure/init-db.sql
@@ -41,6 +41,7 @@ CREATE TABLE role_requests (
     zitadel_sync_error TEXT DEFAULT NULL,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     reviewed_at TIMESTAMP,
+    CONSTRAINT chk_requested_role CHECK (requested_role IN ('developer', 'calendar_editor', 'test_editor')),
     CONSTRAINT chk_role_request_status CHECK (status IN ('pending', 'approved', 'rejected', 'revoked')),
     CONSTRAINT chk_zitadel_sync_status CHECK (zitadel_sync_status IS NULL OR zitadel_sync_status IN ('pending', 'synced', 'failed'))
 );


### PR DESCRIPTION
## Summary

- Add `chk_requested_role` CHECK constraint to the `role_requests` table in `infrastructure/init-db.sql`, enforcing valid values: `developer`, `calendar_editor`, `test_editor`
- Matches the PHP-side validation in `RoleRequestRepository::VALID_ROLES`
- Brings `requested_role` in line with all other enum-like columns which already have CHECK constraints

## Migration for existing deployments

```sql
ALTER TABLE role_requests
ADD CONSTRAINT chk_requested_role
CHECK (requested_role IN ('developer', 'calendar_editor', 'test_editor'));
```

## Test plan

- [ ] Fresh `docker compose up` creates the constraint correctly
- [ ] Existing deployments can apply the ALTER TABLE migration

Closes #519

🤖 Generated with [Claude Code](https://claude.com/claude-code)