### PR TITLE
Implement API key rate limiting enforcement

### DIFF
--- a/phpunit_tests/Services/RateLimiterTest.php
+++ b/phpunit_tests/Services/RateLimiterTest.php
@@ -318,6 +318,73 @@ class RateLimiterTest extends TestCase
         }
     }
 
+    public function testRecordRequestAndGetCountRespectsCapWithOverflow(): void
+    {
+        $identifier = 'apikey_test-cap';
+        $cap        = 3;
+
+        // Requests 1-3: under cap, all recorded
+        for ($i = 1; $i <= $cap; $i++) {
+            $count = $this->rateLimiter->recordRequestAndGetCount($identifier, $cap);
+            $this->assertEquals($i, $count, "Request {$i} should return count {$i}");
+        }
+
+        // Request 4: at cap, one overflow recorded (count becomes cap+1)
+        $count = $this->rateLimiter->recordRequestAndGetCount($identifier, $cap);
+        $this->assertEquals($cap + 1, $count, 'Overflow request should return cap+1');
+
+        // Request 5: beyond overflow, not recorded, count stays at cap+1
+        $count = $this->rateLimiter->recordRequestAndGetCount($identifier, $cap);
+        $this->assertEquals($cap + 1, $count, 'Further requests should not increase count beyond cap+1');
+    }
+
+    public function testRecordRequestAndGetCountTriggersRateLimit(): void
+    {
+        $identifier = 'apikey_test-trigger';
+        $limit      = 3;
+
+        // Requests 1-3: within limit, remaining >= 0
+        for ($i = 1; $i <= $limit; $i++) {
+            $count     = $this->rateLimiter->recordRequestAndGetCount($identifier, $limit);
+            $remaining = $limit - $count;
+            $this->assertGreaterThanOrEqual(0, $remaining, "Request {$i} should not exceed limit");
+        }
+
+        // Request 4: overflow triggers rate limit (remaining < 0)
+        $count     = $this->rateLimiter->recordRequestAndGetCount($identifier, $limit);
+        $remaining = $limit - $count;
+        $this->assertLessThan(0, $remaining, 'Request after limit should trigger rate limiting');
+    }
+
+    public function testGetWindowResetTimeReturnsCorrectTimestamp(): void
+    {
+        $identifier = 'test-reset-time';
+
+        // No attempts: reset time should be approximately now
+        $resetTime = $this->rateLimiter->getWindowResetTime($identifier);
+        $this->assertEqualsWithDelta(time(), $resetTime, 1);
+
+        // Record an attempt
+        $this->rateLimiter->recordRequest($identifier);
+
+        // Reset time should be approximately now + window seconds
+        $resetTime = $this->rateLimiter->getWindowResetTime($identifier);
+        $this->assertEqualsWithDelta(time() + 60, $resetTime, 1);
+    }
+
+    public function testGetAttemptCountReturnsCorrectCount(): void
+    {
+        $identifier = 'test-count';
+
+        $this->assertEquals(0, $this->rateLimiter->getAttemptCount($identifier));
+
+        $this->rateLimiter->recordRequest($identifier);
+        $this->assertEquals(1, $this->rateLimiter->getAttemptCount($identifier));
+
+        $this->rateLimiter->recordRequest($identifier);
+        $this->assertEquals(2, $this->rateLimiter->getAttemptCount($identifier));
+    }
+
     public function testFactoryClampsAttemptsToMinimum(): void
     {
         $saved = $this->saveEnvValues();

--- a/phpunit_tests/Services/RateLimiterTest.php
+++ b/phpunit_tests/Services/RateLimiterTest.php
@@ -360,16 +360,22 @@ class RateLimiterTest extends TestCase
     {
         $identifier = 'test-reset-time';
 
-        // No attempts: reset time should be approximately now
+        // No attempts: reset time should be between before and after
+        $before    = time();
         $resetTime = $this->rateLimiter->getWindowResetTime($identifier);
-        $this->assertEqualsWithDelta(time(), $resetTime, 1);
+        $after     = time();
+        $this->assertGreaterThanOrEqual($before, $resetTime);
+        $this->assertLessThanOrEqual($after, $resetTime);
 
         // Record an attempt
+        $before = time();
         $this->rateLimiter->recordRequest($identifier);
+        $after = time();
 
-        // Reset time should be approximately now + window seconds
+        // Reset time should be between (before + window) and (after + window)
         $resetTime = $this->rateLimiter->getWindowResetTime($identifier);
-        $this->assertEqualsWithDelta(time() + 60, $resetTime, 1);
+        $this->assertGreaterThanOrEqual($before + 60, $resetTime);
+        $this->assertLessThanOrEqual($after + 60, $resetTime);
     }
 
     public function testGetAttemptCountReturnsCorrectCount(): void

--- a/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
+++ b/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
@@ -66,9 +66,10 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
             $limit      = $this->defaultLimit;
         }
 
-        // Atomically record the request and get the new count to avoid TOCTOU race conditions
-        $newCount  = $this->rateLimiter->recordRequestAndGetCount($identifier);
-        $remaining = $limit - $newCount;
+        // Atomically record the request (capped) and get the count.
+        // The cap prevents unbounded file growth from requests that exceed the limit.
+        $count     = $this->rateLimiter->recordRequestAndGetCount($identifier, $limit);
+        $remaining = $limit - $count;
 
         if ($remaining < 0) {
             $retryAfter = $this->rateLimiter->getRetryAfter($identifier);
@@ -107,7 +108,7 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
      * Extract the client IP address from the request.
      *
      * Only trusts proxy headers (X-Forwarded-For, X-Real-IP) when trustProxyHeaders
-     * is enabled. Without this, an attacker can spoof these headers to bypass rate limits.
+     * is enabled. Validates extracted IPs with filter_var to prevent malformed values.
      *
      * @param ServerRequestInterface $request
      * @return string Client IP address
@@ -119,9 +120,11 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
             foreach ($headers as $header) {
                 $value = $request->getHeaderLine($header);
                 if (!empty($value)) {
-                    // X-Forwarded-For may contain multiple IPs; take the first (client IP)
-                    $ips = array_map('trim', explode(',', $value));
-                    return $ips[0];
+                    $ips       = array_map('trim', explode(',', $value));
+                    $candidate = $ips[0];
+                    if (filter_var($candidate, FILTER_VALIDATE_IP) !== false) {
+                        return $candidate;
+                    }
                 }
             }
         }

--- a/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
+++ b/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Http\Middleware;
+
+use LiturgicalCalendar\Api\Http\Exception\TooManyRequestsException;
+use LiturgicalCalendar\Api\Services\RateLimiter;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Rate limiting middleware for API key-authenticated and unauthenticated requests.
+ *
+ * Tracks request counts per API key (or per IP for unauthenticated requests)
+ * within a one-hour sliding window. Throws TooManyRequestsException when the
+ * limit is exceeded, which ErrorHandlingMiddleware converts to a 429 response
+ * with a Retry-After header.
+ *
+ * Must be piped after ApiKeyMiddleware so the api_key request attribute is available.
+ */
+class ApiKeyRateLimitMiddleware implements MiddlewareInterface
+{
+    private RateLimiter $rateLimiter;
+    private int $defaultLimit;
+
+    private const WINDOW_SECONDS = 3600; // 1 hour
+
+    /**
+     * Create the rate limit middleware.
+     *
+     * @param int $defaultLimit Default requests per hour for unauthenticated requests
+     * @param string|null $storagePath Path to store rate limit data (default: system temp dir)
+     */
+    public function __construct(int $defaultLimit = 100, ?string $storagePath = null)
+    {
+        $this->defaultLimit = $defaultLimit;
+        // maxAttempts is set high because we compare against per-key limits ourselves.
+        // The RateLimiter only handles window-based counting and file storage.
+        $this->rateLimiter = new RateLimiter(PHP_INT_MAX, self::WINDOW_SECONDS, $storagePath);
+    }
+
+    /**
+     * Process the request and enforce rate limits.
+     *
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     * @throws TooManyRequestsException If the rate limit is exceeded
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $apiKeyData = $request->getAttribute('api_key');
+        if (is_array($apiKeyData) && isset($apiKeyData['id']) && is_string($apiKeyData['id'])) {
+            $identifier = 'apikey_' . $apiKeyData['id'];
+            $rateLimit  = $apiKeyData['rate_limit_per_hour'] ?? $this->defaultLimit;
+            $limit      = is_int($rateLimit) ? $rateLimit : ( is_numeric($rateLimit) ? intval($rateLimit) : $this->defaultLimit );
+        } else {
+            // Unauthenticated: rate limit by IP address
+            $identifier = 'ip_' . $this->getClientIp($request);
+            $limit      = $this->defaultLimit;
+        }
+
+        // Check current count within the window
+        $currentCount = $this->rateLimiter->getAttemptCount($identifier);
+        $remaining    = $limit - $currentCount;
+        if ($remaining <= 0) {
+            $retryAfter = $this->rateLimiter->getRetryAfter($identifier);
+            throw new TooManyRequestsException(
+                "Rate limit exceeded. Maximum {$limit} requests per hour.",
+                $retryAfter
+            );
+        }
+
+        // Record this request
+        $this->rateLimiter->recordRequest($identifier);
+
+        // Add rate limit headers to response
+        $response = $handler->handle($request);
+        return $response
+            ->withHeader('X-RateLimit-Limit', (string) $limit)
+            ->withHeader('X-RateLimit-Remaining', (string) max(0, $remaining - 1))
+            ->withHeader('X-RateLimit-Reset', (string) ( time() + self::WINDOW_SECONDS ));
+    }
+
+    /**
+     * Create middleware from environment variables.
+     *
+     * @return self
+     */
+    public static function fromEnv(): self
+    {
+        $defaultLimitEnv = getenv('API_KEY_DEFAULT_RATE_LIMIT') ?: ( $_ENV['API_KEY_DEFAULT_RATE_LIMIT'] ?? '' );
+        $defaultLimit    = is_numeric($defaultLimitEnv) ? (int) $defaultLimitEnv : 100;
+        $storagePath     = getenv('RATE_LIMIT_STORAGE_PATH') ?: ( $_ENV['RATE_LIMIT_STORAGE_PATH'] ?? null );
+        $storagePath     = is_string($storagePath) && !empty($storagePath) ? $storagePath : null;
+
+        return new self($defaultLimit, $storagePath);
+    }
+
+    /**
+     * Extract the client IP address from the request.
+     *
+     * @param ServerRequestInterface $request
+     * @return string Client IP address
+     */
+    private function getClientIp(ServerRequestInterface $request): string
+    {
+        // Check common proxy headers
+        $headers = ['X-Forwarded-For', 'X-Real-IP'];
+        foreach ($headers as $header) {
+            $value = $request->getHeaderLine($header);
+            if (!empty($value)) {
+                // X-Forwarded-For may contain multiple IPs; take the first (client IP)
+                $ips = array_map('trim', explode(',', $value));
+                return $ips[0];
+            }
+        }
+
+        $serverParams = $request->getServerParams();
+        $remoteAddr   = $serverParams['REMOTE_ADDR'] ?? '127.0.0.1';
+        return is_string($remoteAddr) ? $remoteAddr : '127.0.0.1';
+    }
+}

--- a/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
+++ b/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
@@ -25,6 +25,7 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
 {
     private RateLimiter $rateLimiter;
     private int $defaultLimit;
+    private bool $trustProxyHeaders;
 
     private const WINDOW_SECONDS = 3600; // 1 hour
 
@@ -33,10 +34,12 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
      *
      * @param int $defaultLimit Default requests per hour for unauthenticated requests
      * @param string|null $storagePath Path to store rate limit data (default: system temp dir)
+     * @param bool $trustProxyHeaders Whether to trust X-Forwarded-For/X-Real-IP headers for client IP
      */
-    public function __construct(int $defaultLimit = 100, ?string $storagePath = null)
+    public function __construct(int $defaultLimit = 100, ?string $storagePath = null, bool $trustProxyHeaders = false)
     {
-        $this->defaultLimit = $defaultLimit;
+        $this->defaultLimit      = $defaultLimit;
+        $this->trustProxyHeaders = $trustProxyHeaders;
         // maxAttempts is set high because we compare against per-key limits ourselves.
         // The RateLimiter only handles window-based counting and file storage.
         $this->rateLimiter = new RateLimiter(PHP_INT_MAX, self::WINDOW_SECONDS, $storagePath);
@@ -63,10 +66,11 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
             $limit      = $this->defaultLimit;
         }
 
-        // Check current count within the window
-        $currentCount = $this->rateLimiter->getAttemptCount($identifier);
-        $remaining    = $limit - $currentCount;
-        if ($remaining <= 0) {
+        // Atomically record the request and get the new count to avoid TOCTOU race conditions
+        $newCount  = $this->rateLimiter->recordRequestAndGetCount($identifier);
+        $remaining = $limit - $newCount;
+
+        if ($remaining < 0) {
             $retryAfter = $this->rateLimiter->getRetryAfter($identifier);
             throw new TooManyRequestsException(
                 "Rate limit exceeded. Maximum {$limit} requests per hour.",
@@ -74,15 +78,12 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
             );
         }
 
-        // Record this request
-        $this->rateLimiter->recordRequest($identifier);
-
         // Add rate limit headers to response
         $response = $handler->handle($request);
         return $response
             ->withHeader('X-RateLimit-Limit', (string) $limit)
-            ->withHeader('X-RateLimit-Remaining', (string) max(0, $remaining - 1))
-            ->withHeader('X-RateLimit-Reset', (string) ( time() + self::WINDOW_SECONDS ));
+            ->withHeader('X-RateLimit-Remaining', (string) max(0, $remaining))
+            ->withHeader('X-RateLimit-Reset', (string) $this->rateLimiter->getWindowResetTime($identifier));
     }
 
     /**
@@ -96,26 +97,32 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
         $defaultLimit    = is_numeric($defaultLimitEnv) ? (int) $defaultLimitEnv : 100;
         $storagePath     = getenv('RATE_LIMIT_STORAGE_PATH') ?: ( $_ENV['RATE_LIMIT_STORAGE_PATH'] ?? null );
         $storagePath     = is_string($storagePath) && !empty($storagePath) ? $storagePath : null;
+        $trustProxy      = getenv('TRUST_PROXY_HEADERS') ?: ( $_ENV['TRUST_PROXY_HEADERS'] ?? 'false' );
+        $trustProxy      = filter_var($trustProxy, FILTER_VALIDATE_BOOLEAN);
 
-        return new self($defaultLimit, $storagePath);
+        return new self($defaultLimit, $storagePath, $trustProxy);
     }
 
     /**
      * Extract the client IP address from the request.
+     *
+     * Only trusts proxy headers (X-Forwarded-For, X-Real-IP) when trustProxyHeaders
+     * is enabled. Without this, an attacker can spoof these headers to bypass rate limits.
      *
      * @param ServerRequestInterface $request
      * @return string Client IP address
      */
     private function getClientIp(ServerRequestInterface $request): string
     {
-        // Check common proxy headers
-        $headers = ['X-Forwarded-For', 'X-Real-IP'];
-        foreach ($headers as $header) {
-            $value = $request->getHeaderLine($header);
-            if (!empty($value)) {
-                // X-Forwarded-For may contain multiple IPs; take the first (client IP)
-                $ips = array_map('trim', explode(',', $value));
-                return $ips[0];
+        if ($this->trustProxyHeaders) {
+            $headers = ['X-Forwarded-For', 'X-Real-IP'];
+            foreach ($headers as $header) {
+                $value = $request->getHeaderLine($header);
+                if (!empty($value)) {
+                    // X-Forwarded-For may contain multiple IPs; take the first (client IP)
+                    $ips = array_map('trim', explode(',', $value));
+                    return $ips[0];
+                }
             }
         }
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -40,6 +40,8 @@ use LiturgicalCalendar\Api\Http\Middleware\HttpsEnforcementMiddleware;
 use LiturgicalCalendar\Api\Http\Middleware\JwtAuthMiddleware;
 use LiturgicalCalendar\Api\Http\Middleware\LoggingMiddleware;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
+use LiturgicalCalendar\Api\Http\Middleware\ApiKeyMiddleware;
+use LiturgicalCalendar\Api\Http\Middleware\ApiKeyRateLimitMiddleware;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAvailabilityMiddleware;
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Repositories\CalendarPermissionRepository;
@@ -517,6 +519,17 @@ class Router
         $pipeline = new MiddlewarePipeline($this->handler);
         $pipeline->pipe(new ErrorHandlingMiddleware($this->psr17Factory, self::$debug, $allowedOrigins)); // outermost middleware
         $pipeline->pipe(new LoggingMiddleware(self::$debug));
+
+        // Apply API key validation and rate limiting for public API routes
+        if (!in_array($route, ['auth', 'admin', 'applications'], true)) {
+            if (Connection::isConfigured()) {
+                $pipeline->pipe(new ApiKeyMiddleware(
+                    new \LiturgicalCalendar\Api\Repositories\ApiKeyRepository(),
+                    new \LiturgicalCalendar\Api\Repositories\AuditLogRepository()
+                ));
+            }
+            $pipeline->pipe(ApiKeyRateLimitMiddleware::fromEnv());
+        }
 
         // Apply HTTPS enforcement middleware for auth, admin, and applications routes in production
         if (in_array($route, ['auth', 'admin', 'applications'], true)) {

--- a/src/Router.php
+++ b/src/Router.php
@@ -527,8 +527,12 @@ class Router
                     new \LiturgicalCalendar\Api\Repositories\ApiKeyRepository(),
                     new \LiturgicalCalendar\Api\Repositories\AuditLogRepository()
                 ));
+                $pipeline->pipe(ApiKeyRateLimitMiddleware::fromEnv());
+            } else {
+                // Without a database, API key validation is unavailable.
+                // Apply IP-only rate limiting for unauthenticated requests.
+                $pipeline->pipe(ApiKeyRateLimitMiddleware::fromEnv());
             }
-            $pipeline->pipe(ApiKeyRateLimitMiddleware::fromEnv());
         }
 
         // Apply HTTPS enforcement middleware for auth, admin, and applications routes in production

--- a/src/Services/RateLimiter.php
+++ b/src/Services/RateLimiter.php
@@ -118,19 +118,22 @@ class RateLimiter
      * Atomically record a request and return the new count within the window.
      *
      * Uses file locking to prevent TOCTOU race conditions between checking
-     * the count and recording the request.
+     * the count and recording the request. When a cap is provided, the request
+     * is only recorded if the current count is below the cap, preventing
+     * unbounded file growth from requests that exceed the limit.
      *
      * @param string $identifier The identifier (e.g., API key ID, IP address)
-     * @return int The count of attempts within the window after recording this request
+     * @param int|null $cap Maximum allowed count; if current count >= cap, the request is not recorded
+     * @return int The count of attempts within the window (after recording if under cap)
      */
-    public function recordRequestAndGetCount(string $identifier): int
+    public function recordRequestAndGetCount(string $identifier, ?int $cap = null): int
     {
         $lockFile   = $this->getLockFilePath($identifier);
         $lockHandle = @fopen($lockFile, 'c');
 
         if ($lockHandle === false) {
-            $this->recordFailedAttemptUnsafe($identifier);
-            return $this->getAttemptCount($identifier);
+            error_log("RateLimiter: failed to open lock file for {$identifier}, falling back to non-atomic operation");
+            return $this->recordFailedAttemptUnsafe($identifier);
         }
 
         try {
@@ -139,16 +142,20 @@ class RateLimiter
                     $data   = $this->loadData($identifier) ?? ['attempts' => []];
                     $cutoff = time() - $this->windowSeconds;
                     /** @var int[] $attempts */
-                    $attempts   = array_values(array_filter($data['attempts'], fn($timestamp) => $timestamp > $cutoff));
-                    $attempts[] = time();
-                    $this->saveData($identifier, ['attempts' => $attempts]);
+                    $attempts = array_values(array_filter($data['attempts'], fn($timestamp) => $timestamp > $cutoff));
+
+                    // Only record if under the cap (or no cap specified)
+                    if ($cap === null || count($attempts) < $cap) {
+                        $attempts[] = time();
+                        $this->saveData($identifier, ['attempts' => $attempts]);
+                    }
                     return count($attempts);
                 } finally {
                     flock($lockHandle, LOCK_UN);
                 }
             } else {
-                $this->recordFailedAttemptUnsafe($identifier);
-                return $this->getAttemptCount($identifier);
+                error_log("RateLimiter: failed to acquire lock for {$identifier}, falling back to non-atomic operation");
+                return $this->recordFailedAttemptUnsafe($identifier);
             }
         } finally {
             fclose($lockHandle);
@@ -222,23 +229,28 @@ class RateLimiter
     }
 
     /**
-     * Record a failed attempt without locking (internal use)
+     * Record a failed attempt without locking (internal use).
+     *
+     * Returns the count of attempts within the window after recording,
+     * so callers in the fallback path can use the in-memory count
+     * without a separate file read.
      *
      * @param string $identifier The identifier (e.g., IP address)
-     * @return void
+     * @return int The count of attempts within the window after recording
      */
-    private function recordFailedAttemptUnsafe(string $identifier): void
+    private function recordFailedAttemptUnsafe(string $identifier): int
     {
         $data = $this->loadData($identifier) ?? ['attempts' => []];
 
         // Clean up old attempts outside the window
         $cutoff           = time() - $this->windowSeconds;
-        $data['attempts'] = array_filter($data['attempts'], fn($timestamp) => $timestamp > $cutoff);
+        $data['attempts'] = array_values(array_filter($data['attempts'], fn($timestamp) => $timestamp > $cutoff));
 
         // Add current attempt
         $data['attempts'][] = time();
 
         $this->saveData($identifier, $data);
+        return count($data['attempts']);
     }
 
     /**

--- a/src/Services/RateLimiter.php
+++ b/src/Services/RateLimiter.php
@@ -101,6 +101,20 @@ class RateLimiter
     }
 
     /**
+     * Record a request for an identifier.
+     *
+     * General-purpose alias for recordFailedAttempt() suitable for API key
+     * rate limiting where every request counts, not just failures.
+     *
+     * @param string $identifier The identifier (e.g., API key ID, IP address)
+     * @return void
+     */
+    public function recordRequest(string $identifier): void
+    {
+        $this->recordFailedAttempt($identifier);
+    }
+
+    /**
      * Record a failed attempt for an identifier
      *
      * Uses file locking to prevent race conditions when multiple processes
@@ -208,6 +222,24 @@ class RateLimiter
         $expiresAt = $oldestAttempt + $this->windowSeconds;
 
         return max(0, $expiresAt - time());
+    }
+
+    /**
+     * Get the number of recorded attempts within the current window.
+     *
+     * @param string $identifier The identifier (e.g., API key ID, IP address)
+     * @return int Number of attempts in the current window
+     */
+    public function getAttemptCount(string $identifier): int
+    {
+        $data = $this->loadData($identifier);
+
+        if ($data === null) {
+            return 0;
+        }
+
+        $cutoff = time() - $this->windowSeconds;
+        return count(array_filter($data['attempts'], fn($timestamp) => $timestamp > $cutoff));
     }
 
     /**

--- a/src/Services/RateLimiter.php
+++ b/src/Services/RateLimiter.php
@@ -115,6 +115,74 @@ class RateLimiter
     }
 
     /**
+     * Atomically record a request and return the new count within the window.
+     *
+     * Uses file locking to prevent TOCTOU race conditions between checking
+     * the count and recording the request.
+     *
+     * @param string $identifier The identifier (e.g., API key ID, IP address)
+     * @return int The count of attempts within the window after recording this request
+     */
+    public function recordRequestAndGetCount(string $identifier): int
+    {
+        $lockFile   = $this->getLockFilePath($identifier);
+        $lockHandle = @fopen($lockFile, 'c');
+
+        if ($lockHandle === false) {
+            $this->recordFailedAttemptUnsafe($identifier);
+            return $this->getAttemptCount($identifier);
+        }
+
+        try {
+            if (flock($lockHandle, LOCK_EX)) {
+                try {
+                    $data   = $this->loadData($identifier) ?? ['attempts' => []];
+                    $cutoff = time() - $this->windowSeconds;
+                    /** @var int[] $attempts */
+                    $attempts   = array_values(array_filter($data['attempts'], fn($timestamp) => $timestamp > $cutoff));
+                    $attempts[] = time();
+                    $this->saveData($identifier, ['attempts' => $attempts]);
+                    return count($attempts);
+                } finally {
+                    flock($lockHandle, LOCK_UN);
+                }
+            } else {
+                $this->recordFailedAttemptUnsafe($identifier);
+                return $this->getAttemptCount($identifier);
+            }
+        } finally {
+            fclose($lockHandle);
+        }
+    }
+
+    /**
+     * Get the UNIX timestamp when the current rate limit window resets.
+     *
+     * Returns the time when the oldest attempt in the window will expire,
+     * or the current time if there are no recorded attempts.
+     *
+     * @param string $identifier The identifier (e.g., API key ID, IP address)
+     * @return int UNIX timestamp of window reset
+     */
+    public function getWindowResetTime(string $identifier): int
+    {
+        $data = $this->loadData($identifier);
+        if ($data === null || empty($data['attempts'])) {
+            return time();
+        }
+
+        $cutoff = time() - $this->windowSeconds;
+        /** @var int[] $attempts */
+        $attempts = array_filter($data['attempts'], fn($timestamp) => $timestamp > $cutoff);
+        if (empty($attempts)) {
+            return time();
+        }
+
+        // The window resets when the oldest attempt expires
+        return min($attempts) + $this->windowSeconds;
+    }
+
+    /**
      * Record a failed attempt for an identifier
      *
      * Uses file locking to prevent race conditions when multiple processes

--- a/src/Services/RateLimiter.php
+++ b/src/Services/RateLimiter.php
@@ -2,6 +2,9 @@
 
 namespace LiturgicalCalendar\Api\Services;
 
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use Psr\Log\LoggerInterface;
+
 /**
  * Simple file-based rate limiter for brute-force protection
  *
@@ -16,6 +19,7 @@ class RateLimiter
     private string $storagePath;
     private int $maxAttempts;
     private int $windowSeconds;
+    private LoggerInterface $logger;
 
     /**
      * Create a new rate limiter instance
@@ -35,6 +39,7 @@ class RateLimiter
         $this->maxAttempts   = $maxAttempts;
         $this->windowSeconds = $windowSeconds;
         $this->storagePath   = $storagePath ?? sys_get_temp_dir();
+        $this->logger        = LoggerFactory::create('rate-limiter', null, 30, false, true, false);
 
         // Ensure the rate limit directory exists
         $rateLimitDir = $this->getRateLimitDir();
@@ -119,8 +124,9 @@ class RateLimiter
      *
      * Uses file locking to prevent TOCTOU race conditions between checking
      * the count and recording the request. When a cap is provided, the request
-     * is only recorded if the current count is below the cap, preventing
-     * unbounded file growth from requests that exceed the limit.
+     * is recorded only when the current count is at or below the cap (allowing
+     * one overflow so callers can detect the breach), then stops recording to
+     * prevent unbounded file growth.
      *
      * @param string $identifier The identifier (e.g., API key ID, IP address)
      * @param int|null $cap Maximum allowed count; records up to cap+1 (one overflow) so callers
@@ -133,7 +139,9 @@ class RateLimiter
         $lockHandle = @fopen($lockFile, 'c');
 
         if ($lockHandle === false) {
-            error_log("RateLimiter: failed to open lock file for {$identifier}, falling back to non-atomic operation");
+            $this->logger->error('Failed to open lock file, falling back to non-atomic operation', [
+                'identifier_hash' => hash('sha256', $identifier),
+            ]);
             return $this->recordFailedAttemptUnsafe($identifier, $cap);
         }
 
@@ -156,7 +164,9 @@ class RateLimiter
                     flock($lockHandle, LOCK_UN);
                 }
             } else {
-                error_log("RateLimiter: failed to acquire lock for {$identifier}, falling back to non-atomic operation");
+                $this->logger->error('Failed to acquire lock, falling back to non-atomic operation', [
+                    'identifier_hash' => hash('sha256', $identifier),
+                ]);
                 return $this->recordFailedAttemptUnsafe($identifier, $cap);
             }
         } finally {

--- a/src/Services/RateLimiter.php
+++ b/src/Services/RateLimiter.php
@@ -123,8 +123,9 @@ class RateLimiter
      * unbounded file growth from requests that exceed the limit.
      *
      * @param string $identifier The identifier (e.g., API key ID, IP address)
-     * @param int|null $cap Maximum allowed count; if current count >= cap, the request is not recorded
-     * @return int The count of attempts within the window (after recording if under cap)
+     * @param int|null $cap Maximum allowed count; records up to cap+1 (one overflow) so callers
+     *                      can detect the limit was exceeded, then stops recording to prevent unbounded growth
+     * @return int The count of attempts within the window after recording
      */
     public function recordRequestAndGetCount(string $identifier, ?int $cap = null): int
     {
@@ -133,7 +134,7 @@ class RateLimiter
 
         if ($lockHandle === false) {
             error_log("RateLimiter: failed to open lock file for {$identifier}, falling back to non-atomic operation");
-            return $this->recordFailedAttemptUnsafe($identifier);
+            return $this->recordFailedAttemptUnsafe($identifier, $cap);
         }
 
         try {
@@ -144,8 +145,9 @@ class RateLimiter
                     /** @var int[] $attempts */
                     $attempts = array_values(array_filter($data['attempts'], fn($timestamp) => $timestamp > $cutoff));
 
-                    // Only record if under the cap (or no cap specified)
-                    if ($cap === null || count($attempts) < $cap) {
+                    // Record up to cap+1: allow one overflow so the caller sees count > cap
+                    // and can trigger a 429, then stop recording to prevent unbounded growth
+                    if ($cap === null || count($attempts) <= $cap) {
                         $attempts[] = time();
                         $this->saveData($identifier, ['attempts' => $attempts]);
                     }
@@ -155,7 +157,7 @@ class RateLimiter
                 }
             } else {
                 error_log("RateLimiter: failed to acquire lock for {$identifier}, falling back to non-atomic operation");
-                return $this->recordFailedAttemptUnsafe($identifier);
+                return $this->recordFailedAttemptUnsafe($identifier, $cap);
             }
         } finally {
             fclose($lockHandle);
@@ -233,12 +235,14 @@ class RateLimiter
      *
      * Returns the count of attempts within the window after recording,
      * so callers in the fallback path can use the in-memory count
-     * without a separate file read.
+     * without a separate file read. Mirrors the cap behavior of
+     * recordRequestAndGetCount (allows one overflow, then stops).
      *
      * @param string $identifier The identifier (e.g., IP address)
+     * @param int|null $cap Maximum allowed count (allows one overflow, then stops recording)
      * @return int The count of attempts within the window after recording
      */
-    private function recordFailedAttemptUnsafe(string $identifier): int
+    private function recordFailedAttemptUnsafe(string $identifier, ?int $cap = null): int
     {
         $data = $this->loadData($identifier) ?? ['attempts' => []];
 
@@ -246,8 +250,10 @@ class RateLimiter
         $cutoff           = time() - $this->windowSeconds;
         $data['attempts'] = array_values(array_filter($data['attempts'], fn($timestamp) => $timestamp > $cutoff));
 
-        // Add current attempt
-        $data['attempts'][] = time();
+        // Record up to cap+1 (same overflow behavior as the locked path)
+        if ($cap === null || count($data['attempts']) <= $cap) {
+            $data['attempts'][] = time();
+        }
 
         $this->saveData($identifier, $data);
         return count($data['attempts']);


### PR DESCRIPTION
## Summary

- Add `ApiKeyRateLimitMiddleware` that enforces request rate limits per API key (or per IP for unauthenticated requests) using the existing file-based `RateLimiter` service
- Wire `ApiKeyMiddleware` + `ApiKeyRateLimitMiddleware` into the Router pipeline for all public API routes
- Add `recordRequest()` alias and `getAttemptCount()` method to `RateLimiter` for general-purpose request counting

## How it works

- **Authenticated requests**: rate limited by API key ID, using `rate_limit_per_hour` from the database (default 1000)
- **Unauthenticated requests**: rate limited by client IP, using `API_KEY_DEFAULT_RATE_LIMIT` env var (default 100/hr)
- Exceeding the limit throws `TooManyRequestsException` → HTTP 429 with `Retry-After` header
- Every response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers

## Middleware pipeline order

1. `ErrorHandlingMiddleware` (outermost)
2. `LoggingMiddleware`
3. `ApiKeyMiddleware` (validates key, sets request attribute) — only when DB is configured
4. `ApiKeyRateLimitMiddleware` (enforces limits)
5. Route-specific auth middleware (OIDC, JWT, etc.)
6. Handler

## Test plan

- [ ] Verify `composer analyse` passes (PHPStan level 10)
- [ ] Verify `composer lint` passes
- [ ] Verify unauthenticated requests get rate limited after 100 requests/hour
- [ ] Verify API key-authenticated requests use their `rate_limit_per_hour` value
- [ ] Verify `X-RateLimit-*` headers are present in responses
- [ ] Verify 429 response includes `Retry-After` header when limit exceeded

Closes #516

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API-key-based rate limiting for public API endpoints (defaults to 100 requests/hour)
  * Rate limit response headers: limit, remaining, and window reset
  * Requests over the limit return HTTP 429 with Retry-After
  * IP-only fallback when API key is absent/invalid
  * Middleware now enforces rate limits on public routes and can be configured from environment

* **Tests**
  * Added unit tests covering rate counting, overflow behavior, and window reset timing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->