### PR TITLE
Add pagination support for admin users list endpoint

### DIFF
--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -1336,6 +1336,22 @@
         "summary": "List all users with roles",
         "operationId": "adminListUsers",
         "description": "List all users in the project with their assigned roles. Requires admin role.",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of users to return (1-1000, default 100)",
+            "schema": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 100}
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Number of users to skip for pagination (default 0)",
+            "schema": {"type": "integer", "minimum": 0, "default": 0}
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK: List of users",
@@ -6129,28 +6145,63 @@
         "required": ["pending_role_requests", "pending_permission_requests", "total", "items"],
         "additionalProperties": false
       },
+      "AdminUserWithRoles": {
+        "type": "object",
+        "properties": {
+          "userId": {"type": "string"},
+          "username": {"type": "string"},
+          "displayName": {"type": "string"},
+          "firstName": {"type": "string"},
+          "lastName": {"type": "string"},
+          "email": {"type": "string", "format": "email"},
+          "emailVerified": {"type": "boolean"},
+          "roles": {"type": "array", "items": {"type": "string"}},
+          "grants": {"type": "array", "items": {"type": "object"}}
+        },
+        "required": ["userId"]
+      },
+      "AdminUserWithoutRoles": {
+        "type": "object",
+        "properties": {
+          "userId": {"type": "string"},
+          "username": {"type": "string"},
+          "displayName": {"type": "string"},
+          "firstName": {"type": "string"},
+          "lastName": {"type": "string"},
+          "email": {"type": "string", "format": "email"},
+          "emailVerified": {"type": "boolean"},
+          "roles": {"type": "array", "items": {"type": "string"}, "maxItems": 0},
+          "state": {}
+        },
+        "required": ["userId"]
+      },
+      "PaginationMetadata": {
+        "type": "object",
+        "properties": {
+          "limit": {"type": "integer", "description": "Maximum number of results per page"},
+          "offset": {"type": "integer", "description": "Number of results skipped"},
+          "hasMore": {"type": "boolean", "description": "Whether more results exist beyond this page"}
+        },
+        "required": ["limit", "offset", "hasMore"]
+      },
       "AdminUsersResponse": {
         "type": "object",
         "properties": {
-          "users": {
+          "usersWithRoles": {
             "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "userId": {"type": "string"},
-                "displayName": {"type": "string"},
-                "email": {"type": "string", "format": "email"},
-                "roles": {"type": "array", "items": {"type": "string"}},
-                "grants": {"type": "array", "items": {"type": "object"}}
-              },
-              "required": ["userId"],
-              "additionalProperties": false
-            }
+            "items": {"$ref": "#/components/schemas/AdminUserWithRoles"}
           },
-          "total": {"type": "integer"}
+          "usersWithoutRoles": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/AdminUserWithoutRoles"}
+          },
+          "totalWithRoles": {"type": "integer"},
+          "totalWithoutRoles": {"type": "integer"},
+          "total": {"type": "integer", "description": "Total users returned in this response"},
+          "reportedTotal": {"type": "integer", "description": "Total user count reported by the identity provider"},
+          "pagination": {"$ref": "#/components/schemas/PaginationMetadata"}
         },
-        "required": ["users", "total"],
-        "additionalProperties": false
+        "required": ["usersWithRoles", "usersWithoutRoles", "totalWithRoles", "totalWithoutRoles", "total", "reportedTotal", "pagination"]
       },
       "SuccessResponse": {
         "type": "object",

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -1363,6 +1363,7 @@
               }
             }
           },
+          "400": {"$ref": "#/components/responses/BadRequest400"},
           "401": {"$ref": "#/components/responses/Unauthorized401"},
           "403": {"$ref": "#/components/responses/Forbidden403"}
         }

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -6146,6 +6146,16 @@
         "required": ["pending_role_requests", "pending_permission_requests", "total", "items"],
         "additionalProperties": false
       },
+      "UserGrant": {
+        "type": "object",
+        "properties": {
+          "grantId": {"type": "string"},
+          "roles": {"type": "array", "items": {"type": "string"}},
+          "state": {"type": ["integer", "null"], "description": "Grant state from identity provider"}
+        },
+        "required": ["grantId", "roles"],
+        "additionalProperties": false
+      },
       "AdminUserWithRoles": {
         "type": "object",
         "properties": {
@@ -6157,9 +6167,10 @@
           "email": {"type": "string", "format": "email"},
           "emailVerified": {"type": "boolean"},
           "roles": {"type": "array", "items": {"type": "string"}},
-          "grants": {"type": "array", "items": {"type": "object"}}
+          "grants": {"type": "array", "items": {"$ref": "#/components/schemas/UserGrant"}}
         },
-        "required": ["userId"]
+        "required": ["userId"],
+        "additionalProperties": false
       },
       "AdminUserWithoutRoles": {
         "type": "object",
@@ -6172,9 +6183,10 @@
           "email": {"type": "string", "format": "email"},
           "emailVerified": {"type": "boolean"},
           "roles": {"type": "array", "items": {"type": "string"}, "maxItems": 0},
-          "state": {}
+          "state": {"type": ["string", "null"], "description": "User state from identity provider (e.g., USER_STATE_ACTIVE)"}
         },
-        "required": ["userId"]
+        "required": ["userId"],
+        "additionalProperties": false
       },
       "PaginationMetadata": {
         "type": "object",
@@ -6183,7 +6195,8 @@
           "offset": {"type": "integer", "description": "Number of results skipped"},
           "hasMore": {"type": "boolean", "description": "Whether more results exist beyond this page"}
         },
-        "required": ["limit", "offset", "hasMore"]
+        "required": ["limit", "offset", "hasMore"],
+        "additionalProperties": false
       },
       "AdminUsersResponse": {
         "type": "object",
@@ -6202,7 +6215,8 @@
           "reportedTotal": {"type": "integer", "description": "Total user count reported by the identity provider"},
           "pagination": {"$ref": "#/components/schemas/PaginationMetadata"}
         },
-        "required": ["usersWithRoles", "usersWithoutRoles", "totalWithRoles", "totalWithoutRoles", "total", "reportedTotal", "pagination"]
+        "required": ["usersWithRoles", "usersWithoutRoles", "totalWithRoles", "totalWithoutRoles", "total", "reportedTotal", "pagination"],
+        "additionalProperties": false
       },
       "SuccessResponse": {
         "type": "object",

--- a/src/Handlers/Admin/UsersHandler.php
+++ b/src/Handlers/Admin/UsersHandler.php
@@ -138,10 +138,10 @@ final class UsersHandler extends AbstractHandler
 
         $zitadel = ZitadelService::fromEnv();
 
-        // Fetch users with roles
-        $usersWithRolesResult = $zitadel->listProjectUsers($limit, $offset);
+        // Fetch all users with roles (unpaginated to ensure complete role data for merging)
+        $usersWithRolesResult = $zitadel->listProjectUsers();
 
-        // Fetch all users
+        // Fetch paginated list of all users
         $allUsersResult = $zitadel->listAllUsers($limit, $offset);
 
         // Defensive checks for API response structure

--- a/src/Handlers/Admin/UsersHandler.php
+++ b/src/Handlers/Admin/UsersHandler.php
@@ -156,22 +156,45 @@ final class UsersHandler extends AbstractHandler
         // Defensive checks for API response structure
         $allUsersArray = $allUsersResult['users'] ?? [];
 
-        // Build a map of users with roles (keyed by userId)
+        // Build a map of users with roles (keyed by userId), merging grants across pages
         /** @var array<string, array<string, mixed>> $usersWithRolesMap */
         $usersWithRolesMap = [];
         foreach ($usersWithRolesArray as $user) {
-            // Flatten roles from all grants into a single array
-            $roles = [];
+            $userId = $user['userId'] ?? null;
+            if (!is_string($userId)) {
+                continue;
+            }
+
+            $grants = [];
             if (isset($user['grants']) && is_array($user['grants'])) {
-                foreach ($user['grants'] as $grant) {
+                $grants = $user['grants'];
+            }
+
+            if (isset($usersWithRolesMap[$userId])) {
+                // Merge grants from additional pages for the same user
+                $existing           = $usersWithRolesMap[$userId];
+                $existingGrants     = is_array($existing['grants'] ?? null) ? $existing['grants'] : [];
+                $mergedGrants       = array_merge($existingGrants, $grants);
+                $existing['grants'] = $mergedGrants;
+
+                // Re-flatten roles from all merged grants
+                $roles = [];
+                foreach ($mergedGrants as $grant) {
                     if (is_array($grant) && isset($grant['roles']) && is_array($grant['roles'])) {
                         $roles = array_merge($roles, $grant['roles']);
                     }
                 }
-            }
-            $user['roles'] = array_values(array_unique(array_filter($roles, 'is_string')));
-            $userId        = $user['userId'] ?? null;
-            if (is_string($userId)) {
+                $existing['roles']          = array_values(array_unique(array_filter($roles, 'is_string')));
+                $usersWithRolesMap[$userId] = $existing;
+            } else {
+                // Flatten roles from grants
+                $roles = [];
+                foreach ($grants as $grant) {
+                    if (is_array($grant) && isset($grant['roles']) && is_array($grant['roles'])) {
+                        $roles = array_merge($roles, $grant['roles']);
+                    }
+                }
+                $user['roles']              = array_values(array_unique(array_filter($roles, 'is_string')));
                 $usersWithRolesMap[$userId] = $user;
             }
         }

--- a/src/Handlers/Admin/UsersHandler.php
+++ b/src/Handlers/Admin/UsersHandler.php
@@ -138,8 +138,8 @@ final class UsersHandler extends AbstractHandler
 
         $zitadel = ZitadelService::fromEnv();
 
-        // Fetch all users with roles (unpaginated to ensure complete role data for merging)
-        $usersWithRolesResult = $zitadel->listProjectUsers();
+        // Fetch all users with roles (high limit to ensure complete role data for merging)
+        $usersWithRolesResult = $zitadel->listProjectUsers(self::MAX_LIMIT);
 
         // Fetch paginated list of all users
         $allUsersResult = $zitadel->listAllUsers($limit, $offset);

--- a/src/Handlers/Admin/UsersHandler.php
+++ b/src/Handlers/Admin/UsersHandler.php
@@ -138,15 +138,23 @@ final class UsersHandler extends AbstractHandler
 
         $zitadel = ZitadelService::fromEnv();
 
-        // Fetch all users with roles (high limit to ensure complete role data for merging)
-        $usersWithRolesResult = $zitadel->listProjectUsers(self::MAX_LIMIT);
+        // Fetch all project users with roles by paging through the full set.
+        // This ensures the complete role data is available for merging regardless of count.
+        $usersWithRolesArray = [];
+        $projectOffset       = 0;
+        do {
+            $page                = $zitadel->listProjectUsers(self::MAX_LIMIT, $projectOffset);
+            $pageUsers           = $page['users'] ?? [];
+            $usersWithRolesArray = array_merge($usersWithRolesArray, $pageUsers);
+            $projectOffset      += self::MAX_LIMIT;
+            $projectTotal        = $page['total'] ?? 0;
+        } while ($projectOffset < $projectTotal);
 
         // Fetch paginated list of all users
         $allUsersResult = $zitadel->listAllUsers($limit, $offset);
 
         // Defensive checks for API response structure
-        $usersWithRolesArray = $usersWithRolesResult['users'] ?? [];
-        $allUsersArray       = $allUsersResult['users'] ?? [];
+        $allUsersArray = $allUsersResult['users'] ?? [];
 
         // Build a map of users with roles (keyed by userId)
         /** @var array<string, array<string, mixed>> $usersWithRolesMap */
@@ -168,17 +176,17 @@ final class UsersHandler extends AbstractHandler
             }
         }
 
-        // Separate users into those with roles and those without
+        // Separate current-page users into those with roles and those without.
+        // Only users from the paginated listAllUsers response are included to
+        // preserve consistent pagination semantics (total/hasMore).
         $usersWithRoles    = [];
         $usersWithoutRoles = [];
-        $seenUserIds       = [];
 
         foreach ($allUsersArray as $user) {
             $userId = $user['userId'] ?? null;
             if (!is_string($userId)) {
                 continue;
             }
-            $seenUserIds[$userId] = true;
             if (isset($usersWithRolesMap[$userId])) {
                 // User has roles - merge role info with email verification from the all-users list
                 $userWithRoles                  = $usersWithRolesMap[$userId];
@@ -188,16 +196,6 @@ final class UsersHandler extends AbstractHandler
                 // User has no roles
                 $user['roles']       = [];
                 $usersWithoutRoles[] = $user;
-            }
-        }
-
-        // Ensure all role-bearing users are included, even if not in allUsersArray
-        // (e.g., due to pagination limits in listAllUsers)
-        foreach ($usersWithRolesMap as $userId => $userWithRoles) {
-            if (!isset($seenUserIds[$userId])) {
-                // User has roles but wasn't in allUsersArray - add with emailVerified defaulting to false
-                $userWithRoles['emailVerified'] = $userWithRoles['emailVerified'] ?? false;
-                $usersWithRoles[]               = $userWithRoles;
             }
         }
 

--- a/src/Handlers/Admin/UsersHandler.php
+++ b/src/Handlers/Admin/UsersHandler.php
@@ -80,7 +80,7 @@ final class UsersHandler extends AbstractHandler
         // admin/users/{userId}/roles/{role}
 
         if ($method === RequestMethod::GET) {
-            return $this->listUsers($response);
+            return $this->listUsers($request, $response);
         }
 
         // DELETE requires userId and role
@@ -101,21 +101,48 @@ final class UsersHandler extends AbstractHandler
         return $this->revokeRole($response, $userId, $role);
     }
 
+    private const DEFAULT_LIMIT = 100;
+    private const MAX_LIMIT     = 1000;
+
     /**
      * List all users (with and without roles).
      *
+     * Accepts optional `limit` and `offset` query parameters for pagination.
+     *
+     * @param ServerRequestInterface $request
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    private function listUsers(ResponseInterface $response): ResponseInterface
+    private function listUsers(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
+        $queryParams = $request->getQueryParams();
+
+        $limit  = self::DEFAULT_LIMIT;
+        $offset = 0;
+
+        if (isset($queryParams['limit'])) {
+            $limitParam = filter_var($queryParams['limit'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 1, 'max_range' => self::MAX_LIMIT]]);
+            if ($limitParam === false) {
+                throw new ValidationException('limit must be an integer between 1 and ' . self::MAX_LIMIT);
+            }
+            $limit = $limitParam;
+        }
+
+        if (isset($queryParams['offset'])) {
+            $offsetParam = filter_var($queryParams['offset'], FILTER_VALIDATE_INT, ['options' => ['min_range' => 0]]);
+            if ($offsetParam === false) {
+                throw new ValidationException('offset must be a non-negative integer');
+            }
+            $offset = $offsetParam;
+        }
+
         $zitadel = ZitadelService::fromEnv();
 
         // Fetch users with roles
-        $usersWithRolesResult = $zitadel->listProjectUsers();
+        $usersWithRolesResult = $zitadel->listProjectUsers($limit, $offset);
 
         // Fetch all users
-        $allUsersResult = $zitadel->listAllUsers();
+        $allUsersResult = $zitadel->listAllUsers($limit, $offset);
 
         // Defensive checks for API response structure
         $usersWithRolesArray = $usersWithRolesResult['users'] ?? [];
@@ -184,6 +211,11 @@ final class UsersHandler extends AbstractHandler
             'totalWithoutRoles' => count($usersWithoutRoles),
             'total'             => $processedTotal,
             'reportedTotal'     => $reportedTotal,
+            'pagination'        => [
+                'limit'   => $limit,
+                'offset'  => $offset,
+                'hasMore' => ( $offset + $limit ) < $reportedTotal,
+            ],
         ]);
     }
 


### PR DESCRIPTION
## Summary

- Accept `limit` and `offset` query parameters on `GET /admin/users` with validation (`limit`: 1-1000, `offset`: >= 0)
- Return `pagination` metadata in the response (`limit`, `offset`, `hasMore`)
- Only paginate `listAllUsers()` — `listProjectUsers()` always fetches the full set to avoid merge mismatches when annotating roles onto the paginated user list

Closes #482

## Test plan

- [ ] Verify `GET /admin/users` returns pagination metadata with default values (limit=100, offset=0)
- [ ] Verify `GET /admin/users?limit=10&offset=0` returns at most 10 users with correct `hasMore`
- [ ] Verify `GET /admin/users?limit=0` returns a validation error
- [ ] Verify `GET /admin/users?offset=-1` returns a validation error
- [ ] Verify users with roles are always complete regardless of pagination offset

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled pagination on the admin users endpoint with limit (1–1000, default 100) and offset (default 0).
  * Responses now separate users with roles and users without roles, with independent counts plus a reportedTotal.
  * Added pagination metadata in responses (limit, offset, hasMore) and clearer response structure.

* **Bug Fixes**
  * Invalid pagination inputs now return a 400 Bad Request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->