### PR TITLE
Cache ZitadelService role lookups in OidcAuthMiddleware

### DIFF
--- a/src/Http/Middleware/OidcAuthMiddleware.php
+++ b/src/Http/Middleware/OidcAuthMiddleware.php
@@ -412,9 +412,14 @@ class OidcAuthMiddleware implements MiddlewareInterface
         // If roles are not present in the token (e.g., JWT Profile grant for service accounts),
         // look them up via the Zitadel Management API with a short-lived cache
         if (empty($roles) && is_string($sub) && ZitadelService::isConfigured()) {
+            $sanitize = static fn(string $v): string => str_replace(
+                ['{', '}', '(', ')', '/', '\\', '@', ':'],
+                '_',
+                $v
+            );
             $cacheDir = dirname(__DIR__, 3) . '/cache';
             $cache    = new FilesystemAdapter('roles', 300, $cacheDir);
-            $cacheKey = 'user_roles_' . str_replace(['{', '}', '(', ')', '/', '\\', '@', ':'], '_', $sub);
+            $cacheKey = $sanitize($this->issuer) . '_' . $sanitize($this->projectId ?? '') . '_' . $sanitize($sub);
 
             try {
                 $cachedItem = $cache->getItem($cacheKey);
@@ -428,10 +433,19 @@ class OidcAuthMiddleware implements MiddlewareInterface
                     $cache->save($cachedItem);
                 }
             } catch (\Exception $e) {
-                $this->logger->debug('Failed to look up roles from Zitadel Management API', [
+                $this->logger->debug('Role cache/lookup failed, falling back to API', [
                     'error'  => $e->getMessage(),
                     'userId' => $sub,
                 ]);
+                try {
+                    $zitadelService = ZitadelService::fromEnv();
+                    $roles          = $zitadelService->getUserRoles($sub);
+                } catch (\Exception $fallbackEx) {
+                    $this->logger->debug('Fallback role lookup also failed', [
+                        'error'  => $fallbackEx->getMessage(),
+                        'userId' => $sub,
+                    ]);
+                }
             }
         }
 

--- a/src/Http/Middleware/OidcAuthMiddleware.php
+++ b/src/Http/Middleware/OidcAuthMiddleware.php
@@ -410,11 +410,23 @@ class OidcAuthMiddleware implements MiddlewareInterface
         }
 
         // If roles are not present in the token (e.g., JWT Profile grant for service accounts),
-        // look them up via the Zitadel Management API
+        // look them up via the Zitadel Management API with a short-lived cache
         if (empty($roles) && is_string($sub) && ZitadelService::isConfigured()) {
+            $cacheDir = dirname(__DIR__, 3) . '/cache';
+            $cache    = new FilesystemAdapter('roles', 300, $cacheDir);
+            $cacheKey = 'user_roles_' . str_replace(['{', '}', '(', ')', '/', '\\', '@', ':'], '_', $sub);
+
             try {
-                $zitadelService = ZitadelService::fromEnv();
-                $roles          = $zitadelService->getUserRoles($sub);
+                $cachedItem = $cache->getItem($cacheKey);
+                if ($cachedItem->isHit()) {
+                    $cached = $cachedItem->get();
+                    $roles  = is_array($cached) ? array_filter($cached, 'is_string') : [];
+                } else {
+                    $zitadelService = ZitadelService::fromEnv();
+                    $roles          = $zitadelService->getUserRoles($sub);
+                    $cachedItem->set($roles);
+                    $cache->save($cachedItem);
+                }
             } catch (\Exception $e) {
                 $this->logger->debug('Failed to look up roles from Zitadel Management API', [
                     'error'  => $e->getMessage(),


### PR DESCRIPTION
## Summary

- Cache user roles looked up via the Zitadel Management API with a 5-minute TTL
- Uses `FilesystemAdapter` (same pattern as existing JWKS caching) stored under `/cache/roles/`
- Avoids re-instantiating `ZitadelService` and hitting the Management API on every request for service account tokens that lack roles in the JWT payload
- Falls back to uncached API call if cache operations fail

Closes #549

## Test plan

- [x] Verify authenticated requests with service account tokens still resolve roles correctly
- [x] Verify cached roles are returned on subsequent requests (check `/cache/roles/` directory)
- [x] Verify role changes propagate within 5 minutes (cache TTL)
- [x] PHPUnit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved authentication role resolution by adding a short-lived (5 minute) local cache to reduce redundant API calls.
  * On cache hits, roles are applied immediately; on misses the system fetches and caches roles.
  * Added robust fallback and debug logging so role lookups retry via the API if cache read/write fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->