### PR TITLE
Use dedicated service-account PAT instead of admin PAT

### DIFF
--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -480,6 +480,33 @@ generate_service_account_key() {
     fi
 }
 
+# Function to create a personal access token for a service account
+create_service_account_pat() {
+    local pat="$1"
+    local user_id="$2"
+
+    echo -e "${YELLOW}Creating PAT for service account ${user_id}...${NC}" >&2
+
+    local result
+    result=$(curl -s -X POST "${ZITADEL_URL}/management/v1/users/${user_id}/pats" \
+        -H "Authorization: Bearer $pat" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"expirationDate\": \"2030-01-01T00:00:00Z\"
+        }")
+
+    local token
+    token=$(echo "$result" | jq -r '.token // empty')
+
+    if [ -n "$token" ]; then
+        echo -e "${GREEN}Service account PAT created${NC}" >&2
+        echo "$token"
+    else
+        echo -e "${RED}Failed to create service account PAT: $result${NC}" >&2
+        exit 1
+    fi
+}
+
 # Main execution
 main() {
     # Handle --docker-init: start Docker stack if not running
@@ -511,6 +538,7 @@ main() {
     SERVICE_ACCOUNT_ID=$(create_test_service_account "$PAT" "$PROJECT_ID")
     assign_project_role "$PAT" "$PROJECT_ID" "$SERVICE_ACCOUNT_ID" "admin"
     SERVICE_KEY_FILE=$(generate_service_account_key "$PAT" "$SERVICE_ACCOUNT_ID")
+    SERVICE_ACCOUNT_PAT=$(create_service_account_pat "$PAT" "$SERVICE_ACCOUNT_ID")
 
     # Create Frontend OIDC app
     echo
@@ -529,7 +557,7 @@ main() {
     echo -e "  Project ID:      ${PROJECT_ID}"
     echo -e "  Client ID:       ${FRONTEND_CLIENT_ID}"
     echo -e "  Client Secret:   ${FRONTEND_CLIENT_SECRET}"
-    echo -e "  Service Token:   ${PAT}"
+    echo -e "  SA PAT:          ${SERVICE_ACCOUNT_PAT}"
     echo -e "  Test SA Key:     ${SERVICE_KEY_FILE}"
     echo
     echo -e "${GREEN}Roles created:${NC}"
@@ -557,7 +585,10 @@ main() {
                 update_env_file "$target" "ZITADEL_ISSUER" "${ZITADEL_URL}"
                 update_env_file "$target" "ZITADEL_CLIENT_ID" "$FRONTEND_CLIENT_ID"
                 update_env_file "$target" "ZITADEL_PROJECT_ID" "$PROJECT_ID"
-                update_env_file "$target" "ZITADEL_MACHINE_TOKEN" "$PAT"
+                # Only the API needs a machine token for Management API calls
+                if [ "$label" = "API" ]; then
+                    update_env_file "$target" "ZITADEL_MACHINE_TOKEN" "$SERVICE_ACCOUNT_PAT"
+                fi
                 echo -e "${GREEN}Updated ${label}: $target${NC}"
             else
                 echo -e "${YELLOW}Skipped ${label} (no .env file found in $dir)${NC}"

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -38,6 +38,7 @@ PROJECT_DIR="${SCRIPT_DIR}/.."
 UPDATE_ENV="${UPDATE_ENV:-false}"
 DOCKER_INIT="${DOCKER_INIT:-false}"
 FORCE_SECRETS="${FORCE_SECRETS:-false}"
+SHOW_SECRETS="${SHOW_SECRETS:-false}"
 for arg in "$@"; do
     case $arg in
         --update-env)
@@ -48,6 +49,9 @@ for arg in "$@"; do
             ;;
         --force-secrets)
             FORCE_SECRETS="true"
+            ;;
+        --show-secrets)
+            SHOW_SECRETS="true"
             ;;
     esac
 done
@@ -557,7 +561,11 @@ main() {
     echo -e "  Project ID:      ${PROJECT_ID}"
     echo -e "  Client ID:       ${FRONTEND_CLIENT_ID}"
     echo -e "  Client Secret:   ${FRONTEND_CLIENT_SECRET}"
-    echo -e "  SA PAT:          ${SERVICE_ACCOUNT_PAT}"
+    if [ "${SHOW_SECRETS}" = "true" ]; then
+        echo -e "  SA PAT:          ${SERVICE_ACCOUNT_PAT}"
+    else
+        echo -e "  SA PAT:          ****${SERVICE_ACCOUNT_PAT: -4}"
+    fi
     echo -e "  Test SA Key:     ${SERVICE_KEY_FILE}"
     echo
     echo -e "${GREEN}Roles created:${NC}"

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -114,10 +114,12 @@ create_project() {
         -d "{\"queries\": [{\"nameQuery\": {\"name\": \"${PROJECT_NAME}\", \"method\": \"TEXT_QUERY_METHOD_EQUALS\"}}]}")
 
     existing_id=$(echo "$existing" | jq -r '.result[0].id // empty')
+    local org_id
+    org_id=$(echo "$existing" | jq -r '.result[0].details.resourceOwner // empty')
 
     if [ -n "$existing_id" ]; then
         echo -e "${GREEN}Project already exists with ID: $existing_id${NC}" >&2
-        echo "$existing_id"
+        echo "${existing_id}:${org_id}"
         return 0
     fi
 
@@ -128,10 +130,11 @@ create_project() {
         -d "{\"name\": \"${PROJECT_NAME}\"}")
 
     project_id=$(echo "$result" | jq -r '.id // empty')
+    org_id=$(echo "$result" | jq -r '.details.resourceOwner // empty')
 
     if [ -n "$project_id" ]; then
         echo -e "${GREEN}Project created with ID: $project_id${NC}" >&2
-        echo "$project_id"
+        echo "${project_id}:${org_id}"
     else
         echo -e "${RED}Failed to create project: $result${NC}" >&2
         exit 1
@@ -489,7 +492,8 @@ generate_service_account_key() {
 assign_org_role() {
     local pat="$1"
     local user_id="$2"
-    local role="$3"
+    local org_id="$3"
+    local role="$4"
 
     echo -e "${YELLOW}Assigning org role '${role}' to user ${user_id}...${NC}" >&2
 
@@ -499,17 +503,17 @@ assign_org_role() {
         -H "Content-Type: application/json" \
         -d "{
             \"userId\": \"${user_id}\",
-            \"resource\": { \"instance\": true },
+            \"resource\": { \"organization_id\": \"${org_id}\" },
             \"roles\": [\"${role}\"]
         }")
 
     if echo "$result" | jq -e '.creationDate' > /dev/null 2>&1; then
         echo -e "${GREEN}Org role '${role}' assigned successfully${NC}" >&2
-    elif echo "$result" | jq -e '.code == 6' > /dev/null 2>&1; then
-        # ALREADY_EXISTS
+    elif echo "$result" | jq -e '.code == "already_exists"' > /dev/null 2>&1; then
         echo -e "${GREEN}Org role '${role}' already assigned${NC}" >&2
     else
-        echo -e "${YELLOW}Org role assignment result: ${result}${NC}" >&2
+        echo -e "${RED}Failed to assign org role '${role}': ${result}${NC}" >&2
+        exit 1
     fi
 }
 
@@ -569,8 +573,11 @@ main() {
     # Get admin PAT
     PAT=$(get_admin_pat)
 
-    # Create project
-    PROJECT_ID=$(create_project "$PAT")
+    # Create project (returns "projectId:orgId")
+    local project_result
+    project_result=$(create_project "$PAT")
+    PROJECT_ID="${project_result%%:*}"
+    ORG_ID="${project_result#*:}"
 
     # Create roles
     echo
@@ -580,7 +587,7 @@ main() {
     echo
     SERVICE_ACCOUNT_ID=$(create_test_service_account "$PAT" "$PROJECT_ID")
     assign_project_role "$PAT" "$PROJECT_ID" "$SERVICE_ACCOUNT_ID" "admin"
-    assign_org_role "$PAT" "$SERVICE_ACCOUNT_ID" "ORG_OWNER"
+    assign_org_role "$PAT" "$SERVICE_ACCOUNT_ID" "$ORG_ID" "ORG_OWNER"
     SERVICE_KEY_FILE=$(generate_service_account_key "$PAT" "$SERVICE_ACCOUNT_ID")
     SERVICE_ACCOUNT_PAT=$(create_service_account_pat "$PAT" "$SERVICE_ACCOUNT_ID")
 

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -596,6 +596,15 @@ main() {
                 # Only the API needs a machine token for Management API calls
                 if [ "$label" = "API" ]; then
                     update_env_file "$target" "ZITADEL_MACHINE_TOKEN" "$SERVICE_ACCOUNT_PAT"
+                else
+                    # Remove stale ZITADEL_MACHINE_TOKEN from non-API env files
+                    if grep -q "^ZITADEL_MACHINE_TOKEN=" "$target" 2>/dev/null; then
+                        if [[ "$OSTYPE" == "darwin"* ]]; then
+                            sed -i '' '/^ZITADEL_MACHINE_TOKEN=/d' "$target"
+                        else
+                            sed -i '/^ZITADEL_MACHINE_TOKEN=/d' "$target"
+                        fi
+                    fi
                 fi
                 echo -e "${GREEN}Updated ${label}: $target${NC}"
             else

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -459,18 +459,18 @@ generate_service_account_key() {
         -H "Authorization: Bearer $pat" \
         -H "Content-Type: application/json" \
         -d "{
-            \"type\": \"KEY_TYPE_JSON\",
             \"expirationDate\": \"2030-01-01T00:00:00Z\"
         }")
 
-    key_details=$(echo "$result" | jq -r '.keyDetails // empty')
+    local key_content
+    key_content=$(echo "$result" | jq -r '.keyContent // empty')
 
-    if [ -n "$key_details" ]; then
+    if [ -n "$key_content" ]; then
         # Decode base64 portably (GNU uses -d, BSD/macOS uses -D)
         if echo "dGVzdA==" | base64 -d >/dev/null 2>&1; then
-            echo "$key_details" | base64 -d > "$key_file"
+            echo "$key_content" | base64 -d > "$key_file"
         elif echo "dGVzdA==" | base64 -D >/dev/null 2>&1; then
-            echo "$key_details" | base64 -D > "$key_file"
+            echo "$key_content" | base64 -D > "$key_file"
         else
             echo -e "${RED}No supported base64 decode option found${NC}" >&2
             exit 1

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -455,7 +455,7 @@ generate_service_account_key() {
         return 0
     fi
 
-    result=$(curl -s -X POST "${ZITADEL_URL}/management/v1/users/${user_id}/keys" \
+    result=$(curl -s -X POST "${ZITADEL_URL}/v2/users/${user_id}/keys" \
         -H "Authorization: Bearer $pat" \
         -H "Content-Type: application/json" \
         -d "{
@@ -484,6 +484,35 @@ generate_service_account_key() {
     fi
 }
 
+# Function to assign an org-level role to a user via the v2 InternalPermissionService
+# Required for Management API access (e.g., user lookups, grant management)
+assign_org_role() {
+    local pat="$1"
+    local user_id="$2"
+    local role="$3"
+
+    echo -e "${YELLOW}Assigning org role '${role}' to user ${user_id}...${NC}" >&2
+
+    local result
+    result=$(curl -s -X POST "${ZITADEL_URL}/zitadel.internal_permission.v2.InternalPermissionService/CreateAdministrator" \
+        -H "Authorization: Bearer $pat" \
+        -H "Content-Type: application/json" \
+        -d "{
+            \"userId\": \"${user_id}\",
+            \"resource\": { \"instance\": true },
+            \"roles\": [\"${role}\"]
+        }")
+
+    if echo "$result" | jq -e '.creationDate' > /dev/null 2>&1; then
+        echo -e "${GREEN}Org role '${role}' assigned successfully${NC}" >&2
+    elif echo "$result" | jq -e '.code == 6' > /dev/null 2>&1; then
+        # ALREADY_EXISTS
+        echo -e "${GREEN}Org role '${role}' already assigned${NC}" >&2
+    else
+        echo -e "${YELLOW}Org role assignment result: ${result}${NC}" >&2
+    fi
+}
+
 # Function to create a personal access token for a service account
 create_service_account_pat() {
     local pat="$1"
@@ -500,7 +529,7 @@ create_service_account_pat() {
     echo -e "${YELLOW}Creating PAT for service account ${user_id}...${NC}" >&2
 
     local result
-    result=$(curl -s -X POST "${ZITADEL_URL}/management/v1/users/${user_id}/pats" \
+    result=$(curl -s -X POST "${ZITADEL_URL}/v2/users/${user_id}/pats" \
         -H "Authorization: Bearer $pat" \
         -H "Content-Type: application/json" \
         -d "{
@@ -551,6 +580,7 @@ main() {
     echo
     SERVICE_ACCOUNT_ID=$(create_test_service_account "$PAT" "$PROJECT_ID")
     assign_project_role "$PAT" "$PROJECT_ID" "$SERVICE_ACCOUNT_ID" "admin"
+    assign_org_role "$PAT" "$SERVICE_ACCOUNT_ID" "ORG_OWNER"
     SERVICE_KEY_FILE=$(generate_service_account_key "$PAT" "$SERVICE_ACCOUNT_ID")
     SERVICE_ACCOUNT_PAT=$(create_service_account_pat "$PAT" "$SERVICE_ACCOUNT_ID")
 

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -488,6 +488,14 @@ generate_service_account_key() {
 create_service_account_pat() {
     local pat="$1"
     local user_id="$2"
+    local pat_file="${PROJECT_DIR}/service-account.pat"
+
+    # Reuse existing PAT file unless --force-secrets is set
+    if [ -f "$pat_file" ] && [ "$FORCE_SECRETS" != "true" ]; then
+        echo -e "${GREEN}PAT file already exists (use --force-secrets to regenerate)${NC}" >&2
+        cat "$pat_file"
+        return 0
+    fi
 
     echo -e "${YELLOW}Creating PAT for service account ${user_id}...${NC}" >&2
 
@@ -503,7 +511,9 @@ create_service_account_pat() {
     token=$(echo "$result" | jq -r '.token // empty')
 
     if [ -n "$token" ]; then
-        echo -e "${GREEN}Service account PAT created${NC}" >&2
+        echo "$token" > "$pat_file"
+        chmod 600 "$pat_file" || { echo -e "${RED}Failed to set permissions on $pat_file${NC}" >&2; exit 1; }
+        echo -e "${GREEN}Service account PAT created and saved to $pat_file${NC}" >&2
         echo "$token"
     else
         echo -e "${RED}Failed to create service account PAT: $result${NC}" >&2


### PR DESCRIPTION
## Summary

- Add `create_service_account_pat()` function that creates a PAT for the test service account via Zitadel's Management API
- Write `ZITADEL_MACHINE_TOKEN` with the service-account PAT **only** to the API project's `.env` file
- Frontend and Tests `.env` files no longer receive a machine token (they don't need Management API access)
- The admin PAT is still used for setup operations but is no longer persisted in any `.env` file

Closes #548

## Test plan

- [ ] Run `./scripts/setup-zitadel.sh --docker-init --update-env` and verify:
  - API `.env` gets `ZITADEL_MACHINE_TOKEN` with the service-account PAT (not admin PAT)
  - Frontend `.env` does NOT contain `ZITADEL_MACHINE_TOKEN`
  - Tests `.env` does NOT contain `ZITADEL_MACHINE_TOKEN`
- [ ] Verify the API can still perform Management API operations (user lookups, role queries) using the service-account PAT
- [ ] Verify `--force-secrets` flag regenerates the PAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional flag to reveal full generated secrets; otherwise tokens are masked.
  * Setup now grants an org-owner role to the created service account and creates or reuses a service-account access token, persisting it locally.
  * Service-account keys/tokens are generated via updated platform APIs.

* **Chores**
  * Initialization prints and uses the service-account token instead of the admin token.
  * .env updates set the machine token only for the API environment and remove tokens from other environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->