### PR TITLE
ci: add Codecov coverage + test-results upload to PHPUnit job

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,7 +11,8 @@ on:
       '.env.example',
       'jsondata/**',
       'i18n/**',
-      'infrastructure/init-db.sql'
+      'infrastructure/init-db.sql',
+      '.github/workflows/phpunit.yml'
     ]
   pull_request:
     branches: [ development, stable ]
@@ -59,6 +60,7 @@ jobs:
           php-version: ${{ env.PHP_VERSION }}
           extensions: yaml, intl, zip, calendar, gettext, apcu, opcache, pdo_pgsql
           ini-values: apcu.enable_cli=1, opcache.enable=1, opcache.enable_cli=1
+          coverage: pcov
 
       - name: Cache Composer dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -126,8 +128,25 @@ jobs:
           echo "Server did not respond on localhost:8000 after $MAX_TRIES seconds."
           exit 1
 
-      - name: Run tests
-        run: time composer test
+      - name: Run tests with coverage and JUnit output
+        run: time composer test:coverage
+
+      - name: Upload coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: Liturgical-Calendar/LiturgicalCalendarAPI
+          files: ./coverage.xml
+          fail_ci_if_error: false
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml
+          fail_ci_if_error: false
 
       - name: Show logs on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,8 @@ infrastructure/*.env
 
 # Local git worktrees
 .worktrees/
+
+# Coverage and test-result artifacts produced by composer test:coverage
+coverage.xml
+junit.xml
+.phpunit.cache/

--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
         "parallel-lint": "parallel-lint --exclude .git --exclude vendor .",
         "test": "phpunit --testdox --display-warnings",
         "test:quick": "phpunit --testdox --display-warnings --exclude-group slow",
+        "test:coverage": "phpunit --display-warnings --coverage-clover coverage.xml --log-junit junit.xml",
         "start": "./start-server.sh",
         "stop": "./stop-server.sh",
         "ws:start": "./ws-start-server.sh",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,4 +10,9 @@
       <directory suffix="Test.php">phpunit_tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory>src</directory>
+    </include>
+  </source>
 </phpunit>


### PR DESCRIPTION
## Summary

- Wire up code coverage reporting via [Codecov](https://about.codecov.io) on the existing `phpunit_tests` job.
- Use `pcov` for coverage measurement (≈10× faster than xdebug, no debugger overhead).
- Restrict coverage scope to `src/` via a `<source>` block in `phpunit.xml.dist`.
- Upload `coverage.xml` (Clover) via `codecov/codecov-action@v5.5.4` and `junit.xml` via `codecov/test-results-action@v1.2.1`, both pinned to commit SHA per repo convention.

## What changed

| File | Change |
|---|---|
| `phpunit.xml.dist` | Add `<source><include><directory>src</directory></include></source>` so coverage is measured against first-party code only |
| `composer.json` | New `test:coverage` script: `phpunit --display-warnings --coverage-clover coverage.xml --log-junit junit.xml`. Existing `test` and `test:quick` are unchanged. |
| `.github/workflows/phpunit.yml` | `coverage: pcov` for setup-php; replace `composer test` with `composer test:coverage`; add Codecov + test-results upload steps gated on `!cancelled()` with `fail_ci_if_error: false`; add the workflow file itself to `paths:` |
| `.gitignore` | Ignore `coverage.xml`, `junit.xml`, `.phpunit.cache/` |

## Required before merge

1. Add `CODECOV_TOKEN` as a repo secret: **Settings → Secrets and variables → Actions → New repository secret**. Generate the token from the Codecov dashboard for this repo.
2. Connect the repo to Codecov ([about.codecov.io](https://about.codecov.io) → connect → select `Liturgical-Calendar/LiturgicalCalendarAPI`).

Without `CODECOV_TOKEN` set, the two upload steps log a warning but the build stays green (`fail_ci_if_error: false`).

## Why pcov over xdebug

- `pcov` is purpose-built for line-coverage and is roughly 10× faster than xdebug for the same workload, with no debugger machinery to load.
- `setup-php`'s `coverage: pcov` parameter handles installation and INI config automatically.

## Test plan

- [ ] Confirm `CODECOV_TOKEN` is set in repo secrets.
- [ ] On the PR, the `phpunit_tests` job still runs the existing test suite (Postgres service container + dev server bring-up + tests).
- [ ] The "Upload coverage to Codecov" step appears in the run and reports a successful upload (or a warning if the token is missing — that's the `fail_ci_if_error: false` path).
- [ ] The "Upload test results to Codecov" step also runs and reports JUnit upload.
- [ ] Codecov dashboard for this repo shows a coverage figure for the PR commit.
- [ ] Verify `composer test` and `composer test:quick` still work locally without coverage overhead (pcov only loads in CI).

## Risks / tradeoffs

- pcov adds a small per-test overhead (~10–30% on coverage runs). If the CI run becomes too slow, the easiest fallback is to add a separate job that runs `composer test:coverage` only on `development` push, while PRs stick to `composer test`.
- This adds two third-party actions (`codecov-action`, `test-results-action`). Both are official Codecov actions, both pinned to SHA, and both have `fail_ci_if_error: false` so a Codecov outage cannot block merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)