### PR TITLE
feat: integrate Doctrine Migrations + fix test rate-limit isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ phpstan.neon
 phpunit.xml
 !phpunit.xml.dist
 /*.php
+!/doctrine-migrations.php
 /*.txt
 /*.js
 *.cache

--- a/bin/doctrine-migrations
+++ b/bin/doctrine-migrations
@@ -1,0 +1,61 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+use Doctrine\DBAL\DriverManager;
+use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
+use Doctrine\Migrations\Configuration\Migration\PhpFile;
+use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Tools\Console\ConsoleRunner;
+use Dotenv\Dotenv;
+
+$projectRoot = dirname(__DIR__);
+
+require_once $projectRoot . '/vendor/autoload.php';
+
+$dotenv = Dotenv::createImmutable(
+    $projectRoot,
+    ['.env', '.env.local', '.env.development', '.env.test', '.env.staging', '.env.production'],
+    false
+);
+$dotenv->safeLoad();
+
+$readEnv = static function (string $key): ?string {
+    $value = $_ENV[$key] ?? $_SERVER[$key] ?? getenv($key);
+    if ($value === false || $value === '') {
+        return null;
+    }
+    return is_string($value) ? $value : (string) $value;
+};
+
+$dbHost     = $readEnv('DB_HOST');
+$dbPort     = $readEnv('DB_PORT') ?? '5432';
+$dbName     = $readEnv('DB_NAME');
+$dbUser     = $readEnv('DB_USER');
+$dbPassword = $readEnv('DB_PASSWORD');
+
+if ($dbHost === null || $dbName === null || $dbUser === null || $dbPassword === null) {
+    fwrite(
+        STDERR,
+        "Database configuration missing. Required environment variables: " .
+        "DB_HOST, DB_NAME, DB_USER, DB_PASSWORD\n"
+    );
+    exit(1);
+}
+
+$connection = DriverManager::getConnection([
+    'driver'   => 'pdo_pgsql',
+    'host'     => $dbHost,
+    'port'     => (int) $dbPort,
+    'dbname'   => $dbName,
+    'user'     => $dbUser,
+    'password' => $dbPassword,
+]);
+
+$dependencyFactory = DependencyFactory::fromConnection(
+    new PhpFile($projectRoot . '/doctrine-migrations.php'),
+    new ExistingConnection($connection)
+);
+
+ConsoleRunner::run([], $dependencyFactory);

--- a/bin/doctrine-migrations
+++ b/bin/doctrine-migrations
@@ -44,10 +44,19 @@ if ($dbHost === null || $dbName === null || $dbUser === null || $dbPassword === 
     exit(1);
 }
 
+if (!ctype_digit($dbPort) || (int) $dbPort < 1 || (int) $dbPort > 65535) {
+    fwrite(
+        STDERR,
+        "Invalid DB_PORT '{$dbPort}': must be an integer between 1 and 65535.\n"
+    );
+    exit(1);
+}
+$dbPortInt = (int) $dbPort;
+
 $connection = DriverManager::getConnection([
     'driver'   => 'pdo_pgsql',
     'host'     => $dbHost,
-    'port'     => (int) $dbPort,
+    'port'     => $dbPortInt,
     'dbname'   => $dbName,
     'user'     => $dbUser,
     'password' => $dbPassword,

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,9 @@
         "firebase/php-jwt": "^6.11 || ^7.0",
         "symfony/cache": "^8.0",
         "plesk/ratchetphp": "^1.0",
-        "symfony/yaml": "^8.0"
+        "symfony/yaml": "^8.0",
+        "doctrine/dbal": "^4.4",
+        "doctrine/migrations": "^3.9"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^4.0",
@@ -86,7 +88,12 @@
         "start": "./start-server.sh",
         "stop": "./stop-server.sh",
         "ws:start": "./ws-start-server.sh",
-        "ws:stop": "./ws-stop-server.sh"
+        "ws:stop": "./ws-stop-server.sh",
+        "db:migrate": "@php bin/doctrine-migrations migrate --no-interaction",
+        "db:migrations:status": "@php bin/doctrine-migrations status",
+        "db:migrations:generate": "@php bin/doctrine-migrations generate",
+        "db:migrations:sync": "@php bin/doctrine-migrations sync-metadata-storage",
+        "db:migrations:mark-applied": "@php bin/doctrine-migrations version --add --all --no-interaction"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,356 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c9b8d3716420d758217dcd3ad5ec185",
+    "content-hash": "284f6b151019a350d2bb0f64a9bd64d4",
     "packages": [
+        {
+            "name": "doctrine/dbal",
+            "version": "4.4.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/dbal.git",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/61e730f1658814821a85f2402c945f3883407dec",
+                "reference": "61e730f1658814821a85f2402c945f3883407dec",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1.5",
+                "php": "^8.2",
+                "psr/cache": "^1|^2|^3",
+                "psr/log": "^1|^2|^3"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "14.0.0",
+                "fig/log-test": "^1",
+                "jetbrains/phpstorm-stubs": "2023.2",
+                "phpstan/phpstan": "2.1.30",
+                "phpstan/phpstan-phpunit": "2.0.7",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "11.5.50",
+                "slevomat/coding-standard": "8.27.1",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "symfony/cache": "^6.3.8|^7.0|^8.0",
+                "symfony/console": "^5.4|^6.3|^7.0|^8.0"
+            },
+            "suggest": {
+                "symfony/console": "For helpful console commands such as SQL execution and import of files."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\DBAL\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                }
+            ],
+            "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+            "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+            "keywords": [
+                "abstraction",
+                "database",
+                "db2",
+                "dbal",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oci8",
+                "oracle",
+                "pdo",
+                "pgsql",
+                "postgresql",
+                "queryobject",
+                "sasql",
+                "sql",
+                "sqlite",
+                "sqlserver",
+                "sqlsrv"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/dbal/issues",
+                "source": "https://github.com/doctrine/dbal/tree/4.4.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-20T08:52:12+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "doctrine/event-manager",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/event-manager.git",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/event-manager/zipball/dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "reference": "dda33921b198841ca8dbad2eaa5d4d34769d18cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "conflict": {
+                "doctrine/common": "<2.9"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "phpdocumentor/guides-cli": "^1.4",
+                "phpstan/phpstan": "^2.1.32",
+                "phpunit/phpunit": "^10.5.58"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                },
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com"
+                }
+            ],
+            "description": "The Doctrine Event Manager is a simple PHP event system that was built to be used with the various Doctrine projects.",
+            "homepage": "https://www.doctrine-project.org/projects/event-manager.html",
+            "keywords": [
+                "event",
+                "event dispatcher",
+                "event manager",
+                "event system",
+                "events"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/event-manager/issues",
+                "source": "https://github.com/doctrine/event-manager/tree/2.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fevent-manager",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-29T07:11:08+00:00"
+        },
+        {
+            "name": "doctrine/migrations",
+            "version": "3.9.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/migrations.git",
+                "reference": "96cb2a89b56c9efb0bac38e606dc0b0f13e650ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/96cb2a89b56c9efb0bac38e606dc0b0f13e650ec",
+                "reference": "96cb2a89b56c9efb0bac38e606dc0b0f13e650ec",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2",
+                "doctrine/dbal": "^3.6 || ^4",
+                "doctrine/deprecations": "^0.5.3 || ^1",
+                "doctrine/event-manager": "^1.2 || ^2.0",
+                "php": "^8.1",
+                "psr/log": "^1.1.3 || ^2 || ^3",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/var-exporter": "^6.2 || ^7.0 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/orm": "<2.12 || >=4"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14",
+                "doctrine/orm": "^2.13 || ^3",
+                "doctrine/persistence": "^2 || ^3 || ^4",
+                "doctrine/sql-formatter": "^1.0",
+                "ext-pdo_sqlite": "*",
+                "fig/log-test": "^1",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-phpunit": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpstan/phpstan-symfony": "^2",
+                "phpunit/phpunit": "^10.3 || ^11.0 || ^12.0",
+                "symfony/cache": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/process": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "doctrine/sql-formatter": "Allows to generate formatted SQL with the diff command.",
+                "symfony/yaml": "Allows the use of yaml for migration configuration files."
+            },
+            "bin": [
+                "bin/doctrine-migrations"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Migrations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Michael Simonson",
+                    "email": "contact@mikesimonson.com"
+                }
+            ],
+            "description": "PHP Doctrine Migrations project offer additional functionality on top of the database abstraction layer (DBAL) for versioning your database schema and easily deploying changes to it. It is a very easy to use and a powerful tool.",
+            "homepage": "https://www.doctrine-project.org/projects/migrations.html",
+            "keywords": [
+                "database",
+                "dbal",
+                "migrations"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/migrations/issues",
+                "source": "https://github.com/doctrine/migrations/tree/3.9.7"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fmigrations",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-23T19:33:20+00:00"
+        },
         {
             "name": "evenement/evenement",
             "version": "v3.0.2",
@@ -2633,6 +2981,96 @@
             "time": "2025-03-13T15:25:07+00:00"
         },
         {
+            "name": "symfony/console",
+            "version": "v8.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/7113778e2e91f4709cb3194a75dfa9c0d028d94d",
+                "reference": "7113778e2e91f4709cb3194a75dfa9c0d028d94d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/string": "^7.4|^8.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0|2.0|3.0"
+            },
+            "require-dev": {
+                "psr/log": "^1|^2|^3",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Eases the creation of beautiful and testable command line interfaces",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cli",
+                "command-line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v8.0.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-29T15:02:55+00:00"
+        },
+        {
             "name": "symfony/deprecation-contracts",
             "version": "v3.6.0",
             "source": {
@@ -2843,6 +3281,173 @@
             ],
             "support": {
                 "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-grapheme",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "reference": "4864388bfbd3001ce88e234fab652acd91fdc57e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's grapheme_* functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "grapheme",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.37.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-04-26T13:13:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.37.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
+                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -3204,6 +3809,162 @@
                 }
             ],
             "time": "2025-07-15T11:30:57+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides a way to profile code",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/stopwatch/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
+        },
+        {
+            "name": "symfony/string",
+            "version": "v8.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/string.git",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/string/zipball/ae9488f874d7603f9d2dfbf120203882b645d963",
+                "reference": "ae9488f874d7603f9d2dfbf120203882b645d963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "symfony/translation-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "Resources/functions.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\String\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "grapheme",
+                "i18n",
+                "string",
+                "unicode",
+                "utf-8",
+                "utf8"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v8.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/var-exporter",
@@ -5764,5 +6525,5 @@
         "ext-zip": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/doctrine-migrations.php
+++ b/doctrine-migrations.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'table_storage'           => [
+        'table_name'                 => 'doctrine_migration_versions',
+        'version_column_name'        => 'version',
+        'version_column_length'      => 191,
+        'executed_at_column_name'    => 'executed_at',
+        'execution_time_column_name' => 'execution_time',
+    ],
+    'migrations_paths'        => [
+        'LiturgicalCalendar\\Api\\Migrations' => __DIR__ . '/src/Migrations',
+    ],
+    'all_or_nothing'          => true,
+    'transactional'           => true,
+    'check_database_platform' => true,
+    'organize_migrations'     => 'none',
+];

--- a/phpunit_tests/ApiTestCase.php
+++ b/phpunit_tests/ApiTestCase.php
@@ -36,7 +36,13 @@ abstract class ApiTestCase extends TestCase
         // so a saturated previous run doesn't carry over within the limiter's
         // window. Honoured only when APP_ENV is dev/test (see
         // ApiKeyRateLimitMiddleware::getClientIp()).
-        self::$currentTestIp = '192.0.2.' . ( ( abs(crc32(static::class . '|' . getmypid())) % 254 ) + 1 );
+        //
+        // Octet range 200-254 is reserved for per-class IPs to keep three
+        // disjoint subranges within 192.0.2.0/24:
+        //   1-99    : per-method IPs (LoginRateLimitTest)
+        //   100-199 : bucket-rotation (CalendarTest::testGetCalendarSampleAllCalendars)
+        //   200-254 : per-class default (here)
+        self::$currentTestIp = '192.0.2.' . ( ( abs(crc32(static::class . '|' . getmypid())) % 55 ) + 200 );
 
         // Create a shared CurlMultiHandler that will persist connections
         self::$multiHandler = new CurlMultiHandler(['max_handles' => 50]); // pool size; tune as needed
@@ -206,7 +212,12 @@ abstract class ApiTestCase extends TestCase
      */
     protected static function hostRegex(): string
     {
-        $host             = $_ENV['API_HOST'] ?? '';
+        $host = $_ENV['API_HOST'] ?? '';
+        // Strip IPv6 brackets so '[::1]' matches the '::1' alias (same
+        // normalization isIPAddress() applies).
+        if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
+            $host = substr($host, 1, -1);
+        }
         $localhostAliases = ['localhost', '127.0.0.1', '0.0.0.0', '::1'];
         if (in_array($host, $localhostAliases, true)) {
             return '(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])';

--- a/phpunit_tests/ApiTestCase.php
+++ b/phpunit_tests/ApiTestCase.php
@@ -7,6 +7,8 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Handler\CurlMultiHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use Psr\Http\Message\RequestInterface;
 
 abstract class ApiTestCase extends TestCase
 {
@@ -23,13 +25,34 @@ abstract class ApiTestCase extends TestCase
     private static string $responseBody       = '';
     private static bool $preferV4             = true; // default to IPv4 unless detected otherwise
     private static string $addr               = '';
+    protected static string $currentTestIp    = '192.0.2.1';
 
     public static function setUpBeforeClass(): void
     {
+        // Per-class synthetic client IP (RFC 5737 TEST-NET-1). Each test class
+        // gets its own rate-limit budget so the full suite never saturates a
+        // single IP, and the host's natural IP is never used at all. Mixing in
+        // getmypid() keeps consecutive `composer test` runs on different IPs,
+        // so a saturated previous run doesn't carry over within the limiter's
+        // window. Honoured only when APP_ENV is dev/test (see
+        // ApiKeyRateLimitMiddleware::getClientIp()).
+        self::$currentTestIp = '192.0.2.' . ( ( abs(crc32(static::class . '|' . getmypid())) % 254 ) + 1 );
+
         // Create a shared CurlMultiHandler that will persist connections
         self::$multiHandler = new CurlMultiHandler(['max_handles' => 50]); // pool size; tune as needed
 
         $stack = HandlerStack::create(self::$multiHandler);
+        // Inject the per-class X-Forwarded-For on every outgoing request unless
+        // the test has already set one (LoginRateLimitTest sets a per-method IP
+        // for budget-isolation purposes).
+        // Reads $currentTestIp at call time so subsequent setUpBeforeClass
+        // invocations (one per test class) flip the value cleanly.
+        $stack->push(Middleware::mapRequest(static function (RequestInterface $request): RequestInterface {
+            if ($request->hasHeader('X-Forwarded-For')) {
+                return $request;
+            }
+            return $request->withHeader('X-Forwarded-For', ApiTestCase::$currentTestIp);
+        }));
 
         // Validate required environment variables
         $requiredEnvVars = ['API_PROTOCOL', 'API_HOST', 'API_PORT'];
@@ -166,6 +189,30 @@ abstract class ApiTestCase extends TestCase
         }
 
         return filter_var($host, FILTER_VALIDATE_IP) !== false;
+    }
+
+    /**
+     * Regex fragment matching the configured API_HOST plus equivalent
+     * localhost forms the dev server may report.
+     *
+     * Why: the PHP built-in server, Docker port forwarding, and curl can
+     * each surface a different localhost variant in URLs even though they
+     * all reach the same process. A test that hardcodes only `localhost`
+     * fails when the server's $_SERVER['SERVER_NAME'] resolves to
+     * `0.0.0.0` (e.g. when bound to all interfaces inside a container).
+     *
+     * Returns a fragment with no surrounding delimiters, ready to embed
+     * in a larger pattern via sprintf.
+     */
+    protected static function hostRegex(): string
+    {
+        $host             = $_ENV['API_HOST'] ?? '';
+        $localhostAliases = ['localhost', '127.0.0.1', '0.0.0.0', '::1'];
+        if (in_array($host, $localhostAliases, true)) {
+            return '(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])';
+        }
+
+        return preg_quote($host, '/');
     }
 
     private static function detectBinding(int $port): array

--- a/phpunit_tests/Http/ApiKeyRateLimitMiddlewareTest.php
+++ b/phpunit_tests/Http/ApiKeyRateLimitMiddlewareTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http;
+
+use LiturgicalCalendar\Api\Http\Exception\TooManyRequestsException;
+use LiturgicalCalendar\Api\Http\Middleware\ApiKeyRateLimitMiddleware;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Unit tests for ApiKeyRateLimitMiddleware client-IP resolution.
+ *
+ * Exercises getClientIp() through process() to cover the env-read branch
+ * that distinguishes dev/test (proxy headers honoured) from production
+ * (REMOTE_ADDR only, unless trustProxyHeaders is explicitly set).
+ */
+final class ApiKeyRateLimitMiddlewareTest extends TestCase
+{
+    private string $storagePath = '';
+
+    /** @var array<string, string> */
+    private array $envBackup = [];
+
+    private RequestHandlerInterface $okHandler;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->storagePath = sys_get_temp_dir() . DIRECTORY_SEPARATOR
+            . 'litcal_test_rl_' . bin2hex(random_bytes(6));
+
+        $this->envBackup = [
+            'APP_ENV_env'    => $_ENV['APP_ENV']    ?? '__UNSET__',
+            'APP_ENV_getenv' => getenv('APP_ENV') === false ? '__UNSET__' : (string) getenv('APP_ENV'),
+        ];
+
+        $this->okHandler = new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(200);
+            }
+        };
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->envBackup['APP_ENV_env'] === '__UNSET__') {
+            unset($_ENV['APP_ENV']);
+        } else {
+            $_ENV['APP_ENV'] = $this->envBackup['APP_ENV_env'];
+        }
+        if ($this->envBackup['APP_ENV_getenv'] === '__UNSET__') {
+            putenv('APP_ENV');
+        } else {
+            putenv('APP_ENV=' . $this->envBackup['APP_ENV_getenv']);
+        }
+
+        // Cleanup is constrained to the sandbox directory created in setUp().
+        // realpath() canonicalizes both sides so symlinks/.. tricks can't
+        // escape the sandbox even if the rate-limiter ever wrote unusual paths.
+        $sandboxReal = realpath($this->storagePath);
+        if ($sandboxReal !== false && is_dir($sandboxReal)) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($sandboxReal, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+            foreach ($iterator as $entry) {
+                /** @var \SplFileInfo $entry */
+                $entryReal = realpath($entry->getPathname());
+                if ($entryReal === false || !str_starts_with($entryReal, $sandboxReal . DIRECTORY_SEPARATOR)) {
+                    continue;
+                }
+                if ($entry->isDir()) {
+                    @rmdir($entryReal);
+                } elseif ($entry->isFile()) {
+                    @unlink($entryReal);
+                }
+            }
+            @rmdir($sandboxReal);
+        }
+
+        parent::tearDown();
+    }
+
+    private function makeRequest(string $forwardedFor, string $remoteAddr = '203.0.113.1'): ServerRequestInterface
+    {
+        return new ServerRequest(
+            'GET',
+            '/calendar',
+            ['X-Forwarded-For' => $forwardedFor],
+            null,
+            '1.1',
+            ['REMOTE_ADDR' => $remoteAddr]
+        );
+    }
+
+    public function testAppEnvTestHonoursForwardedForAndIsolatesPerIp(): void
+    {
+        $_ENV['APP_ENV'] = 'test';
+        putenv('APP_ENV=test');
+
+        $limit      = 3;
+        $middleware = new ApiKeyRateLimitMiddleware($limit, $this->storagePath, false);
+
+        // Saturate the IP 198.51.100.7 budget exactly.
+        for ($i = 0; $i < $limit; $i++) {
+            $response = $middleware->process($this->makeRequest('198.51.100.7'), $this->okHandler);
+            $this->assertSame(200, $response->getStatusCode());
+        }
+
+        // A different X-Forwarded-For must have its own untouched budget,
+        // proving the middleware keyed on the forwarded value (not REMOTE_ADDR).
+        $other = $middleware->process($this->makeRequest('198.51.100.99'), $this->okHandler);
+        $this->assertSame(200, $other->getStatusCode());
+        $this->assertSame((string) ( $limit - 1 ), $other->getHeaderLine('X-RateLimit-Remaining'));
+
+        // The original IP is now over-limit and must throw.
+        $this->expectException(TooManyRequestsException::class);
+        $middleware->process($this->makeRequest('198.51.100.7'), $this->okHandler);
+    }
+
+    public function testAppEnvProductionIgnoresForwardedForWithoutTrustProxy(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        putenv('APP_ENV=production');
+
+        $limit      = 2;
+        $middleware = new ApiKeyRateLimitMiddleware($limit, $this->storagePath, false);
+
+        // Two requests from different X-Forwarded-For values but the same
+        // REMOTE_ADDR. With proxy headers untrusted, both must count against
+        // the REMOTE_ADDR bucket and exhaust the limit.
+        $r1 = $middleware->process($this->makeRequest('198.51.100.10', '203.0.113.50'), $this->okHandler);
+        $r2 = $middleware->process($this->makeRequest('198.51.100.20', '203.0.113.50'), $this->okHandler);
+        $this->assertSame(200, $r1->getStatusCode());
+        $this->assertSame(200, $r2->getStatusCode());
+
+        $this->expectException(TooManyRequestsException::class);
+        $middleware->process($this->makeRequest('198.51.100.30', '203.0.113.50'), $this->okHandler);
+    }
+
+    public function testEnvFallbackFromGetenvWhenSuperglobalUnset(): void
+    {
+        // Simulate a runtime where $_ENV doesn't carry APP_ENV (e.g. PHP-FPM
+        // with restrictive variables_order) but getenv() does — the new
+        // getenv() ?: ($_ENV[...] ?? '') read must still detect dev/test.
+        unset($_ENV['APP_ENV']);
+        putenv('APP_ENV=test');
+
+        $limit      = 2;
+        $middleware = new ApiKeyRateLimitMiddleware($limit, $this->storagePath, false);
+
+        $r1 = $middleware->process($this->makeRequest('198.51.100.40'), $this->okHandler);
+        $r2 = $middleware->process($this->makeRequest('198.51.100.40'), $this->okHandler);
+        $this->assertSame(200, $r1->getStatusCode());
+        $this->assertSame(200, $r2->getStatusCode());
+
+        // If getenv() weren't consulted, APP_ENV would resolve to '' (production-
+        // like) and the per-IP forwarded address would be ignored, so requests
+        // from the same REMOTE_ADDR would exhaust together. The test asserts
+        // the X-Forwarded-For path is taken: a different forwarded IP gets a
+        // fresh budget.
+        $other = $middleware->process($this->makeRequest('198.51.100.41'), $this->okHandler);
+        $this->assertSame(200, $other->getStatusCode());
+        $this->assertSame((string) ( $limit - 1 ), $other->getHeaderLine('X-RateLimit-Remaining'));
+    }
+
+    public function testTrustProxyHeadersOverridesProductionEnv(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        putenv('APP_ENV=production');
+
+        $limit      = 2;
+        $middleware = new ApiKeyRateLimitMiddleware($limit, $this->storagePath, true);
+
+        // trustProxyHeaders=true must honour X-Forwarded-For even outside
+        // dev/test, so two distinct forwarded IPs each get their own budget.
+        $a = $middleware->process($this->makeRequest('198.51.100.50', '203.0.113.99'), $this->okHandler);
+        $b = $middleware->process($this->makeRequest('198.51.100.51', '203.0.113.99'), $this->okHandler);
+        $this->assertSame((string) ( $limit - 1 ), $a->getHeaderLine('X-RateLimit-Remaining'));
+        $this->assertSame((string) ( $limit - 1 ), $b->getHeaderLine('X-RateLimit-Remaining'));
+    }
+}

--- a/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
+++ b/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
@@ -23,11 +23,15 @@ class LoginRateLimitTest extends ApiTestCase
      * across full-suite reruns within the 15-minute window, or between the host
      * test runner and a containerized API. The earlier reset-by-filesystem-delete
      * approach didn't work in containerized setups.
+     *
+     * Octet range 1-99 is reserved for per-method IPs so they never collide
+     * with CalendarTest's bucket-rotation range (100-199) or ApiTestCase's
+     * per-class range (200-254).
      */
     protected function setUp(): void
     {
         parent::setUp();
-        $this->testIp = '192.0.2.' . ( ( abs(crc32($this->name())) % 254 ) + 1 );
+        $this->testIp = '192.0.2.' . ( ( abs(crc32($this->name())) % 99 ) + 1 );
     }
 
     /**

--- a/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
+++ b/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
@@ -3,100 +3,46 @@
 namespace LiturgicalCalendar\Tests\Routes\Auth;
 
 use LiturgicalCalendar\Tests\ApiTestCase;
+use PHPUnit\Framework\Attributes\Group;
 
 /**
  * Integration tests for login endpoint rate limiting
  *
  * These tests verify that the /auth/login endpoint properly enforces rate limiting
  * to protect against brute-force attacks.
- *
- * Note: These tests are marked @group slow because they make multiple HTTP requests
- * and may take longer to complete.
- *
- * @group slow
  */
+#[Group('slow')]
 class LoginRateLimitTest extends ApiTestCase
 {
+    private string $testIp = '';
+
     /**
-     * Clear rate limit state before each test.
-     *
-     * This ensures that rate limit state doesn't carry over from previous tests.
+     * Each test method gets its own synthetic client IP from RFC 5737 TEST-NET-1
+     * (192.0.2.0/24). The login rate limiter keys on client IP, so per-method
+     * isolation gives every test a fresh budget — no shared state across tests,
+     * across full-suite reruns within the 15-minute window, or between the host
+     * test runner and a containerized API. The earlier reset-by-filesystem-delete
+     * approach didn't work in containerized setups.
      */
     protected function setUp(): void
     {
         parent::setUp();
-        $this->resetRateLimitState();
+        $this->testIp = '192.0.2.' . ( ( abs(crc32($this->name())) % 254 ) + 1 );
     }
 
     /**
-     * Reset rate limit state by clearing files and attempting successful login.
+     * Headers for /auth/login requests, including the per-test X-Forwarded-For
+     * that ClientIpTrait::getClientIp() honours.
      *
-     * We attempt to clear files directly first (works when test process shares
-     * filesystem with API), then fall back to successful login approach for
-     * environments where the API runs in a container with different filesystem.
+     * @return array<string, string>
      */
-    private function resetRateLimitState(): void
+    private function loginHeaders(): array
     {
-        // Clear rate limit files directly (works in local dev)
-        $this->clearRateLimitFiles();
-
-        // Also attempt a successful login as a fallback for containerized environments
-        // where we may not have filesystem access to the API's rate limit storage
-        $response = self::$http->post('/auth/login', [
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Accept'       => 'application/json'
-            ],
-            'json'    => [
-                'username' => $_ENV['ADMIN_USERNAME'] ?? 'admin',
-                'password' => $_ENV['ADMIN_PASSWORD'] ?? 'password'
-            ]
-        ]);
-
-        if ($response->getStatusCode() !== 200) {
-            $this->fail(
-                'Admin login in resetRateLimitState() failed with status ' .
-                $response->getStatusCode() . '. Check ADMIN_USERNAME/ADMIN_PASSWORD configuration.'
-            );
-        }
-    }
-
-    /**
-     * Clear all rate limit files from the storage directory.
-     *
-     * This is a best-effort operation that silently fails if the directory
-     * doesn't exist or files can't be deleted (e.g., in containerized CI
-     * environments where the API has a different filesystem).
-     */
-    private function clearRateLimitFiles(): void
-    {
-        // Get the storage path (default is system temp dir)
-        $storagePath  = $_ENV['RATE_LIMIT_STORAGE_PATH'] ?? sys_get_temp_dir();
-        $rateLimitDir = rtrim($storagePath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . 'litcal_rate_limits';
-
-        if (!is_dir($rateLimitDir)) {
-            return;
-        }
-
-        $files = glob($rateLimitDir . DIRECTORY_SEPARATOR . '*.json');
-        if ($files === false) {
-            return;
-        }
-
-        foreach ($files as $file) {
-            @unlink($file);
-            // Also remove corresponding lock file
-            $lockFile = str_replace('.json', '.lock', $file);
-            @unlink($lockFile);
-        }
-
-        // Clean up any orphaned lock files
-        $lockFiles = glob($rateLimitDir . DIRECTORY_SEPARATOR . '*.lock');
-        if ($lockFiles !== false) {
-            foreach ($lockFiles as $lockFile) {
-                @unlink($lockFile);
-            }
-        }
+        return [
+            'X-Forwarded-For' => $this->testIp,
+            'Content-Type'    => 'application/json',
+            'Accept'          => 'application/json',
+        ];
     }
 
     /**
@@ -110,10 +56,7 @@ class LoginRateLimitTest extends ApiTestCase
 
         for ($i = 0; $i < $maxAttempts; $i++) {
             $response = self::$http->post('/auth/login', [
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                    'Accept'       => 'application/json'
-                ],
+                'headers' => $this->loginHeaders(),
                 'json'    => [
                     'username' => 'admin',
                     'password' => 'wrong-' . uniqid()
@@ -129,10 +72,7 @@ class LoginRateLimitTest extends ApiTestCase
 
         // Return the rate-limited response
         return self::$http->post('/auth/login', [
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Accept'       => 'application/json'
-            ],
+            'headers' => $this->loginHeaders(),
             'json'    => [
                 'username' => 'admin',
                 'password' => 'wrong-final'
@@ -148,10 +88,7 @@ class LoginRateLimitTest extends ApiTestCase
     public function testLoginFailsWithInvalidCredentials(): void
     {
         $response = self::$http->post('/auth/login', [
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Accept'       => 'application/json'
-            ],
+            'headers' => $this->loginHeaders(),
             'json'    => [
                 'username' => 'admin',
                 'password' => 'wrong-password-' . uniqid()
@@ -179,10 +116,7 @@ class LoginRateLimitTest extends ApiTestCase
         // Make failed login attempts up to the limit
         for ($i = 0; $i < $maxAttempts; $i++) {
             $response = self::$http->post('/auth/login', [
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                    'Accept'       => 'application/json'
-                ],
+                'headers' => $this->loginHeaders(),
                 'json'    => [
                     'username' => 'admin',
                     'password' => 'wrong-password-attempt-' . $i
@@ -199,10 +133,7 @@ class LoginRateLimitTest extends ApiTestCase
 
         // The next attempt should be rate limited (429)
         $response = self::$http->post('/auth/login', [
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Accept'       => 'application/json'
-            ],
+            'headers' => $this->loginHeaders(),
             'json'    => [
                 'username' => 'admin',
                 'password' => 'wrong-password-final'
@@ -271,10 +202,7 @@ class LoginRateLimitTest extends ApiTestCase
         $failedAttempts = max(1, $maxAttempts - 2);
         for ($i = 0; $i < $failedAttempts; $i++) {
             $response = self::$http->post('/auth/login', [
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                    'Accept'       => 'application/json'
-                ],
+                'headers' => $this->loginHeaders(),
                 'json'    => [
                     'username' => 'admin',
                     'password' => 'wrong-password-clear-test-' . $i
@@ -285,10 +213,7 @@ class LoginRateLimitTest extends ApiTestCase
 
         // Now login successfully
         $response = self::$http->post('/auth/login', [
-            'headers' => [
-                'Content-Type' => 'application/json',
-                'Accept'       => 'application/json'
-            ],
+            'headers' => $this->loginHeaders(),
             'json'    => [
                 'username' => $_ENV['ADMIN_USERNAME'] ?? 'admin',
                 'password' => $_ENV['ADMIN_PASSWORD'] ?? 'password'
@@ -305,10 +230,7 @@ class LoginRateLimitTest extends ApiTestCase
         // Make the same number of failed attempts as before
         for ($i = 0; $i < $failedAttempts; $i++) {
             $response = self::$http->post('/auth/login', [
-                'headers' => [
-                    'Content-Type' => 'application/json',
-                    'Accept'       => 'application/json'
-                ],
+                'headers' => $this->loginHeaders(),
                 'json'    => [
                     'username' => 'admin',
                     'password' => 'wrong-password-after-clear-' . $i
@@ -340,16 +262,5 @@ class LoginRateLimitTest extends ApiTestCase
             $contentType,
             'Rate limit response should use application/problem+json content type'
         );
-    }
-
-    /**
-     * Clean up rate limit data after each test.
-     *
-     * This ensures that rate limit state doesn't carry over to other test classes.
-     */
-    protected function tearDown(): void
-    {
-        $this->resetRateLimitState();
-        parent::tearDown();
     }
 }

--- a/phpunit_tests/Routes/Readonly/CalendarTest.php
+++ b/phpunit_tests/Routes/Readonly/CalendarTest.php
@@ -149,7 +149,7 @@ final class CalendarTest extends ApiTestCase
                     // a single IP's unauthenticated budget. 192.0.2.100-199 are reserved
                     // here for this bucket-rotation; ApiTestCase's per-class default is
                     // skipped because we're setting the header explicitly.
-                    $bucketIp = '192.0.2.' . ( 100 + ( (int) ( $idx / 500 ) ) % 100 );
+                    $bucketIp = '192.0.2.' . ( 100 + intdiv($idx, 500) % 100 );
                     yield self::$http
                         ->getAsync($request['uri'], [
                             'http_errors' => false,

--- a/phpunit_tests/Routes/Readonly/CalendarTest.php
+++ b/phpunit_tests/Routes/Readonly/CalendarTest.php
@@ -144,9 +144,16 @@ final class CalendarTest extends ApiTestCase
         $each = new EachPromise(
             ( function () use ($requests, &$responses, &$errors) {
                 foreach ($requests as $idx => $request) {
+                    // Rotate X-Forwarded-For every 500 requests. This test spans 80 years
+                    // × every national + diocesan calendar — easily 1000+ calls, more than
+                    // a single IP's unauthenticated budget. 192.0.2.100-199 are reserved
+                    // here for this bucket-rotation; ApiTestCase's per-class default is
+                    // skipped because we're setting the header explicitly.
+                    $bucketIp = '192.0.2.' . ( 100 + ( (int) ( $idx / 500 ) ) % 100 );
                     yield self::$http
                         ->getAsync($request['uri'], [
-                            'http_errors' => false
+                            'http_errors' => false,
+                            'headers'     => [ 'X-Forwarded-For' => $bucketIp ],
                         ])
                         ->then(
                             function (ResponseInterface $response) use ($idx, $request, &$responses) {

--- a/phpunit_tests/Routes/Readonly/CalendarsTest.php
+++ b/phpunit_tests/Routes/Readonly/CalendarsTest.php
@@ -356,8 +356,8 @@ final class CalendarsTest extends ApiTestCase
 
             self::$WIDER_REGION_API_PATH_PATTERN = sprintf(
                 '/^%s:\/\/%s:%d\/data\/widerregion\/(Europe|Africa|Asia|Oceania|Americas)\?locale=\{locale\}$/',
-                $_ENV['API_PROTOCOL'],
-                $_ENV['API_HOST'],
+                preg_quote($_ENV['API_PROTOCOL'], '/'),
+                self::hostRegex(),
                 $_ENV['API_PORT']
             );
         }

--- a/phpunit_tests/Routes/Readonly/SchemasTest.php
+++ b/phpunit_tests/Routes/Readonly/SchemasTest.php
@@ -22,8 +22,8 @@ final class SchemasTest extends ApiTestCase
 
         $regex = sprintf(
             '/^%s:\/\/%s:%d\/schemas\/(?:[A-Z][A-Za-z]+|openapi)\.json$/',
-            $_ENV['API_PROTOCOL'],
-            $_ENV['API_HOST'],
+            preg_quote($_ENV['API_PROTOCOL'], '/'),
+            self::hostRegex(),
             $_ENV['API_PORT']
         );
 

--- a/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
+++ b/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
@@ -115,7 +115,15 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
      */
     private function getClientIp(ServerRequestInterface $request): string
     {
-        if ($this->trustProxyHeaders) {
+        // Honour proxy headers when explicitly trusted, or when running in a
+        // local dev/test environment so the test suite can isolate per-class
+        // rate-limit budgets without saturating the host's natural IP.
+        // Production (APP_ENV=staging|production) is unaffected.
+        $appEnv     = $_ENV['APP_ENV'] ?? '';
+        $devOrTest  = is_string($appEnv) && in_array($appEnv, ['development', 'test'], true);
+        $trustProxy = $this->trustProxyHeaders || $devOrTest;
+
+        if ($trustProxy) {
             $headers = ['X-Forwarded-For', 'X-Real-IP'];
             foreach ($headers as $header) {
                 $value = $request->getHeaderLine($header);

--- a/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
+++ b/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
@@ -119,7 +119,10 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
         // local dev/test environment so the test suite can isolate per-class
         // rate-limit budgets without saturating the host's natural IP.
         // Production (APP_ENV=staging|production) is unaffected.
-        $appEnv     = $_ENV['APP_ENV'] ?? '';
+        // Read APP_ENV via getenv() with $_ENV fallback to behave consistently
+        // across CLI, FPM, and container environments (matches the pattern in
+        // fromEnv() above).
+        $appEnv     = getenv('APP_ENV') ?: ( $_ENV['APP_ENV'] ?? '' );
         $devOrTest  = is_string($appEnv) && in_array($appEnv, ['development', 'test'], true);
         $trustProxy = $this->trustProxyHeaders || $devOrTest;
 


### PR DESCRIPTION
## Summary

- Integrates Doctrine DBAL + Migrations as the schema-management tool going forward, closing #546. Adds `bin/doctrine-migrations`, `doctrine-migrations.php`, and five `db:*` composer scripts. `scripts/init-db.sql` remains the v0 baseline; future schema changes layer on top via `src/Migrations/`.
- Fixes the test suite's rate-limit saturation problem. The full suite goes from 37 failures + 1 error to 0 failures.

## Doctrine Migrations (#546)

| Item | Notes |
|------|-------|
| `bin/doctrine-migrations` | Executable CLI entry. Reads `$_ENV`/`$_SERVER` first (then `getenv`) since `Dotenv::createImmutable` doesn't write via `putenv`. |
| `doctrine-migrations.php` | Config: `doctrine_migration_versions` tracking table, `LiturgicalCalendar\Api\Migrations` namespace, `all_or_nothing` + `transactional` enabled. |
| Composer scripts | `db:migrate`, `db:migrations:status`, `db:migrations:generate`, `db:migrations:sync`, `db:migrations:mark-applied` |

### Bootstrap on existing servers

```bash
composer db:migrations:sync
```

This creates the tracking table. `mark-applied --all` is a no-op when zero migration classes exist, so `sync-metadata-storage` is the right command for first-time setup. (Issue #546 has been updated with this clarification.)

## Test rate-limit isolation

Two interacting problems caused 37+1 failures in `composer test`:

1. **`LoginRateLimitTest::resetRateLimitState()` was structurally broken in containerized setups.** Step 1 (delete `/tmp` files) targets the host's `/tmp` while the API container has its own. Step 2 (admin-login fallback) cannot recover from saturation because the rate-limit gate fires before authentication, so the success path can never clear the counter.
2. **`ApiKeyRateLimitMiddleware` rate-limited every test request against a single IP.** With 257 tests + concurrent batched calls in `testGetCalendarSampleAllCalendars`, the host IP exceeded `UNAUTHENTICATED_RATE_LIMIT=1000` per hour and stayed saturated across runs within the 15-minute window.

### Fix

- `ApiKeyRateLimitMiddleware::getClientIp()` honors `X-Forwarded-For` when `APP_ENV ∈ {test, development}` regardless of `TRUST_PROXY_HEADERS`. Production behavior is unchanged.
- `ApiTestCase` injects a per-class synthetic IP from RFC 5737 TEST-NET-1 (`192.0.2.0/24`) via a Guzzle handler-stack middleware. PID is mixed in so consecutive runs land on different IPs. The middleware respects an existing `X-Forwarded-For` so per-method overrides win.
- `LoginRateLimitTest` now uses a per-method IP (`192.0.2.x` derived from test name) and the `#[Group('slow')]` PHP attribute, since PHPUnit 12 silently ignores the PHPDoc `@group` annotation.
- `testGetCalendarSampleAllCalendars` rotates IPs every 500 requests across `192.0.2.100-199` since it spans 80 years × all national + diocesan calendars (>1000 calls).
- `ApiTestCase::hostRegex()` helper returns a regex fragment matching `localhost`, `127.0.0.1`, `0.0.0.0`, `[::1]` when `API_HOST` is a localhost alias, so URL assertions don't break when the dev server's `SERVER_NAME` resolves to `0.0.0.0` (Docker, all-interfaces bind, etc.). Used by `CalendarsTest` and `SchemasTest`.

## Test plan

- [x] `composer parallel-lint` clean
- [x] `composer lint` clean
- [x] `composer analyse` (PHPStan level 10) clean
- [x] `composer test:quick` — 0 failures (down from 24)
- [x] `composer test` (full suite incl. slow) — 0 failures, 0 errors (down from 37+1)
- [x] `composer db:migrations:status` connects to local Postgres, reports 0 migrations
- [x] `composer db:migrations:sync` creates `doctrine_migration_versions` table
- [x] `composer db:migrate` correctly errors when no migration classes exist
- [ ] CI verification (Codecov / GitHub Actions)

## Notes for reviewers

- This PR adds zero migration classes — those land with #573. The migration infrastructure is independently useful (also unblocks #545's automated deployment).
- The `infrastructure/README.md` table at lines ~195-198 still lists `role_requests` and `permission_requests` as separate tables; they were unified into `access_requests` in the OpenFGA work. Worth a follow-up cleanup but out of scope here.
- The `TRUST_PROXY_HEADERS` flag in `ApiKeyRateLimitMiddleware` is still required for production environments using a real reverse proxy. The dev/test concession only applies when `APP_ENV` is explicitly `test` or `development`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database migration commands to the project CLI for managing schema migrations.

* **Chores**
  * Added migration tooling and configuration to project dependencies and config.
  * Ensured migration config file is tracked (no longer ignored).
  * Added a CLI entrypoint to run migrations.
  * Middleware now respects proxy IP headers in development and test environments.

* **Tests**
  * Improved test infrastructure to inject per-test synthetic client IPs and better isolate rate-limit tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/574)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->