### PR TITLE
test(coverage): unit-test src/Params and src/Database (issue #570 M1)

### DIFF
--- a/phpunit_tests/Database/ConnectionTest.php
+++ b/phpunit_tests/Database/ConnectionTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Database;
+
+use LiturgicalCalendar\Api\Database\Connection;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(Connection::class)]
+final class ConnectionTest extends TestCase
+{
+    /** @var array<string,string|false> */
+    private array $savedEnv = [];
+
+    protected function setUp(): void
+    {
+        // Capture existing values so each test starts from a clean,
+        // restorable slate. getenv returns false when unset.
+        foreach (['DB_HOST', 'DB_PORT', 'DB_NAME', 'DB_USER', 'DB_PASSWORD'] as $name) {
+            $this->savedEnv[$name] = getenv($name);
+            putenv($name);
+        }
+        Connection::close();
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->savedEnv as $name => $value) {
+            if ($value === false) {
+                putenv($name);
+            } else {
+                putenv("{$name}={$value}");
+            }
+        }
+        Connection::close();
+    }
+
+    public function testIsConfiguredReturnsFalseWhenEnvUnset(): void
+    {
+        self::assertFalse(Connection::isConfigured());
+    }
+
+    public function testIsConfiguredReturnsFalseWhenAnyRequiredVarMissing(): void
+    {
+        putenv('DB_HOST=db.example.test');
+        putenv('DB_NAME=litcal');
+        putenv('DB_USER=postgres');
+        // DB_PASSWORD intentionally left unset
+
+        self::assertFalse(Connection::isConfigured());
+    }
+
+    public function testIsConfiguredReturnsFalseWhenRequiredVarIsEmpty(): void
+    {
+        putenv('DB_HOST=');
+        putenv('DB_NAME=litcal');
+        putenv('DB_USER=postgres');
+        putenv('DB_PASSWORD=secret');
+
+        self::assertFalse(Connection::isConfigured());
+    }
+
+    public function testIsConfiguredAcceptsEmptyPassword(): void
+    {
+        // Connection only requires that DB_PASSWORD exist as an env var,
+        // an empty string is permitted (some local Postgres setups use trust auth).
+        putenv('DB_HOST=db.example.test');
+        putenv('DB_NAME=litcal');
+        putenv('DB_USER=postgres');
+        putenv('DB_PASSWORD=');
+
+        self::assertTrue(Connection::isConfigured());
+    }
+
+    public function testIsConfiguredReturnsTrueWhenAllRequiredVarsPresent(): void
+    {
+        putenv('DB_HOST=db.example.test');
+        putenv('DB_NAME=litcal');
+        putenv('DB_USER=postgres');
+        putenv('DB_PASSWORD=secret');
+
+        self::assertTrue(Connection::isConfigured());
+    }
+
+    public function testIsInitializedFalseBeforeFirstUse(): void
+    {
+        self::assertFalse(Connection::isInitialized());
+    }
+
+    public function testGetInstanceThrowsWhenConfigurationMissing(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Database configuration missing');
+
+        Connection::getInstance();
+    }
+
+    public function testGetInstanceWrapsPdoExceptionAsRuntimeException(): void
+    {
+        // Point at a host that cannot accept connections so PDO fails fast.
+        // The wrapper should surface the failure as RuntimeException with
+        // the PDO message preserved in the chain.
+        putenv('DB_HOST=127.0.0.1');
+        putenv('DB_PORT=1');
+        putenv('DB_NAME=nonexistent');
+        putenv('DB_USER=nobody');
+        putenv('DB_PASSWORD=none');
+
+        try {
+            Connection::getInstance();
+            self::fail('Expected RuntimeException was not thrown');
+        } catch (RuntimeException $e) {
+            self::assertStringStartsWith('Failed to connect to database', $e->getMessage());
+            self::assertInstanceOf(\PDOException::class, $e->getPrevious());
+            self::assertFalse(
+                Connection::isInitialized(),
+                'A failed connection attempt must not mark the singleton as initialized'
+            );
+        }
+    }
+
+    public function testCloseResetsInitializationFlag(): void
+    {
+        // Manually drive the singleton into an "initialized" state via reflection
+        // because we cannot rely on a live Postgres in unit tests. close() is the
+        // hook tests use to reset state between cases — verify it actually resets.
+        $reflection = new \ReflectionClass(Connection::class);
+        $reflection->setStaticPropertyValue('initialized', true);
+        $reflection->setStaticPropertyValue('instance', null);
+
+        Connection::close();
+
+        self::assertFalse(Connection::isInitialized());
+    }
+
+    public function testWakeupThrowsRuntimeException(): void
+    {
+        // The class is final and uses a private constructor, so we use
+        // reflection to obtain an unserialized instance and invoke __wakeup
+        // explicitly to verify the singleton-protection behaviour.
+        $reflection = new \ReflectionClass(Connection::class);
+        $instance   = $reflection->newInstanceWithoutConstructor();
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Cannot unserialize singleton');
+
+        $instance->__wakeup();
+    }
+}

--- a/phpunit_tests/Params/CalendarParamsTest.php
+++ b/phpunit_tests/Params/CalendarParamsTest.php
@@ -25,8 +25,14 @@ final class CalendarParamsTest extends TestCase
     {
         // Stand in a file:// URL pointing at the bundled metadata fixture so
         // the constructor's HTTP fetch resolves locally and deterministically.
+        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
+        if ($fixturePath === false) {
+            throw new \RuntimeException(
+                'Missing fixture directory: ' . __DIR__ . '/../fixtures/api'
+            );
+        }
         self::$savedApiPath = Router::$apiPath ?? '';
-        Router::$apiPath    = 'file://' . realpath(__DIR__ . '/../fixtures/api');
+        Router::$apiPath    = 'file://' . $fixturePath;
     }
 
     public static function tearDownAfterClass(): void

--- a/phpunit_tests/Params/CalendarParamsTest.php
+++ b/phpunit_tests/Params/CalendarParamsTest.php
@@ -1,0 +1,411 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Params;
+
+use LiturgicalCalendar\Api\Enum\Ascension;
+use LiturgicalCalendar\Api\Enum\CorpusChristi;
+use LiturgicalCalendar\Api\Enum\Epiphany;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\YearType;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CalendarParams::class)]
+final class CalendarParamsTest extends TestCase
+{
+    private static string $savedApiPath = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        // Stand in a file:// URL pointing at the bundled metadata fixture so
+        // the constructor's HTTP fetch resolves locally and deterministically.
+        self::$savedApiPath = Router::$apiPath ?? '';
+        Router::$apiPath    = 'file://' . realpath(__DIR__ . '/../fixtures/api');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath = self::$savedApiPath;
+    }
+
+    public function testConstructorAppliesDefaults(): void
+    {
+        $params = new CalendarParams();
+
+        self::assertSame((int) date('Y'), $params->Year);
+        self::assertSame(LitLocale::LATIN, $params->Locale);
+        self::assertSame(YearType::LITURGICAL, $params->YearType);
+        self::assertSame(Epiphany::JAN6, $params->Epiphany);
+        self::assertSame(Ascension::THURSDAY, $params->Ascension);
+        self::assertSame(CorpusChristi::THURSDAY, $params->CorpusChristi);
+        self::assertNull($params->ReturnType);
+        self::assertNull($params->NationalCalendar);
+        self::assertNull($params->DiocesanCalendar);
+        self::assertFalse($params->EternalHighPriest);
+    }
+
+    public function testEmptyParamsLeavesDefaultsUnchanged(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams([]);
+
+        self::assertSame((int) date('Y'), $params->Year);
+    }
+
+    public function testValidYearAsIntegerIsApplied(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams(['year' => 2030]);
+
+        self::assertSame(2030, $params->Year);
+    }
+
+    public function testValidYearAsFourDigitStringIsApplied(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams(['year' => '2025']);
+
+        self::assertSame(2025, $params->Year);
+    }
+
+    public function testYearStringWithWrongLengthIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('numeric String with 4 digits');
+
+        $params->setParams(['year' => '202']);
+    }
+
+    public function testYearBelowLowerLimitIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('out of bounds');
+
+        $params->setParams(['year' => 1969]);
+    }
+
+    public function testYearAboveUpperLimitIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('out of bounds');
+
+        $params->setParams(['year' => 10000]);
+    }
+
+    public function testEpiphanyAscensionAndCorpusChristiAreApplied(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams([
+            'epiphany'       => 'SUNDAY_JAN2_JAN8',
+            'ascension'      => 'SUNDAY',
+            'corpus_christi' => 'SUNDAY',
+        ]);
+
+        self::assertSame(Epiphany::SUNDAY_JAN2_JAN8, $params->Epiphany);
+        self::assertSame(Ascension::SUNDAY, $params->Ascension);
+        self::assertSame(CorpusChristi::SUNDAY, $params->CorpusChristi);
+    }
+
+    public function testInvalidEpiphanyIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('parameter `epiphany`');
+
+        $params->setParams(['epiphany' => 'NOPE']);
+    }
+
+    public function testInvalidAscensionIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('parameter `ascension`');
+
+        $params->setParams(['ascension' => 'NOPE']);
+    }
+
+    public function testInvalidCorpusChristiIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('parameter `corpus_christi`');
+
+        $params->setParams(['corpus_christi' => 'NOPE']);
+    }
+
+    public function testYearTypeIsApplied(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams(['year_type' => 'CIVIL']);
+
+        self::assertSame(YearType::CIVIL, $params->YearType);
+    }
+
+    public function testInvalidYearTypeIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('parameter `year_type`');
+
+        $params->setParams(['year_type' => 'lunar']);
+    }
+
+    public function testEternalHighPriestAcceptsBoolean(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams(['eternal_high_priest' => true]);
+
+        self::assertTrue($params->EternalHighPriest);
+    }
+
+    public function testEternalHighPriestAcceptsBooleanishString(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams(['eternal_high_priest' => 'true']); // @phpstan-ignore-line
+
+        self::assertTrue($params->EternalHighPriest);
+    }
+
+    public function testEternalHighPriestRejectsGarbage(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('eternal_high_priest');
+
+        $params->setParams(['eternal_high_priest' => 'maybe']); // @phpstan-ignore-line
+    }
+
+    public function testLocaleIsCanonicalisedAndAccepted(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams(['locale' => 'en-us']);
+
+        self::assertSame('en_US', $params->Locale);
+    }
+
+    public function testInvalidLocaleIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('parameter `locale`');
+
+        $params->setParams(['locale' => 'xx_YY']);
+    }
+
+    public function testReturnTypeIsApplied(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams(['return_type' => 'YML']);
+
+        self::assertSame(ReturnTypeParam::YAML, $params->ReturnType);
+    }
+
+    public function testReturnTypeRespectsAllowedSubset(): void
+    {
+        $params = new CalendarParams();
+        $params->setAllowedReturnTypes([ReturnTypeParam::JSON]);
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('parameter `return_type`');
+
+        $params->setParams(['return_type' => 'XML']);
+    }
+
+    public function testNationalCalendarIsAcceptedFromMetadata(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams(['national_calendar' => 'IT']);
+
+        self::assertSame('IT', $params->NationalCalendar);
+    }
+
+    public function testVaticanIsAcceptedAsImplicitNationalCalendar(): void
+    {
+        // 'VA' is the General Roman Calendar — accepted even when not present
+        // in the metadata's national_calendars_keys list.
+        $params = new CalendarParams();
+        $params->setParams(['national_calendar' => 'VA']);
+
+        self::assertSame('VA', $params->NationalCalendar);
+    }
+
+    public function testUnknownNationalCalendarIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('national_calendar');
+
+        $params->setParams(['national_calendar' => 'ZZ']);
+    }
+
+    public function testDiocesanCalendarIsAcceptedFromMetadata(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams(['diocesan_calendar' => 'romamo_it']);
+
+        self::assertSame('romamo_it', $params->DiocesanCalendar);
+    }
+
+    public function testUnknownDiocesanCalendarIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Diocesan calendar');
+
+        $params->setParams(['diocesan_calendar' => 'nowhere']);
+    }
+
+    public function testHolyDaysOfObligationOverride(): void
+    {
+        $params = new CalendarParams();
+        $params->setParams([
+            'holydays_of_obligation' => [
+                'Christmas'            => true,
+                'Epiphany'             => false,
+                'Ascension'            => true,
+                'CorpusChristi'        => true,
+                'MaryMotherOfGod'      => true,
+                'ImmaculateConception' => true,
+                'Assumption'           => true,
+                'StJoseph'             => true,
+                'StsPeterPaulAp'       => true,
+                'AllSaints'            => true,
+            ],
+        ]);
+
+        self::assertFalse($params->HolyDaysOfObligation['Epiphany']);
+        self::assertTrue($params->HolyDaysOfObligation['Christmas']);
+    }
+
+    public function testHolyDaysOfObligationMissingRequiredKeyIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('missing required keys');
+
+        $params->setParams([
+            'holydays_of_obligation' => [
+                'Christmas'            => true,
+                'Epiphany'             => true,
+                'Ascension'            => true,
+                'CorpusChristi'        => true,
+                'MaryMotherOfGod'      => true,
+                'ImmaculateConception' => true,
+                'Assumption'           => true,
+                'StJoseph'             => true,
+                'StsPeterPaulAp'       => true,
+                // AllSaints intentionally missing
+            ],
+        ]);
+    }
+
+    public function testHolyDaysOfObligationUnknownKeyIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid key');
+
+        $params->setParams([
+            'holydays_of_obligation' => [
+                'Christmas'            => true,
+                'Epiphany'             => true,
+                'Ascension'            => true,
+                'CorpusChristi'        => true,
+                'MaryMotherOfGod'      => true,
+                'ImmaculateConception' => true,
+                'Assumption'           => true,
+                'StJoseph'             => true,
+                'StsPeterPaulAp'       => true,
+                'AllSaints'            => true,
+                'NotAHoliday'          => true,
+            ],
+        ]);
+    }
+
+    public function testNonStringValueRejectedForStringParam(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Expected value of type String');
+
+        $params->setParams(['locale' => 123]); // @phpstan-ignore-line
+    }
+
+    public function testInitParamsFromRequestPathYearOnly(): void
+    {
+        $params = new CalendarParams();
+        $params->initParamsFromRequestPath(['2024']);
+
+        self::assertSame(2024, $params->Year);
+    }
+
+    public function testInitParamsFromRequestPathRequiresNumericYear(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Year value');
+
+        $params->initParamsFromRequestPath(['notayear']);
+    }
+
+    public function testInitParamsFromRequestPathNationFormat(): void
+    {
+        $params = new CalendarParams();
+        $params->initParamsFromRequestPath(['nation', 'IT', '2024']);
+
+        self::assertSame('IT', $params->NationalCalendar);
+        self::assertSame(2024, $params->Year);
+    }
+
+    public function testInitParamsFromRequestPathDioceseFormat(): void
+    {
+        $params = new CalendarParams();
+        $params->initParamsFromRequestPath(['diocese', 'romamo_it']);
+
+        self::assertSame('romamo_it', $params->DiocesanCalendar);
+    }
+
+    public function testInitParamsFromRequestPathRejectsBadCategory(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('first parameter');
+
+        $params->initParamsFromRequestPath(['planet', 'mars']);
+    }
+
+    public function testInitParamsFromRequestPathRejectsTooManyParts(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('at most three');
+
+        $params->initParamsFromRequestPath(['nation', 'IT', '2024', 'extra']);
+    }
+}

--- a/phpunit_tests/Params/DecreesParamsTest.php
+++ b/phpunit_tests/Params/DecreesParamsTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Params;
+
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Params\DecreesParams;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DecreesParams::class)]
+final class DecreesParamsTest extends TestCase
+{
+    public function testEmptyParamsLeavesLocaleNull(): void
+    {
+        $params = new DecreesParams([]);
+
+        self::assertNull($params->Locale);
+    }
+
+    public function testValidLocaleIsReducedToPrimaryLanguage(): void
+    {
+        $params = new DecreesParams(['locale' => 'en_US']);
+
+        self::assertSame('en', $params->Locale);
+    }
+
+    public function testValidLatinLocaleIsAccepted(): void
+    {
+        $params = new DecreesParams(['locale' => 'la_VA']);
+
+        self::assertSame('la', $params->Locale);
+    }
+
+    public function testCanonicalizationNormalisesHyphenForm(): void
+    {
+        $params = new DecreesParams(['locale' => 'en-us']);
+
+        self::assertSame('en', $params->Locale);
+    }
+
+    public function testUnsupportedLocaleThrowsValidationException(): void
+    {
+        // \Locale::canonicalize is permissive and rarely returns null; it
+        // normalises 'not-a-locale' into 'not@a=locale' which then trips the
+        // LitLocale::isValid branch.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('for param `locale`');
+
+        new DecreesParams(['locale' => 'not-a-locale']);
+    }
+
+    public function testPayloadIsAssignedAsProvided(): void
+    {
+        $payload         = new \stdClass();
+        $payload->some   = 'value';
+        $payload->nested = (object) ['x' => 1];
+
+        $params = new DecreesParams(['payload' => $payload]);
+
+        self::assertSame($payload, $params->Payload);
+    }
+
+    public function testUnknownKeysAreIgnored(): void
+    {
+        $params = new DecreesParams(['locale' => 'en', 'unknown' => 'value']);
+
+        self::assertSame('en', $params->Locale);
+    }
+}

--- a/phpunit_tests/Params/EasterParamsTest.php
+++ b/phpunit_tests/Params/EasterParamsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Params;
+
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Params\EasterParams;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EasterParams::class)]
+final class EasterParamsTest extends TestCase
+{
+    public function testEmptyParamsLeavesLocaleNull(): void
+    {
+        $params = new EasterParams([]);
+
+        self::assertNull($params->Locale);
+    }
+
+    public function testValidLocalePopulatesBothLocaleAndBaseLocale(): void
+    {
+        $params = new EasterParams(['locale' => 'en_US']);
+
+        self::assertSame('en_US', $params->Locale);
+        self::assertSame('en', $params->baseLocale);
+    }
+
+    public function testLatinLocaleIsAccepted(): void
+    {
+        $params = new EasterParams(['locale' => 'la_VA']);
+
+        self::assertSame('la_VA', $params->Locale);
+        self::assertSame('la', $params->baseLocale);
+    }
+
+    public function testCanonicalizationNormalisesHyphenAndCase(): void
+    {
+        $params = new EasterParams(['locale' => 'fr-fr']);
+
+        self::assertSame('fr_FR', $params->Locale);
+        self::assertSame('fr', $params->baseLocale);
+    }
+
+    public function testUnsupportedLocaleThrowsValidationException(): void
+    {
+        // \Locale::canonicalize is permissive and rarely returns null; it
+        // normalises 'not-a-locale' into 'not@a=locale' which then trips the
+        // LitLocale::isValid branch.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('for param `locale`');
+
+        new EasterParams(['locale' => 'not-a-locale']);
+    }
+
+    public function testUnknownLocaleValueThrowsValidationException(): void
+    {
+        // Canonicalizes successfully but is not in the supported set.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('xx_ZZ');
+
+        new EasterParams(['locale' => 'xx_ZZ']);
+    }
+
+    public function testUnrelatedParamsAreIgnored(): void
+    {
+        $params = new EasterParams(['ignored' => 'value']);
+
+        self::assertNull($params->Locale);
+    }
+}

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -18,8 +18,14 @@ final class EventsParamsTest extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
+        if ($fixturePath === false) {
+            throw new \RuntimeException(
+                'Missing fixture directory: ' . __DIR__ . '/../fixtures/api'
+            );
+        }
         self::$savedApiPath = Router::$apiPath ?? '';
-        Router::$apiPath    = 'file://' . realpath(__DIR__ . '/../fixtures/api');
+        Router::$apiPath    = 'file://' . $fixturePath;
     }
 
     public static function tearDownAfterClass(): void

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Params;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Params\EventsParams;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventsParams::class)]
+final class EventsParamsTest extends TestCase
+{
+    private static string $savedApiPath = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$savedApiPath = Router::$apiPath ?? '';
+        Router::$apiPath    = 'file://' . realpath(__DIR__ . '/../fixtures/api');
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath = self::$savedApiPath;
+    }
+
+    public function testConstructorAppliesDefaults(): void
+    {
+        $params = new EventsParams();
+
+        self::assertSame((int) date('Y'), $params->Year);
+        self::assertFalse($params->EternalHighPriest);
+        self::assertNull($params->NationalCalendar);
+        self::assertNull($params->DiocesanCalendar);
+        self::assertNotEmpty($params->calendarsMetadata->national_calendars_keys);
+    }
+
+    public function testValidLocaleSplitsLocaleAndBase(): void
+    {
+        $params = new EventsParams(['locale' => 'en_US']);
+
+        self::assertSame('en_US', $params->Locale);
+        self::assertSame('en', $params->baseLocale);
+    }
+
+    public function testUnsupportedLocaleFallsBackToLatin(): void
+    {
+        // Per current behavior, when a locale is canonicalisable but unsupported,
+        // it silently falls back to Latin rather than rejecting outright.
+        $params = new EventsParams(['locale' => 'not-a-locale']);
+
+        self::assertSame(LitLocale::LATIN, $params->Locale);
+        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $params->baseLocale);
+    }
+
+    public function testNationalCalendarFromMetadataIsAccepted(): void
+    {
+        $params = new EventsParams(['national_calendar' => 'IT']);
+
+        self::assertSame('IT', $params->NationalCalendar);
+    }
+
+    public function testNationalCalendarVaForcesLatinAndSkipsAssignment(): void
+    {
+        // VA is the General Roman Calendar — the branch hard-codes the locale
+        // back to Latin and intentionally does not assign NationalCalendar so
+        // downstream code treats the request as "no nation override".
+        $params = new EventsParams(['national_calendar' => 'VA']);
+
+        self::assertSame(LitLocale::LATIN, $params->Locale);
+        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $params->baseLocale);
+        self::assertFalse($params->EternalHighPriest);
+        self::assertNull($params->NationalCalendar);
+    }
+
+    public function testUnknownNationalCalendarIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('nation parameter');
+
+        new EventsParams(['national_calendar' => 'ZZ']);
+    }
+
+    public function testDiocesanCalendarFromMetadataIsAccepted(): void
+    {
+        $params = new EventsParams(['diocesan_calendar' => 'romamo_it']);
+
+        self::assertSame('romamo_it', $params->DiocesanCalendar);
+    }
+
+    public function testUnknownDiocesanCalendarIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('diocese parameter');
+
+        new EventsParams(['diocesan_calendar' => 'nowhere']);
+    }
+
+    public function testEternalHighPriestAcceptsBooleanish(): void
+    {
+        $params = new EventsParams(['eternal_high_priest' => 'true']); // @phpstan-ignore-line
+
+        self::assertTrue($params->EternalHighPriest);
+    }
+
+    public function testEternalHighPriestRejectsGarbage(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('eternal_high_priest');
+
+        new EventsParams(['eternal_high_priest' => 'maybe']); // @phpstan-ignore-line
+    }
+
+    public function testUnknownKeysAreSilentlyIgnored(): void
+    {
+        $params = new EventsParams(['locale' => 'en_US', 'noise' => 'whatever']); // @phpstan-ignore-line
+
+        self::assertSame('en_US', $params->Locale);
+    }
+
+    public function testNationalCalendarValueIsUppercased(): void
+    {
+        // Only valid values reach the strtoupper branch, so we verify by passing
+        // 'IT' and confirming the stored value equals strtoupper('IT'). The
+        // metadata fixture only exposes 'IT' and 'US' as valid keys.
+        $params = new EventsParams(['national_calendar' => 'IT']);
+
+        self::assertSame('IT', $params->NationalCalendar);
+    }
+}

--- a/phpunit_tests/Params/MissalsParamsTest.php
+++ b/phpunit_tests/Params/MissalsParamsTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Params;
+
+use LiturgicalCalendar\Api\Handlers\MissalsHandler;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Models\MissalsPath\MissalMetadata;
+use LiturgicalCalendar\Api\Models\MissalsPath\MissalMetadataMap;
+use LiturgicalCalendar\Api\Params\MissalsParams;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MissalsParams::class)]
+final class MissalsParamsTest extends TestCase
+{
+    /** @var MissalMetadataMap|null */
+    private static ?MissalMetadataMap $savedIndex = null;
+
+    /** @var string[] */
+    private static array $savedAvailableLangs = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$savedIndex          = MissalsHandler::$missalsIndex;
+        self::$savedAvailableLangs = MissalsHandler::$availableLangs;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        MissalsHandler::$missalsIndex   = self::$savedIndex;
+        MissalsHandler::$availableLangs = self::$savedAvailableLangs;
+    }
+
+    protected function setUp(): void
+    {
+        // Reset to a clean per-test state.
+        MissalsHandler::$missalsIndex   = self::buildIndex();
+        MissalsHandler::$availableLangs = [];
+    }
+
+    private static function buildIndex(): MissalMetadataMap
+    {
+        $index = new MissalMetadataMap();
+        $index->addMissal(MissalMetadata::fromArray([
+            'missal_id'      => 'EDITIO_TYPICA_1970',
+            'name'           => 'Editio Typica 1970',
+            'region'         => 'VA',
+            'locales'        => ['la', 'en'],
+            'api_path'       => '/missals/EDITIO_TYPICA_1970',
+            'year_published' => 1970,
+            'year_limits'    => ['since_year' => 1970, 'until_year' => 2002],
+        ]));
+        $index->addMissal(MissalMetadata::fromArray([
+            'missal_id'      => 'IT_1983',
+            'name'           => 'Messale Romano 1983',
+            'region'         => 'IT',
+            'locales'        => ['it'],
+            'api_path'       => '/missals/IT_1983',
+            'year_published' => 1983,
+            'year_limits'    => ['since_year' => 1983, 'until_year' => null],
+        ]));
+        return $index;
+    }
+
+    public function testEmptyParamsIsANoop(): void
+    {
+        // Empty params returns before touching the static index, so even an
+        // unset index must not raise. Force the index null to prove this.
+        MissalsHandler::$missalsIndex = null;
+
+        $params = new MissalsParams([]);
+
+        self::assertNull($params->Locale);
+        self::assertNull($params->Year);
+        self::assertNull($params->Region);
+        self::assertFalse($params->IncludeEmpty);
+    }
+
+    public function testThrowsServiceUnavailableWhenIndexIsNull(): void
+    {
+        MissalsHandler::$missalsIndex = null;
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('Missals index temporarily unavailable');
+
+        new MissalsParams(['year' => 1970]);
+    }
+
+    public function testValidYearAsIntegerIsAccepted(): void
+    {
+        $params = new MissalsParams(['year' => 1970]);
+
+        self::assertSame(1970, $params->Year);
+    }
+
+    public function testValidYearAsNumericStringIsAccepted(): void
+    {
+        $params = new MissalsParams(['year' => '1983']); // @phpstan-ignore-line
+
+        self::assertSame(1983, $params->Year);
+    }
+
+    public function testNonIntegerYearStringIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('it must be an integer');
+
+        new MissalsParams(['year' => 'abc']); // @phpstan-ignore-line
+    }
+
+    public function testYearOutsideKnownMissalsIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('for param `year`');
+
+        new MissalsParams(['year' => 9999]);
+    }
+
+    public function testValidRegionIsAccepted(): void
+    {
+        $params = new MissalsParams(['region' => 'IT']);
+
+        self::assertSame('IT', $params->Region);
+    }
+
+    public function testInvalidRegionIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('for param `region`');
+
+        new MissalsParams(['region' => 'XX']);
+    }
+
+    public function testValidLocaleSplitsLocaleAndBaseLocale(): void
+    {
+        $params = new MissalsParams(['locale' => 'en_US']);
+
+        self::assertSame('en_US', $params->Locale);
+        self::assertSame('en', $params->baseLocale);
+    }
+
+    public function testUnsupportedLocaleIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('not supported by this server');
+
+        new MissalsParams(['locale' => 'not-a-locale']);
+    }
+
+    public function testLocaleNotSupportedByMissalIsRejected(): void
+    {
+        // When availableLangs is constrained, the chosen locale's primary
+        // language must appear in the list — otherwise we surface that
+        // mismatch with a more specific error.
+        MissalsHandler::$availableLangs = ['fr', 'it'];
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('not a valid locale for the requested Missal');
+
+        new MissalsParams(['locale' => 'en_US']);
+    }
+
+    public function testIncludeEmptyTrueFlipsTheFlagAndPropagates(): void
+    {
+        $params = new MissalsParams(['include_empty' => true]);
+
+        self::assertTrue($params->IncludeEmpty);
+    }
+
+    public function testIncludeEmptyAcceptsStringTruthyValues(): void
+    {
+        $params = new MissalsParams(['include_empty' => 'true']); // @phpstan-ignore-line
+
+        self::assertTrue($params->IncludeEmpty);
+    }
+
+    public function testIncludeEmptyRejectsNonBooleanish(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('for param `include_empty`');
+
+        new MissalsParams(['include_empty' => 'maybe']); // @phpstan-ignore-line
+    }
+
+    public function testPayloadIsAssigned(): void
+    {
+        $payload      = new \stdClass();
+        $payload->key = 'value';
+
+        $params = new MissalsParams(['payload' => $payload]);
+
+        self::assertSame($payload, $params->Payload);
+    }
+
+    public function testUnknownKeysAreSilentlyIgnored(): void
+    {
+        $params = new MissalsParams(['locale' => 'la_VA', 'unknown' => 'whatever']); // @phpstan-ignore-line
+
+        self::assertSame('la_VA', $params->Locale);
+        self::assertSame('la', $params->baseLocale);
+    }
+}

--- a/phpunit_tests/Params/RegionalDataParamsTest.php
+++ b/phpunit_tests/Params/RegionalDataParamsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Params;
+
+use LiturgicalCalendar\Api\Enum\PathCategory;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanData;
+use LiturgicalCalendar\Api\Params\RegionalDataParams;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RegionalDataParams::class)]
+final class RegionalDataParamsTest extends TestCase
+{
+    public function testCategoryAndKeyAreRequired(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Expected params `category` and `key`');
+
+        new RegionalDataParams([]); // @phpstan-ignore-line - intentional missing params
+    }
+
+    public function testMissingKeyThrowsValidationException(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        new RegionalDataParams(['category' => PathCategory::NATION]); // @phpstan-ignore-line
+    }
+
+    public function testCategoryAndKeyAreAssigned(): void
+    {
+        $params = new RegionalDataParams([
+            'category' => PathCategory::NATION,
+            'key'      => 'IT',
+        ]);
+
+        self::assertSame(PathCategory::NATION, $params->category);
+        self::assertSame('IT', $params->key);
+        self::assertNull($params->locale);
+        self::assertNull($params->i18nRequest);
+    }
+
+    public function testI18nRequestIsAssignedWhenProvided(): void
+    {
+        $params = new RegionalDataParams([
+            'category'    => PathCategory::DIOCESE,
+            'key'         => 'romamo_it',
+            'i18nRequest' => 'it',
+        ]);
+
+        self::assertSame('it', $params->i18nRequest);
+    }
+
+    public function testValidLocaleIsCanonicalised(): void
+    {
+        $params = new RegionalDataParams([
+            'category' => PathCategory::WIDERREGION,
+            'key'      => 'Europe',
+            'locale'   => 'fr-fr',
+        ]);
+
+        self::assertSame('fr_FR', $params->locale);
+    }
+
+    public function testUnsupportedLocaleThrowsValidationException(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('for param `locale`');
+
+        new RegionalDataParams([
+            'category' => PathCategory::NATION,
+            'key'      => 'IT',
+            'locale'   => 'not-a-locale',
+        ]);
+    }
+
+    public function testPayloadRequiresRawPayload(): void
+    {
+        $reflection = new \ReflectionClass(DiocesanData::class);
+        /** @var DiocesanData $payload */
+        $payload = $reflection->newInstanceWithoutConstructor();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('rawPayload is required');
+
+        new RegionalDataParams([
+            'category' => PathCategory::DIOCESE,
+            'key'      => 'romamo_it',
+            'payload'  => $payload,
+        ]); // @phpstan-ignore-line
+    }
+
+    public function testPayloadAndRawPayloadAreAssignedTogether(): void
+    {
+        $reflection = new \ReflectionClass(DiocesanData::class);
+        /** @var DiocesanData $payload */
+        $payload          = $reflection->newInstanceWithoutConstructor();
+        $rawPayload       = new \stdClass();
+        $rawPayload->name = 'Diocese of Rome';
+
+        $params = new RegionalDataParams([
+            'category'   => PathCategory::DIOCESE,
+            'key'        => 'romamo_it',
+            'payload'    => $payload,
+            'rawPayload' => $rawPayload,
+        ]);
+
+        self::assertSame($payload, $params->payload);
+        self::assertSame($rawPayload, $params->rawPayload);
+    }
+}

--- a/phpunit_tests/fixtures/api/calendars
+++ b/phpunit_tests/fixtures/api/calendars
@@ -24,6 +24,17 @@
           "corpus_christi": "SUNDAY",
           "eternal_high_priest": true
         }
+      },
+      {
+        "calendar_id": "VA",
+        "locales": ["la_VA"],
+        "missals": ["EDITIO_TYPICA_1970"],
+        "settings": {
+          "epiphany": "JAN6",
+          "ascension": "THURSDAY",
+          "corpus_christi": "THURSDAY",
+          "eternal_high_priest": false
+        }
       }
     ],
     "national_calendars_keys": ["IT", "US", "VA"],

--- a/phpunit_tests/fixtures/api/calendars
+++ b/phpunit_tests/fixtures/api/calendars
@@ -1,0 +1,51 @@
+{
+  "litcal_metadata": {
+    "national_calendars": [
+      {
+        "calendar_id": "IT",
+        "locales": ["it"],
+        "missals": ["EDITIO_TYPICA_1970", "IT_1983"],
+        "wider_region": "Europe",
+        "settings": {
+          "epiphany": "JAN6",
+          "ascension": "SUNDAY",
+          "corpus_christi": "SUNDAY",
+          "eternal_high_priest": false
+        }
+      },
+      {
+        "calendar_id": "US",
+        "locales": ["en", "es_US"],
+        "missals": ["EDITIO_TYPICA_1970", "USA_2011"],
+        "wider_region": "Americas",
+        "settings": {
+          "epiphany": "SUNDAY_JAN2_JAN8",
+          "ascension": "SUNDAY",
+          "corpus_christi": "SUNDAY",
+          "eternal_high_priest": true
+        }
+      }
+    ],
+    "national_calendars_keys": ["IT", "US", "VA"],
+    "diocesan_calendars": [
+      {
+        "calendar_id": "romamo_it",
+        "diocese": "Roma",
+        "nation": "IT",
+        "locales": ["it"],
+        "timezone": "Europe/Vatican"
+      }
+    ],
+    "diocesan_calendars_keys": ["romamo_it"],
+    "diocesan_groups": [],
+    "wider_regions": [
+      {
+        "name": "Europe",
+        "locales": ["en", "it", "fr", "de"],
+        "api_path": "/calendars/wider_region/Europe"
+      }
+    ],
+    "wider_regions_keys": ["Europe"],
+    "locales": ["en", "it", "es_US", "fr", "de"]
+  }
+}


### PR DESCRIPTION
Adds 95 in-process unit tests covering all seven src/Params classes plus
src/Database/Connection. These run without the dev API server or Postgres,
so they exercise paths that the existing HTTP-based integration suite cannot
hit deterministically (env-driven branches, validation rejections, singleton
lifecycle).

CalendarParams and EventsParams resolve calendar metadata via
Utilities::jsonUrlToObject in their constructors; tests redirect that fetch
to a local file:// URL by overriding Router::\$apiPath against a small
fixture in phpunit_tests/fixtures/api/calendars. MissalsParams tests stand
in MissalsHandler::\$missalsIndex with a hand-built MissalMetadataMap,
restoring the previous value in tearDownAfterClass.

This is the M1 milestone (Params + Database) of the layered plan in #570.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for database connection lifecycle, configuration validation, and error handling.
  * Added multiple API parameter validation test suites covering calendar, events, missals, easter, decrees, and regional data behaviors (validation, parsing, and canonicalization).
  * Added bundled fixtures with calendar metadata, locale mappings, and diocesan calendar definitions to support deterministic parameter tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/577)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->