### PR TITLE
test(coverage): unit-test src/Repositories against real Postgres (issue #570 M2)

### DIFF
--- a/phpunit_tests/Repositories/AccessRequestRepositoryTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryTest.php
@@ -1,0 +1,296 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(AccessRequestRepository::class)]
+final class AccessRequestRepositoryTest extends RepositoryTestCase
+{
+    private AccessRequestRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new AccessRequestRepository(self::$pdo);
+    }
+
+    /** @return list<array{object_type:string,object_id:string,relation:string}> */
+    private function samplePermissions(): array
+    {
+        return [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+            ['object_type' => 'diocesan_calendar', 'object_id' => 'romamo_it', 'relation' => 'viewer'],
+        ];
+    }
+
+    public function testCreateReturnsUuidAndPersistsPermissionsAsJsonb(): void
+    {
+        $id = $this->repo->create(
+            'user-1',
+            'a@b.test',
+            'Alice',
+            'calendar_editor',
+            $this->samplePermissions(),
+            'because',
+            'I have credentials'
+        );
+
+        self::assertNotEmpty($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('user-1', $row['zitadel_user_id']);
+        self::assertSame('a@b.test', $row['user_email']);
+        self::assertSame('Alice', $row['user_name']);
+        self::assertSame('calendar_editor', $row['requested_role']);
+        self::assertSame('pending', $row['status']);
+        // getById decodes JSONB permissions back to an array; assertEquals
+        // because PG may have reordered the keys within each tuple.
+        self::assertEquals($this->samplePermissions(), $row['permissions']);
+        self::assertSame('because', $row['justification']);
+        self::assertSame('I have credentials', $row['credentials']);
+    }
+
+    public function testCreateRejectsUnknownRole(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid role');
+
+        $this->repo->create('u', 'e@e.test', null, 'bogus_role', []);
+    }
+
+    public function testGetByIdReturnsNullForMissingRow(): void
+    {
+        self::assertNull($this->repo->getById('00000000-0000-0000-0000-000000000000'));
+    }
+
+    public function testHasPendingRequestIsScopedToUserAndRole(): void
+    {
+        $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+
+        self::assertTrue($this->repo->hasPendingRequest('user-1', 'developer'));
+        self::assertFalse($this->repo->hasPendingRequest('user-1', 'calendar_editor'));
+        self::assertFalse($this->repo->hasPendingRequest('user-2', 'developer'));
+        // Defense-in-depth: unknown roles can't be pending.
+        self::assertFalse($this->repo->hasPendingRequest('user-1', 'bogus'));
+    }
+
+    public function testHasApprovedRoleTracksAcrossRoles(): void
+    {
+        $devId = $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+
+        self::assertFalse($this->repo->hasApprovedRole('user-1'));
+
+        self::assertTrue($this->repo->approve($devId, 'admin'));
+        self::assertTrue($this->repo->hasApprovedRole('user-1'));
+    }
+
+    public function testGetByUserReturnsRowsForThatUserOnly(): void
+    {
+        $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+        $this->repo->create('user-1', 'a@b.test', null, 'calendar_editor', []);
+        $this->repo->create('user-2', 'b@b.test', null, 'developer', []);
+
+        $rows = $this->repo->getByUser('user-1');
+
+        self::assertCount(2, $rows);
+        foreach ($rows as $row) {
+            self::assertSame('user-1', $row['zitadel_user_id']);
+        }
+    }
+
+    public function testGetPendingReturnsOnlyPendingOldestFirst(): void
+    {
+        $first = $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+        usleep(2000);
+        $second     = $this->repo->create('user-2', 'b@b.test', null, 'developer', []);
+        $approvedId = $this->repo->create('user-3', 'c@b.test', null, 'developer', []);
+        $this->repo->approve($approvedId, 'admin');
+
+        $pending = $this->repo->getPending();
+
+        self::assertCount(2, $pending);
+        self::assertSame($first, $pending[0]['id']);
+        self::assertSame($second, $pending[1]['id']);
+        self::assertSame(2, $this->repo->countPending());
+    }
+
+    public function testGetAllOptionallyFiltersByStatus(): void
+    {
+        $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+        $approvedId = $this->repo->create('user-2', 'b@b.test', null, 'developer', []);
+        $this->repo->approve($approvedId, 'admin');
+
+        self::assertCount(2, $this->repo->getAll());
+        self::assertCount(1, $this->repo->getAll('approved'));
+        self::assertCount(1, $this->repo->getAll('pending'));
+    }
+
+    public function testGetAllRejectsBadStatus(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repo->getAll('weird');
+    }
+
+    public function testGetCountsReportsAllFourBuckets(): void
+    {
+        $a = $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+        $b = $this->repo->create('user-2', 'b@b.test', null, 'developer', []);
+        $c = $this->repo->create('user-3', 'c@b.test', null, 'developer', []);
+        $d = $this->repo->create('user-4', 'd@b.test', null, 'developer', []);
+
+        $this->repo->approve($a, 'admin');
+        $this->repo->reject($b, 'admin');
+        $this->repo->approve($c, 'admin');
+        $this->repo->revoke($c, 'admin');
+        // $d stays pending.
+
+        $counts = $this->repo->getCounts();
+
+        self::assertSame(1, $counts['pending']);
+        self::assertSame(1, $counts['approved']);
+        self::assertSame(1, $counts['rejected']);
+        self::assertSame(1, $counts['revoked']);
+    }
+
+    public function testApproveRejectRevokeStateGuards(): void
+    {
+        $id = $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+
+        self::assertTrue($this->repo->approve($id, 'admin', 'ok'));
+        // Approving twice does nothing (status != 'pending').
+        self::assertFalse($this->repo->approve($id, 'admin'));
+        // Reject after approve is rejected (only matches pending).
+        self::assertFalse($this->repo->reject($id, 'admin'));
+        // Revoke flips approved → revoked.
+        self::assertTrue($this->repo->revoke($id, 'admin', 'cleanup'));
+        // Revoke again is a no-op (status != 'approved').
+        self::assertFalse($this->repo->revoke($id, 'admin'));
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('revoked', $row['status']);
+    }
+
+    public function testResubmitRequiresRejectedStatusAndUpdatesPermissions(): void
+    {
+        $id = $this->repo->create('user-1', 'a@b.test', null, 'developer', $this->samplePermissions());
+        // Resubmit fails while still pending.
+        self::assertFalse($this->repo->resubmit($id, []));
+
+        self::assertTrue($this->repo->reject($id, 'admin', 'try again'));
+
+        $newPerms = [
+            ['object_type' => 'test_definition', 'object_id' => 'all', 'relation' => 'editor'],
+        ];
+        self::assertTrue($this->repo->resubmit($id, $newPerms, 'better case'));
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('pending', $row['status']);
+        // Postgres JSONB normalises key order, so assertSame would be brittle;
+        // assertEquals compares contents regardless of insertion order.
+        self::assertEquals($newPerms, $row['permissions']);
+        self::assertSame('better case', $row['justification']);
+        self::assertNull($row['reviewed_by']);
+    }
+
+    public function testResubmitKeepsExistingJustificationWhenNullProvided(): void
+    {
+        $id = $this->repo->create('user-1', 'a@b.test', null, 'developer', [], 'original-reason');
+        $this->repo->reject($id, 'admin');
+
+        self::assertTrue($this->repo->resubmit($id, []));
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('original-reason', $row['justification']);
+    }
+
+    public function testCascadeRevokeByRoleOnlyTouchesApprovedMatches(): void
+    {
+        // A unique partial index disallows two pending rows for the same
+        // (user, role), so we approve as we go to free the slot.
+        $approvedDev = $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+        $this->repo->approve($approvedDev, 'admin');
+
+        $approvedEditor = $this->repo->create('user-1', 'a@b.test', null, 'calendar_editor', []);
+        $this->repo->approve($approvedEditor, 'admin');
+
+        // Now there's no pending developer for user-1, so we can create one.
+        $pendingDev = $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+
+        $otherUser = $this->repo->create('user-2', 'b@b.test', null, 'developer', []);
+        $this->repo->approve($otherUser, 'admin');
+
+        $touched = $this->repo->cascadeRevokeByRole('user-1', 'developer', 'because');
+
+        self::assertSame(1, $touched);
+        $devRow = $this->repo->getById($approvedDev);
+        self::assertNotNull($devRow);
+        self::assertSame('revoked', $devRow['status']);
+        self::assertSame('system:cascade', $devRow['reviewed_by']);
+        // Other rows untouched.
+        $editorRow = $this->repo->getById($approvedEditor);
+        self::assertNotNull($editorRow);
+        self::assertSame('approved', $editorRow['status']);
+        $pendingRow = $this->repo->getById($pendingDev);
+        self::assertNotNull($pendingRow);
+        self::assertSame('pending', $pendingRow['status']);
+        $otherRow = $this->repo->getById($otherUser);
+        self::assertNotNull($otherRow);
+        self::assertSame('approved', $otherRow['status']);
+    }
+
+    public function testUpdateZitadelSyncStatusValidatesValue(): void
+    {
+        $id = $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+
+        $this->repo->updateZitadelSyncStatus($id, 'failed', 'boom');
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('failed', $row['zitadel_sync_status']);
+        self::assertSame('boom', $row['zitadel_sync_error']);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->repo->updateZitadelSyncStatus($id, 'nope');
+    }
+
+    public function testRemovePermissionTupleOnlyTouchesApprovedRowsWithMatch(): void
+    {
+        $approved        = $this->repo->create('user-1', 'a@b.test', null, 'developer', $this->samplePermissions());
+        $approvedNoMatch = $this->repo->create(
+            'user-1',
+            'a@b.test',
+            null,
+            'calendar_editor',
+            [['object_type' => 'wider_region', 'object_id' => 'Europe', 'relation' => 'editor']]
+        );
+        $pending         = $this->repo->create('user-1', 'a@b.test', null, 'test_editor', $this->samplePermissions());
+
+        $this->repo->approve($approved, 'admin');
+        $this->repo->approve($approvedNoMatch, 'admin');
+        // $pending stays pending — must not be touched.
+
+        $changed = $this->repo->removePermissionTuple('user-1', 'national_calendar', 'IT', 'editor');
+
+        self::assertSame(1, $changed);
+
+        $row = $this->repo->getById($approved);
+        self::assertNotNull($row);
+        /** @var list<array{object_type:string,object_id:string,relation:string}> $perms */
+        $perms = $row['permissions'];
+        self::assertCount(1, $perms);
+        self::assertSame('diocesan_calendar', $perms[0]['object_type']);
+
+        // Pending row untouched.
+        $pendingRow = $this->repo->getById($pending);
+        self::assertNotNull($pendingRow);
+        self::assertCount(2, $pendingRow['permissions']);
+    }
+}

--- a/phpunit_tests/Repositories/ApiKeyRepositoryTest.php
+++ b/phpunit_tests/Repositories/ApiKeyRepositoryTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\ApiKeyRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ApiKeyRepository::class)]
+final class ApiKeyRepositoryTest extends RepositoryTestCase
+{
+    private ApiKeyRepository $repo;
+    private string $appId;
+    private string $ownerUserId;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo        = new ApiKeyRepository(self::$pdo);
+        $this->ownerUserId = 'user_' . bin2hex(random_bytes(4));
+        $this->appId       = $this->insertApplication([
+            'zitadel_user_id' => $this->ownerUserId,
+            'status'          => 'approved',
+            'is_active'       => true,
+        ]);
+    }
+
+    public function testGenerateReturnsPlainKeyAndStoresRecord(): void
+    {
+        $result = $this->repo->generate($this->appId, 'CI key', 'read', 500);
+
+        self::assertNotEmpty($result['key']);
+        // Default APP_ENV in tests isn't 'production', so the env tag is 'test'.
+        self::assertStringStartsWith('litcal_test_', $result['key']);
+        self::assertIsArray($result['record']);
+        self::assertSame('CI key', $result['record']['name']);
+        self::assertSame('read', $result['record']['scope']);
+        self::assertSame(500, $result['record']['rate_limit_per_hour']);
+        self::assertTrue((bool) $result['record']['is_active']);
+        // key_prefix is the first 20 chars of the plaintext key.
+        self::assertSame(substr($result['key'], 0, 20), $result['record']['key_prefix']);
+    }
+
+    public function testValidateReturnsRowForActiveApprovedKey(): void
+    {
+        $generated = $this->repo->generate($this->appId);
+        $row       = $this->repo->validate($generated['key']);
+
+        self::assertNotNull($row);
+        self::assertSame($this->appId, $row['application_id']);
+        self::assertSame($this->ownerUserId, $row['zitadel_user_id']);
+        // First validate() reads the row first and then updates last_used_at,
+        // so the returned snapshot still has it null. Re-validate to confirm
+        // the timestamp was actually written.
+        self::assertNull($row['last_used_at']);
+        $secondPass = $this->repo->validate($generated['key']);
+        self::assertNotNull($secondPass);
+        self::assertNotNull($secondPass['last_used_at']);
+    }
+
+    public function testValidateRejectsUnknownKey(): void
+    {
+        self::assertNull($this->repo->validate('litcal_test_does_not_exist'));
+    }
+
+    public function testValidateRejectsRevokedKey(): void
+    {
+        $generated = $this->repo->generate($this->appId);
+        /** @var array<string,mixed> $record */
+        $record = $generated['record'];
+        /** @var string $id */
+        $id = $record['id'];
+
+        self::assertTrue($this->repo->revoke($id, $this->ownerUserId));
+        self::assertNull($this->repo->validate($generated['key']));
+    }
+
+    public function testValidateRejectsKeyWhoseApplicationIsInactive(): void
+    {
+        $generated = $this->repo->generate($this->appId);
+        self::$pdo->prepare('UPDATE applications SET is_active = FALSE WHERE id = :id')
+            ->execute(['id' => $this->appId]);
+
+        self::assertNull($this->repo->validate($generated['key']));
+    }
+
+    public function testValidateRejectsKeyWhoseApplicationIsNotApproved(): void
+    {
+        // Pending applications shouldn't be issuing live traffic even if they
+        // somehow already have keys generated.
+        $pendingApp = $this->insertApplication([
+            'zitadel_user_id' => $this->ownerUserId,
+            'status'          => 'pending',
+            'is_active'       => true,
+        ]);
+        $generated  = $this->repo->generate($pendingApp);
+
+        self::assertNull($this->repo->validate($generated['key']));
+    }
+
+    public function testValidateRejectsExpiredKey(): void
+    {
+        $past      = new \DateTimeImmutable('2000-01-01 00:00:00', new \DateTimeZone('Europe/Vatican'));
+        $generated = $this->repo->generate($this->appId, null, 'read', 1000, $past);
+
+        self::assertNull($this->repo->validate($generated['key']));
+    }
+
+    public function testGetByApplicationReturnsKeysInsertedNewestFirst(): void
+    {
+        $first = $this->repo->generate($this->appId, 'first');
+        usleep(2000);
+        $second = $this->repo->generate($this->appId, 'second');
+
+        $rows = $this->repo->getByApplication($this->appId);
+
+        self::assertCount(2, $rows);
+        self::assertSame('second', $rows[0]['name']);
+        self::assertSame('first', $rows[1]['name']);
+        // No raw hashes are leaked via this read path.
+        foreach ($rows as $row) {
+            self::assertArrayNotHasKey('key_hash', $row);
+        }
+    }
+
+    public function testGetByIdReturnsRowOrNull(): void
+    {
+        $generated = $this->repo->generate($this->appId);
+        /** @var array<string,mixed> $record */
+        $record = $generated['record'];
+        /** @var string $id */
+        $id = $record['id'];
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame($id, $row['id']);
+        self::assertSame($this->ownerUserId, $row['zitadel_user_id']);
+
+        self::assertNull($this->repo->getById('00000000-0000-0000-0000-000000000000'));
+    }
+
+    public function testRevokeFailsForNonOwner(): void
+    {
+        $generated = $this->repo->generate($this->appId);
+        /** @var array<string,mixed> $record */
+        $record = $generated['record'];
+        /** @var string $id */
+        $id = $record['id'];
+
+        self::assertFalse($this->repo->revoke($id, 'stranger'));
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertTrue((bool) $row['is_active']);
+    }
+
+    public function testDeleteRequiresOwnerAndCorrectApp(): void
+    {
+        $generated = $this->repo->generate($this->appId);
+        /** @var array<string,mixed> $record */
+        $record = $generated['record'];
+        /** @var string $id */
+        $id = $record['id'];
+
+        self::assertFalse($this->repo->delete($id, 'stranger', $this->appId));
+        self::assertFalse($this->repo->delete($id, $this->ownerUserId, '00000000-0000-0000-0000-000000000000'));
+        self::assertTrue($this->repo->delete($id, $this->ownerUserId, $this->appId));
+        self::assertNull($this->repo->getById($id));
+    }
+
+    public function testRotateRevokesOldAndIssuesNew(): void
+    {
+        $original = $this->repo->generate($this->appId, 'original', 'read', 250);
+        /** @var array<string,mixed> $record */
+        $record = $original['record'];
+        /** @var string $oldId */
+        $oldId = $record['id'];
+
+        $rotated = $this->repo->rotate($oldId, $this->ownerUserId);
+
+        self::assertNotNull($rotated);
+        self::assertNotSame($original['key'], $rotated['key']);
+        // Old key is now revoked.
+        $oldRow = $this->repo->getById($oldId);
+        self::assertNotNull($oldRow);
+        self::assertFalse((bool) $oldRow['is_active']);
+        // New key preserves scope/limit and tags the rotation in its name.
+        self::assertIsArray($rotated['record']);
+        self::assertSame('original (rotated)', $rotated['record']['name']);
+        self::assertSame(250, $rotated['record']['rate_limit_per_hour']);
+        self::assertSame('read', $rotated['record']['scope']);
+    }
+
+    public function testRotateRefusesNonOwner(): void
+    {
+        $generated = $this->repo->generate($this->appId);
+        /** @var array<string,mixed> $record */
+        $record = $generated['record'];
+        /** @var string $id */
+        $id = $record['id'];
+
+        self::assertNull($this->repo->rotate($id, 'stranger'));
+    }
+
+    public function testCountActiveByApplicationOnlyCountsActive(): void
+    {
+        $a = $this->repo->generate($this->appId, 'a');
+        $this->repo->generate($this->appId, 'b');
+        /** @var array<string,mixed> $aRecord */
+        $aRecord = $a['record'];
+        /** @var string $aId */
+        $aId = $aRecord['id'];
+        $this->repo->revoke($aId, $this->ownerUserId);
+
+        self::assertSame(1, $this->repo->countActiveByApplication($this->appId));
+    }
+
+    public function testCountActiveByApplicationsBatchReturnsAllRequestedIdsEvenIfZero(): void
+    {
+        $other = $this->insertApplication(['zitadel_user_id' => $this->ownerUserId]);
+        $this->repo->generate($this->appId, 'k1');
+        $this->repo->generate($this->appId, 'k2');
+
+        $counts = $this->repo->countActiveByApplications([$this->appId, $other]);
+
+        self::assertSame(2, $counts[$this->appId]);
+        self::assertSame(0, $counts[$other]);
+    }
+
+    public function testCountActiveByApplicationsHandlesEmptyInput(): void
+    {
+        self::assertSame([], $this->repo->countActiveByApplications([]));
+    }
+
+    public function testGetUsageStatsReturnsSummaryOrEmpty(): void
+    {
+        $generated = $this->repo->generate($this->appId, 'stats');
+        /** @var array<string,mixed> $record */
+        $record = $generated['record'];
+        /** @var string $id */
+        $id = $record['id'];
+
+        $stats = $this->repo->getUsageStats($id);
+        self::assertSame($id, $stats['key_id']);
+        // key_prefix is the first 20 chars of the plaintext key.
+        self::assertSame(substr($generated['key'], 0, 20), $stats['key_prefix']);
+        self::assertTrue((bool) $stats['is_active']);
+
+        self::assertSame([], $this->repo->getUsageStats('00000000-0000-0000-0000-000000000000'));
+    }
+}

--- a/phpunit_tests/Repositories/ApplicationRepositoryTest.php
+++ b/phpunit_tests/Repositories/ApplicationRepositoryTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\ApplicationRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ApplicationRepository::class)]
+final class ApplicationRepositoryTest extends RepositoryTestCase
+{
+    private ApplicationRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new ApplicationRepository(self::$pdo);
+    }
+
+    public function testCreateReturnsRowWithGeneratedUuidAndDefaults(): void
+    {
+        $row = $this->repo->create('user-1', 'App One', 'desc', 'https://example.test', 'read');
+
+        self::assertNotEmpty($row['id']);
+        self::assertSame('App One', $row['name']);
+        self::assertSame('desc', $row['description']);
+        self::assertSame('https://example.test', $row['website']);
+        self::assertSame('read', $row['requested_scope']);
+        self::assertSame('pending', $row['status']);
+        self::assertTrue((bool) $row['is_active']);
+    }
+
+    public function testCreateRejectsInvalidScope(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid requested_scope');
+
+        $this->repo->create('user-1', 'App', null, null, 'admin');
+    }
+
+    public function testGetByUuidAndGetByIdAreAliases(): void
+    {
+        $created = $this->repo->create('user-1', 'App');
+        /** @var string $id */
+        $id = $created['id'];
+
+        $byUuid = $this->repo->getByUuid($id);
+        $byId   = $this->repo->getById($id);
+
+        self::assertNotNull($byUuid);
+        self::assertSame($byUuid, $byId);
+    }
+
+    public function testGetByUuidReturnsNullForMissingRow(): void
+    {
+        self::assertNull($this->repo->getByUuid('00000000-0000-0000-0000-000000000000'));
+    }
+
+    public function testGetByUserReturnsRowsInDescendingOrder(): void
+    {
+        $first = $this->repo->create('user-x', 'First');
+        // Slight delay ensures created_at differs by at least 1 microsecond
+        // even though the SQL DEFAULT uses CURRENT_TIMESTAMP.
+        usleep(2000);
+        $second = $this->repo->create('user-x', 'Second');
+
+        $rows = $this->repo->getByUser('user-x');
+
+        self::assertCount(2, $rows);
+        self::assertSame($second['id'], $rows[0]['id']);
+        self::assertSame($first['id'], $rows[1]['id']);
+    }
+
+    public function testUpdateChangesAllowedFieldsAndIgnoresOthers(): void
+    {
+        $row = $this->repo->create('user-1', 'Original');
+        /** @var string $id */
+        $id = $row['id'];
+
+        $updated = $this->repo->update($id, 'user-1', [
+            'name'        => 'Renamed',
+            'description' => 'New desc',
+            'website'     => 'https://new.test',
+            'status'      => 'approved', // disallowed — must be ignored
+        ]);
+
+        self::assertNotNull($updated);
+        self::assertSame('Renamed', $updated['name']);
+        self::assertSame('New desc', $updated['description']);
+        self::assertSame('https://new.test', $updated['website']);
+        self::assertSame('pending', $updated['status']);
+    }
+
+    public function testUpdateWithEmptyDataReturnsCurrentRowForOwner(): void
+    {
+        $row = $this->repo->create('user-1', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+
+        $result = $this->repo->update($id, 'user-1', []);
+
+        self::assertNotNull($result);
+        self::assertSame($id, $result['id']);
+    }
+
+    public function testUpdateWithEmptyDataReturnsNullForNonOwner(): void
+    {
+        $row = $this->repo->create('owner', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+
+        self::assertNull($this->repo->update($id, 'stranger', []));
+    }
+
+    public function testUpdateNotOwnerReturnsNull(): void
+    {
+        $row = $this->repo->create('owner', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+
+        self::assertNull($this->repo->update($id, 'someone-else', ['name' => 'Hijack']));
+    }
+
+    public function testDeactivateAndReactivateFlipIsActive(): void
+    {
+        $row = $this->repo->create('user-1', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+
+        self::assertTrue($this->repo->deactivate($id, 'user-1'));
+        $afterOff = $this->repo->getByUuid($id);
+        self::assertNotNull($afterOff);
+        self::assertFalse((bool) $afterOff['is_active']);
+
+        self::assertTrue($this->repo->reactivate($id, 'user-1'));
+        $afterOn = $this->repo->getByUuid($id);
+        self::assertNotNull($afterOn);
+        self::assertTrue((bool) $afterOn['is_active']);
+    }
+
+    public function testDeactivateFailsForNonOwner(): void
+    {
+        $row = $this->repo->create('owner', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+
+        self::assertFalse($this->repo->deactivate($id, 'stranger'));
+    }
+
+    public function testDeleteRemovesRowForOwner(): void
+    {
+        $row = $this->repo->create('user-1', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+
+        self::assertTrue($this->repo->delete($id, 'user-1'));
+        self::assertNull($this->repo->getByUuid($id));
+    }
+
+    public function testDeleteFailsForNonOwner(): void
+    {
+        $row = $this->repo->create('owner', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+
+        self::assertFalse($this->repo->delete($id, 'stranger'));
+    }
+
+    public function testIsOwnerAndCountByUser(): void
+    {
+        $this->repo->create('user-a', 'A1');
+        $this->repo->create('user-a', 'A2');
+        $row = $this->repo->create('user-b', 'B1');
+        /** @var string $id */
+        $id = $row['id'];
+
+        self::assertTrue($this->repo->isOwner($id, 'user-b'));
+        self::assertFalse($this->repo->isOwner($id, 'user-a'));
+        self::assertSame(2, $this->repo->countByUser('user-a'));
+        self::assertSame(1, $this->repo->countByUser('user-b'));
+        self::assertSame(0, $this->repo->countByUser('user-c'));
+    }
+
+    public function testGetPendingApplicationsReturnsOnlyPendingInOrder(): void
+    {
+        $a = $this->repo->create('user-1', 'Pending A');
+        usleep(2000);
+        $b        = $this->repo->create('user-2', 'Pending B');
+        $approved = $this->repo->create('user-3', 'Approved');
+        /** @var string $approvedId */
+        $approvedId = $approved['id'];
+        $this->repo->approveApplication($approvedId, 'admin');
+
+        $pending = $this->repo->getPendingApplications();
+
+        // Pending rows are returned oldest first (created_at ASC).
+        self::assertCount(2, $pending);
+        self::assertSame($a['id'], $pending[0]['id']);
+        self::assertSame($b['id'], $pending[1]['id']);
+        self::assertSame(2, $this->repo->countPendingApplications());
+    }
+
+    public function testGetAllApplicationsWithoutFilterReturnsEverything(): void
+    {
+        $this->repo->create('user-1', 'A');
+        $this->repo->create('user-2', 'B');
+
+        self::assertCount(2, $this->repo->getAllApplications());
+    }
+
+    public function testGetAllApplicationsFiltersByStatus(): void
+    {
+        $approved = $this->repo->create('user-1', 'X');
+        /** @var string $approvedId */
+        $approvedId = $approved['id'];
+        $this->repo->approveApplication($approvedId, 'admin');
+        $this->repo->create('user-2', 'Y'); // stays pending
+
+        $approvedRows = $this->repo->getAllApplications('approved');
+        $pendingRows  = $this->repo->getAllApplications('pending');
+
+        self::assertCount(1, $approvedRows);
+        self::assertSame($approvedId, $approvedRows[0]['id']);
+        self::assertCount(1, $pendingRows);
+    }
+
+    public function testGetAllApplicationsRejectsBadFilter(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repo->getAllApplications('not-a-status');
+    }
+
+    public function testApproveRejectRevokeStateMachine(): void
+    {
+        $row = $this->repo->create('user-1', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+
+        $approved = $this->repo->approveApplication($id, 'admin', 'looks good');
+        self::assertNotNull($approved);
+        self::assertSame('approved', $approved['status']);
+        self::assertSame('admin', $approved['reviewed_by']);
+        self::assertSame('looks good', $approved['review_notes']);
+        self::assertTrue($this->repo->isApproved($id));
+
+        // Cannot approve an already-approved row again — UPDATE matches nothing.
+        self::assertNull($this->repo->approveApplication($id, 'admin'));
+
+        // Revoke flips approved → revoked.
+        $revoked = $this->repo->revokeApplication($id, 'admin', 'misuse');
+        self::assertNotNull($revoked);
+        self::assertSame('revoked', $revoked['status']);
+        self::assertFalse($this->repo->isApproved($id));
+
+        // Revoke is a no-op on a revoked row.
+        self::assertNull($this->repo->revokeApplication($id, 'admin'));
+    }
+
+    public function testRejectAndResubmit(): void
+    {
+        $row = $this->repo->create('user-1', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+
+        $rejected = $this->repo->rejectApplication($id, 'admin', 'no good');
+        self::assertNotNull($rejected);
+        self::assertSame('rejected', $rejected['status']);
+
+        // Reject only matches pending rows.
+        self::assertNull($this->repo->rejectApplication($id, 'admin'));
+
+        // Owner can resubmit a rejected row.
+        $resubmitted = $this->repo->resubmitApplication($id, 'user-1');
+        self::assertNotNull($resubmitted);
+        self::assertSame('pending', $resubmitted['status']);
+        self::assertNull($resubmitted['reviewed_by']);
+        self::assertNull($resubmitted['review_notes']);
+
+        // Approve-after-reject path is allowed (status IN (pending, rejected)).
+        $rejectedAgain = $this->repo->rejectApplication($id, 'admin');
+        self::assertNotNull($rejectedAgain);
+        $approvedAfterReject = $this->repo->approveApplication($id, 'admin');
+        self::assertNotNull($approvedAfterReject);
+        self::assertSame('approved', $approvedAfterReject['status']);
+    }
+
+    public function testResubmitFailsForNonOwner(): void
+    {
+        $row = $this->repo->create('owner', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+        $this->repo->rejectApplication($id, 'admin');
+
+        self::assertNull($this->repo->resubmitApplication($id, 'stranger'));
+    }
+
+    public function testIsApprovedRequiresActive(): void
+    {
+        $row = $this->repo->create('user-1', 'X');
+        /** @var string $id */
+        $id = $row['id'];
+        $this->repo->approveApplication($id, 'admin');
+        $this->repo->deactivate($id, 'user-1');
+
+        self::assertFalse($this->repo->isApproved($id));
+    }
+}

--- a/phpunit_tests/Repositories/AuditLogRepositoryTest.php
+++ b/phpunit_tests/Repositories/AuditLogRepositoryTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\AuditLogRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(AuditLogRepository::class)]
+final class AuditLogRepositoryTest extends RepositoryTestCase
+{
+    private AuditLogRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new AuditLogRepository(self::$pdo);
+    }
+
+    public function testLogPersistsAllColumns(): void
+    {
+        // log() casts the UUID PK to int, so the returned value is always 0
+        // in practice — that's a quirk of the existing API, not something
+        // this test should validate. Just verify the row was written.
+        $this->repo->log(
+            'user-1',
+            'create_application',
+            'application',
+            'app-abc',
+            ['name' => 'X'],
+            '203.0.113.7',
+            'curl/7.0',
+            true
+        );
+
+        $rows = $this->repo->query();
+        self::assertCount(1, $rows);
+        self::assertSame('user-1', $rows[0]['zitadel_user_id']);
+        self::assertSame('create_application', $rows[0]['action']);
+        self::assertSame('application', $rows[0]['resource_type']);
+        self::assertSame('app-abc', $rows[0]['resource_id']);
+        self::assertSame('203.0.113.7', $rows[0]['ip_address']);
+        self::assertSame('curl/7.0', $rows[0]['user_agent']);
+        self::assertTrue((bool) $rows[0]['success']);
+        // details JSONB is decoded back to an array on read.
+        self::assertSame(['name' => 'X'], $rows[0]['details']);
+    }
+
+    public function testLogPermitsNullUserForAnonymousActions(): void
+    {
+        $this->repo->log(null, 'rate_limit_breach', 'session');
+
+        $rows = $this->repo->query();
+        self::assertCount(1, $rows);
+        self::assertNull($rows[0]['zitadel_user_id']);
+    }
+
+    public function testQueryFiltersByMultipleColumns(): void
+    {
+        $this->repo->log('user-1', 'login', 'session', null, null, '10.0.0.1');
+        $this->repo->log('user-1', 'login', 'session', null, null, '10.0.0.2', null, false);
+        $this->repo->log('user-2', 'login', 'session');
+        $this->repo->log('user-1', 'logout', 'session');
+
+        self::assertCount(2, $this->repo->query(['user_id' => 'user-1', 'action' => 'login']));
+        self::assertCount(1, $this->repo->query(['action' => 'login', 'success' => false]));
+        self::assertCount(1, $this->repo->query(['ip_address' => '10.0.0.1']));
+    }
+
+    public function testQueryRespectsLimitAndOffset(): void
+    {
+        for ($i = 0; $i < 5; $i++) {
+            $this->repo->log('user-x', 'login', 'session');
+            usleep(1500);
+        }
+
+        $page1 = $this->repo->query([], 2, 0);
+        $page2 = $this->repo->query([], 2, 2);
+
+        self::assertCount(2, $page1);
+        self::assertCount(2, $page2);
+        self::assertNotEquals($page1[0]['id'], $page2[0]['id']);
+    }
+
+    public function testQueryFiltersByDateRange(): void
+    {
+        $this->repo->log('user-x', 'login', 'session');
+
+        // Far past → far future should include everything.
+        $all = $this->repo->query([
+            'from_date' => '1900-01-01 00:00:00',
+            'to_date'   => '2999-12-31 23:59:59',
+        ]);
+        self::assertCount(1, $all);
+
+        // Future-only range should exclude everything.
+        $none = $this->repo->query(['from_date' => '2999-01-01 00:00:00']);
+        self::assertCount(0, $none);
+    }
+
+    public function testGetByUserGetByResourceAndLoginAttempts(): void
+    {
+        $this->repo->log('user-a', 'login', 'session');
+        $this->repo->log('user-b', 'login', 'session');
+        $this->repo->log('user-a', 'create_application', 'application', 'app-1');
+
+        self::assertCount(2, $this->repo->getByUser('user-a'));
+        self::assertCount(1, $this->repo->getByResource('application', 'app-1'));
+        self::assertCount(1, $this->repo->getLoginAttempts('user-a'));
+    }
+
+    public function testGetFailedActionsRequiresSuccessFalse(): void
+    {
+        $this->repo->log('user-1', 'login', 'session', null, null, null, null, true);
+        $this->repo->log('user-1', 'login', 'session', null, null, null, null, false);
+        $this->repo->log('user-1', 'login', 'session', null, null, null, null, false);
+
+        $failed = $this->repo->getFailedActions();
+
+        self::assertCount(2, $failed);
+        foreach ($failed as $row) {
+            self::assertFalse((bool) $row['success']);
+        }
+    }
+
+    public function testCountAppliesSameFilterAsQuery(): void
+    {
+        $this->repo->log('user-1', 'login', 'session');
+        $this->repo->log('user-1', 'login', 'session');
+        $this->repo->log('user-2', 'login', 'session');
+
+        self::assertSame(3, $this->repo->count());
+        self::assertSame(2, $this->repo->count(['user_id' => 'user-1']));
+    }
+
+    public function testPurgeOldDeletesRowsBeyondRetention(): void
+    {
+        $this->repo->log('user-1', 'login', 'session');
+        // Force one row's created_at into the distant past, beyond the 365-day window.
+        self::$pdo->exec(
+            "UPDATE audit_log SET created_at = CURRENT_TIMESTAMP - INTERVAL '400 days'"
+        );
+
+        $deleted = $this->repo->purgeOld(365);
+
+        self::assertSame(1, $deleted);
+        self::assertSame(0, $this->repo->count());
+    }
+
+    public function testHelperLoginLogoutAndFailedLoginShortcuts(): void
+    {
+        $this->repo->logLogin('user-1', '198.51.100.1', 'Mozilla');
+        $this->repo->logLogout('user-1', '198.51.100.1');
+        $this->repo->logFailedLogin('user-1', '198.51.100.2', 'curl', ['reason' => 'bad_pw']);
+
+        $rows = $this->repo->query([], 100);
+
+        self::assertCount(3, $rows);
+        $byAction = [];
+        foreach ($rows as $row) {
+            $byAction[$row['action']][] = $row;
+        }
+        self::assertCount(2, $byAction['login']);
+        self::assertCount(1, $byAction['logout']);
+
+        $failedLogin = array_values(array_filter(
+            $byAction['login'],
+            static fn (array $r): bool => !(bool) $r['success']
+        ));
+        self::assertCount(1, $failedLogin);
+        self::assertSame(['reason' => 'bad_pw'], $failedLogin[0]['details']);
+    }
+}

--- a/phpunit_tests/Repositories/AuditLogRepositoryTest.php
+++ b/phpunit_tests/Repositories/AuditLogRepositoryTest.php
@@ -18,12 +18,9 @@ final class AuditLogRepositoryTest extends RepositoryTestCase
         $this->repo = new AuditLogRepository(self::$pdo);
     }
 
-    public function testLogPersistsAllColumns(): void
+    public function testLogPersistsAllColumnsAndReturnsId(): void
     {
-        // log() casts the UUID PK to int, so the returned value is always 0
-        // in practice — that's a quirk of the existing API, not something
-        // this test should validate. Just verify the row was written.
-        $this->repo->log(
+        $id = $this->repo->log(
             'user-1',
             'create_application',
             'application',
@@ -34,8 +31,12 @@ final class AuditLogRepositoryTest extends RepositoryTestCase
             true
         );
 
+        // log() returns the UUID of the inserted row.
+        self::assertMatchesRegularExpression('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $id);
+
         $rows = $this->repo->query();
         self::assertCount(1, $rows);
+        self::assertSame($id, $rows[0]['id']);
         self::assertSame('user-1', $rows[0]['zitadel_user_id']);
         self::assertSame('create_application', $rows[0]['action']);
         self::assertSame('application', $rows[0]['resource_type']);

--- a/phpunit_tests/Repositories/RepositoryTestCase.php
+++ b/phpunit_tests/Repositories/RepositoryTestCase.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Base class for repository tests that need a real Postgres connection.
+ *
+ * Looks for DB_HOST / DB_NAME / DB_USER / DB_PASSWORD in either $_ENV or
+ * getenv() (CI's phpunit workflow writes them to .env.local, which the
+ * test bootstrap loads; local devs can do the same). When configured,
+ * opens one connection per test class and TRUNCATEs the four target
+ * tables before every test for isolation.
+ *
+ * When unconfigured, marks the test as skipped with a clear message so
+ * the rest of the suite still runs. The CI run is the place that
+ * actually enforces coverage on this layer (per #570 / #568).
+ *
+ * Per-test rollback (the strategy the issue suggests) does not work for
+ * us because ApiKeyRepository::rotate() opens its own transaction; PDO
+ * has no real nested-transaction support, so the inner beginTransaction
+ * would error out. TRUNCATE … CASCADE is functionally equivalent and
+ * sidesteps that.
+ */
+abstract class RepositoryTestCase extends TestCase
+{
+    protected static ?PDO $pdo = null;
+
+    /** @var array<int,string> Tables truncated before each test, in any order — CASCADE handles FKs. */
+    protected const TABLES = ['api_keys', 'applications', 'access_requests', 'audit_log'];
+
+    public static function setUpBeforeClass(): void
+    {
+        $host     = self::env('DB_HOST');
+        $port     = self::env('DB_PORT') ?? '5432';
+        $name     = self::env('DB_NAME');
+        $user     = self::env('DB_USER');
+        $password = self::env('DB_PASSWORD');
+
+        if ($host === null || $name === null || $user === null || $password === null) {
+            self::$pdo = null;
+            return;
+        }
+
+        try {
+            self::$pdo = new PDO(
+                sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $name),
+                $user,
+                $password,
+                [
+                    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                    PDO::ATTR_EMULATE_PREPARES   => false,
+                    PDO::ATTR_TIMEOUT            => 5,
+                ]
+            );
+            // Pin the session TZ so date assertions don't drift by environment.
+            self::$pdo->exec("SET timezone TO 'Europe/Vatican'");
+        } catch (\PDOException $e) {
+            self::$pdo = null;
+            // Defer reporting to setUp(); class-level skip messages aren't shown
+            // without --debug, but per-test skips are.
+            self::$skipReason = 'Postgres unreachable: ' . $e->getMessage();
+        }
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        self::$pdo        = null;
+        self::$skipReason = null;
+    }
+
+    protected function setUp(): void
+    {
+        if (self::$pdo === null) {
+            $this->markTestSkipped(
+                self::$skipReason
+                ?? 'Repository tests require Postgres credentials in DB_HOST/DB_NAME/DB_USER/DB_PASSWORD. '
+                . 'CI sets these via .env.local; locally, set them or run scripts/init-db.sql against your dev cluster.'
+            );
+        }
+
+        // CASCADE clears api_keys when applications get nuked (FK ON DELETE CASCADE);
+        // listing every table explicitly is safer than relying on cascade alone and
+        // keeps the truncate fast (these tables stay small in tests).
+        self::$pdo->exec('TRUNCATE TABLE ' . implode(', ', self::TABLES) . ' RESTART IDENTITY CASCADE');
+    }
+
+    private static ?string $skipReason = null;
+
+    private static function env(string $name): ?string
+    {
+        if (isset($_ENV[$name]) && $_ENV[$name] !== '') {
+            return (string) $_ENV[$name];
+        }
+
+        $value = getenv($name);
+        if ($value === false || $value === '') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Convenience: insert a minimal applications row and return its id.
+     * Tests that need an application but don't care about its specifics
+     * can pull this in rather than re-deriving the schema.
+     *
+     * @param array<string,mixed> $overrides Override any column default.
+     */
+    protected function insertApplication(array $overrides = []): string
+    {
+        $row = array_merge(
+            [
+                'zitadel_user_id' => 'user_' . bin2hex(random_bytes(4)),
+                'name'            => 'Test App',
+                'description'     => null,
+                'website'         => null,
+                'status'          => 'approved',
+                'requested_scope' => 'read',
+                'is_active'       => true,
+            ],
+            $overrides
+        );
+
+        $stmt = self::$pdo->prepare(
+            'INSERT INTO applications
+                (zitadel_user_id, name, description, website, status, requested_scope, is_active)
+             VALUES
+                (:zitadel_user_id, :name, :description, :website, :status, :requested_scope, :is_active)
+             RETURNING id'
+        );
+        $stmt->execute([
+            'zitadel_user_id' => $row['zitadel_user_id'],
+            'name'            => $row['name'],
+            'description'     => $row['description'],
+            'website'         => $row['website'],
+            'status'          => $row['status'],
+            'requested_scope' => $row['requested_scope'],
+            'is_active'       => $row['is_active'] ? 'true' : 'false',
+        ]);
+
+        return (string) $stmt->fetchColumn();
+    }
+}

--- a/src/Repositories/AuditLogRepository.php
+++ b/src/Repositories/AuditLogRepository.php
@@ -91,7 +91,7 @@ class AuditLogRepository
      * @param string|null $ipAddress Client IP address
      * @param string|null $userAgent Client user agent
      * @param bool $success Whether the action was successful
-     * @return int The ID of the log entry
+     * @return string The UUID of the log entry
      */
     public function log(
         ?string $userId,
@@ -102,7 +102,7 @@ class AuditLogRepository
         ?string $ipAddress = null,
         ?string $userAgent = null,
         bool $success = true
-    ): int {
+    ): string {
         $stmt = $this->db->prepare(
             'INSERT INTO audit_log
                 (zitadel_user_id, action, resource_type, resource_id, details, ip_address, user_agent, success)
@@ -122,7 +122,7 @@ class AuditLogRepository
             'success'       => $success ? 'true' : 'false',
         ]);
 
-        return (int) $stmt->fetchColumn();
+        return (string) $stmt->fetchColumn();
     }
 
     /**


### PR DESCRIPTION
Adds 65 in-process tests across all four repository classes (`Application`, `ApiKey`, `AuditLog`, `AccessRequest`), 230 assertions, exercised against the `postgres:17` service container the CI workflow already provisions.

This is the **M2 milestone** of the layered coverage plan in #570.

## Summary

- New `phpunit_tests/Repositories/RepositoryTestCase.php` base class:
  - Shared per-class PDO opened in `setUpBeforeClass` (env-driven via `DB_HOST` / `DB_NAME` / `DB_USER` / `DB_PASSWORD`).
  - Per-test isolation via `TRUNCATE ... CASCADE` on the four target tables in `setUp`.
  - `markTestSkipped` with a clear message when DB credentials aren't present, so devs without a local Postgres cluster still see green on the rest of the suite.
  - `insertApplication()` helper for tests that need an existing application row but don't care about its specifics.
- `ApplicationRepositoryTest` — 22 tests covering create/CRUD, scope validation, owner-scoped update/deactivate/delete, the approve→reject→revoke→resubmit state machine, and the admin listing/counts paths.
- `ApiKeyRepositoryTest` — 17 tests covering generate, validate's five rejection branches (unknown, revoked, inactive app, pending app, expired), getByApplication ordering, owner-scoped revoke/delete, rotate (including the internal transaction path), counts (single + batch + empty input), and usage stats.
- `AuditLogRepositoryTest` — 10 tests covering log + JSONB details round-trip, anonymous null user, filter combinations, pagination, date-range filters, helpers (`logLogin` / `logLogout` / `logFailedLogin`), `getFailedActions`, `count`, and `purgeOld`.
- `AccessRequestRepositoryTest` — 16 tests covering create + role validation, getById/getByUser/getPending/getAll, status filters, getCounts, the approve/reject/revoke state guards, resubmit's two paths (with and without updated justification), `cascadeRevokeByRole`, `updateZitadelSyncStatus` validation, and `removePermissionTuple`.

## Notes for review

- The issue suggests per-test transaction rollback for isolation. I tried that first and hit a wall: `ApiKeyRepository::rotate()` calls `beginTransaction()` itself, and PDO has no real nested-transaction support — the inner begin would error. `TRUNCATE ... CASCADE` per test is functionally equivalent and sidesteps the conflict; explained in a comment at the top of `RepositoryTestCase.php`.
- One pre-existing quirk surfaced while writing the audit-log tests: `AuditLogRepository::log()` declares an `int` return but the `audit_log.id` column is a UUID, so `(int) $stmt->fetchColumn()` is always `0` in practice. The test acknowledges this in a comment rather than asserting on the returned id — happy to file a follow-up to either fix the signature (`string`) or document the quirk if useful. (Callers in `src/` ignore the return value, so low impact.)

## Verification

- Locally: `vendor/bin/phpunit phpunit_tests/Repositories phpunit_tests/Database phpunit_tests/Params phpunit_tests/Enum` — **161 tests, 398 assertions, all green** against a freshly-`scripts/init-db.sql`'d Postgres 16.
- `composer analyse` (PHPStan level 10): clean.
- `composer lint` (PSR-12 + project rules): clean.

## Test plan

- [ ] CI's `phpunit` job runs the new `phpunit_tests/Repositories/` suite green against the workflow's `postgres:17` service.
- [ ] Codecov picks up coverage on `src/Repositories/*` (currently 0%) and reports it as part of the per-layer trend toward the ≥80% goal in #570.
- [ ] Existing M1 suite (`phpunit_tests/Params/`, `phpunit_tests/Database/`) keeps passing.

## Related

- #570 — parent coverage epic
- #577 — M1 (Params + Database), already merged into `development`
- #576 / #578 — separate `EventsParams` bugs surfaced while writing M1

Next planned milestones (separate PRs): M3 (Auth + Admin handlers), M4 (remaining handlers), M5 (Services), M6 (Models + Enums + Http + Router).


---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suites for repository operations including access requests, API keys, applications, and audit logging with validation of authorization rules, state transitions, and data persistence.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/579)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->