### PR TITLE
test(coverage): unit-test the remaining src/Handlers (issue #570 M4)

### DIFF
--- a/phpunit_tests/Handlers/AbstractHandlerTestCase.php
+++ b/phpunit_tests/Handlers/AbstractHandlerTestCase.php
@@ -51,16 +51,24 @@ abstract class AbstractHandlerTestCase extends TestCase
      * to a known string value, even if it was uninitialised before setUp ran.
      * The typed-string property on Router can't accept null.
      */
-    private static string $savedApiPath = '';
+    private static string $savedApiPath     = '';
+    private static string $savedApiFilePath = '';
 
     public static function setUpBeforeClass(): void
     {
-        // Pin Router::$apiPath so handlers that read it (e.g. for building
-        // self-links) get a stable, predictable value in tests. isset() is
-        // false for typed-uninitialised properties, so we fall back to ''
+        // Pin Router::$apiPath + Router::$apiFilePath so handlers that read
+        // them (for self-links + JsonData::*->path() filesystem lookups)
+        // get stable, predictable values in tests. isset() is false for
+        // typed-uninitialised properties, so we fall back to defaults
         // rather than tripping an Error on the access.
-        self::$savedApiPath = isset(Router::$apiPath) ? Router::$apiPath : '';
-        Router::$apiPath    = '';
+        self::$savedApiPath     = isset(Router::$apiPath) ? Router::$apiPath : '';
+        self::$savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        Router::$apiPath        = '';
+        // apiFilePath is used as a prefix when JsonData enum cases build
+        // filesystem paths like '<root>/jsondata/schemas/Foo.json', so set
+        // it to the project root with a trailing slash, matching Router's
+        // production behaviour.
+        Router::$apiFilePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
 
         if (static::$requiresDatabase) {
             $host     = self::env('DB_HOST');
@@ -95,8 +103,9 @@ abstract class AbstractHandlerTestCase extends TestCase
 
     public static function tearDownAfterClass(): void
     {
-        self::$pdo       = null;
-        Router::$apiPath = self::$savedApiPath;
+        self::$pdo           = null;
+        Router::$apiPath     = self::$savedApiPath;
+        Router::$apiFilePath = self::$savedApiFilePath;
     }
 
     protected function setUp(): void

--- a/phpunit_tests/Handlers/ApplicationsHandlerTest.php
+++ b/phpunit_tests/Handlers/ApplicationsHandlerTest.php
@@ -98,8 +98,7 @@ final class ApplicationsHandlerTest extends AbstractHandlerTestCase
             ])->withAttribute('oidc_user', $this->devUser())
         );
 
-        self::assertGreaterThanOrEqual(200, $response->getStatusCode());
-        self::assertLessThan(300, $response->getStatusCode());
+        self::assertSame(201, $response->getStatusCode());
         $body = $this->decodeJsonBody($response);
         self::assertSame('My App', $body['application']['name']);
         self::assertSame('pending', $body['application']['status']);

--- a/phpunit_tests/Handlers/ApplicationsHandlerTest.php
+++ b/phpunit_tests/Handlers/ApplicationsHandlerTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\ApplicationsHandler;
+use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Repositories\ApiKeyRepository;
+use LiturgicalCalendar\Api\Repositories\ApplicationRepository;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ApplicationsHandler::class)]
+final class ApplicationsHandlerTest extends AbstractHandlerTestCase
+{
+    protected static bool $requiresDatabase = true;
+
+    private function devUser(string $sub = 'dev-user-1'): array
+    {
+        return ['sub' => $sub, 'roles' => ['developer']];
+    }
+
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new ApplicationsHandler() )->handle(
+            $this->requestFor('OPTIONS', '/applications', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testPutIsMethodNotAllowed(): void
+    {
+        $this->expectException(MethodNotAllowedException::class);
+        ( new ApplicationsHandler() )->handle(
+            $this->requestFor('PUT', '/applications', [])
+                ->withAttribute('oidc_user', $this->devUser())
+        );
+    }
+
+    public function testMissingOidcUserIsUnauthorized(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        ( new ApplicationsHandler() )->handle($this->requestFor('GET', '/applications'));
+    }
+
+    public function testNonDeveloperIsForbidden(): void
+    {
+        $this->expectException(ForbiddenException::class);
+        ( new ApplicationsHandler() )->handle(
+            $this->requestFor('GET', '/applications')
+                ->withAttribute('oidc_user', ['sub' => 'viewer', 'roles' => ['viewer']])
+        );
+    }
+
+    public function testListReturnsOnlyUsersOwnApplications(): void
+    {
+        $repo = new ApplicationRepository(self::$pdo);
+        $repo->create('dev-user-1', 'Mine');
+        $repo->create('other-user', 'Theirs');
+
+        $response = ( new ApplicationsHandler() )->handle(
+            $this->requestFor('GET', '/applications')
+                ->withAttribute('oidc_user', $this->devUser())
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertSame(1, $body['total']);
+        self::assertSame('Mine', $body['applications'][0]['name']);
+        self::assertArrayHasKey('uuid', $body['applications'][0]);
+        self::assertSame(0, $body['applications'][0]['key_count']);
+    }
+
+    public function testCreateRequiresName(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('name is required');
+
+        ( new ApplicationsHandler() )->handle(
+            $this->requestFor('POST', '/applications', [], ['description' => 'no name'])
+                ->withAttribute('oidc_user', $this->devUser())
+        );
+    }
+
+    public function testCreateHappyPath(): void
+    {
+        $response = ( new ApplicationsHandler() )->handle(
+            $this->requestFor('POST', '/applications', [], [
+                'name'        => 'My App',
+                'description' => 'desc',
+                'website'     => 'https://example.test',
+            ])->withAttribute('oidc_user', $this->devUser())
+        );
+
+        self::assertGreaterThanOrEqual(200, $response->getStatusCode());
+        self::assertLessThan(300, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertSame('My App', $body['application']['name']);
+        self::assertSame('pending', $body['application']['status']);
+    }
+
+    public function testGetApplicationByUuidRequiresOwnership(): void
+    {
+        $repo = new ApplicationRepository(self::$pdo);
+        $row  = $repo->create('other-user', 'Theirs');
+        /** @var string $id */
+        $id = $row['id'];
+
+        // Handler differentiates "not yours" from "doesn't exist" by emitting
+        // ForbiddenException when the row is found but owned by someone else.
+        $this->expectException(ForbiddenException::class);
+        ( new ApplicationsHandler() )->handle(
+            $this->requestFor('GET', '/applications/' . $id)
+                ->withAttribute('oidc_user', $this->devUser())
+        );
+    }
+
+    public function testInvalidPathIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new ApplicationsHandler() )->handle(
+            $this->requestFor('GET', '/no-applications-here')
+                ->withAttribute('oidc_user', $this->devUser())
+        );
+    }
+
+    public function testListApiKeysForOwnedApprovedApp(): void
+    {
+        $appRepo = new ApplicationRepository(self::$pdo);
+        $row     = $appRepo->create('dev-user-1', 'X');
+        /** @var string $appId */
+        $appId = $row['id'];
+        $appRepo->approveApplication($appId, 'admin');
+
+        $keyRepo = new ApiKeyRepository(self::$pdo);
+        $keyRepo->generate($appId, 'k1');
+
+        $response = ( new ApplicationsHandler() )->handle(
+            $this->requestFor('GET', '/applications/' . $appId . '/keys')
+                ->withAttribute('oidc_user', $this->devUser())
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertCount(1, $body['keys']);
+        self::assertSame('k1', $body['keys'][0]['name']);
+    }
+}

--- a/phpunit_tests/Handlers/CalendarHandlerTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * CalendarHandler is the heart of the API — it computes the full liturgical
+ * calendar for a year. This suite exercises the request-shape gates and a
+ * handful of happy-path year computations. Deep coverage of edge cases
+ * (suppression, transfer rules, Easter cycle anomalies) lives in the
+ * external UnitTestInterface integration suite by design.
+ */
+#[CoversClass(CalendarHandler::class)]
+final class CalendarHandlerTest extends AbstractHandlerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // CalendarHandler's CalendarParams fetches /calendars metadata from
+        // Router::$apiPath; route it at the M1 fixture so the constructor
+        // succeeds without an HTTP server.
+        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
+        self::assertNotFalse($fixturePath, 'M1 calendars fixture must be present');
+        Router::$apiPath = 'file://' . $fixturePath;
+    }
+
+    /**
+     * In production, Router::buildHandler() calls setAllowedReturnTypes()
+     * before invoking the handler; without it CalendarParams rejects the
+     * default-negotiated 'JSON' return type. Centralise the setup here.
+     */
+    private function makeHandler(array $pathParams = []): CalendarHandler
+    {
+        $handler = new CalendarHandler($pathParams);
+        $handler->setAllowedReturnTypes([
+            ReturnTypeParam::JSON,
+            ReturnTypeParam::YAML,
+            ReturnTypeParam::XML,
+            ReturnTypeParam::ICS,
+        ]);
+        return $handler;
+    }
+
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = $this->makeHandler()->handle(
+            $this->requestFor('OPTIONS', '/calendar', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetForCurrentYearReturnsCalendarShape(): void
+    {
+        $response = $this->makeHandler()->handle(
+            $this->requestFor('GET', '/calendar', ['Accept-Language' => 'la'])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+
+        // CalendarHandler produces a fixed top-level shape.
+        self::assertArrayHasKey('settings', $body);
+        self::assertArrayHasKey('metadata', $body);
+        self::assertArrayHasKey('litcal', $body);
+        self::assertNotEmpty($body['litcal'], 'A computed calendar must contain liturgical events');
+    }
+
+    public function testGetForExplicitYearAppliesIt(): void
+    {
+        $response = $this->makeHandler(['2025'])->handle(
+            $this->requestFor('GET', '/calendar/2025', ['Accept-Language' => 'la'])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertSame(2025, $body['settings']['year']);
+    }
+
+    public function testYearOutsideRangeIsValidationError(): void
+    {
+        // YEAR_LOWER_LIMIT is 1970; 1900 must be rejected.
+        $this->expectException(ValidationException::class);
+        $this->makeHandler(['1900'])
+            ->handle($this->requestFor('GET', '/calendar/1900', ['Accept-Language' => 'la']));
+    }
+
+    public function testNonNumericYearPathIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->makeHandler(['twenty-twenty-five'])
+            ->handle($this->requestFor('GET', '/calendar/twenty-twenty-five', ['Accept-Language' => 'la']));
+    }
+
+    public function testInvalidNationalCalendarPathIsValidationError(): void
+    {
+        // 'nation' segment + unknown nation key triggers CalendarParams's
+        // validation against the M1 fixture's national_calendars_keys.
+        $this->expectException(ValidationException::class);
+        $this->makeHandler(['nation', 'ZZ', '2025'])
+            ->handle($this->requestFor('GET', '/calendar/nation/ZZ/2025', ['Accept-Language' => 'la']));
+    }
+}

--- a/phpunit_tests/Handlers/DecreesHandlerTest.php
+++ b/phpunit_tests/Handlers/DecreesHandlerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\DecreesHandler;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(DecreesHandler::class)]
+final class DecreesHandlerTest extends AbstractHandlerTestCase
+{
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new DecreesHandler() )->handle(
+            $this->requestFor('OPTIONS', '/decrees', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetReturnsDecreesIndex(): void
+    {
+        $response = ( new DecreesHandler() )->handle(
+            $this->requestFor('GET', '/decrees', ['Accept-Language' => 'la'])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_decrees', $body);
+        self::assertNotEmpty($body['litcal_decrees']);
+        // Each entry has a decree_id we can look up individually.
+        self::assertNotEmpty($body['litcal_decrees'][0]['decree_id']);
+    }
+
+    public function testGetSingleDecreeReturnsThatDecree(): void
+    {
+        // Discover the first decree id from the index, then ask for it by id.
+        $indexResp = ( new DecreesHandler() )->handle(
+            $this->requestFor('GET', '/decrees', ['Accept-Language' => 'la'])
+        );
+        $decreeId  = $this->decodeJsonBody($indexResp)['litcal_decrees'][0]['decree_id'];
+        self::assertIsString($decreeId);
+        self::assertNotEmpty($decreeId);
+
+        $handler = new DecreesHandler([$decreeId]);
+        $resp    = $handler->handle($this->requestFor('GET', '/decrees/' . $decreeId, ['Accept-Language' => 'la']));
+
+        self::assertSame(200, $resp->getStatusCode());
+        $body = $this->decodeJsonBody($resp);
+        self::assertSame($decreeId, $body['decree_id']);
+    }
+
+    public function testUnknownDecreeIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        ( new DecreesHandler(['totally-not-a-real-decree-id']) )
+            ->handle($this->requestFor('GET', '/decrees/totally-not-a-real-decree-id', ['Accept-Language' => 'la']));
+    }
+
+    public function testTooManyPathParamsIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new DecreesHandler(['a', 'b']) )
+            ->handle($this->requestFor('GET', '/decrees/a/b', ['Accept-Language' => 'la']));
+    }
+
+    public function testPutIsNotImplemented(): void
+    {
+        $resp = ( new DecreesHandler() )->handle(
+            $this->requestFor(
+                'PUT',
+                '/decrees',
+                ['Accept-Language' => 'la'],
+                ['decree_id' => 'fake']
+            )
+        );
+        self::assertSame(405, $resp->getStatusCode());
+    }
+}

--- a/phpunit_tests/Handlers/EasterHandlerTest.php
+++ b/phpunit_tests/Handlers/EasterHandlerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\EasterHandler;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(EasterHandler::class)]
+final class EasterHandlerTest extends AbstractHandlerTestCase
+{
+    private const CACHE_DIR = 'engineCache/easter';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Each test starts from a cold cache — the handler's ETag and 304
+        // branches only run on cache misses.
+        if (is_dir(self::CACHE_DIR)) {
+            foreach ((array) glob(self::CACHE_DIR . '/*') as $file) {
+                if (is_string($file) && is_file($file)) {
+                    unlink($file);
+                }
+            }
+        }
+    }
+
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new EasterHandler() )->handle(
+            $this->requestFor('OPTIONS', '/easter', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetReturnsEasterDatesAndEtag(): void
+    {
+        // Latin path: avoids the IntlDateFormatter setup; uses LatinUtils.
+        // Locale via Accept-Language so EasterParams picks it up.
+        $response = ( new EasterHandler() )->handle(
+            $this->requestFor('GET', '/easter', ['Accept-Language' => 'la'])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotEmpty($response->getHeaderLine('ETag'));
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_easter', $body);
+        self::assertNotEmpty($body['litcal_easter']);
+        // 1583..9999 inclusive — exactly 8417 entries.
+        self::assertCount(8417, $body['litcal_easter']);
+        self::assertArrayHasKey('lastCoincidence', $body);
+        self::assertArrayHasKey('lastCoincidenceString', $body);
+
+        // Sanity-check one well-known date: Easter 2025 (Gregorian) is Apr 20.
+        $entry2025 = $body['litcal_easter'][2025 - 1583];
+        self::assertSame(
+            ( new \DateTime('2025-04-20') )->format('U'),
+            (string) $entry2025['gregorianEaster']
+        );
+    }
+
+    public function testConditionalGetWithMatchingEtagReturns304(): void
+    {
+        // First (cold) call to learn the ETag. Important: the handler only
+        // checks If-None-Match on the cache-miss path, so we must clear the
+        // cache between the two calls to keep both runs cold.
+        $first = ( new EasterHandler() )->handle(
+            $this->requestFor('GET', '/easter', ['Accept-Language' => 'la'])
+        );
+        $etag  = trim($first->getHeaderLine('ETag'), ' "');
+        self::assertNotEmpty($etag);
+
+        unlink(self::CACHE_DIR . '/la.json');
+
+        $second = ( new EasterHandler() )->handle(
+            $this->requestFor('GET', '/easter', [
+                'Accept-Language' => 'la',
+                'If-None-Match'   => '"' . $etag . '"',
+            ])
+        );
+
+        self::assertSame(304, $second->getStatusCode());
+        self::assertSame('0', $second->getHeaderLine('Content-Length'));
+    }
+}

--- a/phpunit_tests/Handlers/EventsHandlerTest.php
+++ b/phpunit_tests/Handlers/EventsHandlerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\EventsHandler;
+use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(EventsHandler::class)]
+final class EventsHandlerTest extends AbstractHandlerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // EventsHandler constructs an EventsParams, which fetches
+        // /calendars metadata via file_get_contents during its constructor.
+        // Point Router::$apiPath at the file:// fixture introduced in M1 so
+        // the fetch is deterministic and offline.
+        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
+        self::assertNotFalse($fixturePath, 'M1 calendars fixture must be present');
+        Router::$apiPath = 'file://' . $fixturePath;
+    }
+
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new EventsHandler() )->handle(
+            $this->requestFor('OPTIONS', '/events', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetReturnsLiturgicalEvents(): void
+    {
+        $response = ( new EventsHandler() )->handle(
+            $this->requestFor('GET', '/events', ['Accept-Language' => 'la'])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_events', $body);
+        self::assertNotEmpty($body['litcal_events']);
+        self::assertArrayHasKey('settings', $body);
+        self::assertSame('la', $body['settings']['locale']);
+        // Each event has an event_key (the catalog id used by frontends).
+        self::assertArrayHasKey('event_key', $body['litcal_events'][0]);
+    }
+
+    public function testGetForNationalCalendarReturnsThatCalendar(): void
+    {
+        $handler  = new EventsHandler(['nation', 'IT']);
+        $response = $handler->handle($this->requestFor('GET', '/events/nation/IT', ['Accept-Language' => 'it']));
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertSame('IT', $body['settings']['national_calendar']);
+    }
+
+    public function testBadResourceTypeIsUnprocessable(): void
+    {
+        $this->expectException(UnprocessableContentException::class);
+        ( new EventsHandler(['galaxy', 'IT']) )
+            ->handle($this->requestFor('GET', '/events/galaxy/IT', ['Accept-Language' => 'la']));
+    }
+
+    public function testTooFewPathPartsIsUnprocessable(): void
+    {
+        // count=1 misses the count-2 branch and falls through to the error
+        // path. UnprocessableContentException is the expected surface.
+        $this->expectException(UnprocessableContentException::class);
+        ( new EventsHandler(['nation']) )
+            ->handle($this->requestFor('GET', '/events/nation', ['Accept-Language' => 'la']));
+    }
+
+    public function testUnknownDiocesanCalendarIsValidationError(): void
+    {
+        // 'diocese' is a valid resource path but the second segment is an
+        // unknown diocesan key, which EventsParams rejects.
+        $this->expectException(ValidationException::class);
+        ( new EventsHandler(['diocese', 'nowhere_zz']) )
+            ->handle($this->requestFor('GET', '/events/diocese/nowhere_zz', ['Accept-Language' => 'la']));
+    }
+}

--- a/phpunit_tests/Handlers/MetadataHandlerTest.php
+++ b/phpunit_tests/Handlers/MetadataHandlerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\MetadataHandler;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(MetadataHandler::class)]
+final class MetadataHandlerTest extends AbstractHandlerTestCase
+{
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new MetadataHandler() )->handle(
+            $this->requestFor('OPTIONS', '/calendars', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetReturnsCalendarsMetadata(): void
+    {
+        $response = ( new MetadataHandler() )->handle($this->requestFor('GET', '/calendars'));
+
+        self::assertSame(200, $response->getStatusCode());
+        $etag = trim($response->getHeaderLine('ETag'), ' "');
+        self::assertNotEmpty($etag);
+
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_metadata', $body);
+        self::assertArrayHasKey('national_calendars', $body['litcal_metadata']);
+        self::assertArrayHasKey('national_calendars_keys', $body['litcal_metadata']);
+        self::assertArrayHasKey('diocesan_calendars', $body['litcal_metadata']);
+        self::assertArrayHasKey('diocesan_calendars_keys', $body['litcal_metadata']);
+        self::assertArrayHasKey('wider_regions', $body['litcal_metadata']);
+        self::assertArrayHasKey('locales', $body['litcal_metadata']);
+        // The "VA" General Roman calendar is always present.
+        self::assertContains('VA', $body['litcal_metadata']['national_calendars_keys']);
+    }
+
+    public function testConditionalGetWithMatchingEtagReturns304(): void
+    {
+        $first = ( new MetadataHandler() )->handle($this->requestFor('GET', '/calendars'));
+        $etag  = trim($first->getHeaderLine('ETag'), ' "');
+        self::assertNotEmpty($etag);
+
+        $second = ( new MetadataHandler() )->handle(
+            $this->requestFor('GET', '/calendars', ['If-None-Match' => '"' . $etag . '"'])
+        );
+
+        self::assertSame(304, $second->getStatusCode());
+        self::assertSame('0', $second->getHeaderLine('Content-Length'));
+    }
+}

--- a/phpunit_tests/Handlers/MissalsHandlerTest.php
+++ b/phpunit_tests/Handlers/MissalsHandlerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\MissalsHandler;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(MissalsHandler::class)]
+final class MissalsHandlerTest extends AbstractHandlerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // The handler caches its built index on a static; reset so each test
+        // starts cold and we can also verify the build path.
+        MissalsHandler::$missalsIndex = null;
+    }
+
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new MissalsHandler() )->handle(
+            $this->requestFor('OPTIONS', '/missals', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetReturnsMissalsIndex(): void
+    {
+        $response = ( new MissalsHandler() )->handle(
+            $this->requestFor('GET', '/missals', ['Accept-Language' => 'la'])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        // MissalsParams canonicalizes Accept-Language 'la' down to 'la'
+        // (its short form) rather than expanding to 'la_VA'.
+        self::assertSame('la', $response->getHeaderLine('X-Litcal-Missals-Locale'));
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_missals', $body);
+        self::assertNotEmpty($body['litcal_missals']);
+        // Each entry has a missal_id we can look up individually.
+        self::assertArrayHasKey('missal_id', $body['litcal_missals'][0]);
+    }
+
+    public function testGetReturnsSingleMissalByPathId(): void
+    {
+        // First, discover a missal_id from the index.
+        $indexResp = ( new MissalsHandler() )->handle(
+            $this->requestFor('GET', '/missals', ['Accept-Language' => 'la'])
+        );
+        $missalId  = $this->decodeJsonBody($indexResp)['litcal_missals'][0]['missal_id'];
+        self::assertIsString($missalId);
+
+        $handler = new MissalsHandler([$missalId]);
+        $resp    = $handler->handle($this->requestFor('GET', '/missals/' . $missalId, ['Accept-Language' => 'la']));
+
+        self::assertSame(200, $resp->getStatusCode());
+        $body = $this->decodeJsonBody($resp);
+        // Single-missal response is an array of event rows.
+        self::assertIsArray($body);
+    }
+
+    public function testUnknownMissalIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        ( new MissalsHandler(['NOT_A_REAL_MISSAL']) )
+            ->handle($this->requestFor('GET', '/missals/NOT_A_REAL_MISSAL', ['Accept-Language' => 'la']));
+    }
+
+    public function testTooManyPathParamsIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new MissalsHandler(['a', 'b']) )
+            ->handle($this->requestFor('GET', '/missals/a/b', ['Accept-Language' => 'la']));
+    }
+
+    public function testPutIsMethodNotAllowed(): void
+    {
+        $this->expectException(MethodNotAllowedException::class);
+        ( new MissalsHandler() )->handle(
+            $this->requestFor('PUT', '/missals', ['Accept-Language' => 'la'], ['name' => 'fake'])
+        );
+    }
+
+    public function testRegionFilterIsApplied(): void
+    {
+        $response = ( new MissalsHandler() )->handle(
+            $this->requestFor('GET', '/missals?region=IT', ['Accept-Language' => 'la'])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('IT', $response->getHeaderLine('X-Litcal-Missals-Region'));
+        $body = $this->decodeJsonBody($response);
+        // Every returned missal must match the region filter.
+        foreach ($body['litcal_missals'] as $missal) {
+            self::assertSame('IT', $missal['region']);
+        }
+    }
+}

--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
+use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * RegionalDataHandler serves and edits per-nation / per-diocese / per-wider-
+ * region calendar source data. The PUT/PATCH/DELETE branches are gated by
+ * JWT auth middleware (added by the router before handler invocation) and
+ * involve disk writes; this suite covers the read paths and the path /
+ * category validators that run before any side effects.
+ */
+#[CoversClass(RegionalDataHandler::class)]
+final class RegionalDataHandlerTest extends AbstractHandlerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // The handler resolves national/diocesan keys against the /calendars
+        // metadata; route the fetch at the M1 fixture so the lookups succeed
+        // deterministically without an HTTP server.
+        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
+        self::assertNotFalse($fixturePath, 'M1 calendars fixture must be present');
+        Router::$apiPath = 'file://' . $fixturePath;
+    }
+
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new RegionalDataHandler() )->handle(
+            $this->requestFor('OPTIONS', '/data', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testTooFewPathParamsIsValidationError(): void
+    {
+        // GET requires at least two segments (category + key); pass one.
+        $this->expectException(ValidationException::class);
+        ( new RegionalDataHandler(['nation']) )
+            ->handle($this->requestFor('GET', '/data/nation'));
+    }
+
+    public function testInvalidCategoryIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new RegionalDataHandler(['planet', 'mars']) )
+            ->handle($this->requestFor('GET', '/data/planet/mars'));
+    }
+
+    public function testGetForUnknownNationalCalendarIsUnprocessable(): void
+    {
+        // 'ZZ' isn't a real nation key; the handler surfaces an
+        // UnprocessableContentException listing valid keys.
+        $this->expectException(UnprocessableContentException::class);
+        ( new RegionalDataHandler(['nation', 'ZZ']) )
+            ->handle($this->requestFor('GET', '/data/nation/ZZ'));
+    }
+
+    public function testPutWithoutPayloadIsValidationError(): void
+    {
+        // PUT requires exactly 1 path param (the category). Passing the
+        // request without a body trips the empty-payload check in
+        // parseBodyPayload → ValidationException.
+        $this->expectException(ValidationException::class);
+        ( new RegionalDataHandler(['nation']) )
+            ->handle($this->requestFor('PUT', '/data/nation', ['Content-Type' => 'application/json'], ''));
+    }
+}

--- a/phpunit_tests/Handlers/SchemasHandlerTest.php
+++ b/phpunit_tests/Handlers/SchemasHandlerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\SchemasHandler;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(SchemasHandler::class)]
+final class SchemasHandlerTest extends AbstractHandlerTestCase
+{
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new SchemasHandler() )->handle(
+            $this->requestFor('OPTIONS', '/schemas', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testNoPathParamsReturnsSchemaIndex(): void
+    {
+        $response = ( new SchemasHandler() )->handle($this->requestFor('GET', '/schemas'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/json', $response->getHeaderLine('Content-Type'));
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_schemas', $body);
+        self::assertIsArray($body['litcal_schemas']);
+        self::assertNotEmpty($body['litcal_schemas']);
+        // Each entry is a URL ending in .json
+        foreach ($body['litcal_schemas'] as $entry) {
+            self::assertStringEndsWith('.json', $entry);
+        }
+    }
+
+    public function testKnownSchemaFileIsReturnedRaw(): void
+    {
+        // Pick a known schema that lives in jsondata/schemas/. LitCalTest.json
+        // ships with the repo per CLAUDE.md's docs.
+        $handler = new SchemasHandler(['LitCalTest.json']);
+
+        $response = $handler->handle($this->requestFor('GET', '/schemas/LitCalTest.json'));
+
+        self::assertSame(200, $response->getStatusCode());
+        $raw = (string) $response->getBody();
+        self::assertJson($raw, 'Schema body must be valid JSON');
+    }
+
+    public function testMissingSchemaIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        $handler = new SchemasHandler(['Does_Not_Exist.json']);
+        $handler->handle($this->requestFor('GET', '/schemas/Does_Not_Exist.json'));
+    }
+
+    public function testTooManyPathParamsIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        $handler = new SchemasHandler(['a.json', 'b.json']);
+        $handler->handle($this->requestFor('GET', '/schemas/a.json/b.json'));
+    }
+}

--- a/phpunit_tests/Handlers/TemporaleHandlerTest.php
+++ b/phpunit_tests/Handlers/TemporaleHandlerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\TemporaleHandler;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * TemporaleHandler serves the Proper of Time data with translations and
+ * lectionary readings. Deep coverage of the read-write paths (PUT / PATCH /
+ * DELETE — JWT/DB-gated) lives in M5 once Services have mock seams; this
+ * suite focuses on the read paths and the gates that run before the
+ * write-path side effects.
+ */
+#[CoversClass(TemporaleHandler::class)]
+final class TemporaleHandlerTest extends AbstractHandlerTestCase
+{
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new TemporaleHandler() )->handle(
+            $this->requestFor('OPTIONS', '/temporale', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetReturnsTemporaleData(): void
+    {
+        $response = ( new TemporaleHandler() )->handle(
+            $this->requestFor('GET', '/temporale', ['Accept-Language' => 'la'])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        // The handler returns a list of temporale event objects, each with
+        // an event_key. The shape varies (sometimes wrapped, sometimes raw),
+        // so just verify the response is JSON-parseable and non-empty.
+        self::assertNotEmpty($body);
+    }
+
+    public function testInvalidLocaleQueryIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new TemporaleHandler() )->handle(
+            $this->requestFor('GET', '/temporale?locale=clearly-not-a-locale')
+        );
+    }
+}

--- a/phpunit_tests/Handlers/TestsHandlerTest.php
+++ b/phpunit_tests/Handlers/TestsHandlerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\TestsHandler;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(TestsHandler::class)]
+final class TestsHandlerTest extends AbstractHandlerTestCase
+{
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new TestsHandler() )->handle(
+            $this->requestFor('OPTIONS', '/tests', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetReturnsTestSuiteIndex(): void
+    {
+        $response = ( new TestsHandler() )->handle($this->requestFor('GET', '/tests'));
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_tests', $body);
+        self::assertNotEmpty($body['litcal_tests']);
+    }
+
+    public function testGetSingleTestByNameReturnsThatTest(): void
+    {
+        // MaryMotherChurchTest ships with the repo per jsondata/tests/.
+        $handler  = new TestsHandler(['MaryMotherChurchTest']);
+        $response = $handler->handle($this->requestFor('GET', '/tests/MaryMotherChurchTest'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertJson((string) $response->getBody());
+    }
+
+    public function testUnknownTestIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+        ( new TestsHandler(['NotARealTest']) )
+            ->handle($this->requestFor('GET', '/tests/NotARealTest'));
+    }
+
+    public function testTooManyPathParamsIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new TestsHandler(['a', 'b']) )
+            ->handle($this->requestFor('GET', '/tests/a/b'));
+    }
+
+    public function testPutWithMalformedPayloadIsValidationError(): void
+    {
+        // PUT (writes), with a JSON array of scalars (not objects). parseBodyPayload
+        // surfaces this as a ValidationException at the AbstractHandler layer before
+        // TestsHandler's own object check fires.
+        $this->expectException(ValidationException::class);
+        $req = $this->requestFor('PUT', '/tests', [], '[1, 2, 3]')
+            ->withHeader('Content-Type', 'application/json');
+        ( new TestsHandler() )->handle($req);
+    }
+}

--- a/src/Handlers/ApplicationsHandler.php
+++ b/src/Handlers/ApplicationsHandler.php
@@ -260,7 +260,9 @@ final class ApplicationsHandler extends AbstractHandler
             $application['uuid'] = $application['id'];
         }
 
-        $response = $response->withStatus(StatusCode::CREATED->value);
+        // encodeResponseBody overwrites the response status with its $statusCode
+        // argument (default OK), so the only effective way to emit 201 here is
+        // to pass it through rather than calling ->withStatus() first.
         return $this->encodeResponseBody($response, [
             'success'     => true,
             'message'     => 'Application request submitted successfully. An admin will review your application.',
@@ -462,7 +464,8 @@ final class ApplicationsHandler extends AbstractHandler
             $expiresAt
         );
 
-        $response = $response->withStatus(StatusCode::CREATED->value);
+        // encodeResponseBody's $statusCode argument is what actually sticks;
+        // the prior $response->withStatus() was a no-op overwritten below.
         return $this->encodeResponseBody($response, [
             'success' => true,
             'message' => 'API key generated successfully. Save this key - it will not be shown again.',


### PR DESCRIPTION
Adds **60 in-process tests (183 assertions)** covering the 11 non-Auth/Admin handlers in `src/Handlers/`, completing handler coverage of the API. With M1–M3 also merged, the standalone in-process suite is now **317 tests / 807 assertions** — exercised on every PR by CI's `phpunit` job against the workflow's `postgres:17` service.

This is the **M4 milestone** of the layered plan in #570.

## Coverage

| File | Tests | Coverage focus |
| --- | --- | --- |
| `SchemasHandlerTest` | 5 | preflight, JSON-schema index, single-schema read, missing/too-many-params |
| `EasterHandlerTest` | 3 | preflight, 200 + ETag + 8417-year body, cache-aware 304 conditional GET |
| `DecreesHandlerTest` | 6 | preflight, index, single-by-id, unknown id, too-many-params, PUT-not-implemented |
| `MissalsHandlerTest` | 7 | preflight, index, single-by-id, region filter, X-Litcal-* headers, missing missal, PUT-not-implemented |
| `MetadataHandlerTest` | 3 | preflight, shape (`litcal_metadata`, VA presence), conditional GET (304) |
| `EventsHandlerTest` | 6 | preflight, GET shape, `nation/{key}` path form, bad resource type, too-few-parts, unknown diocese key |
| `TestsHandlerTest` | 6 | preflight, index, single-by-name, missing, too-many-params, malformed PUT body |
| `ApplicationsHandlerTest` | 10 | preflight, method allowlist, OIDC auth/developer-role gates, list/create/get/keys for owned + non-owned applications |
| `CalendarHandlerTest` | 6 | preflight, year-only path, explicit-year path, year bounds, non-numeric year, unknown nation key (uses M1 fixture) |
| `TemporaleHandlerTest` | 3 | preflight, read happy path, invalid `locale` query |
| `RegionalDataHandlerTest` | 5 | preflight, path-shape validation, category validation, unknown nation key, empty PUT body |

## Harness updates (`AbstractHandlerTestCase`)

- Pin `Router::$apiFilePath` alongside `Router::$apiPath` in `setUpBeforeClass`, so handlers that resolve filesystem paths via `JsonData` enum cases (e.g. `jsondata/schemas`, `jsondata/tests`, `jsondata/sourcedata/calendars`) work in-process. `tearDownAfterClass` restores both.
- The M1 `phpunit_tests/fixtures/api/calendars` fixture is reused per-class by handler tests whose handlers construct `CalendarParams` / `EventsParams` (which fetch the calendar metadata via `Utilities::jsonUrlToObject(Route::CALENDARS->path())`): `EventsHandlerTest`, `CalendarHandlerTest`, `RegionalDataHandlerTest`.

## Notes for review

- **CalendarHandler is 5128 LOC** and computes the full liturgical year. This suite covers the public request-shape surface (preflight, year/nation routing, bounds checks, end-to-end shape of a real computation) but defers deep edge-case coverage (suppression rules, transfer rules, Easter-cycle anomalies) to the external [UnitTestInterface](https://github.com/Liturgical-Calendar/UnitTestInterface) integration suite, which already exists for that purpose.
- **CalendarHandler test setup** calls `setAllowedReturnTypes(...)` before invoking, mirroring what `Router::buildHandler()` does in production. Without that call, `CalendarParams` rejects the default-negotiated `'JSON'` return type — a small in-router assumption surfaced here for the first time.
- **TemporaleHandler / RegionalDataHandler PUT/PATCH/DELETE** branches are gated by JWT auth middleware that the router prepends before handler invocation, and involve disk writes. This suite covers the read paths and the path/category validators that run before any side effects. The write paths land naturally when the auth middleware is unit-tested in M5/M6.
- **EasterHandler `If-None-Match` quirk**: the 304 path only fires on cache-miss, because the cache-hit code path returns the cached body before checking `If-None-Match`. Documented in a comment in the conditional-GET test; not changing here.

## Verification

Locally — full standalone suite:

```bash
vendor/bin/phpunit \
  phpunit_tests/Handlers \
  phpunit_tests/Database \
  phpunit_tests/Params \
  phpunit_tests/Repositories \
  phpunit_tests/Enum
# OK (317 tests, 807 assertions)
```

- `composer analyse` (PHPStan level 10): clean
- `composer lint` (PSR-12 + project rules): clean

## Test plan

- [ ] CI `phpunit` job runs the new `phpunit_tests/Handlers/*.php` suite green against the workflow's `postgres:17` service and the env vars CI writes to `.env.local`.
- [ ] Codecov picks up coverage on the 11 handlers covered here (all currently 0%).
- [ ] Existing M1 + M2 + M3 suites keep passing.

## Related

- #570 — parent coverage epic
- #577 (merged) — M1 (Params + Database)
- #579 (merged) — M2 (Repositories)
- #580 (merged) — M3 (Auth + Admin handlers)

Next planned: **M5 (Services)** — `JwtService`, `OpenFgaClient`, `ZitadelService`, `RoleCascadeService`, leveraging Guzzle's `MockHandler` (already used in the existing `OpenFgaClientTest`). **M6** then covers the remaining `Models/`, `Enum/`, `Http/`, and `Router` layers.


---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage across all API handlers: request validation, error handling, CORS preflight, caching/ETag behavior, conditional GETs, and data retrieval for calendars, events, missals, decrees, easter, schemas, temporale, regional data, tests, and applications. Base test setup now ensures deterministic, isolated execution and database-backed scenarios for application/key workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/581)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->