### PR TITLE
test: unit-test src/Enum, src/Http, src/Models, Router (issue #570 M6)

### DIFF
--- a/phpunit_tests/Enum/ICSErrorLevelTest.php
+++ b/phpunit_tests/Enum/ICSErrorLevelTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\ICSErrorLevel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ICSErrorLevel::class)]
+final class ICSErrorLevelTest extends TestCase
+{
+    public function testConstants(): void
+    {
+        self::assertSame(1, ICSErrorLevel::REPAIRED);
+        self::assertSame(2, ICSErrorLevel::WARNING);
+        self::assertSame(3, ICSErrorLevel::FATAL);
+    }
+
+    public function testCastsToHumanReadableString(): void
+    {
+        self::assertSame('Repaired value', (string) new ICSErrorLevel(ICSErrorLevel::REPAIRED));
+        self::assertSame('Warning', (string) new ICSErrorLevel(ICSErrorLevel::WARNING));
+        self::assertSame('Fatal Error', (string) new ICSErrorLevel(ICSErrorLevel::FATAL));
+    }
+
+    public function testRejectsLevelBelowOne(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new ICSErrorLevel(0);
+    }
+
+    public function testRejectsLevelAboveThree(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new ICSErrorLevel(4);
+    }
+}

--- a/phpunit_tests/Enum/JsonDataTest.php
+++ b/phpunit_tests/Enum/JsonDataTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\JsonDataConstants;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(JsonData::class)]
+#[CoversClass(JsonDataConstants::class)]
+final class JsonDataTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // JsonData::path() concatenates Router::$apiFilePath; populate it.
+        Router::getApiPaths();
+    }
+
+    public function testConstantHierarchyComposesCorrectly(): void
+    {
+        self::assertSame('jsondata', JsonDataConstants::FOLDER);
+        self::assertSame('jsondata/schemas', JsonDataConstants::SCHEMAS_FOLDER);
+        self::assertSame('jsondata/sourcedata', JsonDataConstants::SOURCEDATA_FOLDER);
+        self::assertSame('jsondata/sourcedata/decrees', JsonDataConstants::DECREES_FOLDER);
+        self::assertSame('jsondata/sourcedata/decrees/decrees.json', JsonDataConstants::DECREES_FILE);
+        self::assertSame('jsondata/sourcedata/missals', JsonDataConstants::MISSALS_FOLDER);
+        self::assertSame(
+            'jsondata/sourcedata/missals/propriumdetempore',
+            JsonDataConstants::TEMPORALE_FOLDER
+        );
+        self::assertSame(
+            'jsondata/sourcedata/missals/propriumdetempore/propriumdetempore.json',
+            JsonDataConstants::TEMPORALE_FILE
+        );
+        self::assertSame('jsondata/sourcedata/calendars', JsonDataConstants::CALENDARS_FOLDER);
+        self::assertSame(
+            'jsondata/sourcedata/calendars/nations',
+            JsonDataConstants::NATIONAL_CALENDARS_FOLDER
+        );
+        self::assertSame(
+            'jsondata/sourcedata/calendars/dioceses',
+            JsonDataConstants::DIOCESAN_CALENDARS_FOLDER
+        );
+        self::assertSame('jsondata/world_dioceses.json', JsonDataConstants::CATHOLIC_DIOCESES_LATIN_RITE);
+    }
+
+    public function testEnumCaseValuesEchoConstants(): void
+    {
+        self::assertSame(JsonDataConstants::FOLDER, JsonData::FOLDER->value);
+        self::assertSame(JsonDataConstants::SCHEMAS_FOLDER, JsonData::SCHEMAS_FOLDER->value);
+        self::assertSame(JsonDataConstants::DECREES_FILE, JsonData::DECREES_FILE->value);
+        self::assertSame(
+            JsonDataConstants::CATHOLIC_DIOCESES_LATIN_RITE,
+            JsonData::CATHOLIC_DIOCESES_LATIN_RITE->value
+        );
+    }
+
+    public function testPathPrependsApiFilePath(): void
+    {
+        $path = JsonData::FOLDER->path();
+        self::assertSame(Router::$apiFilePath . 'jsondata', $path);
+
+        $schemaPath = JsonData::SCHEMAS_FOLDER->path();
+        self::assertStringEndsWith('jsondata/schemas', $schemaPath);
+    }
+}

--- a/phpunit_tests/Enum/LectionaryCategoryTest.php
+++ b/phpunit_tests/Enum/LectionaryCategoryTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LectionaryCategory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LectionaryCategory::class)]
+final class LectionaryCategoryTest extends TestCase
+{
+    public function testForEventKeyAdvent(): void
+    {
+        self::assertSame(LectionaryCategory::WEEKDAYS_ADVENT, LectionaryCategory::forEventKey('AdventWeekday1Mon'));
+        self::assertSame(LectionaryCategory::WEEKDAYS_ADVENT, LectionaryCategory::forEventKey('AdventWeekdayDec18'));
+    }
+
+    public function testForEventKeyChristmas(): void
+    {
+        self::assertSame(LectionaryCategory::WEEKDAYS_CHRISTMAS, LectionaryCategory::forEventKey('ChristmasWeekdayDec29'));
+        self::assertSame(LectionaryCategory::WEEKDAYS_CHRISTMAS, LectionaryCategory::forEventKey('DayAfterEpiphany'));
+    }
+
+    public function testForEventKeyLent(): void
+    {
+        self::assertSame(LectionaryCategory::WEEKDAYS_LENT, LectionaryCategory::forEventKey('AshWednesday'));
+        self::assertSame(LectionaryCategory::WEEKDAYS_LENT, LectionaryCategory::forEventKey('LentWeekday3Mon'));
+        self::assertSame(LectionaryCategory::WEEKDAYS_LENT, LectionaryCategory::forEventKey('MonHolyWeek'));
+        self::assertSame(LectionaryCategory::WEEKDAYS_LENT, LectionaryCategory::forEventKey('FridayAfterAshWednesday'));
+    }
+
+    public function testForEventKeyEaster(): void
+    {
+        self::assertSame(LectionaryCategory::WEEKDAYS_EASTER, LectionaryCategory::forEventKey('MonOctaveEaster'));
+        self::assertSame(LectionaryCategory::WEEKDAYS_EASTER, LectionaryCategory::forEventKey('EasterWeekday3'));
+    }
+
+    public function testForEventKeyOrdinary(): void
+    {
+        self::assertSame(LectionaryCategory::WEEKDAYS_ORDINARY, LectionaryCategory::forEventKey('OrdWeekday5Tue'));
+    }
+
+    public function testForEventKeySanctorum(): void
+    {
+        self::assertSame(LectionaryCategory::SANCTORUM, LectionaryCategory::forEventKey('ImmaculateHeart'));
+    }
+
+    public function testForEventKeyDefault(): void
+    {
+        self::assertSame(LectionaryCategory::SUNDAYS_SOLEMNITIES, LectionaryCategory::forEventKey('Easter'));
+        self::assertSame(LectionaryCategory::SUNDAYS_SOLEMNITIES, LectionaryCategory::forEventKey('OrdSunday7'));
+    }
+
+    public function testHasYearCycle(): void
+    {
+        self::assertTrue(LectionaryCategory::SUNDAYS_SOLEMNITIES->hasYearCycle());
+        self::assertFalse(LectionaryCategory::WEEKDAYS_ADVENT->hasYearCycle());
+        self::assertFalse(LectionaryCategory::WEEKDAYS_ORDINARY->hasYearCycle());
+    }
+
+    public function testHasTwoYearCycle(): void
+    {
+        self::assertTrue(LectionaryCategory::WEEKDAYS_ORDINARY->hasTwoYearCycle());
+        self::assertFalse(LectionaryCategory::SUNDAYS_SOLEMNITIES->hasTwoYearCycle());
+    }
+
+    public function testFolderAndFile(): void
+    {
+        self::assertSame(JsonData::LECTIONARY_SUNDAYS_SOLEMNITIES_A_FOLDER, LectionaryCategory::SUNDAYS_SOLEMNITIES->folder());
+        self::assertSame(JsonData::LECTIONARY_SUNDAYS_SOLEMNITIES_A_FILE, LectionaryCategory::SUNDAYS_SOLEMNITIES->file());
+        self::assertSame(JsonData::LECTIONARY_WEEKDAYS_ORDINARY_I_FOLDER, LectionaryCategory::WEEKDAYS_ORDINARY->folder());
+        self::assertSame(JsonData::LECTIONARY_WEEKDAYS_ORDINARY_I_FILE, LectionaryCategory::WEEKDAYS_ORDINARY->file());
+        self::assertSame(JsonData::LECTIONARY_WEEKDAYS_ADVENT_FOLDER, LectionaryCategory::WEEKDAYS_ADVENT->folder());
+        self::assertSame(JsonData::LECTIONARY_WEEKDAYS_CHRISTMAS_FILE, LectionaryCategory::WEEKDAYS_CHRISTMAS->file());
+        self::assertSame(JsonData::LECTIONARY_SAINTS_FOLDER, LectionaryCategory::SANCTORUM->folder());
+    }
+
+    public function testLiturgicalColor(): void
+    {
+        self::assertSame(['purple'], LectionaryCategory::WEEKDAYS_ADVENT->liturgicalColor());
+        self::assertSame(['purple'], LectionaryCategory::WEEKDAYS_LENT->liturgicalColor());
+        self::assertSame(['white'], LectionaryCategory::WEEKDAYS_CHRISTMAS->liturgicalColor());
+        self::assertSame(['white'], LectionaryCategory::WEEKDAYS_EASTER->liturgicalColor());
+        self::assertSame(['green'], LectionaryCategory::WEEKDAYS_ORDINARY->liturgicalColor());
+        self::assertSame([], LectionaryCategory::SUNDAYS_SOLEMNITIES->liturgicalColor());
+        self::assertSame([], LectionaryCategory::SANCTORUM->liturgicalColor());
+    }
+
+    public function testIsFerial(): void
+    {
+        self::assertTrue(LectionaryCategory::WEEKDAYS_ADVENT->isFerial());
+        self::assertTrue(LectionaryCategory::WEEKDAYS_ORDINARY->isFerial());
+        self::assertFalse(LectionaryCategory::SUNDAYS_SOLEMNITIES->isFerial());
+        self::assertFalse(LectionaryCategory::SANCTORUM->isFerial());
+    }
+
+    public function testFolderForYear(): void
+    {
+        self::assertSame(
+            JsonData::LECTIONARY_SUNDAYS_SOLEMNITIES_A_FOLDER,
+            LectionaryCategory::SUNDAYS_SOLEMNITIES->folderForYear('A')
+        );
+        self::assertSame(
+            JsonData::LECTIONARY_SUNDAYS_SOLEMNITIES_B_FOLDER,
+            LectionaryCategory::SUNDAYS_SOLEMNITIES->folderForYear('b')
+        );
+        self::assertSame(
+            JsonData::LECTIONARY_SUNDAYS_SOLEMNITIES_C_FOLDER,
+            LectionaryCategory::SUNDAYS_SOLEMNITIES->folderForYear('C')
+        );
+    }
+
+    public function testFolderForYearRejectsInvalidYear(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LectionaryCategory::SUNDAYS_SOLEMNITIES->folderForYear('D');
+    }
+
+    public function testFolderForYearRejectsCategoryWithoutYearCycle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('does not have year cycles');
+        LectionaryCategory::WEEKDAYS_ADVENT->folderForYear('A');
+    }
+
+    public function testFileForYear(): void
+    {
+        self::assertSame(
+            JsonData::LECTIONARY_SUNDAYS_SOLEMNITIES_A_FILE,
+            LectionaryCategory::SUNDAYS_SOLEMNITIES->fileForYear('A')
+        );
+        self::assertSame(
+            JsonData::LECTIONARY_SUNDAYS_SOLEMNITIES_C_FILE,
+            LectionaryCategory::SUNDAYS_SOLEMNITIES->fileForYear('c')
+        );
+    }
+
+    public function testFileForYearRejectsInvalidYear(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LectionaryCategory::SUNDAYS_SOLEMNITIES->fileForYear('Z');
+    }
+
+    public function testFileForYearRejectsCategoryWithoutYearCycle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LectionaryCategory::WEEKDAYS_LENT->fileForYear('A');
+    }
+
+    public function testFolderAndFileForTwoYearCycle(): void
+    {
+        self::assertSame(
+            JsonData::LECTIONARY_WEEKDAYS_ORDINARY_I_FOLDER,
+            LectionaryCategory::WEEKDAYS_ORDINARY->folderForTwoYearCycle('I')
+        );
+        self::assertSame(
+            JsonData::LECTIONARY_WEEKDAYS_ORDINARY_II_FOLDER,
+            LectionaryCategory::WEEKDAYS_ORDINARY->folderForTwoYearCycle('ii')
+        );
+        self::assertSame(
+            JsonData::LECTIONARY_WEEKDAYS_ORDINARY_I_FILE,
+            LectionaryCategory::WEEKDAYS_ORDINARY->fileForTwoYearCycle('i')
+        );
+        self::assertSame(
+            JsonData::LECTIONARY_WEEKDAYS_ORDINARY_II_FILE,
+            LectionaryCategory::WEEKDAYS_ORDINARY->fileForTwoYearCycle('II')
+        );
+    }
+
+    public function testFolderForTwoYearCycleRejectsInvalidYear(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LectionaryCategory::WEEKDAYS_ORDINARY->folderForTwoYearCycle('III');
+    }
+
+    public function testFolderForTwoYearCycleRejectsCategoryWithoutTwoYearCycle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LectionaryCategory::WEEKDAYS_ADVENT->folderForTwoYearCycle('I');
+    }
+
+    public function testFileForTwoYearCycleRejectsInvalidYear(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LectionaryCategory::WEEKDAYS_ORDINARY->fileForTwoYearCycle('III');
+    }
+
+    public function testFileForTwoYearCycleRejectsCategoryWithoutTwoYearCycle(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LectionaryCategory::WEEKDAYS_LENT->fileForTwoYearCycle('I');
+    }
+
+    public function testGetPatterns(): void
+    {
+        self::assertIsArray(LectionaryCategory::WEEKDAYS_ADVENT->getPatterns());
+        self::assertIsArray(LectionaryCategory::WEEKDAYS_ORDINARY->getPatterns());
+        self::assertNull(LectionaryCategory::SUNDAYS_SOLEMNITIES->getPatterns());
+        self::assertNull(LectionaryCategory::SANCTORUM->getPatterns());
+    }
+
+    public function testEventKeys(): void
+    {
+        self::assertSame(['ImmaculateHeart'], LectionaryCategory::SANCTORUM->eventKeys());
+        self::assertNull(LectionaryCategory::WEEKDAYS_ADVENT->eventKeys());
+        self::assertNull(LectionaryCategory::SUNDAYS_SOLEMNITIES->eventKeys());
+    }
+
+    public function testSpecialEventKeysAndFerialCategories(): void
+    {
+        self::assertSame(['ImmaculateHeart'], LectionaryCategory::specialEventKeys());
+        $ferial = LectionaryCategory::ferialCategories();
+        self::assertCount(5, $ferial);
+        self::assertContains(LectionaryCategory::WEEKDAYS_ADVENT, $ferial);
+        self::assertContains(LectionaryCategory::WEEKDAYS_ORDINARY, $ferial);
+        self::assertNotContains(LectionaryCategory::SANCTORUM, $ferial);
+        self::assertNotContains(LectionaryCategory::SUNDAYS_SOLEMNITIES, $ferial);
+    }
+
+    public function testAll(): void
+    {
+        self::assertSame(LectionaryCategory::cases(), LectionaryCategory::all());
+    }
+}

--- a/phpunit_tests/Enum/LitColorTest.php
+++ b/phpunit_tests/Enum/LitColorTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\LitColor;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LitColor::class)]
+final class LitColorTest extends TestCase
+{
+    public function testCases(): void
+    {
+        self::assertSame('green', LitColor::GREEN->value);
+        self::assertSame('purple', LitColor::PURPLE->value);
+        self::assertSame('white', LitColor::WHITE->value);
+        self::assertSame('red', LitColor::RED->value);
+        self::assertSame('rose', LitColor::ROSE->value);
+    }
+
+    public function testIsValid(): void
+    {
+        self::assertTrue(LitColor::isValid('green'));
+        self::assertTrue(LitColor::isValid('rose'));
+        self::assertFalse(LitColor::isValid('blue'));
+    }
+
+    public function testI18nLatin(): void
+    {
+        self::assertSame('viridis', LitColor::GREEN->i18n(LitLocale::LATIN));
+        self::assertSame('purpura', LitColor::PURPLE->i18n(LitLocale::LATIN));
+        self::assertSame('albus', LitColor::WHITE->i18n(LitLocale::LATIN_PRIMARY_LANGUAGE));
+        self::assertSame('ruber', LitColor::RED->i18n(LitLocale::LATIN));
+        self::assertSame('rosea', LitColor::ROSE->i18n(LitLocale::LATIN));
+    }
+
+    public function testI18nNonLatinReturnsAtLeastOriginalValueWhenNoTranslation(): void
+    {
+        // No gettext catalog is loaded in unit tests; _() falls through to the
+        // original string. We only care that the call doesn't blow up.
+        self::assertSame('green', LitColor::GREEN->i18n('en_US'));
+        self::assertSame('purple', LitColor::PURPLE->i18n('en_US'));
+        self::assertSame('white', LitColor::WHITE->i18n('en_US'));
+        self::assertSame('red', LitColor::RED->i18n('en_US'));
+        self::assertSame('rose', LitColor::ROSE->i18n('en_US'));
+    }
+}

--- a/phpunit_tests/Enum/LitCommonTest.php
+++ b/phpunit_tests/Enum/LitCommonTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\LitCommon;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LitCommon::class)]
+final class LitCommonTest extends TestCase
+{
+    public function testCaseValuesMatchEnglish(): void
+    {
+        self::assertSame('Proper', LitCommon::PROPRIO->value);
+        self::assertSame('Blessed Virgin Mary', LitCommon::BEATAE_MARIAE_VIRGINIS->value);
+        self::assertSame('', LitCommon::NONE->value);
+    }
+
+    public function testLatinMapCoversAllCases(): void
+    {
+        $caseNames = array_map(static fn (LitCommon $c): string => $c->name, LitCommon::cases());
+        self::assertSame($caseNames, array_keys(LitCommon::LATIN));
+    }
+
+    public function testLatinValueExamples(): void
+    {
+        self::assertSame('Beatæ Mariæ Virginis', LitCommon::LATIN[LitCommon::BEATAE_MARIAE_VIRGINIS->name]);
+        self::assertSame('Pro papa', LitCommon::LATIN[LitCommon::PRO_PAPA->name]);
+        self::assertSame('', LitCommon::LATIN[LitCommon::NONE->name]);
+    }
+
+    public function testGeneralCommonsConstantContents(): void
+    {
+        self::assertContains(LitCommon::PROPRIO, LitCommon::COMMUNES_GENERALIS);
+        self::assertContains(LitCommon::DEDICATIONIS_ECCLESIAE, LitCommon::COMMUNES_GENERALIS);
+        self::assertContains(LitCommon::SANCTORUM_ET_SANCTARUM, LitCommon::COMMUNES_GENERALIS);
+        self::assertCount(8, LitCommon::COMMUNES_GENERALIS);
+    }
+
+    public function testSubCommonGroupings(): void
+    {
+        self::assertContains(LitCommon::PRO_UNO_MARTYRE, LitCommon::COMMUNE_MARTYRUM);
+        self::assertContains(LitCommon::PRO_PAPA, LitCommon::COMMUNE_PASTORUM);
+        self::assertContains(LitCommon::PRO_UNA_VIRGINE, LitCommon::COMMUNE_VIRGINUM);
+        self::assertContains(LitCommon::PRO_ABBATE, LitCommon::COMMUNE_SANCTORUM);
+    }
+
+    public function testTranslateReturnsStrings(): void
+    {
+        foreach (LitCommon::cases() as $case) {
+            $translated = $case->translate();
+            self::assertIsString($translated);
+        }
+        // NONE always translates to empty string.
+        self::assertSame('', LitCommon::NONE->translate());
+    }
+
+    public function testPossessiveForFeminineSingular(): void
+    {
+        // Without a catalog pgettext() returns msgid 'of the' / 'of'.
+        self::assertSame('of the', LitCommon::BEATAE_MARIAE_VIRGINIS->possessive());
+        self::assertSame('of the', LitCommon::DEDICATIONIS_ECCLESIAE->possessive());
+    }
+
+    public function testPossessiveForPluralFeminine(): void
+    {
+        self::assertSame('of', LitCommon::VIRGINUM->possessive());
+    }
+
+    public function testPossessiveForPluralMasculine(): void
+    {
+        self::assertSame('of', LitCommon::MARTYRUM->possessive());
+        self::assertSame('of', LitCommon::PASTORUM->possessive());
+        self::assertSame('of', LitCommon::DOCTORUM->possessive());
+        self::assertSame('of', LitCommon::SANCTORUM_ET_SANCTARUM->possessive());
+    }
+
+    public function testPossessiveForSingularMasculineDefault(): void
+    {
+        // PROPRIO is in the General Commons but not matched by any other arm —
+        // it falls into the default (SING_MASC) branch.
+        self::assertSame('of the', LitCommon::PROPRIO->possessive());
+    }
+
+    public function testPossessiveRejectsNonGeneralCommons(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('PRO_UNO_MARTYRE');
+        LitCommon::PRO_UNO_MARTYRE->possessive();
+    }
+}

--- a/phpunit_tests/Enum/LitGradeTest.php
+++ b/phpunit_tests/Enum/LitGradeTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LitGrade::class)]
+final class LitGradeTest extends TestCase
+{
+    public function testNumericPrecedenceValues(): void
+    {
+        self::assertSame(7, LitGrade::HIGHER_SOLEMNITY->value);
+        self::assertSame(6, LitGrade::SOLEMNITY->value);
+        self::assertSame(5, LitGrade::FEAST_LORD->value);
+        self::assertSame(4, LitGrade::FEAST->value);
+        self::assertSame(3, LitGrade::MEMORIAL->value);
+        self::assertSame(2, LitGrade::MEMORIAL_OPT->value);
+        self::assertSame(1, LitGrade::COMMEMORATION->value);
+        self::assertSame(0, LitGrade::WEEKDAY->value);
+        self::assertSame(-1, LitGrade::INVALID->value);
+    }
+
+    public function testI18nLatinAbbreviatedAndFull(): void
+    {
+        self::assertSame('feria', LitGrade::WEEKDAY->i18n(LitLocale::LATIN, html: false));
+        self::assertSame('f', LitGrade::WEEKDAY->i18n(LitLocale::LATIN, html: false, abbreviate: true));
+        self::assertSame('SOLLEMNITAS', LitGrade::SOLEMNITY->i18n(LitLocale::LATIN, html: false));
+        self::assertSame('S', LitGrade::SOLEMNITY->i18n(LitLocale::LATIN, html: false, abbreviate: true));
+        self::assertSame('Memoria obligatoria', LitGrade::MEMORIAL->i18n(LitLocale::LATIN, html: false));
+        self::assertSame('FESTUM', LitGrade::FEAST->i18n(LitLocale::LATIN, html: false));
+        self::assertSame('FESTUM DOMINI', LitGrade::FEAST_LORD->i18n(LitLocale::LATIN, html: false));
+        self::assertSame('memoria ad libitum', LitGrade::MEMORIAL_OPT->i18n(LitLocale::LATIN, html: false));
+        self::assertSame('commemoratio', LitGrade::COMMEMORATION->i18n(LitLocale::LATIN, html: false));
+        self::assertSame('ignotus', LitGrade::INVALID->i18n(LitLocale::LATIN, html: false));
+    }
+
+    public function testHtmlWrapping(): void
+    {
+        // WEEKDAY wraps in <I>...</I>.
+        self::assertSame('<I>feria</I>', LitGrade::WEEKDAY->i18n(LitLocale::LATIN));
+        // SOLEMNITY wraps in <B>...</B>.
+        self::assertSame('<B>SOLLEMNITAS</B>', LitGrade::SOLEMNITY->i18n(LitLocale::LATIN));
+        // HIGHER_SOLEMNITY wraps in <B><I>...</I></B>.
+        self::assertStringStartsWith('<B><I>', LitGrade::HIGHER_SOLEMNITY->i18n(LitLocale::LATIN));
+        self::assertStringEndsWith('</I></B>', LitGrade::HIGHER_SOLEMNITY->i18n(LitLocale::LATIN));
+        // FEAST uses no wrapping tags.
+        self::assertSame('FESTUM', LitGrade::FEAST->i18n(LitLocale::LATIN));
+    }
+
+    public function testI18nNonLatinDelegatesToGettext(): void
+    {
+        // Without a gettext catalog _() returns the msgid, so we only assert
+        // it doesn't blow up and that the format markers around the value match.
+        $result = LitGrade::SOLEMNITY->i18n('en_US', html: false);
+        self::assertIsString($result);
+        self::assertNotEmpty($result);
+    }
+
+    public function testHigherSolemnityAbbreviatedLatin(): void
+    {
+        self::assertSame('S✝', LitGrade::HIGHER_SOLEMNITY->i18n(LitLocale::LATIN, html: false, abbreviate: true));
+    }
+}

--- a/phpunit_tests/Enum/LitLocaleTest.php
+++ b/phpunit_tests/Enum/LitLocaleTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LitLocale::class)]
+final class LitLocaleTest extends TestCase
+{
+    public function testLatinConstantsAndDefaults(): void
+    {
+        self::assertSame('la_VA', LitLocale::LATIN);
+        self::assertSame('la', LitLocale::LATIN_PRIMARY_LANGUAGE);
+        self::assertContains('la', LitLocale::$values);
+        self::assertContains('la_VA', LitLocale::$values);
+    }
+
+    public function testIsValidRecognisesLatin(): void
+    {
+        self::assertTrue(LitLocale::isValid('la'));
+        self::assertTrue(LitLocale::isValid('la_VA'));
+    }
+
+    public function testIsValidRecognisesIcuLocaleAfterInit(): void
+    {
+        LitLocale::init();
+        // 'en' should always be present in ICU data.
+        self::assertTrue(LitLocale::isValid('en'));
+        self::assertFalse(LitLocale::isValid('definitely-not-a-locale'));
+    }
+
+    public function testAreValid(): void
+    {
+        self::assertTrue(LitLocale::areValid(['la', 'la_VA']));
+        self::assertFalse(LitLocale::areValid(['la', 'not-a-locale']));
+    }
+
+    public function testGetSupportedLocalesIncludesLatin(): void
+    {
+        LitLocale::init();
+        $locales = LitLocale::getSupportedLocales();
+        self::assertContains('la', $locales);
+        self::assertContains('la_VA', $locales);
+    }
+
+    public function testInitFiltersOutPosix(): void
+    {
+        // Reset to force re-initialization.
+        LitLocale::$AllAvailableLocales = [];
+        LitLocale::init();
+        foreach (LitLocale::$AllAvailableLocales as $locale) {
+            self::assertStringNotContainsString('POSIX', $locale);
+        }
+    }
+}

--- a/phpunit_tests/Enum/LitSchemaTest.php
+++ b/phpunit_tests/Enum/LitSchemaTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LitSchema::class)]
+final class LitSchemaTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // Ensure Router static paths are populated so LitSchema::path() works.
+        Router::getApiPaths();
+    }
+
+    public function testEachCaseHasNonEmptyPath(): void
+    {
+        foreach (LitSchema::cases() as $case) {
+            $path = $case->path();
+            self::assertIsString($path);
+            self::assertStringEndsWith('.json', $path);
+            self::assertStringContainsString('schemas', $path);
+        }
+    }
+
+    public function testErrorMessagesAreDistinctAndStartWithSchemaPrefix(): void
+    {
+        $messages = [];
+        foreach (LitSchema::cases() as $case) {
+            $err = $case->error();
+            self::assertStringStartsWith('Schema validation error:', $err);
+            $messages[$case->name] = $err;
+        }
+        self::assertSame(count($messages), count(array_unique($messages)));
+    }
+
+    public function testFromUrlRoundTripsForEveryCase(): void
+    {
+        foreach (LitSchema::cases() as $case) {
+            $resolved = LitSchema::fromURL($case->path());
+            self::assertSame($case, $resolved);
+        }
+    }
+
+    public function testFromUrlRejectsUnknownUrl(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid schema URL: /not-real.json');
+        LitSchema::fromURL('/not-real.json');
+    }
+}

--- a/phpunit_tests/Enum/LitSeasonTest.php
+++ b/phpunit_tests/Enum/LitSeasonTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\LitSeason;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LitSeason::class)]
+final class LitSeasonTest extends TestCase
+{
+    public function testForEventKeyAdvent(): void
+    {
+        self::assertSame(LitSeason::ADVENT, LitSeason::forEventKey('Advent1'));
+        self::assertSame(LitSeason::ADVENT, LitSeason::forEventKey('AdventWeekday1'));
+    }
+
+    public function testForEventKeyChristmas(): void
+    {
+        self::assertSame(LitSeason::CHRISTMAS, LitSeason::forEventKey('Christmas'));
+        self::assertSame(LitSeason::CHRISTMAS, LitSeason::forEventKey('Epiphany'));
+        self::assertSame(LitSeason::CHRISTMAS, LitSeason::forEventKey('BaptismLord'));
+        self::assertSame(LitSeason::CHRISTMAS, LitSeason::forEventKey('HolyFamily'));
+        self::assertSame(LitSeason::CHRISTMAS, LitSeason::forEventKey('MaryMotherOfGod'));
+        self::assertSame(LitSeason::CHRISTMAS, LitSeason::forEventKey('DayAfterEpiphanyJan7'));
+    }
+
+    public function testForEventKeyLent(): void
+    {
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('AshWednesday'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('Lent3'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('LentWeekday2Mon'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('PalmSun'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('MonHolyWeek'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('HolyThursChrism'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('FridayAfterAshWednesday'));
+    }
+
+    public function testForEventKeyEasterTriduum(): void
+    {
+        self::assertSame(LitSeason::EASTER_TRIDUUM, LitSeason::forEventKey('HolyThurs'));
+        self::assertSame(LitSeason::EASTER_TRIDUUM, LitSeason::forEventKey('GoodFri'));
+        self::assertSame(LitSeason::EASTER_TRIDUUM, LitSeason::forEventKey('EasterVigil'));
+    }
+
+    public function testForEventKeyEaster(): void
+    {
+        self::assertSame(LitSeason::EASTER, LitSeason::forEventKey('Easter'));
+        self::assertSame(LitSeason::EASTER, LitSeason::forEventKey('Easter2'));
+        self::assertSame(LitSeason::EASTER, LitSeason::forEventKey('MonOctaveEaster'));
+        self::assertSame(LitSeason::EASTER, LitSeason::forEventKey('EasterWeekday3Tue'));
+        self::assertSame(LitSeason::EASTER, LitSeason::forEventKey('Ascension'));
+        self::assertSame(LitSeason::EASTER, LitSeason::forEventKey('Pentecost'));
+    }
+
+    public function testForEventKeyDefaultsToOrdinaryTime(): void
+    {
+        self::assertSame(LitSeason::ORDINARY_TIME, LitSeason::forEventKey('OrdSunday5'));
+        self::assertSame(LitSeason::ORDINARY_TIME, LitSeason::forEventKey('CorpusChristi'));
+        self::assertSame(LitSeason::ORDINARY_TIME, LitSeason::forEventKey('Trinity'));
+    }
+
+    public function testI18nLatin(): void
+    {
+        self::assertSame('Tempus Adventus', LitSeason::ADVENT->i18n(LitLocale::LATIN));
+        self::assertSame('Tempus Nativitatis', LitSeason::CHRISTMAS->i18n(LitLocale::LATIN));
+        self::assertSame('Tempus Quadragesima', LitSeason::LENT->i18n(LitLocale::LATIN));
+        self::assertSame('Triduum Paschale', LitSeason::EASTER_TRIDUUM->i18n(LitLocale::LATIN));
+        self::assertSame('Tempus Paschale', LitSeason::EASTER->i18n(LitLocale::LATIN));
+        self::assertSame('Tempus per annum', LitSeason::ORDINARY_TIME->i18n(LitLocale::LATIN));
+    }
+
+    public function testI18nNonLatinReturnsTranslatedString(): void
+    {
+        // No catalog loaded → falls back to msgid.
+        self::assertSame('Advent', LitSeason::ADVENT->i18n('en_US'));
+        self::assertSame('Christmas', LitSeason::CHRISTMAS->i18n('en_US'));
+    }
+}

--- a/phpunit_tests/Enum/ReadingsTypeTest.php
+++ b/phpunit_tests/Enum/ReadingsTypeTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\ReadingsType;
+use LiturgicalCalendar\Api\Models\Lectionary\ReadingsMap;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ReadingsType::class)]
+final class ReadingsTypeTest extends TestCase
+{
+    public function testForEventKeySpecialEvents(): void
+    {
+        self::assertSame(ReadingsType::CHRISTMAS, ReadingsType::forEventKey('Christmas'));
+        self::assertSame(ReadingsType::FESTIVE_WITH_VIGIL, ReadingsType::forEventKey('Pentecost'));
+        self::assertSame(ReadingsType::EASTER_VIGIL, ReadingsType::forEventKey('EasterVigil'));
+        self::assertSame(ReadingsType::PALM_SUNDAY, ReadingsType::forEventKey('PalmSun'));
+        self::assertSame(ReadingsType::WITH_EVENING, ReadingsType::forEventKey('Easter'));
+        self::assertSame(ReadingsType::MULTIPLE_SCHEMAS, ReadingsType::forEventKey('AllSouls'));
+    }
+
+    public function testForEventKeyFerial(): void
+    {
+        self::assertSame(ReadingsType::FERIAL, ReadingsType::forEventKey('AdventWeekday2Mon'));
+        self::assertSame(ReadingsType::FERIAL, ReadingsType::forEventKey('AdventWeekdayDec18'));
+        self::assertSame(ReadingsType::FERIAL, ReadingsType::forEventKey('ChristmasWeekdayDec29'));
+        self::assertSame(ReadingsType::FERIAL, ReadingsType::forEventKey('DayAfterEpiphany'));
+        self::assertSame(ReadingsType::FERIAL, ReadingsType::forEventKey('LentWeekday3Mon'));
+        self::assertSame(ReadingsType::FERIAL, ReadingsType::forEventKey('FridayAfterAshWednesday'));
+        self::assertSame(ReadingsType::FERIAL, ReadingsType::forEventKey('EasterWeekday3Tue'));
+        self::assertSame(ReadingsType::FERIAL, ReadingsType::forEventKey('OrdWeekday20Fri'));
+    }
+
+    public function testForEventKeyDefaultsToFestive(): void
+    {
+        self::assertSame(ReadingsType::FESTIVE, ReadingsType::forEventKey('OrdSunday5'));
+        self::assertSame(ReadingsType::FESTIVE, ReadingsType::forEventKey('Trinity'));
+    }
+
+    public function testExpectedKeys(): void
+    {
+        self::assertSame(ReadingsMap::FESTIVE_KEYS, ReadingsType::FESTIVE->expectedKeys());
+        self::assertSame(ReadingsMap::FERIAL_KEYS, ReadingsType::FERIAL->expectedKeys());
+        self::assertSame(ReadingsMap::READINGS_CHRISTMAS_KEYS, ReadingsType::CHRISTMAS->expectedKeys());
+        self::assertSame(ReadingsMap::READINGS_WITH_VIGIL_KEYS, ReadingsType::FESTIVE_WITH_VIGIL->expectedKeys());
+        self::assertSame(ReadingsMap::EASTER_VIGIL_KEYS, ReadingsType::EASTER_VIGIL->expectedKeys());
+        self::assertSame(ReadingsMap::PALM_SUNDAY_KEYS, ReadingsType::PALM_SUNDAY->expectedKeys());
+        self::assertSame(ReadingsMap::READINGS_WITH_EVENING_MASS_KEYS, ReadingsType::WITH_EVENING->expectedKeys());
+        self::assertSame(ReadingsMap::READINGS_MULTIPLE_SCHEMAS_KEYS, ReadingsType::MULTIPLE_SCHEMAS->expectedKeys());
+        self::assertSame(ReadingsMap::READINGS_SEASONAL_KEYS, ReadingsType::SEASONAL->expectedKeys());
+    }
+
+    public function testHasNestedStructure(): void
+    {
+        self::assertTrue(ReadingsType::CHRISTMAS->hasNestedStructure());
+        self::assertTrue(ReadingsType::FESTIVE_WITH_VIGIL->hasNestedStructure());
+        self::assertTrue(ReadingsType::WITH_EVENING->hasNestedStructure());
+        self::assertTrue(ReadingsType::MULTIPLE_SCHEMAS->hasNestedStructure());
+        self::assertTrue(ReadingsType::SEASONAL->hasNestedStructure());
+        self::assertFalse(ReadingsType::FESTIVE->hasNestedStructure());
+        self::assertFalse(ReadingsType::FERIAL->hasNestedStructure());
+        self::assertFalse(ReadingsType::EASTER_VIGIL->hasNestedStructure());
+        self::assertFalse(ReadingsType::PALM_SUNDAY->hasNestedStructure());
+    }
+
+    public function testNestedKeys(): void
+    {
+        self::assertNull(ReadingsType::FESTIVE->nestedKeys());
+        self::assertSame(ReadingsMap::FESTIVE_KEYS, ReadingsType::CHRISTMAS->nestedKeys());
+        // SEASONAL nests ferial readings.
+        self::assertSame(ReadingsMap::FERIAL_KEYS, ReadingsType::SEASONAL->nestedKeys());
+    }
+
+    public function testValidateStructureFestiveHappyPath(): void
+    {
+        $readings = (object) array_fill_keys(ReadingsMap::FESTIVE_KEYS, 'Some reading text');
+        self::assertTrue(ReadingsType::FESTIVE->validateStructure($readings));
+    }
+
+    public function testValidateStructureMissingKey(): void
+    {
+        $readings = (object) array_fill_keys(ReadingsMap::FERIAL_KEYS, 'text');
+        // Festive expects more keys than ferial.
+        self::assertFalse(ReadingsType::FESTIVE->validateStructure($readings));
+        $err = ReadingsType::FESTIVE->getValidationError($readings);
+        self::assertStringContainsString('missing keys', $err);
+    }
+
+    public function testValidateStructureExtraKey(): void
+    {
+        $readings        = (object) array_fill_keys(ReadingsMap::FESTIVE_KEYS, 'text');
+        $readings->extra = 'oops';
+        self::assertFalse(ReadingsType::FESTIVE->validateStructure($readings));
+        $err = ReadingsType::FESTIVE->getValidationError($readings);
+        self::assertStringContainsString('unexpected keys', $err);
+    }
+
+    public function testValidateStructureNonStringValueFlat(): void
+    {
+        $readings = (object) array_fill_keys(ReadingsMap::FESTIVE_KEYS, 'text');
+        // Replace one with an int.
+        $firstKey            = ReadingsMap::FESTIVE_KEYS[0];
+        $readings->$firstKey = 123;
+        self::assertFalse(ReadingsType::FESTIVE->validateStructure($readings));
+    }
+
+    public function testValidateStructureNestedHappyPath(): void
+    {
+        $inner    = array_fill_keys(ReadingsMap::FESTIVE_KEYS, 'text');
+        $readings = new \stdClass();
+        foreach (ReadingsMap::READINGS_CHRISTMAS_KEYS as $outer) {
+            $readings->$outer = (object) $inner;
+        }
+        self::assertTrue(ReadingsType::CHRISTMAS->validateStructure($readings));
+    }
+
+    public function testValidateStructureNestedNonObject(): void
+    {
+        $readings = new \stdClass();
+        foreach (ReadingsMap::READINGS_CHRISTMAS_KEYS as $outer) {
+            // Should be an object, give it a string instead.
+            $readings->$outer = 'not an object';
+        }
+        self::assertFalse(ReadingsType::CHRISTMAS->validateStructure($readings));
+        $err = ReadingsType::CHRISTMAS->getValidationError($readings);
+        self::assertStringContainsString('must be an object', $err);
+    }
+
+    public function testValidateStructureNestedMissingInnerKey(): void
+    {
+        $inner    = array_fill_keys(ReadingsMap::FERIAL_KEYS, 'text'); // ferial < festive
+        $readings = new \stdClass();
+        foreach (ReadingsMap::READINGS_CHRISTMAS_KEYS as $outer) {
+            $readings->$outer = (object) $inner;
+        }
+        self::assertFalse(ReadingsType::CHRISTMAS->validateStructure($readings));
+    }
+
+    public function testSpecialEventKeysContainsKnownEvents(): void
+    {
+        $keys = ReadingsType::specialEventKeys();
+        self::assertContains('Christmas', $keys);
+        self::assertContains('Pentecost', $keys);
+        self::assertContains('EasterVigil', $keys);
+        self::assertContains('PalmSun', $keys);
+        self::assertContains('Easter', $keys);
+        self::assertContains('AllSouls', $keys);
+    }
+}

--- a/phpunit_tests/Enum/RomanMissalTest.php
+++ b/phpunit_tests/Enum/RomanMissalTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\RomanMissal;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RomanMissal::class)]
+final class RomanMissalTest extends TestCase
+{
+    private static string $savedApiPath;
+    private static string $savedApiFilePath;
+
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+        self::$savedApiPath     = Router::$apiPath;
+        self::$savedApiFilePath = Router::$apiFilePath;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath     = self::$savedApiPath;
+        Router::$apiFilePath = self::$savedApiFilePath;
+    }
+
+    public function testIsValid(): void
+    {
+        self::assertTrue(RomanMissal::isValid(RomanMissal::EDITIO_TYPICA_1970));
+        self::assertTrue(RomanMissal::isValid(RomanMissal::USA_EDITION_2011));
+        self::assertFalse(RomanMissal::isValid('nope'));
+    }
+
+    public function testIsLatinMissal(): void
+    {
+        self::assertTrue(RomanMissal::isLatinMissal(RomanMissal::EDITIO_TYPICA_1970));
+        self::assertTrue(RomanMissal::isLatinMissal(RomanMissal::EDITIO_TYPICA_TERTIA_2002));
+        self::assertFalse(RomanMissal::isLatinMissal(RomanMissal::USA_EDITION_2011));
+        self::assertFalse(RomanMissal::isLatinMissal('not-a-missal'));
+    }
+
+    public function testGetNameKnown(): void
+    {
+        self::assertSame('Editio Typica 1970', RomanMissal::getName(RomanMissal::EDITIO_TYPICA_1970));
+        self::assertSame(
+            '2011 Roman Missal issued by the USCCB',
+            RomanMissal::getName(RomanMissal::USA_EDITION_2011)
+        );
+    }
+
+    public function testGetNameUnknownThrows(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid missal_id: nope');
+        RomanMissal::getName('nope');
+    }
+
+    public function testGetSanctoraleFileNameForKnownEditionReturnsPath(): void
+    {
+        $path = RomanMissal::getSanctoraleFileName(RomanMissal::EDITIO_TYPICA_1970);
+        self::assertIsString($path);
+        self::assertStringContainsString('propriumdesanctis_1970/propriumdesanctis_1970.json', $path);
+    }
+
+    public function testGetSanctoraleFileNameReturnsFalseWhenNotAvailable(): void
+    {
+        self::assertFalse(RomanMissal::getSanctoraleFileName(RomanMissal::REIMPRESSIO_EMENDATA_1971));
+    }
+
+    public function testGetSanctoraleFileNameRejectsInvalidId(): void
+    {
+        $this->expectException(ValidationException::class);
+        RomanMissal::getSanctoraleFileName('nope');
+    }
+
+    public function testGetSanctoraleI18nFilePath(): void
+    {
+        $path = RomanMissal::getSanctoraleI18nFilePath(RomanMissal::EDITIO_TYPICA_1970);
+        self::assertIsString($path);
+        self::assertStringContainsString('propriumdesanctis_1970/i18n/', $path);
+        self::assertFalse(RomanMissal::getSanctoraleI18nFilePath(RomanMissal::ITALY_EDITION_2020));
+    }
+
+    public function testGetSanctoraleI18nFilePathRejectsInvalidId(): void
+    {
+        $this->expectException(ValidationException::class);
+        RomanMissal::getSanctoraleI18nFilePath('nope');
+    }
+
+    public function testGetLectionaryFilePath(): void
+    {
+        // USA 2011 has lectionary; 1970 does not.
+        $path = RomanMissal::getLectionaryFilePath(RomanMissal::USA_EDITION_2011);
+        self::assertIsString($path);
+        self::assertStringContainsString('propriumdesanctis_US_2011/lectionary/', $path);
+        self::assertFalse(RomanMissal::getLectionaryFilePath(RomanMissal::EDITIO_TYPICA_1970));
+    }
+
+    public function testGetLectionaryFilePathRejectsInvalidId(): void
+    {
+        $this->expectException(ValidationException::class);
+        RomanMissal::getLectionaryFilePath('nope');
+    }
+
+    public function testGetYearLimits(): void
+    {
+        $limits = RomanMissal::getYearLimits(RomanMissal::ITALY_EDITION_1983);
+        self::assertSame(1983, $limits['since_year']);
+        self::assertSame(2002, $limits['until_year']);
+        $limits2 = RomanMissal::getYearLimits(RomanMissal::EDITIO_TYPICA_1970);
+        self::assertSame(1970, $limits2['since_year']);
+        self::assertArrayNotHasKey('until_year', $limits2);
+    }
+
+    public function testGetYearLimitsRejectsInvalidId(): void
+    {
+        $this->expectException(ValidationException::class);
+        RomanMissal::getYearLimits('nope');
+    }
+
+    public function testGetMissalIdsIncludesEverything(): void
+    {
+        $ids = RomanMissal::getMissalIds();
+        self::assertContains(RomanMissal::EDITIO_TYPICA_1970, $ids);
+        self::assertContains(RomanMissal::USA_EDITION_2011, $ids);
+        self::assertContains(RomanMissal::CANADA_EDITION_2016, $ids);
+    }
+
+    public function testGetLatinMissalIdsOnlyContainsEditioTypica(): void
+    {
+        $latin = RomanMissal::getLatinMissalIds();
+        foreach ($latin as $id) {
+            self::assertStringStartsWith('EDITIO_TYPICA_', $id);
+        }
+        self::assertNotContains(RomanMissal::USA_EDITION_2011, $latin);
+        self::assertNotContains(RomanMissal::ITALY_EDITION_1983, $latin);
+    }
+}

--- a/phpunit_tests/Enum/RouteTest.php
+++ b/phpunit_tests/Enum/RouteTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\Route;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Route::class)]
+final class RouteTest extends TestCase
+{
+    private static string $savedApiPath;
+
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+        self::$savedApiPath = Router::$apiPath;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath = self::$savedApiPath;
+    }
+
+    public function testCaseValues(): void
+    {
+        self::assertSame('/calendars', Route::CALENDARS->value);
+        self::assertSame('/calendar', Route::CALENDAR->value);
+        self::assertSame('/calendar/nation', Route::CALENDAR_NATIONAL->value);
+        self::assertSame('/calendar/diocese', Route::CALENDAR_DIOCESAN->value);
+        self::assertSame('/decrees', Route::DECREES->value);
+        self::assertSame('/tests', Route::TESTS->value);
+        self::assertSame('/events', Route::EVENTS->value);
+        self::assertSame('/events/nation', Route::EVENTS_NATIONAL->value);
+        self::assertSame('/events/diocese', Route::EVENTS_DIOCESAN->value);
+        self::assertSame('/data', Route::DATA->value);
+        self::assertSame('/data/widerregion', Route::DATA_WIDERREGION->value);
+        self::assertSame('/data/nation', Route::DATA_NATIONAL->value);
+        self::assertSame('/data/diocese', Route::DATA_DIOCESAN->value);
+        self::assertSame('/easter', Route::EASTER->value);
+        self::assertSame('/schemas', Route::SCHEMAS->value);
+        self::assertSame('/missals', Route::MISSALS->value);
+        self::assertSame('/_ops/migrate', Route::OPS_MIGRATE->value);
+        self::assertSame('/_ops/migrate/status', Route::OPS_MIGRATE_STATUS->value);
+    }
+
+    public function testPathPrependsApiPath(): void
+    {
+        Router::$apiPath = 'https://api.example.test';
+        self::assertSame('https://api.example.test/calendar', Route::CALENDAR->path());
+        self::assertSame('https://api.example.test/data/diocese', Route::DATA_DIOCESAN->path());
+    }
+}

--- a/phpunit_tests/Enum/SimpleEnumsTest.php
+++ b/phpunit_tests/Enum/SimpleEnumsTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\Ascension;
+use LiturgicalCalendar\Api\Enum\CacheDuration;
+use LiturgicalCalendar\Api\Enum\CalEventAction;
+use LiturgicalCalendar\Api\Enum\CorpusChristi;
+use LiturgicalCalendar\Api\Enum\DateRelation;
+use LiturgicalCalendar\Api\Enum\Epiphany;
+use LiturgicalCalendar\Api\Enum\LitEventTestAssertion;
+use LiturgicalCalendar\Api\Enum\LitEventTestType;
+use LiturgicalCalendar\Api\Enum\LitEventType;
+use LiturgicalCalendar\Api\Enum\ParamError;
+use LiturgicalCalendar\Api\Enum\PathCategory;
+use LiturgicalCalendar\Api\Enum\YearType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Smoke tests for the simple/value-only enums — verifies enum cases resolve from
+ * value and the EnumToArrayTrait helpers (names, values, asArray, isValid,
+ * areValid) work where mixed in.
+ */
+#[CoversClass(Ascension::class)]
+#[CoversClass(CacheDuration::class)]
+#[CoversClass(CalEventAction::class)]
+#[CoversClass(CorpusChristi::class)]
+#[CoversClass(DateRelation::class)]
+#[CoversClass(Epiphany::class)]
+#[CoversClass(LitEventType::class)]
+#[CoversClass(LitEventTestType::class)]
+#[CoversClass(LitEventTestAssertion::class)]
+#[CoversClass(PathCategory::class)]
+#[CoversClass(YearType::class)]
+#[CoversClass(ParamError::class)]
+final class SimpleEnumsTest extends TestCase
+{
+    public function testAscensionCases(): void
+    {
+        self::assertSame('THURSDAY', Ascension::THURSDAY->value);
+        self::assertSame('SUNDAY', Ascension::SUNDAY->value);
+        self::assertTrue(Ascension::isValid('THURSDAY'));
+        self::assertFalse(Ascension::isValid('MONDAY'));
+        self::assertSame(['THURSDAY', 'SUNDAY'], Ascension::values());
+        self::assertSame(['THURSDAY' => 'THURSDAY', 'SUNDAY' => 'SUNDAY'], Ascension::asArray());
+    }
+
+    public function testCorpusChristiCases(): void
+    {
+        self::assertSame(CorpusChristi::THURSDAY, CorpusChristi::from('THURSDAY'));
+        self::assertSame(CorpusChristi::SUNDAY, CorpusChristi::from('SUNDAY'));
+        self::assertTrue(CorpusChristi::areValid(['THURSDAY', 'SUNDAY']));
+        self::assertFalse(CorpusChristi::areValid(['THURSDAY', 'WEDNESDAY']));
+    }
+
+    public function testEpiphanyCases(): void
+    {
+        self::assertSame(['SUNDAY_JAN2_JAN8', 'JAN6'], Epiphany::names());
+        self::assertSame(['SUNDAY_JAN2_JAN8', 'JAN6'], Epiphany::values());
+        self::assertTrue(Epiphany::isValid('JAN6'));
+    }
+
+    public function testCacheDurationCases(): void
+    {
+        // No trait — bare enum.
+        self::assertSame('DAY', CacheDuration::DAY->value);
+        self::assertSame('WEEK', CacheDuration::WEEK->value);
+        self::assertSame('MONTH', CacheDuration::MONTH->value);
+        self::assertSame('YEAR', CacheDuration::YEAR->value);
+        self::assertSame(CacheDuration::MONTH, CacheDuration::from('MONTH'));
+    }
+
+    public function testCalEventActionCases(): void
+    {
+        self::assertSame('makePatron', CalEventAction::MakePatron->value);
+        self::assertSame('setProperty', CalEventAction::SetProperty->value);
+        self::assertSame('moveEvent', CalEventAction::MoveEvent->value);
+        self::assertSame('createNew', CalEventAction::CreateNew->value);
+        self::assertSame('makeDoctor', CalEventAction::MakeDoctor->value);
+    }
+
+    public function testDateRelationCases(): void
+    {
+        self::assertSame('before', DateRelation::Before->value);
+        self::assertSame('after', DateRelation::After->value);
+        self::assertTrue(DateRelation::isValid('after'));
+        self::assertFalse(DateRelation::isValid('during'));
+    }
+
+    public function testLitEventTypeCases(): void
+    {
+        self::assertSame('fixed', LitEventType::FIXED->value);
+        self::assertSame('mobile', LitEventType::MOBILE->value);
+        self::assertSame(['fixed', 'mobile'], LitEventType::values());
+    }
+
+    public function testLitEventTestTypeCases(): void
+    {
+        self::assertSame('exactCorrespondence', LitEventTestType::EXACT_CORRESPONDENCE->value);
+        self::assertSame('exactCorrespondenceSince', LitEventTestType::EXACT_CORRESPONDENCE_SINCE->value);
+        self::assertSame('variableCorrespondence', LitEventTestType::VARIABLE_CORRESPONDENCE->value);
+    }
+
+    public function testLitEventTestAssertionCases(): void
+    {
+        self::assertSame('eventNotExists', LitEventTestAssertion::EVENT_NOT_EXISTS->value);
+        self::assertSame(
+            'eventExists AND hasExpectedDate',
+            LitEventTestAssertion::EVENT_EXISTS_AND_HAS_EXPECTED_DATE->value
+        );
+    }
+
+    public function testPathCategoryCases(): void
+    {
+        self::assertSame(['nation', 'diocese', 'widerregion'], PathCategory::values());
+        self::assertTrue(PathCategory::isValid('nation'));
+        self::assertFalse(PathCategory::isValid('planet'));
+    }
+
+    public function testYearTypeCases(): void
+    {
+        self::assertSame('CIVIL', YearType::CIVIL->value);
+        self::assertSame('LITURGICAL', YearType::LITURGICAL->value);
+        self::assertTrue(YearType::areValid(['CIVIL', 'LITURGICAL']));
+    }
+
+    public function testParamErrorGetMessage(): void
+    {
+        self::assertSame('No error', ParamError::NONE->getMessage());
+        self::assertSame('Invalid locale provided', ParamError::INVALID_LOCALE->getMessage());
+        self::assertSame('Invalid year provided', ParamError::INVALID_YEAR->getMessage());
+        self::assertSame('Invalid region provided', ParamError::INVALID_REGION->getMessage());
+        self::assertSame('Missing required parameter', ParamError::MISSING_REQUIRED_PARAM->getMessage());
+        self::assertSame('An unknown error occurred', ParamError::UNKNOWN_ERROR->getMessage());
+        self::assertSame(0, ParamError::NONE->value);
+        self::assertSame(5, ParamError::UNKNOWN_ERROR->value);
+    }
+}

--- a/phpunit_tests/EnvironmentTest.php
+++ b/phpunit_tests/EnvironmentTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Environment;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Environment::class)]
+final class EnvironmentTest extends TestCase
+{
+    private const UNSET = "\0__unset__\0";
+
+    /** @var mixed */
+    private $savedAppEnv;
+
+    protected function setUp(): void
+    {
+        $this->savedAppEnv = array_key_exists('APP_ENV', $_ENV) ? $_ENV['APP_ENV'] : self::UNSET;
+        unset($_ENV['APP_ENV']);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->savedAppEnv === self::UNSET) {
+            unset($_ENV['APP_ENV']);
+        } else {
+            $_ENV['APP_ENV'] = $this->savedAppEnv;
+        }
+    }
+
+    public function testDefaultsToDevelopment(): void
+    {
+        self::assertSame('development', Environment::getName());
+        self::assertTrue(Environment::isDevelopment());
+        self::assertFalse(Environment::isProduction());
+    }
+
+    public function testNormalisesUppercaseAndWhitespace(): void
+    {
+        $_ENV['APP_ENV'] = '  PRODUCTION  ';
+        self::assertSame('production', Environment::getName());
+        self::assertTrue(Environment::isProduction());
+        self::assertFalse(Environment::isDevelopment());
+    }
+
+    public function testStagingIsProductionLike(): void
+    {
+        $_ENV['APP_ENV'] = 'staging';
+        self::assertTrue(Environment::isProduction());
+        self::assertFalse(Environment::isDevelopment());
+    }
+
+    public function testTestIsDevelopmentLike(): void
+    {
+        $_ENV['APP_ENV'] = 'test';
+        self::assertTrue(Environment::isDevelopment());
+        self::assertFalse(Environment::isProduction());
+    }
+
+    public function testNonStringFallsBackToDevelopment(): void
+    {
+        // Forced non-string assignment to exercise the defensive branch.
+        $_ENV['APP_ENV'] = ['nope'];
+        self::assertSame('development', Environment::getName());
+    }
+}

--- a/phpunit_tests/Http/AuthorizationMiddlewareTest.php
+++ b/phpunit_tests/Http/AuthorizationMiddlewareTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http;
+
+use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Middleware\AuthorizationMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+#[CoversClass(AuthorizationMiddleware::class)]
+final class AuthorizationMiddlewareTest extends TestCase
+{
+    private function handler(): RequestHandlerInterface
+    {
+        return new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(200, [], 'reached-handler');
+            }
+        };
+    }
+
+    private function request(): ServerRequestInterface
+    {
+        return ( new Psr17Factory() )->createServerRequest('GET', '/');
+    }
+
+    public function testRejectsMissingOidcUser(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('Not authenticated');
+        ( new AuthorizationMiddleware('admin') )
+            ->process($this->request(), $this->handler());
+    }
+
+    public function testRejectsTokenWithoutSubject(): void
+    {
+        $request = $this->request()->withAttribute('oidc_user', ['roles' => ['admin']]);
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('Invalid user token');
+        ( new AuthorizationMiddleware('admin') )->process($request, $this->handler());
+    }
+
+    public function testAdminBypassesRoleCheck(): void
+    {
+        $request  = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['admin']]);
+        $response = ( new AuthorizationMiddleware('calendar_editor') )
+            ->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRequiredRolePresentLetsThrough(): void
+    {
+        $request  = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['calendar_editor']]);
+        $response = ( new AuthorizationMiddleware('calendar_editor') )
+            ->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRequiredRoleMissingThrowsForbidden(): void
+    {
+        $request = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['viewer']]);
+        $this->expectException(ForbiddenException::class);
+        $this->expectExceptionMessage('Missing required role: calendar_editor');
+        ( new AuthorizationMiddleware('calendar_editor') )->process($request, $this->handler());
+    }
+
+    public function testFactoryHelpers(): void
+    {
+        // Each factory should produce a middleware that accepts only its own role
+        // (or admin). We verify via a developer user against each.
+        $devRequest = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['developer']]);
+        $editorReq  = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['calendar_editor']]);
+        $testReq    = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['test_editor']]);
+        $adminReq   = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['admin']]);
+
+        self::assertSame(200, AuthorizationMiddleware::forDeveloper()->process($devRequest, $this->handler())->getStatusCode());
+        self::assertSame(200, AuthorizationMiddleware::forCalendarEditor()->process($editorReq, $this->handler())->getStatusCode());
+        self::assertSame(200, AuthorizationMiddleware::forTestEditor()->process($testReq, $this->handler())->getStatusCode());
+        self::assertSame(200, AuthorizationMiddleware::forAdmin()->process($adminReq, $this->handler())->getStatusCode());
+    }
+}

--- a/phpunit_tests/Http/AuthorizationMiddlewareTest.php
+++ b/phpunit_tests/Http/AuthorizationMiddlewareTest.php
@@ -73,18 +73,47 @@ final class AuthorizationMiddlewareTest extends TestCase
         ( new AuthorizationMiddleware('calendar_editor') )->process($request, $this->handler());
     }
 
-    public function testFactoryHelpers(): void
+    /**
+     * @return iterable<string, array{0:\Closure():AuthorizationMiddleware,1:string,2:string}>
+     */
+    public static function factoryProvider(): iterable
     {
-        // Each factory should produce a middleware that accepts only its own role
-        // (or admin). We verify via a developer user against each.
-        $devRequest = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['developer']]);
-        $editorReq  = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['calendar_editor']]);
-        $testReq    = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['test_editor']]);
-        $adminReq   = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['admin']]);
+        // tuple = [factory closure, role that should be accepted, role that should NOT]
+        yield 'developer'       => [static fn (): AuthorizationMiddleware => AuthorizationMiddleware::forDeveloper(), 'developer', 'calendar_editor'];
+        yield 'calendar_editor' => [static fn (): AuthorizationMiddleware => AuthorizationMiddleware::forCalendarEditor(), 'calendar_editor', 'developer'];
+        yield 'test_editor'     => [static fn (): AuthorizationMiddleware => AuthorizationMiddleware::forTestEditor(), 'test_editor', 'developer'];
+        yield 'admin'           => [static fn (): AuthorizationMiddleware => AuthorizationMiddleware::forAdmin(), 'admin', 'developer'];
+    }
 
-        self::assertSame(200, AuthorizationMiddleware::forDeveloper()->process($devRequest, $this->handler())->getStatusCode());
-        self::assertSame(200, AuthorizationMiddleware::forCalendarEditor()->process($editorReq, $this->handler())->getStatusCode());
-        self::assertSame(200, AuthorizationMiddleware::forTestEditor()->process($testReq, $this->handler())->getStatusCode());
-        self::assertSame(200, AuthorizationMiddleware::forAdmin()->process($adminReq, $this->handler())->getStatusCode());
+    #[\PHPUnit\Framework\Attributes\DataProvider('factoryProvider')]
+    public function testFactoryAcceptsItsOwnRole(\Closure $make, string $allowed, string $denied): void
+    {
+        $request  = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => [$allowed]]);
+        $response = $make()->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('factoryProvider')]
+    public function testFactoryRejectsMismatchedRole(\Closure $make, string $allowed, string $denied): void
+    {
+        $request = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => [$denied]]);
+        $this->expectException(ForbiddenException::class);
+        $make()->process($request, $this->handler());
+    }
+
+    public function testAllFactoriesLetAdminThrough(): void
+    {
+        // Admin role bypasses every factory's required-role check.
+        $adminReq = $this->request()->withAttribute('oidc_user', ['sub' => 'u1', 'roles' => ['admin']]);
+        foreach (
+            [
+                AuthorizationMiddleware::forDeveloper(),
+                AuthorizationMiddleware::forCalendarEditor(),
+                AuthorizationMiddleware::forTestEditor(),
+                AuthorizationMiddleware::forAdmin(),
+            ] as $mw
+        ) {
+            self::assertSame(200, $mw->process($adminReq, $this->handler())->getStatusCode());
+        }
     }
 }

--- a/phpunit_tests/Http/CookieHelperTest.php
+++ b/phpunit_tests/Http/CookieHelperTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http;
+
+use LiturgicalCalendar\Api\Http\CookieHelper;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CookieHelper::class)]
+final class CookieHelperTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private array $savedServer = [];
+
+    /** @var array<string,mixed> */
+    private array $savedEnv = [];
+
+    /** Sentinel for keys that were not originally present. */
+    private const UNSET = "\0__unset__\0";
+
+    private const SERVER_KEYS = [
+        'REQUEST_SCHEME',
+        'HTTPS',
+        'SERVER_PORT',
+        'HTTP_X_FORWARDED_PROTO',
+        'HTTP_HOST',
+        'SERVER_NAME',
+        'COOKIE_DOMAIN',
+    ];
+
+    private const ENV_KEYS = ['COOKIE_DOMAIN'];
+
+    protected function setUp(): void
+    {
+        foreach (self::SERVER_KEYS as $k) {
+            $this->savedServer[$k] = array_key_exists($k, $_SERVER) ? $_SERVER[$k] : self::UNSET;
+            unset($_SERVER[$k]);
+        }
+        foreach (self::ENV_KEYS as $k) {
+            $this->savedEnv[$k] = array_key_exists($k, $_ENV) ? $_ENV[$k] : self::UNSET;
+            unset($_ENV[$k]);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->savedServer as $k => $v) {
+            if ($v === self::UNSET) {
+                unset($_SERVER[$k]);
+            } else {
+                $_SERVER[$k] = $v;
+            }
+        }
+        foreach ($this->savedEnv as $k => $v) {
+            if ($v === self::UNSET) {
+                unset($_ENV[$k]);
+            } else {
+                $_ENV[$k] = $v;
+            }
+        }
+    }
+
+    public function testIsSecureDetectsHttps(): void
+    {
+        $_SERVER['HTTPS'] = 'on';
+        self::assertTrue(CookieHelper::isSecure());
+    }
+
+    public function testIsSecureDetectsRequestScheme(): void
+    {
+        $_SERVER['REQUEST_SCHEME'] = 'https';
+        self::assertTrue(CookieHelper::isSecure());
+    }
+
+    public function testIsSecureDetectsPort443(): void
+    {
+        $_SERVER['SERVER_PORT'] = '443';
+        self::assertTrue(CookieHelper::isSecure());
+    }
+
+    public function testIsSecureDetectsForwardedProto(): void
+    {
+        $_SERVER['HTTP_X_FORWARDED_PROTO'] = 'https';
+        self::assertTrue(CookieHelper::isSecure());
+    }
+
+    public function testIsSecureFalseByDefault(): void
+    {
+        self::assertFalse(CookieHelper::isSecure());
+    }
+
+    public function testGetCookieDomainPrefersEnvOverride(): void
+    {
+        $_ENV['COOKIE_DOMAIN'] = '.example.com';
+        $_SERVER['HTTP_HOST']  = 'foo.example.com';
+        self::assertSame('.example.com', CookieHelper::getCookieDomain());
+    }
+
+    public function testGetCookieDomainStripsPort(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'api.example.com:8080';
+        self::assertSame('api.example.com', CookieHelper::getCookieDomain());
+    }
+
+    public function testGetCookieDomainReturnsEmptyForLocalhost(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        self::assertSame('', CookieHelper::getCookieDomain());
+
+        $_SERVER['HTTP_HOST'] = '127.0.0.1:8000';
+        self::assertSame('', CookieHelper::getCookieDomain());
+    }
+
+    public function testGetCookieDomainFallsBackToServerName(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'api.example.com';
+        self::assertSame('api.example.com', CookieHelper::getCookieDomain());
+    }
+
+    public function testBuildCookieHeaderBasic(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $header               = CookieHelper::buildCookieHeader('foo', 'bar baz');
+        // url-encoded value, default path '/', HttpOnly, SameSite=Lax, no Secure, no Domain.
+        self::assertStringContainsString('foo=bar+baz', $header);
+        self::assertStringContainsString('Path=/', $header);
+        self::assertStringContainsString('HttpOnly', $header);
+        self::assertStringContainsString('SameSite=Lax', $header);
+        self::assertStringNotContainsString('Secure', $header);
+        self::assertStringNotContainsString('Domain=', $header);
+        self::assertStringNotContainsString('Max-Age', $header);
+    }
+
+    public function testBuildCookieHeaderPersistentEmitsMaxAgeAndExpires(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $header               = CookieHelper::buildCookieHeader('k', 'v', maxAge: 3600);
+        self::assertStringContainsString('Max-Age=3600', $header);
+        self::assertMatchesRegularExpression('/Expires=[A-Z][a-z]{2}, /', $header);
+    }
+
+    public function testBuildCookieHeaderDeletionUsesMaxAgeZeroAndEpochExpiry(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $header               = CookieHelper::buildCookieHeader('k', '', maxAge: -1);
+        self::assertStringContainsString('Max-Age=0', $header);
+        self::assertStringContainsString('Expires=Thu, 01 Jan 1970 00:00:00 GMT', $header);
+    }
+
+    public function testBuildCookieHeaderSecureAndDomain(): void
+    {
+        $_SERVER['HTTPS']     = 'on';
+        $_SERVER['HTTP_HOST'] = 'api.example.com';
+        $header               = CookieHelper::buildCookieHeader('k', 'v', sameSite: 'None');
+        self::assertStringContainsString('Secure', $header);
+        self::assertStringContainsString('SameSite=None', $header);
+        self::assertStringContainsString('Domain=api.example.com', $header);
+    }
+
+    public function testBuildCookieHeaderDowngradesSameSiteNoneWhenInsecure(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'api.example.com';
+        // No HTTPS — SameSite=None must be downgraded to Lax (None+!Secure is rejected by browsers).
+        $header = CookieHelper::buildCookieHeader('k', 'v', sameSite: 'None');
+        self::assertStringContainsString('SameSite=Lax', $header);
+    }
+
+    public function testSetAccessTokenCookieAttachesToResponse(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $response             = new Response();
+        $response             = CookieHelper::setAccessTokenCookie($response, 'tk', 1800);
+        self::assertNotEmpty($response->getHeaderLine('Set-Cookie'));
+        self::assertStringContainsString(CookieHelper::ACCESS_TOKEN_COOKIE . '=tk', $response->getHeaderLine('Set-Cookie'));
+        self::assertStringContainsString('Max-Age=1800', $response->getHeaderLine('Set-Cookie'));
+    }
+
+    public function testSetRefreshTokenCookieRememberMeFalseIsSessionCookie(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $response             = new Response();
+        $response             = CookieHelper::setRefreshTokenCookie($response, 'rt', 604800, rememberMe: false);
+        $header               = $response->getHeaderLine('Set-Cookie');
+        self::assertStringContainsString(CookieHelper::REFRESH_TOKEN_COOKIE . '=rt', $header);
+        // Session cookie — no Max-Age.
+        self::assertStringNotContainsString('Max-Age=', $header);
+        self::assertStringContainsString('Path=/auth', $header);
+        self::assertStringContainsString('SameSite=Strict', $header);
+    }
+
+    public function testSetRefreshTokenCookieRememberMeTrueIsPersistent(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $response             = new Response();
+        $response             = CookieHelper::setRefreshTokenCookie($response, 'rt', 7200, rememberMe: true);
+        self::assertStringContainsString('Max-Age=7200', $response->getHeaderLine('Set-Cookie'));
+    }
+
+    public function testClearAuthCookiesAddsBothDeletionHeaders(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $response             = new Response();
+        $response             = CookieHelper::clearAuthCookies($response);
+        $headers              = $response->getHeader('Set-Cookie');
+        self::assertCount(2, $headers);
+        $combined = implode("\n", $headers);
+        self::assertStringContainsString(CookieHelper::ACCESS_TOKEN_COOKIE, $combined);
+        self::assertStringContainsString(CookieHelper::REFRESH_TOKEN_COOKIE, $combined);
+        self::assertStringContainsString('Max-Age=0', $combined);
+    }
+
+    public function testGetAccessAndRefreshTokenFromCookies(): void
+    {
+        $cookies = [
+            CookieHelper::ACCESS_TOKEN_COOKIE  => 'abc',
+            CookieHelper::REFRESH_TOKEN_COOKIE => 'def',
+        ];
+        self::assertSame('abc', CookieHelper::getAccessToken($cookies));
+        self::assertSame('def', CookieHelper::getRefreshToken($cookies));
+        self::assertNull(CookieHelper::getAccessToken([]));
+        self::assertNull(CookieHelper::getRefreshToken([]));
+    }
+}

--- a/phpunit_tests/Http/Enum/AcceptHeaderTest.php
+++ b/phpunit_tests/Http/Enum/AcceptHeaderTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Enum;
+
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AcceptHeader::class)]
+final class AcceptHeaderTest extends TestCase
+{
+    public function testCommonMimeTypeValues(): void
+    {
+        self::assertSame('application/json', AcceptHeader::JSON->value);
+        self::assertSame('application/yaml', AcceptHeader::YAML->value);
+        self::assertSame('application/xml', AcceptHeader::XML->value);
+        self::assertSame('text/calendar', AcceptHeader::ICS->value);
+        self::assertSame('application/octet-stream', AcceptHeader::ATTACHMENT->value);
+    }
+
+    public function testToReturnTypeParamRoundTrip(): void
+    {
+        // Every AcceptHeader case must map to a ReturnTypeParam whose
+        // toResponseContentType maps back to the original AcceptHeader.
+        foreach (AcceptHeader::cases() as $case) {
+            $rt = $case->toReturnTypeParam();
+            self::assertInstanceOf(ReturnTypeParam::class, $rt);
+            self::assertSame($case, $rt->toResponseContentType());
+        }
+    }
+
+    public function testIsValid(): void
+    {
+        self::assertTrue(AcceptHeader::isValid('application/json'));
+        self::assertTrue(AcceptHeader::isValid('text/calendar'));
+        self::assertFalse(AcceptHeader::isValid('application/x-not-real'));
+    }
+}

--- a/phpunit_tests/Http/Enum/AcceptabilityLevelTest.php
+++ b/phpunit_tests/Http/Enum/AcceptabilityLevelTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Enum;
+
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AcceptabilityLevel::class)]
+final class AcceptabilityLevelTest extends TestCase
+{
+    public function testCases(): void
+    {
+        $cases = AcceptabilityLevel::cases();
+        self::assertContains(AcceptabilityLevel::LAX, $cases);
+        self::assertContains(AcceptabilityLevel::INTERMEDIATE, $cases);
+        self::assertContains(AcceptabilityLevel::STRICT, $cases);
+        self::assertContains(AcceptabilityLevel::DEFAULT, $cases);
+        self::assertCount(4, $cases);
+    }
+}

--- a/phpunit_tests/Http/Enum/CharsetTest.php
+++ b/phpunit_tests/Http/Enum/CharsetTest.php
@@ -63,4 +63,18 @@ final class CharsetTest extends TestCase
         $this->expectException(UnsupportedCharsetException::class);
         Charset::fromLabel('not-a-charset');
     }
+
+    public function testEmptyStringLabelRaises(): void
+    {
+        $this->expectException(UnsupportedCharsetException::class);
+        Charset::fromLabel('');
+    }
+
+    public function testWhitespaceOnlyLabelRaises(): void
+    {
+        // fromLabel() trims before matching, so whitespace-only collapses to ''
+        // and lands in the default arm.
+        $this->expectException(UnsupportedCharsetException::class);
+        Charset::fromLabel('   ');
+    }
 }

--- a/phpunit_tests/Http/Enum/CharsetTest.php
+++ b/phpunit_tests/Http/Enum/CharsetTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Enum;
+
+use LiturgicalCalendar\Api\Http\Enum\Charset;
+use LiturgicalCalendar\Api\Http\Exception\UnsupportedCharsetException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Charset::class)]
+final class CharsetTest extends TestCase
+{
+    public function testCommonCanonicalLabels(): void
+    {
+        self::assertSame(Charset::UTF8, Charset::fromLabel('utf-8'));
+        self::assertSame(Charset::UTF8, Charset::fromLabel('UTF-8'));
+        self::assertSame(Charset::UTF8, Charset::fromLabel(' utf-8 '));
+        self::assertSame(Charset::UTF16LE, Charset::fromLabel('utf-16'));
+        self::assertSame(Charset::UTF16BE, Charset::fromLabel('utf-16be'));
+    }
+
+    public function testWindows1252Aliases(): void
+    {
+        foreach (['windows-1252', 'cp1252', 'iso-8859-1', 'ascii', 'us-ascii', 'latin1', 'l1'] as $alias) {
+            self::assertSame(Charset::WINDOWS1252, Charset::fromLabel($alias));
+        }
+    }
+
+    public function testIsoVariantsAndJapaneseLabels(): void
+    {
+        self::assertSame(Charset::WINDOWS1250, Charset::fromLabel('iso-8859-2'));
+        self::assertSame(Charset::WINDOWS1251, Charset::fromLabel('iso-8859-5'));
+        self::assertSame(Charset::SHIFTJIS, Charset::fromLabel('shift_jis'));
+        self::assertSame(Charset::SHIFTJIS, Charset::fromLabel('sjis'));
+        self::assertSame(Charset::EUCJP, Charset::fromLabel('euc-jp'));
+        self::assertSame(Charset::EUCKR, Charset::fromLabel('korean'));
+    }
+
+    public function testChineseLabels(): void
+    {
+        self::assertSame(Charset::GBK, Charset::fromLabel('gb2312'));
+        self::assertSame(Charset::GBK, Charset::fromLabel('chinese'));
+        self::assertSame(Charset::GB18030, Charset::fromLabel('gb18030'));
+        self::assertSame(Charset::BIG5, Charset::fromLabel('big5-hkscs'));
+    }
+
+    public function testKoi8Variants(): void
+    {
+        self::assertSame(Charset::KOI8R, Charset::fromLabel('cskoi8r'));
+        self::assertSame(Charset::KOI8U, Charset::fromLabel('koi8-u'));
+    }
+
+    public function testMacVariants(): void
+    {
+        self::assertSame(Charset::MACINTOSH, Charset::fromLabel('mac'));
+        self::assertSame(Charset::MACCYRILLIC, Charset::fromLabel('mac-cyrillic'));
+    }
+
+    public function testUnsupportedLabelRaises(): void
+    {
+        $this->expectException(UnsupportedCharsetException::class);
+        Charset::fromLabel('not-a-charset');
+    }
+}

--- a/phpunit_tests/Http/Enum/ContentEncodingTest.php
+++ b/phpunit_tests/Http/Enum/ContentEncodingTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Enum;
+
+use LiturgicalCalendar\Api\Http\Enum\ContentEncoding;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContentEncoding::class)]
+final class ContentEncodingTest extends TestCase
+{
+    public function testCases(): void
+    {
+        self::assertSame('br', ContentEncoding::BR->value);
+        self::assertSame('gzip', ContentEncoding::GZIP->value);
+        self::assertSame('deflate', ContentEncoding::DEFLATE->value);
+        self::assertSame('identity', ContentEncoding::IDENTITY->value);
+    }
+
+    public function testFromValueOrNull(): void
+    {
+        self::assertSame(ContentEncoding::BR, ContentEncoding::fromValueOrNull('br'));
+        self::assertSame(ContentEncoding::GZIP, ContentEncoding::fromValueOrNull('gzip'));
+        // x-gzip is normalized to GZIP.
+        self::assertSame(ContentEncoding::GZIP, ContentEncoding::fromValueOrNull('x-gzip'));
+        self::assertSame(ContentEncoding::DEFLATE, ContentEncoding::fromValueOrNull('  DEFLATE '));
+        self::assertSame(ContentEncoding::IDENTITY, ContentEncoding::fromValueOrNull('identity'));
+        self::assertNull(ContentEncoding::fromValueOrNull('compress'));
+    }
+}

--- a/phpunit_tests/Http/Enum/RequestContentTypeTest.php
+++ b/phpunit_tests/Http/Enum/RequestContentTypeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Enum;
+
+use LiturgicalCalendar\Api\Http\Enum\RequestContentType;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RequestContentType::class)]
+final class RequestContentTypeTest extends TestCase
+{
+    public function testCaseValues(): void
+    {
+        self::assertSame('application/json', RequestContentType::JSON->value);
+        self::assertSame('application/yaml', RequestContentType::YAML->value);
+        self::assertSame('application/xml', RequestContentType::XML->value);
+        self::assertSame('application/x-www-form-urlencoded', RequestContentType::FORMDATA->value);
+        self::assertSame('multipart/form-data', RequestContentType::MULTIPART->value);
+    }
+
+    public function testIsValid(): void
+    {
+        self::assertTrue(RequestContentType::isValid('application/json'));
+        self::assertFalse(RequestContentType::isValid('not/real'));
+    }
+}

--- a/phpunit_tests/Http/Enum/RequestMethodTest.php
+++ b/phpunit_tests/Http/Enum/RequestMethodTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Enum;
+
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RequestMethod::class)]
+final class RequestMethodTest extends TestCase
+{
+    public function testCaseValues(): void
+    {
+        self::assertSame('GET', RequestMethod::GET->value);
+        self::assertSame('POST', RequestMethod::POST->value);
+        self::assertSame('PUT', RequestMethod::PUT->value);
+        self::assertSame('PATCH', RequestMethod::PATCH->value);
+        self::assertSame('DELETE', RequestMethod::DELETE->value);
+        self::assertSame('OPTIONS', RequestMethod::OPTIONS->value);
+        self::assertSame('HEAD', RequestMethod::HEAD->value);
+        self::assertSame('CONNECT', RequestMethod::CONNECT->value);
+        self::assertSame('TRACE', RequestMethod::TRACE->value);
+    }
+
+    public function testIsValid(): void
+    {
+        self::assertTrue(RequestMethod::isValid('GET'));
+        self::assertTrue(RequestMethod::isValid('TRACE'));
+        self::assertFalse(RequestMethod::isValid('PATCHY'));
+    }
+
+    public function testAreValid(): void
+    {
+        self::assertTrue(RequestMethod::areValid(['GET', 'POST']));
+        self::assertFalse(RequestMethod::areValid(['GET', 'NOT_A_METHOD']));
+    }
+}

--- a/phpunit_tests/Http/Enum/ReturnTypeParamTest.php
+++ b/phpunit_tests/Http/Enum/ReturnTypeParamTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Enum;
+
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ReturnTypeParam::class)]
+final class ReturnTypeParamTest extends TestCase
+{
+    public function testCaseValues(): void
+    {
+        self::assertSame('JSON', ReturnTypeParam::JSON->value);
+        self::assertSame('YML', ReturnTypeParam::YAML->value);
+        self::assertSame('XML', ReturnTypeParam::XML->value);
+        self::assertSame('ICS', ReturnTypeParam::ICS->value);
+    }
+
+    public function testToResponseContentTypeAndAlias(): void
+    {
+        self::assertSame(AcceptHeader::JSON, ReturnTypeParam::JSON->toResponseContentType());
+        self::assertSame(AcceptHeader::YAML, ReturnTypeParam::YAML->toResponseContentType());
+        self::assertSame(AcceptHeader::ICS, ReturnTypeParam::ICS->toResponseContentType());
+        self::assertSame(
+            ReturnTypeParam::XML->toResponseContentType(),
+            ReturnTypeParam::XML->toAcceptMimeType()
+        );
+    }
+
+    public function testEveryReturnTypeMapsToAnAcceptHeader(): void
+    {
+        foreach (ReturnTypeParam::cases() as $case) {
+            self::assertInstanceOf(AcceptHeader::class, $case->toResponseContentType());
+        }
+    }
+}

--- a/phpunit_tests/Http/Enum/StatusCodeTest.php
+++ b/phpunit_tests/Http/Enum/StatusCodeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Enum;
+
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(StatusCode::class)]
+final class StatusCodeTest extends TestCase
+{
+    public function testNumericValues(): void
+    {
+        self::assertSame(102, StatusCode::PROCESSING->value);
+        self::assertSame(200, StatusCode::OK->value);
+        self::assertSame(201, StatusCode::CREATED->value);
+        self::assertSame(204, StatusCode::NO_CONTENT->value);
+        self::assertSame(304, StatusCode::NOT_MODIFIED->value);
+        self::assertSame(400, StatusCode::BAD_REQUEST->value);
+        self::assertSame(401, StatusCode::UNAUTHORIZED->value);
+        self::assertSame(403, StatusCode::FORBIDDEN->value);
+        self::assertSame(404, StatusCode::NOT_FOUND->value);
+        self::assertSame(405, StatusCode::METHOD_NOT_ALLOWED->value);
+        self::assertSame(406, StatusCode::NOT_ACCEPTABLE->value);
+        self::assertSame(409, StatusCode::CONFLICT->value);
+        self::assertSame(415, StatusCode::UNSUPPORTED_MEDIA_TYPE->value);
+        self::assertSame(422, StatusCode::UNPROCESSABLE_CONTENT->value);
+        self::assertSame(429, StatusCode::TOO_MANY_REQUESTS->value);
+        self::assertSame(500, StatusCode::INTERNAL_SERVER_ERROR->value);
+        self::assertSame(501, StatusCode::NOT_IMPLEMENTED->value);
+        self::assertSame(503, StatusCode::SERVICE_UNAVAILABLE->value);
+    }
+
+    public function testReasonPhrases(): void
+    {
+        self::assertSame('Processing', StatusCode::PROCESSING->toString());
+        self::assertSame('OK', StatusCode::OK->toString());
+        self::assertSame('Created', StatusCode::CREATED->toString());
+        self::assertSame('No Content', StatusCode::NO_CONTENT->toString());
+        self::assertSame('Not Modified', StatusCode::NOT_MODIFIED->toString());
+        self::assertSame('Bad Request', StatusCode::BAD_REQUEST->toString());
+        self::assertSame('Unauthorized', StatusCode::UNAUTHORIZED->toString());
+        self::assertSame('Forbidden', StatusCode::FORBIDDEN->toString());
+        self::assertSame('Not Found', StatusCode::NOT_FOUND->toString());
+        self::assertSame('Method Not Allowed', StatusCode::METHOD_NOT_ALLOWED->toString());
+        self::assertSame('Not Acceptable', StatusCode::NOT_ACCEPTABLE->toString());
+        self::assertSame('Conflict', StatusCode::CONFLICT->toString());
+        self::assertSame('Unsupported Media Type', StatusCode::UNSUPPORTED_MEDIA_TYPE->toString());
+        self::assertSame('Unprocessable Content', StatusCode::UNPROCESSABLE_CONTENT->toString());
+        self::assertSame('Too Many Requests', StatusCode::TOO_MANY_REQUESTS->toString());
+        self::assertSame('Internal Server Error', StatusCode::INTERNAL_SERVER_ERROR->toString());
+        self::assertSame('Not Implemented', StatusCode::NOT_IMPLEMENTED->toString());
+        self::assertSame('Service Unavailable', StatusCode::SERVICE_UNAVAILABLE->toString());
+    }
+
+    public function testReasonIsAliasForToString(): void
+    {
+        foreach (StatusCode::cases() as $case) {
+            self::assertSame($case->toString(), $case->reason());
+        }
+    }
+}

--- a/phpunit_tests/Http/Exception/ApiExceptionTest.php
+++ b/phpunit_tests/Http/Exception/ApiExceptionTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Exception;
+
+use LiturgicalCalendar\Api\Http\Exception\ApiException;
+use LiturgicalCalendar\Api\Http\Exception\ConflictException;
+use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
+use LiturgicalCalendar\Api\Http\Exception\ImplementationException;
+use LiturgicalCalendar\Api\Http\Exception\InternalServerErrorException;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\NotAcceptableException;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\ResourceConflictException;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\Http\Exception\TooManyRequestsException;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
+use LiturgicalCalendar\Api\Http\Exception\UnsupportedCharsetException;
+use LiturgicalCalendar\Api\Http\Exception\UnsupportedMediaTypeException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Http\Exception\YamlException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises the ApiException base contract plus each concrete subclass's
+ * canonical status / title / type. Some exceptions add extras (TooManyRequests
+ * retry-after, Yaml custom status) which are spot-checked separately.
+ */
+#[CoversClass(ApiException::class)]
+#[CoversClass(ConflictException::class)]
+#[CoversClass(ForbiddenException::class)]
+#[CoversClass(ImplementationException::class)]
+#[CoversClass(InternalServerErrorException::class)]
+#[CoversClass(MethodNotAllowedException::class)]
+#[CoversClass(NotAcceptableException::class)]
+#[CoversClass(NotFoundException::class)]
+#[CoversClass(ResourceConflictException::class)]
+#[CoversClass(ServiceUnavailableException::class)]
+#[CoversClass(TooManyRequestsException::class)]
+#[CoversClass(UnauthorizedException::class)]
+#[CoversClass(UnprocessableContentException::class)]
+#[CoversClass(UnsupportedCharsetException::class)]
+#[CoversClass(UnsupportedMediaTypeException::class)]
+#[CoversClass(ValidationException::class)]
+#[CoversClass(YamlException::class)]
+final class ApiExceptionTest extends TestCase
+{
+    public function testToArrayProducesProblemDetails(): void
+    {
+        $err = new NotFoundException('missing widget');
+        self::assertSame(404, $err->getStatus());
+        self::assertSame('Not Found', $err->getTitle());
+        self::assertStringContainsString('404-not-found', $err->getType());
+
+        $arr = $err->toArray();
+        self::assertSame([
+            'type'   => $err->getType(),
+            'title'  => 'Not Found',
+            'status' => 404,
+            'detail' => 'missing widget',
+        ], $arr);
+    }
+
+    public function testToArrayDebugIncludesFileLineTrace(): void
+    {
+        $err = new NotFoundException('boom');
+        $arr = $err->toArray(includeDebug: true);
+        self::assertArrayHasKey('file', $arr);
+        self::assertArrayHasKey('line', $arr);
+        self::assertArrayHasKey('trace', $arr);
+        self::assertIsArray($arr['trace']);
+    }
+
+    public function testPreviousExceptionPropagates(): void
+    {
+        $cause = new \RuntimeException('cause');
+        $err   = new ValidationException('bad input', $cause);
+        self::assertSame($cause, $err->getPrevious());
+    }
+
+    /**
+     * @return iterable<string, array{class-string<ApiException>, int, string}>
+     */
+    public static function exceptionShapeProvider(): iterable
+    {
+        return [
+            'conflict'            => [ConflictException::class, 409, 'Conflict'],
+            'forbidden'           => [ForbiddenException::class, 403, 'Forbidden'],
+            'implementation'      => [ImplementationException::class, 501, 'Not Implemented'],
+            'internal'            => [InternalServerErrorException::class, 500, 'Internal Server Error'],
+            'method-not-allowed'  => [MethodNotAllowedException::class, 405, 'Method Not Allowed'],
+            'not-acceptable'      => [NotAcceptableException::class, 406, 'Not Acceptable'],
+            'not-found'           => [NotFoundException::class, 404, 'Not Found'],
+            'resource-conflict'   => [ResourceConflictException::class, 409, 'Conflict'],
+            'service-unavail'     => [ServiceUnavailableException::class, 503, 'Service Unavailable'],
+            'unauthorized'        => [UnauthorizedException::class, 401, 'Unauthorized'],
+            'unprocessable'       => [UnprocessableContentException::class, 422, 'Unprocessable Content'],
+            'unsupported-media'   => [UnsupportedMediaTypeException::class, 415, 'Unsupported Media Type'],
+            'unsupported-charset' => [UnsupportedCharsetException::class, 415, 'Unsupported Media Type'],
+            'validation'          => [ValidationException::class, 400, 'Bad Request'],
+            'yaml'                => [YamlException::class, 422, 'Invalid YAML data'],
+        ];
+    }
+
+    #[\PHPUnit\Framework\Attributes\DataProvider('exceptionShapeProvider')]
+    public function testEachExceptionHasCorrectStatusAndTitle(
+        string $class,
+        int $expectedStatus,
+        string $expectedTitle
+    ): void {
+        /** @var ApiException $err */
+        $err = new $class('custom message');
+        self::assertSame($expectedStatus, $err->getStatus());
+        self::assertSame($expectedTitle, $err->getTitle());
+        self::assertSame('custom message', $err->getMessage());
+        self::assertNotEmpty($err->getType());
+    }
+
+    public function testTooManyRequestsRetryAfter(): void
+    {
+        $err = new TooManyRequestsException('Slow down', retryAfter: 30);
+        self::assertSame(429, $err->getStatus());
+        self::assertSame(30, $err->getRetryAfter());
+        $arr = $err->toArray();
+        self::assertSame(30, $arr['retryAfter']);
+    }
+
+    public function testTooManyRequestsOmitsRetryAfterWhenZero(): void
+    {
+        $err = new TooManyRequestsException();
+        self::assertSame(0, $err->getRetryAfter());
+        self::assertArrayNotHasKey('retryAfter', $err->toArray());
+    }
+
+    public function testTooManyRequestsClampsNegativeRetryAfter(): void
+    {
+        $err = new TooManyRequestsException(retryAfter: -10);
+        self::assertSame(0, $err->getRetryAfter());
+    }
+
+    public function testYamlExceptionAllowsCustomStatus(): void
+    {
+        $err = new YamlException('bad yaml', 400);
+        self::assertSame(400, $err->getStatus());
+        self::assertSame('Invalid YAML data', $err->getTitle());
+    }
+
+    public function testUnauthorizedHasRfcTypeUrl(): void
+    {
+        $err = new UnauthorizedException();
+        self::assertStringContainsString('401-unauthorized', $err->getType());
+    }
+}

--- a/phpunit_tests/Http/HttpsEnforcementMiddlewareTest.php
+++ b/phpunit_tests/Http/HttpsEnforcementMiddlewareTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http;
+
+use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
+use LiturgicalCalendar\Api\Http\Middleware\HttpsEnforcementMiddleware;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+#[CoversClass(HttpsEnforcementMiddleware::class)]
+final class HttpsEnforcementMiddlewareTest extends TestCase
+{
+    private const UNSET = "\0__unset__\0";
+
+    /** @var mixed */
+    private $savedAppEnv;
+    /** @var mixed */
+    private $savedEnforcement;
+
+    protected function setUp(): void
+    {
+        $this->savedAppEnv      = array_key_exists('APP_ENV', $_ENV) ? $_ENV['APP_ENV'] : self::UNSET;
+        $this->savedEnforcement = array_key_exists('HTTPS_ENFORCEMENT', $_ENV) ? $_ENV['HTTPS_ENFORCEMENT'] : self::UNSET;
+        unset($_ENV['APP_ENV'], $_ENV['HTTPS_ENFORCEMENT']);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['APP_ENV' => $this->savedAppEnv, 'HTTPS_ENFORCEMENT' => $this->savedEnforcement] as $k => $v) {
+            if ($v === self::UNSET) {
+                unset($_ENV[$k]);
+            } else {
+                $_ENV[$k] = $v;
+            }
+        }
+    }
+
+    private function handler(): RequestHandlerInterface
+    {
+        return new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(200);
+            }
+        };
+    }
+
+    public function testSkipsEnforcementInDevelopment(): void
+    {
+        $request  = ( new Psr17Factory() )->createServerRequest('GET', 'http://example.test/auth/login');
+        $response = ( new HttpsEnforcementMiddleware() )->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testSkipsEnforcementWhenExplicitlyDisabled(): void
+    {
+        $_ENV['APP_ENV']           = 'production';
+        $_ENV['HTTPS_ENFORCEMENT'] = 'false';
+        $request                   = ( new Psr17Factory() )->createServerRequest('GET', 'http://example.test/auth/login');
+        $response                  = ( new HttpsEnforcementMiddleware() )->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testRequiresHttpsInProduction(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        $request         = ( new Psr17Factory() )->createServerRequest('GET', 'http://example.test/auth/login');
+        $this->expectException(ForbiddenException::class);
+        $this->expectExceptionMessage('HTTPS is required');
+        ( new HttpsEnforcementMiddleware() )->process($request, $this->handler());
+    }
+
+    public function testAcceptsHttpsUriScheme(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        $request         = ( new Psr17Factory() )->createServerRequest('GET', 'https://example.test/auth/login');
+        $response        = ( new HttpsEnforcementMiddleware() )->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testAcceptsForwardedProtoHttps(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        $request         = ( new Psr17Factory() )
+            ->createServerRequest('GET', 'http://example.test/auth/login')
+            ->withHeader('X-Forwarded-Proto', 'https');
+        $response        = ( new HttpsEnforcementMiddleware() )->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testAcceptsServerHttpsParam(): void
+    {
+        $_ENV['APP_ENV'] = 'staging';
+        $factory         = new Psr17Factory();
+        $request         = $factory->createServerRequest(
+            'GET',
+            'http://example.test/auth/login',
+            ['HTTPS' => 'on']
+        );
+        $response        = ( new HttpsEnforcementMiddleware() )->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testAcceptsServerPort443(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        $factory         = new Psr17Factory();
+        $request         = $factory->createServerRequest(
+            'GET',
+            'http://example.test/auth/login',
+            ['SERVER_PORT' => '443']
+        );
+        $response        = ( new HttpsEnforcementMiddleware() )->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testAcceptsRequestSchemeServerParam(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        $factory         = new Psr17Factory();
+        $request         = $factory->createServerRequest(
+            'GET',
+            'http://example.test/auth/login',
+            ['REQUEST_SCHEME' => 'https']
+        );
+        $response        = ( new HttpsEnforcementMiddleware() )->process($request, $this->handler());
+        self::assertSame(200, $response->getStatusCode());
+    }
+}

--- a/phpunit_tests/Http/Logs/LoggerFactoryTest.php
+++ b/phpunit_tests/Http/Logs/LoggerFactoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Logs;
+
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use Monolog\Logger;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LoggerFactory::class)]
+final class LoggerFactoryTest extends TestCase
+{
+    private string $tmpDir;
+
+    /** @var array<class-string, \ReflectionProperty> */
+    private static array $reflectionCache = [];
+
+    /** @var mixed */
+    private mixed $savedLogsFolder = null;
+    private bool $logsFolderWasSet = false;
+
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/litcal_test_logs_' . bin2hex(random_bytes(4));
+        mkdir($this->tmpDir, 0755, true);
+
+        // Snapshot the static logsFolder so we can restore it — other tests
+        // (e.g. handler tests that build their own loggers) rely on whatever
+        // value was in place before this class ran.
+        $folder                 = self::folderProperty();
+        $this->logsFolderWasSet = $folder->isInitialized(null);
+        if ($this->logsFolderWasSet) {
+            $this->savedLogsFolder = $folder->getValue(null);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        // Clear the logger cache so each test gets a fresh logger
+        // (LoggerFactory memoises by $logName).
+        self::loggersProperty()->setValue(null, []);
+
+        // Restore the saved logsFolder (if any) so other tests are unaffected.
+        if ($this->logsFolderWasSet && is_string($this->savedLogsFolder)) {
+            self::folderProperty()->setValue(null, $this->savedLogsFolder);
+        }
+
+        if (is_dir($this->tmpDir)) {
+            foreach (glob($this->tmpDir . '/*') ?: [] as $file) {
+                if (is_file($file)) {
+                    unlink($file);
+                }
+            }
+            rmdir($this->tmpDir);
+        }
+    }
+
+    private static function loggersProperty(): \ReflectionProperty
+    {
+        return self::$reflectionCache['apiLoggers'] ??= new \ReflectionProperty(LoggerFactory::class, 'apiLoggers');
+    }
+
+    private static function folderProperty(): \ReflectionProperty
+    {
+        return self::$reflectionCache['logsFolder'] ??= new \ReflectionProperty(LoggerFactory::class, 'logsFolder');
+    }
+
+    public function testCreateReturnsLoggerAndWritesPlainLog(): void
+    {
+        $logger = LoggerFactory::create('factorytest', $this->tmpDir, 2, false, true, false);
+        self::assertInstanceOf(Logger::class, $logger);
+
+        $logger->info('hello world');
+        $files = glob($this->tmpDir . '/factorytest-*.log') ?: [];
+        self::assertNotEmpty($files);
+    }
+
+    public function testCreateMemoisesPerLogName(): void
+    {
+        $logger1 = LoggerFactory::create('memoised', $this->tmpDir, 2, false, false, false);
+        $logger2 = LoggerFactory::create('memoised', $this->tmpDir, 2, false, false, false);
+        self::assertSame($logger1, $logger2);
+    }
+
+    public function testCreateRejectsUnwritablePath(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        LoggerFactory::create('rejecttest', '/this/path/should/not/exist');
+    }
+
+    public function testCreateAcceptsExistingWritableDir(): void
+    {
+        $logger = LoggerFactory::create('writabletest', $this->tmpDir);
+        self::assertInstanceOf(Logger::class, $logger);
+    }
+}

--- a/phpunit_tests/Http/Logs/PrettyLineFormatterTest.php
+++ b/phpunit_tests/Http/Logs/PrettyLineFormatterTest.php
@@ -77,8 +77,11 @@ final class PrettyLineFormatterTest extends TestCase
         $formatter = new PrettyLineFormatter();
         $message   = "\033[0;36mhello\033[0m";
         $output    = $formatter->format($this->makeRecord(Level::Info, $message));
-        // Should not have wrapped with an additional green colour code.
+        // The pre-coloured message must appear verbatim (cyan, not re-wrapped).
         self::assertStringContainsString($message, $output);
+        // And the Info-level green wrapper must NOT have been applied around it.
+        self::assertStringNotContainsString("\033[0;32m{$message}", $output);
+        self::assertStringNotContainsString("\033[0;32m{$message}\033[0m", $output);
     }
 
     public function testExtraFieldsAreRenderedPretty(): void

--- a/phpunit_tests/Http/Logs/PrettyLineFormatterTest.php
+++ b/phpunit_tests/Http/Logs/PrettyLineFormatterTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Logs;
+
+use LiturgicalCalendar\Api\Http\Logs\PrettyLineFormatter;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PrettyLineFormatter::class)]
+final class PrettyLineFormatterTest extends TestCase
+{
+    private function makeRecord(
+        Level $level,
+        string $message,
+        array $context = [],
+        array $extra = []
+    ): LogRecord {
+        return new LogRecord(
+            datetime: new \DateTimeImmutable('2025-01-01 12:00:00'),
+            channel: 'test',
+            level: $level,
+            message: $message,
+            context: $context,
+            extra: $extra
+        );
+    }
+
+    public function testInfoMessageIsColouredGreen(): void
+    {
+        $formatter = new PrettyLineFormatter();
+        $output    = $formatter->format($this->makeRecord(Level::Info, 'pong'));
+        self::assertStringContainsString("\033[0;32m", $output);
+        self::assertStringContainsString('pong', $output);
+        self::assertStringContainsString("\033[0m", $output);
+    }
+
+    public function testWarningMessageIsColouredYellow(): void
+    {
+        $formatter = new PrettyLineFormatter();
+        $output    = $formatter->format($this->makeRecord(Level::Warning, 'careful'));
+        self::assertStringContainsString("\033[0;33m", $output);
+    }
+
+    public function testResponseContextColoursByStatus(): void
+    {
+        $formatter = new PrettyLineFormatter();
+
+        $output500 = $formatter->format($this->makeRecord(
+            Level::Info,
+            'http',
+            ['type' => 'response', 'response' => new Response(503)]
+        ));
+        self::assertStringContainsString("\033[0;31m", $output500); // red
+
+        $output400 = $formatter->format($this->makeRecord(
+            Level::Info,
+            'http',
+            ['type' => 'response', 'response' => new Response(404)]
+        ));
+        self::assertStringContainsString("\033[0;33m", $output400); // yellow
+
+        $output200 = $formatter->format($this->makeRecord(
+            Level::Info,
+            'http',
+            ['type' => 'response', 'response' => new Response(200)]
+        ));
+        self::assertStringContainsString("\033[0;32m", $output200); // green
+    }
+
+    public function testAlreadyColouredMessageIsLeftAlone(): void
+    {
+        $formatter = new PrettyLineFormatter();
+        $message   = "\033[0;36mhello\033[0m";
+        $output    = $formatter->format($this->makeRecord(Level::Info, $message));
+        // Should not have wrapped with an additional green colour code.
+        self::assertStringContainsString($message, $output);
+    }
+
+    public function testExtraFieldsAreRenderedPretty(): void
+    {
+        $formatter = new PrettyLineFormatter();
+        $record    = $this->makeRecord(
+            Level::Info,
+            'hi',
+            extra: [
+                'flag'   => true,
+                'number' => 42,
+                'nullv'  => null,
+                'list'   => ['a', 'b'],
+                'nested' => ['child' => 'deep'],
+                'obj'    => (object) ['x' => 1],
+            ]
+        );
+        $output    = $formatter->format($record);
+        self::assertStringContainsString('Extra:', $output);
+        self::assertStringContainsString('flag', $output);
+        self::assertStringContainsString('true', $output);
+        self::assertStringContainsString('number', $output);
+        self::assertStringContainsString('42', $output);
+        self::assertStringContainsString('nullv', $output);
+        self::assertStringContainsString('null', $output);
+        self::assertStringContainsString('deep', $output);
+        // Object converted to array vars and rendered (with indent spaces).
+        self::assertMatchesRegularExpression('/x:\s+1/', $output);
+    }
+
+    public function testEmergencyLevelUsesRedBackground(): void
+    {
+        $formatter = new PrettyLineFormatter();
+        $output    = $formatter->format($this->makeRecord(Level::Emergency, 'fire'));
+        self::assertStringContainsString("\033[1;41m", $output);
+    }
+}

--- a/phpunit_tests/Http/Logs/RequestResponseProcessorTest.php
+++ b/phpunit_tests/Http/Logs/RequestResponseProcessorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Logs;
+
+use LiturgicalCalendar\Api\Http\Logs\RequestResponseProcessor;
+use Monolog\Level;
+use Monolog\LogRecord;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RequestResponseProcessor::class)]
+final class RequestResponseProcessorTest extends TestCase
+{
+    private function record(array $context = []): LogRecord
+    {
+        return new LogRecord(
+            datetime: new \DateTimeImmutable(),
+            channel: 'test',
+            level: Level::Info,
+            message: 'msg',
+            context: $context,
+        );
+    }
+
+    public function testProcessesRequestContext(): void
+    {
+        $request = ( new Psr17Factory() )
+            ->createServerRequest('GET', 'https://example.test/foo')
+            ->withHeader('Authorization', 'Bearer secret')
+            ->withHeader('X-Trace', 'abc');
+
+        $proc      = new RequestResponseProcessor();
+        $processed = $proc(
+            $this->record(['type' => 'request', 'request' => $request, 'request_id' => 'r123'])
+        );
+
+        self::assertSame('HTTP/1.1', $processed->extra['protocol']);
+        self::assertSame('r123', $processed->extra['request_id']);
+        self::assertIsInt($processed->extra['pid']);
+        // Sensitive headers redacted.
+        self::assertSame(['[redacted]'], $processed->extra['headers']['Authorization']);
+        // Other headers preserved.
+        self::assertSame(['abc'], $processed->extra['headers']['X-Trace']);
+    }
+
+    public function testProcessesResponseContext(): void
+    {
+        $response  = new Response(200, ['Set-Cookie' => 'foo=bar', 'X-Powered-By' => 'litcal']);
+        $proc      = new RequestResponseProcessor();
+        $processed = $proc(
+            $this->record(['type' => 'response', 'response' => $response, 'request_id' => 'r123'])
+        );
+
+        self::assertSame(200, $processed->extra['status_code']);
+        self::assertSame('r123', $processed->extra['response_id']);
+        self::assertSame(['[redacted]'], $processed->extra['headers']['Set-Cookie']);
+        self::assertSame(['litcal'], $processed->extra['headers']['X-Powered-By']);
+    }
+
+    public function testRequestContextWithoutRequestObjectFallsBackGracefully(): void
+    {
+        $proc      = new RequestResponseProcessor();
+        $processed = $proc($this->record(['type' => 'request', 'request_id' => 'fallback']));
+        // Returns record without throwing — graceful degradation path.
+        self::assertSame('fallback', $processed->extra['request_id']);
+        self::assertIsInt($processed->extra['pid']);
+    }
+
+    public function testRequestContextWithoutRequestIdUsesUnknown(): void
+    {
+        $proc      = new RequestResponseProcessor();
+        $processed = $proc($this->record(['type' => 'request']));
+        self::assertSame('unknown', $processed->extra['request_id']);
+    }
+
+    public function testResponseContextWithoutResponseThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $proc = new RequestResponseProcessor();
+        $proc($this->record(['type' => 'response', 'request_id' => 'r1']));
+    }
+
+    public function testUnknownTypeThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $proc = new RequestResponseProcessor();
+        $proc($this->record(['type' => 'wat']));
+    }
+
+    public function testMissingTypeThrows(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $proc = new RequestResponseProcessor();
+        $proc($this->record([]));
+    }
+}

--- a/phpunit_tests/Http/Server/MiddlewarePipelineTest.php
+++ b/phpunit_tests/Http/Server/MiddlewarePipelineTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http\Server;
+
+use LiturgicalCalendar\Api\Http\Server\MiddlewarePipeline;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+#[CoversClass(MiddlewarePipeline::class)]
+final class MiddlewarePipelineTest extends TestCase
+{
+    private function terminalHandler(string $marker = 'inner'): RequestHandlerInterface
+    {
+        return new class ($marker) implements RequestHandlerInterface {
+            public function __construct(private string $marker)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return ( new Response(200) )
+                    ->withHeader('X-Inner', $this->marker);
+            }
+        };
+    }
+
+    private function decoratingMiddleware(string $name): MiddlewareInterface
+    {
+        return new class ($name) implements MiddlewareInterface {
+            public function __construct(private string $name)
+            {
+            }
+
+            public function process(
+                ServerRequestInterface $request,
+                RequestHandlerInterface $handler
+            ): ResponseInterface {
+                return $handler->handle($request)
+                    ->withAddedHeader('X-Stack', $this->name);
+            }
+        };
+    }
+
+    public function testEmptyPipelineDelegatesToDefaultHandler(): void
+    {
+        $pipeline = new MiddlewarePipeline($this->terminalHandler('default'));
+        $factory  = new Psr17Factory();
+        $response = $pipeline->handle($factory->createServerRequest('GET', '/'));
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('default', $response->getHeaderLine('X-Inner'));
+    }
+
+    public function testMiddlewareRunsInQueueOrderAroundHandler(): void
+    {
+        $pipeline = new MiddlewarePipeline($this->terminalHandler());
+        $pipeline->pipe($this->decoratingMiddleware('outer'));
+        $pipeline->pipe($this->decoratingMiddleware('inner'));
+
+        $response = $pipeline->handle(( new Psr17Factory() )->createServerRequest('GET', '/'));
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('inner', $response->getHeaderLine('X-Inner'));
+        // Both middlewares ran — pipeline appends "inner" first (innermost) then
+        // "outer" wraps it, so getHeader returns them in chronological order.
+        self::assertSame(['inner', 'outer'], $response->getHeader('X-Stack'));
+    }
+
+    public function testShortCircuitMiddlewareSkipsTerminalHandler(): void
+    {
+        $pipeline = new MiddlewarePipeline($this->terminalHandler('should-not-run'));
+
+        // This middleware never calls $handler->handle.
+        $short = new class implements MiddlewareInterface {
+            public function process(
+                ServerRequestInterface $request,
+                RequestHandlerInterface $handler
+            ): ResponseInterface {
+                return new Response(418);
+            }
+        };
+        $pipeline->pipe($short);
+
+        $response = $pipeline->handle(( new Psr17Factory() )->createServerRequest('GET', '/'));
+        self::assertSame(418, $response->getStatusCode());
+        self::assertFalse($response->hasHeader('X-Inner'));
+    }
+}

--- a/phpunit_tests/Models/AbstractJsonClassesTest.php
+++ b/phpunit_tests/Models/AbstractJsonClassesTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models;
+
+use LiturgicalCalendar\Api\Models\AbstractJsonRepresentation;
+use LiturgicalCalendar\Api\Models\AbstractJsonSrcData;
+use LiturgicalCalendar\Api\Models\AbstractJsonSrcDataArray;
+use LiturgicalCalendar\Api\Models\MissalsPath\MissalYearLimits;
+use LiturgicalCalendar\Api\Models\PropriumDeTemporeMap;
+use LiturgicalCalendar\Api\Models\RelativeLiturgicalDate;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Exercises the shared contract of AbstractJsonRepresentation,
+ * AbstractJsonSrcData, and AbstractJsonSrcDataArray via concrete subclasses
+ * that already exist in the codebase (RelativeLiturgicalDate for the
+ * SrcData variant, MissalYearLimits for the Representation variant, and
+ * PropriumDeTemporeMap for the SrcDataArray variant).
+ */
+#[CoversClass(AbstractJsonRepresentation::class)]
+#[CoversClass(AbstractJsonSrcData::class)]
+#[CoversClass(AbstractJsonSrcDataArray::class)]
+final class AbstractJsonClassesTest extends TestCase
+{
+    public function testFromArrayRejectsStdClassFirstElementForSrcData(): void
+    {
+        // RelativeLiturgicalDate uses AbstractJsonSrcData. Pass an array whose
+        // first element is a stdClass — that should error directing callers to fromObject.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Please use fromObject instead.');
+        RelativeLiturgicalDate::fromArray([new \stdClass(), 'irrelevant']);
+    }
+
+    public function testFromArrayRejectsStdClassFirstElementForRepresentation(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        MissalYearLimits::fromArray([new \stdClass()]);
+    }
+
+    public function testFromArrayRejectsStdClassFirstElementForSrcDataArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        PropriumDeTemporeMap::fromArray([new \stdClass()]);
+    }
+
+    public function testLockingPreventsFurtherMutationForSrcData(): void
+    {
+        $rel = RelativeLiturgicalDate::fromArray([
+            'day_of_the_week' => 'Monday',
+            'relative_time'   => 'after',
+            'event_key'       => 'Pentecost',
+        ]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("Cannot modify locked object property 'extra'");
+        $rel->extra = 'nope';
+    }
+
+    public function testLockingPreventsFurtherMutationForRepresentation(): void
+    {
+        $limits = MissalYearLimits::fromArray(['since_year' => 1970]);
+
+        $this->expectException(\LogicException::class);
+        $limits->extra = 'nope';
+    }
+
+    public function testLockingPreventsFurtherMutationForSrcDataArray(): void
+    {
+        // PropriumDeTemporeMap is a concrete AbstractJsonSrcDataArray subclass.
+        $map = PropriumDeTemporeMap::fromArray([
+            ['event_key' => 'Easter', 'grade' => 7, 'type' => 'mobile', 'color' => ['white']],
+        ]);
+
+        $this->expectException(\LogicException::class);
+        $map->extra = 'nope';
+    }
+
+    public function testRepresentationFromObjectHappyPath(): void
+    {
+        $limits = MissalYearLimits::fromObject((object) ['since_year' => 1970]);
+        self::assertSame(1970, $limits->since_year);
+        self::assertNull($limits->until_year);
+    }
+
+    public function testSrcDataArrayFromObjectRoundTrip(): void
+    {
+        $event = (object) ['event_key' => 'Christmas', 'grade' => 7, 'type' => 'fixed', 'color' => ['white']];
+        $map   = PropriumDeTemporeMap::fromObject([$event]);
+        self::assertInstanceOf(PropriumDeTemporeMap::class, $map);
+    }
+}

--- a/phpunit_tests/Models/Auth/UserTest.php
+++ b/phpunit_tests/Models/Auth/UserTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Auth;
+
+use LiturgicalCalendar\Api\Models\Auth\User;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(User::class)]
+final class UserTest extends TestCase
+{
+    private const UNSET = "\0__unset__\0";
+
+    /** @var array<string,mixed> */
+    private array $savedEnv = [];
+
+    private const VARS = ['ADMIN_USERNAME', 'ADMIN_PASSWORD_HASH', 'APP_ENV'];
+
+    protected function setUp(): void
+    {
+        foreach (self::VARS as $k) {
+            $this->savedEnv[$k] = array_key_exists($k, $_ENV) ? $_ENV[$k] : self::UNSET;
+            unset($_ENV[$k]);
+        }
+
+        // Reset the static dev password cache between tests for hermeticity.
+        $devCache = new \ReflectionProperty(User::class, 'devPasswordHash');
+        $devCache->setValue(null, null);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->savedEnv as $k => $v) {
+            if ($v === self::UNSET) {
+                unset($_ENV[$k]);
+            } else {
+                $_ENV[$k] = $v;
+            }
+        }
+    }
+
+    public function testConstructorAndDefaults(): void
+    {
+        $user = new User('alice', 'hashed');
+        self::assertSame('alice', $user->username);
+        self::assertSame('hashed', $user->passwordHash);
+        self::assertSame(['admin'], $user->roles);
+        self::assertTrue($user->hasRole('admin'));
+        self::assertFalse($user->hasRole('developer'));
+    }
+
+    public function testToArray(): void
+    {
+        $user = new User('bob', 'h', ['developer', 'admin']);
+        self::assertSame(['username' => 'bob', 'roles' => ['developer', 'admin']], $user->toArray());
+    }
+
+    public function testAuthenticateWithExplicitHash(): void
+    {
+        $_ENV['APP_ENV']             = 'production';
+        $_ENV['ADMIN_USERNAME']      = 'admin';
+        $_ENV['ADMIN_PASSWORD_HASH'] = password_hash('sekret', PASSWORD_BCRYPT);
+
+        $user = User::authenticate('admin', 'sekret');
+        self::assertNotNull($user);
+        self::assertSame('admin', $user->username);
+    }
+
+    public function testAuthenticateRejectsWrongUsername(): void
+    {
+        $_ENV['APP_ENV']             = 'production';
+        $_ENV['ADMIN_USERNAME']      = 'admin';
+        $_ENV['ADMIN_PASSWORD_HASH'] = password_hash('sekret', PASSWORD_BCRYPT);
+        self::assertNull(User::authenticate('not-admin', 'sekret'));
+    }
+
+    public function testAuthenticateRejectsWrongPassword(): void
+    {
+        $_ENV['APP_ENV']             = 'production';
+        $_ENV['ADMIN_USERNAME']      = 'admin';
+        $_ENV['ADMIN_PASSWORD_HASH'] = password_hash('sekret', PASSWORD_BCRYPT);
+        self::assertNull(User::authenticate('admin', 'wrong'));
+    }
+
+    public function testAuthenticateRequiresAppEnv(): void
+    {
+        // No APP_ENV set.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('APP_ENV must be set');
+        User::authenticate('admin', 'pw');
+    }
+
+    public function testAuthenticateRejectsInvalidAppEnv(): void
+    {
+        $_ENV['APP_ENV'] = 'qa';
+        $this->expectException(\RuntimeException::class);
+        User::authenticate('admin', 'pw');
+    }
+
+    public function testAuthenticateProductionRequiresHash(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('ADMIN_PASSWORD_HASH');
+        User::authenticate('admin', 'whatever');
+    }
+
+    public function testAuthenticateDevelopmentDefaultPassword(): void
+    {
+        $_ENV['APP_ENV'] = 'development';
+        // No hash set — dev fallback to literal "password".
+        $user = User::authenticate('admin', 'password');
+        self::assertNotNull($user);
+        self::assertSame('admin', $user->username);
+    }
+
+    public function testAuthenticateDevelopmentWrongPasswordFails(): void
+    {
+        $_ENV['APP_ENV'] = 'development';
+        self::assertNull(User::authenticate('admin', 'not-password'));
+    }
+
+    public function testFromJwtPayloadHappyPath(): void
+    {
+        $user = User::fromJwtPayload((object) ['sub' => 'admin', 'roles' => ['admin', 'developer']]);
+        self::assertNotNull($user);
+        self::assertSame('admin', $user->username);
+        self::assertSame(['admin', 'developer'], $user->roles);
+        self::assertSame('', $user->passwordHash);
+    }
+
+    public function testFromJwtPayloadDefaultsToAdminRoleWhenRolesMissing(): void
+    {
+        $user = User::fromJwtPayload((object) ['sub' => 'admin']);
+        self::assertNotNull($user);
+        self::assertSame(['admin'], $user->roles);
+    }
+
+    public function testFromJwtPayloadRejectsMissingSub(): void
+    {
+        self::assertNull(User::fromJwtPayload(new \stdClass()));
+    }
+
+    public function testFromJwtPayloadRejectsNonStringSub(): void
+    {
+        self::assertNull(User::fromJwtPayload((object) ['sub' => 123]));
+    }
+
+    public function testFromJwtPayloadRejectsNonArrayRoles(): void
+    {
+        self::assertNull(User::fromJwtPayload((object) ['sub' => 'admin', 'roles' => 'admin']));
+    }
+
+    public function testFromJwtPayloadRejectsNonStringRoleEntry(): void
+    {
+        self::assertNull(User::fromJwtPayload((object) ['sub' => 'admin', 'roles' => ['admin', 123]]));
+    }
+}

--- a/phpunit_tests/Models/Calendar/LitCommonsTest.php
+++ b/phpunit_tests/Models/Calendar/LitCommonsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar;
+
+use LiturgicalCalendar\Api\Enum\LitCommon;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\LitMassVariousNeeds;
+use LiturgicalCalendar\Api\Models\Calendar\LitCommons;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LitCommons::class)]
+final class LitCommonsTest extends TestCase
+{
+    public function testCreateEmptyArrayReturnsNoneSentinel(): void
+    {
+        $commons = LitCommons::create([]);
+        self::assertNotNull($commons);
+        self::assertTrue($commons->has(LitCommon::NONE));
+        self::assertSame([], $commons->jsonSerialize());
+    }
+
+    public function testCreateWithSingleProprioStringReturnsProper(): void
+    {
+        $commons = LitCommons::create([LitCommon::PROPRIO->value]);
+        self::assertNotNull($commons);
+        self::assertTrue($commons->has(LitCommon::PROPRIO));
+    }
+
+    public function testCreateWithSingleProprioEnumReturnsProper(): void
+    {
+        $commons = LitCommons::create([LitCommon::PROPRIO]);
+        self::assertNotNull($commons);
+        self::assertTrue($commons->has(LitCommon::PROPRIO));
+    }
+
+    public function testCreateFromLitCommonEnumArray(): void
+    {
+        $commons = LitCommons::create([LitCommon::MARTYRUM, LitCommon::PASTORUM]);
+        self::assertNotNull($commons);
+        self::assertTrue($commons->has(LitCommon::MARTYRUM));
+        self::assertTrue($commons->has(LitCommon::PASTORUM));
+    }
+
+    public function testCreateFromStringArrayWithGeneralAndSpecific(): void
+    {
+        // 'Martyrs:For One Martyr' splits on colon into general:specific.
+        $commons = LitCommons::create(['Martyrs:For One Martyr']);
+        self::assertNotNull($commons);
+        self::assertTrue($commons->has(LitCommon::MARTYRUM));
+        self::assertTrue($commons->has(LitCommon::PRO_UNO_MARTYRE));
+    }
+
+    public function testCreateFromUnknownStringReturnsNull(): void
+    {
+        // Unknown common label: returns null (signalling LitMassVariousNeeds path).
+        $commons = LitCommons::create(['NotARealCommon']);
+        self::assertNull($commons);
+    }
+
+    public function testCreateFromMixedTypesRejects(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('same type');
+        LitCommons::create([LitCommon::MARTYRUM, 'Pastors']);
+    }
+
+    public function testCreateFromLitMassVariousNeedsReturnsNull(): void
+    {
+        $commons = LitCommons::create([LitMassVariousNeeds::PRO_PAPA]);
+        self::assertNull($commons);
+    }
+
+    public function testFullTranslateProper(): void
+    {
+        $commons = LitCommons::create([LitCommon::PROPRIO]);
+        self::assertNotNull($commons);
+        $translated = $commons->fullTranslate(LitLocale::LATIN_PRIMARY_LANGUAGE);
+        // Latin translation of Proprio.
+        self::assertSame('Proprio', $translated);
+    }
+
+    public function testFullTranslateNoneReturnsEmptyString(): void
+    {
+        $commons = LitCommons::create([]);
+        self::assertNotNull($commons);
+        self::assertSame('', $commons->fullTranslate(LitLocale::LATIN_PRIMARY_LANGUAGE));
+    }
+
+    public function testFullTranslateCommonBuildsFromTheCommonPhrase(): void
+    {
+        $commons = LitCommons::create([LitCommon::MARTYRUM]);
+        self::assertNotNull($commons);
+        $latin = $commons->fullTranslate(LitLocale::LATIN_PRIMARY_LANGUAGE);
+        self::assertStringContainsString('De Commune', $latin);
+        self::assertStringContainsString('Martyrum', $latin);
+    }
+}

--- a/phpunit_tests/Models/ConditionalRuleTest.php
+++ b/phpunit_tests/Models/ConditionalRuleTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models;
+
+use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Models\ConditionalRule;
+use LiturgicalCalendar\Api\Models\ConditionalRuleAction;
+use LiturgicalCalendar\Api\Models\ConditionalRuleCondition;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConditionalRule::class)]
+#[CoversClass(ConditionalRuleCondition::class)]
+#[CoversClass(ConditionalRuleAction::class)]
+final class ConditionalRuleTest extends TestCase
+{
+    public function testConditionFromArrayWeekday(): void
+    {
+        $c = ConditionalRuleCondition::fromArray(['if_weekday' => 'Monday']);
+        self::assertSame('monday', $c->if_weekday);
+        self::assertNull($c->if_grade);
+    }
+
+    public function testConditionFromArrayGrade(): void
+    {
+        $c = ConditionalRuleCondition::fromArray(['if_grade' => LitGrade::SOLEMNITY->value]);
+        self::assertSame(LitGrade::SOLEMNITY, $c->if_grade);
+        self::assertNull($c->if_weekday);
+    }
+
+    public function testConditionRequiresAtLeastOneProperty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('at least one of `if_weekday` or `if_grade`');
+        ConditionalRuleCondition::fromArray([]);
+    }
+
+    public function testConditionRejectsBothProperties(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRuleCondition::fromArray(['if_weekday' => 'Monday', 'if_grade' => 3]);
+    }
+
+    public function testConditionRejectsInvalidWeekdayValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRuleCondition::fromArray(['if_weekday' => 'Funday']);
+    }
+
+    public function testConditionRejectsNonStringWeekday(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRuleCondition::fromArray(['if_weekday' => 123]);
+    }
+
+    public function testConditionRejectsNonIntGrade(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRuleCondition::fromArray(['if_grade' => 'six']);
+    }
+
+    public function testConditionRejectsOutOfRangeGrade(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRuleCondition::fromArray(['if_grade' => 99]);
+    }
+
+    public function testConditionFromObjectAlsoSupported(): void
+    {
+        $c = ConditionalRuleCondition::fromObject((object) ['if_weekday' => 'Friday']);
+        self::assertSame('friday', $c->if_weekday);
+    }
+
+    public function testConditionFromObjectRequiresAtLeastOneProperty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRuleCondition::fromObject(new \stdClass());
+    }
+
+    public function testActionFromArrayMove(): void
+    {
+        $a = ConditionalRuleAction::fromArray(['move' => 'P1D']);
+        self::assertSame('P1D', $a->move);
+        self::assertNull($a->move_to);
+    }
+
+    public function testActionFromArrayMoveTo(): void
+    {
+        $a = ConditionalRuleAction::fromArray(['move_to' => 'next monday']);
+        self::assertSame('next monday', $a->move_to);
+        self::assertNull($a->move);
+    }
+
+    public function testActionRequiresAtLeastOneProperty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRuleAction::fromArray([]);
+    }
+
+    public function testActionRejectsBothProperties(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRuleAction::fromArray(['move' => 'P1D', 'move_to' => 'next monday']);
+    }
+
+    public function testActionRejectsNonStringMove(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRuleAction::fromArray(['move' => 5]);
+    }
+
+    public function testActionApplyForwardInterval(): void
+    {
+        $action = ConditionalRuleAction::fromArray(['move' => 'P3D']);
+        $date   = new DateTime('2025-01-01');
+        $moved  = $action->apply($date);
+        self::assertSame('2025-01-04', $moved->format('Y-m-d'));
+    }
+
+    public function testActionApplyBackwardInterval(): void
+    {
+        $action = ConditionalRuleAction::fromArray(['move' => '-P2D']);
+        $date   = new DateTime('2025-01-10');
+        $moved  = $action->apply($date);
+        self::assertSame('2025-01-08', $moved->format('Y-m-d'));
+    }
+
+    public function testActionApplyRejectsInvalidMoveInterval(): void
+    {
+        $action = ConditionalRuleAction::fromArray(['move' => 'oneday']);
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('Invalid `move` interval');
+        $action->apply(new DateTime('2025-01-01'));
+    }
+
+    public function testActionApplyMoveTo(): void
+    {
+        // 2025-01-01 is a Wednesday.
+        $action = ConditionalRuleAction::fromArray(['move_to' => 'next monday']);
+        $moved  = $action->apply(new DateTime('2025-01-01'));
+        self::assertSame('2025-01-06', $moved->format('Y-m-d'));
+    }
+
+    public function testConditionalRuleFromArrayWiresChildren(): void
+    {
+        $rule = ConditionalRule::fromArray([
+            'condition' => ['if_weekday' => 'Monday'],
+            'then'      => ['move' => 'P1D'],
+        ]);
+        self::assertSame('monday', $rule->condition->if_weekday);
+        self::assertSame('P1D', $rule->then->move);
+    }
+
+    public function testConditionalRuleFromArrayRequiresBothKeys(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRule::fromArray([
+            'condition' => ['if_weekday' => 'Monday'],
+        ]);
+    }
+
+    public function testConditionalRuleFromObjectWiresChildren(): void
+    {
+        $rule = ConditionalRule::fromObject((object) [
+            'condition' => (object) ['if_weekday' => 'Tuesday'],
+            'then'      => (object) ['move_to' => 'next wednesday'],
+        ]);
+        self::assertSame('tuesday', $rule->condition->if_weekday);
+        self::assertSame('next wednesday', $rule->then->move_to);
+    }
+
+    public function testConditionalRuleFromObjectRequiresBothProperties(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        ConditionalRule::fromObject((object) ['condition' => (object) ['if_weekday' => 'Monday']]);
+    }
+}

--- a/phpunit_tests/Models/LitCalItemTest.php
+++ b/phpunit_tests/Models/LitCalItemTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models;
+
+use LiturgicalCalendar\Api\Enum\CalEventAction;
+use LiturgicalCalendar\Api\Models\LitCalItem;
+use LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemCreateNewFixed;
+use LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemCreateNewMetadata;
+use LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemMoveEvent;
+use LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemMoveEventMetadata;
+use LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemSetPropertyName;
+use LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemSetPropertyNameMetadata;
+use LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemSetPropertyGrade;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Verifies the polymorphic dispatch in LitCalItem (it picks a concrete
+ * LiturgicalEventData / LiturgicalEventMetadata pair based on metadata.action
+ * and, for setProperty, metadata.property).
+ */
+#[CoversClass(LitCalItem::class)]
+final class LitCalItemTest extends TestCase
+{
+    public function testFromObjectMoveEvent(): void
+    {
+        $item = LitCalItem::fromObject((object) [
+            'liturgical_event' => (object) [
+                'event_key' => 'CorpusChristi',
+                'day'       => 7,
+                'month'     => 6,
+            ],
+            'metadata'         => (object) [
+                'action'     => CalEventAction::MoveEvent->value,
+                'since_year' => 2020,
+                'until_year' => null,
+                'missal'     => 'IT_2020',
+                'reason'     => 'CEI moved the feast',
+            ],
+        ]);
+        self::assertInstanceOf(LitCalItemMoveEvent::class, $item->liturgical_event);
+        self::assertInstanceOf(LitCalItemMoveEventMetadata::class, $item->metadata);
+        self::assertSame('CorpusChristi', $item->getEventKey());
+    }
+
+    public function testFromObjectCreateNewFixed(): void
+    {
+        $item = LitCalItem::fromObject((object) [
+            'liturgical_event' => (object) [
+                'event_key' => 'OurLadyOfFatima',
+                'day'       => 13,
+                'month'     => 5,
+                'color'     => ['white'],
+                'grade'     => 3,
+                'common'    => ['Blessed Virgin Mary'],
+            ],
+            'metadata'         => (object) [
+                'action'     => CalEventAction::CreateNew->value,
+                'since_year' => 2002,
+            ],
+        ]);
+        self::assertInstanceOf(LitCalItemCreateNewFixed::class, $item->liturgical_event);
+        self::assertInstanceOf(LitCalItemCreateNewMetadata::class, $item->metadata);
+    }
+
+    public function testFromObjectCreateNewRequiresDayMonthOrStrtotime(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('day');
+        LitCalItem::fromObject((object) [
+            'liturgical_event' => (object) [
+                'event_key' => 'OurLadyOfFatima',
+                'color'     => ['white'],
+                'grade'     => 3,
+                'common'    => ['Blessed Virgin Mary'],
+            ],
+            'metadata'         => (object) ['action' => CalEventAction::CreateNew->value, 'since_year' => 2002],
+        ]);
+    }
+
+    public function testFromObjectSetPropertyName(): void
+    {
+        $item = LitCalItem::fromObject((object) [
+            'liturgical_event' => (object) ['event_key' => 'StGeorge', 'name' => 'St George, Martyr'],
+            'metadata'         => (object) [
+                'action'     => CalEventAction::SetProperty->value,
+                'property'   => 'name',
+                'since_year' => 1970,
+            ],
+        ]);
+        self::assertInstanceOf(LitCalItemSetPropertyName::class, $item->liturgical_event);
+        self::assertInstanceOf(LitCalItemSetPropertyNameMetadata::class, $item->metadata);
+
+        // setName flows through the unlock/lock pattern.
+        $item->setName('Renamed');
+        self::assertSame('Renamed', $item->liturgical_event->name);
+    }
+
+    public function testFromObjectSetPropertyGrade(): void
+    {
+        $item = LitCalItem::fromObject((object) [
+            'liturgical_event' => (object) ['event_key' => 'StGeorge', 'grade' => 4],
+            'metadata'         => (object) [
+                'action'     => CalEventAction::SetProperty->value,
+                'property'   => 'grade',
+                'since_year' => 1970,
+            ],
+        ]);
+        self::assertInstanceOf(LitCalItemSetPropertyGrade::class, $item->liturgical_event);
+    }
+
+    public function testFromObjectSetPropertyRejectsUnknownProperty(): void
+    {
+        $this->expectException(\ValueError::class);
+        LitCalItem::fromObject((object) [
+            'liturgical_event' => (object) ['event_key' => 'StGeorge'],
+            'metadata'         => (object) [
+                'action'     => CalEventAction::SetProperty->value,
+                'property'   => 'color',
+                'since_year' => 1970,
+            ],
+        ]);
+    }
+
+    public function testFromObjectRejectsUnknownAction(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('metadata.action must be one of');
+        LitCalItem::fromObject((object) [
+            'liturgical_event' => (object) ['event_key' => 'X'],
+            'metadata'         => (object) ['action' => 'destroyEvent', 'since_year' => 2020],
+        ]);
+    }
+
+    public function testFromObjectRejectsMissingTopLevelKeys(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('liturgical_event');
+        LitCalItem::fromObject((object) ['metadata' => (object) ['action' => 'moveEvent']]);
+    }
+
+    public function testFromObjectRejectsMetadataWithoutAction(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('action');
+        LitCalItem::fromObject((object) [
+            'liturgical_event' => (object) ['event_key' => 'X'],
+            'metadata'         => (object) ['since_year' => 2020],
+        ]);
+    }
+
+    public function testCreateNewWithoutEventKeyThrows(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('event_key');
+        LitCalItem::fromObject((object) [
+            'liturgical_event' => (object) [
+                'day'    => 1,
+                'month'  => 1,
+                'color'  => ['white'],
+                'grade'  => 3,
+                'common' => [],
+            ],
+            'metadata'         => (object) ['action' => 'createNew', 'since_year' => 2020],
+        ]);
+    }
+
+    public function testFromArrayMoveEvent(): void
+    {
+        $item = LitCalItem::fromArray([
+            'liturgical_event' => ['event_key' => 'CorpusChristi', 'day' => 7, 'month' => 6],
+            'metadata'         => [
+                'action'     => 'moveEvent',
+                'since_year' => 2020,
+                'until_year' => null,
+                'missal'     => 'IT_2020',
+                'reason'     => 'CEI',
+            ],
+        ]);
+        self::assertInstanceOf(LitCalItemMoveEvent::class, $item->liturgical_event);
+    }
+
+    public function testFromArrayRejectsMissingMetadataAction(): void
+    {
+        $this->expectException(\ValueError::class);
+        LitCalItem::fromArray([
+            'liturgical_event' => ['event_key' => 'X'],
+            'metadata'         => ['since_year' => 2020],
+        ]);
+    }
+
+    public function testFromArrayRejectsMissingTopLevelKeys(): void
+    {
+        $this->expectException(\ValueError::class);
+        LitCalItem::fromArray(['metadata' => ['action' => 'moveEvent']]);
+    }
+}

--- a/phpunit_tests/Models/Metadata/MetadataCalendarsTest.php
+++ b/phpunit_tests/Models/Metadata/MetadataCalendarsTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Metadata;
+
+use LiturgicalCalendar\Api\Enum\Ascension;
+use LiturgicalCalendar\Api\Enum\CorpusChristi;
+use LiturgicalCalendar\Api\Enum\Epiphany;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanGroupItem;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataNationalCalendarItem;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataNationalCalendarSettings;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataWiderRegionItem;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MetadataCalendars::class)]
+#[CoversClass(MetadataDiocesanCalendarItem::class)]
+#[CoversClass(MetadataDiocesanGroupItem::class)]
+#[CoversClass(MetadataNationalCalendarItem::class)]
+#[CoversClass(MetadataNationalCalendarSettings::class)]
+#[CoversClass(MetadataWiderRegionItem::class)]
+final class MetadataCalendarsTest extends TestCase
+{
+    public function testNationalCalendarSettingsFromArray(): void
+    {
+        $settings = MetadataNationalCalendarSettings::fromArray([
+            'epiphany'               => Epiphany::JAN6->value,
+            'ascension'              => Ascension::THURSDAY->value,
+            'corpus_christi'         => CorpusChristi::SUNDAY->value,
+            'eternal_high_priest'    => false,
+            'holydays_of_obligation' => ['Christmas' => true, 'Custom' => false],
+        ]);
+
+        self::assertSame(Epiphany::JAN6, $settings->epiphany);
+        self::assertSame(Ascension::THURSDAY, $settings->ascension);
+        self::assertSame(CorpusChristi::SUNDAY, $settings->corpus_christi);
+        self::assertFalse($settings->eternal_high_priest);
+        self::assertSame(false, $settings->holydays_of_obligation['Custom']);
+    }
+
+    public function testNationalCalendarSettingsRejectsInvalidHolydaysType(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('holydays_of_obligation');
+        MetadataNationalCalendarSettings::fromArray([
+            'epiphany'               => Epiphany::JAN6->value,
+            'ascension'              => Ascension::THURSDAY->value,
+            'corpus_christi'         => CorpusChristi::SUNDAY->value,
+            'eternal_high_priest'    => false,
+            'holydays_of_obligation' => 'not-an-array',
+        ]);
+    }
+
+    public function testNationalCalendarSettingsRejectsNonBooleanHolyday(): void
+    {
+        $this->expectException(\ValueError::class);
+        MetadataNationalCalendarSettings::fromArray([
+            'epiphany'               => Epiphany::JAN6->value,
+            'ascension'              => Ascension::THURSDAY->value,
+            'corpus_christi'         => CorpusChristi::SUNDAY->value,
+            'eternal_high_priest'    => false,
+            'holydays_of_obligation' => ['Christmas' => 'yes'],
+        ]);
+    }
+
+    public function testNationalCalendarSettingsFromObjectAndSerialize(): void
+    {
+        $settings = MetadataNationalCalendarSettings::fromObject((object) [
+            'epiphany'               => Epiphany::SUNDAY_JAN2_JAN8->value,
+            'ascension'              => Ascension::SUNDAY->value,
+            'corpus_christi'         => CorpusChristi::SUNDAY->value,
+            'eternal_high_priest'    => true,
+            'holydays_of_obligation' => (object) ['Christmas' => true],
+        ]);
+        $arr      = $settings->jsonSerialize();
+        self::assertSame(Epiphany::SUNDAY_JAN2_JAN8->value, $arr['epiphany']);
+        self::assertTrue($arr['eternal_high_priest']);
+    }
+
+    public function testDiocesanGroupItemRoundTrip(): void
+    {
+        $group = MetadataDiocesanGroupItem::fromArray(['group_name' => 'CEI', 'dioceses' => ['rome', 'milan']]);
+        self::assertSame('CEI', $group->group_name);
+        self::assertSame(['rome', 'milan'], $group->dioceses);
+        self::assertSame(
+            ['group_name' => 'CEI', 'dioceses' => ['rome', 'milan']],
+            $group->jsonSerialize()
+        );
+
+        $fromObj = MetadataDiocesanGroupItem::fromObject((object) ['group_name' => 'CCCB', 'dioceses' => ['toronto']]);
+        self::assertSame('CCCB', $fromObj->group_name);
+    }
+
+    public function testWiderRegionItemRoundTrip(): void
+    {
+        $wr = MetadataWiderRegionItem::fromArray([
+            'name'     => 'Europa',
+            'locales'  => ['it', 'la'],
+            'api_path' => 'https://api.example/wider/Europa',
+        ]);
+        self::assertSame('Europa', $wr->name);
+        self::assertSame(['it', 'la'], $wr->locales);
+        self::assertSame('https://api.example/wider/Europa', $wr->api_path);
+        self::assertSame(
+            ['name' => 'Europa', 'locales' => ['it', 'la'], 'api_path' => 'https://api.example/wider/Europa'],
+            $wr->jsonSerialize()
+        );
+
+        $wrObj = MetadataWiderRegionItem::fromObject((object) [
+            'name'     => 'LatinAmerica',
+            'locales'  => ['es'],
+            'api_path' => 'https://api.example/wider/LatinAmerica',
+        ]);
+        self::assertSame('LatinAmerica', $wrObj->name);
+    }
+
+    public function testDiocesanCalendarItemRoundTrip(): void
+    {
+        $dc = MetadataDiocesanCalendarItem::fromArray([
+            'calendar_id' => 'romadi_it',
+            'diocese'     => 'Roma',
+            'nation'      => 'IT',
+            'locales'     => ['it'],
+            'timezone'    => 'Europe/Vatican',
+            'group'       => 'CEI',
+        ]);
+        self::assertSame('romadi_it', $dc->calendar_id);
+        self::assertSame('Roma', $dc->diocese);
+        self::assertSame('CEI', $dc->group);
+        self::assertNull($dc->settings);
+
+        $serialized = $dc->jsonSerialize();
+        self::assertSame('CEI', $serialized['group']);
+        self::assertArrayNotHasKey('settings', $serialized);
+    }
+
+    public function testDiocesanCalendarItemRejectsDiocesalDataShape(): void
+    {
+        // diocese_id is a sentinel used by DiocesanMetadata, not by MetadataDiocesanCalendarItem.
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('DiocesanMetadata');
+        MetadataDiocesanCalendarItem::fromArray([
+            'diocese_id'  => 'rome',
+            'calendar_id' => 'romadi_it',
+            'diocese'     => 'Roma',
+            'nation'      => 'IT',
+            'locales'     => ['it'],
+            'timezone'    => 'Europe/Vatican',
+        ]);
+    }
+
+    public function testDiocesanCalendarItemFromObjectRejectsDiocesalDataShape(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        MetadataDiocesanCalendarItem::fromObject((object) [
+            'diocese_id'  => 'rome',
+            'calendar_id' => 'romadi_it',
+            'diocese'     => 'Roma',
+            'nation'      => 'IT',
+            'locales'     => ['it'],
+            'timezone'    => 'Europe/Vatican',
+        ]);
+    }
+
+    public function testMetadataCalendarsBuiltFromEmpty(): void
+    {
+        $mc = new MetadataCalendars();
+        self::assertSame([], $mc->national_calendars);
+        self::assertSame([], $mc->locales);
+        $arr = $mc->jsonSerialize();
+        self::assertSame([], $arr['national_calendars']);
+        self::assertSame([], $arr['locales']);
+    }
+
+    public function testMetadataCalendarsPushAndSerialize(): void
+    {
+        $mc     = new MetadataCalendars();
+        $nation = new MetadataNationalCalendarItem(
+            'IT',
+            ['it'],
+            ['IT_2020'],
+            MetadataNationalCalendarSettings::fromArray([
+                'epiphany'            => Epiphany::JAN6->value,
+                'ascension'           => Ascension::SUNDAY->value,
+                'corpus_christi'      => CorpusChristi::SUNDAY->value,
+                'eternal_high_priest' => true,
+            ]),
+            null,
+            []
+        );
+        $mc->pushNationalCalendarMetadata($nation);
+        self::assertSame(['IT'], $mc->national_calendars_keys);
+
+        $diocese = new MetadataDiocesanCalendarItem(
+            calendar_id: 'romadi_it',
+            diocese: 'Roma',
+            nation: 'IT',
+            locales: ['it'],
+            timezone: 'Europe/Vatican',
+            group: 'CEI'
+        );
+        $mc->pushDiocesanCalendarMetadata($diocese);
+        self::assertSame(['romadi_it'], $mc->diocesan_calendars_keys);
+        self::assertCount(1, $mc->diocesan_groups);
+        self::assertSame('CEI', $mc->diocesan_groups[0]->group_name);
+        // The IT national calendar should have romadi_it pushed into its dioceses list.
+        self::assertContains('romadi_it', $mc->national_calendars[0]->dioceses);
+
+        // Push a second diocese into the same group — should append to existing group.
+        $milano = new MetadataDiocesanCalendarItem(
+            calendar_id: 'milanodi_it',
+            diocese: 'Milano',
+            nation: 'IT',
+            locales: ['it'],
+            timezone: 'Europe/Vatican',
+            group: 'CEI'
+        );
+        $mc->pushDiocesanCalendarMetadata($milano);
+        self::assertCount(1, $mc->diocesan_groups);
+        self::assertContains('milanodi_it', $mc->diocesan_groups[0]->dioceses);
+
+        // Wider region push.
+        $wr = MetadataWiderRegionItem::fromArray(['name' => 'EU', 'locales' => ['it'], 'api_path' => 'p']);
+        $mc->pushWiderRegionMetadata($wr);
+        self::assertSame(['EU'], $mc->wider_regions_keys);
+    }
+}

--- a/phpunit_tests/Models/MissalsMapTest.php
+++ b/phpunit_tests/Models/MissalsMapTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models;
+
+use LiturgicalCalendar\Api\Models\MissalsMap;
+use LiturgicalCalendar\Api\Models\PropriumDeSanctisMap;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MissalsMap::class)]
+final class MissalsMapTest extends TestCase
+{
+    public function testInitWithMissalsAndArrayAccess(): void
+    {
+        $m1  = PropriumDeSanctisMap::fromObject([]);
+        $m2  = PropriumDeSanctisMap::fromObject([]);
+        $map = MissalsMap::initWithMissals(['a' => $m1, 'b' => $m2]);
+        self::assertTrue($map->offsetExists('a'));
+        self::assertSame($m1, $map->offsetGet('a'));
+        self::assertSame($m2, $map['b']);
+    }
+
+    public function testIteratorYieldsAllEntries(): void
+    {
+        $m1     = PropriumDeSanctisMap::fromObject([]);
+        $map    = MissalsMap::initWithMissals(['x' => $m1]);
+        $values = iterator_to_array($map);
+        self::assertSame(['x' => $m1], $values);
+    }
+
+    public function testOffsetSetAndUnset(): void
+    {
+        $m1  = PropriumDeSanctisMap::fromObject([]);
+        $m2  = PropriumDeSanctisMap::fromObject([]);
+        $map = MissalsMap::initWithMissals(['a' => $m1]);
+        $map->offsetSet('b', $m2);
+        self::assertTrue($map->offsetExists('b'));
+        $map->offsetUnset('a');
+        self::assertFalse($map->offsetExists('a'));
+    }
+}

--- a/phpunit_tests/Models/MissalsPath/MissalMetadataTest.php
+++ b/phpunit_tests/Models/MissalsPath/MissalMetadataTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\MissalsPath;
+
+use LiturgicalCalendar\Api\Models\MissalsPath\MissalMetadata;
+use LiturgicalCalendar\Api\Models\MissalsPath\MissalYearLimits;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MissalMetadata::class)]
+#[CoversClass(MissalYearLimits::class)]
+final class MissalMetadataTest extends TestCase
+{
+    public function testYearLimitsFromArrayWithUntilYear(): void
+    {
+        $limits = MissalYearLimits::fromArray(['since_year' => 1970, 'until_year' => 2002]);
+        self::assertSame(1970, $limits->since_year);
+        self::assertSame(2002, $limits->until_year);
+    }
+
+    public function testYearLimitsFromArrayOmitsUntilYearWhenNullInJson(): void
+    {
+        $limits = MissalYearLimits::fromArray(['since_year' => 1970]);
+        self::assertNull($limits->until_year);
+        // Serialization omits until_year when null.
+        self::assertSame(['since_year' => 1970], $limits->jsonSerialize());
+    }
+
+    public function testYearLimitsFromObject(): void
+    {
+        $limits = MissalYearLimits::fromObject((object) ['since_year' => 1983, 'until_year' => 2002]);
+        self::assertSame(1983, $limits->since_year);
+        self::assertSame(2002, $limits->until_year);
+        self::assertSame(['since_year' => 1983, 'until_year' => 2002], $limits->jsonSerialize());
+    }
+
+    public function testMissalMetadataFromArrayHappyPath(): void
+    {
+        $missal = MissalMetadata::fromArray([
+            'missal_id'      => 'EDITIO_TYPICA_1970',
+            'name'           => 'Editio Typica 1970',
+            'region'         => 'VA',
+            'locales'        => ['la'],
+            'api_path'       => 'https://example.test/missals/EDITIO_TYPICA_1970',
+            'year_published' => 1970,
+            'year_limits'    => ['since_year' => 1970],
+        ]);
+
+        self::assertSame('EDITIO_TYPICA_1970', $missal->missal_id);
+        self::assertSame('Editio Typica 1970', $missal->name);
+        self::assertSame('VA', $missal->region);
+        self::assertSame(['la'], $missal->locales);
+        self::assertSame(1970, $missal->year_published);
+        self::assertSame(1970, $missal->year_limits->since_year);
+
+        $serialized = $missal->jsonSerialize();
+        self::assertSame('EDITIO_TYPICA_1970', $serialized['missal_id']);
+        self::assertSame(['since_year' => 1970], $serialized['year_limits']);
+    }
+
+    public function testMissalMetadataFromObjectHappyPath(): void
+    {
+        $missal = MissalMetadata::fromObject((object) [
+            'missal_id'      => 'IT_1983',
+            'name'           => 'CEI 1983',
+            'region'         => 'IT',
+            'locales'        => ['it'],
+            'api_path'       => null,
+            'year_published' => 1983,
+            'year_limits'    => (object) ['since_year' => 1983, 'until_year' => 2002],
+        ]);
+        self::assertSame('IT_1983', $missal->missal_id);
+        self::assertNull($missal->api_path);
+        self::assertSame(2002, $missal->year_limits->until_year);
+    }
+
+    public function testMissalMetadataLockingPreventsMutation(): void
+    {
+        $missal = MissalMetadata::fromArray([
+            'missal_id'      => 'EDITIO_TYPICA_1970',
+            'name'           => 'Editio Typica 1970',
+            'region'         => 'VA',
+            'locales'        => [],
+            'api_path'       => null,
+            'year_published' => 1970,
+            'year_limits'    => ['since_year' => 1970],
+        ]);
+
+        $this->expectException(\LogicException::class);
+        $missal->extra = 'nope';
+    }
+}

--- a/phpunit_tests/Models/RelativeLiturgicalDateTest.php
+++ b/phpunit_tests/Models/RelativeLiturgicalDateTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models;
+
+use LiturgicalCalendar\Api\Enum\DateRelation;
+use LiturgicalCalendar\Api\Models\RelativeLiturgicalDate;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RelativeLiturgicalDate::class)]
+final class RelativeLiturgicalDateTest extends TestCase
+{
+    public function testFromArrayHappyPath(): void
+    {
+        $rel = RelativeLiturgicalDate::fromArray([
+            'day_of_the_week' => 'Monday',
+            'relative_time'   => 'after',
+            'event_key'       => 'Pentecost',
+        ]);
+        self::assertSame('Monday', $rel->day_of_the_week);
+        self::assertSame(DateRelation::After, $rel->relative_time);
+        self::assertSame('Pentecost', $rel->event_key);
+        self::assertSame('Monday after Pentecost', (string) $rel);
+    }
+
+    public function testFromArrayRejectsMissingKeys(): void
+    {
+        $this->expectException(\ValueError::class);
+        $this->expectExceptionMessage('event_key');
+        RelativeLiturgicalDate::fromArray([
+            'day_of_the_week' => 'Monday',
+            'relative_time'   => 'after',
+        ]);
+    }
+
+    public function testFromArrayRejectsInvalidRelativeTime(): void
+    {
+        $this->expectException(\ValueError::class);
+        RelativeLiturgicalDate::fromArray([
+            'day_of_the_week' => 'Monday',
+            'relative_time'   => 'around',
+            'event_key'       => 'Pentecost',
+        ]);
+    }
+
+    public function testFromObjectHappyPath(): void
+    {
+        $rel = RelativeLiturgicalDate::fromObject((object) [
+            'day_of_the_week' => 'Sunday',
+            'relative_time'   => 'before',
+            'event_key'       => 'CorpusChristi',
+        ]);
+        self::assertSame(DateRelation::Before, $rel->relative_time);
+        self::assertSame('Sunday before CorpusChristi', (string) $rel);
+    }
+
+    public function testFromObjectRejectsMissingProps(): void
+    {
+        $this->expectException(\ValueError::class);
+        RelativeLiturgicalDate::fromObject((object) ['day_of_the_week' => 'Monday']);
+    }
+}

--- a/phpunit_tests/RouterTest.php
+++ b/phpunit_tests/RouterTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Router::route() is end-to-end (constructs handlers, emits, calls die())
+ * so it isn't directly testable in-process. These tests target the
+ * stateless / static helpers exposed on Router that the broader codebase
+ * (and Route, JsonData enum, handler tests) lean on.
+ */
+#[CoversClass(Router::class)]
+final class RouterTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private array $savedServer = [];
+
+    /** @var array<string,mixed> */
+    private array $savedEnv = [];
+
+    private const UNSET = "\0__unset__\0";
+
+    private const SERVER_KEYS = [
+        'REQUEST_SCHEME',
+        'HTTPS',
+        'SERVER_PORT',
+        'SERVER_ADDR',
+        'REMOTE_ADDR',
+        'SERVER_NAME',
+    ];
+
+    protected function setUp(): void
+    {
+        foreach (self::SERVER_KEYS as $k) {
+            $this->savedServer[$k] = array_key_exists($k, $_SERVER) ? $_SERVER[$k] : self::UNSET;
+            unset($_SERVER[$k]);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->savedServer as $k => $v) {
+            if ($v === self::UNSET) {
+                unset($_SERVER[$k]);
+            } else {
+                $_SERVER[$k] = $v;
+            }
+        }
+    }
+
+    public function testDetectRequestSchemeDefaultsToHttp(): void
+    {
+        self::assertSame('http', Router::detectRequestScheme());
+    }
+
+    public function testDetectRequestSchemeViaRequestScheme(): void
+    {
+        $_SERVER['REQUEST_SCHEME'] = 'https';
+        self::assertSame('https', Router::detectRequestScheme());
+    }
+
+    public function testDetectRequestSchemeViaHttpsOn(): void
+    {
+        $_SERVER['HTTPS'] = 'on';
+        self::assertSame('https', Router::detectRequestScheme());
+    }
+
+    public function testDetectRequestSchemeViaPort443(): void
+    {
+        $_SERVER['SERVER_PORT'] = '443';
+        self::assertSame('https', Router::detectRequestScheme());
+    }
+
+    public function testIsLocalhostFromServerAddr(): void
+    {
+        $_SERVER['SERVER_ADDR'] = '127.0.0.1';
+        self::assertTrue(Router::isLocalhost());
+    }
+
+    public function testIsLocalhostFromRemoteAddr(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '::1';
+        self::assertTrue(Router::isLocalhost());
+    }
+
+    public function testIsLocalhostFromServerName(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        self::assertTrue(Router::isLocalhost());
+    }
+
+    public function testIsLocalhostFalseForExternalServer(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'api.example.com';
+        $_SERVER['SERVER_ADDR'] = '203.0.113.42';
+        $_SERVER['REMOTE_ADDR'] = '198.51.100.7';
+        self::assertFalse(Router::isLocalhost());
+    }
+
+    public function testGetApiPathsCliMode(): void
+    {
+        // In CLI mode (PHP_SAPI === 'cli', which is true under PHPUnit),
+        // getApiPaths reads API_PROTOCOL/HOST/PORT/BASE_PATH from $_ENV.
+        // The bootstrap already populated everything, so just call and
+        // verify the static state is well-formed.
+        Router::getApiPaths();
+        self::assertIsString(Router::$apiPath);
+        self::assertIsString(Router::$apiBase);
+        self::assertIsString(Router::$apiFilePath);
+        // $apiPath should not end with a slash (rtrim'd).
+        self::assertStringEndsNotWith('/', Router::$apiPath);
+        // $apiFilePath should be the project root (where composer.json lives) with trailing separator.
+        self::assertFileExists(Router::$apiFilePath . 'composer.json');
+    }
+}

--- a/phpunit_tests/RouterTest.php
+++ b/phpunit_tests/RouterTest.php
@@ -20,9 +20,6 @@ final class RouterTest extends TestCase
     /** @var array<string,mixed> */
     private array $savedServer = [];
 
-    /** @var array<string,mixed> */
-    private array $savedEnv = [];
-
     private const UNSET = "\0__unset__\0";
 
     private const SERVER_KEYS = [


### PR DESCRIPTION
## Summary

Final milestone of [#570](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/570). Adds **~325 new offline, in-process tests** across `src/Enum/`, `src/Http/`, `src/Models/`, and `Router`. No `src/` changes.

**Coverage added:**

- **Enums** (`src/Enum/*`)
  - `EnumToArrayTrait` (via concrete subclasses) — `names()`, `values()`, `asArray()`, `isValid()`, `areValid()`
  - `LitColor` / `LitLocale` / `LitGrade` / `LitSeason` / `LitCommon` / `LitSchema` / `JsonData` + `JsonDataConstants` / `RomanMissal` / `LectionaryCategory` / `ReadingsType` / `Route`
  - Smaller value enums (`Ascension`, `CorpusChristi`, `Epiphany`, `CacheDuration`, `CalEventAction`, `DateRelation`, `LitEventType`, `LitEventTestType`, `LitEventTestAssertion`, `PathCategory`, `YearType`, `ParamError`, `ICSErrorLevel`)
- **Http enums** (`src/Http/Enum/*`) — `StatusCode`, `AcceptHeader` (round-trip with `ReturnTypeParam`), `RequestMethod`, `RequestContentType`, `Charset` (label normalization + `UnsupportedCharsetException` path), `AcceptabilityLevel`, `ContentEncoding`
- **Http exceptions** (`src/Http/Exception/*`) — `ApiException` base contract + every concrete subclass via `DataProvider`; `TooManyRequestsException` retry-after; `YamlException` custom status; RFC type-URL conventions
- **Http middleware** — `AuthorizationMiddleware` (role check, admin bypass, factory helpers); `HttpsEnforcementMiddleware` (production gating + every secure-detection branch)
- **Http logs** — `LoggerFactory` (memoisation, validation, custom path, hermetic state restore), `PrettyLineFormatter` (color coding by level / response status, pre-coloured passthrough, extra-fields pretty-print), `RequestResponseProcessor` (header redaction, request/response shape, error cases)
- **Http server** — `MiddlewarePipeline` composition + short-circuit
- **`Http\CookieHelper`** — HTTPS detection, domain resolution, cookie header assembly (including `SameSite=None` downgrade when insecure), access/refresh helpers
- **`Environment`** helper
- **Models** — `AbstractJsonRepresentation` / `AbstractJsonSrcData` / `AbstractJsonSrcDataArray` lock-and-validate contract; `ConditionalRule` + `Condition` + `Action` (including `apply()` and `matches()` invariants); `LitCalItem` polymorphic dispatch by `metadata.action` / `metadata.property`; `LitCommons` factory branches; `MissalMetadata` / `MissalYearLimits` / `MissalsMap`; `Auth/User` (`authenticate`, `fromJwtPayload`, all rejection paths); `Metadata/*` (national/diocesan/group/widerregion + settings)
- **Router** — stateless helpers: `detectRequestScheme`, `isLocalhost`, `getApiPaths` (CLI mode)

## Numbers

| Layer        | New tests |
|--------------|-----------|
| Enum         | 116       |
| Http         |  85       |
| Models       |  96       |
| Router       |   9       |
| Environment  |   6       |
| **Total**    | **~325 new** (913 / 2917 assertions overall) |

- Lint clean (`composer lint`)
- PHPStan level 10 clean (`composer analyse`)
- Pre-existing 8 errors in `phpunit_tests/Routes/Readonly/*` are integration tests requiring a live server — not in M6 scope

## Test plan

- [x] `composer test:quick` (the 8 errors are pre-existing Routes integration tests requiring a live server, not new)
- [x] `composer lint`
- [x] `composer analyse`

https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp


---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded comprehensive test coverage across enums, HTTP middleware, models, authentication, and routing components to ensure system reliability and correctness.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/583)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->