### PR TITLE
fix(params): make EventsParams national_calendar=VA override order-independent (#576)

### DIFF
--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -128,6 +128,22 @@ final class EventsParamsTest extends TestCase
         ]);
     }
 
+    public function testRepeatedSetParamsVaClearsPreviousNationalCalendar(): void
+    {
+        // setParams() is public; switching from a real nation to VA on the same
+        // instance must clear NationalCalendar so the post-loop VA invariants
+        // fully describe the request shape (no stale nation override left over).
+        $params = new EventsParams(['national_calendar' => 'IT']);
+        self::assertSame('IT', $params->NationalCalendar);
+
+        $params->setParams(['national_calendar' => 'VA']);
+
+        self::assertNull($params->NationalCalendar);
+        self::assertSame(LitLocale::LATIN, $params->Locale);
+        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $params->baseLocale);
+        self::assertFalse($params->EternalHighPriest);
+    }
+
     public function testUnknownNationalCalendarIsRejected(): void
     {
         $this->expectException(ValidationException::class);

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -82,6 +82,52 @@ final class EventsParamsTest extends TestCase
         self::assertNull($params->NationalCalendar);
     }
 
+    /**
+     * Regression for #576: when national_calendar=VA appears anywhere in the
+     * input, its locale=la_VA / eternal_high_priest=false invariants must win
+     * regardless of where it sits relative to sibling keys.
+     */
+    public function testNationalCalendarVaOverridesEvenWhenItComesFirst(): void
+    {
+        $params = new EventsParams([
+            'national_calendar'   => 'VA',
+            'eternal_high_priest' => true,
+            'locale'              => 'en_US',
+        ]);
+
+        self::assertSame(LitLocale::LATIN, $params->Locale);
+        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $params->baseLocale);
+        self::assertFalse($params->EternalHighPriest);
+        self::assertNull($params->NationalCalendar);
+    }
+
+    public function testNationalCalendarVaOverridesWhenItComesLast(): void
+    {
+        $params = new EventsParams([
+            'eternal_high_priest' => true,
+            'locale'              => 'en_US',
+            'national_calendar'   => 'VA',
+        ]);
+
+        self::assertSame(LitLocale::LATIN, $params->Locale);
+        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $params->baseLocale);
+        self::assertFalse($params->EternalHighPriest);
+        self::assertNull($params->NationalCalendar);
+    }
+
+    public function testInvalidSiblingValuesStillRejectedEvenWhenVaIsSet(): void
+    {
+        // VA only overrides the *successfully* parsed sibling values; it does
+        // not silence input validation for malformed siblings.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('eternal_high_priest');
+
+        new EventsParams([
+            'national_calendar'   => 'VA',
+            'eternal_high_priest' => 'maybe', // @phpstan-ignore-line
+        ]);
+    }
+
     public function testUnknownNationalCalendarIsRejected(): void
     {
         $this->expectException(ValidationException::class);

--- a/src/Params/EventsParams.php
+++ b/src/Params/EventsParams.php
@@ -161,6 +161,9 @@ class EventsParams implements ParamsInterface
             $this->Locale            = LitLocale::LATIN;
             $this->baseLocale        = LitLocale::LATIN_PRIMARY_LANGUAGE;
             $this->EternalHighPriest = false;
+            // Clear any prior non-VA national override so a second setParams()
+            // call that switches to VA fully resets the request shape.
+            $this->NationalCalendar = null;
         }
     }
 

--- a/src/Params/EventsParams.php
+++ b/src/Params/EventsParams.php
@@ -100,6 +100,14 @@ class EventsParams implements ParamsInterface
             // If no parameters are provided, we can just return
             return;
         }
+
+        // national_calendar=VA selects the General Roman Calendar and forces
+        // locale=la_VA + eternal_high_priest=false. Defer those writes until
+        // after the loop so they're not overwritten by sibling iterations
+        // regardless of the order the caller passed the keys in
+        // (foreach iterates a snapshot, so mutating $params mid-loop is a no-op).
+        $forceVaInvariants = false;
+
         foreach ($params as $key => $value) {
             if (in_array($key, self::ALLOWED_PARAMS)) {
                 switch ($key) {
@@ -124,11 +132,7 @@ class EventsParams implements ParamsInterface
                             throw new ValidationException($description);
                         }
                         if ($value === 'VA') {
-                            $this->Locale                  = LitLocale::LATIN;
-                            $this->baseLocale              = LitLocale::LATIN_PRIMARY_LANGUAGE;
-                            $this->EternalHighPriest       = false;
-                            $params['eternal_high_priest'] = false;
-                            $params['locale']              = LitLocale::LATIN;
+                            $forceVaInvariants = true;
                         } else {
                             $this->NationalCalendar = strtoupper($value);
                         }
@@ -151,6 +155,12 @@ class EventsParams implements ParamsInterface
                         break;
                 }
             }
+        }
+
+        if ($forceVaInvariants) {
+            $this->Locale            = LitLocale::LATIN;
+            $this->baseLocale        = LitLocale::LATIN_PRIMARY_LANGUAGE;
+            $this->EternalHighPriest = false;
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes #576.

`EventsParams::setParams()` was supposed to force `locale=la_VA` and `eternal_high_priest=false` whenever the caller passes `national_calendar=VA`. It tried to do that by writing back into the `$params` array mid-`foreach`, but PHP `foreach` iterates a snapshot, so those writes never reached subsequent iterations. Whichever sibling key the caller passed *after* `national_calendar` would clobber the VA-mandated value.

### Fix

Track a `$forceVaInvariants` flag during the loop and apply the VA overrides once the loop has finished:

```diff
+    $forceVaInvariants = false;
     foreach ($params as $key => $value) {
         // ...
                 case 'national_calendar':
                     // ...
                     if ($value === 'VA') {
-                        $this->Locale                  = LitLocale::LATIN;
-                        $this->baseLocale              = LitLocale::LATIN_PRIMARY_LANGUAGE;
-                        $this->EternalHighPriest       = false;
-                        $params['eternal_high_priest'] = false; // no-op
-                        $params['locale']              = LitLocale::LATIN; // no-op
+                        $forceVaInvariants = true;
                     } else {
                         $this->NationalCalendar = strtoupper($value);
                     }
         // ...
     }
+    if ($forceVaInvariants) {
+        $this->Locale            = LitLocale::LATIN;
+        $this->baseLocale        = LitLocale::LATIN_PRIMARY_LANGUAGE;
+        $this->EternalHighPriest = false;
+    }
```

Sibling input validation still runs inside the loop, so malformed `locale` / `eternal_high_priest` values are still rejected even when VA is set — VA only overrides the *successfully parsed* sibling values, not the validation itself.

### Tests

Three new regression tests in `EventsParamsTest`:

- `testNationalCalendarVaOverridesEvenWhenItComesFirst` — VA first, then `eternal_high_priest=true, locale=en_US` ⇒ Latin / EHP=false
- `testNationalCalendarVaOverridesWhenItComesLast` — same payload in reverse order ⇒ same result (was already passing)
- `testInvalidSiblingValuesStillRejectedEvenWhenVaIsSet` — `eternal_high_priest='maybe'` alongside VA still raises `ValidationException`

The existing `testNationalCalendarVaForcesLatinAndSkipsAssignment` continues to cover the VA-only payload.

## Test plan

- [x] `composer test:quick` — 926 tests / 2939 assertions (the 8 errors are pre-existing integration tests in `Routes/Readonly/*` requiring a live server; not related to this change)
- [x] `composer lint` clean
- [x] `composer analyse` (PHPStan level 10) clean

https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp


---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of national calendar parameter handling to ensure uniform behavior regardless of input order.

* **Tests**
  * Added regression tests for national calendar configuration and validation scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/584)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->