### PR TITLE
fix(params): reject unsupported locale in EventsParams instead of silent Latin fallback (#578)

### DIFF
--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -52,14 +52,29 @@ final class EventsParamsTest extends TestCase
         self::assertSame('en', $params->baseLocale);
     }
 
-    public function testUnsupportedLocaleFallsBackToLatin(): void
+    public function testUnsupportedLocaleIsRejected(): void
     {
-        // Per current behavior, when a locale is canonicalisable but unsupported,
-        // it silently falls back to Latin rather than rejecting outright.
-        $params = new EventsParams(['locale' => 'not-a-locale']);
+        // Regression for #578: EventsParams now matches the rest of the
+        // src/Params/ family — an unsupported (but canonicalisable) locale
+        // raises ValidationException rather than silently falling back to
+        // Latin.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Invalid value');
+        $this->expectExceptionMessage('param `locale`');
 
-        self::assertSame(LitLocale::LATIN, $params->Locale);
-        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $params->baseLocale);
+        new EventsParams(['locale' => 'not-a-locale']);
+    }
+
+    public function testEmptyLocaleStringIsRejected(): void
+    {
+        // Locale::canonicalize('') returns 'en_US_POSIX' on this build, which
+        // is unsupported — so empty strings end up in the new unsupported-locale
+        // arm rather than the upstream null-canonicalize guard. Either way, the
+        // user gets a ValidationException with the locale-rejection message.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('param `locale`');
+
+        new EventsParams(['locale' => '']);
     }
 
     public function testNationalCalendarFromMetadataIsAccepted(): void

--- a/src/Params/EventsParams.php
+++ b/src/Params/EventsParams.php
@@ -117,7 +117,12 @@ class EventsParams implements ParamsInterface
                             throw new ValidationException('Invalid locale string: ' . $value);
                         }
 
-                        $this->Locale = LitLocale::isValid($locale) ? $locale : LitLocale::LATIN;
+                        if (false === LitLocale::isValid($locale)) {
+                            $description = "Invalid value `$locale` for param `locale`, valid values are: la, la_VA, "
+                                . implode(', ', LitLocale::$AllAvailableLocales);
+                            throw new ValidationException($description);
+                        }
+                        $this->Locale = $locale;
                         $baseLocale   = \Locale::getPrimaryLanguage($this->Locale);
                         if (null === $baseLocale) {
                             $description = '“The evil spirit had bound his tongue, and together with his tongue had fettered his soul.” — St. John Chrysostom, Homily 32 on Matthew';


### PR DESCRIPTION
## Summary

Fixes #578.

`EventsParams::setParams()` silently fell back to `LitLocale::LATIN` when given a canonicalisable but unsupported locale, while every other params class in `src/Params/` (`DecreesParams`, `EasterParams`, `CalendarParams`, `MissalsParams`, `RegionalDataParams`) raises `ValidationException` for the same input. A client asking for an events list in (say) Vietnamese got Latin back with no signal that the requested locale wasn't available.

### Fix

```diff
-    $this->Locale = LitLocale::isValid($locale) ? $locale : LitLocale::LATIN;
+    if (false === LitLocale::isValid($locale)) {
+        $description = "Invalid value `$locale` for param `locale`, valid values are: la, la_VA, "
+            . implode(', ', LitLocale::$AllAvailableLocales);
+        throw new ValidationException($description);
+    }
+    $this->Locale = $locale;
```

Mirrors `DecreesParams::setParams` exactly — same message format, same enum-list disclosure.

### Tests

- **`testUnsupportedLocaleIsRejected`** — renamed and inverted from the previous `testUnsupportedLocaleFallsBackToLatin`, which had been added in M1 (#577) specifically to document the silent fallback as a known wart. Now asserts `ValidationException`.
- **`testEmptyLocaleStringIsRejected`** — empties don't actually hit the upstream null-canonicalize guard because `Locale::canonicalize('')` returns `en_US_POSIX` on this build; they fall into the new unsupported-locale arm instead. Either way the caller gets `ValidationException`.

### Compatibility note

This is a **breaking change** for any client that was relying on the silent fallback. The behaviour was undocumented and inconsistent with the rest of the API surface, so the practical impact should be low — but worth flagging in release notes.

### Stacks with #584

PR #584 (fix for #576) also touches `EventsParams::setParams`. Both PRs are small and the conflict is mechanical; whichever lands first, the second will need a tiny rebase.

## Test plan

- [x] `composer test:quick` — 924 tests / 2931 assertions (the 8 errors are pre-existing integration tests in `Routes/Readonly/*` requiring a live server; not related to this change)
- [x] `composer lint` clean
- [x] `composer analyse` (PHPStan level 10) clean

https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp


---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter locale validation: Unsupported and empty locale values are now rejected with validation errors instead of silently falling back to a default locale.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/585)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->