### PR TITLE
feat(coverage): instrument dev server with pcov so HTTP tests contribute to coverage (#569)

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -95,8 +95,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gettext locales-all
 
-      - name: Start the PHP web server
+      - name: Start the PHP web server (instrumented with pcov)
+        # PCOV_SERVER_COVERAGE_DIR triggers the bootstrap hook in
+        # public/index.php that dumps per-request pcov data so HTTP integration
+        # tests in phpunit_tests/Routes/* contribute to the merged report
+        # (otherwise pcov sees only the PHPUnit process). The hook is also
+        # gated on APP_ENV=test, so it stays dormant in production.
         run: composer start
+        env:
+          PCOV_SERVER_COVERAGE_DIR: ${{ github.workspace }}/coverage/pcov-server
 
       - name: Wait for server PID and HTTP readiness
         id: server-check
@@ -130,6 +137,25 @@ jobs:
 
       - name: Run tests with coverage and JUnit output
         run: time composer test:coverage
+
+      - name: Stop the PHP web server
+        # Stop before merging so per-request shutdown handlers flush their
+        # final dump files (and so a stalled worker doesn't hold the job open).
+        if: ${{ !cancelled() }}
+        run: composer stop || true
+
+      - name: Merge server pcov dumps into the clover report
+        if: ${{ !cancelled() }}
+        # Folds the per-request coverage data captured by the dev-server
+        # bootstrap hook (public/index.php) into the in-process clover PHPUnit
+        # produced. After this step coverage.xml reflects both layers.
+        run: |
+          if [ -d coverage/pcov-server ] && [ -n "$(ls -A coverage/pcov-server 2>/dev/null)" ]; then
+            php scripts/merge-pcov-coverage.php coverage.xml coverage/pcov-server coverage.merged.xml
+            mv coverage.merged.xml coverage.xml
+          else
+            echo "No server-side pcov dumps to merge; using PHPUnit coverage as-is."
+          fi
 
       - name: Upload coverage to Codecov
         if: ${{ !cancelled() }}

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -149,12 +149,32 @@ jobs:
         # Folds the per-request coverage data captured by the dev-server
         # bootstrap hook (public/index.php) into the in-process clover PHPUnit
         # produced. After this step coverage.xml reflects both layers.
+        # The merger's stderr is tee'd into $GITHUB_STEP_SUMMARY so the
+        # "lifted N lines across M files" headline is visible on the run
+        # summary page without digging through job logs.
         run: |
-          if [ -d coverage/pcov-server ] && [ -n "$(ls -A coverage/pcov-server 2>/dev/null)" ]; then
-            php scripts/merge-pcov-coverage.php coverage.xml coverage/pcov-server coverage.merged.xml
-            mv coverage.merged.xml coverage.xml
-          else
-            echo "No server-side pcov dumps to merge; using PHPUnit coverage as-is."
+          {
+            echo "## pcov server-side dump merge"
+            echo ""
+            if [ -d coverage/pcov-server ] && [ -n "$(ls -A coverage/pcov-server 2>/dev/null)" ]; then
+              echo '```'
+              php scripts/merge-pcov-coverage.php coverage.xml coverage/pcov-server coverage.merged.xml 2>&1
+              echo '```'
+              mv coverage.merged.xml coverage.xml
+            else
+              echo "_No server-side pcov dumps to merge; using PHPUnit coverage as-is._"
+            fi
+            echo ""
+          } | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Coverage summary
+        if: ${{ !cancelled() }}
+        # Emit a per-layer Markdown table from the merged clover so the
+        # project totals + bucket breakdown surface directly on the workflow
+        # run page (no Codecov round-trip needed).
+        run: |
+          if [ -f coverage.xml ]; then
+            php scripts/coverage-summary.php coverage.xml >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload coverage to Codecov

--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,8 @@ infrastructure/*.env
 
 # Coverage and test-result artifacts produced by composer test:coverage
 coverage.xml
+coverage.merged.xml
+coverage/
 junit.xml
 .phpunit.cache/
+server.coverage.pid

--- a/composer.json
+++ b/composer.json
@@ -85,6 +85,8 @@
         "test": "phpunit --testdox --display-warnings",
         "test:quick": "phpunit --testdox --display-warnings --exclude-group slow",
         "test:coverage": "phpunit --display-warnings --coverage-clover coverage.xml --log-junit junit.xml",
+        "test:coverage:full": "./scripts/coverage-with-server.sh",
+        "coverage:merge": "@php scripts/merge-pcov-coverage.php",
         "start": "./start-server.sh",
         "stop": "./stop-server.sh",
         "ws:start": "./ws-start-server.sh",

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "test:quick": "phpunit --testdox --display-warnings --exclude-group slow",
         "test:coverage": "phpunit --display-warnings --coverage-clover coverage.xml --log-junit junit.xml",
         "test:coverage:full": "./scripts/coverage-with-server.sh",
-        "coverage:merge": "@php scripts/merge-pcov-coverage.php",
+        "coverage:merge": "@php scripts/merge-pcov-coverage.php coverage.xml coverage/pcov-server coverage.merged.xml",
         "start": "./start-server.sh",
         "stop": "./stop-server.sh",
         "ws:start": "./ws-start-server.sh",

--- a/public/index.php
+++ b/public/index.php
@@ -70,6 +70,51 @@ $dotenv->ifPresent(['API_PORT'])->isInteger();
 $dotenv->ifPresent(['APP_ENV'])->notEmpty()->allowedValues(['development', 'test', 'staging', 'production']);
 $dotenv->ifPresent(['CORS_ALLOWED_ORIGINS'])->notEmpty();
 
+// Optional: when running under the integration-test coverage harness, instrument
+// the server with pcov so HTTP integration tests contribute to coverage. Gated
+// on three signals so this never fires in production by accident:
+//   1) the pcov extension is loaded,
+//   2) APP_ENV=test,
+//   3) PCOV_SERVER_COVERAGE_DIR points at a writable directory.
+// Each request appends a serialized \pcov\collect() snapshot under that dir;
+// scripts/merge-pcov-coverage.php folds those snapshots into the clover report.
+// Read PCOV_SERVER_COVERAGE_DIR via getenv() rather than $_ENV because the
+// orchestration layer (CI workflow / coverage helper script) passes it through
+// the shell environment, and PHP's default variables_order ("GPCS") leaves
+// $_ENV empty for arbitrary shell variables. APP_ENV is checked the same way
+// for symmetry (it usually comes from .env.local but may also be exported).
+$pcovServerCoverageDir = getenv('PCOV_SERVER_COVERAGE_DIR');
+$pcovAppEnv            = $_ENV['APP_ENV'] ?? getenv('APP_ENV');
+if (
+    extension_loaded('pcov')
+    && $pcovAppEnv === 'test'
+    && is_string($pcovServerCoverageDir) && $pcovServerCoverageDir !== ''
+) {
+    \pcov\start();
+    $pcovCoverageDir = $pcovServerCoverageDir;
+    register_shutdown_function(static function () use ($pcovCoverageDir): void {
+        try {
+            \pcov\stop();
+            $data = \pcov\collect();
+            if ($data === []) {
+                return;
+            }
+            if (!is_dir($pcovCoverageDir) && !@mkdir($pcovCoverageDir, 0755, true) && !is_dir($pcovCoverageDir)) {
+                return;
+            }
+            $file = sprintf(
+                '%s/pcov-%d-%s.cov',
+                rtrim($pcovCoverageDir, '/'),
+                getmypid(),
+                bin2hex(random_bytes(8))
+            );
+            @file_put_contents($file, serialize($data), LOCK_EX);
+        } catch (\Throwable) {
+            // Coverage instrumentation must never crash a response. Swallow.
+        }
+    });
+}
+
 $logsFolder = $projectFolder . DIRECTORY_SEPARATOR . 'logs';
 if (!file_exists($logsFolder)) {
     if (!mkdir($logsFolder, 0755, true)) {

--- a/scripts/coverage-summary.php
+++ b/scripts/coverage-summary.php
@@ -1,0 +1,114 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Read a clover XML file and emit a Markdown-formatted coverage summary
+ * (project totals + per-layer breakdown of src/) on stdout.
+ *
+ * Intended for piping into $GITHUB_STEP_SUMMARY in the CI workflow so the
+ * coverage numbers are visible directly on the run's summary page without
+ * digging into Codecov.
+ *
+ * Usage:
+ *   php scripts/coverage-summary.php <clover.xml> [<srcRoot>]
+ *
+ * - <clover.xml>: clover report to read.
+ * - <srcRoot>:    optional; absolute path to src/ used to bucket files by
+ *                 their top-level subdirectory (Handlers, Models, …). Defaults
+ *                 to <repo>/src.
+ */
+
+if ($argc < 2 || $argc > 3) {
+    fwrite(STDERR, "Usage: {$argv[0]} <clover.xml> [<srcRoot>]\n");
+    exit(1);
+}
+
+$cloverPath = $argv[1];
+$srcRoot    = $argv[2] ?? realpath(__DIR__ . '/../src');
+
+if (!is_string($srcRoot) || !is_dir($srcRoot)) {
+    fwrite(STDERR, "src root not found: " . var_export($srcRoot, true) . "\n");
+    exit(1);
+}
+if (!is_file($cloverPath) || !is_readable($cloverPath)) {
+    fwrite(STDERR, "Missing or unreadable clover: $cloverPath\n");
+    exit(1);
+}
+
+$xml = simplexml_load_file($cloverPath);
+if ($xml === false) {
+    fwrite(STDERR, "Failed to parse clover XML: $cloverPath\n");
+    exit(1);
+}
+
+$srcRootReal = rtrim($srcRoot, '/');
+
+/** @var array<string,array{stmts:int,covered:int,files:int}> $buckets */
+$buckets    = [];
+$totalStmts = 0;
+$totalCov   = 0;
+$totalFiles = 0;
+
+$ingest = function (\SimpleXMLElement $fileEl) use (&$buckets, &$totalStmts, &$totalCov, &$totalFiles, $srcRootReal): void {
+    $name = (string) $fileEl['name'];
+    if ($name === '' || strpos($name, $srcRootReal) !== 0) {
+        return;
+    }
+    $rel    = ltrim(substr($name, strlen($srcRootReal)), '/');
+    $parts  = explode('/', $rel);
+    $bucket = (count($parts) <= 1) ? '(root)' : $parts[0];
+
+    $m       = $fileEl->metrics;
+    $stmts   = (int) $m['statements'];
+    $covered = (int) $m['coveredstatements'];
+
+    if (!isset($buckets[$bucket])) {
+        $buckets[$bucket] = ['stmts' => 0, 'covered' => 0, 'files' => 0];
+    }
+    $buckets[$bucket]['stmts']   += $stmts;
+    $buckets[$bucket]['covered'] += $covered;
+    $buckets[$bucket]['files']++;
+    $totalStmts += $stmts;
+    $totalCov   += $covered;
+    $totalFiles++;
+};
+
+foreach ($xml->project->package as $pkg) {
+    foreach ($pkg->file as $fileEl) {
+        $ingest($fileEl);
+    }
+}
+foreach ($xml->project->file as $fileEl) {
+    $ingest($fileEl);
+}
+
+ksort($buckets);
+
+$pct = static fn (int $covered, int $stmts): string => $stmts > 0
+    ? sprintf('%.1f%%', 100 * $covered / $stmts)
+    : '—';
+
+echo "## Coverage report\n\n";
+
+echo sprintf(
+    "**Project total: %s** (%d / %d statements covered across %d files)\n\n",
+    $pct($totalCov, $totalStmts),
+    $totalCov,
+    $totalStmts,
+    $totalFiles
+);
+
+echo "| Layer | Files | Statements | Covered | Coverage |\n";
+echo "| :--- | ---: | ---: | ---: | ---: |\n";
+foreach ($buckets as $name => $b) {
+    echo sprintf(
+        "| `%s` | %d | %d | %d | %s |\n",
+        $name,
+        $b['files'],
+        $b['stmts'],
+        $b['covered'],
+        $pct($b['covered'], $b['stmts'])
+    );
+}

--- a/scripts/coverage-summary.php
+++ b/scripts/coverage-summary.php
@@ -29,7 +29,7 @@ $cloverPath = $argv[1];
 $srcRoot    = $argv[2] ?? realpath(__DIR__ . '/../src');
 
 if (!is_string($srcRoot) || !is_dir($srcRoot)) {
-    fwrite(STDERR, "src root not found: " . var_export($srcRoot, true) . "\n");
+    fwrite(STDERR, 'src root not found: ' . var_export($srcRoot, true) . "\n");
     exit(1);
 }
 if (!is_file($cloverPath) || !is_readable($cloverPath)) {
@@ -58,7 +58,7 @@ $ingest = function (\SimpleXMLElement $fileEl) use (&$buckets, &$totalStmts, &$t
     }
     $rel    = ltrim(substr($name, strlen($srcRootReal)), '/');
     $parts  = explode('/', $rel);
-    $bucket = (count($parts) <= 1) ? '(root)' : $parts[0];
+    $bucket = ( count($parts) <= 1 ) ? '(root)' : $parts[0];
 
     $m       = $fileEl->metrics;
     $stmts   = (int) $m['statements'];

--- a/scripts/coverage-with-server.sh
+++ b/scripts/coverage-with-server.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Run the full PHPUnit suite against a pcov-instrumented dev server and emit a
+# unified clover report at coverage/clover.xml.
+#
+# Pre-reqs:
+#   - php with the pcov extension available (any of: installed system-wide,
+#     loaded via php.ini, or buildable; the script just calls plain php).
+#   - vendor/ populated (`composer install`).
+#   - pcov.enabled=1 will be forced on the command line, so users don't need
+#     it on in their default php.ini.
+#
+# Output:
+#   coverage/phpunit-clover.xml  - in-process clover from PHPUnit
+#   coverage/pcov-server/*.cov   - per-request pcov dumps from the dev server
+#   coverage/clover.xml          - merged report (PHPUnit + per-request)
+#
+# Environment:
+#   API_HOST   default 127.0.0.1
+#   API_PORT   default 8000
+#   PHP_CLI_SERVER_WORKERS  default 6
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+API_HOST="${API_HOST:-127.0.0.1}"
+API_PORT="${API_PORT:-8000}"
+export PHP_CLI_SERVER_WORKERS="${PHP_CLI_SERVER_WORKERS:-6}"
+
+COV_DIR="$PWD/coverage/pcov-server"
+CLOVER_RAW="$PWD/coverage/phpunit-clover.xml"
+CLOVER_OUT="$PWD/coverage/clover.xml"
+SERVER_PID_FILE="$PWD/server.coverage.pid"
+
+# Clean any previous coverage state.
+rm -rf "$COV_DIR" "$CLOVER_RAW" "$CLOVER_OUT"
+mkdir -p "$COV_DIR" "$PWD/coverage"
+
+# The bootstrap hook in public/index.php reads PCOV_SERVER_COVERAGE_DIR from
+# the process environment (not $_ENV); exporting it propagates to the server.
+export PCOV_SERVER_COVERAGE_DIR="$COV_DIR"
+
+# Start the dev server with pcov enabled, in the background.
+echo "Starting pcov-instrumented server on http://$API_HOST:$API_PORT ..."
+php -d pcov.enabled=1 -d pcov.directory=src \
+    -S "$API_HOST:$API_PORT" -t public \
+    > /dev/null 2>&1 &
+SERVER_PID=$!
+echo "$SERVER_PID" > "$SERVER_PID_FILE"
+
+# Ensure the server is killed even on test failure / abort.
+cleanup() {
+    if [ -f "$SERVER_PID_FILE" ]; then
+        local pid
+        pid="$(cat "$SERVER_PID_FILE")"
+        # SIGTERM lets workers finish + run shutdown handlers (so the final
+        # per-request dump for in-flight requests lands).
+        kill -TERM "$pid" 2>/dev/null || true
+        wait "$pid" 2>/dev/null || true
+        rm -f "$SERVER_PID_FILE"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# Wait for the server to bind.
+for _ in $(seq 1 30); do
+    if nc -z "$API_HOST" "$API_PORT" 2>/dev/null; then
+        echo "Server is ready."
+        break
+    fi
+    sleep 0.5
+done
+
+if ! nc -z "$API_HOST" "$API_PORT" 2>/dev/null; then
+    echo "Server failed to come up on $API_HOST:$API_PORT" >&2
+    exit 1
+fi
+
+# Run PHPUnit with in-process coverage. Tests in phpunit_tests/Routes/* will
+# hit the instrumented server; tests elsewhere run in-process.
+echo "Running PHPUnit suite ..."
+php -d pcov.enabled=1 -d pcov.directory=src \
+    vendor/bin/phpunit \
+        --display-warnings \
+        --exclude-group slow \
+        --coverage-clover "$CLOVER_RAW" \
+        --log-junit "$PWD/coverage/junit.xml" \
+    || PHPUNIT_EXIT=$?
+
+# Stop the server before merging so all per-request shutdown handlers have
+# fired and their dump files are on disk.
+cleanup
+trap - EXIT INT TERM
+
+# Merge the per-request dumps into the PHPUnit clover.
+echo "Merging pcov dumps ..."
+php scripts/merge-pcov-coverage.php "$CLOVER_RAW" "$COV_DIR" "$CLOVER_OUT"
+
+exit "${PHPUNIT_EXIT:-0}"

--- a/scripts/merge-pcov-coverage.php
+++ b/scripts/merge-pcov-coverage.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Merge per-request pcov dumps produced by the dev-server instrumentation hook
+ * in public/index.php into a clover report produced by PHPUnit's
+ * --coverage-clover flag, and emit a unified clover file.
+ *
+ * Usage:
+ *   php scripts/merge-pcov-coverage.php <phpunit-clover.xml> <pcov-dump-dir> <out-clover.xml>
+ *
+ * - <phpunit-clover.xml>: the clover file PHPUnit generated for in-process tests.
+ * - <pcov-dump-dir>:     directory of *.cov files written by public/index.php
+ *                        (each file is `serialize(\pcov\collect())`).
+ * - <out-clover.xml>:    where to write the merged clover.
+ *
+ * Behavior:
+ *   For each pcov dump, the script union-merges the set of lines marked as
+ *   "executed" (state === 1) into the count attribute of the corresponding
+ *   `<line>` element in the clover. File-level `<metrics>` are recomputed.
+ *   Package and project metrics are recomputed too.
+ *
+ *   Files / lines that appear in pcov data but NOT in the clover are skipped
+ *   silently — the clover defines the authoritative set of executable lines
+ *   (driven by PHPUnit's source filter), and a divergence in pcov-seen lines
+ *   indicates either dead code or a file outside `<source><include>`.
+ */
+
+if ($argc !== 4) {
+    fwrite(STDERR, "Usage: {$argv[0]} <phpunit-clover.xml> <pcov-dump-dir> <out-clover.xml>\n");
+    exit(1);
+}
+
+[$_, $cloverIn, $pcovDir, $cloverOut] = $argv;
+
+if (!is_file($cloverIn) || !is_readable($cloverIn)) {
+    fwrite(STDERR, "Missing or unreadable clover input: $cloverIn\n");
+    exit(1);
+}
+if (!is_dir($pcovDir) || !is_readable($pcovDir)) {
+    fwrite(STDERR, "Missing or unreadable pcov dump dir: $pcovDir\n");
+    exit(1);
+}
+
+$xml = new DOMDocument();
+$xml->preserveWhiteSpace = false;
+$xml->formatOutput       = true;
+if (!$xml->load($cloverIn)) {
+    fwrite(STDERR, "Failed to parse clover XML: $cloverIn\n");
+    exit(1);
+}
+
+$xpath = new DOMXPath($xml);
+
+// Build path-keyed file lookup from clover.
+/** @var array<string,DOMElement> $filesByPath */
+$filesByPath = [];
+foreach ($xpath->query('//file') as $fileEl) {
+    if (!$fileEl instanceof DOMElement) {
+        continue;
+    }
+    $name = $fileEl->getAttribute('name');
+    if ($name !== '') {
+        $filesByPath[$name] = $fileEl;
+    }
+}
+
+if ($filesByPath === []) {
+    fwrite(STDERR, "Clover contained no <file> entries; nothing to merge into.\n");
+    exit(1);
+}
+
+// Union the set of executed lines across every pcov dump.
+/** @var array<string,array<int,true>> $pcovHits */
+$pcovHits = [];
+$dumpFiles = glob(rtrim($pcovDir, '/') . '/*.cov') ?: [];
+foreach ($dumpFiles as $dump) {
+    $raw = @file_get_contents($dump);
+    if ($raw === false || $raw === '') {
+        continue;
+    }
+    $data = @unserialize($raw, ['allowed_classes' => false]);
+    if (!is_array($data)) {
+        continue;
+    }
+    foreach ($data as $file => $lines) {
+        if (!is_string($file) || !is_array($lines)) {
+            continue;
+        }
+        foreach ($lines as $lineNo => $state) {
+            // pcov state codes (from include/pcov.h):
+            //   1  = executed
+            //  -1  = executable but not executed (covers the line at module load)
+            //   0  = not coverable (whitespace / comment)
+            // We only union state === 1 hits — uncovered/not-coverable info already
+            // lives in the PHPUnit clover.
+            if ($state === 1 && is_int($lineNo)) {
+                $pcovHits[$file][$lineNo] = true;
+            }
+        }
+    }
+}
+
+$mergedFiles  = 0;
+$liftedLines  = 0;
+foreach ($pcovHits as $file => $lineSet) {
+    if (!isset($filesByPath[$file])) {
+        continue;
+    }
+    $fileEl    = $filesByPath[$file];
+    $bumpedAny = false;
+    foreach ($xpath->query('./line', $fileEl) as $lineEl) {
+        if (!$lineEl instanceof DOMElement) {
+            continue;
+        }
+        $num = (int) $lineEl->getAttribute('num');
+        if (!isset($lineSet[$num])) {
+            continue;
+        }
+        $count = (int) $lineEl->getAttribute('count');
+        if ($count === 0) {
+            $liftedLines++;
+            $bumpedAny = true;
+        }
+        $lineEl->setAttribute('count', (string) max($count, 1));
+    }
+    if ($bumpedAny) {
+        $mergedFiles++;
+    }
+}
+
+// Recompute per-file <metrics>.
+$totalStmts        = 0;
+$totalCovStmts     = 0;
+$totalMethods      = 0;
+$totalCovMethods   = 0;
+$totalConditionals = 0;
+$totalCovConds     = 0;
+$totalLines        = 0;
+$totalNcloc        = 0;
+$totalClasses      = 0;
+foreach ($filesByPath as $fileEl) {
+    $fileStmts = 0;
+    $fileCovStmts = 0;
+    $fileMethods = 0;
+    $fileCovMethods = 0;
+    $fileConds = 0;
+    $fileCovConds = 0;
+    foreach ($xpath->query('./line', $fileEl) as $lineEl) {
+        if (!$lineEl instanceof DOMElement) {
+            continue;
+        }
+        $type  = $lineEl->getAttribute('type');
+        $count = (int) $lineEl->getAttribute('count');
+        if ($type === 'stmt') {
+            $fileStmts++;
+            if ($count > 0) {
+                $fileCovStmts++;
+            }
+        } elseif ($type === 'method') {
+            $fileMethods++;
+            if ($count > 0) {
+                $fileCovMethods++;
+            }
+        } elseif ($type === 'cond') {
+            $fileConds++;
+            if ($count > 0) {
+                $fileCovConds++;
+            }
+        }
+    }
+    $metricsEl = $xpath->query('./metrics', $fileEl)->item(0);
+    if ($metricsEl instanceof DOMElement) {
+        $metricsEl->setAttribute('statements', (string) $fileStmts);
+        $metricsEl->setAttribute('coveredstatements', (string) $fileCovStmts);
+        $metricsEl->setAttribute('methods', (string) $fileMethods);
+        $metricsEl->setAttribute('coveredmethods', (string) $fileCovMethods);
+        $metricsEl->setAttribute('conditionals', (string) $fileConds);
+        $metricsEl->setAttribute('coveredconditionals', (string) $fileCovConds);
+        // 'elements' / 'coveredelements' = sum of the three categories.
+        $elements = $fileStmts + $fileMethods + $fileConds;
+        $covEls   = $fileCovStmts + $fileCovMethods + $fileCovConds;
+        $metricsEl->setAttribute('elements', (string) $elements);
+        $metricsEl->setAttribute('coveredelements', (string) $covEls);
+
+        // Preserve loc/ncloc/classes if present; aggregate for project totals.
+        $totalLines   += (int) $metricsEl->getAttribute('loc');
+        $totalNcloc   += (int) $metricsEl->getAttribute('ncloc');
+        $totalClasses += (int) $metricsEl->getAttribute('classes');
+    }
+    $totalStmts        += $fileStmts;
+    $totalCovStmts     += $fileCovStmts;
+    $totalMethods      += $fileMethods;
+    $totalCovMethods   += $fileCovMethods;
+    $totalConditionals += $fileConds;
+    $totalCovConds     += $fileCovConds;
+}
+
+// Recompute <project>/<metrics>.
+$projectMetricsList = $xpath->query('/coverage/project/metrics');
+$projectMetricsEl   = $projectMetricsList instanceof DOMNodeList ? $projectMetricsList->item(0) : null;
+if ($projectMetricsEl instanceof DOMElement) {
+    $projectMetricsEl->setAttribute('statements', (string) $totalStmts);
+    $projectMetricsEl->setAttribute('coveredstatements', (string) $totalCovStmts);
+    $projectMetricsEl->setAttribute('methods', (string) $totalMethods);
+    $projectMetricsEl->setAttribute('coveredmethods', (string) $totalCovMethods);
+    $projectMetricsEl->setAttribute('conditionals', (string) $totalConditionals);
+    $projectMetricsEl->setAttribute('coveredconditionals', (string) $totalCovConds);
+    $projectMetricsEl->setAttribute('elements', (string) ($totalStmts + $totalMethods + $totalConditionals));
+    $projectMetricsEl->setAttribute(
+        'coveredelements',
+        (string) ($totalCovStmts + $totalCovMethods + $totalCovConds)
+    );
+    if ($projectMetricsEl->hasAttribute('loc')) {
+        $projectMetricsEl->setAttribute('loc', (string) $totalLines);
+    }
+    if ($projectMetricsEl->hasAttribute('ncloc')) {
+        $projectMetricsEl->setAttribute('ncloc', (string) $totalNcloc);
+    }
+    if ($projectMetricsEl->hasAttribute('classes')) {
+        $projectMetricsEl->setAttribute('classes', (string) $totalClasses);
+    }
+    if ($projectMetricsEl->hasAttribute('files')) {
+        $projectMetricsEl->setAttribute('files', (string) count($filesByPath));
+    }
+}
+
+@mkdir(dirname($cloverOut), 0755, true);
+if (false === $xml->save($cloverOut)) {
+    fwrite(STDERR, "Failed to write merged clover: $cloverOut\n");
+    exit(1);
+}
+
+$dumpCount = count($dumpFiles);
+$pctBefore = '';
+$pctAfter  = '';
+if ($totalStmts > 0) {
+    $pctAfter = sprintf(' (%.1f%%)', 100 * $totalCovStmts / $totalStmts);
+}
+fprintf(
+    STDERR,
+    "Merged %d pcov dump(s) from %s into %s\n  -> lifted %d previously-uncovered line(s) across %d file(s)\n  -> project statements: %d covered / %d total%s\n",
+    $dumpCount,
+    $pcovDir,
+    $cloverOut,
+    $liftedLines,
+    $mergedFiles,
+    $totalCovStmts,
+    $totalStmts,
+    $pctAfter
+);

--- a/scripts/merge-pcov-coverage.php
+++ b/scripts/merge-pcov-coverage.php
@@ -43,7 +43,7 @@ if (!is_dir($pcovDir) || !is_readable($pcovDir)) {
     exit(1);
 }
 
-$xml = new DOMDocument();
+$xml                     = new DOMDocument();
 $xml->preserveWhiteSpace = false;
 $xml->formatOutput       = true;
 if (!$xml->load($cloverIn)) {
@@ -73,7 +73,7 @@ if ($filesByPath === []) {
 
 // Union the set of executed lines across every pcov dump.
 /** @var array<string,array<int,true>> $pcovHits */
-$pcovHits = [];
+$pcovHits  = [];
 $dumpFiles = glob(rtrim($pcovDir, '/') . '/*.cov') ?: [];
 foreach ($dumpFiles as $dump) {
     $raw = @file_get_contents($dump);
@@ -102,8 +102,8 @@ foreach ($dumpFiles as $dump) {
     }
 }
 
-$mergedFiles  = 0;
-$liftedLines  = 0;
+$mergedFiles = 0;
+$liftedLines = 0;
 foreach ($pcovHits as $file => $lineSet) {
     if (!isset($filesByPath[$file])) {
         continue;
@@ -141,12 +141,12 @@ $totalLines        = 0;
 $totalNcloc        = 0;
 $totalClasses      = 0;
 foreach ($filesByPath as $fileEl) {
-    $fileStmts = 0;
-    $fileCovStmts = 0;
-    $fileMethods = 0;
+    $fileStmts      = 0;
+    $fileCovStmts   = 0;
+    $fileMethods    = 0;
     $fileCovMethods = 0;
-    $fileConds = 0;
-    $fileCovConds = 0;
+    $fileConds      = 0;
+    $fileCovConds   = 0;
     foreach ($xpath->query('./line', $fileEl) as $lineEl) {
         if (!$lineEl instanceof DOMElement) {
             continue;
@@ -207,10 +207,10 @@ if ($projectMetricsEl instanceof DOMElement) {
     $projectMetricsEl->setAttribute('coveredmethods', (string) $totalCovMethods);
     $projectMetricsEl->setAttribute('conditionals', (string) $totalConditionals);
     $projectMetricsEl->setAttribute('coveredconditionals', (string) $totalCovConds);
-    $projectMetricsEl->setAttribute('elements', (string) ($totalStmts + $totalMethods + $totalConditionals));
+    $projectMetricsEl->setAttribute('elements', (string) ( $totalStmts + $totalMethods + $totalConditionals ));
     $projectMetricsEl->setAttribute(
         'coveredelements',
-        (string) ($totalCovStmts + $totalCovMethods + $totalCovConds)
+        (string) ( $totalCovStmts + $totalCovMethods + $totalCovConds )
     );
     if ($projectMetricsEl->hasAttribute('loc')) {
         $projectMetricsEl->setAttribute('loc', (string) $totalLines);


### PR DESCRIPTION
## Summary

Closes #569.

The PHPUnit suite spans two processes: the in-process unit tests (M1–M6, ~700 tests) are observed by pcov inside the PHPUnit process and contribute to coverage as normal; the HTTP integration tests under `phpunit_tests/Routes/` hit a separate `php -S` dev server via Guzzle, and that server's runtime was previously invisible to pcov. The code those tests exercise (`Router::route`, every handler body, the calendar-calculation spine in `LiturgicalEventCollection`) registered as "uncovered" in the report.

This PR instruments the dev server too, then merges the per-request coverage data into the clover Codecov reads.

## What's in the box

### `public/index.php` — bootstrap hook (triple-gated)

```php
$pcovServerCoverageDir = getenv('PCOV_SERVER_COVERAGE_DIR');
$pcovAppEnv            = $_ENV['APP_ENV'] ?? getenv('APP_ENV');
if (
    extension_loaded('pcov')
    && $pcovAppEnv === 'test'
    && is_string($pcovServerCoverageDir) && $pcovServerCoverageDir !== ''
) {
    \pcov\start();
    register_shutdown_function(static function () use (...): void {
        try {
            \pcov\stop();
            $data = \pcov\collect();
            // serialize() → unique-named .cov file under the configured dir
        } catch (\Throwable) {
            // Coverage instrumentation must never crash a response.
        }
    });
}
```

- The triple gate (extension loaded + `APP_ENV=test` + env var set) means the hook stays dormant in production. Dotenv only loads keys listed in `->required()` / `->ifPresent()`; `PCOV_SERVER_COVERAGE_DIR` is read via `getenv()` because PHP's default `variables_order=GPCS` leaves `$_ENV` empty for arbitrary shell vars. (Found this the hard way while debugging the local probe.)
- Wrapped in `try { … } catch (\Throwable)` — coverage instrumentation must never affect the response.
- Per-request file naming (`pcov-<pid>-<random>.cov`) avoids contention between `PHP_CLI_SERVER_WORKERS` workers writing in parallel.

### `scripts/merge-pcov-coverage.php` — clover merger

Standalone PHP script. Reads the PHPUnit-produced clover, union-folds every `*.cov` dump into matching `<line>` elements (bumping `count` for previously-uncovered lines that pcov found executed), then recomputes file + project metrics. Files / lines that appear in pcov but not in the clover are skipped silently — the clover defines the authoritative set of executable lines from PHPUnit's source filter.

### `scripts/coverage-with-server.sh` — local orchestrator

Boots a pcov-instrumented server, waits for it to bind, runs PHPUnit with coverage, traps EXIT to kill the server gracefully (so shutdown handlers flush their final dumps), then runs the merger.

### `composer.json`

```
"test:coverage:full":  "./scripts/coverage-with-server.sh"
"coverage:merge":      "@php scripts/merge-pcov-coverage.php"
```

### `.github/workflows/phpunit.yml`

Three small changes:

1. Export `PCOV_SERVER_COVERAGE_DIR` to the `composer start` step.
2. Add a `composer stop || true` step before merging so per-request shutdown handlers flush.
3. Add a merge step that folds `coverage/pcov-server/*.cov` into `coverage.xml` (skipped gracefully if no dumps were produced).

Codecov keeps reading `./coverage.xml` — it just now contains the merged totals.

## Measurement

Local, in this dev box (no Postgres, many integration tests fail because DB-backed routes can't reach the database):

```
=== BEFORE (in-process only) ===
Layer              Stmts   Covered  Coverage
(root)              2141       116    5.4%
Handlers            6807      1410   20.7%
Http                1493       768   51.4%
Models              4088       813   19.9%
Repositories         631         0    0.0%
... TOTAL          17245      4435   25.7%

=== AFTER (+ HTTP via pcov) ===
Layer              Stmts   Covered  Coverage   Δ
(root)              2141       307   14.3%   +8.9 pp   ← Router::route() now exercised
Handlers            6807      1426   20.9%   +0.2 pp
Http                1493       834   55.9%   +4.5 pp
Models              4088       813   19.9%   ±0
... TOTAL          17245      4709   27.3%   +1.6 pp
```

In CI with the Postgres service running and the integration tests passing, the lift in `Handlers`, `Models`, `Map`, and `Test` will be substantially bigger — those layers are mostly exercised end-to-end by the `Routes/*` tests, which couldn't run cleanly here. The estimate from the issue's analysis is ~20 pp overall in a well-configured CI environment.

## Local usage

```
composer test:coverage:full
```

Produces `coverage/clover.xml`. The pcov extension is required (`pecl install pcov` or `apt install php-pcov`).

## Test plan

- [x] Bootstrap hook fires only when all three gates pass; per-request dumps land under the configured dir
- [x] Merger preserves clover structure, only bumps `count` (never decrements), recomputes metrics
- [x] `composer lint` clean, `composer analyse` (PHPStan level 10) clean
- [x] Unit suite still passes (928 tests, the 8 pre-existing errors are integration tests that need a live server)

https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp


---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced code coverage instrumentation for integration tests using pcov.
  * Added automated coverage collection and reporting for HTTP server requests.
  * Improved test coverage merging to provide unified reports.

* **Chores**
  * Updated build configuration and coverage artifact management.
  * Added new test coverage scripts to development tooling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/586)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->