### PR TITLE
test(routes): cover /tests, /missals, /decrees HTTP endpoints end-to-end

### DIFF
--- a/phpunit_tests/Routes/Readonly/DecreesTest.php
+++ b/phpunit_tests/Routes/Readonly/DecreesTest.php
@@ -7,7 +7,7 @@ namespace LiturgicalCalendar\Tests\Routes\Readonly;
 use LiturgicalCalendar\Tests\ApiTestCase;
 
 /**
- * End-to-end tests for the /decrees endpoint and its single-decree variant.
+ * Integration tests for the /decrees endpoint and its single-decree variant.
  *
  * The Decrees endpoint serves Dicastery for Divine Worship rulings that
  * modify the liturgical calendar (e.g. adding Mary Mother of the Church

--- a/phpunit_tests/Routes/Readonly/DecreesTest.php
+++ b/phpunit_tests/Routes/Readonly/DecreesTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Readonly;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+/**
+ * End-to-end tests for the /decrees endpoint and its single-decree variant.
+ *
+ * The Decrees endpoint serves Dicastery for Divine Worship rulings that
+ * modify the liturgical calendar (e.g. adding Mary Mother of the Church
+ * 2018, upgrading St Mary Magdalene 2016). DecreesHandler loads these from
+ * jsondata/sourcedata/decrees/decrees.json + applies the requested locale's
+ * i18n strings.
+ */
+final class DecreesTest extends ApiTestCase
+{
+    public function testListReturnsJsonCollection(): void
+    {
+        $response = self::$http->get('/decrees', []);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringStartsWith('application/json', $response->getHeaderLine('Content-Type'));
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), json_last_error_msg());
+        $this->assertIsObject($data);
+        $this->assertObjectHasProperty('litcal_decrees', $data);
+        $this->assertIsArray($data->litcal_decrees);
+        $this->assertNotEmpty($data->litcal_decrees);
+
+        $decreeIds = [];
+        foreach ($data->litcal_decrees as $d) {
+            $this->assertIsObject($d);
+            $this->assertObjectHasProperty('decree_id', $d);
+            $this->assertObjectHasProperty('decree_date', $d);
+            $this->assertObjectHasProperty('decree_protocol', $d);
+            $this->assertObjectHasProperty('description', $d);
+            $this->assertIsString($d->decree_id);
+            $this->assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}$/', $d->decree_date);
+            $decreeIds[] = $d->decree_id;
+        }
+
+        // StMaryMagdalene_Upgrade is committed and stable; safe to anchor on.
+        $this->assertContains('StMaryMagdalene_Upgrade', $decreeIds);
+    }
+
+    public function testSingleDecreeReturnsDefinition(): void
+    {
+        $response = self::$http->get('/decrees/StMaryMagdalene_Upgrade', []);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsObject($data);
+        $this->assertSame('StMaryMagdalene_Upgrade', $data->decree_id);
+        $this->assertObjectHasProperty('decree_date', $data);
+        $this->assertObjectHasProperty('decree_protocol', $data);
+        $this->assertObjectHasProperty('description', $data);
+    }
+
+    public function testUnknownDecreeIdReturnsClientError(): void
+    {
+        $response = self::$http->get('/decrees/NOT_A_REAL_DECREE', []);
+        $status   = $response->getStatusCode();
+        $this->assertGreaterThanOrEqual(400, $status);
+        $this->assertLessThan(500, $status);
+    }
+
+    public function testListHonoursLocaleHeader(): void
+    {
+        // Latin is always available since decrees are issued in Latin. Asking
+        // for la-VA should succeed and return Latin-localised description text.
+        $response = self::$http->get('/decrees', ['headers' => ['Accept-Language' => 'la-VA']]);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsObject($data);
+        $this->assertIsArray($data->litcal_decrees);
+        $this->assertNotEmpty($data->litcal_decrees);
+    }
+}

--- a/phpunit_tests/Routes/Readonly/MissalsTest.php
+++ b/phpunit_tests/Routes/Readonly/MissalsTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Readonly;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+/**
+ * End-to-end tests for the /missals endpoint and its single-missal variant.
+ *
+ * Exercises MissalsHandler + the propriumdesanctis loading path that the
+ * unit tests don't reach (the unit tests cover MissalMetadata / MissalsMap
+ * shape, not the disk-IO + JSON Schema validation that runs on a real
+ * request).
+ */
+final class MissalsTest extends ApiTestCase
+{
+    public function testListReturnsJsonCollection(): void
+    {
+        $response = self::$http->get('/missals', []);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringStartsWith('application/json', $response->getHeaderLine('Content-Type'));
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), json_last_error_msg());
+        $this->assertIsObject($data);
+        $this->assertObjectHasProperty('litcal_missals', $data);
+        $this->assertIsArray($data->litcal_missals);
+        $this->assertNotEmpty($data->litcal_missals);
+
+        $missalIds = [];
+        foreach ($data->litcal_missals as $missal) {
+            $this->assertIsObject($missal);
+            $this->assertObjectHasProperty('missal_id', $missal);
+            $this->assertObjectHasProperty('name', $missal);
+            $this->assertObjectHasProperty('region', $missal);
+            $this->assertObjectHasProperty('locales', $missal);
+            $this->assertObjectHasProperty('year_published', $missal);
+            $this->assertObjectHasProperty('year_limits', $missal);
+            $this->assertIsString($missal->missal_id);
+            $this->assertIsArray($missal->locales);
+            $this->assertIsInt($missal->year_published);
+            $missalIds[] = $missal->missal_id;
+        }
+
+        $this->assertContains('EDITIO_TYPICA_1970', $missalIds, 'Editio Typica 1970 should always be listed');
+    }
+
+    public function testListSupportsRegionFilter(): void
+    {
+        $response = self::$http->get('/missals', ['query' => ['region' => 'VA']]);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsObject($data);
+        $this->assertIsArray($data->litcal_missals);
+        foreach ($data->litcal_missals as $m) {
+            $this->assertSame('VA', $m->region, 'Region filter should restrict to VA');
+        }
+    }
+
+    public function testSingleMissalReturnsPropriumDeSanctis(): void
+    {
+        // Editio Typica 1970 is the canonical missal; its propriumdesanctis is
+        // committed under jsondata/sourcedata/missals/propriumdesanctis_1970/.
+        $response = self::$http->get('/missals/EDITIO_TYPICA_1970', []);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsArray($data, 'Single-missal response should be the proprium array');
+        $this->assertNotEmpty($data);
+
+        $first = $data[0];
+        $this->assertIsObject($first);
+        $this->assertObjectHasProperty('event_key', $first);
+        $this->assertObjectHasProperty('grade', $first);
+        $this->assertObjectHasProperty('color', $first);
+        $this->assertIsInt($first->grade);
+        $this->assertIsArray($first->color);
+    }
+
+    public function testUnknownMissalIdReturnsClientError(): void
+    {
+        $response = self::$http->get('/missals/NOT_A_REAL_MISSAL_ID', []);
+        $status   = $response->getStatusCode();
+        $this->assertGreaterThanOrEqual(400, $status, "Expected 4xx for unknown missal_id, got $status");
+        $this->assertLessThan(500, $status, "Expected 4xx (not 5xx) for unknown missal_id, got $status");
+    }
+}

--- a/phpunit_tests/Routes/Readonly/MissalsTest.php
+++ b/phpunit_tests/Routes/Readonly/MissalsTest.php
@@ -7,7 +7,7 @@ namespace LiturgicalCalendar\Tests\Routes\Readonly;
 use LiturgicalCalendar\Tests\ApiTestCase;
 
 /**
- * End-to-end tests for the /missals endpoint and its single-missal variant.
+ * Integration tests for the /missals endpoint and its single-missal variant.
  *
  * Exercises MissalsHandler + the propriumdesanctis loading path that the
  * unit tests don't reach (the unit tests cover MissalMetadata / MissalsMap

--- a/phpunit_tests/Routes/Readonly/TestsTest.php
+++ b/phpunit_tests/Routes/Readonly/TestsTest.php
@@ -7,7 +7,7 @@ namespace LiturgicalCalendar\Tests\Routes\Readonly;
 use LiturgicalCalendar\Tests\ApiTestCase;
 
 /**
- * End-to-end tests for the /tests endpoint and its single-resource variant.
+ * Integration tests for the /tests endpoint and its single-resource variant.
  *
  * Serves the catalog of test definitions used by the UnitTestInterface
  * websocket runner. The HTTP endpoint itself doesn't invoke LitTestRunner —

--- a/phpunit_tests/Routes/Readonly/TestsTest.php
+++ b/phpunit_tests/Routes/Readonly/TestsTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Readonly;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+/**
+ * End-to-end tests for the /tests endpoint and its single-resource variant.
+ *
+ * Serves the catalog of test definitions used by the UnitTestInterface
+ * websocket runner. The HTTP endpoint itself doesn't invoke LitTestRunner —
+ * that path lives in Health.php / the websocket harness — but the JSON
+ * payload + content negotiation surface here was previously uncovered.
+ */
+final class TestsTest extends ApiTestCase
+{
+    public function testListReturnsJsonCollection(): void
+    {
+        $response = self::$http->get('/tests', []);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringStartsWith('application/json', $response->getHeaderLine('Content-Type'));
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertSame(JSON_ERROR_NONE, json_last_error(), json_last_error_msg());
+        $this->assertIsObject($data);
+        $this->assertObjectHasProperty('litcal_tests', $data);
+        $this->assertIsArray($data->litcal_tests);
+        $this->assertNotEmpty($data->litcal_tests, 'Expected at least one test definition');
+
+        foreach ($data->litcal_tests as $test) {
+            $this->assertIsObject($test);
+            $this->assertObjectHasProperty('name', $test);
+            $this->assertObjectHasProperty('event_key', $test);
+            $this->assertObjectHasProperty('test_type', $test);
+            $this->assertObjectHasProperty('assertions', $test);
+            $this->assertIsString($test->name);
+            $this->assertIsString($test->event_key);
+            $this->assertIsString($test->test_type);
+            $this->assertIsArray($test->assertions);
+        }
+    }
+
+    public function testSingleTestByNameReturnsDefinition(): void
+    {
+        // MaryMotherChurchTest is committed to jsondata/tests/ and is a stable
+        // pick (added 2018 by decree, won't move).
+        $response = self::$http->get('/tests/MaryMotherChurchTest', []);
+        $this->assertSame(200, $response->getStatusCode());
+
+        $data = json_decode((string) $response->getBody());
+        $this->assertIsObject($data);
+        $this->assertSame('MaryMotherChurchTest', $data->name);
+        $this->assertSame('MaryMotherChurch', $data->event_key);
+        $this->assertIsArray($data->assertions);
+        $this->assertNotEmpty($data->assertions);
+
+        foreach ($data->assertions as $a) {
+            $this->assertObjectHasProperty('year', $a);
+            $this->assertObjectHasProperty('assert', $a);
+            $this->assertIsInt($a->year);
+        }
+    }
+
+    public function testUnknownTestNameReturns404(): void
+    {
+        $response = self::$http->get('/tests/NoSuchTestName_Xyz', []);
+        $this->assertSame(404, $response->getStatusCode());
+    }
+
+    public function testListRespectsYamlAcceptHeader(): void
+    {
+        $response = self::$http->get('/tests', ['headers' => ['Accept' => 'application/yaml']]);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringStartsWith('application/yaml', $response->getHeaderLine('Content-Type'));
+
+        // We don't depend on ext-yaml in the test process (it's only loaded
+        // server-side). The header confirms negotiation; a body shape check
+        // confirms the YAML encoder actually ran.
+        $body = (string) $response->getBody();
+        $this->assertStringContainsString('litcal_tests:', $body, 'YAML body should contain the top-level key');
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to **#569**. Adds three `Routes/Readonly/*` HTTP integration tests for endpoints that previously had no end-to-end coverage:

- `/tests` (list + single + 404 + YAML negotiation)
- `/missals` (list + region filter + single + 404)
- `/decrees` (list + single + 404 + locale negotiation)

All three follow the existing pattern (`EasterTest`, `EventsTest`, etc.) — Guzzle against the live dev server, parsing the response shape end-to-end.

## Coverage lift

Measured locally with the docker stack up (Postgres + OpenFGA — ghcr.io was blocked from this sandbox so Zitadel didn't come up; CI has it) and the dev-server pcov hook from #569 active:

| Layer | Before (with #569) | After (this PR + #569) | Δ |
|---|---:|---:|---:|
| (root) | 29.6% | 32.6% | **+3.0 pp** |
| Database | 95.9% | 95.9% | 0 |
| Enum | 81.6% | 86.1% | **+4.5 pp** ← RomanMissal validation via `/missals/{id}` |
| Handlers | 47.5% | 48.1% | **+0.6 pp** |
| Http | 60.2% | 60.2% | 0 |
| Map | 82.7% | 82.7% | 0 |
| Models | 53.7% | 55.5% | **+1.8 pp** ← Decrees + MissalsPath models in real load path |
| Params | 89.1% | 89.1% | 0 |
| Repositories | 97.0% | 97.0% | 0 |
| Services | 59.8% | 59.8% | 0 |
| Test | 0.0% | 0.0% | 0 (see note) |
| **TOTAL** | **52.1%** | **53.2%** | **+1.1 pp** (+200 lines across 70 files) |

## Note on `src/Test/`

I initially targeted this layer expecting the `/tests` endpoint to invoke `LitTestRunner`. It doesn't — `src/Test/` is only reached by the **WebSocket test harness** (`src/Health.php:1239`), driven by the [UnitTestInterface](https://github.com/Liturgical-Calendar/UnitTestInterface) frontend over `composer ws:start`. The HTTP `/tests` endpoint serves the **catalog** of test definitions (which is genuinely useful coverage and is what these tests exercise), but doesn't run them. To cover `src/Test/` we'd need WebSocket-driven tests, which is a different bag and out of scope here.

## Relationship to #569

These tests run independently — they pass with or without #569 merged. The per-layer coverage *numbers* cited above only materialise on Codecov once #569 lands (because they depend on the dev-server pcov hook + merger pipeline that #569 introduces). Whichever PR lands first, the other will rebase cleanly.

## Test plan

- [x] `vendor/bin/phpunit phpunit_tests/Routes/Readonly/{Tests,Missals,Decrees}Test.php` — 12/12 pass against a live `php -S` server
- [x] `composer lint` clean
- [x] `composer analyse` (PHPStan level 10) clean
- [x] Full suite still passes (1000 tests, 150K assertions in our local stack run)

https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp


---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_