### PR TITLE
fix(tests): isolate LoginHandlerTest rate-limiter storage from HTTP server

### DIFF
--- a/phpunit_tests/Handlers/Auth/LoginHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/LoginHandlerTest.php
@@ -17,6 +17,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(LoginHandler::class)]
 final class LoginHandlerTest extends AbstractHandlerTestCase
 {
+    private ?string $savedRateLimitStoragePath  = null;
+    private static ?string $rateLimitStorageDir = null;
+
     /**
      * Each test gets a unique synthetic IP so the rate limiter doesn't carry
      * state between cases. The handler reads X-Forwarded-For when present.
@@ -30,9 +33,56 @@ final class LoginHandlerTest extends AbstractHandlerTestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        // Pin the rate-limit storage to a per-process isolated directory so
+        // failed-attempt records written by these in-process unit tests can
+        // never leak into the HTTP server's RateLimiter, which during CI
+        // shares the same sys_get_temp_dir(). Without this, when one of
+        // these tests happens to hash to an IP also used by the
+        // /auth/login integration tests in phpunit_tests/Routes/Auth/, the
+        // server reads a poisoned counter and the integration test trips
+        // its 5-attempt budget early.
+        if (self::$rateLimitStorageDir === null) {
+            self::$rateLimitStorageDir = sys_get_temp_dir()
+                . DIRECTORY_SEPARATOR
+                . 'litcal_unit_rate_limits_'
+                . getmypid()
+                . '_'
+                . bin2hex(random_bytes(4));
+        }
+        $existing                        = $_ENV['RATE_LIMIT_STORAGE_PATH'] ?? null;
+        $this->savedRateLimitStoragePath = is_string($existing) ? $existing : null;
+        $_ENV['RATE_LIMIT_STORAGE_PATH'] = self::$rateLimitStorageDir;
+
         // Clear any rate-limit state for this test's synthetic IP so consecutive
         // runs of this class don't interfere with each other.
         RateLimiterFactory::fromEnv()->clearAttempts($this->clientIp());
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->savedRateLimitStoragePath === null) {
+            unset($_ENV['RATE_LIMIT_STORAGE_PATH']);
+        } else {
+            $_ENV['RATE_LIMIT_STORAGE_PATH'] = $this->savedRateLimitStoragePath;
+        }
+        parent::tearDown();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        if (self::$rateLimitStorageDir !== null && is_dir(self::$rateLimitStorageDir)) {
+            $litcalDir = self::$rateLimitStorageDir . DIRECTORY_SEPARATOR . 'litcal_rate_limits';
+            if (is_dir($litcalDir)) {
+                foreach (glob($litcalDir . DIRECTORY_SEPARATOR . '*') ?: [] as $file) {
+                    @unlink($file);
+                }
+                @rmdir($litcalDir);
+            }
+            @rmdir(self::$rateLimitStorageDir);
+        }
+        self::$rateLimitStorageDir = null;
+        parent::tearDownAfterClass();
     }
 
     public function testOptionsPreflightSucceeds(): void


### PR DESCRIPTION
## Summary

Fixes the intermittent CI failure last seen on workflow run [25704528867](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/actions/runs/25704528867) (merged commit `3aae826`):

```text
1) LiturgicalCalendar\Tests\Routes\Auth\LoginRateLimitTest::testRateLimitingTriggeredAfterMaxAttempts
Expected 401 on attempt 5 of 5
Failed asserting that 429 matches expected 401.
phpunit_tests/Routes/Auth/LoginRateLimitTest.php:131
```

## Root cause

`LoginHandlerTest` runs in-process and uses `RateLimiterFactory::fromEnv()`, which falls back to `sys_get_temp_dir()` — the **same** `/tmp/litcal_rate_limits/` directory the dev HTTP server's rate-limiter reads from in CI.

- `testBadCredentialsAreUnauthorized` records 1 failed attempt at synthetic IP `192.0.2.<crc32(class|method|pid) % 100 + 1>`.
- `testRateLimitingTriggeredAfterMaxAttempts` deterministically hits `192.0.2.17` (from `crc32(method-name) % 99 + 1`).
- When the unit-test pid lands on a collision, the integration test sees 1 stale "attempt" in the file when it starts, so its 5th request trips the 5-attempt budget one early and returns 429 instead of 401.

Reproduced exactly by seeding `/tmp/litcal_rate_limits/<sha256(192.0.2.17)>.json` with a single fresh timestamp — same line:131, same message as in CI.

## Fix

Pin `$_ENV['RATE_LIMIT_STORAGE_PATH']` for the duration of `LoginHandlerTest` to a per-process subdirectory under `sys_get_temp_dir()`, restore it in `tearDown`, and clean up the subdirectory in `tearDownAfterClass`. The HTTP server never reads this path, so the unit tests can't poison the integration tests' counters no matter what the pid-dependent hash lands on.

## Test plan

- [x] Reproduced the failure locally by poisoning `/tmp/litcal_rate_limits/<sha256(192.0.2.17)>.json` — identical error at the same line
- [x] After the fix, `LoginHandlerTest` leaves no files in `/tmp/litcal_rate_limits/`
- [x] `vendor/bin/phpunit phpunit_tests/Handlers/Auth/ phpunit_tests/Routes/Auth/` — 52 tests, 151 assertions, all green
- [x] `composer lint` on the changed file — clean
- [x] `composer analyse` on the changed file — clean

https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp

---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test isolation for authentication-related tests by implementing dedicated temporary storage handling and proper cleanup procedures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/590)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->