### PR TITLE
test(coverage): cover src/Test/ via executeUnitTest WS action (#589)

### DIFF
--- a/phpunit_tests/Test/LitTestRunnerTest.php
+++ b/phpunit_tests/Test/LitTestRunnerTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Test;
+
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Test\LitTestRunner;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * In-process unit tests for LitTestRunner.
+ *
+ * Companion to phpunit_tests/WebSocket/ExecuteUnitTestTest.php — the
+ * WS-driven tests cover the happy paths and the setup-time errors that
+ * committed test JSONs can reach. The assertion-failure branches (event
+ * present when it should not be, date mismatch, event missing when it
+ * should be present) are awkward to trigger over WS because the calendar
+ * always reflects the current rules; here we synthesise mismatched
+ * data directly so the failure paths — and the `jsonData` attachment
+ * that goes with them — are exercised deterministically.
+ *
+ * Reads test instructions from the committed jsondata/tests/ folder via
+ * LitTestRunner's constructor (no fixtures needed), then feeds in
+ * hand-built calendar payloads.
+ */
+#[CoversClass(LitTestRunner::class)]
+final class LitTestRunnerTest extends TestCase
+{
+    private static string $savedApiFilePath = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        // LitTestRunner's constructor reads JsonData::TESTS_FOLDER->path(),
+        // which composes Router::$apiFilePath as a prefix. The static is
+        // typed and uninitialised when the production bootstrap hasn't
+        // run, so we pin it to the project root here for the duration
+        // of the class and restore it afterwards. Mirrors the pattern
+        // in phpunit_tests/Handlers/AbstractHandlerTestCase.
+        self::$savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        Router::$apiFilePath    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiFilePath = self::$savedApiFilePath;
+    }
+
+    /**
+     * Build a minimal calendar response with the given litcal events and year.
+     *
+     * The LitTestRunner only reads `settings->year`, optional
+     * `settings->national_calendar` / `settings->diocesan_calendar`, and
+     * the `litcal` array. Anything else gets passed through into the
+     * `jsonData` attachment but isn't inspected.
+     *
+     * @param array<int,\stdClass> $litcal
+     */
+    private function calendarPayload(int $year, array $litcal): \stdClass
+    {
+        return (object) [
+            'settings' => (object) ['year' => $year],
+            'litcal'   => $litcal,
+        ];
+    }
+
+    public function testEventExistsAndHasExpectedDateProducesSuccess(): void
+    {
+        // 2019: MaryMotherChurchTest expects MaryMotherChurch on 2019-06-10.
+        $data   = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2019-06-10T00:00:00+00:00'],
+        ]);
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $this->assertTrue($runner->isReady());
+        $runner->runTest();
+
+        $msg = $runner->getMessage();
+        $this->assertSame('success', $msg->type);
+        $this->assertSame('MaryMotherChurchTest', $msg->test);
+        $this->assertStringContainsString('expected_value = 2019-06-10', $msg->text);
+        $this->assertObjectNotHasProperty('jsonData', $msg);
+    }
+
+    public function testEventExistsButHasWrongDateAttachesJsonData(): void
+    {
+        // Same year (2019) but date deliberately off-by-one. Expected
+        // is 2019-06-10; provide 2019-06-11. LitTestRunner emits the
+        // "expected to have a date value of X, instead it had Y" branch
+        // and attaches jsonData.
+        $data   = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2019-06-11T00:00:00+00:00'],
+        ]);
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $msg = $runner->getMessage();
+        $this->assertSame('error', $msg->type);
+        $this->assertStringContainsString('2019-06-10', $msg->text);
+        $this->assertStringContainsString('2019-06-11', $msg->text);
+        $this->assertObjectHasProperty(
+            'jsonData',
+            $msg,
+            'Assertion-failure errors should carry the full calendar payload'
+        );
+        $this->assertSame($data, $msg->jsonData);
+    }
+
+    public function testEventExpectedButMissingAttachesJsonData(): void
+    {
+        // No MaryMotherChurch event at all in 2019's litcal — the runner
+        // hits the "should exist, instead it was not found" branch.
+        $data   = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'SomeOtherEvent', 'date' => '2019-06-10T00:00:00+00:00'],
+        ]);
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $msg = $runner->getMessage();
+        $this->assertSame('error', $msg->type);
+        $this->assertStringContainsString('should exist, instead it was not found', $msg->text);
+        $this->assertObjectHasProperty('jsonData', $msg);
+    }
+
+    public function testEventShouldNotExistButFoundAttachesJsonData(): void
+    {
+        // 2017 is in MaryMotherChurchTest's "eventNotExists" zone (the
+        // memorial wasn't yet instituted). Putting MaryMotherChurch in
+        // anyway should fail the assertion and attach jsonData.
+        $data   = $this->calendarPayload(2017, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2017-06-05T00:00:00+00:00'],
+        ]);
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $msg = $runner->getMessage();
+        $this->assertSame('error', $msg->type);
+        $this->assertStringContainsString('should not exist', $msg->text);
+        $this->assertObjectHasProperty('jsonData', $msg);
+    }
+
+    public function testOutOfBoundsYearProducesErrorWithoutJsonData(): void
+    {
+        // MaryMotherChurchTest has assertions for 2015–2019 only.
+        // Year 2099 is out of bounds → setup-time error, no jsonData.
+        $data   = $this->calendarPayload(2099, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2099-05-25T00:00:00+00:00'],
+        ]);
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $msg = $runner->getMessage();
+        $this->assertSame('error', $msg->type);
+        $this->assertStringContainsString('Out of bounds', $msg->text);
+        $this->assertObjectNotHasProperty('jsonData', $msg, 'Setup errors should not carry the full calendar payload');
+    }
+
+    public function testUnknownTestNameProducesErrorWithoutJsonData(): void
+    {
+        $data   = $this->calendarPayload(2019, []);
+        $runner = new LitTestRunner('Definitely_No_Such_Test_Definition_Xyz', $data);
+        $this->assertFalse($runner->isReady());
+
+        $msg = $runner->getMessage();
+        $this->assertSame('error', $msg->type);
+        $this->assertStringContainsString('could not read Test instructions', $msg->text);
+        $this->assertObjectNotHasProperty('jsonData', $msg);
+    }
+
+    public function testGetMessageWithoutRunningProducesFallbackError(): void
+    {
+        // Constructing a ready runner without calling runTest() leaves
+        // ::$Message null; getMessage() falls through to the fallback
+        // "unknown error" path. Setup-style, no jsonData.
+        $data   = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2019-06-10T00:00:00+00:00'],
+        ]);
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $this->assertTrue($runner->isReady());
+
+        $msg = $runner->getMessage();
+        $this->assertSame('error', $msg->type);
+        $this->assertStringContainsString('unknown error', $msg->text);
+        $this->assertObjectNotHasProperty('jsonData', $msg);
+    }
+
+    public function testNationalCalendarSettingsAppearInMessageText(): void
+    {
+        // When settings->national_calendar is present, the success
+        // message text mentions "the national calendar of <X>". Exercises
+        // LitTestRunner::getCalendarType() + ::getCalendarName().
+        $data                              = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2019-06-10T00:00:00+00:00'],
+        ]);
+        $data->settings->national_calendar = 'US';
+
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $msg = $runner->getMessage();
+        $this->assertSame('success', $msg->type);
+        $this->assertStringContainsString('Calendar US', $msg->text);
+    }
+
+    public function testDiocesanCalendarSettingsAppearInMessageText(): void
+    {
+        $data                              = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2019-06-10T00:00:00+00:00'],
+        ]);
+        $data->settings->diocesan_calendar = 'rotter_nl';
+
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $msg = $runner->getMessage();
+        $this->assertSame('success', $msg->type);
+        $this->assertStringContainsString('Calendar rotter_nl', $msg->text);
+    }
+}

--- a/phpunit_tests/Test/TestItemTest.php
+++ b/phpunit_tests/Test/TestItemTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Test;
+
+use LiturgicalCalendar\Api\Test\TestItem;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * In-process unit tests for TestItem.
+ *
+ * Companion to the WS-driven integration coverage in
+ * phpunit_tests/WebSocket/ExecuteUnitTestTest.php — the integration suite
+ * exercises only the happy paths each committed test JSON actually exposes
+ * (no file in jsondata/tests/ uses `year_until`, `excludes`, or the
+ * array-form `national_calendars` / `diocesan_calendars`, and none is
+ * deliberately malformed), so the validation throws here cover the gaps.
+ */
+#[CoversClass(TestItem::class)]
+final class TestItemTest extends TestCase
+{
+    /**
+     * @return \stdClass A minimal valid TestItem-compatible object.
+     */
+    private function baseObject(): \stdClass
+    {
+        return (object) [
+            'name'        => 'SampleTest',
+            'event_key'   => 'sample_event',
+            'description' => 'sample',
+            'test_type'   => 'exactCorrespondenceSince',
+            'assertions'  => [
+                (object) [
+                    'year'           => 2020,
+                    'expected_value' => null,
+                    'assert'         => 'eventNotExists',
+                    'assertion'      => 'a',
+                ],
+            ],
+        ];
+    }
+
+    public function testConstructsFromMinimalValidObject(): void
+    {
+        $item = new TestItem($this->baseObject());
+
+        $this->assertSame('SampleTest', $item->name);
+        $this->assertSame('sample_event', $item->event_key);
+        $this->assertSame('exactCorrespondenceSince', $item->test_type);
+        $this->assertNull($item->year_since);
+        $this->assertNull($item->year_until);
+        $this->assertNull($item->applies_to);
+        $this->assertNull($item->excludes);
+    }
+
+    public function testStoresOptionalYearBounds(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->year_since = 2011;
+        $obj->year_until = 2030;
+
+        $item = new TestItem($obj);
+
+        $this->assertSame(2011, $item->year_since);
+        $this->assertSame(2030, $item->year_until);
+    }
+
+    public function testStoresAppliesToAndExcludesObjects(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['national_calendar' => 'US'];
+        $obj->excludes   = (object) ['diocesan_calendar' => 'rotter_nl'];
+
+        $item = new TestItem($obj);
+
+        $this->assertIsObject($item->applies_to);
+        $this->assertSame('US', $item->applies_to->national_calendar);
+        $this->assertIsObject($item->excludes);
+        $this->assertSame('rotter_nl', $item->excludes->diocesan_calendar);
+    }
+
+    public function testAcceptsArrayFormNationalCalendars(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['national_calendars' => ['US', 'IT']];
+
+        $item = new TestItem($obj);
+
+        $this->assertIsObject($item->applies_to);
+        $this->assertSame(['US', 'IT'], $item->applies_to->national_calendars);
+    }
+
+    public function testAcceptsArrayFormDiocesanCalendars(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['diocesan_calendars' => ['rotter_nl', 'romamo_it']];
+
+        $item = new TestItem($obj);
+
+        $this->assertIsObject($item->applies_to);
+        $this->assertSame(['rotter_nl', 'romamo_it'], $item->applies_to->diocesan_calendars);
+    }
+
+    public function testThrowsOnMissingRequiredProperty(): void
+    {
+        $obj = $this->baseObject();
+        unset($obj->event_key);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required property: event_key');
+        new TestItem($obj);
+    }
+
+    public function testThrowsOnNonStringRequiredProperty(): void
+    {
+        $obj            = $this->baseObject();
+        $obj->test_type = 123;
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Property `test_type` must be a string');
+        new TestItem($obj);
+    }
+
+    public function testThrowsOnNonIntYearSince(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->year_since = '2011';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`year_since` must be an integer');
+        new TestItem($obj);
+    }
+
+    public function testThrowsOnNonIntYearUntil(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->year_until = '2030';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`year_until` must be an integer');
+        new TestItem($obj);
+    }
+
+    public function testThrowsOnNonObjectAppliesTo(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = 'US';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`applies_to` must be an object');
+        new TestItem($obj);
+    }
+
+    public function testThrowsOnNonObjectExcludes(): void
+    {
+        $obj           = $this->baseObject();
+        $obj->excludes = 'US';
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`excludes` must be an object');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenAppliesToHasNoRecognisedKey(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['unrelated_key' => 'whatever'];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`applies_to` must have at least one of the properties');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenNationalCalendarIsNotString(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['national_calendar' => 123];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`national_calendar` must have a string value');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenDiocesanCalendarIsNotString(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['diocesan_calendar' => 123];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`diocesan_calendar` must have a string value');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenNationalCalendarsIsNotArray(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['national_calendars' => 'US'];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`national_calendars` must have an array value');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenNationalCalendarsContainsNonString(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['national_calendars' => ['US', 123]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`national_calendars` must have an array of strings');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenDiocesanCalendarsIsNotArray(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['diocesan_calendars' => 'rotter_nl'];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`diocesan_calendars` must have an array value');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenDiocesanCalendarsContainsNonString(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['diocesan_calendars' => ['rotter_nl', 0]];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`diocesan_calendars` must have an array of strings');
+        new TestItem($obj);
+    }
+}

--- a/phpunit_tests/Test/TestsMapTest.php
+++ b/phpunit_tests/Test/TestsMapTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Test;
+
+use LiturgicalCalendar\Api\Test\TestsMap;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Companion unit tests for TestsMap that exercise the lookup branches that
+ * the WS-driven integration tests skip — `get()` (covered indirectly via
+ * the WS path) plus the negative paths of `has()`, `isReady()`,
+ * `retrieveAssertionForYear()`, and `getYearsSupported()`.
+ */
+#[CoversClass(TestsMap::class)]
+final class TestsMapTest extends TestCase
+{
+    private function buildAssertion(int $year): \stdClass
+    {
+        return (object) [
+            'year'           => $year,
+            'expected_value' => null,
+            'assert'         => 'eventNotExists',
+            'assertion'      => 'note',
+        ];
+    }
+
+    private function buildTestObject(string $name, int ...$years): \stdClass
+    {
+        $assertions = [];
+        foreach ($years as $y) {
+            $assertions[] = $this->buildAssertion($y);
+        }
+        return (object) [
+            'name'        => $name,
+            'event_key'   => 'evt',
+            'description' => 'd',
+            'test_type'   => 'exactCorrespondenceSince',
+            'assertions'  => $assertions,
+        ];
+    }
+
+    public function testHasReturnsFalseForUnknownTest(): void
+    {
+        $map = new TestsMap();
+
+        $this->assertFalse($map->has('Nope'));
+        $this->assertFalse($map->isReady('Nope'));
+    }
+
+    public function testAddPopulatesHasIsReadyAndGetYearsSupported(): void
+    {
+        $map = new TestsMap();
+        $map->add('SampleTest', $this->buildTestObject('SampleTest', 2018, 2019, 2020));
+
+        $this->assertTrue($map->has('SampleTest'));
+        $this->assertTrue($map->isReady('SampleTest'));
+        $this->assertSame([2018, 2019, 2020], $map->getYearsSupported('SampleTest'));
+    }
+
+    public function testGetReturnsTheUnderlyingTestItem(): void
+    {
+        $map = new TestsMap();
+        $map->add('SampleTest', $this->buildTestObject('SampleTest', 2020));
+
+        $item = $map->get('SampleTest');
+        $this->assertSame('SampleTest', $item->name);
+    }
+
+    public function testRetrieveAssertionForKnownYearReturnsTheAssertion(): void
+    {
+        $map = new TestsMap();
+        $map->add('SampleTest', $this->buildTestObject('SampleTest', 2018, 2019, 2020));
+
+        $assertion = $map->retrieveAssertionForYear('SampleTest', 2019);
+        $this->assertNotNull($assertion);
+        $this->assertSame(2019, $assertion->year);
+    }
+
+    public function testRetrieveAssertionForUnknownYearReturnsNull(): void
+    {
+        $map = new TestsMap();
+        $map->add('SampleTest', $this->buildTestObject('SampleTest', 2018));
+
+        $this->assertNull($map->retrieveAssertionForYear('SampleTest', 1999));
+    }
+
+    public function testRetrieveAssertionForUnknownTestReturnsNull(): void
+    {
+        $map = new TestsMap();
+
+        $this->assertNull($map->retrieveAssertionForYear('Nope', 2020));
+    }
+
+    public function testIsReadyReturnsFalseForEmptyAssertions(): void
+    {
+        $map = new TestsMap();
+        $map->add('NoAssertions', $this->buildTestObject('NoAssertions'));
+
+        $this->assertTrue($map->has('NoAssertions'));
+        $this->assertFalse($map->isReady('NoAssertions'), 'A test with no assertions should not be considered ready');
+    }
+}

--- a/phpunit_tests/WebSocket/ExecuteUnitTestTest.php
+++ b/phpunit_tests/WebSocket/ExecuteUnitTestTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\WebSocket;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the executeUnitTest WebSocket action.
+ *
+ * This is the only entry point that reaches src/Test/ — LitTestRunner is
+ * instantiated only inside Health::executeUnitTest(), which is invoked via
+ * the Ratchet WebSocket handler at public/LitCalTestServer.php. Driving it
+ * here closes the 0% coverage gap on src/Test/ that was called out in
+ * issue #589 (follow-up to #588).
+ *
+ * Flow: the action triggers an internal HTTP call back into the API server
+ * (`/calendar/<year>?year_type=CIVIL` for the Vatican universal calendar),
+ * then constructs a LitTestRunner around the decoded response and runs the
+ * assertion for the requested year. The single reply frame carries
+ * `type: success` or `type: error`.
+ *
+ * Skipped automatically when either ws://127.0.0.1:8082 or
+ * http://127.0.0.1:8000 is unreachable, because the action needs both to
+ * complete a roundtrip.
+ */
+final class ExecuteUnitTestTest extends TestCase
+{
+    private string $wsHost;
+    private int $wsPort;
+    private string $apiHost;
+    private int $apiPort;
+
+    protected function setUp(): void
+    {
+        $this->wsHost  = (string) ( $_ENV['WS_HOST'] ?? '127.0.0.1' );
+        $this->wsPort  = (int) ( $_ENV['WS_PORT'] ?? 8082 );
+        $this->apiHost = (string) ( $_ENV['API_HOST'] ?? '127.0.0.1' );
+        $this->apiPort = (int) ( $_ENV['API_PORT'] ?? 8000 );
+
+        $wsProbe = @stream_socket_client(
+            sprintf('tcp://%s:%d', $this->wsHost, $this->wsPort),
+            $_e,
+            $_m,
+            1.0
+        );
+        if ($wsProbe === false) {
+            $this->markTestSkipped(
+                sprintf('WS server not reachable on %s:%d — start it with `composer ws:start`.', $this->wsHost, $this->wsPort)
+            );
+        }
+        fclose($wsProbe);
+
+        $apiProbe = @stream_socket_client(
+            sprintf('tcp://%s:%d', $this->apiHost, $this->apiPort),
+            $_e,
+            $_m,
+            1.0
+        );
+        if ($apiProbe === false) {
+            $this->markTestSkipped(
+                sprintf(
+                    'HTTP API not reachable on %s:%d — start it with `composer start`. '
+                    . 'executeUnitTest needs both the WS server AND the HTTP API.',
+                    $this->apiHost,
+                    $this->apiPort
+                )
+            );
+        }
+        fclose($apiProbe);
+    }
+
+    /**
+     * Connect, send an executeUnitTest payload, and read until a frame
+     * arrives that looks like the response (carries a `type` key). 30s
+     * read timeout because the WS handler dispatches an internal HTTP
+     * call before replying, and pcov instrumentation slows that path on
+     * the CI runner.
+     *
+     * @param array<string,mixed> $payload
+     */
+    private function executeUnitTest(array $payload): \stdClass
+    {
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 30.0);
+        try {
+            $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
+            $client->sendText($encoded);
+            $reply = $client->receiveText();
+        } finally {
+            $client->close();
+        }
+
+        $decoded = json_decode($reply);
+        $this->assertInstanceOf(\stdClass::class, $decoded, 'WS reply should decode as a JSON object. Got: ' . substr($reply, 0, 200));
+        $this->assertObjectHasProperty('type', $decoded, 'WS reply missing `type` key. Body starts: ' . substr($reply, 0, 200));
+
+        return $decoded;
+    }
+
+    public function testHappyPathRunsLitTestRunnerAndReportsSuccess(): void
+    {
+        // MaryMotherChurchTest has explicit assertions for years 2015–2019.
+        // Year 2019 with the Vatican universal calendar exercises the
+        // LitTestRunner happy path (eventExists AND hasExpectedDate).
+        $reply = $this->executeUnitTest([
+            'action'   => 'executeUnitTest',
+            'category' => 'nationalcalendar',
+            'calendar' => 'VA',
+            'year'     => 2019,
+            'test'     => 'MaryMotherChurchTest',
+        ]);
+
+        $this->assertSame('success', $reply->type, 'Expected success for year=2019. Got: ' . ( $reply->text ?? '(no text)' ));
+        $this->assertObjectHasProperty('test', $reply);
+        $this->assertSame('MaryMotherChurchTest', $reply->test);
+        $this->assertObjectHasProperty('classes', $reply);
+        $this->assertSame('.MaryMotherChurchTest.year-2019.test-valid', $reply->classes);
+        $this->assertObjectHasProperty('text', $reply);
+        $this->assertStringContainsString('MaryMotherChurchTest passed', $reply->text);
+        // The success path does NOT attach jsonData — see Test/LitTestRunner::setMessage().
+        $this->assertObjectNotHasProperty('jsonData', $reply);
+    }
+
+    public function testOutOfBoundsYearReportsError(): void
+    {
+        // 2020 has no explicit assertion in MaryMotherChurchTest.json
+        // (assertions stop at 2019). TestsMap::retrieveAssertionForYear()
+        // returns null and LitTestRunner::runTest() emits the
+        // "Out of bounds error" branch. This is a config-time error, not
+        // an assertion failure, so the reply does NOT embed the calendar
+        // jsonData — that attachment is reserved for actual assertion
+        // mismatches (see Test\LitTestRunnerTest::test...AssertionFailure
+        // for the path that does carry jsonData).
+        $reply = $this->executeUnitTest([
+            'action'   => 'executeUnitTest',
+            'category' => 'nationalcalendar',
+            'calendar' => 'VA',
+            'year'     => 2020,
+            'test'     => 'MaryMotherChurchTest',
+        ]);
+
+        $this->assertSame('error', $reply->type);
+        $this->assertObjectHasProperty('text', $reply);
+        $this->assertStringContainsString('Out of bounds', $reply->text);
+        $this->assertStringContainsString('MaryMotherChurchTest', $reply->text);
+        $this->assertObjectHasProperty('classes', $reply);
+        $this->assertSame('.MaryMotherChurchTest.year-2020.test-valid', $reply->classes);
+        $this->assertObjectNotHasProperty('jsonData', $reply, 'Out-of-bounds (setup-time) errors should not carry the full calendar payload');
+    }
+
+    public function testUnknownTestNameReportsError(): void
+    {
+        // A test name that has no JSON definition in jsondata/tests/
+        // makes the LitTestRunner constructor fall through to the
+        // "could not read Test instructions" branch (file_exists() false).
+        // Setup-time error: no jsonData attached.
+        $reply = $this->executeUnitTest([
+            'action'   => 'executeUnitTest',
+            'category' => 'nationalcalendar',
+            'calendar' => 'VA',
+            'year'     => 2019,
+            'test'     => 'NoSuchTest_Xyz_589',
+        ]);
+
+        $this->assertSame('error', $reply->type);
+        $this->assertObjectHasProperty('text', $reply);
+        $this->assertStringContainsString('could not read Test instructions', $reply->text);
+        $this->assertStringContainsString('NoSuchTest_Xyz_589', $reply->text);
+        $this->assertObjectHasProperty('test', $reply);
+        $this->assertSame('NoSuchTest_Xyz_589', $reply->test);
+        $this->assertObjectNotHasProperty('jsonData', $reply);
+    }
+
+    public function testDiocesanCalendarTestPassesAndExercisesDiocesanAppliesTo(): void
+    {
+        // rotter_nl_HLaurentiusdiakenenmartelaarpatroonvanhetbisdomTest.json
+        // carries `applies_to: {diocesan_calendar: "rotter_nl"}`, which is the
+        // mirror branch of PrayerUnbornTest's national_calendar arm in
+        // TestItem::checkAppliesToExcludesConditions(). Together they cover
+        // both single-calendar specifiers; the array-form properties
+        // (national_calendars / diocesan_calendars) are still better suited
+        // to direct unit tests since no committed test JSON uses them.
+        //
+        // Drives the diocesancalendar arm of buildCalendarRequestPath()
+        // in Health.php for free.
+        $reply = $this->executeUnitTest([
+            'action'   => 'executeUnitTest',
+            'category' => 'diocesancalendar',
+            'calendar' => 'rotter_nl',
+            'year'     => 2020,
+            'test'     => 'rotter_nl_HLaurentiusdiakenenmartelaarpatroonvanhetbisdomTest',
+        ]);
+
+        $this->assertSame('success', $reply->type, 'Expected success. Got: ' . ( $reply->text ?? '(no text)' ));
+        $this->assertObjectHasProperty('test', $reply);
+        $this->assertSame('rotter_nl_HLaurentiusdiakenenmartelaarpatroonvanhetbisdomTest', $reply->test);
+        $this->assertObjectHasProperty('text', $reply);
+        $this->assertStringContainsString('passed for the Calendar rotter_nl', $reply->text);
+    }
+
+    public function testNationSpecificTestPassesAndExercisesAppliesTo(): void
+    {
+        // PrayerUnbornTest.json carries `year_since: 2011` and
+        // `applies_to: {national_calendar: "US"}`, so loading it through
+        // the WS handler hits TestItem's optional-property paths
+        // (year_since branch + applies_to validation +
+        // checkAppliesToExcludesConditions's `national_calendar` arm)
+        // that MaryMotherChurchTest doesn't touch.
+        //
+        // 2020 falls in the test's explicit assertions and Jan 22 is a
+        // Wednesday in 2020 (no Sunday/solemnity collision), so the
+        // assertion compares against 2020-01-22.
+        $reply = $this->executeUnitTest([
+            'action'   => 'executeUnitTest',
+            'category' => 'nationalcalendar',
+            'calendar' => 'US',
+            'year'     => 2020,
+            'test'     => 'PrayerUnbornTest',
+        ]);
+
+        $this->assertSame('success', $reply->type, 'Expected success. Got: ' . ( $reply->text ?? '(no text)' ));
+        $this->assertObjectHasProperty('test', $reply);
+        $this->assertSame('PrayerUnbornTest', $reply->test);
+        $this->assertObjectHasProperty('classes', $reply);
+        $this->assertSame('.PrayerUnbornTest.year-2020.test-valid', $reply->classes);
+        $this->assertObjectHasProperty('text', $reply);
+        $this->assertStringContainsString('PrayerUnbornTest passed', $reply->text);
+    }
+}

--- a/phpunit_tests/WebSocket/WsTestClient.php
+++ b/phpunit_tests/WebSocket/WsTestClient.php
@@ -18,7 +18,9 @@ namespace LiturgicalCalendar\Tests\WebSocket;
  *
  * Binary frames, continuation frames, fragmented payloads, ping/pong, and
  * frames > 65535 bytes are NOT supported. None of those are needed by the
- * Health WebSocket handler we're exercising.
+ * Health WebSocket handler we're exercising — its replies are slim
+ * `{type, text, classes, test}` objects since #589 trimmed the `jsonData`
+ * payload from non-assertion error frames.
  */
 final class WsTestClient
 {

--- a/src/Test/LitTestRunner.php
+++ b/src/Test/LitTestRunner.php
@@ -189,7 +189,7 @@ class LitTestRunner
                         $errorMessage = is_null($assertion->expected_value)
                             ? " The event {$eventKey} should not exist, instead the event has a date value of {$eventBeingTested->date}"
                             : " What is going on here? We expected the event not to exist, and in fact it doesn't. We should never get here!";
-                        $this->setError($messageIfError . $errorMessage);
+                        $this->setAssertionFailure($messageIfError . $errorMessage);
                     }
                     break;
                 case LitEventTestAssertion::EVENT_EXISTS_AND_HAS_EXPECTED_DATE:
@@ -200,10 +200,10 @@ class LitTestRunner
                         if ($actualValue === $assertion->expected_value) {
                             $this->setSuccess("expected_value = {$assertion->expected_value}, actualValue = {$actualValue}");
                         } else {
-                            $this->setError($messageIfError . $secondErrorMessage);
+                            $this->setAssertionFailure($messageIfError . $secondErrorMessage);
                         }
                     } else {
-                        $this->setError($messageIfError . $firstErrorMessage);
+                        $this->setAssertionFailure($messageIfError . $firstErrorMessage);
                     }
                     break;
                 default:
@@ -240,10 +240,17 @@ class LitTestRunner
     /**
      * Sets the message details based on the provided type and optional text. Called by {@see \LiturgicalCalendar\Api\Test\LitTestRunner::setError()} and {@see \LiturgicalCalendar\Api\Test\LitTestRunner::setSuccess()}.
      *
-     * @param string $type The type of the message ('success' or 'error').
-     * @param string|null $text The optional text to include in the message.
+     * The `$attachJsonData` flag is set only by
+     * {@see \LiturgicalCalendar\Api\Test\LitTestRunner::setAssertionFailure()},
+     * which is the only error path that needs the diagnostic calendar
+     * payload attached to the reply. Setup-time and configuration errors
+     * leave it off so reply frames stay small.
+     *
+     * @param string      $type           The type of the message ('success' or 'error').
+     * @param string|null $text           The optional text to include in the message.
+     * @param bool        $attachJsonData When true, attaches `$this->dataToTest` to `jsonData`.
      */
-    private function setMessage(string $type, ?string $text = null): void
+    private function setMessage(string $type, ?string $text = null, bool $attachJsonData = false): void
     {
         $this->Message          = new \stdClass();
         $this->Message->type    = $type;
@@ -256,8 +263,10 @@ class LitTestRunner
                 $this->Message->text = "$this->Test passed for the Calendar {$this->getCalendarName()} for the year {$this->dataToTest->settings->year}: " . $text;
             }
         } else {
-            $this->Message->text     = $text;
-            $this->Message->jsonData = $this->dataToTest;
+            $this->Message->text = $text;
+            if ($attachJsonData) {
+                $this->Message->jsonData = $this->dataToTest;
+            }
         }
     }
 
@@ -272,6 +281,28 @@ class LitTestRunner
     private function setError(string $text): void
     {
         $this->setMessage('error', $text);
+    }
+
+    /**
+     * Sets the message to be an assertion-failure error and attaches the
+     * full calendar payload to the message under `jsonData`. The frontend
+     * UnitTestInterface uses this attachment to show the actual server
+     * response when the asserted event isn't where it should be (or is
+     * present when it shouldn't be).
+     *
+     * Used only from the three assertion-mismatch branches in
+     * {@see \LiturgicalCalendar\Api\Test\LitTestRunner::runTest()}. Setup-
+     * and configuration-time errors (test-instructions missing, schema
+     * mismatch, out-of-bounds year, internal-state mismatch) call
+     * {@see \LiturgicalCalendar\Api\Test\LitTestRunner::setError()}
+     * instead — those replies would have carried ~450 KB of irrelevant
+     * calendar JSON on every error message.
+     *
+     * @param string $text The text of the assertion-failure error message.
+     */
+    private function setAssertionFailure(string $text): void
+    {
+        $this->setMessage('error', $text, true);
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #589 — `src/Test/` was the last `src/` layer still at 0% coverage after #586/#587/#588.

## Background

`LitTestRunner` is instantiated only inside `Health::executeUnitTest()` (`src/Health.php:1239`), invoked through the Ratchet WS handler. The 4th test sketched in #588 (`testExecuteUnitTestRunsLitTestRunner`) was dropped after seeing the server log

```text
An error has occurred: Unable to write to stream: fwrite(): Send of 4 bytes failed with errno=32 Broken pipe
```

…and assuming a Ratchet event-loop/promise timing race. The real cause was simpler:

`LitTestRunner::setMessage()` unconditionally attached `$this->dataToTest` (the full calendar, ~450 KB) to every error reply. `WsTestClient::receiveText()` capped at 65535 bytes (RFC 6455 length≤125 → 16-bit length), threw before reading the frame, and closed mid-send. The "Send of 4 bytes" was the server's WS frame *header* write going to a half-dead socket.

## What changed

This PR fixes the underlying bloat instead of extending the client to swallow huge frames.

**`src/Test/LitTestRunner.php`** — split the error path:

- New `setAssertionFailure()` (used only by the three assertion-mismatch branches in `runTest()`) attaches `jsonData` so the frontend can show the actual server response when an asserted event isn't where it should be.
- `setError()` stays slim for setup-time errors (test instructions missing, schema mismatch, out-of-bounds year, internal-state issues). These gain nothing from a 450 KB attachment.
- `setMessage()` gains an `$attachJsonData` flag (default false).

**Behavior change for WS consumers**: error-typed replies from `executeUnitTest` no longer carry `jsonData` unless they describe an actual assertion failure. Coordinate with the `UnitTestInterface` frontend before relying on `jsonData` for non-failure error displays.

**Tests added:**

- `phpunit_tests/WebSocket/ExecuteUnitTestTest.php` — 5 WS integration tests
  - happy path, out-of-bounds year (no `jsonData`), unknown test name (no `jsonData`), national-calendar test (PrayerUnbornTest year=2020), diocesan-calendar test (rotter_nl)
  - skip cleanly when either WS (:8082) or HTTP API (:8000) is down

- `phpunit_tests/Test/LitTestRunnerTest.php` — 9 in-process unit tests
  - exercises the three assertion-failure branches (with `jsonData`) using synthetic mismatched data, plus the setup-time paths (without `jsonData`)
  - WS round-trip can't easily craft a date mismatch since the live calendar always reflects the correct rules

- `phpunit_tests/Test/TestItemTest.php` — 18 unit tests for `TestItem` validation paths and array-form `national_calendars` / `diocesan_calendars` (no committed test JSON uses these)

- `phpunit_tests/Test/TestsMapTest.php` — 7 unit tests for `TestsMap` lookup/negative paths

`WsTestClient` is unchanged from #588 — no RFC 6455 64-bit-length frame support needed.

## Coverage lift on `src/Test/`

| File | Before | After |
|------|-------:|------:|
| `AssertionCollection.php` | 0/3 (0%) | 3/3 (**100%**) |
| `AssertionItem.php` | 0/21 (0%) | 15/21 (**71.4%**) |
| `LitTestRunner.php` | 0/86 (0%) | 73/88 (**83.0%**) |
| `TestItem.php` | 0/50 (0%) | 50/50 (**100%**) |
| `TestsMap.php` | 0/18 (0%) | 18/18 (**100%**) |
| **TOTAL** | **0/178 (0.0%)** | **159/180 (88.3%)** |

Acceptance criteria from #589:

- [x] `src/Test/` ≥ 70% statement coverage — **88.3%**
- [x] At least one happy-path + one error-path test for `executeUnitTest` — 1 happy + 2 setup-error + 2 more happy paths over WS, plus 4 assertion-failure paths via the in-process unit test
- [ ] No flake — three consecutive CI runs on `development` stay green — will verify once merged

## Test plan

- [x] `vendor/bin/phpunit phpunit_tests/Test/ phpunit_tests/WebSocket/` — 42 tests, 143 assertions, green
- [x] `composer lint` on changed files — clean
- [x] `composer analyse` (PHPStan level 10, src/ only) — clean
- [x] Coverage measured locally with both servers up + pcov bootstrap hook → 88.3% on `src/Test/`

https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp