### PR TITLE
ci(coverage): set APP_ENV=test so server-side pcov hooks fire

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -83,6 +83,12 @@ jobs:
       - name: Configure environment for testing
         run: |
           cp .env.example .env.local
+          # Override APP_ENV to 'test' so the pcov bootstrap hooks in
+          # public/index.php + public/LitCalTestServer.php fire — both gate
+          # on APP_ENV === 'test'. Without this we silently fall back to
+          # PHPUnit's in-process coverage only, since .env.example ships
+          # APP_ENV=development.
+          echo "APP_ENV=test" >> .env.local
           echo "UNAUTHENTICATED_RATE_LIMIT=999999" >> .env.local
           echo "DB_HOST=localhost" >> .env.local
           echo "DB_PORT=5432" >> .env.local
@@ -186,7 +192,13 @@ jobs:
               echo '```'
               mv coverage.merged.xml coverage.xml
             else
-              echo "_No server-side pcov dumps to merge; using PHPUnit coverage as-is._"
+              echo "> [!WARNING]"
+              echo "> **No server-side pcov dumps were produced.** Coverage will reflect PHPUnit's in-process"
+              echo "> coverage only — the HTTP- and WS-driven integration tests in phpunit_tests/Routes/"
+              echo "> and phpunit_tests/WebSocket/ won't contribute. This usually means the pcov bootstrap"
+              echo "> hook in public/index.php / public/LitCalTestServer.php didn't fire. Check that"
+              echo "> APP_ENV=test is set in .env.local and that PCOV_SERVER_COVERAGE_DIR is exported"
+              echo "> when starting both servers."
             fi
             echo ""
           } | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Closes the **20-point coverage gap** between local runs and Codecov uploads. Locally the suite measures **61.4%**; Codecov has been reporting **~41%** since #586 landed. The cause was entirely environmental:

- `public/index.php` and `public/LitCalTestServer.php` both gate the pcov bootstrap hook on `APP_ENV === 'test'` (intent: stay dormant in production / development).
- The CI workflow does `cp .env.example .env.local` and `.env.example` ships `APP_ENV=development`.
- So in CI, neither bootstrap fires → no server-side pcov dumps → the merge step falls through to `_No server-side pcov dumps to merge; using PHPUnit coverage as-is._` → the HTTP- and WS-driven integration tests in `phpunit_tests/Routes/` and `phpunit_tests/WebSocket/` contribute nothing.

My local `.env.local` has `APP_ENV=test`, which is why the same suite measures 61.4% on this host.

## Changes

`.github/workflows/phpunit.yml`:

1. Append `APP_ENV=test` to `.env.local` in the "Configure environment for testing" step.

2. Upgrade the "no server-side dumps" fallback message in the merge step from an italicised note to a GitHub admonition (`> [!WARNING]`) with a pointer to the two likely root causes. Same regression should never land silently again.

No source / test changes — the harness was already correct; only the CI invocation was broken.

## Expected outcome

After this lands, Codecov should jump from ~41% to ~61% on `development` (matching what `composer test:coverage` produces locally with the same env). The next coverage push (issue #589 + sibling WS actions, write-path tests, etc.) will start from a real baseline.

## Test plan

- [ ] CI green on this PR (PHPUnit job in particular)
- [ ] Workflow summary on the PR's CI run shows `Merged N pcov dump(s) ... lifted M previously-uncovered line(s)` (not the warning fallback)
- [ ] Codecov delta on this PR shows a ~20pp jump

https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp

---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_