### PR TITLE
test(coverage): cover validateCalendar + executeValidation WS actions (#589)

### DIFF
--- a/phpunit_tests/WebSocket/ExecuteValidationTest.php
+++ b/phpunit_tests/WebSocket/ExecuteValidationTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\WebSocket;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the executeValidation WebSocket action.
+ *
+ * `executeValidation` is the second of the three async actions on the
+ * Ratchet handler in src/Health.php (alongside `executeUnitTest` and
+ * `validateCalendar`). It validates that:
+ *
+ *   - a JSON file on disk (`category: 'sourceDataCheck'`,
+ *     `sourceFile: <identifier>`) exists, is JSON, and conforms to
+ *     its JSON Schema; OR
+ *   - a folder of i18n JSON files (`sourceFolder: <identifier>`) all
+ *     decode and validate; OR
+ *   - a resource served by the API (`category: 'resourceDataCheck'`,
+ *     `sourceFile: <URL>`) decodes and matches a schema.
+ *
+ * Each scenario emits a sequence of frames (`file-exists`,
+ * `json-valid`, `schema-valid`, plus a final `validation` summary in
+ * the folder case). The handler short-circuits at the failing step on
+ * error. Three of the four scenarios below exercise stable, committed
+ * paths in jsondata/sourcedata/.
+ *
+ * Skipped automatically when either ws://127.0.0.1:8082 or
+ * http://127.0.0.1:8000 is unreachable — the WS server may fan out to
+ * the HTTP API for resourceDataCheck.
+ */
+final class ExecuteValidationTest extends TestCase
+{
+    private string $wsHost;
+    private int $wsPort;
+    private string $apiHost;
+    private int $apiPort;
+
+    protected function setUp(): void
+    {
+        $this->wsHost  = (string) ( $_ENV['WS_HOST'] ?? '127.0.0.1' );
+        $this->wsPort  = (int) ( $_ENV['WS_PORT'] ?? 8082 );
+        $this->apiHost = (string) ( $_ENV['API_HOST'] ?? '127.0.0.1' );
+        $this->apiPort = (int) ( $_ENV['API_PORT'] ?? 8000 );
+
+        $wsProbe = @stream_socket_client(sprintf('tcp://%s:%d', $this->wsHost, $this->wsPort), $_e, $_m, 1.0);
+        if ($wsProbe === false) {
+            $this->markTestSkipped(
+                sprintf('WS server not reachable on %s:%d — start it with `composer ws:start`.', $this->wsHost, $this->wsPort)
+            );
+        }
+        fclose($wsProbe);
+
+        $apiProbe = @stream_socket_client(sprintf('tcp://%s:%d', $this->apiHost, $this->apiPort), $_e, $_m, 1.0);
+        if ($apiProbe === false) {
+            $this->markTestSkipped(
+                sprintf('HTTP API not reachable on %s:%d — start it with `composer start`.', $this->apiHost, $this->apiPort)
+            );
+        }
+        fclose($apiProbe);
+    }
+
+    /**
+     * Read up to `$expectedFrames` frames or until the socket times out.
+     *
+     * @param array<string,mixed> $payload
+     * @return array<int,\stdClass>
+     */
+    private function executeValidation(array $payload, int $expectedFrames): array
+    {
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 30.0);
+        try {
+            $client->sendText(json_encode($payload, JSON_THROW_ON_ERROR));
+
+            $frames = [];
+            for ($i = 0; $i < $expectedFrames; $i++) {
+                $reply   = $client->receiveText();
+                $decoded = json_decode($reply);
+                $this->assertInstanceOf(\stdClass::class, $decoded, "Frame {$i} did not decode as JSON: " . substr($reply, 0, 200));
+                $this->assertObjectHasProperty('type', $decoded, "Frame {$i} missing `type`");
+                $frames[] = $decoded;
+            }
+            return $frames;
+        } finally {
+            $client->close();
+        }
+    }
+
+    public function testSourceDataCheckPropriumDeSanctis1970IsValid(): void
+    {
+        // The 1970 Editio Typica's Sanctorale ships in the repo and is
+        // schema-valid by construction. Exercises the
+        // proprium-de-sanctis-<year> branch of executeValidation's
+        // sourceDataCheck path (including the regex match on the
+        // `validate` field and the RomanMissal::getSanctoraleFileName
+        // resolution).
+        $frames = $this->executeValidation([
+            'action'     => 'executeValidation',
+            'category'   => 'sourceDataCheck',
+            'validate'   => 'proprium-de-sanctis-1970',
+            'sourceFile' => 'proprium-de-sanctis-1970',
+        ], 3);
+
+        $this->assertSame('success', $frames[0]->type);
+        $this->assertSame('.proprium-de-sanctis-1970.file-exists', $frames[0]->classes);
+        $this->assertSame('success', $frames[1]->type);
+        $this->assertSame('.proprium-de-sanctis-1970.json-valid', $frames[1]->classes);
+        $this->assertSame('success', $frames[2]->type);
+        $this->assertSame('.proprium-de-sanctis-1970.schema-valid', $frames[2]->classes);
+    }
+
+    public function testResourceDataCheckMetadataDecodesAsJson(): void
+    {
+        // resourceDataCheck against the /metadata endpoint hits the
+        // schema-lookup arm that the sourceDataCheck path doesn't.
+        // (The third frame ends up as a schema-detection error in this
+        // setup since the validate-key→schema map doesn't expose the
+        // metadata schema by URL — but the first two frames are stable
+        // and exercise the resourceDataCheck branch deterministically.)
+        $frames = $this->executeValidation([
+            'action'     => 'executeValidation',
+            'category'   => 'resourceDataCheck',
+            'validate'   => 'metadata',
+            'sourceFile' => sprintf('http://%s:%d/metadata', $this->apiHost, $this->apiPort),
+        ], 2);
+
+        $this->assertSame('success', $frames[0]->type);
+        $this->assertSame('.metadata.file-exists', $frames[0]->classes);
+        $this->assertStringContainsString('/metadata', $frames[0]->text);
+
+        $this->assertSame('success', $frames[1]->type);
+        $this->assertSame('.metadata.json-valid', $frames[1]->classes);
+        $this->assertStringContainsString('decoded as JSON', $frames[1]->text);
+    }
+
+    public function testMissingSourceFileReturnsEchobotValidationError(): void
+    {
+        // executeValidation requires `sourceFile` (or `sourceFolder`).
+        // Omitting both should be rejected by validateMessageProperties()
+        // before the action dispatches, so the reply is the standard
+        // "echobot"-typed validation-error envelope rather than a
+        // sequence of per-phase frames.
+        $frames = $this->executeValidation([
+            'action'   => 'executeValidation',
+            'category' => 'resourceDataCheck',
+            'validate' => 'metadata',
+        ], 1);
+
+        $this->assertSame('echobot', $frames[0]->type);
+        $this->assertObjectHasProperty('errorMsg', $frames[0]);
+        $this->assertNotEmpty($frames[0]->errorMsg);
+    }
+}

--- a/phpunit_tests/WebSocket/ExecuteValidationTest.php
+++ b/phpunit_tests/WebSocket/ExecuteValidationTest.php
@@ -77,7 +77,7 @@ final class ExecuteValidationTest extends TestCase
             $frames = [];
             for ($i = 0; $i < $expectedFrames; $i++) {
                 $reply   = $client->receiveText();
-                $decoded = json_decode($reply);
+                $decoded = json_decode($reply, false, 512, JSON_THROW_ON_ERROR);
                 $this->assertInstanceOf(\stdClass::class, $decoded, "Frame {$i} did not decode as JSON: " . substr($reply, 0, 200));
                 $this->assertObjectHasProperty('type', $decoded, "Frame {$i} missing `type`");
                 $frames[] = $decoded;

--- a/phpunit_tests/WebSocket/ValidateCalendarTest.php
+++ b/phpunit_tests/WebSocket/ValidateCalendarTest.php
@@ -82,7 +82,7 @@ final class ValidateCalendarTest extends TestCase
             $frames = [];
             for ($i = 0; $i < $expectedFrames; $i++) {
                 $reply   = $client->receiveText();
-                $decoded = json_decode($reply);
+                $decoded = json_decode($reply, false, 512, JSON_THROW_ON_ERROR);
                 $this->assertInstanceOf(\stdClass::class, $decoded, "Frame {$i} did not decode as JSON: " . substr($reply, 0, 200));
                 $this->assertObjectHasProperty('type', $decoded, "Frame {$i} missing `type`");
                 $frames[] = $decoded;

--- a/phpunit_tests/WebSocket/ValidateCalendarTest.php
+++ b/phpunit_tests/WebSocket/ValidateCalendarTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\WebSocket;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests for the validateCalendar WebSocket action.
+ *
+ * `validateCalendar` is one of the three async actions on the Ratchet
+ * WebSocket handler in src/Health.php. It fetches a calendar from the
+ * HTTP API (`Route::CALENDAR->path() . /<year>?year_type=CIVIL` or the
+ * `/nation/<X>/<year>` / `/diocese/<X>/<year>` variants), then runs
+ * format-specific validation against the appropriate schema:
+ *
+ *   - JSON → validateDataAgainstSchema against `LitSchema::LITCAL`
+ *   - XML  → DOMDocument::schemaValidate against `LiturgicalCalendar.xsd`
+ *   - ICS  → Sabre\VObject\Reader + Document::validate()
+ *   - YML  → Symfony YAML parser + JSON-shaped schema validation
+ *
+ * Each happy path emits three messages over the WS connection — a
+ * `file-exists` success, a `json-valid` (format-decoded) success, and a
+ * `schema-valid` success. Errors short-circuit at the failing step.
+ *
+ * Together with phpunit_tests/WebSocket/ExecuteUnitTestTest.php +
+ * ExecuteValidationTest.php this covers the three executeXxx /
+ * validateXxx async branches in Health.php that were at 0% before
+ * issue #589's follow-ups.
+ *
+ * Skipped automatically when either ws://127.0.0.1:8082 or
+ * http://127.0.0.1:8000 is unreachable — the action needs both.
+ */
+final class ValidateCalendarTest extends TestCase
+{
+    private string $wsHost;
+    private int $wsPort;
+    private string $apiHost;
+    private int $apiPort;
+
+    protected function setUp(): void
+    {
+        $this->wsHost  = (string) ( $_ENV['WS_HOST'] ?? '127.0.0.1' );
+        $this->wsPort  = (int) ( $_ENV['WS_PORT'] ?? 8082 );
+        $this->apiHost = (string) ( $_ENV['API_HOST'] ?? '127.0.0.1' );
+        $this->apiPort = (int) ( $_ENV['API_PORT'] ?? 8000 );
+
+        $wsProbe = @stream_socket_client(sprintf('tcp://%s:%d', $this->wsHost, $this->wsPort), $_e, $_m, 1.0);
+        if ($wsProbe === false) {
+            $this->markTestSkipped(
+                sprintf('WS server not reachable on %s:%d — start it with `composer ws:start`.', $this->wsHost, $this->wsPort)
+            );
+        }
+        fclose($wsProbe);
+
+        $apiProbe = @stream_socket_client(sprintf('tcp://%s:%d', $this->apiHost, $this->apiPort), $_e, $_m, 1.0);
+        if ($apiProbe === false) {
+            $this->markTestSkipped(
+                sprintf('HTTP API not reachable on %s:%d — start it with `composer start`. validateCalendar needs both.', $this->apiHost, $this->apiPort)
+            );
+        }
+        fclose($apiProbe);
+    }
+
+    /**
+     * Send a payload, then keep reading frames until either `$expectedFrames`
+     * arrive or the socket times out — whichever comes first. Unlike the
+     * unary executeUnitTest action, validateCalendar emits a sequence of
+     * messages (file-exists → json-valid → schema-valid), and the WS
+     * handler never closes after the last one — we have to time out.
+     *
+     * @param array<string,mixed> $payload
+     * @return array<int,\stdClass>
+     */
+    private function validateCalendar(array $payload, int $expectedFrames): array
+    {
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 30.0);
+        try {
+            $client->sendText(json_encode($payload, JSON_THROW_ON_ERROR));
+
+            $frames = [];
+            for ($i = 0; $i < $expectedFrames; $i++) {
+                $reply   = $client->receiveText();
+                $decoded = json_decode($reply);
+                $this->assertInstanceOf(\stdClass::class, $decoded, "Frame {$i} did not decode as JSON: " . substr($reply, 0, 200));
+                $this->assertObjectHasProperty('type', $decoded, "Frame {$i} missing `type`");
+                $frames[] = $decoded;
+            }
+            return $frames;
+        } finally {
+            $client->close();
+        }
+    }
+
+    /**
+     * Assert that the given frame is a successful `<phase>` message for
+     * the Vatican universal calendar in the given year.
+     */
+    private function assertPhase(\stdClass $frame, string $phase, int $year, string $calendar = 'VA'): void
+    {
+        $this->assertSame('success', $frame->type, "Expected success on {$phase}, got error: " . ( $frame->text ?? '?' ));
+        $this->assertObjectHasProperty('classes', $frame);
+        $this->assertSame(".calendar-{$calendar}.{$phase}.year-{$year}", $frame->classes);
+    }
+
+    public function testJsonHappyPathEmitsThreeSuccessMessages(): void
+    {
+        $frames = $this->validateCalendar([
+            'action'       => 'validateCalendar',
+            'calendar'     => 'VA',
+            'year'         => 2020,
+            'category'     => 'nationalcalendar',
+            'responsetype' => 'JSON',
+        ], 3);
+
+        $this->assertPhase($frames[0], 'file-exists', 2020);
+        $this->assertPhase($frames[1], 'json-valid', 2020);
+        $this->assertStringContainsString('decoded as JSON', $frames[1]->text);
+        $this->assertPhase($frames[2], 'schema-valid', 2020);
+        $this->assertStringContainsString('validated against the Schema', $frames[2]->text);
+    }
+
+    public function testXmlHappyPathEmitsThreeSuccessMessages(): void
+    {
+        $frames = $this->validateCalendar([
+            'action'       => 'validateCalendar',
+            'calendar'     => 'VA',
+            'year'         => 2020,
+            'category'     => 'nationalcalendar',
+            'responsetype' => 'XML',
+        ], 3);
+
+        $this->assertPhase($frames[0], 'file-exists', 2020);
+        $this->assertPhase($frames[1], 'json-valid', 2020);
+        $this->assertStringContainsString('decoded as XML', $frames[1]->text);
+        $this->assertPhase($frames[2], 'schema-valid', 2020);
+        // The XML schema validator embeds the .xsd path in the success text.
+        $this->assertStringContainsString('LiturgicalCalendar.xsd', $frames[2]->text);
+    }
+
+    public function testIcsHappyPathEmitsThreeSuccessMessages(): void
+    {
+        $frames = $this->validateCalendar([
+            'action'       => 'validateCalendar',
+            'calendar'     => 'VA',
+            'year'         => 2020,
+            'category'     => 'nationalcalendar',
+            'responsetype' => 'ICS',
+        ], 3);
+
+        $this->assertPhase($frames[0], 'file-exists', 2020);
+        $this->assertPhase($frames[1], 'json-valid', 2020);
+        $this->assertStringContainsString('decoded as ICS', $frames[1]->text);
+        $this->assertPhase($frames[2], 'schema-valid', 2020);
+        // The iCalendar validator success text mentions RFC 5545.
+        $this->assertStringContainsString('rfc5545', $frames[2]->text);
+    }
+
+    public function testYmlHappyPathEmitsThreeSuccessMessages(): void
+    {
+        $frames = $this->validateCalendar([
+            'action'       => 'validateCalendar',
+            'calendar'     => 'VA',
+            'year'         => 2020,
+            'category'     => 'nationalcalendar',
+            'responsetype' => 'YML',
+        ], 3);
+
+        $this->assertPhase($frames[0], 'file-exists', 2020);
+        $this->assertPhase($frames[1], 'json-valid', 2020);
+        $this->assertStringContainsString('decoded as YAML', $frames[1]->text);
+        $this->assertPhase($frames[2], 'schema-valid', 2020);
+    }
+
+    public function testUnknownCalendarFailsAtJsonValidPhase(): void
+    {
+        // The first message is always the "file-exists" success because
+        // the WS handler reports any non-error HTTP response (the 404
+        // page) as a "file" that exists. The body, however, isn't a
+        // valid LitCal JSON document, so the json-valid phase fails.
+        $frames = $this->validateCalendar([
+            'action'       => 'validateCalendar',
+            'calendar'     => 'NONEXISTENT_NATION_589',
+            'year'         => 2020,
+            'category'     => 'nationalcalendar',
+            'responsetype' => 'JSON',
+        ], 2);
+
+        $this->assertSame('success', $frames[0]->type);
+        $this->assertSame('.calendar-NONEXISTENT_NATION_589.file-exists.year-2020', $frames[0]->classes);
+        $this->assertSame('error', $frames[1]->type);
+        $this->assertSame('.calendar-NONEXISTENT_NATION_589.json-valid.year-2020', $frames[1]->classes);
+        $this->assertObjectHasProperty('responsetype', $frames[1]);
+        $this->assertSame('JSON', $frames[1]->responsetype);
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #589 / #591. Adds WS-driven integration tests for the **two sibling async actions** on the Ratchet handler in `src/Health.php` — `validateCalendar` and `executeValidation`. Together with the `executeUnitTest` tests in #591, this closes the largest single-file coverage gap left after the recent wave.

## Coverage lift on `src/Health.php`

Measured locally with both servers up + pcov bootstrap firing (`APP_ENV=test`):

| Before | After | Δ |
|---:|---:|---:|
| 187/1054 (17.7%) | **439/1054 (41.7%)** | **+252 stmts (+24pp)** |

The bulk of the remaining ~615 uncovered statements are in `executeValidation`'s i18n-folder + diocese-metadata branches, which need a fuller harness (folder-of-files schema validation, the `findDioceseMetadata` lookup, cache-backed promise machinery for real-world payloads). Worth a separate PR.

## Changes

`phpunit_tests/WebSocket/ValidateCalendarTest.php` — 5 tests:

- JSON / XML / ICS / YML happy paths against `VA` 2020 → each produces the three-message sequence (`file-exists` → `json-valid` → `schema-valid`) the frontend expects.
- Unknown calendar identifier → short-circuits at the `json-valid` phase; `responsetype` echoed back.

`phpunit_tests/WebSocket/ExecuteValidationTest.php` — 3 tests:

- `sourceDataCheck` against `proprium-de-sanctis-1970` → regex-resolved Sanctorale path, three-message success sequence.
- `resourceDataCheck` against `/metadata` → URL-fetch + JSON-decode arm, distinct from the on-disk path.
- Missing `sourceFile` → `validateMessageProperties()` rejects before dispatch, server replies with the standard `echobot`-typed validation-error envelope.

Both classes skip cleanly when either `ws://127.0.0.1:8082` or `http://127.0.0.1:8000` is unreachable.

No source / `WsTestClient` changes — every WS reply here is well under 65535 bytes.

## Notes / sequencing

- Branch is off `development` (not stacked on #592). The tests pass locally regardless of #592's status; #592 just makes them visible on Codecov.
- After both this PR + #592 land, Codecov should show ~64-66% (61% local baseline + ~3-5pp from these tests).

## Test plan

- [x] `vendor/bin/phpunit phpunit_tests/WebSocket/` — 16 tests, 161 assertions, green
- [x] `composer lint` on changed files — clean
- [x] `composer analyse` (PHPStan level 10) — clean
- [x] Coverage measured locally → `src/Health.php` 17.7% → 41.7%

https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp

---
_Generated by [Claude Code](https://claude.ai/code/session_018tynbsLbtvgLGQr8ma1QKp)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests covering the WebSocket executeValidation workflow, including valid checks, metadata retrieval, and error handling for missing inputs.
  * Expanded validateCalendar integration tests to verify end-to-end behavior for JSON, XML, ICS, and YML formats and a negative case for unknown calendars.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->