### PR TITLE
fix(deploy): invalidate OPcache after rsync + tolerate empty migrations

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -219,6 +219,33 @@ jobs:
             -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
             ./ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/"
 
+      - name: Reset OPcache
+        if: steps.shape.outputs.skip != 'true'
+        env:
+          DEPLOY_TOKEN: ${{ secrets.DEPLOY_TOKEN }}
+          BASE: ${{ vars.VPS_APP_BASE_URL }}
+          SUBDIR: ${{ steps.params.outputs.deploy_subdir }}
+        # Without this, php-fpm can keep serving cached bytecode of the
+        # pre-deploy code (especially when rsync preserves source mtimes
+        # that pre-date the cached entries, leaving OPcache's revalidate
+        # check unconvinced anything has changed). opcache_reset() is
+        # process-shared on FPM SAPI, so one call clears all workers.
+        run: |
+          set -euo pipefail
+          if [ -z "${DEPLOY_TOKEN}" ]; then
+            echo "::error::DEPLOY_TOKEN secret is empty." >&2
+            exit 1
+          fi
+          if [ -z "${BASE}" ]; then
+            echo "::error::Repository variable VPS_APP_BASE_URL is not set." >&2
+            exit 1
+          fi
+          curl -fsS --retry 3 --retry-delay 3 --max-time 30 \
+            -X POST \
+            -H "X-Deploy-Token: ${DEPLOY_TOKEN}" \
+            -H "Accept: text/plain" \
+            "${BASE%/}/${SUBDIR}/_ops/opcache-reset"
+
       - name: Run database migrations
         if: steps.shape.outputs.skip != 'true'
         env:

--- a/phpunit_tests/Routes/Ops/MigrateHandlerTest.php
+++ b/phpunit_tests/Routes/Ops/MigrateHandlerTest.php
@@ -360,6 +360,100 @@ PHP;
         }
     }
 
+
+    public function testPostMigrateRejectsConfigThatDoesNotReturnArray(): void
+    {
+        // include returns int 42 — countMigrationFiles() must surface this as
+        // a hard error instead of treating it like "0 migrations registered".
+        $configFile = sys_get_temp_dir() . '/litcal_test_migrate_cfg_' . bin2hex(random_bytes(6)) . '.php';
+        file_put_contents($configFile, "<?php\nreturn 42;\n");
+        $this->tempPaths[] = $configFile;
+
+        $handler = new MigrateHandler($this->connection, $configFile);
+        $handler->setAllowedRequestMethods([
+            \LiturgicalCalendar\Api\Http\Enum\RequestMethod::POST,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('did not return an array');
+        $handler->handle(new ServerRequest('POST', '/_ops/migrate'));
+    }
+
+    public function testPostMigrateRejectsConfigMissingMigrationsPathsKey(): void
+    {
+        $configFile = sys_get_temp_dir() . '/litcal_test_migrate_cfg_' . bin2hex(random_bytes(6)) . '.php';
+        file_put_contents($configFile, "<?php\nreturn " . var_export([
+            'table_storage' => ['table_name' => 'doctrine_migration_versions'],
+        ], true) . ";\n");
+        $this->tempPaths[] = $configFile;
+
+        $handler = new MigrateHandler($this->connection, $configFile);
+        $handler->setAllowedRequestMethods([
+            \LiturgicalCalendar\Api\Http\Enum\RequestMethod::POST,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('missing the "migrations_paths" key');
+        $handler->handle(new ServerRequest('POST', '/_ops/migrate'));
+    }
+
+    public function testPostMigrateRejectsConfigWithNonArrayMigrationsPaths(): void
+    {
+        $configFile = sys_get_temp_dir() . '/litcal_test_migrate_cfg_' . bin2hex(random_bytes(6)) . '.php';
+        file_put_contents($configFile, "<?php\nreturn " . var_export(['migrations_paths' => 'not-an-array'], true) . ";\n");
+        $this->tempPaths[] = $configFile;
+
+        $handler = new MigrateHandler($this->connection, $configFile);
+        $handler->setAllowedRequestMethods([
+            \LiturgicalCalendar\Api\Http\Enum\RequestMethod::POST,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('must be an array');
+        $handler->handle(new ServerRequest('POST', '/_ops/migrate'));
+    }
+
+    public function testPostMigrateRejectsMigrationsPathEntryThatIsNotADirectory(): void
+    {
+        $configFile = sys_get_temp_dir() . '/litcal_test_migrate_cfg_' . bin2hex(random_bytes(6)) . '.php';
+        $bogusDir   = sys_get_temp_dir() . '/litcal_test_migrate_nope_' . bin2hex(random_bytes(6));
+        file_put_contents($configFile, "<?php\nreturn " . var_export([
+            'migrations_paths' => ['LiturgicalCalendar\\TestMigrations' => $bogusDir],
+        ], true) . ";\n");
+        $this->tempPaths[] = $configFile;
+
+        $handler = new MigrateHandler($this->connection, $configFile);
+        $handler->setAllowedRequestMethods([
+            \LiturgicalCalendar\Api\Http\Enum\RequestMethod::POST,
+        ]);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('is not an existing directory');
+        $handler->handle(new ServerRequest('POST', '/_ops/migrate'));
+    }
+
+    public function testPostMigrateEmptyPathsReturns200WithNoOpNotice(): void
+    {
+        // Empty migrations_paths array is the deploy-time happy path that
+        // motivated this PR: workflow lands code before any Version*.php
+        // exists. countMigrationFiles() returns 0 → handler writes an info
+        // notice and returns 200 instead of letting Doctrine fail.
+        $configFile = $this->writeConfig([]);
+
+        $handler = new MigrateHandler($this->connection, $configFile);
+        $handler->setAllowedRequestMethods([
+            \LiturgicalCalendar\Api\Http\Enum\RequestMethod::POST,
+        ]);
+
+        $response = $handler->handle(new ServerRequest('POST', '/_ops/migrate'));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString(
+            'No migration files registered',
+            (string) $response->getBody()
+        );
+    }
+
     /**
      * Build a synthetic Doctrine migration class as PHP source, creating
      * the named table on up() and dropping it on down().

--- a/phpunit_tests/Routes/Ops/OpcacheResetHandlerTest.php
+++ b/phpunit_tests/Routes/Ops/OpcacheResetHandlerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Ops;
+
+use LiturgicalCalendar\Api\Handlers\Ops\OpcacheResetHandler;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OpcacheResetHandler::class)]
+final class OpcacheResetHandlerTest extends TestCase
+{
+    /**
+     * Determine whether opcache is loaded AND enabled in the current SAPI,
+     * without calling opcache_reset() ourselves. opcache_reset() can return
+     * false on its second consecutive call when the cache is empty, so we
+     * must not "probe" with it — the handler under test must be the one
+     * making the call.
+     */
+    private function opcacheIsActive(): bool
+    {
+        if (!function_exists('opcache_reset') || !function_exists('opcache_get_status')) {
+            return false;
+        }
+        $status = @opcache_get_status(false);
+        return is_array($status) && ( $status['opcache_enabled'] ?? false ) === true;
+    }
+
+    public function testPostReturns200WhenOpcacheIsEnabled(): void
+    {
+        if (!$this->opcacheIsActive()) {
+            $this->markTestSkipped(
+                'opcache extension is not active in this SAPI (opcache.enable_cli is off or extension missing). '
+                . 'See testPostReturns500WhenOpcacheIsDisabled / testPostReturns503WhenOpcacheExtensionMissing.'
+            );
+        }
+
+        $handler = new OpcacheResetHandler();
+        $handler->setAllowedRequestMethods([
+            \LiturgicalCalendar\Api\Http\Enum\RequestMethod::POST,
+        ]);
+
+        $response = $handler->handle(new ServerRequest('POST', '/_ops/opcache-reset'));
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringContainsString('text/plain', $response->getHeaderLine('Content-Type'));
+        $this->assertStringContainsString('OPcache reset', (string) $response->getBody());
+    }
+
+    public function testPostReturns500WhenOpcacheIsDisabled(): void
+    {
+        if (!function_exists('opcache_reset')) {
+            $this->markTestSkipped('opcache extension not loaded; 503 path will run instead.');
+        }
+        if ($this->opcacheIsActive()) {
+            $this->markTestSkipped(
+                'opcache is active in this SAPI; the 500 path only fires when the extension is '
+                . 'loaded-but-disabled. See testPostReturns200WhenOpcacheIsEnabled.'
+            );
+        }
+
+        $handler = new OpcacheResetHandler();
+        $handler->setAllowedRequestMethods([
+            \LiturgicalCalendar\Api\Http\Enum\RequestMethod::POST,
+        ]);
+
+        $response = $handler->handle(new ServerRequest('POST', '/_ops/opcache-reset'));
+
+        $this->assertSame(500, $response->getStatusCode());
+        $this->assertStringContainsString('opcache_reset() returned false', (string) $response->getBody());
+    }
+
+    public function testPostReturns503WhenOpcacheExtensionMissing(): void
+    {
+        if (function_exists('opcache_reset')) {
+            $this->markTestSkipped(
+                'opcache extension is loaded; the 503 fallback only fires when the '
+                . 'function does not exist at all.'
+            );
+        }
+
+        $handler = new OpcacheResetHandler();
+        $handler->setAllowedRequestMethods([
+            \LiturgicalCalendar\Api\Http\Enum\RequestMethod::POST,
+        ]);
+
+        $response = $handler->handle(new ServerRequest('POST', '/_ops/opcache-reset'));
+
+        $this->assertSame(503, $response->getStatusCode());
+        $this->assertStringContainsString('OPcache extension is not loaded', (string) $response->getBody());
+    }
+
+    public function testGetWithDisallowedMethodThrowsMethodNotAllowed(): void
+    {
+        $handler = new OpcacheResetHandler();
+        $handler->setAllowedRequestMethods([
+            \LiturgicalCalendar\Api\Http\Enum\RequestMethod::POST,
+        ]);
+
+        $this->expectException(\LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException::class);
+        $handler->handle(new ServerRequest('GET', '/_ops/opcache-reset'));
+    }
+}

--- a/src/Handlers/Ops/MigrateHandler.php
+++ b/src/Handlers/Ops/MigrateHandler.php
@@ -57,6 +57,22 @@ final class MigrateHandler extends AbstractHandler
         }
         ignore_user_abort(true);
 
+        // Validate the `to` query parameter up-front so a malformed value is
+        // rejected with 400 regardless of whether any migrations are
+        // registered. (Doing this after the empty-migrations short-circuit
+        // below would let bad input through whenever migrations_paths is
+        // empty.)
+        $to = null;
+        if ($request->getMethod() === 'POST') {
+            $toParam = $request->getQueryParams()['to'] ?? null;
+            if (is_string($toParam) && $toParam !== '') {
+                if (!preg_match('/^[A-Za-z0-9_]+$/', $toParam)) {
+                    return new Response(400, ['Content-Type' => 'text/plain'], "Invalid 'to' parameter\n");
+                }
+                $to = $toParam;
+            }
+        }
+
         if ($this->connection === null) {
             $this->connection = self::buildConnectionFromEnv();
         }
@@ -108,11 +124,7 @@ final class MigrateHandler extends AbstractHandler
                         'command'          => 'migrations:migrate',
                         '--no-interaction' => true,
                     ];
-                    $to           = $request->getQueryParams()['to'] ?? null;
-                    if (is_string($to) && $to !== '') {
-                        if (!preg_match('/^[A-Za-z0-9_]+$/', $to)) {
-                            return new Response(400, ['Content-Type' => 'text/plain'], "Invalid 'to' parameter\n");
-                        }
+                    if ($to !== null) {
                         $migrateInput['version'] = $to;
                     }
                     $exitCode = $app->run(new ArrayInput($migrateInput), $output);
@@ -139,20 +151,53 @@ final class MigrateHandler extends AbstractHandler
      * no-op. Reads the migrations config file directly rather than going
      * through Doctrine's internal repository APIs (those vary across
      * minor versions; plain glob is stable).
+     *
+     * Throws on any config/IO error so a misconfigured deploy fails loudly
+     * rather than silently swallowing a path that should have held
+     * migrations.
      */
     private function countMigrationFiles(): int
     {
-        /** @var array<string, mixed> $config */
+        /** @var mixed $config */
         $config = include $this->configFile;
-        $paths  = $config['migrations_paths'] ?? [];
-        $count  = 0;
-        if (is_array($paths)) {
-            foreach ($paths as $dir) {
-                if (is_string($dir) && is_dir($dir)) {
-                    $matches = glob($dir . DIRECTORY_SEPARATOR . 'Version*.php') ?: [];
-                    $count  += count($matches);
-                }
+        if (!is_array($config)) {
+            throw new \RuntimeException(sprintf(
+                'MigrateHandler: migrations config %s did not return an array.',
+                $this->configFile
+            ));
+        }
+        if (!array_key_exists('migrations_paths', $config)) {
+            throw new \RuntimeException(sprintf(
+                'MigrateHandler: migrations config %s is missing the "migrations_paths" key.',
+                $this->configFile
+            ));
+        }
+        $paths = $config['migrations_paths'];
+        if (!is_array($paths)) {
+            throw new \RuntimeException(sprintf(
+                'MigrateHandler: "migrations_paths" in %s must be an array.',
+                $this->configFile
+            ));
+        }
+
+        $count = 0;
+        foreach ($paths as $dir) {
+            if (!is_string($dir) || !is_dir($dir)) {
+                // A configured path that isn't a real directory is a
+                // misconfiguration, not "zero migrations". Surface it.
+                throw new \RuntimeException(sprintf(
+                    'MigrateHandler: migrations_paths entry %s is not an existing directory.',
+                    is_string($dir) ? $dir : '(non-string)'
+                ));
             }
+            $matches = glob($dir . DIRECTORY_SEPARATOR . 'Version*.php');
+            if ($matches === false) {
+                throw new \RuntimeException(sprintf(
+                    'MigrateHandler: glob() failed scanning %s for Version*.php',
+                    $dir
+                ));
+            }
+            $count += count($matches);
         }
         return $count;
     }

--- a/src/Handlers/Ops/MigrateHandler.php
+++ b/src/Handlers/Ops/MigrateHandler.php
@@ -57,12 +57,15 @@ final class MigrateHandler extends AbstractHandler
         }
         ignore_user_abort(true);
 
-        // Validate the `to` query parameter up-front so a malformed value is
-        // rejected with 400 regardless of whether any migrations are
-        // registered. (Doing this after the empty-migrations short-circuit
-        // below would let bad input through whenever migrations_paths is
-        // empty.)
-        $to = null;
+        // For POST: validate the `to` query parameter and the migrations
+        // config up-front, before bootstrapping Doctrine. Doctrine's
+        // PhpFile loader throws raw TypeErrors for malformed configs and
+        // silently treats a missing `migrations_paths` key as zero
+        // migrations, so doing this first gives us clear error messages
+        // and lets us short-circuit the no-op case without spinning up a
+        // DB connection.
+        $to             = null;
+        $migrationCount = null;
         if ($request->getMethod() === 'POST') {
             $toParam = $request->getQueryParams()['to'] ?? null;
             if (is_string($toParam) && $toParam !== '') {
@@ -71,6 +74,7 @@ final class MigrateHandler extends AbstractHandler
                 }
                 $to = $toParam;
             }
+            $migrationCount = $this->countMigrationFiles();
         }
 
         if ($this->connection === null) {
@@ -117,7 +121,7 @@ final class MigrateHandler extends AbstractHandler
                 // healthy deploy red. Treat empty as a successful no-op so
                 // the workflow can land code before any migrations are
                 // written for it.
-                if ($this->countMigrationFiles() === 0) {
+                if ($migrationCount === 0) {
                     fwrite($output->getStream(), "  [INFO] No migration files registered; nothing to apply.\n");
                 } else {
                     $migrateInput = [

--- a/src/Handlers/Ops/MigrateHandler.php
+++ b/src/Handlers/Ops/MigrateHandler.php
@@ -94,18 +94,29 @@ final class MigrateHandler extends AbstractHandler
                 '--no-interaction' => true,
             ]), $output);
             if ($exitCode === 0) {
-                $migrateInput = [
-                    'command'          => 'migrations:migrate',
-                    '--no-interaction' => true,
-                ];
-                $to           = $request->getQueryParams()['to'] ?? null;
-                if (is_string($to) && $to !== '') {
-                    if (!preg_match('/^[A-Za-z0-9_]+$/', $to)) {
-                        return new Response(400, ['Content-Type' => 'text/plain'], "Invalid 'to' parameter\n");
+                // Guard against the "no registered migrations" case. When the
+                // configured migrations_paths contain zero Version*.php files,
+                // `migrations:migrate` fails with `version "latest" couldn't
+                // be reached` — exit code 1 — which would otherwise turn a
+                // healthy deploy red. Treat empty as a successful no-op so
+                // the workflow can land code before any migrations are
+                // written for it.
+                if ($this->countMigrationFiles() === 0) {
+                    fwrite($output->getStream(), "  [INFO] No migration files registered; nothing to apply.\n");
+                } else {
+                    $migrateInput = [
+                        'command'          => 'migrations:migrate',
+                        '--no-interaction' => true,
+                    ];
+                    $to           = $request->getQueryParams()['to'] ?? null;
+                    if (is_string($to) && $to !== '') {
+                        if (!preg_match('/^[A-Za-z0-9_]+$/', $to)) {
+                            return new Response(400, ['Content-Type' => 'text/plain'], "Invalid 'to' parameter\n");
+                        }
+                        $migrateInput['version'] = $to;
                     }
-                    $migrateInput['version'] = $to;
+                    $exitCode = $app->run(new ArrayInput($migrateInput), $output);
                 }
-                $exitCode = $app->run(new ArrayInput($migrateInput), $output);
             }
         }
 
@@ -118,6 +129,32 @@ final class MigrateHandler extends AbstractHandler
             ['Content-Type' => 'text/plain; charset=utf-8'],
             $body
         );
+    }
+
+    /**
+     * Count Version*.php files across all configured migrations_paths.
+     *
+     * Used to detect the "no migrations registered" state up-front, since
+     * Doctrine's migrate command errors out instead of treating it as a
+     * no-op. Reads the migrations config file directly rather than going
+     * through Doctrine's internal repository APIs (those vary across
+     * minor versions; plain glob is stable).
+     */
+    private function countMigrationFiles(): int
+    {
+        /** @var array<string, mixed> $config */
+        $config = include $this->configFile;
+        $paths  = $config['migrations_paths'] ?? [];
+        $count  = 0;
+        if (is_array($paths)) {
+            foreach ($paths as $dir) {
+                if (is_string($dir) && is_dir($dir)) {
+                    $matches = glob($dir . DIRECTORY_SEPARATOR . 'Version*.php') ?: [];
+                    $count  += count($matches);
+                }
+            }
+        }
+        return $count;
     }
 
     private static function buildConnectionFromEnv(): Connection

--- a/src/Handlers/Ops/OpcacheResetHandler.php
+++ b/src/Handlers/Ops/OpcacheResetHandler.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Ops;
+
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use Nyholm\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Invalidates the OPcache so freshly rsync'd code is picked up.
+ *
+ * POST /_ops/opcache-reset
+ *
+ * The deploy workflow can land new files on disk while php-fpm keeps
+ * serving cached bytecode for the old files (especially when rsync
+ * preserves source mtimes that pre-date the cached entries). On the FPM
+ * SAPI opcache lives in process-shared memory, so a single
+ * opcache_reset() call from any worker invalidates the cache for all of
+ * them — the next request recompiles from disk.
+ *
+ * Authentication is the responsibility of DeployTokenMiddleware piped
+ * upstream by the Router. This handler assumes the request has passed
+ * the token gate.
+ */
+final class OpcacheResetHandler extends AbstractHandler
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->validateRequestMethod($request);
+
+        if (!function_exists('opcache_reset')) {
+            return new Response(
+                503,
+                ['Content-Type' => 'text/plain; charset=utf-8'],
+                "OPcache extension is not loaded; nothing to reset.\n"
+            );
+        }
+
+        $ok = @opcache_reset();
+        if ($ok === false) {
+            // Either the extension is loaded-but-disabled (opcache.enable=0)
+            // or the calling script is on opcache.restrict_api's blacklist.
+            return new Response(
+                500,
+                ['Content-Type' => 'text/plain; charset=utf-8'],
+                "opcache_reset() returned false (opcache disabled, or restrict_api blocks this caller).\n"
+            );
+        }
+
+        return new Response(
+            200,
+            ['Content-Type' => 'text/plain; charset=utf-8'],
+            "OPcache reset.\n"
+        );
+    }
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -32,6 +32,7 @@ use LiturgicalCalendar\Api\Handlers\Admin\PermissionAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\UsersHandler;
 use LiturgicalCalendar\Api\Handlers\ApplicationsHandler;
 use LiturgicalCalendar\Api\Handlers\Ops\MigrateHandler;
+use LiturgicalCalendar\Api\Handlers\Ops\OpcacheResetHandler;
 use LiturgicalCalendar\Api\Http\Enum\StatusCode;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\Http\Middleware\AuthorizationMiddleware;
@@ -532,6 +533,10 @@ class Router
                     $migrateHandler = new MigrateHandler();
                     $migrateHandler->setAllowedRequestMethods([RequestMethod::GET]);
                     $this->handler = $migrateHandler;
+                } elseif (count($requestPathParts) === 1 && $requestPathParts[0] === 'opcache-reset') {
+                    $opcacheResetHandler = new OpcacheResetHandler();
+                    $opcacheResetHandler->setAllowedRequestMethods([RequestMethod::POST]);
+                    $this->handler = $opcacheResetHandler;
                 } else {
                     $this->response = new Response(StatusCode::NOT_FOUND->value, [], null, $this->request->getProtocolVersion(), StatusCode::NOT_FOUND->reason());
                     $this->emitResponse();


### PR DESCRIPTION
## Background

Today's first API staging deploy via the `deploy.yaml` workflow exposed two latent issues that caused the workflow to go red even when the underlying deploy was healthy. Both surfaced together because the symptoms compounded:

1. The deploy looked successful, but `litcal-staging.johnromanodorazio.com` (the frontend) reported CORS failures calling `/api/dev/auth/access-requests`. The actual cause: that route returned 404, never reaching CORS middleware. PHP-FPM was serving cached bytecode of the **pre-deploy** API code, which didn't have that route registered yet. Manual `systemctl reload plesk-php84-fpm` cleared OPcache and the route appeared.
2. Once OPcache was clean, the migrate step still failed: `[ERROR] The version "latest" couldn't be reached, there are no registered migrations.` The schema migrations for the auth/admin track haven't been written yet; `src/Migrations/` is empty (just `.gitkeep`). Doctrine treats "no migrations" as an error rather than a no-op, so the workflow stays red.

This PR fixes both ergonomics issues. The actual missing migration files for the auth/admin schema are out of scope here — that's product work.

## Changes

### 1. New `POST /_ops/opcache-reset` endpoint

`src/Handlers/Ops/OpcacheResetHandler.php` — calls `opcache_reset()` and returns text/plain. Gated by `DeployTokenMiddleware` (same auth as `/_ops/migrate`, since it's registered under the `_ops` route prefix).

Why this works for FPM specifically: OPcache lives in process-shared memory across all FPM workers, so a single `opcache_reset()` call from any worker invalidates the cache for all of them — the next request to each worker recompiles from disk.

Why the existing `revalidate_freq=2` didn't save us: rsync's `--archive` preserves source mtimes from the GitHub runner's freshly-checked-out files. Those mtimes can pre-date the cache entries' reference time, so OPcache's revalidate check stays unconvinced anything changed and continues serving the cached bytecode indefinitely.

### 2. `MigrateHandler` tolerates the "no migrations" case

Before running `migrations:migrate`, the handler now globs the configured `migrations_paths` for `Version*.php` files. If the count is zero, it writes a `[INFO] No migration files registered; nothing to apply.` notice and returns 200 — instead of invoking Doctrine and getting back the "version latest couldn't be reached" failure.

Uses a direct file scan rather than Doctrine's internal `MigrationsRepository` API because that internal API has shifted between minor Doctrine versions; `glob()` is stable.

### 3. Workflow yaml: add a `Reset OPcache` step between rsync and migrate

```yaml
- name: Deploy via rsync          # unchanged
- name: Reset OPcache             # NEW — calls /_ops/opcache-reset
- name: Run database migrations   # unchanged (now sees fresh bytecode)
- name: Post-deploy health check  # unchanged
```

The new step uses the same `DEPLOY_TOKEN` secret and the same env-validation pattern as the existing migrate step. `--retry 3 --retry-delay 3 --max-time 30` because opcache reset is fast but worth being robust against the rare SSH/HTTP blip.

## Test plan

- [x] `composer parallel-lint` — 367 files, no errors
- [x] `composer lint` (phpcs) — clean
- [x] `composer analyse` (phpstan level 10) — **0 errors**
- [x] YAML syntax valid (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] After merge: trigger `workflow_dispatch → staging`, observe the new `Reset OPcache` step completes (HTTP 200, `OPcache reset.`)
- [ ] Same run: `Run database migrations` step succeeds with `[INFO] No migration files registered; nothing to apply.` instead of the previous 500
- [ ] Health check passes; `/api/dev/auth/access-requests` returns 401 (route registered, auth needed) with proper CORS headers

## Security

- New endpoint is registered under `_ops/`, which is already covered by `DeployTokenMiddleware` (token-gated, fail-closed on empty token). No new attack surface beyond what `/_ops/migrate` already exposes.
- `opcache_reset()` only resets the userland bytecode cache; it doesn't touch sessions, configs, or data.
- `migrations_paths` is read from `$this->configFile` (the same trusted config file `MigrateHandler` already uses to bootstrap Doctrine), not from request input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic OPcache reset added to the deployment sequence.
  * New OPcache reset endpoint for manual invocation (POST).

* **Improvements**
  * Migration process now detects when no migration files exist and skips running migrations.
  * Migration request input is validated to reject malformed target parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->