### PR TITLE
refactor(init-db): strip application DDL; migrations are single source of truth

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -101,6 +101,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gettext locales-all
 
+      - name: Apply Doctrine migrations
+        # scripts/init-db.sql is bootstrap-only (roles, databases, pgcrypto,
+        # empty doctrine_migration_versions tracking table). Application
+        # tables (access_requests, applications, api_keys, audit_log) are
+        # created by Doctrine migrations and must be applied before the
+        # PHP web server starts — Routes/* and Handlers/Admin/* tests
+        # exercise endpoints that query those tables directly.
+        run: composer db:migrate
+
       - name: Start the PHP web server (instrumented with pcov)
         # PCOV_SERVER_COVERAGE_DIR triggers the bootstrap hook in
         # public/index.php that dumps per-request pcov data so HTTP integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,46 @@ The API supports full cookie-only authentication where:
 
 See [Authentication Roadmap](docs/enhancements/AUTHENTICATION_ROADMAP.md) for implementation details.
 
+### Local Development Bootstrap
+
+The API server runs on the **host** (not in a container). The `docker-compose.yml`
+stack provides only the dependent infrastructure (Postgres, Zitadel, OpenFGA,
+Mailpit, Adminer). Fresh-clone setup is a three-step sequence:
+
+```bash
+# 1. Start the infrastructure (Postgres + Zitadel + OpenFGA + ...).
+#    On first run, scripts/init-db.sql creates roles, databases, the pgcrypto
+#    extension, and an empty doctrine_migration_versions table. It does NOT
+#    create application tables — those live in src/Migrations/.
+docker compose up -d
+
+# 2. Install PHP dependencies.
+composer install
+
+# 3. Apply Doctrine migrations to create the application schema
+#    (access_requests, applications, api_keys, audit_log, ...).
+#    Re-runnable: a no-op once everything is up-to-date.
+composer db:migrate
+
+# 4. Start the API server.
+composer start
+```
+
+**After-pull:** if a new migration has landed since your last pull, re-run
+`composer db:migrate` before `composer start`. There's no auto-apply on
+server startup — migrations are an explicit step.
+
+**Schema is authoritative in `src/Migrations/`, not in `init-db.sql`.** When
+adding a new table or column:
+
+- Generate a migration: `composer db:migrations:generate`, then edit it.
+- Apply locally: `composer db:migrate`.
+- Verify with `composer db:migrations:status`.
+
+Do NOT add application-table DDL to `scripts/init-db.sql` — that script is
+bootstrap-only (roles, databases, pgcrypto, the empty migrations tracking
+table). Anything else there silently diverges from the migration history.
+
 ### Testing
 
 ```bash

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -5,7 +5,7 @@
 -- applications, api_keys, audit_log) lives in Doctrine migrations under
 -- src/Migrations/ and is applied via `composer db:migrate` (or by hitting
 -- `POST /_ops/migrate` once the API server is running). See CLAUDE.md →
--- "Local Development Setup".
+-- "Local Development Bootstrap".
 --
 -- What this script does NOT do:
 --   * Create application tables (handled by Version20260518120000 and later)

--- a/scripts/init-db.sql
+++ b/scripts/init-db.sql
@@ -1,6 +1,16 @@
 -- LiturgicalCalendar Database Initialization
 -- This script runs on first PostgreSQL startup to create required databases and users.
 --
+-- This is a BOOTSTRAP-ONLY script. Application-table DDL (access_requests,
+-- applications, api_keys, audit_log) lives in Doctrine migrations under
+-- src/Migrations/ and is applied via `composer db:migrate` (or by hitting
+-- `POST /_ops/migrate` once the API server is running). See CLAUDE.md →
+-- "Local Development Setup".
+--
+-- What this script does NOT do:
+--   * Create application tables (handled by Version20260518120000 and later)
+--   * Pre-mark migrations as applied (Doctrine records that itself)
+--
 -- NOTE: The passwords below are DEVELOPMENT DEFAULTS ONLY.
 -- For production, override them via environment variables in docker-compose.yml
 -- (POSTGRES_PASSWORD, and create users with strong generated passwords).
@@ -26,146 +36,20 @@ GRANT ALL PRIVILEGES ON DATABASE litcal TO litcal;
 -- Grant schema permissions
 GRANT ALL ON SCHEMA public TO litcal;
 
--- Enable pgcrypto extension for UUID generation
--- This runs as postgres superuser (which has permissions), but in the litcal database context
+-- Enable pgcrypto extension for UUID generation (gen_random_uuid()).
+-- Runs as postgres superuser inside the litcal database; required by
+-- the baseline migration's CREATE TABLE ... DEFAULT gen_random_uuid().
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
--- Unified access requests table
--- Bundles a Zitadel role request with fine-grained OpenFGA permissions.
--- On approval: Zitadel role is granted + all OpenFGA tuples are created.
--- On revoke: Zitadel role is removed + all OpenFGA tuples are deleted.
---
--- Granted calendar permissions are managed by OpenFGA relationship tuples.
--- See infrastructure/openfga-model.json and scripts/setup-openfga.sh.
-CREATE TABLE access_requests (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    zitadel_user_id VARCHAR(255) NOT NULL,
-    user_email VARCHAR(255) NOT NULL,
-    user_name VARCHAR(255),
-    requested_role VARCHAR(50) NOT NULL,
-    permissions JSONB NOT NULL DEFAULT '[]',
-    justification TEXT,
-    credentials TEXT,
-    status VARCHAR(20) NOT NULL DEFAULT 'pending',
-    reviewed_by VARCHAR(255),
-    review_notes TEXT,
-    zitadel_sync_status VARCHAR(20) DEFAULT NULL,
-    zitadel_sync_error TEXT DEFAULT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    reviewed_at TIMESTAMP,
-    CONSTRAINT chk_requested_role CHECK (requested_role IN ('developer', 'calendar_editor', 'test_editor')),
-    CONSTRAINT chk_access_request_status CHECK (status IN ('pending', 'approved', 'rejected', 'revoked')),
-    CONSTRAINT chk_zitadel_sync_status CHECK (zitadel_sync_status IS NULL OR zitadel_sync_status IN ('pending', 'synced', 'failed'))
-);
-
-CREATE INDEX idx_access_requests_status ON access_requests(status);
-CREATE INDEX idx_access_requests_user ON access_requests(zitadel_user_id);
-CREATE INDEX idx_access_requests_created ON access_requests(created_at);
-CREATE INDEX idx_access_requests_sync_status ON access_requests(zitadel_sync_status)
-WHERE zitadel_sync_status = 'failed';
-
--- At most one pending request per (user, role): defense-in-depth against races
--- and direct DB inserts. Application layer also checks via hasPendingRequest().
-CREATE UNIQUE INDEX idx_access_requests_unique_pending_user_role
-ON access_requests(zitadel_user_id, requested_role)
-WHERE status = 'pending';
-
-COMMENT ON TABLE access_requests IS 'Unified role + permission requests — role via Zitadel, permissions via OpenFGA';
-COMMENT ON COLUMN access_requests.requested_role IS 'Zitadel role: developer, calendar_editor, test_editor';
-COMMENT ON COLUMN access_requests.permissions IS 'JSON array of OpenFGA tuples: [{object_type, object_id, relation}, ...]';
-COMMENT ON COLUMN access_requests.status IS 'Status: pending, approved, rejected, revoked';
-COMMENT ON COLUMN access_requests.zitadel_sync_status IS 'Zitadel role sync: null (not attempted), pending, synced, failed';
-
--- Applications (for API developers)
-CREATE TABLE applications (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    zitadel_user_id VARCHAR(255) NOT NULL,
-    name VARCHAR(255) NOT NULL,
-    description TEXT,
-    website VARCHAR(500),
-    status VARCHAR(20) NOT NULL DEFAULT 'pending',
-    requested_scope VARCHAR(10) NOT NULL DEFAULT 'read',
-    reviewed_by VARCHAR(255),
-    review_notes TEXT,
-    reviewed_at TIMESTAMP,
-    is_active BOOLEAN DEFAULT TRUE,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT chk_application_status CHECK (status IN ('pending', 'approved', 'rejected', 'revoked')),
-    CONSTRAINT chk_application_requested_scope CHECK (requested_scope IN ('read', 'write'))
-);
-
-CREATE INDEX idx_applications_user ON applications(zitadel_user_id);
-CREATE INDEX idx_applications_status ON applications(status);
-
-COMMENT ON TABLE applications IS 'Registered applications for API key management';
-
--- API Keys
-CREATE TABLE api_keys (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    application_id UUID NOT NULL REFERENCES applications(id) ON DELETE CASCADE,
-    key_hash VARCHAR(255) UNIQUE NOT NULL,
-    key_prefix VARCHAR(20) NOT NULL,
-    name VARCHAR(100),
-    scope VARCHAR(20) DEFAULT 'read',
-    rate_limit_per_hour INTEGER DEFAULT 100,
-    is_active BOOLEAN DEFAULT TRUE,
-    last_used_at TIMESTAMP,
-    expires_at TIMESTAMP,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    CONSTRAINT chk_api_keys_scope CHECK (scope IN ('read', 'write'))
-);
-
-CREATE INDEX idx_api_keys_hash ON api_keys(key_hash);
-CREATE INDEX idx_api_keys_prefix ON api_keys(key_prefix);
-
-COMMENT ON TABLE api_keys IS 'API keys for application authentication';
-COMMENT ON COLUMN api_keys.key_hash IS 'SHA-256 hash of the API key';
-COMMENT ON COLUMN api_keys.key_prefix IS 'First 20 characters for identification';
-COMMENT ON COLUMN api_keys.scope IS 'Scope: read, write';
-
--- Audit log
-CREATE TABLE audit_log (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    zitadel_user_id VARCHAR(255),
-    action VARCHAR(100) NOT NULL,
-    resource_type VARCHAR(50) NOT NULL,
-    resource_id VARCHAR(100),
-    details JSONB,
-    ip_address INET,
-    user_agent TEXT,
-    success BOOLEAN DEFAULT TRUE,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-
-CREATE INDEX idx_audit_log_user ON audit_log(zitadel_user_id);
-CREATE INDEX idx_audit_log_created ON audit_log(created_at);
-CREATE INDEX idx_audit_log_action ON audit_log(action);
-
-COMMENT ON TABLE audit_log IS 'Audit trail for security and compliance';
-
--- Grant permissions to litcal user on all tables
--- (No sequence grants needed since we use UUID primary keys instead of SERIAL)
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO litcal;
-
--- Mark the Doctrine baseline migration as already applied so the API's
--- /_ops/migrate endpoint sees nothing to do on first run (which is what
--- we want — the schema above is identical to what
--- src/Migrations/Version20260518120000.php would create).
---
--- We create the tracking table here with the same shape Doctrine
--- creates via `migrations:sync-metadata-storage`, then insert the
--- baseline row. Doctrine on first call will detect the table exists
--- and is up-to-date; nothing fires CREATE TABLE conflicts.
+-- Create the Doctrine migrations tracking table empty so the litcal
+-- user has guaranteed write access on first migrate. (Doctrine's
+-- sync-metadata-storage would create it on its own, but doing it here
+-- keeps ownership/permissions explicit and matches the shape Doctrine
+-- expects.) No baseline INSERT — the first /_ops/migrate run applies
+-- Version20260518120000 normally and Doctrine records the row itself.
 CREATE TABLE IF NOT EXISTS doctrine_migration_versions (
     version VARCHAR(191) NOT NULL PRIMARY KEY,
     executed_at TIMESTAMP NULL,
     execution_time INTEGER NULL
 );
 GRANT ALL PRIVILEGES ON doctrine_migration_versions TO litcal;
-
-INSERT INTO doctrine_migration_versions (version, executed_at, execution_time)
-VALUES
-    ('LiturgicalCalendar\Api\Migrations\Version20260518120000',
-     CURRENT_TIMESTAMP, 0)
-ON CONFLICT (version) DO NOTHING;


### PR DESCRIPTION
Closes #600.

## Summary

- `scripts/init-db.sql` becomes **bootstrap-only**: roles, databases, `pgcrypto`, and an empty `doctrine_migration_versions` tracking table (+ GRANT to litcal). All application-table DDL is removed.
- `Version20260518120000` is now the sole source of truth for application schema. Fresh installs apply it via `composer db:migrate`; staging's pre-marked tracking row keeps the next `/_ops/migrate` a no-op.
- `CLAUDE.md` gains a "Local Development Bootstrap" subsection documenting the host-side flow: `docker compose up -d` → `composer install` → `composer db:migrate` → `composer start`.

## Why

PR #599 left two copies of the application schema — `init-db.sql` and `Version20260518120000.php`. Anyone editing the SQL file to add a column without writing a migration would silently diverge the two. Removing the duplication makes `src/Migrations/` the single, blame-able source of truth, and removes the "don't edit the DDL block in init-db.sql" convention that was only documented in PR #599's description.

## Auto-migrate scope (acceptance-criterion adjustment)

Issue #600 listed "Docker-compose stack startup applies migrations automatically" as an AC. After investigation: the API server runs on the **host**, not in a container — `docker-compose.yml` only provides Postgres/Zitadel/OpenFGA/Mailpit/Adminer. There's no API container to wire an auto-migrate step into. Documenting the host-side workflow in CLAUDE.md is the proportionate fix; adding a one-shot migrate container would couple docker-compose to a host-side `composer install` having already populated `vendor/`, which is more fragile than the doc-only path.

## Existing-environment safety

- **Staging**: pre-marked by PR #599. Its tracking row stays. Next `/_ops/migrate` is still a no-op. No deploy-time risk.
- **Local-dev volumes created against the old init-db.sql**: schema already exists, baseline marker already inserted. Future migrations apply normally. No action needed.
- **Brand-new fresh installs**: apply `Version20260518120000` cleanly via Doctrine — the same DDL that init-db.sql used to run, just executed through the migration framework.
- **Production**: still empty (per `Version20260518120000`'s docblock). On first prod deploy, the migration creates the schema. Unchanged.

## Test plan

- [x] `composer parallel-lint` — 369 files, no errors
- [x] `composer lint` (phpcs) — clean
- [x] `composer analyse` (phpstan level 10) — 0 errors
- [x] `composer lint:md` — 23 files, 0 errors
- [ ] Manual: wipe `postgres_data` volume → `docker compose up -d` → `composer install && composer db:migrate && composer start` → verify `\d access_requests applications api_keys audit_log doctrine_migration_versions` in psql shows all five tables, with the baseline migration recorded in the tracking table.

## Follow-up

#601 (api_keys index cleanup) builds on this PR — once init-db.sql no longer carries application DDL, that issue becomes a pure new-migration with no init-db.sql changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added local development setup guidance covering infrastructure startup, dependency installation, database migrations, and API server configuration.

* **Chores**
  * Updated test workflow to execute database migrations before running tests.
  * Simplified database bootstrap process; application tables are now created via migrations rather than initialization scripts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->