### PR TITLE
fix(schema): drop redundant idx_api_keys_hash, add idx_api_keys_application_id

### DIFF
--- a/src/Migrations/Version20260519000000.php
+++ b/src/Migrations/Version20260519000000.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * api_keys: drop redundant idx_api_keys_hash, add idx_api_keys_application_id.
+ *
+ * Two index issues flagged by CodeRabbit on PR #599's baseline schema:
+ *
+ *   1. idx_api_keys_hash is redundant. `key_hash` is declared
+ *      VARCHAR(255) UNIQUE NOT NULL, and Postgres auto-creates a unique
+ *      B-tree index to enforce the constraint (api_keys_key_hash_key).
+ *      The separate non-unique index is dead weight — second index to
+ *      maintain on every write, no query-planner benefit.
+ *
+ *   2. idx_api_keys_application_id is missing. `application_id` is a
+ *      foreign key (UUID NOT NULL REFERENCES applications(id) ON DELETE
+ *      CASCADE). Postgres does NOT auto-index FK columns, so queries
+ *      like "list keys for application X" and cascade-deletes from
+ *      applications do sequential scans on api_keys.
+ *
+ * Idempotency: `DROP INDEX IF EXISTS` and `CREATE INDEX IF NOT EXISTS`
+ * make this safe to re-run against an environment that already had the
+ * fix applied out of band.
+ */
+final class Version20260519000000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'api_keys: drop redundant idx_api_keys_hash, add idx_api_keys_application_id';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS idx_api_keys_hash');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_api_keys_application_id ON api_keys(application_id)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('DROP INDEX IF EXISTS idx_api_keys_application_id');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash)');
+    }
+}


### PR DESCRIPTION
Closes #601.

## Summary

New migration `Version20260519000000` fixes two `api_keys` index issues flagged by CodeRabbit in PR #599's baseline review:

| Issue | Fix |
|-------|-----|
| `idx_api_keys_hash` is redundant — `key_hash` is `UNIQUE NOT NULL`, so Postgres already maintains a unique B-tree index (`api_keys_key_hash_key`) for it. The extra non-unique index just costs writes and disk. | `DROP INDEX IF EXISTS idx_api_keys_hash` |
| `idx_api_keys_application_id` is missing — `application_id` is `NOT NULL REFERENCES applications(id) ON DELETE CASCADE`, and Postgres does NOT auto-index FK columns. "List keys for app X" and cascade-deletes seq-scan today. | `CREATE INDEX IF NOT EXISTS idx_api_keys_application_id ON api_keys(application_id)` |

## Why a new migration (not editing the baseline)

Per the issue: the baseline `Version20260518120000` is meant to be a faithful snapshot of what shipped to staging on 2026-05-18. Mixing schema improvements into it would break the "baseline = production reality" invariant, and CodeRabbit's findings wouldn't be attributable to a specific decision or independently rollback-able.

## Idempotency

`DROP INDEX IF EXISTS` and `CREATE INDEX IF NOT EXISTS` make the migration safe to re-run against any environment where the fix was applied out of band.

## No init-db.sql changes

PR #602 (issue #600) just stripped the application DDL — including `idx_api_keys_hash` — from `scripts/init-db.sql`. Migrations are now the single source of truth, so this PR is a pure new-migration with no SQL bootstrap touch.

## Behavior on each environment

| Environment | State before | After this migration |
|-------------|--------------|----------------------|
| Fresh (Doctrine creates schema) | Baseline runs → `idx_api_keys_hash` + unique constraint | DROP IF EXISTS removes `idx_api_keys_hash`; FK index added. Final state: one unique index on `key_hash`, one regular index on `application_id`, one on `key_prefix`. |
| Staging (pre-marked baseline, schema bootstrapped via init-db.sql 2026-05-18) | Has both `idx_api_keys_hash` and the unique constraint-backed index | This migration drops the redundant one, adds the FK index. |
| Local dev volumes from before PR #602 | Same as staging (init-db.sql ran with old DDL) | Same fix applies. |

## Test plan

- [x] `composer parallel-lint` — 370 files, no errors
- [x] `composer lint` (phpcs) — clean
- [x] `composer analyse` (phpstan level 10) — 0 errors
- [ ] CI: `composer db:migrate` step (added in PR #602) applies both `Version20260518120000` and the new `Version20260519000000` against the postgres service container before phpunit runs
- [ ] After merge to staging: `\d api_keys` shows `idx_api_keys_application_id` present and no `idx_api_keys_hash` (only the unique `api_keys_key_hash_key` from the column constraint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized database indexes on the API keys table for improved query performance and efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->