### PR TITLE
feat(docker): add litcal-migrate one-shot service for auto-applied schema

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,5 @@
 !public/index.php
 !.env.example
 !scripts
+!bin
+!doctrine-migrations.php

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,31 +96,50 @@ See [Authentication Roadmap](docs/enhancements/AUTHENTICATION_ROADMAP.md) for im
 ### Local Development Bootstrap
 
 The API server runs on the **host** (not in a container). The `docker-compose.yml`
-stack provides only the dependent infrastructure (Postgres, Zitadel, OpenFGA,
-Mailpit, Adminer). Fresh-clone setup is a three-step sequence:
+stack provides the dependent infrastructure (Postgres, Zitadel, OpenFGA,
+Mailpit, Adminer) plus a one-shot `litcal-migrate` container that applies
+all pending Doctrine migrations against the litcal database. Fresh-clone
+setup is a three-step sequence:
 
 ```bash
-# 1. Start the infrastructure (Postgres + Zitadel + OpenFGA + ...).
-#    On first run, scripts/init-db.sql creates roles, databases, the pgcrypto
-#    extension, and an empty doctrine_migration_versions table. It does NOT
-#    create application tables — those live in src/Migrations/.
-docker compose up -d
+# 1. Start (or restart) the infrastructure and apply migrations.
+#
+#    Always pass --build so newly-pulled migration files land in the
+#    litcal-migrate image before it runs. --build is cheap when nothing
+#    in the build context changed (cached layers).
+#
+#    On first run: scripts/init-db.sql creates roles, databases, the
+#    pgcrypto extension, and the empty doctrine_migration_versions
+#    tracking table. The litcal-migrate one-shot then applies
+#    Version20260518120000 (and any later migrations) to create the
+#    application schema — access_requests, applications, api_keys,
+#    audit_log, ... — and exits.
+#
+#    On subsequent runs: db comes up healthy from the persisted volume;
+#    litcal-migrate re-runs and is a no-op if everything is up-to-date,
+#    or applies whatever new migrations the rebuild picked up.
+docker compose up -d --build
 
-# 2. Install PHP dependencies.
+# 2. Install PHP dependencies on the host (separate from the container).
 composer install
 
-# 3. Apply Doctrine migrations to create the application schema
-#    (access_requests, applications, api_keys, audit_log, ...).
-#    Re-runnable: a no-op once everything is up-to-date.
-composer db:migrate
-
-# 4. Start the API server.
+# 3. Start the API server on the host.
 composer start
 ```
 
-**After-pull:** if a new migration has landed since your last pull, re-run
-`composer db:migrate` before `composer start`. There's no auto-apply on
-server startup — migrations are an explicit step.
+**After-pull workflow:** re-run `docker compose up -d --build`. The
+`--build` flag triggers a rebuild of the litcal-migrate image whenever
+`src/Migrations/` (or any other COPY'd path) has changed, so newly-
+pulled migrations apply automatically without a manual `composer
+db:migrate` step.
+
+**Manual migrate (escape hatch):** if for any reason you need to run
+migrations from the host instead — debugging, running a single
+migration up/down, generating a new one — the composer scripts still
+work: `composer db:migrate`, `composer db:migrations:status`,
+`composer db:migrations:generate`. These require `vendor/` populated on
+the host (i.e. `composer install` first) and a Postgres reachable on
+`localhost:5432`.
 
 **Schema is authoritative in `src/Migrations/`, not in `init-db.sql`.** When
 adding a new table or column:

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,14 @@ COPY ./.env.example ./.env.local
 # so consumers (e.g., frontend docker-compose) can extract them.
 COPY ./scripts ./scripts
 
+# Include the Doctrine migrations CLI script + its config so the
+# docker-compose `litcal-migrate` one-shot service can invoke
+# `php bin/doctrine-migrations migrate --no-interaction`. Both files
+# are tiny (the CLI bootstraps DependencyFactory from env vars; the
+# config declares table_storage + migrations_paths).
+COPY ./bin ./bin
+COPY ./doctrine-migrations.php ./
+
 # Stage 2: final build
 FROM php:8.4-cli AS main
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,6 +166,37 @@ services:
       - postgres_data:/var/lib/postgresql/data:rw
       - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
 
+  # One-shot Doctrine migrate runner for the litcal database.
+  # scripts/init-db.sql is bootstrap-only (roles, databases, pgcrypto, empty
+  # doctrine_migration_versions tracking table). Application-table DDL
+  # (access_requests, applications, api_keys, audit_log, ...) lives in
+  # src/Migrations/ and is applied by this service against the running db.
+  #
+  # Re-runnable: a no-op when everything is up-to-date. Always rebuild the
+  # image with `docker compose up -d --build` so newly-pulled migrations
+  # land in the container before this service runs.
+  #
+  # NOTE: this service exists so a fresh `docker compose up -d --build`
+  # from a wiped postgres_data volume produces a fully migrated schema
+  # with no manual `composer db:migrate` step. The API server itself
+  # still runs on the host via `composer start` — only migrations run
+  # in-container.
+  litcal-migrate:
+    build: .
+    command: ["php", "bin/doctrine-migrations", "migrate", "--no-interaction"]
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: litcal
+      DB_USER: litcal
+      DB_PASSWORD: litcal_secure_password
+    depends_on:
+      db:
+        condition: service_healthy
+    networks:
+      - zitadel
+    restart: "no"
+
   # Adminer - Database management UI
   # Access at: http://localhost:8088
   # Login: System=PostgreSQL, Server=db, Username=postgres, Password=postgres


### PR DESCRIPTION
Follow-up to #602 (issue #600). Closes the original "Docker-compose stack startup applies migrations automatically" acceptance criterion that #602 had relaxed to doc-only.

## Why now

On reconsideration, the host-side `composer db:migrate` step #602 documented is still a foot-gun in two scenarios:

| Scenario | Foot-gun |
|----------|----------|
| Fresh `docker compose up -d` from wiped postgres_data | Stack comes up but schema is missing until human runs `composer db:migrate`. API endpoints return 500 with `relation "api_keys" does not exist` until the human notices. |
| Pull, restart stack | Same shape — newly-added migration files don't reach the DB unless the human remembered to re-run `composer db:migrate`. |

A short-lived migrate service eliminates the foot-gun symmetrically with how `openfga-migrate` already works in the same compose file.

## Changes

| File | Change |
|------|--------|
| `docker-compose.yml` | New `litcal-migrate` service: `build: .`, runs `php bin/doctrine-migrations migrate --no-interaction` against `DB_HOST=db`, `depends_on: db {condition: service_healthy}`, `restart: "no"`. |
| `Dockerfile` | Add `COPY ./bin ./bin` and `COPY ./doctrine-migrations.php ./` in the build stage so the migrate CLI + config land in the final image. |
| `.dockerignore` | Whitelist `!bin` and `!doctrine-migrations.php` (the file uses `*` blacklist + selective overrides; without these the new COPYs are silently empty). |
| `CLAUDE.md` | Rewrite "Local Development Bootstrap" — the canonical flow drops the host-side `composer db:migrate` step. New flow: `docker compose up -d --build` → `composer install` → `composer start`. Documented escape hatch retained for manual host-side runs (debugging, generating new migrations). |

## Approach rationale

- **Reuse existing Dockerfile** (multi-stage, PHP 8.4 + intl/pdo_pgsql + composer `--no-dev`) rather than introduce a separate migrate image family. The Doctrine migrate dependencies (`doctrine/migrations`, `doctrine/dbal`, `vlucas/phpdotenv`) are already in the prod `require` block, so `--no-dev` is fine.
- **`--build` on every `up`** rather than docs-only "rebuild when migrations change". The user pretty much never wants to skip `--build` here, and `--build` is cached when nothing in the build context changed.
- **`restart: "no"`** so the one-shot doesn't loop after a clean exit (the default `restart: unless-stopped` would treat exit-0 as "fell over, restart me").
- **No CI workflow changes needed.** GitHub Actions doesn't use docker-compose for phpunit — the workflow has its own `composer db:migrate` step (added in PR #602) running against the postgres service container.

## Behavior

- **Fresh volume + `docker compose up -d --build`**: db comes up, init-db.sql creates roles/databases/pgcrypto + empty tracking table, litcal-migrate runs after db healthy → applies `Version20260518120000` (+ `Version20260519000000` once #603 merges), exits 0. API ready to serve as soon as `composer start` runs on the host.
- **Existing volume + `docker compose up -d --build`**: db comes up from persisted state, litcal-migrate runs and is a no-op if up-to-date, or applies whichever migrations the rebuild's `src/Migrations/` brought in.
- **Manual host-side `composer db:migrate`**: still works (composer scripts unchanged). Useful for debugging, single up/down, or running `composer db:migrations:generate`.

## Test plan

- [x] `docker compose config --quiet` — schema valid
- [x] `docker compose build litcal-migrate` — image builds cleanly (~240s cold cache, much less when layers cached)
- [x] `docker run --rm liturgicalcalendarapi-litcal-migrate php bin/doctrine-migrations` — CLI invokes, exits with the expected "Database configuration missing" message when env vars are absent (proving the binary + config landed correctly)
- [x] `composer lint:md` — 23 files, 0 errors
- [ ] Reviewer: wipe postgres_data volume → `docker compose up -d --build` → `docker compose logs litcal-migrate` should show `[notice] Migrated.` (or "no migrations to execute" on re-run). `psql -h localhost -U litcal -d litcal -c '\dt'` shows all five application tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database migrations now automatically execute during Docker container initialization with `docker compose up -d --build`.

* **Documentation**
  * Updated local development setup guide with streamlined workflow steps.
  * Added after-pull workflow section and manual migration escape hatch documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/604?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->