### PR TITLE
feat(zitadel): scaffold per-org email template customization for LitCal

### DIFF
--- a/infrastructure/zitadel-message-texts/README.md
+++ b/infrastructure/zitadel-message-texts/README.md
@@ -1,0 +1,174 @@
+# Zitadel Message Text Customizations — LiturgicalCalendar Org
+
+This directory holds the per-language, per-template overrides for the
+notification emails Zitadel sends to **Liturgical Calendar** users on the
+umbrella `auth.catholicdigitalcommons.org` instance.
+
+Each `{locale}/{template}.json` file maps 1:1 to a Zitadel Management API
+endpoint of the form:
+
+```text
+PUT {ZITADEL_URL}/management/v1/text/message/{template}/{locale}
+```
+
+The `scripts/setup-zitadel-message-texts.sh` runner walks this tree and
+PUTs each file. See "Running the setup" below.
+
+## Why these exist
+
+Zitadel ships [translated defaults for 22 languages](#supported-languages)
+covering subject lines, button labels, greetings, and body text. Those
+defaults are perfectly serviceable but generic — they say nothing about
+Liturgical Calendar or the Catholic Digital Commons Foundation, and the
+"From" line is umbrella-wide (`Catholic Digital Commons Foundation
+<noreply@catholicdigitalcommons.org>`) for every property hosted on the
+shared identity stack. Customizing the **body** is how we add LitCal-
+specific context (project name, footer, expectations) so the email
+that lands in a recipient's inbox reads like it came from the
+Liturgical Calendar project, not a generic auth provider.
+
+Scope: the PUTs are made authenticated as a machine user inside the
+`LiturgicalCalendar` Org, so the overrides only apply to that org. Other
+umbrella properties (cdcf-website, BibleGet, ...) keep their own overrides
+or fall back to Zitadel defaults.
+
+## Directory layout
+
+```text
+infrastructure/zitadel-message-texts/
+├── README.md                         # this file
+└── en/                               # English templates (canonical seed)
+    ├── domain-claimed.json
+    ├── init.json
+    ├── invite-user.json
+    ├── password-change.json
+    ├── password-reset.json
+    ├── passwordless-registration.json
+    ├── verify-email.json
+    └── verify-email-otp.json
+```
+
+To add a new language, copy `en/` to `{locale}/` and translate the
+strings in each JSON file. Locales without an override directory fall
+back to Zitadel's built-in default for that language.
+
+## Template types
+
+The eight templates currently scaffolded are the email-based ones. SMS
+templates (`verify-phone`, `verify-sms-otp`) are intentionally **not**
+included — Liturgical Calendar doesn't use SMS verification, and the
+SMS template fields differ structurally (no subject/button/footer).
+Add them later if SMS gets enabled.
+
+| Template                    | When sent                                              |
+|-----------------------------|--------------------------------------------------------|
+| `init`                      | New user created (server-side), needs to set password  |
+| `invite-user`               | Existing org member invites a new user                 |
+| `verify-email`              | Email address confirmation (link-based)                |
+| `verify-email-otp`          | Email address confirmation (one-time-code based)       |
+| `password-reset`            | User requests password reset                           |
+| `password-change`           | Confirmation after password successfully changed       |
+| `passwordless-registration` | User starts passkey enrollment                         |
+| `domain-claimed`            | User's email domain claimed by another org             |
+
+## Field schema
+
+Each JSON file accepts the following keys. All are optional — any key
+you omit falls back to Zitadel's default for that locale/template.
+
+| Key          | Typical use                                   |
+|--------------|-----------------------------------------------|
+| `title`      | H1 inside the email body                      |
+| `preHeader`  | Inbox preview snippet (shown next to subject) |
+| `subject`    | Email subject line                            |
+| `greeting`   | First line of the body (see variables below)  |
+| `text`       | Main body copy                                |
+| `buttonText` | Label on the call-to-action button            |
+| `footerText` | Closing line below the button                 |
+
+## Template variables
+
+Strings can interpolate Zitadel context variables via Go template
+syntax. Commonly available:
+
+- `{{.PreferredLoginName}}` — user's preferred login name (`user@org.tld`)
+- `{{.FirstName}}` / `{{.LastName}}` / `{{.DisplayName}}` — name fields
+- `{{.UserName}}` — the loginname portion
+- `{{.OTP}}` — one-time code (only in `verify-email-otp`)
+
+See the [Zitadel docs](https://zitadel.com/docs/guides/manage/customize/texts)
+for the full per-template variable list. Using a variable that doesn't
+exist for a given template renders empty.
+
+## Supported languages
+
+Zitadel 2.x ships built-in defaults for these 22 locales. Any locale
+not listed here will be rejected by the API.
+
+```text
+ar  bg  cs  de  en  es  fr  hu
+id  it  ja  ko  mk  nl  pl  pt
+ro  ru  sv  tr  uk  zh
+```
+
+**Notes for LitCal:**
+
+- `la` (Latin) is **not** in Zitadel's defaults — ICU has no Latin
+  locale. Latin-preferring users fall back to English at the message-
+  text layer regardless of any `Accept-Language: la` they send.
+- `sk` (Slovak) and `vi` (Vietnamese) — supported by LitCal but **not**
+  by Zitadel. Users with these as preferred locales will receive
+  English messages.
+
+## Running the setup
+
+The runner is `scripts/setup-zitadel-message-texts.sh` (repo root).
+
+**Required environment:**
+
+```bash
+export ZITADEL_URL=https://auth.catholicdigitalcommons.org
+export ZITADEL_PAT=<PAT for a machine user inside LiturgicalCalendar Org>
+```
+
+The PAT must belong to a machine user that holds at least the
+`ORG_OWNER` or `ORG_SETTINGS_MANAGER` role inside the `LiturgicalCalendar`
+Org. Create one in the umbrella Zitadel console under
+`LiturgicalCalendar` Org → Users → Service Users → New → assign role
+→ Personal Access Tokens → Generate.
+
+**Default run** (push every locale, every template):
+
+```bash
+./scripts/setup-zitadel-message-texts.sh
+```
+
+**Dry run** (print what would be PUT, no network calls):
+
+```bash
+./scripts/setup-zitadel-message-texts.sh --dry-run
+```
+
+**Scope to a single locale and/or template** (iteration):
+
+```bash
+./scripts/setup-zitadel-message-texts.sh --locale=en
+./scripts/setup-zitadel-message-texts.sh --template=verify-email
+./scripts/setup-zitadel-message-texts.sh --locale=en --template=verify-email
+```
+
+The runner is idempotent — PUTting the same body twice is a no-op on
+the Zitadel side.
+
+## Reverting a template
+
+To restore Zitadel's default for a given `{template, locale}` pair,
+either delete the file from this directory and re-run the script (no:
+the script only PUTs, never DELETEs) **or** issue the reset endpoint
+manually:
+
+```bash
+curl -X POST \
+  -H "Authorization: Bearer $ZITADEL_PAT" \
+  "$ZITADEL_URL/management/v1/text/message/{template}/{locale}/_reset"
+```

--- a/infrastructure/zitadel-message-texts/en/domain-claimed.json
+++ b/infrastructure/zitadel-message-texts/en/domain-claimed.json
@@ -1,0 +1,9 @@
+{
+  "title": "Your Email Domain Was Claimed",
+  "preHeader": "Action required on your Liturgical Calendar account.",
+  "subject": "Your email domain has been claimed — Liturgical Calendar",
+  "greeting": "Hello {{.PreferredLoginName}},",
+  "text": "The domain of your email address has been claimed by an organization on the Catholic Digital Commons Foundation identity service. At your next sign-in you'll be asked to choose a new login name. Your account data, including your Liturgical Calendar settings and history, is preserved.",
+  "buttonText": "Sign In",
+  "footerText": "Liturgical Calendar is a project of the Catholic Digital Commons Foundation."
+}

--- a/infrastructure/zitadel-message-texts/en/init.json
+++ b/infrastructure/zitadel-message-texts/en/init.json
@@ -1,0 +1,9 @@
+{
+  "title": "Welcome to Liturgical Calendar",
+  "preHeader": "Activate your Liturgical Calendar account.",
+  "subject": "Welcome — activate your Liturgical Calendar account",
+  "greeting": "Hello {{.PreferredLoginName}},",
+  "text": "Your account has been created on the Catholic Digital Commons Foundation identity service. Click the button below to set your password and finish activating your access to the Liturgical Calendar project.",
+  "buttonText": "Activate Account",
+  "footerText": "Liturgical Calendar is a project of the Catholic Digital Commons Foundation. If you weren't expecting this email, you can safely ignore it."
+}

--- a/infrastructure/zitadel-message-texts/en/invite-user.json
+++ b/infrastructure/zitadel-message-texts/en/invite-user.json
@@ -1,0 +1,9 @@
+{
+  "title": "You've Been Invited",
+  "preHeader": "Accept your invitation to Liturgical Calendar.",
+  "subject": "You've been invited to Liturgical Calendar",
+  "greeting": "Hello {{.PreferredLoginName}},",
+  "text": "You've been invited to join the Liturgical Calendar project on the Catholic Digital Commons Foundation identity service. Click the button below to accept the invitation and set up your account.",
+  "buttonText": "Accept Invitation",
+  "footerText": "Liturgical Calendar is a project of the Catholic Digital Commons Foundation. If you weren't expecting this invitation, you can safely ignore it."
+}

--- a/infrastructure/zitadel-message-texts/en/password-change.json
+++ b/infrastructure/zitadel-message-texts/en/password-change.json
@@ -1,0 +1,9 @@
+{
+  "title": "Your Password Was Changed",
+  "preHeader": "Heads up — your password was just updated.",
+  "subject": "Your Liturgical Calendar password was changed",
+  "greeting": "Hello {{.PreferredLoginName}},",
+  "text": "This is a confirmation that the password for your Liturgical Calendar account was just changed. If this was you, no action is needed. If it wasn't, please reset your password immediately and contact us.",
+  "buttonText": "Sign In",
+  "footerText": "Liturgical Calendar is a project of the Catholic Digital Commons Foundation."
+}

--- a/infrastructure/zitadel-message-texts/en/password-reset.json
+++ b/infrastructure/zitadel-message-texts/en/password-reset.json
@@ -1,0 +1,9 @@
+{
+  "title": "Reset Your Password",
+  "preHeader": "Use this link to set a new password.",
+  "subject": "Reset your Liturgical Calendar password",
+  "greeting": "Hello {{.PreferredLoginName}},",
+  "text": "We received a request to reset the password for your Liturgical Calendar account. Click the button below to choose a new one. If you didn't request a reset, you can safely ignore this email — your password will remain unchanged.",
+  "buttonText": "Reset Password",
+  "footerText": "Liturgical Calendar is a project of the Catholic Digital Commons Foundation."
+}

--- a/infrastructure/zitadel-message-texts/en/passwordless-registration.json
+++ b/infrastructure/zitadel-message-texts/en/passwordless-registration.json
@@ -1,0 +1,9 @@
+{
+  "title": "Set Up Passwordless Sign-In",
+  "preHeader": "Enable a passkey for faster, more secure sign-in.",
+  "subject": "Set up passwordless sign-in for Liturgical Calendar",
+  "greeting": "Hello {{.PreferredLoginName}},",
+  "text": "Click the button below to register a passkey for your Liturgical Calendar account. After setup, you'll be able to sign in without a password using your device's biometrics or PIN.",
+  "buttonText": "Register Passkey",
+  "footerText": "Liturgical Calendar is a project of the Catholic Digital Commons Foundation."
+}

--- a/infrastructure/zitadel-message-texts/en/verify-email-otp.json
+++ b/infrastructure/zitadel-message-texts/en/verify-email-otp.json
@@ -1,0 +1,9 @@
+{
+  "title": "Your Verification Code",
+  "preHeader": "Use this one-time code to verify your email.",
+  "subject": "Your Liturgical Calendar verification code",
+  "greeting": "Hello {{.PreferredLoginName}},",
+  "text": "Your one-time verification code is {{.OTP}}. Enter it on the verification page to confirm your email address. This code expires shortly — please use it promptly.",
+  "buttonText": "Verify",
+  "footerText": "Liturgical Calendar is a project of the Catholic Digital Commons Foundation. If you didn't request this code, please secure your account."
+}

--- a/infrastructure/zitadel-message-texts/en/verify-email.json
+++ b/infrastructure/zitadel-message-texts/en/verify-email.json
@@ -1,0 +1,9 @@
+{
+  "title": "Verify Your Email",
+  "preHeader": "One last step to confirm your email address.",
+  "subject": "Verify your email — Liturgical Calendar",
+  "greeting": "Hello {{.PreferredLoginName}},",
+  "text": "Please confirm the email address associated with your Liturgical Calendar account by clicking the button below.",
+  "buttonText": "Verify Email",
+  "footerText": "Liturgical Calendar is a project of the Catholic Digital Commons Foundation. If you didn't request this, you can safely ignore this email — no further action is needed."
+}

--- a/scripts/setup-zitadel-message-texts.sh
+++ b/scripts/setup-zitadel-message-texts.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+# Zitadel Message Text Setup Script for LiturgicalCalendar.
+#
+# Walks infrastructure/zitadel-message-texts/{locale}/{template}.json and
+# PUTs each file to the umbrella Zitadel Management API:
+#
+#     PUT {ZITADEL_URL}/management/v1/text/message/{template}/{locale}
+#
+# Scope: PUTs are made authenticated as a machine user inside the
+# LiturgicalCalendar Org, so overrides only apply to that org.
+#
+# Usage:
+#   ZITADEL_URL=https://auth.catholicdigitalcommons.org \
+#   ZITADEL_PAT=<personal-access-token> \
+#     ./scripts/setup-zitadel-message-texts.sh
+#
+#   ./scripts/setup-zitadel-message-texts.sh --dry-run
+#   ./scripts/setup-zitadel-message-texts.sh --locale=en
+#   ./scripts/setup-zitadel-message-texts.sh --template=verify-email
+#   ./scripts/setup-zitadel-message-texts.sh --locale=en --template=verify-email
+#
+# Required env (unless --dry-run):
+#   ZITADEL_URL   base URL of the umbrella Zitadel
+#   ZITADEL_PAT   PAT for a machine user with ORG_OWNER or
+#                 ORG_SETTINGS_MANAGER inside LiturgicalCalendar Org
+#
+# Idempotent: PUTting the same body twice is a no-op on Zitadel's side.
+
+set -euo pipefail
+
+if [ -z "${BASH_VERSINFO[0]:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    echo "Error: Bash >= 4 is required (current: ${BASH_VERSION:-unknown})." >&2
+    echo "On macOS, run: brew install bash && /opt/homebrew/bin/bash $0 $*" >&2
+    exit 1
+fi
+
+# Colors (skip when not a TTY)
+if [ -t 1 ]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+    YELLOW='\033[1;33m'
+    BLUE='\033[0;34m'
+    DIM='\033[2m'
+    NC='\033[0m'
+else
+    RED=''; GREEN=''; YELLOW=''; BLUE=''; DIM=''; NC=''
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATES_DIR="${SCRIPT_DIR}/../infrastructure/zitadel-message-texts"
+
+# Zitadel's 22 built-in locales. Any locale dir not in this set is rejected
+# upstream — we fail fast locally with a clear message instead of letting
+# the API return 400 for every PUT.
+SUPPORTED_LOCALES=(ar bg cs de en es fr hu id it ja ko mk nl pl pt ro ru sv tr uk zh)
+
+DRY_RUN=false
+LOCALE_FILTER=""
+TEMPLATE_FILTER=""
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  --dry-run              Print what would be PUT without making network calls
+  --locale=<code>        Only push templates under {locale}/ (e.g. --locale=en)
+  --template=<name>      Only push {name}.json across all locales (e.g. --template=verify-email)
+  -h, --help             Show this help
+
+Required env (unless --dry-run):
+  ZITADEL_URL            e.g. https://auth.catholicdigitalcommons.org
+  ZITADEL_PAT            Personal Access Token (machine user in target org)
+
+EOF
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --locale=*) LOCALE_FILTER="${arg#*=}" ;;
+        --template=*) TEMPLATE_FILTER="${arg#*=}" ;;
+        -h|--help) usage; exit 0 ;;
+        *)
+            echo -e "${RED}Unknown argument: ${arg}${NC}" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo -e "${RED}Error: jq is required but not installed.${NC}" >&2
+    exit 1
+fi
+if ! command -v curl >/dev/null 2>&1; then
+    echo -e "${RED}Error: curl is required but not installed.${NC}" >&2
+    exit 1
+fi
+
+if [ ! -d "$TEMPLATES_DIR" ]; then
+    echo -e "${RED}Error: templates directory not found: ${TEMPLATES_DIR}${NC}" >&2
+    exit 1
+fi
+
+# Validate --locale filter against the supported set if provided.
+if [ -n "$LOCALE_FILTER" ]; then
+    valid=false
+    for sl in "${SUPPORTED_LOCALES[@]}"; do
+        [ "$sl" = "$LOCALE_FILTER" ] && valid=true && break
+    done
+    if ! $valid; then
+        echo -e "${RED}Error: locale '${LOCALE_FILTER}' is not in Zitadel's supported set.${NC}" >&2
+        echo -e "${DIM}Supported: ${SUPPORTED_LOCALES[*]}${NC}" >&2
+        exit 2
+    fi
+fi
+
+if ! $DRY_RUN; then
+    : "${ZITADEL_URL:?need ZITADEL_URL (e.g. https://auth.catholicdigitalcommons.org)}"
+    : "${ZITADEL_PAT:?need ZITADEL_PAT (Personal Access Token for an org machine user)}"
+    # Strip trailing slash from URL so we don't end up with double slashes.
+    ZITADEL_URL="${ZITADEL_URL%/}"
+fi
+
+echo -e "${BLUE}Zitadel message-text sync${NC}"
+echo -e "  templates dir: ${DIM}${TEMPLATES_DIR}${NC}"
+if $DRY_RUN; then
+    echo -e "  mode:          ${YELLOW}DRY RUN${NC} (no network calls)"
+else
+    echo -e "  target:        ${ZITADEL_URL}"
+fi
+[ -n "$LOCALE_FILTER" ]   && echo -e "  locale filter: ${LOCALE_FILTER}"
+[ -n "$TEMPLATE_FILTER" ] && echo -e "  template filter: ${TEMPLATE_FILTER}"
+echo
+
+pushed=0
+skipped=0
+failed=0
+
+for locale_dir in "$TEMPLATES_DIR"/*/; do
+    locale=$(basename "$locale_dir")
+
+    # Skip a dir that's not a recognised Zitadel locale — surfaces typos.
+    in_supported=false
+    for sl in "${SUPPORTED_LOCALES[@]}"; do
+        [ "$sl" = "$locale" ] && in_supported=true && break
+    done
+    if ! $in_supported; then
+        echo -e "${YELLOW}skip${NC} ${locale}/  (not in Zitadel's supported locales)"
+        continue
+    fi
+
+    if [ -n "$LOCALE_FILTER" ] && [ "$locale" != "$LOCALE_FILTER" ]; then
+        continue
+    fi
+
+    for tmpl_file in "$locale_dir"*.json; do
+        [ -f "$tmpl_file" ] || continue
+
+        template=$(basename "$tmpl_file" .json)
+
+        if [ -n "$TEMPLATE_FILTER" ] && [ "$template" != "$TEMPLATE_FILTER" ]; then
+            continue
+        fi
+
+        # Validate JSON before sending.
+        if ! jq empty "$tmpl_file" >/dev/null 2>&1; then
+            echo -e "${RED}fail${NC} ${locale}/${template}.json — invalid JSON"
+            failed=$((failed + 1))
+            continue
+        fi
+
+        url="${ZITADEL_URL:-(dry)}/management/v1/text/message/${template}/${locale}"
+
+        if $DRY_RUN; then
+            echo -e "${BLUE}PUT${NC}  ${url}"
+            jq -c . "$tmpl_file"
+            pushed=$((pushed + 1))
+            continue
+        fi
+
+        # Make the request, capture HTTP status + body.
+        http_code=$(curl -sS -o /tmp/.zitadel-msg-resp.$$ -w "%{http_code}" \
+            -X PUT \
+            -H "Authorization: Bearer ${ZITADEL_PAT}" \
+            -H "Content-Type: application/json" \
+            -d @"$tmpl_file" \
+            "$url" || echo "000")
+
+        if [ "$http_code" = "200" ]; then
+            echo -e "${GREEN}ok${NC}   PUT ${template}/${locale}"
+            pushed=$((pushed + 1))
+        else
+            echo -e "${RED}fail${NC} PUT ${template}/${locale} — HTTP ${http_code}"
+            if [ -s /tmp/.zitadel-msg-resp.$$ ]; then
+                jq -r '.message // .' /tmp/.zitadel-msg-resp.$$ 2>/dev/null | sed 's/^/       /' || \
+                    sed 's/^/       /' /tmp/.zitadel-msg-resp.$$
+            fi
+            failed=$((failed + 1))
+        fi
+        rm -f /tmp/.zitadel-msg-resp.$$
+    done
+done
+
+echo
+echo -e "${BLUE}Summary${NC}"
+echo -e "  pushed:  ${GREEN}${pushed}${NC}"
+echo -e "  skipped: ${skipped}"
+if [ "$failed" -gt 0 ]; then
+    echo -e "  failed:  ${RED}${failed}${NC}"
+    exit 1
+fi
+echo -e "  failed:  ${failed}"

--- a/scripts/setup-zitadel-message-texts.sh
+++ b/scripts/setup-zitadel-message-texts.sh
@@ -148,6 +148,7 @@ for locale_dir in "$TEMPLATES_DIR"/*/; do
     done
     if ! $in_supported; then
         echo -e "${YELLOW}skip${NC} ${locale}/  (not in Zitadel's supported locales)"
+        skipped=$((skipped + 1))
         continue
     fi
 
@@ -212,3 +213,18 @@ if [ "$failed" -gt 0 ]; then
     exit 1
 fi
 echo -e "  failed:  ${failed}"
+
+# Fail loudly if filters were set but matched zero template files. Without
+# this guard, a typo like --template=verify-emails (extra 's') would exit 0
+# with "pushed: 0", silently signalling success for a no-op. The locale
+# filter is already validated against SUPPORTED_LOCALES up front, but the
+# template filter is matched against on-disk filenames — so this is where
+# the typo gets caught.
+if [ "$pushed" -eq 0 ] && [ "$failed" -eq 0 ] && { [ -n "$LOCALE_FILTER" ] || [ -n "$TEMPLATE_FILTER" ]; }; then
+    echo
+    echo -e "${RED}Error: filters matched zero template files.${NC}" >&2
+    [ -n "$LOCALE_FILTER" ]   && echo -e "  --locale=${LOCALE_FILTER}" >&2
+    [ -n "$TEMPLATE_FILTER" ] && echo -e "  --template=${TEMPLATE_FILTER}" >&2
+    echo -e "${DIM}Check the template name spelling; available templates are the .json file basenames under each locale dir.${NC}" >&2
+    exit 1
+fi


### PR DESCRIPTION
Follow-up to #597.

## Summary

Scaffolds the final actionable from issue #597: customize the body of the emails Zitadel sends to **Liturgical Calendar** users on the umbrella `auth.catholicdigitalcommons.org` instance, so they read like they came from the Liturgical Calendar project rather than generic Zitadel defaults. The "From" line stays umbrella-wide (Zitadel only supports one active SMTP sender per instance) — only the body content is customized.

**This PR adds the scaffold. It doesn't push anything anywhere.** The runner is opt-in, env-gated, and idempotent. Pushing happens only when a human invokes `./scripts/setup-zitadel-message-texts.sh` against a target Zitadel.

## What's in this PR

```text
infrastructure/zitadel-message-texts/
├── README.md                          # workflow + supported locales + auth
└── en/                                # English seed (canonical)
    ├── domain-claimed.json
    ├── init.json
    ├── invite-user.json
    ├── password-change.json
    ├── password-reset.json
    ├── passwordless-registration.json
    ├── verify-email-otp.json
    └── verify-email.json
scripts/
└── setup-zitadel-message-texts.sh     # bash runner that PUTs to Zitadel
```

Eight templates — all email-based. SMS templates (`verify-phone`, `verify-sms-otp`) are intentionally excluded: LitCal doesn't use SMS verification, and the SMS template field schema differs structurally (no `subject`/`buttonText`/`footerText`). Easy to add later if SMS gets enabled.

## English copy choices

- Project name everywhere: **Liturgical Calendar**
- Umbrella identification: **Catholic Digital Commons Foundation identity service**
- Footer constant: `Liturgical Calendar is a project of the Catholic Digital Commons Foundation.`
- Variables: standard Zitadel ones — `{{.PreferredLoginName}}` for greeting, `{{.OTP}}` in the OTP template
- All seven Zitadel fields (`title`, `preHeader`, `subject`, `greeting`, `text`, `buttonText`, `footerText`) are populated for every template so reviewers see the full payload at a glance. Any field a translator omits at runtime falls back to Zitadel's locale default.

## How to add other languages

Copy `en/` to `{locale}/` and translate. The runner validates each subdir against Zitadel's 22 supported locales:

```text
ar bg cs de en es fr hu id it ja ko mk nl pl pt ro ru sv tr uk zh
```

Typos surface as a per-dir `skip` line rather than 400s per request from the API. Per discussion: `la` / `sk` / `vi` (which LitCal supports but Zitadel doesn't) fall back to `en` at the message-text layer.

## Runner ergonomics

```bash
# All locales, all templates (canonical use)
ZITADEL_URL=https://auth.catholicdigitalcommons.org \
ZITADEL_PAT=<machine-user-pat> \
  ./scripts/setup-zitadel-message-texts.sh

# Inspect what would be sent — zero network calls
./scripts/setup-zitadel-message-texts.sh --dry-run

# Iterate on one locale or one template
./scripts/setup-zitadel-message-texts.sh --locale=en
./scripts/setup-zitadel-message-texts.sh --template=verify-email
./scripts/setup-zitadel-message-texts.sh --locale=en --template=verify-email
```

- `set -euo pipefail`, bash 4+ guard (matches `scripts/setup-zitadel.sh` convention)
- `jq` pre-validates each JSON file before PUTting
- HTTP status surfaced per file with the API's error message extracted (`jq -r '.message'` from response body)
- Coloured `ok` / `fail` / `skip` output + final summary; exit non-zero if any push fails
- Idempotent: PUTting the same body twice is a no-op on Zitadel's side

## Reverting a template

Documented in the README. Either delete the JSON file (runner only PUTs, never DELETEs) **or** `POST .../_reset` via a one-line curl shown in the README.

## Auth requirements

The runner needs a Zitadel Personal Access Token for a machine user inside the **`LiturgicalCalendar`** Org with `ORG_OWNER` or `ORG_SETTINGS_MANAGER`. The umbrella Zitadel console workflow to create one is in the README (`...Org → Users → Service Users → New → assign role → Personal Access Tokens → Generate`).

The PAT is **not** stored in the repo. It's supplied to the runner via env var (`ZITADEL_PAT`) when a human runs the script.

## Image bundling

`scripts/` is bundled into the project Docker image (per `Dockerfile`'s `COPY ./scripts ./scripts` and `.dockerignore !scripts`), so `scripts/setup-zitadel-message-texts.sh` travels with the image identically to how `scripts/setup-zitadel.sh` does today. No Dockerfile changes needed.

## Test plan

- [x] `composer parallel-lint` — 369 files, no errors
- [x] `composer lint:md` — 24 files, 0 errors
- [x] `./scripts/setup-zitadel-message-texts.sh --dry-run` — 8 ok, 0 fail
- [x] `./scripts/setup-zitadel-message-texts.sh --dry-run --template=verify-email` — 1 ok, 0 fail (filter works)
- [x] `./scripts/setup-zitadel-message-texts.sh --locale=xx` — clean error + supported-locale list (rejects unsupported)
- [x] `./scripts/setup-zitadel-message-texts.sh` (no env) — fails fast on missing `ZITADEL_URL`
- [ ] Whoever holds the umbrella admin PAT: run against the live umbrella Zitadel, eyeball the resulting emails (signup → verification email lands in inbox, displays Liturgical Calendar branding in the body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable email notification templates for password resets, email verification, user invitations, domain claims, password changes, passwordless registration, and account setup.

* **Documentation**
  * Added comprehensive guide for managing and deploying email message customizations for the Liturgical Calendar organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/606?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->