### PR TITLE
ci(deploy): retry transient SSH/rsync failures + add curl --retry to migrate

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -214,15 +214,32 @@ jobs:
             "${DEPLOY_PATH}/cache" \
             "${DEPLOY_PATH}/public/engineCache" \
             "${DEPLOY_PATH}/logs")
-          ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
-            -o IdentitiesOnly=yes \
-            -o StrictHostKeyChecking=yes \
-            -o UserKnownHostsFile=~/.ssh/known_hosts \
-            -o ConnectTimeout=10 \
-            -o ServerAliveInterval=15 \
-            -o ServerAliveCountMax=2 \
-            "${VPS_USER}@${VPS_HOST}" \
-            "${remote_cmd}"
+          # Retry on transient SSH failures (connection reset, fail2ban
+          # backoff, MaxStartups contention). 3 attempts with 10s/20s
+          # backoff — total worst-case wait 30s before giving up.
+          attempt=1
+          max=3
+          while true; do
+            if ssh -i ~/.ssh/deploy_key -p "${VPS_PORT}" \
+                -o IdentitiesOnly=yes \
+                -o StrictHostKeyChecking=yes \
+                -o UserKnownHostsFile=~/.ssh/known_hosts \
+                -o ConnectTimeout=10 \
+                -o ServerAliveInterval=15 \
+                -o ServerAliveCountMax=2 \
+                "${VPS_USER}@${VPS_HOST}" \
+                "${remote_cmd}"; then
+              break
+            fi
+            if [ "$attempt" -ge "$max" ]; then
+              echo "::error::ssh mkdir failed after ${max} attempts" >&2
+              exit 1
+            fi
+            delay=$((attempt * 10))
+            echo "::warning::ssh mkdir attempt ${attempt} failed; retrying in ${delay}s..." >&2
+            sleep "$delay"
+            attempt=$((attempt + 1))
+          done
 
       - name: Deploy via rsync
         if: steps.shape.outputs.skip != 'true'
@@ -233,13 +250,33 @@ jobs:
           DEPLOY_PATH: ${{ steps.params.outputs.deploy_path }}
         run: |
           set -euo pipefail
-          rsync \
-            --archive --no-owner --no-group \
-            --compress --human-readable --verbose \
-            --delete --protect-args \
-            --exclude-from=.github/deploy/rsync-exclude.txt \
-            -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
-            ./ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/"
+          # Retry on transient SSH-layer failures the underlying rsync
+          # surfaces as "Connection reset by peer" / exit code 255. Same
+          # 3-attempt 10s/20s backoff as the mkdir step above. rsync's own
+          # --partial would help for mid-transfer drops, but the failures
+          # we've seen happen at SSH key exchange — before rsync has any
+          # bytes on the wire — so a wrapper retry is the right level.
+          attempt=1
+          max=3
+          while true; do
+            if rsync \
+                --archive --no-owner --no-group \
+                --compress --human-readable --verbose \
+                --delete --protect-args \
+                --exclude-from=.github/deploy/rsync-exclude.txt \
+                -e "ssh -i ~/.ssh/deploy_key -p ${VPS_PORT} -o IdentitiesOnly=yes -o StrictHostKeyChecking=yes -o UserKnownHostsFile=~/.ssh/known_hosts -o ConnectTimeout=10 -o ServerAliveInterval=15 -o ServerAliveCountMax=2" \
+                ./ "${VPS_USER}@${VPS_HOST}:${DEPLOY_PATH%/}/"; then
+              break
+            fi
+            if [ "$attempt" -ge "$max" ]; then
+              echo "::error::rsync failed after ${max} attempts" >&2
+              exit 1
+            fi
+            delay=$((attempt * 10))
+            echo "::warning::rsync attempt ${attempt} failed; retrying in ${delay}s..." >&2
+            sleep "$delay"
+            attempt=$((attempt + 1))
+          done
 
       - name: Reset OPcache
         if: steps.shape.outputs.skip != 'true'
@@ -284,7 +321,14 @@ jobs:
             echo "::error::Repository variable VPS_APP_BASE_URL is not set." >&2
             exit 1
           fi
-          curl -fsS --max-time 600 \
+          # --retry 2 covers transient TCP-layer failures (connection
+          # reset, refused) without retrying on HTTP error codes. The
+          # migrate endpoint is idempotent — Doctrine wraps each
+          # migration in a transaction (transactional: true) and uses
+          # sync-metadata-storage to claim each version atomically, so
+          # a dropped connection mid-run rolls back cleanly and the
+          # next attempt re-applies whatever didn't commit.
+          curl -fsS --max-time 600 --retry 2 --retry-delay 5 \
             -X POST \
             -H "X-Deploy-Token: ${DEPLOY_TOKEN}" \
             -H "Accept: text/plain" \

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -321,14 +321,22 @@ jobs:
             echo "::error::Repository variable VPS_APP_BASE_URL is not set." >&2
             exit 1
           fi
-          # --retry 2 covers transient TCP-layer failures (connection
-          # reset, refused) without retrying on HTTP error codes. The
-          # migrate endpoint is idempotent — Doctrine wraps each
-          # migration in a transaction (transactional: true) and uses
-          # sync-metadata-storage to claim each version atomically, so
-          # a dropped connection mid-run rolls back cleanly and the
-          # next attempt re-applies whatever didn't commit.
-          curl -fsS --max-time 600 --retry 2 --retry-delay 5 \
+          # Retry transient TCP failures on the migrate request. Default
+          # `--retry` covers timeouts and 5xx but does NOT cover
+          # connection-refused — that's gated by `--retry-connrefused`,
+          # which we explicitly enable here so a PHP-FPM restart blip
+          # between OPcache reset and this call doesn't fail the deploy.
+          # (Connection-reset mid-stream is still not retried by default;
+          # we'd need `--retry-all-errors` for that, which is more
+          # aggressive than warranted at this point — add later if we
+          # observe RST-class failures in practice.)
+          # Safe to retry: the migrate endpoint is idempotent — Doctrine
+          # wraps each migration in a transaction (transactional: true)
+          # and uses sync-metadata-storage to claim each version
+          # atomically, so a dropped connection mid-run rolls back
+          # cleanly and the next attempt re-applies whatever didn't
+          # commit.
+          curl -fsS --max-time 600 --retry 2 --retry-delay 5 --retry-connrefused \
             -X POST \
             -H "X-Deploy-Token: ${DEPLOY_TOKEN}" \
             -H "Accept: text/plain" \


### PR DESCRIPTION
PR #605's deploy red-lighted at the rsync step with `kex_exchange_identification: read: Connection reset by peer` — the remote SSH daemon reset the connection before key exchange even completed. The next manual rerun succeeded on the first attempt, confirming it was transient. Three plausible causes: fail2ban backoff window (PR #603 deployed 12 min before), `MaxStartups` contention, or a brief OVH network blip.

Whitelisting GitHub Actions runner IPs upstream isn't practical — the pool is ~10k+ Azure ranges rotating weekly, which is effectively "most of Azure North America" and so isn't really an allowlist. Workflow-side retry is the cheapest mitigation.

## Changes

| Step | Change | Why |
|------|--------|-----|
| `Ensure deploy + cache + logs dirs exist` (SSH) | Wrap ssh in 3-attempt loop, 10s/20s backoff | First SSH op of the deploy — same connection-reset surface as rsync |
| `Deploy via rsync` (rsync over SSH) | Wrap rsync in 3-attempt loop, 10s/20s backoff | The exact failure that triggered this PR. SSH key exchange fails before rsync has any bytes on the wire, so wrapping rsync (vs. rsync `--partial`) is the right level |
| `Run database migrations` (HTTPS curl) | Add `--retry 2 --retry-delay 5` | Transient TCP-layer failures on the curl. `/_ops/migrate` is safe to retry (Doctrine `transactional: true` rolls back partial runs cleanly) |
| `Reset OPcache` | Unchanged | Already has `curl --retry 3 --retry-delay 3` from PR #598 |

## Worst-case timing

- mkdir step: 30s extra wait before failing hard (was: instant fail)
- rsync step: 30s extra wait before failing hard
- migrate curl: 10s extra wait before failing hard

Total worst-case added latency: 70 seconds, only on retry. Happy-path deploys see zero overhead — the loops execute the underlying command once and break.

## No new deps

Hand-rolled bash loop pattern, no third-party action introduced. Keeps the supply-chain footprint identical.

## Retry logic, generalized

Same shape used for both SSH steps:

```bash
attempt=1
max=3
while true; do
  if <command>; then break; fi
  if [ "$attempt" -ge "$max" ]; then
    echo "::error::<cmd> failed after ${max} attempts" >&2
    exit 1
  fi
  delay=$((attempt * 10))
  echo "::warning::<cmd> attempt ${attempt} failed; retrying in ${delay}s..." >&2
  sleep "$delay"
  attempt=$((attempt + 1))
done
```

GitHub Actions surfaces the `::warning::` line as a yellow annotation on the run summary, so even successful-on-retry deploys leave a visible breadcrumb.

## Doctrine `transactional: true` — why migrate is safe to retry

From `doctrine-migrations.php`:

```php
'all_or_nothing'  => true,
'transactional'   => true,
```

If the HTTPS connection drops while Doctrine is mid-migration, the SQL transaction rolls back, the version row never gets inserted into `doctrine_migration_versions`, and the next attempt re-runs the whole migration from scratch. No partial state to clean up.

## Future considerations (not in this PR)

- **fail2ban allowlist** of `api.github.com/meta`'s `actions` ranges via a daily cron on the VPS — only worthwhile if retries-with-backoff prove insufficient. Adds maintenance overhead (the IP set drifts).
- **Self-hosted GitHub runner** inside the VPS network — eliminates the SSH-from-internet hop entirely. Heaviest option, best long-term posture, but a new service to maintain.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy.yaml'))"` — workflow parses cleanly after the edits
- [ ] Next real deploy (next merge to `development`): happy-path completes with zero retries, single rsync invocation in the log
- [ ] First post-merge deploy that hits a transient: `::warning::rsync attempt 1 failed; retrying in 10s...` appears as a yellow annotation, then the deploy succeeds on attempt 2 or 3 — what this PR exists to achieve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment robustness with automatic retry logic for transient SSH and network connectivity failures. Directory creation, file synchronization, and database migrations now include built-in recovery with backoff strategies (up to 3 retry attempts), reducing deployment failures caused by temporary connection disruptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/607?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->