### PR TITLE
fix(zitadel-msg-texts): strip hyphens from URL segment (7/8 PUTs were 404)

### DIFF
--- a/infrastructure/zitadel-message-texts/README.md
+++ b/infrastructure/zitadel-message-texts/README.md
@@ -8,8 +8,14 @@ Each `{locale}/{template}.json` file maps 1:1 to a Zitadel Management API
 endpoint of the form:
 
 ```text
-PUT {ZITADEL_URL}/management/v1/text/message/{template}/{locale}
+PUT {ZITADEL_URL}/management/v1/text/message/{messageType}/{locale}
 ```
+
+where `{messageType}` is the JSON filename with hyphens stripped — Zitadel's
+URL path segments are all lowercase with no separators (`verify-email.json`
+→ `verifyemail`, `passwordless-registration.json` → `passwordlessregistration`,
+`init.json` → `init` unchanged). Filenames stay hyphenated here for
+readability; the runner does the strip.
 
 The `scripts/setup-zitadel-message-texts.sh` runner walks this tree and
 PUTs each file. See "Running the setup" below.

--- a/scripts/setup-zitadel-message-texts.sh
+++ b/scripts/setup-zitadel-message-texts.sh
@@ -172,7 +172,13 @@ for locale_dir in "$TEMPLATES_DIR"/*/; do
             continue
         fi
 
-        url="${ZITADEL_URL:-(dry)}/management/v1/text/message/${template}/${locale}"
+        # Zitadel collapses hyphens in URL path segments — `verify-email`
+        # is `verifyemail` on the wire, `password-reset` is `passwordreset`,
+        # etc. We keep filenames hyphenated for readability and strip them
+        # only at URL-build time. (Filename verify-email.json → URL segment
+        # verifyemail; init.json → init unchanged.)
+        url_segment="${template//-/}"
+        url="${ZITADEL_URL:-(dry)}/management/v1/text/message/${url_segment}/${locale}"
 
         if $DRY_RUN; then
             echo -e "${BLUE}PUT${NC}  ${url}"

--- a/scripts/setup-zitadel-message-texts.sh
+++ b/scripts/setup-zitadel-message-texts.sh
@@ -176,8 +176,11 @@ for locale_dir in "$TEMPLATES_DIR"/*/; do
         # is `verifyemail` on the wire, `password-reset` is `passwordreset`,
         # etc. We keep filenames hyphenated for readability and strip them
         # only at URL-build time. (Filename verify-email.json → URL segment
-        # verifyemail; init.json → init unchanged.)
+        # verifyemail; init.json → init unchanged.) Also lowercase to
+        # stay canonical if a contributor ever lands a mixed-case
+        # filename — Zitadel rejects non-canonical case with 404.
         url_segment="${template//-/}"
+        url_segment="${url_segment,,}"
         url="${ZITADEL_URL:-(dry)}/management/v1/text/message/${url_segment}/${locale}"
 
         if $DRY_RUN; then


### PR DESCRIPTION
First live run of PR #606's setup script against the umbrella Zitadel surfaced a path-naming mismatch — 7 of 8 templates returned HTTP 404, only `init` succeeded:

\`\`\`
fail PUT domain-claimed/en — HTTP 404
ok   PUT init/en
fail PUT invite-user/en — HTTP 404
fail PUT password-change/en — HTTP 404
fail PUT password-reset/en — HTTP 404
fail PUT passwordless-registration/en — HTTP 404
fail PUT verify-email-otp/en — HTTP 404
fail PUT verify-email/en — HTTP 404
\`\`\`

## Root cause

Zitadel's REST path segments are all-lowercase with **no separators** — the gRPC method names like `SetCustomVerifyEmailMessageText` translate to URL `verifyemail`, not `verify-email`. Confirmed against the official docs:

| Filename (readable) | URL segment (canonical) |
|---------------------|-------------------------|
| `verify-email` | `verifyemail` |
| `verify-email-otp` | `verifyemailotp` |
| `password-reset` | `passwordreset` |
| `password-change` | `passwordchange` |
| `invite-user` | `inviteuser` |
| `passwordless-registration` | `passwordlessregistration` |
| `domain-claimed` | `domainclaimed` |
| `init` | `init` (unchanged) |

`init` was the only template without a hyphen, hence the 1/8 success rate.

## Fix

One-line change in the runner: strip hyphens from the template basename when constructing the URL (`${template//-/}`). Filenames stay hyphenated on disk for readability — much easier to scan `passwordless-registration.json` than `passwordlessregistration.json` in a directory listing — and the script does the trivial transform at URL-build time.

README updated to document the convention so the next contributor adding a template knows the rule.

## Verified

Dry-run output after the fix — all eight URLs now match the canonical Zitadel path shape:

\`\`\`
PUT (dry)/management/v1/text/message/domainclaimed/en
PUT (dry)/management/v1/text/message/init/en
PUT (dry)/management/v1/text/message/inviteuser/en
PUT (dry)/management/v1/text/message/passwordchange/en
PUT (dry)/management/v1/text/message/passwordreset/en
PUT (dry)/management/v1/text/message/passwordlessregistration/en
PUT (dry)/management/v1/text/message/verifyemailotp/en
PUT (dry)/management/v1/text/message/verifyemail/en
\`\`\`

## Staging follow-up after merge + deploy

Re-run the setup script. The seven failed templates are still on Zitadel defaults; only `init/en` is customized. Re-running is idempotent — `init/en` re-PUT is a no-op on Zitadel's side.

\`\`\`bash
ssh ubuntu@catholicdigitalcommons.org
cd /var/www/vhosts/johnromanodorazio.com/httpdocs/LiturgicalCalendar/api/dev
ZITADEL_URL=https://auth.catholicdigitalcommons.org \\
ZITADEL_PAT=<paste-PAT> \\
  ./scripts/setup-zitadel-message-texts.sh
\`\`\`

Expected output: \`pushed: 8, skipped: 0, failed: 0\`.

## Test plan

- [x] \`./scripts/setup-zitadel-message-texts.sh --dry-run\` — all 8 URLs match the canonical Zitadel REST path shape
- [x] \`composer lint:md\` — 24 files, 0 errors
- [x] \`composer parallel-lint\` — passes
- [ ] After merge + staging deploy: re-run the script on the server, expect 8 pushed / 0 failed
- [ ] Manual: trigger a Zitadel notification (e.g., signup → verification email) and confirm the body shows the LitCal/CDCF branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Zitadel message-text configuration docs to clarify template naming transformation rules (e.g., `verify-email.json` → `verifyemail`) and the required endpoint format.

* **Bug Fixes**
  * Fixed message template URL path normalization to correctly remove hyphens and lowercase template names, ensuring proper API endpoint construction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Liturgical-Calendar/LiturgicalCalendarAPI/pull/608?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->