### PR TITLE
feat(api): user-facing notifications endpoint pair (#573)

### DIFF
--- a/docs/superpowers/plans/2026-05-30-issue-573-user-notifications-plan.md
+++ b/docs/superpowers/plans/2026-05-30-issue-573-user-notifications-plan.md
@@ -1,0 +1,1856 @@
+# Issue #573 — User-facing notifications endpoint pair — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `GET /auth/notifications` (inbox + unread badge) and `POST /auth/notifications/seen` (mark-seen bookmark)
+endpoints so frontend can render a notification bell for access-request review events.
+
+**Architecture:** New `user_notification_state` table holds one-row-per-user last-seen timestamp.
+`NotificationsHandler` (under `src/Handlers/Auth/`) dispatches on method + URI tail and delegates to
+`UserNotificationRepository`. OIDC-gated via the existing `OidcAuthMiddleware::fromEnv()`. Inbox returns the user's
+last 50 reviewed access-requests with an `unread` boolean per item; `unread_count` and `total` use Postgres window
+functions over the full filtered set. `POST /seen` upserts via
+`INSERT ... ON CONFLICT (user_id) DO UPDATE ... RETURNING NOW()` so timestamps come from the DB clock (single source
+of truth).
+
+**Tech Stack:** PHP 8.4+, PostgreSQL, Doctrine migrations, PSR-7/15/17, PHPUnit, PHPStan level 10, phpcs (PSR-12), Redocly (OpenAPI), markdownlint, CaptainHook.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md`
+
+**Pre-flight (one-time, run once before Task 1):**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI
+git checkout development
+git pull --ff-only origin development
+git checkout -b feature/issue-573-user-notifications
+docker compose up -d --build      # bring up Postgres + Zitadel + run any pending migrations
+composer install                  # ensure vendor/ is fresh
+```
+
+Expected: containers `litcal-db`, `litcal-zitadel`, `litcal-openfga`, `litcal-migrate` (exited 0), `litcal-mailpit`,
+`litcal-adminer` all healthy. `composer install` shows "Nothing to install".
+
+---
+
+## Task 1 — Database migration
+
+**Files:**
+
+- Create: `src/Migrations/Version20260530140000.php`
+
+- [ ] **Step 1.1: Create the migration file**
+
+Write `src/Migrations/Version20260530140000.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Issue #573: user-facing notification bookmark.
+ *
+ * One row per Zitadel user, holding the last time they marked
+ * their notifications inbox as seen. Absence of a row is treated
+ * as "unseen since epoch" via the read path (no placeholder row
+ * is ever inserted on read).
+ */
+final class Version20260530140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create user_notification_state table for issue #573';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE user_notification_state (
+                user_id                     VARCHAR(255) PRIMARY KEY,
+                last_notification_seen_at   TIMESTAMP NOT NULL DEFAULT TIMESTAMP 'epoch'
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS user_notification_state');
+    }
+}
+```
+
+- [ ] **Step 1.2: Apply the migration locally**
+
+Run: `composer db:migrate`
+
+Expected: Migrations output lists `LiturgicalCalendar\Api\Migrations\Version20260530140000` as applied. No errors.
+
+- [ ] **Step 1.3: Verify the table exists**
+
+Run:
+
+```bash
+docker compose exec -T db psql -U litcal -d litcal -c "\d user_notification_state"
+```
+
+Expected output includes the two columns and `PRIMARY KEY, btree (user_id)`:
+
+```text
+                Table "public.user_notification_state"
+          Column           |            Type             | ... | Default
+---------------------------+-----------------------------+-----+--------------------
+ user_id                   | character varying(255)      | ... |
+ last_notification_seen_at | timestamp without time zone | ... | 'epoch'::timestamp
+Indexes:
+    "user_notification_state_pkey" PRIMARY KEY, btree (user_id)
+```
+
+- [ ] **Step 1.4: Confirm migration status**
+
+Run: `composer db:migrations:status`
+
+Expected: status line shows "Available Migrations: 0", "Executed Migrations: 2" (the baseline + ours).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/Migrations/Version20260530140000.php
+git commit -m "$(cat <<'EOF'
+feat(db): add user_notification_state table for issue #573
+
+One row per Zitadel user holding last_notification_seen_at as a
+TIMESTAMP. Absence of a row = unseen-since-epoch via the read path
+(LEFT JOIN + COALESCE in the upcoming UserNotificationRepository).
+
+Refs: docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: CaptainHook pre-commit passes (phpcs, parallel-lint, markdownlint).
+
+---
+
+## Task 2 — Promote `AccessRequestRepository::decodePermissions` to `public static`
+
+**Files:**
+
+- Modify: `src/Repositories/AccessRequestRepository.php:617-637`
+
+**Rationale:** `UserNotificationRepository` (Task 3) needs to decode the same `permissions` JSONB column. The existing
+method is already pure (no `$this` references), so promoting to `public static` is a safe one-keyword change. We must
+also update the internal callable in `decodePermissionsList` since `[$this, 'decodePermissions']` no longer matches a
+static method.
+
+- [ ] **Step 2.1: Change the method signature**
+
+In `src/Repositories/AccessRequestRepository.php`, replace lines 617-626:
+
+```php
+    private function decodePermissions(array $row): array
+    {
+        if (isset($row['permissions']) && is_string($row['permissions'])) {
+            /** @var array<int, array{object_type: string, object_id: string, relation: string}>|null $decoded */
+            $decoded            = json_decode($row['permissions'], true);
+            $row['permissions'] = is_array($decoded) ? $decoded : [];
+        }
+
+        return $row;
+    }
+```
+
+With:
+
+```php
+    public static function decodePermissions(array $row): array
+    {
+        if (isset($row['permissions']) && is_string($row['permissions'])) {
+            /** @var array<int, array{object_type: string, object_id: string, relation: string}>|null $decoded */
+            $decoded            = json_decode($row['permissions'], true);
+            $row['permissions'] = is_array($decoded) ? $decoded : [];
+        }
+
+        return $row;
+    }
+```
+
+- [ ] **Step 2.2: Update the internal callable**
+
+In the same file, replace line 636:
+
+```php
+        return array_map([$this, 'decodePermissions'], $rows);
+```
+
+With:
+
+```php
+        return array_map([self::class, 'decodePermissions'], $rows);
+```
+
+- [ ] **Step 2.3: Static analysis**
+
+Run: `composer analyse`
+
+Expected: `[OK] No errors`. PHPStan must remain at level 10 clean.
+
+- [ ] **Step 2.4: Run the existing repository tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/AccessRequestRepositoryTest.php`
+
+Expected: all tests pass (no regression from the visibility change).
+
+If that test file doesn't exist, run the broader handler tests that exercise the repo instead:
+
+```bash
+vendor/bin/phpunit phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/Repositories/AccessRequestRepository.php
+git commit -m "$(cat <<'EOF'
+refactor: promote AccessRequestRepository::decodePermissions to public static
+
+The method is already pure (no \$this references). Promoting it lets
+the upcoming UserNotificationRepository reuse the same JSONB → array
+decoder without duplication.
+
+Internal callable in decodePermissionsList updated from \$this to
+self::class.
+
+Refs: docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3 — `UserNotificationRepository` (TDD)
+
+**Files:**
+
+- Create: `src/Repositories/UserNotificationRepository.php`
+- Test: `phpunit_tests/Repositories/UserNotificationRepositoryTest.php`
+
+**Pre-req confirmation:** Inspect `src/Repositories/AccessRequestRepository.php` constructor (lines 60-75 or
+thereabouts) to confirm the exact PDO-acquisition pattern. The constructor signature should be
+`public function __construct(?\PDO $pdo = null)`. Mirror this exactly. If the existing constructor uses
+`Connection::getInstance()->getPdo()` (or `Connection::pdo()`), use the same call.
+
+- [ ] **Step 3.1: Write the failing test file**
+
+Create `phpunit_tests/Repositories/UserNotificationRepositoryTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Repositories\UserNotificationRepository;
+use LiturgicalCalendar\Api\Tests\Handlers\AbstractHandlerTestCase;
+
+final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
+{
+    protected static bool $requiresDatabase = true;
+
+    private UserNotificationRepository $repo;
+    private AccessRequestRepository $accessReqRepo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo          = new UserNotificationRepository(self::$pdo);
+        $this->accessReqRepo = new AccessRequestRepository(self::$pdo);
+    }
+
+    public function testFetchInboxReturnsEmptyShapeWhenUserHasNoRequests(): void
+    {
+        $result = $this->repo->fetchInbox('zitadel-user-empty');
+
+        self::assertSame([], $result['items']);
+        self::assertSame(0, $result['total']);
+        self::assertSame(0, $result['unread_count']);
+        self::assertSame('1970-01-01T00:00:00+00:00', $result['last_seen_at']);
+    }
+
+    public function testFetchInboxExcludesPendingRequests(): void
+    {
+        $this->accessReqRepo->create(
+            'zitadel-user-a',
+            'a@example.test',
+            'User A',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        // Pending — no review yet.
+
+        $result = $this->repo->fetchInbox('zitadel-user-a');
+
+        self::assertSame([], $result['items']);
+        self::assertSame(0, $result['total']);
+        self::assertSame(0, $result['unread_count']);
+    }
+
+    public function testFetchInboxReturnsReviewedItemsAllUnreadWhenNoBookmark(): void
+    {
+        $id1 = $this->accessReqRepo->create(
+            'zitadel-user-b',
+            'b@example.test',
+            'User B',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $id2 = $this->accessReqRepo->create(
+            'zitadel-user-b',
+            'b@example.test',
+            'User B',
+            'developer',
+            [['object_type' => 'test_definition', 'object_id' => 'foo', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id1, 'admin-x', 'welcome');
+        $this->accessReqRepo->reject($id2, 'admin-x', 'denied');
+
+        $result = $this->repo->fetchInbox('zitadel-user-b');
+
+        self::assertCount(2, $result['items']);
+        self::assertSame(2, $result['total']);
+        self::assertSame(2, $result['unread_count']);
+        foreach ($result['items'] as $item) {
+            self::assertTrue($item['unread']);
+            self::assertSame('access_request_reviewed', $item['type']);
+            self::assertIsArray($item['permissions']);
+        }
+    }
+
+    public function testFetchInboxIsolatesUsers(): void
+    {
+        $idA = $this->accessReqRepo->create(
+            'zitadel-user-c',
+            'c@example.test',
+            'C',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $idB = $this->accessReqRepo->create(
+            'zitadel-user-d',
+            'd@example.test',
+            'D',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'FR', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($idA, 'admin-x', null);
+        $this->accessReqRepo->approve($idB, 'admin-x', null);
+
+        $resultC = $this->repo->fetchInbox('zitadel-user-c');
+        self::assertCount(1, $resultC['items']);
+        self::assertSame(1, $resultC['total']);
+        self::assertSame('zitadel-user-c', 'zitadel-user-c'); // sanity
+    }
+
+    public function testFetchInboxRespectsLimit(): void
+    {
+        for ($i = 0; $i < 55; $i++) {
+            $id = $this->accessReqRepo->create(
+                'zitadel-user-e',
+                "e{$i}@example.test",
+                "E{$i}",
+                'developer',
+                [['object_type' => 'test_definition', 'object_id' => "obj-{$i}", 'relation' => 'editor']]
+            );
+            $this->accessReqRepo->approve($id, 'admin-x', null);
+        }
+
+        $result = $this->repo->fetchInbox('zitadel-user-e', limit: 50);
+
+        self::assertCount(50, $result['items']);
+        self::assertSame(55, $result['total']);
+        self::assertSame(55, $result['unread_count']);
+    }
+
+    public function testFetchInboxOrdersByReviewedAtDesc(): void
+    {
+        $id1 = $this->accessReqRepo->create(
+            'zitadel-user-f',
+            'f@example.test',
+            'F',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id1, 'admin-x', null);
+
+        usleep(1_100_000); // 1.1s — coarser than Postgres TIMESTAMP precision
+
+        $id2 = $this->accessReqRepo->create(
+            'zitadel-user-f',
+            'f@example.test',
+            'F',
+            'developer',
+            [['object_type' => 'test_definition', 'object_id' => 't', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id2, 'admin-x', null);
+
+        $result = $this->repo->fetchInbox('zitadel-user-f');
+
+        self::assertSame($id2, $result['items'][0]['request_id']);
+        self::assertSame($id1, $result['items'][1]['request_id']);
+    }
+
+    public function testMarkSeenInsertsRowOnFirstCall(): void
+    {
+        $seenAt = $this->repo->markSeen('zitadel-user-g');
+
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/',
+            $seenAt
+        );
+
+        // Row exists in DB.
+        $stmt = self::$pdo->prepare(
+            'SELECT user_id FROM user_notification_state WHERE user_id = :u'
+        );
+        $stmt->execute(['u' => 'zitadel-user-g']);
+        self::assertSame('zitadel-user-g', $stmt->fetchColumn());
+    }
+
+    public function testMarkSeenAdvancesOnSecondCall(): void
+    {
+        $first = $this->repo->markSeen('zitadel-user-h');
+        usleep(1_100_000);
+        $second = $this->repo->markSeen('zitadel-user-h');
+
+        self::assertGreaterThan($first, $second);
+    }
+
+    public function testMarkSeenThenFetchInboxMarksItemsRead(): void
+    {
+        $id = $this->accessReqRepo->create(
+            'zitadel-user-i',
+            'i@example.test',
+            'I',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id, 'admin-x', null);
+
+        usleep(1_100_000);
+        $this->repo->markSeen('zitadel-user-i');
+
+        $result = $this->repo->fetchInbox('zitadel-user-i');
+        self::assertCount(1, $result['items']);
+        self::assertFalse($result['items'][0]['unread']);
+        self::assertSame(0, $result['unread_count']);
+        self::assertSame(1, $result['total']);
+    }
+
+    public function testFetchInboxDecodesPermissionsJsonb(): void
+    {
+        $id = $this->accessReqRepo->create(
+            'zitadel-user-j',
+            'j@example.test',
+            'J',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id, 'admin-x', null);
+
+        $result = $this->repo->fetchInbox('zitadel-user-j');
+
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']],
+            $result['items'][0]['permissions']
+        );
+    }
+}
+```
+
+- [ ] **Step 3.2: Run the test — confirm it fails (class doesn't exist yet)**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/UserNotificationRepositoryTest.php`
+
+Expected: Errors like "Class 'LiturgicalCalendar\Api\Repositories\UserNotificationRepository' not found" — confirms test is wired up but implementation is missing.
+
+- [ ] **Step 3.3: Write the repository**
+
+Create `src/Repositories/UserNotificationRepository.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Repositories;
+
+use LiturgicalCalendar\Api\Database\Connection;
+
+/**
+ * Repository for user-facing notification state and inbox queries.
+ *
+ * Backs the GET /auth/notifications and POST /auth/notifications/seen
+ * endpoints. Reads from access_requests (filtered to reviewed rows for
+ * the authenticated user) and reads/writes the user_notification_state
+ * bookmark table.
+ *
+ * The "no row yet = unseen since epoch" semantics are handled in the
+ * read path via a NULL → '1970-01-01' fallback. Reads never insert.
+ */
+final class UserNotificationRepository
+{
+    private const EPOCH = '1970-01-01 00:00:00';
+
+    private \PDO $pdo;
+
+    public function __construct(?\PDO $pdo = null)
+    {
+        $this->pdo = $pdo ?? Connection::getInstance()->getPdo();
+    }
+
+    /**
+     * Fetch the user's inbox + unread badge metadata.
+     *
+     * @return array{
+     *     items: array<int, array{
+     *         type: string,
+     *         request_id: string,
+     *         requested_role: string,
+     *         status: string,
+     *         review_notes: ?string,
+     *         reviewed_at: string,
+     *         permissions: array<int, array{object_type: string, object_id: string, relation: string}>,
+     *         unread: bool
+     *     }>,
+     *     total: int,
+     *     unread_count: int,
+     *     last_seen_at: string
+     * }
+     */
+    public function fetchInbox(string $userId, int $limit = 50): array
+    {
+        // Statement A: bookmark (or epoch).
+        $stmt = $this->pdo->prepare(
+            'SELECT last_notification_seen_at FROM user_notification_state WHERE user_id = :uid'
+        );
+        $stmt->execute(['uid' => $userId]);
+        $lastSeenRaw = $stmt->fetchColumn();
+        $lastSeen    = is_string($lastSeenRaw) ? $lastSeenRaw : self::EPOCH;
+
+        // Statement B: items + window-function counts over the full filtered set.
+        $sql  = <<<'SQL'
+            SELECT
+                id,
+                requested_role,
+                status,
+                review_notes,
+                reviewed_at,
+                permissions,
+                (reviewed_at > :last_seen::timestamp) AS unread,
+                COUNT(*) OVER () AS total,
+                COUNT(*) FILTER (
+                    WHERE reviewed_at > :last_seen::timestamp
+                ) OVER () AS unread_count
+            FROM access_requests
+            WHERE zitadel_user_id = :uid
+              AND reviewed_at IS NOT NULL
+            ORDER BY reviewed_at DESC
+            LIMIT :limit
+        SQL;
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->bindValue(':uid', $userId);
+        $stmt->bindValue(':last_seen', $lastSeen);
+        $stmt->bindValue(':limit', $limit, \PDO::PARAM_INT);
+        $stmt->execute();
+        /** @var array<int, array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        if ($rows === []) {
+            return [
+                'items'        => [],
+                'total'        => 0,
+                'unread_count' => 0,
+                'last_seen_at' => $this->iso8601($lastSeen),
+            ];
+        }
+
+        $total       = (int) $rows[0]['total'];
+        $unreadCount = (int) $rows[0]['unread_count'];
+
+        $items = array_map(
+            function (array $row): array {
+                $decoded = AccessRequestRepository::decodePermissions($row);
+                /** @var array<int, array{object_type: string, object_id: string, relation: string}> $perms */
+                $perms = is_array($decoded['permissions']) ? $decoded['permissions'] : [];
+                return [
+                    'type'           => 'access_request_reviewed',
+                    'request_id'     => (string) $row['id'],
+                    'requested_role' => (string) $row['requested_role'],
+                    'status'         => (string) $row['status'],
+                    'review_notes'   => $row['review_notes'] === null ? null : (string) $row['review_notes'],
+                    'reviewed_at'    => $this->iso8601((string) $row['reviewed_at']),
+                    'permissions'    => $perms,
+                    'unread'         => (bool) $row['unread'],
+                ];
+            },
+            $rows
+        );
+
+        return [
+            'items'        => $items,
+            'total'        => $total,
+            'unread_count' => $unreadCount,
+            'last_seen_at' => $this->iso8601($lastSeen),
+        ];
+    }
+
+    /**
+     * Mark the user's inbox as seen. Single source of truth for the
+     * timestamp is the database clock (NOW() in SQL, returned via
+     * RETURNING).
+     *
+     * @return string RFC 3339 UTC timestamp of the new bookmark.
+     */
+    public function markSeen(string $userId): string
+    {
+        $sql  = <<<'SQL'
+            INSERT INTO user_notification_state (user_id, last_notification_seen_at)
+            VALUES (:uid, NOW())
+            ON CONFLICT (user_id) DO UPDATE
+            SET last_notification_seen_at = EXCLUDED.last_notification_seen_at
+            RETURNING last_notification_seen_at
+        SQL;
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(['uid' => $userId]);
+        $seen = (string) $stmt->fetchColumn();
+        return $this->iso8601($seen);
+    }
+
+    /**
+     * Convert a Postgres TIMESTAMP (no TZ) string to RFC 3339 UTC.
+     *
+     * The DB stores wall-clock time in Europe/Vatican per the project
+     * convention; the wire format is always UTC.
+     */
+    private function iso8601(string $dbTimestamp): string
+    {
+        return ( new \DateTimeImmutable($dbTimestamp, new \DateTimeZone('Europe/Vatican')) )
+            ->setTimezone(new \DateTimeZone('UTC'))
+            ->format('Y-m-d\TH:i:sP');
+    }
+}
+```
+
+- [ ] **Step 3.4: Update `AbstractHandlerTestCase` truncation list (prereq for tests)**
+
+In `phpunit_tests/Handlers/AbstractHandlerTestCase.php`, locate the `setUp()` truncation block (around lines 111-124). The current list looks like:
+
+```php
+self::$pdo->exec('TRUNCATE TABLE api_keys, applications, access_requests, audit_log RESTART IDENTITY CASCADE');
+```
+
+Update to:
+
+```php
+self::$pdo->exec('TRUNCATE TABLE api_keys, applications, access_requests, audit_log, user_notification_state RESTART IDENTITY CASCADE');
+```
+
+(The exact original line may differ; the change is adding `user_notification_state` to the comma-separated list.)
+
+- [ ] **Step 3.5: Run the repository tests — expect all pass**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/UserNotificationRepositoryTest.php`
+
+Expected: 10/10 tests pass.
+
+If any fail:
+
+- "Cannot truncate" → Step 3.4 not done.
+- "PDO error: relation user_notification_state does not exist" → migration from Task 1 not applied. Run `composer db:migrate`.
+- Ordering test fails sporadically → increase the `usleep` to `2_100_000` (some CI Postgres builds have coarser timestamp precision than expected).
+
+- [ ] **Step 3.6: Static analysis**
+
+Run: `composer analyse`
+
+Expected: `[OK] No errors`. PHPStan L10 must remain clean.
+
+- [ ] **Step 3.7: Lint**
+
+Run: `composer lint`
+
+Expected: phpcs reports no PSR-12 violations on the new file.
+
+If violations: `composer lint:fix` (auto-fix), then re-run `composer lint`.
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add src/Repositories/UserNotificationRepository.php \
+        phpunit_tests/Repositories/UserNotificationRepositoryTest.php \
+        phpunit_tests/Handlers/AbstractHandlerTestCase.php
+git commit -m "$(cat <<'EOF'
+feat(repo): UserNotificationRepository for issue #573
+
+Two methods:
+- fetchInbox(userId, limit): two SQL statements (bookmark fetch +
+  items/counts via window functions). Returns the inbox shape with
+  total, unread_count, last_seen_at, and per-item unread bool.
+- markSeen(userId): single upsert with RETURNING; DB clock is the
+  single source of truth for the timestamp.
+
+Reuses AccessRequestRepository::decodePermissions (now public static).
+Adds user_notification_state to AbstractHandlerTestCase truncate list
+for per-test isolation.
+
+Refs: docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4 — `NotificationsHandler` GET path (TDD)
+
+**Files:**
+
+- Create: `src/Handlers/Auth/NotificationsHandler.php`
+- Test: `phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php`
+
+- [ ] **Step 4.1: Write the failing test file (GET cases only)**
+
+Create `phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Tests\Handlers\Auth;
+
+use LiturgicalCalendar\Api\Handlers\Auth\NotificationsHandler;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Tests\Handlers\AbstractHandlerTestCase;
+
+final class NotificationsHandlerTest extends AbstractHandlerTestCase
+{
+    protected static bool $requiresDatabase = true;
+
+    public function testGetInboxRequiresAuthentication(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+
+        ( new NotificationsHandler() )->handle(
+            $this->requestFor('GET', '/auth/notifications')
+        );
+    }
+
+    public function testGetInboxReturnsEmptyShapeForNewUser(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications'),
+                'zitadel-user-x'
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertSame([], $body['items']);
+        self::assertSame(0, $body['total']);
+        self::assertSame(0, $body['unread_count']);
+        self::assertSame('1970-01-01T00:00:00+00:00', $body['last_seen_at']);
+    }
+
+    public function testGetInboxReturnsReviewedItemsWithUnreadFlag(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create(
+            'zitadel-user-y',
+            'y@example.test',
+            'Y',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $repo->approve($id, 'admin-z', 'welcome');
+
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications'),
+                'zitadel-user-y'
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertCount(1, $body['items']);
+        self::assertSame($id, $body['items'][0]['request_id']);
+        self::assertSame('access_request_reviewed', $body['items'][0]['type']);
+        self::assertSame('approved', $body['items'][0]['status']);
+        self::assertSame('welcome', $body['items'][0]['review_notes']);
+        self::assertSame('calendar_editor', $body['items'][0]['requested_role']);
+        self::assertTrue($body['items'][0]['unread']);
+        self::assertSame(1, $body['total']);
+        self::assertSame(1, $body['unread_count']);
+    }
+
+    public function testGetInboxUnknownSubPathReturns404(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications/bogus'),
+                'zitadel-user-x'
+            )
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+}
+```
+
+- [ ] **Step 4.2: Run the tests — confirm they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php`
+
+Expected: errors like "Class 'NotificationsHandler' not found".
+
+- [ ] **Step 4.3: Create the handler with GET path support**
+
+Create `src/Handlers/Auth/NotificationsHandler.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Auth;
+
+use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestContentType;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Repositories\UserNotificationRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * User notifications handler — issue #573.
+ *
+ * - GET  /auth/notifications        — Inbox + unread badge.
+ * - POST /auth/notifications/seen   — Mark inbox seen (bookmark).
+ *
+ * OIDC-gated via OidcAuthMiddleware (wired in Router.php). The user
+ * identifier is the Zitadel sub from oidc_user, which keys both the
+ * access_requests query and the user_notification_state row.
+ */
+final class NotificationsHandler extends AbstractHandler
+{
+    private const INBOX_LIMIT = 50;
+
+    private ?UserNotificationRepository $repository = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->allowedRequestMethods      = [RequestMethod::GET, RequestMethod::POST];
+        $this->allowedAcceptHeaders       = [AcceptHeader::JSON];
+        $this->allowedRequestContentTypes = [RequestContentType::JSON];
+        $this->allowCredentials           = true;
+    }
+
+    private function getRepository(): UserNotificationRepository
+    {
+        if ($this->repository === null) {
+            $this->repository = new UserNotificationRepository();
+        }
+        return $this->repository;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+
+        $method = RequestMethod::tryFrom($request->getMethod());
+
+        if ($method === null) {
+            $this->validateRequestMethod($request);
+        }
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime);
+        $response = $response->withHeader('Cache-Control', 'no-store');
+
+        /** @var array{sub?: string, email?: string, name?: string, preferred_username?: string, roles?: array<string>}|null $oidcUser */
+        $oidcUser = $request->getAttribute('oidc_user');
+        if ($oidcUser === null) {
+            throw new UnauthorizedException('Authentication required');
+        }
+        $userId = $oidcUser['sub'] ?? null;
+        if (!is_string($userId) || trim($userId) === '') {
+            throw new UnauthorizedException('Invalid authentication token');
+        }
+
+        $tail = $this->extractSubPath($request->getUri()->getPath());
+
+        if ($method === RequestMethod::GET && $tail === '') {
+            return $this->getInbox($response, $userId);
+        }
+
+        if ($method === RequestMethod::POST && $tail === 'seen') {
+            return $this->markSeen($response, $userId);
+        }
+
+        return $response->withStatus(StatusCode::NOT_FOUND->value, StatusCode::NOT_FOUND->reason());
+    }
+
+    private function getInbox(ResponseInterface $response, string $userId): ResponseInterface
+    {
+        if (!Connection::isConfigured()) {
+            throw new \RuntimeException('Database not configured');
+        }
+        $body = $this->getRepository()->fetchInbox($userId, self::INBOX_LIMIT);
+        $response->getBody()->write((string) json_encode($body, JSON_THROW_ON_ERROR));
+        return $response->withStatus(StatusCode::OK->value);
+    }
+
+    private function markSeen(ResponseInterface $response, string $userId): ResponseInterface
+    {
+        if (!Connection::isConfigured()) {
+            throw new \RuntimeException('Database not configured');
+        }
+        $seenAt = $this->getRepository()->markSeen($userId);
+        $response->getBody()->write((string) json_encode(
+            ['success' => true, 'seen_at' => $seenAt],
+            JSON_THROW_ON_ERROR
+        ));
+        return $response->withStatus(StatusCode::OK->value);
+    }
+
+    private function extractSubPath(string $path): string
+    {
+        $prefix = '/auth/notifications';
+        $base   = isset($_ENV['API_BASE_PATH']) && is_string($_ENV['API_BASE_PATH'])
+            ? rtrim($_ENV['API_BASE_PATH'], '/')
+            : '';
+        $needle = $base . $prefix;
+        $tail   = substr($path, strlen($needle));
+        return trim($tail, '/');
+    }
+}
+```
+
+- [ ] **Step 4.4: Run the tests — confirm GET tests pass**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php`
+
+Expected: 4/4 tests pass.
+
+- [ ] **Step 4.5: Static analysis**
+
+Run: `composer analyse`
+
+Expected: `[OK] No errors`.
+
+- [ ] **Step 4.6: Lint**
+
+Run: `composer lint`
+
+Expected: no violations. If any, run `composer lint:fix`.
+
+- [ ] **Step 4.7: Commit**
+
+```bash
+git add src/Handlers/Auth/NotificationsHandler.php \
+        phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
+git commit -m "$(cat <<'EOF'
+feat(api): NotificationsHandler GET inbox path for issue #573
+
+GET /auth/notifications returns up to 50 recent reviewed access-
+requests for the authenticated user, with unread_count, total, and
+last_seen_at. Inbox items remain visible after marking-as-seen; only
+the unread flag flips.
+
+Auth via OidcAuthMiddleware (wired in next task). Cache-Control:
+no-store. Unknown sub-paths return 404.
+
+Refs: docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5 — `NotificationsHandler` POST /seen + additional unit tests
+
+**Files:**
+
+- Modify: `phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php` (add cases)
+
+The handler already supports POST /seen (Task 4 code includes it). This task expands test coverage.
+
+- [ ] **Step 5.1: Add POST /seen and round-trip tests**
+
+Append these methods to `phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php` inside the class:
+
+```php
+    public function testPostSeenRequiresAuthentication(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+
+        ( new NotificationsHandler() )->handle(
+            $this->requestFor('POST', '/auth/notifications/seen', [], [])
+        );
+    }
+
+    public function testPostSeenInsertsBookmarkAndReturnsTimestamp(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/seen', [], []),
+                'zitadel-user-seen-1'
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/',
+            $body['seen_at']
+        );
+
+        $stmt = self::$pdo->prepare(
+            'SELECT COUNT(*) FROM user_notification_state WHERE user_id = :u'
+        );
+        $stmt->execute(['u' => 'zitadel-user-seen-1']);
+        self::assertSame(1, (int) $stmt->fetchColumn());
+    }
+
+    public function testPostSeenTwiceAdvancesTimestamp(): void
+    {
+        $h = new NotificationsHandler();
+
+        $resp1 = $h->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/seen', [], []),
+                'zitadel-user-seen-2'
+            )
+        );
+        $body1 = $this->decodeJsonBody($resp1);
+
+        usleep(1_100_000);
+
+        $resp2 = $h->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/seen', [], []),
+                'zitadel-user-seen-2'
+            )
+        );
+        $body2 = $this->decodeJsonBody($resp2);
+
+        self::assertGreaterThan($body1['seen_at'], $body2['seen_at']);
+    }
+
+    public function testPostSeenUnknownSubPathReturns404(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/bogus', [], []),
+                'zitadel-user-seen-3'
+            )
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testPostSeenAtBaseUrlReturns404(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications', [], []),
+                'zitadel-user-seen-4'
+            )
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testGetThenSeenThenGetFlipsUnreadFlag(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create(
+            'zitadel-user-rt-1',
+            'rt@example.test',
+            'RT',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $repo->approve($id, 'admin-x', null);
+
+        $h = new NotificationsHandler();
+
+        $body1 = $this->decodeJsonBody($h->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications'),
+                'zitadel-user-rt-1'
+            )
+        ));
+        self::assertSame(1, $body1['unread_count']);
+        self::assertTrue($body1['items'][0]['unread']);
+
+        usleep(1_100_000);
+
+        $h->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/seen', [], []),
+                'zitadel-user-rt-1'
+            )
+        );
+
+        $body2 = $this->decodeJsonBody($h->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications'),
+                'zitadel-user-rt-1'
+            )
+        ));
+        self::assertSame(0, $body2['unread_count']);
+        self::assertFalse($body2['items'][0]['unread']);
+        self::assertSame(1, $body2['total']);
+    }
+```
+
+- [ ] **Step 5.2: Run the expanded tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php`
+
+Expected: 10/10 tests pass (4 from Task 4 + 6 added here).
+
+- [ ] **Step 5.3: Static analysis + lint**
+
+Run:
+
+```bash
+composer analyse
+composer lint
+```
+
+Expected: both clean.
+
+- [ ] **Step 5.4: Commit**
+
+```bash
+git add phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
+git commit -m "$(cat <<'EOF'
+test(api): expand NotificationsHandler tests with POST /seen + round-trip
+
+Adds: auth check, first/second POST timestamps advance, 404 for
+unknown sub-paths (including the bare URL), GET→POST→GET flips
+unread flag and unread_count.
+
+Refs: docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6 — Wire `NotificationsHandler` into the Router (+ OIDC gate)
+
+**Files:**
+
+- Modify: `src/Router.php` (imports, auth dispatch branch, admin dispatch branch, OIDC middleware gate)
+
+- [ ] **Step 6.1: Add the new import; alias the existing admin one**
+
+In `src/Router.php`, find the `use` block containing `LiturgicalCalendar\Api\Handlers\Admin\NotificationsHandler;`.
+Replace that single line with both of these (keeping alphabetical order with surrounding imports):
+
+```php
+use LiturgicalCalendar\Api\Handlers\Admin\NotificationsHandler as AdminNotificationsHandler;
+use LiturgicalCalendar\Api\Handlers\Auth\NotificationsHandler;
+```
+
+- [ ] **Step 6.2: Update the admin dispatch to use the alias**
+
+In `src/Router.php`, locate the `elseif ($adminRoute === 'notifications')` branch (around line 378-382). The current body is:
+
+```php
+                        } elseif ($adminRoute === 'notifications') {
+                            // Admin notifications route
+                            // GET /admin/notifications - Get counts of pending items
+                            $notificationsHandler = new NotificationsHandler();
+                            $this->handler        = $notificationsHandler;
+```
+
+Change `new NotificationsHandler()` to `new AdminNotificationsHandler()`:
+
+```php
+                        } elseif ($adminRoute === 'notifications') {
+                            // Admin notifications route
+                            // GET /admin/notifications - Get counts of pending items
+                            $notificationsHandler = new AdminNotificationsHandler();
+                            $this->handler        = $notificationsHandler;
+```
+
+- [ ] **Step 6.3: Add the auth dispatch branch**
+
+In `src/Router.php`, locate the `auth` case (around line 329-365). Find the last `elseif` inside it (currently `email-verification`, around line 357-362):
+
+```php
+                        } elseif ($authRoute === 'email-verification') {
+                            // Email verification routes for authenticated users
+                            // POST /auth/email-verification/resend - Resend verification email
+                            $emailVerificationHandler = new EmailVerificationHandler();
+                            $this->handler            = $emailVerificationHandler;
+                        } else {
+```
+
+Insert a new `elseif` immediately before the `} else {` (keeping the dispatch alphabetically organized):
+
+```php
+                        } elseif ($authRoute === 'email-verification') {
+                            // Email verification routes for authenticated users
+                            // POST /auth/email-verification/resend - Resend verification email
+                            $emailVerificationHandler = new EmailVerificationHandler();
+                            $this->handler            = $emailVerificationHandler;
+                        } elseif ($authRoute === 'notifications') {
+                            // User notifications routes (issue #573)
+                            // GET  /auth/notifications        - Inbox + unread badge
+                            // POST /auth/notifications/seen   - Mark inbox seen
+                            $notificationsHandler = new NotificationsHandler();
+                            $this->handler        = $notificationsHandler;
+                        } else {
+```
+
+- [ ] **Step 6.4: Add `'notifications'` to the OIDC middleware gate**
+
+In `src/Router.php`, locate the OIDC pipe condition (around line 585). The current check is:
+
+```php
+            ( $route === 'auth' && count($requestPathParts) >= 1 && in_array($requestPathParts[0], ['access-requests', 'email-verification'], true) )
+```
+
+Add `'notifications'`:
+
+```php
+            ( $route === 'auth' && count($requestPathParts) >= 1 && in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications'], true) )
+```
+
+- [ ] **Step 6.5: Static analysis**
+
+Run: `composer analyse`
+
+Expected: `[OK] No errors`. PHPStan must remain L10 clean — confirms the alias rename didn't break any callsite.
+
+- [ ] **Step 6.6: Lint**
+
+Run: `composer lint`
+
+Expected: no violations.
+
+- [ ] **Step 6.7: Run full unit suite — no regressions in adjacent routes**
+
+Run: `composer test`
+
+Expected: all tests pass. Pay particular attention to any admin-notifications tests that depended on the old import name.
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add src/Router.php
+git commit -m "$(cat <<'EOF'
+feat(router): wire NotificationsHandler under /auth/notifications
+
+- Rename existing Admin\NotificationsHandler import to
+  AdminNotificationsHandler to free the bare name for the new
+  Auth\NotificationsHandler.
+- Add auth dispatch branch for /auth/notifications (handler dispatches
+  GET inbox vs POST /seen on URI tail).
+- Add 'notifications' to the OidcAuthMiddleware activation list — same
+  gate as /auth/access-requests.
+
+Refs: docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7 — Integration tests (HTTP round-trip)
+
+**Files:**
+
+- Create: `phpunit_tests/Routes/Auth/NotificationsRoutesTest.php`
+
+- [ ] **Step 7.1: Inspect an existing routes test for the bootstrap pattern**
+
+Examine `phpunit_tests/Routes/Auth/AccessRequestsRoutesTest.php` (or the closest equivalent in `phpunit_tests/Routes/Auth/`). Note:
+
+- the `extends ApiTestCase` declaration,
+- whether it uses `getJwtToken()` or `getZitadelToken()`,
+- the `markTestSkipped` guard pattern,
+- how it issues HTTP requests (cURL or Guzzle?).
+
+Mirror that pattern in the new file.
+
+- [ ] **Step 7.2: Create the routes test**
+
+Create `phpunit_tests/Routes/Auth/NotificationsRoutesTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Tests\Routes\Auth;
+
+use LiturgicalCalendar\Api\Tests\ApiTestCase;
+
+/**
+ * @group slow
+ * Integration tests for /auth/notifications. Requires a running
+ * API server, a configured database, and either a Zitadel OIDC
+ * config or admin login credentials.
+ */
+final class NotificationsRoutesTest extends ApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!self::isDatabaseConfigured()) {
+            self::markTestSkipped('Database not configured.');
+        }
+    }
+
+    public function testInboxRequiresAuth(): void
+    {
+        $response = $this->httpGet('/auth/notifications', []);
+        self::assertSame(401, $response['status']);
+    }
+
+    public function testInboxReturnsExpectedShapeWithBearer(): void
+    {
+        $token = self::getJwtToken();
+        if ($token === null) {
+            self::markTestSkipped('No JWT token obtainable.');
+        }
+
+        $response = $this->httpGet('/auth/notifications', self::authHeaders($token));
+        self::assertSame(200, $response['status']);
+
+        $body = json_decode($response['body'], true);
+        self::assertIsArray($body);
+        self::assertArrayHasKey('items', $body);
+        self::assertArrayHasKey('total', $body);
+        self::assertArrayHasKey('unread_count', $body);
+        self::assertArrayHasKey('last_seen_at', $body);
+        self::assertIsArray($body['items']);
+        self::assertIsInt($body['total']);
+        self::assertIsInt($body['unread_count']);
+        self::assertSame('no-store', $response['headers']['cache-control'] ?? '');
+    }
+
+    public function testPostSeenWithBearer(): void
+    {
+        $token = self::getJwtToken();
+        if ($token === null) {
+            self::markTestSkipped('No JWT token obtainable.');
+        }
+
+        $headers = array_merge(self::authHeaders($token), ['Content-Type' => 'application/json']);
+        $response = $this->httpPost('/auth/notifications/seen', $headers, '{}');
+        self::assertSame(200, $response['status']);
+
+        $body = json_decode($response['body'], true);
+        self::assertTrue($body['success']);
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/',
+            $body['seen_at']
+        );
+    }
+
+    public function testGetSeenGetEndToEnd(): void
+    {
+        $token = self::getJwtToken();
+        if ($token === null) {
+            self::markTestSkipped('No JWT token obtainable.');
+        }
+
+        $headers     = self::authHeaders($token);
+        $postHeaders = array_merge($headers, ['Content-Type' => 'application/json']);
+
+        $this->httpPost('/auth/notifications/seen', $postHeaders, '{}');
+        sleep(1); // ensure NOW() advances past any seeded reviewed_at
+        $second = $this->httpGet('/auth/notifications', $headers);
+        $body   = json_decode($second['body'], true);
+        self::assertSame(0, $body['unread_count']);
+        foreach ($body['items'] as $item) {
+            self::assertFalse($item['unread']);
+        }
+    }
+}
+```
+
+Note on `httpGet` / `httpPost` helpers: if `ApiTestCase` doesn't already expose them, replace with whatever HTTP
+helper the existing routes tests use (likely cURL via a small wrapper or Guzzle). Check the existing routes tests
+first; do not invent a new wrapper.
+
+- [ ] **Step 7.3: Start the API server**
+
+Run: `composer start`
+
+Expected: server listening on `localhost:8000` with 6 workers. Verify with `curl http://localhost:8000/calendar?year=2026 | head -c 100`.
+
+- [ ] **Step 7.4: Run the integration tests**
+
+Run:
+
+```bash
+vendor/bin/phpunit phpunit_tests/Routes/Auth/NotificationsRoutesTest.php --group slow
+```
+
+Expected: 4/4 pass. If Zitadel is not configured locally, tests that need a token will skip rather than fail.
+
+- [ ] **Step 7.5: Stop the API server**
+
+Run: `composer stop`
+
+- [ ] **Step 7.6: Commit**
+
+```bash
+git add phpunit_tests/Routes/Auth/NotificationsRoutesTest.php
+git commit -m "$(cat <<'EOF'
+test(api): integration tests for /auth/notifications
+
+HTTP round-trip coverage: 401 without auth, 200 with expected
+response shape, POST /seen success, GET→POST→GET end-to-end with
+unread_count flipping to 0.
+
+@group slow — requires running API server + configured database.
+
+Refs: docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8 — OpenAPI: tag + schemas
+
+**Files:**
+
+- Modify: `jsondata/schemas/openapi.json`
+
+- [ ] **Step 8.1: Add the new tag**
+
+In `jsondata/schemas/openapi.json`, locate the top-level `"tags"` array. Append a new entry (keep JSON syntactically valid — add the comma to the previous entry):
+
+```json
+{
+  "name": "Notifications",
+  "description": "User-facing in-app notifications. Currently scoped to access-request review events; may expand to other event types."
+}
+```
+
+- [ ] **Step 8.2: Add the three new schemas under `components.schemas`**
+
+Add to `components.schemas` (any order; keep alphabetical if the file is sorted):
+
+```json
+    "UserNotification": {
+      "type": "object",
+      "description": "A single notification item in the authenticated user's inbox.",
+      "properties": {
+        "type":           { "type": "string", "enum": ["access_request_reviewed"], "description": "Discriminator for the notification kind." },
+        "request_id":     { "type": "string", "format": "uuid", "description": "UUID of the underlying access_requests row." },
+        "requested_role": { "type": "string", "description": "The role that was requested (e.g., 'calendar_editor')." },
+        "status":         { "type": "string", "enum": ["approved", "rejected", "revoked"], "description": "Resolution status of the request." },
+        "review_notes":   { "type": ["string", "null"], "description": "Free-text notes from the reviewing admin, if any." },
+        "reviewed_at":    { "type": "string", "format": "date-time", "description": "RFC 3339 UTC timestamp of when the request was reviewed." },
+        "permissions": {
+          "type": "array",
+          "items": { "$ref": "#/components/schemas/Permission" },
+          "description": "The permissions associated with the request."
+        },
+        "unread":         { "type": "boolean", "description": "True if reviewed_at is more recent than the user's last_seen_at bookmark." }
+      },
+      "required": ["type", "request_id", "requested_role", "status", "review_notes", "reviewed_at", "permissions", "unread"],
+      "additionalProperties": false
+    },
+    "UserNotificationsResponse": {
+      "type": "object",
+      "description": "Response from GET /auth/notifications — the inbox with unread badge metadata.",
+      "properties": {
+        "items": {
+          "type": "array",
+          "items": { "$ref": "#/components/schemas/UserNotification" }
+        },
+        "total":        { "type": "integer", "minimum": 0 },
+        "unread_count": { "type": "integer", "minimum": 0 },
+        "last_seen_at": { "type": "string", "format": "date-time" }
+      },
+      "required": ["items", "total", "unread_count", "last_seen_at"],
+      "additionalProperties": false
+    },
+    "NotificationsSeenResponse": {
+      "type": "object",
+      "description": "Response from POST /auth/notifications/seen.",
+      "properties": {
+        "success": { "type": "boolean", "enum": [true] },
+        "seen_at": { "type": "string", "format": "date-time" }
+      },
+      "required": ["success", "seen_at"],
+      "additionalProperties": false
+    }
+```
+
+- [ ] **Step 8.3: Lint OpenAPI**
+
+Run: `composer lint:openapi`
+
+Expected: Redocly passes (0 errors). If `Unauthorized`, `NotAcceptable`, or `UnsupportedMediaType` `$ref` targets are
+missing under `components.responses`, Redocly will flag them when paths are added in Task 9. (Don't pre-add — Task 9
+will surface that need.)
+
+- [ ] **Step 8.4: Commit**
+
+```bash
+git add jsondata/schemas/openapi.json
+git commit -m "$(cat <<'EOF'
+docs(openapi): add Notifications tag and 3 schemas for issue #573
+
+- Tag: "Notifications" — user-facing notification inbox.
+- UserNotification — single inbox item, reuses existing Permission.
+- UserNotificationsResponse — GET /auth/notifications response shape.
+- NotificationsSeenResponse — POST /auth/notifications/seen response.
+
+Path entries added in the next commit.
+
+Refs: docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9 — OpenAPI: paths
+
+**Files:**
+
+- Modify: `jsondata/schemas/openapi.json`
+
+- [ ] **Step 9.1: Confirm shared error responses exist**
+
+Search `jsondata/schemas/openapi.json` for `"Unauthorized":`, `"NotAcceptable":`, `"UnsupportedMediaType":` under `components.responses`:
+
+```bash
+jq '.components.responses | keys' jsondata/schemas/openapi.json
+```
+
+Expected: array containing `"Unauthorized"`, `"NotAcceptable"`, `"UnsupportedMediaType"`. If any is missing, add a
+minimal one mirroring the pattern of the others (e.g., look at how `/auth/login` references its errors).
+
+- [ ] **Step 9.2: Add the two new path entries**
+
+Under top-level `"paths"`, add (alphabetical placement is fine):
+
+```json
+    "/auth/notifications": {
+      "get": {
+        "tags": ["Notifications"],
+        "summary": "Get the authenticated user's notification inbox",
+        "description": "Returns up to 50 most recent reviewed access-requests for the current user, with unread badge count and last-seen bookmark. Inbox items remain visible after marking-as-seen; only the unread flag and unread_count change.",
+        "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Inbox payload.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserNotificationsResponse" }
+              }
+            },
+            "headers": {
+              "Cache-Control": { "schema": { "type": "string", "enum": ["no-store"] } }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "406": { "$ref": "#/components/responses/NotAcceptable" }
+        }
+      }
+    },
+    "/auth/notifications/seen": {
+      "post": {
+        "tags": ["Notifications"],
+        "summary": "Mark the user's notification inbox as seen",
+        "description": "Upserts the user's bookmark so that last_notification_seen_at = NOW() (DB clock). Inbox itself is unchanged; only unread flags and unread_count flip on subsequent GETs.",
+        "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": { "type": "object", "additionalProperties": false }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bookmark updated.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/NotificationsSeenResponse" }
+              }
+            },
+            "headers": {
+              "Cache-Control": { "schema": { "type": "string", "enum": ["no-store"] } }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "406": { "$ref": "#/components/responses/NotAcceptable" },
+          "415": { "$ref": "#/components/responses/UnsupportedMediaType" }
+        }
+      }
+    }
+```
+
+- [ ] **Step 9.3: Lint OpenAPI**
+
+Run: `composer lint:openapi`
+
+Expected: 0 errors. If any `$ref` to `components/responses/...` is unresolved, add the missing shared response definition.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add jsondata/schemas/openapi.json
+git commit -m "$(cat <<'EOF'
+docs(openapi): add /auth/notifications paths for issue #573
+
+- GET  /auth/notifications      — inbox + badge (200 / 401 / 406)
+- POST /auth/notifications/seen — mark-as-seen (200 / 401 / 406 / 415)
+
+Both gated by BearerAuth | CookieAuth (matches /auth/access-requests).
+Cache-Control: no-store on both 200 responses.
+
+Refs: docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10 — Final verification gate
+
+**Files:** none (verification only)
+
+- [ ] **Step 10.1: Full unit test suite**
+
+Run: `composer test`
+
+Expected: 100% pass. Pay attention to:
+
+- existing AdminNotificationsHandler tests (alias rename didn't break them),
+- AccessRequestRepository tests (decodePermissions promotion didn't break them),
+- all new NotificationsHandler / UserNotificationRepository tests.
+
+- [ ] **Step 10.2: Quick subset confirmation**
+
+Run: `composer test:quick`
+
+Expected: pass; ensures non-slow regressions are clean.
+
+- [ ] **Step 10.3: Static analysis L10**
+
+Run: `composer analyse`
+
+Expected: `[OK] No errors`.
+
+- [ ] **Step 10.4: phpcs**
+
+Run: `composer lint`
+
+Expected: 0 violations.
+
+- [ ] **Step 10.5: OpenAPI lint**
+
+Run: `composer lint:openapi`
+
+Expected: 0 errors.
+
+- [ ] **Step 10.6: Markdown lint**
+
+Run: `composer lint:md`
+
+Expected: 0 errors (the spec + plan must remain clean).
+
+- [ ] **Step 10.7: Parallel syntax check**
+
+Run: `composer parallel-lint`
+
+Expected: 0 errors.
+
+- [ ] **Step 10.8: Schema verification — sanity-check the migration is still in the database**
+
+Run:
+
+```bash
+docker compose exec -T db psql -U litcal -d litcal -c "\d user_notification_state"
+docker compose exec -T db psql -U litcal -d litcal -c "SELECT version FROM doctrine_migration_versions ORDER BY version DESC LIMIT 3"
+```
+
+Expected: table exists; migrations list shows `Version20260530140000` as applied.
+
+- [ ] **Step 10.9: Manual smoke test (optional but recommended)**
+
+Start the server, get a token, exercise both endpoints:
+
+```bash
+composer start
+# In another terminal:
+TOKEN=$(curl -s -X POST http://localhost:8000/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"password"}' | jq -r '.access_token')
+curl -i http://localhost:8000/auth/notifications -H "Authorization: Bearer $TOKEN"
+curl -i -X POST http://localhost:8000/auth/notifications/seen \
+  -H "Authorization: Bearer $TOKEN" \
+  -H 'Content-Type: application/json' -d '{}'
+curl -i http://localhost:8000/auth/notifications -H "Authorization: Bearer $TOKEN"
+composer stop
+```
+
+Expected:
+
+- First GET: 200 with `unread_count: 0, total: 0, items: []` for the admin user (no access-requests for them).
+- POST /seen: 200 with `success: true, seen_at` timestamp.
+- Second GET: same shape; `last_seen_at` updated to match the POST's `seen_at`.
+
+(Note: if the local DB has no access-requests for the `admin` user, both GETs show empty inbox. To get a non-trivial
+result, seed an access-request as the admin user first via the existing admin tooling — out of scope for this
+verification.)
+
+- [ ] **Step 10.10: Push the branch**
+
+```bash
+git push -u origin feature/issue-573-user-notifications
+```
+
+- [ ] **Step 10.11: Open PR against `development`**
+
+```bash
+gh pr create --base development \
+  --title 'feat(api): user-facing notifications endpoint pair (#573)' \
+  --body "$(cat <<'EOF'
+Closes #573.
+
+Adds `GET /auth/notifications` (inbox + unread badge) and
+`POST /auth/notifications/seen` (mark-as-seen bookmark) for end users
+to receive in-app feedback on access-request review events.
+
+## Design
+
+Inbox + unread badge UX. The bookmark is the only mutable state
+(one row per Zitadel user in `user_notification_state`). All
+timestamps derive from `NOW()` in SQL — single source of truth.
+
+See `docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md`
+for the full design and `docs/superpowers/plans/2026-05-30-issue-573-user-notifications-plan.md`
+for the implementation plan.
+
+## Changes
+
+- DB: new `user_notification_state` table (migration Version20260530140000).
+- New: `UserNotificationRepository`, `NotificationsHandler`.
+- Modified: `Router.php` (dispatch + OIDC gate), `AccessRequestRepository::decodePermissions` (public static), `AbstractHandlerTestCase` (truncation list), OpenAPI schema (1 tag + 3 schemas + 2 paths).
+
+## Tests
+
+- 10 unit tests for the repository.
+- 10 unit tests for the handler (GET, POST /seen, 404, round-trip).
+- 4 integration tests for the routes (@group slow).
+- Full suite: composer test, analyse, lint, lint:openapi, lint:md all clean.
+
+## Out of scope (deferred)
+
+- Per-item delete / bulk clear UX.
+- Push / WebSocket / email notification channels.
+- Notification types beyond access-request reviews (discriminator in place for future expansion).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR created against `development`. CI runs all linters + tests.
+
+---
+
+## Done
+
+All 10 tasks complete. The endpoint pair is live on the feature branch, all checks green, PR open for review.
+
+## Self-review against the spec
+
+- ✅ §2 contract (response shapes, error matrix) — Tasks 4–5 unit tests + Task 7 integration tests assert each field.
+- ✅ §3 architecture (OIDC gate, single-handler dispatch, two-statement GET, upsert-with-RETURNING POST) — Tasks 3, 4, 6.
+- ✅ §4 migration (TIMESTAMP not TIMESTAMPTZ, VARCHAR(255) PK, default `epoch`) — Task 1.
+- ✅ §5 UserNotificationRepository (window functions, two-statement GET, ISO 8601 normalization) — Task 3.
+- ✅ §6 NotificationsHandler (method + URI-tail dispatch, sub-path extractor, OIDC user check) — Tasks 4–5.
+- ✅ §7 Router wiring (4 edits) — Task 6.
+- ✅ §8 OpenAPI (1 tag + 3 schemas + 2 paths) — Tasks 8–9.
+- ✅ §9 tests (unit + integration matrices, truncation list update) — Tasks 3, 4, 5, 7.
+- ✅ §10 out-of-scope items NOT implemented — confirmed in PR body.
+- ✅ §11 files-touched inventory — every file in the spec's inventory is created/modified.
+- ✅ Verification commands run after each commit and as the final gate (Task 10).
+- ✅ No placeholders (`TODO`, `TBD`, `Add appropriate error handling`).
+- ✅ Type/name consistency: `UserNotificationRepository::fetchInbox` / `markSeen` / `iso8601` used consistently across
+  Tasks 3–5; `AccessRequestRepository::decodePermissions` (now `public static`) called the same way in repo + tests.

--- a/docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
+++ b/docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md
@@ -1,0 +1,697 @@
+# Issue #573 — User-facing notifications endpoint pair
+
+**Status:** Design approved, ready for implementation plan.
+**Date:** 2026-05-30
+**Author:** John R. D'Orazio (with Claude Code, via superpowers:brainstorming)
+**Issue:** [#573](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/573)
+**Blocks:** Corresponding LiturgicalCalendarFrontend issue.
+
+## 1. Goal
+
+When an admin approves, rejects, or revokes an end user's access request via
+`/admin/access-requests/{id}/{action}`, the requesting user currently has no
+in-app feedback. They must navigate to the access-requests page and inspect
+each row's status to discover what changed.
+
+This spec adds a complementary user-facing endpoint pair so the frontend can
+render a notification bell with an unread badge and an inbox view.
+
+## 2. Endpoint contract
+
+### `GET /auth/notifications` — inbox + badge
+
+Returns the authenticated user's last 50 reviewed access-requests, ordered by
+`reviewed_at DESC`, plus the unread badge metadata.
+
+**Auth:** `OidcAuthMiddleware::fromEnv()` (same gate as `/auth/access-requests`).
+In OpenAPI parlance: `BearerAuth | CookieAuth`.
+
+**Response (200):**
+
+```json
+{
+  "items": [
+    {
+      "type": "access_request_reviewed",
+      "request_id": "1234abcd-...",
+      "requested_role": "calendar_editor",
+      "status": "approved",
+      "review_notes": "Welcome to the team.",
+      "reviewed_at": "2026-05-09T12:34:56+00:00",
+      "permissions": [
+        {
+          "object_type": "national_calendar",
+          "object_id": "IT",
+          "relation": "editor"
+        }
+      ],
+      "unread": true
+    }
+  ],
+  "total": 1,
+  "unread_count": 1,
+  "last_seen_at": "1970-01-01T00:00:00+00:00"
+}
+```
+
+**Field semantics:**
+
+| Field            | Meaning                                                                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| `items[].unread` | True iff `reviewed_at > last_seen_at`.                                                                                                       |
+| `total`          | Count of _all_ reviewed access-requests for this user (may exceed `items.length`). Window function `COUNT(*) OVER ()` over the filtered set. |
+| `unread_count`   | Count of `reviewed_at > last_seen_at` across the full filtered set, not just the LIMIT-50 page.                                              |
+| `last_seen_at`   | The user's bookmark. RFC 3339 UTC. Defaults to `1970-01-01T00:00:00+00:00` if the user has never called `/seen`.                             |
+
+**Status values:** `approved | rejected | revoked`. Pending requests (where `reviewed_at IS NULL`) are excluded.
+
+**Headers:** `Cache-Control: no-store`.
+
+### `POST /auth/notifications/seen` — mark inbox seen
+
+Upserts the user's bookmark to `NOW()` using the database clock as single
+source of truth. Inbox items remain visible after this call — only the
+`unread` flags and `unread_count` change on subsequent GETs.
+
+**Auth:** Same as GET.
+
+**Request body:** `{}` (no payload; user identity comes from the auth context).
+Must send `Content-Type: application/json`.
+
+**Response (200):**
+
+```json
+{ "success": true, "seen_at": "2026-05-09T12:35:01+00:00" }
+```
+
+**Headers:** `Cache-Control: no-store`.
+
+### Error matrix (both endpoints)
+
+| Condition                                           | Status                                    |
+| --------------------------------------------------- | ----------------------------------------- |
+| No `oidc_user` attribute (auth failed)              | 401                                       |
+| Method not in `[GET, POST]`                         | 405 with `Allow: GET, POST`               |
+| Unknown sub-path (e.g. `/auth/notifications/bogus`) | 404                                       |
+| `Accept` header excludes JSON                       | 406                                       |
+| `Content-Type` not JSON on POST                     | 415                                       |
+| PDO error                                           | 500 (caught by `ErrorHandlingMiddleware`) |
+
+## 3. Architecture
+
+```text
+Client (cookie or Bearer Authorization header)
+  ↓
+Router (src/Router.php)
+  ↓
+OidcAuthMiddleware::fromEnv()           ← same gate as /auth/access-requests
+  ↓  sets $request->getAttribute('oidc_user') = ['sub' => zitadelUserId, 'roles' => [...]]
+  ↓
+NotificationsHandler::handle()          ← src/Handlers/Auth/NotificationsHandler.php
+  ├─ extracts $userId = $oidcUser['sub']
+  ├─ method dispatch:
+  │    GET  /auth/notifications        → fetchInbox()
+  │    POST /auth/notifications/seen   → markSeen()
+  │    anything else                   → 405 / 404
+  ↓
+UserNotificationRepository              ← src/Repositories/UserNotificationRepository.php
+  ├─ two SELECTs on GET (bookmark, then items + counts via window functions)
+  └─ INSERT ... ON CONFLICT (user_id) DO UPDATE ... RETURNING on POST
+  ↓
+PostgreSQL
+  ├─ access_requests        (existing)
+  └─ user_notification_state (new, one row per user)
+```
+
+**Read consistency:** `markSeen()` uses `NOW()` in SQL and `RETURNING
+last_notification_seen_at`, so the response timestamp comes from Postgres —
+no PHP/DB clock skew. `fetchInbox()` reads `last_notification_seen_at` from
+the same table on every call, so a GET→POST /seen→GET sequence is read-
+consistent.
+
+**Round-trips per request:** GET is two SQL statements (bookmark + items).
+POST is one SQL statement (upsert).
+
+## 4. Database migration
+
+**File:** `src/Migrations/Version20260530140000.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Issue #573: user-facing notification bookmark.
+ *
+ * One row per Zitadel user, holding the last time they marked
+ * their notifications inbox as seen. Absence of a row is treated
+ * as "unseen since epoch" via LEFT JOIN + COALESCE — we never
+ * insert a placeholder row on read.
+ */
+final class Version20260530140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create user_notification_state table for issue #573';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(<<<'SQL'
+            CREATE TABLE user_notification_state (
+                user_id                     VARCHAR(255) PRIMARY KEY,
+                last_notification_seen_at   TIMESTAMP NOT NULL DEFAULT TIMESTAMP 'epoch'
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP TABLE IF EXISTS user_notification_state');
+    }
+}
+```
+
+**Decision notes:**
+
+| Choice                          | Rationale                                                                                                                                                                                                                                      |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `user_id VARCHAR(255)`          | Matches `access_requests.zitadel_user_id` and the `oidc_user['sub']` claim. No FK because there's no local `users` table — Zitadel owns user identity.                                                                                         |
+| `TIMESTAMP` (not `TIMESTAMPTZ`) | Matches `access_requests.reviewed_at` (also `TIMESTAMP`). Cross-type comparisons would do implicit, session-TZ-dependent conversions — avoidable trap. Issue spec said `TIMESTAMPTZ`, but the existing schema convention wins for consistency. |
+| `DEFAULT TIMESTAMP 'epoch'`     | Safety net. The read path uses LEFT JOIN + COALESCE so the default is rarely consulted, but if some future code path INSERTs without specifying the column we still get correct semantics.                                                     |
+| No `created_at`/`updated_at`    | YAGNI. Row's only meaningful column is the timestamp itself. First POST /seen creates the row via UPSERT; subsequent POSTs update it.                                                                                                          |
+| PK = `user_id`                  | All queries are point-lookups by user. No secondary index needed.                                                                                                                                                                              |
+
+**Test-fixture impact:** `phpunit_tests/Handlers/AbstractHandlerTestCase::setUp()`
+currently truncates `api_keys, applications, access_requests, audit_log`. Add
+`user_notification_state` to that list so per-test isolation holds.
+
+## 5. `UserNotificationRepository`
+
+**File:** `src/Repositories/UserNotificationRepository.php`
+
+Constructor: `public function __construct(\PDO $pdo)`. Matches `AccessRequestRepository`.
+
+### Method 1: `fetchInbox(string $userId, int $limit = 50): array`
+
+Two SQL statements (chosen over one CTE-with-window for readability — the
+second statement returns zero rows when the user has no reviewed requests, at
+which point we still need the bookmark from the first for `last_seen_at`).
+
+**Statement A** — fetch bookmark (or epoch):
+
+```sql
+SELECT last_notification_seen_at
+FROM user_notification_state
+WHERE user_id = :uid
+```
+
+PHP fallback when no row exists: `$lastSeen = '1970-01-01 00:00:00';`
+
+**Statement B** — items + aggregate counts via window functions:
+
+```sql
+SELECT
+    id,
+    requested_role,
+    status,
+    review_notes,
+    reviewed_at,
+    permissions,
+    (reviewed_at > :last_seen::timestamp) AS unread,
+    COUNT(*) OVER () AS total,
+    COUNT(*) FILTER (
+        WHERE reviewed_at > :last_seen::timestamp
+    ) OVER () AS unread_count
+FROM access_requests
+WHERE zitadel_user_id = :uid
+  AND reviewed_at IS NOT NULL
+ORDER BY reviewed_at DESC
+LIMIT :limit
+```
+
+If the result set is empty, PHP returns `{items:[], total:0, unread_count:0,
+last_seen_at: <from statement A>}`.
+
+### Method 2: `markSeen(string $userId): string`
+
+Single upsert with `RETURNING`:
+
+```sql
+INSERT INTO user_notification_state (user_id, last_notification_seen_at)
+VALUES (:uid, NOW())
+ON CONFLICT (user_id) DO UPDATE
+SET last_notification_seen_at = EXCLUDED.last_notification_seen_at
+RETURNING last_notification_seen_at
+```
+
+Returns the RFC 3339 string formatted from the DB's returned timestamp.
+
+### Permission decoding — reuse via visibility change
+
+`AccessRequestRepository::decodePermissions(string $json): array` is currently
+private. Promote to `public static`. It's a pure function (input string →
+output array, no state). One-line visibility change in
+`src/Repositories/AccessRequestRepository.php` (~line 617); the new repo calls
+`AccessRequestRepository::decodePermissions($row['permissions'])`.
+
+Alternative considered: extract to a `src/Utils/PermissionsCodec.php`. Rejected
+as overkill for one tiny pure function used in two places.
+
+### Timestamp normalization
+
+`access_requests.reviewed_at` and `user_notification_state.last_notification_seen_at`
+are both `TIMESTAMP` (no TZ). The codebase convention (per `CLAUDE.md`) is
+`Europe/Vatican` internally, RFC 3339 UTC on the wire. Private helper:
+
+```php
+private function iso8601(string $dbTimestamp): string
+{
+    return ( new \DateTimeImmutable($dbTimestamp, new \DateTimeZone('Europe/Vatican')) )
+        ->setTimezone(new \DateTimeZone('UTC'))
+        ->format('Y-m-d\TH:i:sP');
+}
+```
+
+## 6. `NotificationsHandler`
+
+**File:** `src/Handlers/Auth/NotificationsHandler.php`
+
+Extends `AbstractHandler`, dispatches on method + URI tail. Pattern mirrors
+`AccessRequestHandler`.
+
+### Constructor
+
+```php
+public function __construct()
+{
+    parent::__construct();
+    $this->setAllowedRequestMethods([RequestMethod::GET, RequestMethod::POST]);
+    $this->setAllowedAcceptHeaders([AcceptHeader::JSON]);
+    $this->setAllowedRequestContentTypes([RequestContentType::JSON]);
+}
+```
+
+No `return_type` query-param support — per `CLAUDE.md`, that param is reserved
+for `/calendar`. Auth/admin endpoints use `Accept` only.
+
+### Dispatch matrix
+
+| Method | URI tail      | Action                                              |
+| ------ | ------------- | --------------------------------------------------- |
+| `GET`  | `""`          | `fetchInbox` → 200 with full inbox shape            |
+| `POST` | `"seen"`      | `markSeen` → 200 with `{success, seen_at}`          |
+| `GET`  | anything else | 404                                                 |
+| `POST` | anything else | 404                                                 |
+| other  | —             | 405 (set by `AbstractHandler` allowed-method check) |
+
+### Skeleton
+
+```php
+public function handle(ServerRequestInterface $request): ResponseInterface
+{
+    $oidcUser = $request->getAttribute('oidc_user');
+    if ($oidcUser === null || !isset($oidcUser['sub']) || !is_string($oidcUser['sub'])) {
+        throw new UnauthorizedException('Authentication required');
+    }
+    $userId = $oidcUser['sub'];
+
+    $method = $request->getMethod();
+    $tail   = $this->extractSubPath($request->getUri()->getPath());
+
+    $response = $this->initResponse($request);
+    $repo     = new UserNotificationRepository($this->getPdo());
+
+    if ($method === 'GET' && $tail === '') {
+        $body = $repo->fetchInbox($userId, limit: 50);
+        return $this->encodeResponseBody(
+            $response->withHeader('Cache-Control', 'no-store'),
+            $body
+        );
+    }
+
+    if ($method === 'POST' && $tail === 'seen') {
+        $seenAt = $repo->markSeen($userId);
+        return $this->encodeResponseBody(
+            $response->withHeader('Cache-Control', 'no-store'),
+            ['success' => true, 'seen_at' => $seenAt]
+        );
+    }
+
+    return new Response(
+        StatusCode::NOT_FOUND->value, [], null,
+        $request->getProtocolVersion(),
+        StatusCode::NOT_FOUND->reason()
+    );
+}
+
+private function extractSubPath(string $path): string
+{
+    $prefix = '/auth/notifications';
+    $base   = $_ENV['API_BASE_PATH'] ?? '';
+    $needle = rtrim($base, '/') . $prefix;
+    $tail   = substr($path, strlen($needle));
+    return trim($tail, '/');
+}
+```
+
+### PDO acquisition
+
+`AbstractHandler` doesn't currently expose `getPdo()`. The plan must read
+`AccessRequestHandler.php` to confirm the exact mechanism (likely inline
+construction from env vars). Implementation will mirror that pattern.
+
+## 7. Router wiring + middleware activation
+
+Four small edits to `src/Router.php`.
+
+### Edit 1 — Import block
+
+Add:
+
+```php
+use LiturgicalCalendar\Api\Handlers\Admin\NotificationsHandler as AdminNotificationsHandler;
+use LiturgicalCalendar\Api\Handlers\Auth\NotificationsHandler;
+```
+
+The first line renames the existing `Admin\NotificationsHandler` import. This
+frees the bare `NotificationsHandler` name for the new `Auth\` class without
+breaking the project's "unprefixed handler classes per namespace" convention.
+
+### Edit 2 — `auth` dispatch case (~line 345)
+
+Insert as a new `elseif`:
+
+```php
+} elseif ($authRoute === 'notifications') {
+    // User notifications routes
+    // GET  /auth/notifications        - Inbox + unread badge
+    // POST /auth/notifications/seen   - Mark inbox seen
+    $notificationsHandler = new NotificationsHandler();
+    $this->handler        = $notificationsHandler;
+```
+
+### Edit 3 — `admin` dispatch case (~line 381)
+
+Update the existing usage to the alias:
+
+```php
+} elseif ($adminRoute === 'notifications') {
+    // Admin notifications route — GET /admin/notifications
+    $notificationsHandler = new AdminNotificationsHandler();
+    $this->handler        = $notificationsHandler;
+```
+
+### Edit 4 — OIDC middleware activation (~line 585)
+
+Current:
+
+```php
+( $route === 'auth' && count($requestPathParts) >= 1
+    && in_array($requestPathParts[0], ['access-requests', 'email-verification'], true) )
+```
+
+Becomes:
+
+```php
+( $route === 'auth' && count($requestPathParts) >= 1
+    && in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications'], true) )
+```
+
+`OidcAuthMiddleware::fromEnv()` now runs for `/auth/notifications/*`. No JWT
+fallback — data is keyed by Zitadel user IDs, which only OIDC resolves.
+
+## 8. OpenAPI additions
+
+Edits to `jsondata/schemas/openapi.json`.
+
+### Edit 1 — New tag
+
+```json
+{
+  "name": "Notifications",
+  "description": "User-facing in-app notifications. Currently scoped to access-request review events; may expand to other event types."
+}
+```
+
+### Edit 2 — `UserNotification` schema
+
+```json
+{
+  "type": "object",
+  "description": "A single notification item in the authenticated user's inbox.",
+  "properties": {
+    "type": { "type": "string", "enum": ["access_request_reviewed"] },
+    "request_id": { "type": "string", "format": "uuid" },
+    "requested_role": { "type": "string" },
+    "status": { "type": "string", "enum": ["approved", "rejected", "revoked"] },
+    "review_notes": { "type": ["string", "null"] },
+    "reviewed_at": { "type": "string", "format": "date-time" },
+    "permissions": {
+      "type": "array",
+      "items": { "$ref": "#/components/schemas/Permission" }
+    },
+    "unread": { "type": "boolean" }
+  },
+  "required": [
+    "type",
+    "request_id",
+    "requested_role",
+    "status",
+    "review_notes",
+    "reviewed_at",
+    "permissions",
+    "unread"
+  ],
+  "additionalProperties": false
+}
+```
+
+Reuses existing `Permission` component (object_type + object_id + relation).
+
+### Edit 3 — `UserNotificationsResponse` schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": { "$ref": "#/components/schemas/UserNotification" }
+    },
+    "total": { "type": "integer", "minimum": 0 },
+    "unread_count": { "type": "integer", "minimum": 0 },
+    "last_seen_at": { "type": "string", "format": "date-time" }
+  },
+  "required": ["items", "total", "unread_count", "last_seen_at"],
+  "additionalProperties": false
+}
+```
+
+### Edit 4 — `NotificationsSeenResponse` schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "success": { "type": "boolean", "enum": [true] },
+    "seen_at": { "type": "string", "format": "date-time" }
+  },
+  "required": ["success", "seen_at"],
+  "additionalProperties": false
+}
+```
+
+### Edit 5 — `/auth/notifications` (GET) path
+
+```json
+{
+  "/auth/notifications": {
+    "get": {
+      "tags": ["Notifications"],
+      "summary": "Get the authenticated user's notification inbox",
+      "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+      "responses": {
+        "200": {
+          "description": "Inbox payload.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserNotificationsResponse"
+              }
+            }
+          },
+          "headers": {
+            "Cache-Control": {
+              "schema": { "type": "string", "enum": ["no-store"] }
+            }
+          }
+        },
+        "401": { "$ref": "#/components/responses/Unauthorized" },
+        "406": { "$ref": "#/components/responses/NotAcceptable" }
+      }
+    }
+  }
+}
+```
+
+### Edit 6 — `/auth/notifications/seen` (POST) path
+
+```json
+{
+  "/auth/notifications/seen": {
+    "post": {
+      "tags": ["Notifications"],
+      "summary": "Mark the user's notification inbox as seen",
+      "security": [{ "BearerAuth": [] }, { "CookieAuth": [] }],
+      "responses": {
+        "200": {
+          "description": "Bookmark updated.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationsSeenResponse"
+              }
+            }
+          },
+          "headers": {
+            "Cache-Control": {
+              "schema": { "type": "string", "enum": ["no-store"] }
+            }
+          }
+        },
+        "401": { "$ref": "#/components/responses/Unauthorized" },
+        "406": { "$ref": "#/components/responses/NotAcceptable" },
+        "415": { "$ref": "#/components/responses/UnsupportedMediaType" }
+      }
+    }
+  }
+}
+```
+
+The `Unauthorized`, `NotAcceptable`, and `UnsupportedMediaType` `$ref`s
+already exist in `components.responses` per the project's convention. If any
+is missing, add it as part of this PR.
+
+Run `composer lint:openapi` after edits.
+
+## 9. Tests
+
+Two layers: unit (handler-direct) and integration (HTTP round-trip).
+
+### Layer A — Unit tests
+
+**File:** `phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php`
+
+Extends `AbstractHandlerTestCase` with `$requiresDatabase = true`. Uses
+existing `withOidcUser()`, `requestFor()`, `decodeJsonBody()` helpers. Seeds
+rows via `AccessRequestRepository::create()` then `::approve()` /
+`::reject()` / `::revoke()`.
+
+**Pre-req edit:** Add `user_notification_state` to the truncation list in
+`AbstractHandlerTestCase::setUp()` (~lines 111-124).
+
+**GET matrix:**
+
+| #   | Scenario                                            | Assertion                                                                            |
+| --- | --------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| G1  | No `oidc_user` attribute                            | 401, `UnauthorizedException`                                                         |
+| G2  | Valid user, zero reviewed requests                  | 200; `{items:[], total:0, unread_count:0, last_seen_at:"1970-01-01T00:00:00+00:00"}` |
+| G3  | 3 reviewed (approved/rejected/revoked), no bookmark | `total=3`, `unread_count=3`, every `items[].unread === true`                         |
+| G4  | 3 reviewed + bookmark between item #2 and #1        | `unread_count=1`; only newest `unread:true`                                          |
+| G5  | A's 3 + B's 2 in same table                         | A's GET → `total=3`, no B leak                                                       |
+| G6  | Mix of reviewed and pending for same user           | Pending excluded from items/total/unread_count                                       |
+| G7  | 55 reviewed                                         | `items.length === 50`, `total === 55`, items ordered DESC                            |
+| G8  | Permissions JSONB                                   | `items[0].permissions[0]` is decoded object, not string                              |
+| G9  | `Cache-Control: no-store`                           | Header assertion                                                                     |
+| G10 | `GET /auth/notifications/bogus`                     | 404                                                                                  |
+| G11 | `PUT /auth/notifications`                           | 405 with `Allow: GET, POST`                                                          |
+| G12 | `review_notes` is NULL                              | `items[i].review_notes === null`                                                     |
+
+**POST /seen matrix:**
+
+| #   | Scenario                             | Assertion                                                         |
+| --- | ------------------------------------ | ----------------------------------------------------------------- |
+| S1  | No `oidc_user`                       | 401                                                               |
+| S2  | First POST                           | 200; row exists in `user_notification_state`; `seen_at` is recent |
+| S3  | Second POST                          | `seen_at` strictly greater than first                             |
+| S4  | Wrong Content-Type                   | 415                                                               |
+| S5  | `Cache-Control: no-store`            | Header assertion                                                  |
+| S6  | `POST /auth/notifications` (no tail) | 404                                                               |
+| S7  | `POST /auth/notifications/bogus`     | 404                                                               |
+
+**Round-trip:**
+
+| #   | Scenario                                   | Assertion                                                              |
+| --- | ------------------------------------------ | ---------------------------------------------------------------------- |
+| R1  | GET → POST /seen → GET                     | Second GET: same items/total, `unread_count === 0`, all `unread:false` |
+| R2  | GET → POST /seen → seed new reviewed → GET | Third GET: `unread_count === 1`, newest `unread:true`                  |
+| R3  | Two users                                  | A's POST /seen doesn't affect B's `unread_count`                       |
+
+### Layer B — Integration tests
+
+**File:** `phpunit_tests/Routes/Auth/NotificationsRoutesTest.php`
+
+Extends `ApiTestCase`. Gated by `if (!self::isDatabaseConfigured()) self::markTestSkipped(...)` and `getJwtToken()`.
+
+| #   | Test                                                              | Assertion                                         |
+| --- | ----------------------------------------------------------------- | ------------------------------------------------- |
+| I1  | `GET /auth/notifications` without `Authorization`                 | 401                                               |
+| I2  | `GET /auth/notifications` with Bearer                             | 200, body conforms to `UserNotificationsResponse` |
+| I3  | `POST /auth/notifications/seen` with Bearer + JSON `Content-Type` | 200, `{success:true, seen_at}`                    |
+| I4  | GET → POST → GET end-to-end                                       | `unread_count` drops to 0                         |
+
+### Verification commands
+
+```bash
+docker compose up -d --build           # apply the new migration
+composer test phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
+composer test phpunit_tests/Routes/Auth/NotificationsRoutesTest.php
+composer test                          # full suite — no regressions
+composer analyse                       # PHPStan level 10
+composer lint                          # phpcs
+composer lint:openapi                  # Redocly
+```
+
+## 10. Out of scope
+
+Per the issue and the brainstorming session:
+
+- Per-item notification deletion (`DELETE /auth/notifications/{id}`) and bulk
+  clear (`POST /auth/notifications/clear`). Inbox + unread-badge UX is sufficient
+  for v1; if usage data later shows users accumulate noise, the cheapest add is
+  a `last_notification_cleared_at` column + one new route.
+- Push notifications (WebSocket, SSE), email, mobile push. REST polling on the
+  frontend is sufficient.
+- Notification types beyond access-request review events. The
+  `type: "access_request_reviewed"` discriminator is in place so new types can be
+  added without breaking the schema.
+- Pagination for `items[]`. Hard LIMIT 50; the access-requests page covers
+  historical browsing.
+
+## 11. Files touched (summary)
+
+**New:**
+
+- `src/Migrations/Version20260530140000.php`
+- `src/Handlers/Auth/NotificationsHandler.php`
+- `src/Repositories/UserNotificationRepository.php`
+- `phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php`
+- `phpunit_tests/Routes/Auth/NotificationsRoutesTest.php`
+
+**Modified:**
+
+- `src/Router.php` (imports + dispatch branches + middleware gate)
+- `src/Repositories/AccessRequestRepository.php` (`decodePermissions` → `public static`)
+- `phpunit_tests/Handlers/AbstractHandlerTestCase.php` (truncation list)
+- `jsondata/schemas/openapi.json` (tag + 3 schemas + 2 paths)
+
+**Unchanged:**
+
+- `scripts/init-db.sql` — schema is authoritative in `src/Migrations/`, not here.

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -91,6 +91,10 @@
     {
       "name": "Applications",
       "description": "Developer application management (create, update, delete applications and API keys)"
+    },
+    {
+      "name": "Notifications",
+      "description": "User-facing in-app notifications. Currently scoped to access-request review events; may expand to other event types."
     }
   ],
   "paths": {
@@ -1077,8 +1081,17 @@
     },
     "/auth/access-requests": {
       "get": {
-        "tags": ["Access Requests"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Access Requests"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "List user's own access requests",
         "operationId": "getUserAccessRequests",
         "description": "Retrieve all access requests submitted by the authenticated user.",
@@ -1087,16 +1100,29 @@
             "description": "OK: List of user's access requests",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/AccessRequestListResponse"}
+                "schema": {
+                  "$ref": "#/components/schemas/AccessRequestListResponse"
+                }
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          }
         }
       },
       "post": {
-        "tags": ["Access Requests"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Access Requests"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Submit a new access request",
         "operationId": "createAccessRequest",
         "description": "Submit a request for a role and associated permissions. Valid roles are: developer, calendar_editor, test_editor.",
@@ -1118,25 +1144,52 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean", "example": true},
-                    "message": {"type": "string"},
-                    "id": {"type": "string", "format": "uuid"}
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
                   },
-                  "required": ["success", "message", "id"]
+                  "required": [
+                    "success",
+                    "message",
+                    "id"
+                  ]
                 }
               }
             }
           },
-          "400": {"$ref": "#/components/responses/BadRequest400"},
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "422": {"$ref": "#/components/responses/ValidationError422"}
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError422"
+          }
         }
       }
     },
     "/auth/access-requests/status": {
       "get": {
-        "tags": ["Access Requests"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Access Requests"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Get access request status for user",
         "operationId": "getAccessRequestStatus",
         "description": "Check if the user has roles, pending requests, and whether they need to submit an access request.",
@@ -1151,14 +1204,25 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          }
         }
       }
     },
     "/auth/access-requests/{id}/resubmit": {
       "post": {
-        "tags": ["Access Requests"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Access Requests"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Resubmit a rejected access request",
         "operationId": "resubmitAccessRequest",
         "description": "Resubmit a previously rejected access request with updated permissions (and optionally an updated justification). Only the user who created the request may resubmit it, and only when its current status is `rejected` — the request transitions back to `pending` for admin re-review. The role originally requested cannot be changed; create a new request via POST /auth/access-requests for a different role. Permissions in the body are validated identically to POST /auth/access-requests (object_type and relation must match the same enums; role-permission consistency is enforced).",
@@ -1168,7 +1232,10 @@
             "in": "path",
             "required": true,
             "description": "UUID of the access request being resubmitted",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
@@ -1180,7 +1247,9 @@
                 "properties": {
                   "permissions": {
                     "type": "array",
-                    "items": {"$ref": "#/components/schemas/Permission"},
+                    "items": {
+                      "$ref": "#/components/schemas/Permission"
+                    },
                     "minItems": 1,
                     "maxItems": 50,
                     "description": "Updated array of OpenFGA tuples to request. Replaces the original request's permissions on success."
@@ -1191,7 +1260,9 @@
                     "description": "Optional updated justification narrative. When omitted, the original request's justification is preserved."
                   }
                 },
-                "required": ["permissions"],
+                "required": [
+                  "permissions"
+                ],
                 "additionalProperties": false
               }
             }
@@ -1205,16 +1276,30 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean", "example": true},
-                    "message": {"type": "string"},
-                    "id": {"type": "string", "format": "uuid"}
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "id": {
+                      "type": "string",
+                      "format": "uuid"
+                    }
                   },
-                  "required": ["success", "message", "id"]
+                  "required": [
+                    "success",
+                    "message",
+                    "id"
+                  ]
                 }
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
           "403": {
             "description": "Forbidden: the authenticated user is not the original submitter of this request",
             "$ref": "#/components/responses/Forbidden403"
@@ -1228,8 +1313,17 @@
     },
     "/admin/access-requests": {
       "get": {
-        "tags": ["Admin - Access Requests"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Access Requests"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "List all access requests",
         "operationId": "adminListAccessRequests",
         "description": "List all access requests with optional status filter. Requires admin role.",
@@ -1240,7 +1334,12 @@
             "description": "Filter by status",
             "schema": {
               "type": "string",
-              "enum": ["pending", "approved", "rejected", "revoked"]
+              "enum": [
+                "pending",
+                "approved",
+                "rejected",
+                "revoked"
+              ]
             }
           }
         ],
@@ -1249,19 +1348,34 @@
             "description": "OK: List of access requests",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/AccessRequestListResponse"}
+                "schema": {
+                  "$ref": "#/components/schemas/AccessRequestListResponse"
+                }
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
         }
       }
     },
     "/admin/access-requests/{id}/approve": {
       "post": {
-        "tags": ["Admin - Access Requests"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Access Requests"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Approve an access request",
         "operationId": "adminApproveAccessRequest",
         "description": "Approve a pending access request, assign the role in Zitadel, and create OpenFGA permission tuples. Requires admin role.",
@@ -1271,7 +1385,10 @@
             "in": "path",
             "required": true,
             "description": "Access request UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
@@ -1294,16 +1411,31 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/admin/access-requests/{id}/reject": {
       "post": {
-        "tags": ["Admin - Access Requests"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Access Requests"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Reject an access request",
         "operationId": "adminRejectAccessRequest",
         "description": "Reject a pending access request. Requires admin role.",
@@ -1313,7 +1445,10 @@
             "in": "path",
             "required": true,
             "description": "Access request UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
@@ -1333,24 +1468,46 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean"},
-                    "message": {"type": "string"}
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["success", "message"]
+                  "required": [
+                    "success",
+                    "message"
+                  ]
                 }
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/admin/access-requests/{id}/revoke": {
       "post": {
-        "tags": ["Admin - Access Requests"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Access Requests"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Revoke a previously approved access request",
         "operationId": "adminRevokeAccessRequest",
         "description": "Revoke a previously approved access request, remove the role from Zitadel, and delete OpenFGA permission tuples. Requires admin role.",
@@ -1360,7 +1517,10 @@
             "in": "path",
             "required": true,
             "description": "Access request UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
@@ -1383,16 +1543,31 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/admin/notifications": {
       "get": {
-        "tags": ["Admin - Notifications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Notifications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Get admin notification counts",
         "operationId": "adminGetNotifications",
         "description": "Get counts of pending items requiring admin attention. Requires admin role.",
@@ -1407,15 +1582,28 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
         }
       }
     },
     "/admin/users": {
       "get": {
-        "tags": ["Admin - Users"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Users"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "List all users with roles",
         "operationId": "adminListUsers",
         "description": "List all users in the project with their assigned roles. Requires admin role.",
@@ -1425,14 +1613,23 @@
             "in": "query",
             "required": false,
             "description": "Maximum number of users to return (1-1000, default 100)",
-            "schema": {"type": "integer", "minimum": 1, "maximum": 1000, "default": 100}
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 1000,
+              "default": 100
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "required": false,
             "description": "Number of users to skip for pagination (default 0)",
-            "schema": {"type": "integer", "minimum": 0, "default": 0}
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
           }
         ],
         "responses": {
@@ -1446,16 +1643,31 @@
               }
             }
           },
-          "400": {"$ref": "#/components/responses/BadRequest400"},
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"}
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
         }
       }
     },
     "/admin/users/{userId}/roles/{role}": {
       "delete": {
-        "tags": ["Admin - Users"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Users"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Revoke a role from a user",
         "operationId": "adminRevokeUserRole",
         "description": "Revoke a specific role from a user in Zitadel. Requires admin role.",
@@ -1465,14 +1677,18 @@
             "in": "path",
             "required": true,
             "description": "Zitadel user ID",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "role",
             "in": "path",
             "required": true,
             "description": "Role to revoke",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1486,24 +1702,79 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/admin/permissions": {
       "get": {
-        "tags": ["Admin - Permissions"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Permissions"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "List permission tuples",
         "operationId": "adminListPermissions",
         "description": "List OpenFGA permission tuples. Global admins see all; resource admins see only tuples on resources they administer. Supports filtering by user, object_type, object_id, and relation. **Resource admins must supply `object_type`** to scope the listing — calling without one returns 400.",
         "parameters": [
-          {"name": "user", "in": "query", "description": "Filter by user ID", "schema": {"type": "string"}},
-          {"name": "object_type", "in": "query", "description": "Filter by object type. Optional for global admins; required for resource admins (the handler returns 400 without it).", "schema": {"type": "string", "enum": ["national_calendar", "diocesan_calendar", "wider_region", "test_definition"]}},
-          {"name": "object_id", "in": "query", "description": "Filter by object ID", "schema": {"type": "string"}},
-          {"name": "relation", "in": "query", "description": "Filter by relation", "schema": {"type": "string", "enum": ["admin", "viewer", "editor", "deleter"]}}
+          {
+            "name": "user",
+            "in": "query",
+            "description": "Filter by user ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "object_type",
+            "in": "query",
+            "description": "Filter by object type. Optional for global admins; required for resource admins (the handler returns 400 without it).",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "national_calendar",
+                "diocesan_calendar",
+                "wider_region",
+                "test_definition"
+              ]
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "query",
+            "description": "Filter by object ID",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "relation",
+            "in": "query",
+            "description": "Filter by relation",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "admin",
+                "viewer",
+                "editor",
+                "deleter"
+              ]
+            }
+          }
         ],
         "responses": {
           "200": {
@@ -1515,22 +1786,42 @@
                   "properties": {
                     "permissions": {
                       "type": "array",
-                      "items": {"$ref": "#/components/schemas/PermissionTuple"}
+                      "items": {
+                        "$ref": "#/components/schemas/PermissionTuple"
+                      }
                     },
-                    "count": {"type": "integer"}
+                    "count": {
+                      "type": "integer"
+                    }
                   },
-                  "required": ["permissions", "count"]
+                  "required": [
+                    "permissions",
+                    "count"
+                  ]
                 }
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
         }
       },
       "post": {
-        "tags": ["Admin - Permissions"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Permissions"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Grant a permission",
         "operationId": "adminGrantPermission",
         "description": "Create an OpenFGA tuple granting a user a relation on a resource. Requires global admin or resource admin.",
@@ -1538,7 +1829,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/PermissionTupleInput"}
+              "schema": {
+                "$ref": "#/components/schemas/PermissionTupleInput"
+              }
             }
           }
         },
@@ -1550,25 +1843,55 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean"},
-                    "message": {"type": "string"},
-                    "user": {"type": "string"},
-                    "relation": {"type": "string"},
-                    "object": {"type": "string"}
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "string"
+                    },
+                    "relation": {
+                      "type": "string"
+                    },
+                    "object": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["success", "user", "relation", "object"]
+                  "required": [
+                    "success",
+                    "user",
+                    "relation",
+                    "object"
+                  ]
                 }
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "422": {"$ref": "#/components/responses/ValidationError422"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError422"
+          }
         }
       },
       "delete": {
-        "tags": ["Admin - Permissions"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Permissions"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Revoke a permission",
         "operationId": "adminRevokePermission",
         "description": "Delete an OpenFGA tuple revoking a user's relation on a resource. Requires global admin or resource admin.",
@@ -1576,7 +1899,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/PermissionTupleInput"}
+              "schema": {
+                "$ref": "#/components/schemas/PermissionTupleInput"
+              }
             }
           }
         },
@@ -1588,35 +1913,105 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": {"type": "boolean"},
-                    "message": {"type": "string"},
-                    "user": {"type": "string"},
-                    "relation": {"type": "string"},
-                    "object": {"type": "string"}
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "user": {
+                      "type": "string"
+                    },
+                    "relation": {
+                      "type": "string"
+                    },
+                    "object": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["success", "user", "relation", "object"]
+                  "required": [
+                    "success",
+                    "user",
+                    "relation",
+                    "object"
+                  ]
                 }
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "422": {"$ref": "#/components/responses/ValidationError422"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError422"
+          }
         }
       }
     },
     "/admin/permissions/check": {
       "get": {
-        "tags": ["Admin - Permissions"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Permissions"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Check a permission",
         "operationId": "adminCheckPermission",
         "description": "Check if a user has a specific relation on a resource via OpenFGA.",
         "parameters": [
-          {"name": "user", "in": "query", "required": true, "schema": {"type": "string"}},
-          {"name": "object_type", "in": "query", "required": true, "schema": {"type": "string", "enum": ["national_calendar", "diocesan_calendar", "wider_region", "test_definition"]}},
-          {"name": "object_id", "in": "query", "required": true, "schema": {"type": "string"}},
-          {"name": "relation", "in": "query", "required": true, "schema": {"type": "string", "enum": ["admin", "viewer", "editor", "deleter"]}}
+          {
+            "name": "user",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "object_type",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "national_calendar",
+                "diocesan_calendar",
+                "wider_region",
+                "test_definition"
+              ]
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "relation",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "admin",
+                "viewer",
+                "editor",
+                "deleter"
+              ]
+            }
+          }
         ],
         "responses": {
           "200": {
@@ -1626,26 +2021,54 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "allowed": {"type": "boolean"},
-                    "user": {"type": "string"},
-                    "relation": {"type": "string"},
-                    "object": {"type": "string"}
+                    "allowed": {
+                      "type": "boolean"
+                    },
+                    "user": {
+                      "type": "string"
+                    },
+                    "relation": {
+                      "type": "string"
+                    },
+                    "object": {
+                      "type": "string"
+                    }
                   },
-                  "required": ["allowed", "user", "relation", "object"]
+                  "required": [
+                    "allowed",
+                    "user",
+                    "relation",
+                    "object"
+                  ]
                 }
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "422": {"$ref": "#/components/responses/ValidationError422"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "422": {
+            "$ref": "#/components/responses/ValidationError422"
+          }
         }
       }
     },
     "/admin/applications": {
       "get": {
-        "tags": ["Admin - Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "List all applications",
         "operationId": "adminListApplications",
         "description": "List all applications with optional status filter. Requires admin role.",
@@ -1656,7 +2079,12 @@
             "description": "Filter by status",
             "schema": {
               "type": "string",
-              "enum": ["pending", "approved", "rejected", "revoked"]
+              "enum": [
+                "pending",
+                "approved",
+                "rejected",
+                "revoked"
+              ]
             }
           }
         ],
@@ -1671,15 +2099,28 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
         }
       }
     },
     "/admin/applications/pending": {
       "get": {
-        "tags": ["Admin - Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "List pending applications",
         "operationId": "adminListPendingApplications",
         "description": "List all applications awaiting approval. Requires admin role.",
@@ -1694,15 +2135,28 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
         }
       }
     },
     "/admin/applications/{uuid}": {
       "get": {
-        "tags": ["Admin - Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Get single application details",
         "operationId": "adminGetApplication",
         "description": "Get details of a specific application. Requires admin role.",
@@ -1712,7 +2166,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -1726,16 +2183,31 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/admin/applications/{uuid}/approve": {
       "post": {
-        "tags": ["Admin - Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Approve an application",
         "operationId": "adminApproveApplication",
         "description": "Approve a pending or rejected application. Requires admin role.",
@@ -1745,7 +2217,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
@@ -1768,16 +2243,31 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/admin/applications/{uuid}/reject": {
       "post": {
-        "tags": ["Admin - Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Reject an application",
         "operationId": "adminRejectApplication",
         "description": "Reject a pending application. Requires admin role.",
@@ -1787,7 +2277,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
@@ -1810,16 +2303,31 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/admin/applications/{uuid}/revoke": {
       "post": {
-        "tags": ["Admin - Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Admin - Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Revoke an approved application",
         "operationId": "adminRevokeApplication",
         "description": "Revoke a previously approved application. Requires admin role.",
@@ -1829,7 +2337,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
@@ -1852,16 +2363,31 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/applications": {
       "get": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "List user's applications",
         "operationId": "listApplications",
         "description": "List all applications owned by the authenticated user. Requires developer role.",
@@ -1876,13 +2402,26 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
         }
       },
       "post": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Create new application",
         "operationId": "createApplication",
         "description": "Create a new application (starts with 'pending' status). Requires developer role.",
@@ -1907,16 +2446,31 @@
               }
             }
           },
-          "400": {"$ref": "#/components/responses/BadRequest400"},
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"}
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
         }
       }
     },
     "/applications/{uuid}": {
       "get": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Get single application",
         "operationId": "getApplication",
         "description": "Get details of a specific application owned by the user. Requires developer role.",
@@ -1926,7 +2480,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -1940,14 +2497,29 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       },
       "patch": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Update application",
         "operationId": "updateApplication",
         "description": "Update application details. Requires developer role and ownership.",
@@ -1957,7 +2529,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
@@ -1981,15 +2556,32 @@
               }
             }
           },
-          "400": {"$ref": "#/components/responses/BadRequest400"},
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       },
       "delete": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Delete application",
         "operationId": "deleteApplication",
         "description": "Permanently delete an application and all associated API keys. Requires developer role and ownership.",
@@ -1999,7 +2591,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -2013,16 +2608,31 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/applications/{uuid}/resubmit": {
       "post": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Resubmit rejected application",
         "operationId": "resubmitApplication",
         "description": "Resubmit a rejected application for review. Only rejected applications can be resubmitted. Requires developer role and ownership.",
@@ -2032,7 +2642,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -2046,16 +2659,31 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/applications/{uuid}/keys": {
       "get": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "List API keys for application",
         "operationId": "listApiKeys",
         "description": "List all API keys for an application. Requires developer role and ownership.",
@@ -2065,7 +2693,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -2079,14 +2710,29 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       },
       "post": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Generate new API key",
         "operationId": "generateApiKey",
         "description": "Generate a new API key for an approved application. The plain text key is only shown once. Requires developer role and ownership.",
@@ -2096,7 +2742,10 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "requestBody": {
@@ -2119,17 +2768,34 @@
               }
             }
           },
-          "400": {"$ref": "#/components/responses/BadRequest400"},
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/applications/{uuid}/keys/{keyId}": {
       "delete": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Revoke/delete API key",
         "operationId": "revokeApiKey",
         "description": "Revoke (delete) an API key. Requires developer role and ownership.",
@@ -2139,14 +2805,20 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           },
           {
             "name": "keyId",
             "in": "path",
             "required": true,
             "description": "API key ID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -2160,16 +2832,31 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
     "/applications/{uuid}/keys/{keyId}/rotate": {
       "post": {
-        "tags": ["Applications"],
-        "security": [{"BearerAuth": []}, {"CookieAuth": []}],
+        "tags": [
+          "Applications"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
         "summary": "Rotate API key",
         "operationId": "rotateApiKey",
         "description": "Rotate an API key (revoke old, create new with same settings). The new plain text key is only shown once. Requires developer role and ownership.",
@@ -2179,14 +2866,20 @@
             "in": "path",
             "required": true,
             "description": "Application UUID",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           },
           {
             "name": "keyId",
             "in": "path",
             "required": true,
             "description": "API key ID to rotate",
-            "schema": {"type": "string", "format": "uuid"}
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -2200,9 +2893,15 @@
               }
             }
           },
-          "401": {"$ref": "#/components/responses/Unauthorized401"},
-          "403": {"$ref": "#/components/responses/Forbidden403"},
-          "404": {"$ref": "#/components/responses/NotFound404"}
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
         }
       }
     },
@@ -6211,7 +6910,9 @@
               "type": "string"
             },
             "description": "Roles assigned to the user",
-            "example": ["admin"]
+            "example": [
+              "admin"
+            ]
           },
           "exp": {
             "type": "integer",
@@ -6229,7 +6930,12 @@
         "properties": {
           "object_type": {
             "type": "string",
-            "enum": ["national_calendar", "diocesan_calendar", "wider_region", "test_definition"],
+            "enum": [
+              "national_calendar",
+              "diocesan_calendar",
+              "wider_region",
+              "test_definition"
+            ],
             "description": "OpenFGA object type"
           },
           "object_id": {
@@ -6238,52 +6944,153 @@
           },
           "relation": {
             "type": "string",
-            "enum": ["admin", "viewer", "editor", "deleter"],
+            "enum": [
+              "admin",
+              "viewer",
+              "editor",
+              "deleter"
+            ],
             "description": "Permission relation"
           }
         },
-        "required": ["object_type", "object_id", "relation"],
+        "required": [
+          "object_type",
+          "object_id",
+          "relation"
+        ],
         "additionalProperties": false
       },
       "AccessRequest": {
         "type": "object",
         "description": "A unified access request combining role and permission requests",
         "properties": {
-          "id": {"type": "string", "format": "uuid"},
-          "zitadel_user_id": {"type": "string"},
-          "user_email": {"type": "string", "format": "email"},
-          "user_name": {"type": ["string", "null"]},
-          "requested_role": {"type": "string", "enum": ["developer", "calendar_editor", "test_editor"]},
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "zitadel_user_id": {
+            "type": "string"
+          },
+          "user_email": {
+            "type": "string",
+            "format": "email"
+          },
+          "user_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "requested_role": {
+            "type": "string",
+            "enum": [
+              "developer",
+              "calendar_editor",
+              "test_editor"
+            ]
+          },
           "permissions": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/Permission"}
+            "items": {
+              "$ref": "#/components/schemas/Permission"
+            }
           },
-          "justification": {"type": ["string", "null"]},
-          "credentials": {"type": ["string", "null"]},
-          "status": {"type": "string", "enum": ["pending", "approved", "rejected", "revoked"]},
-          "reviewed_by": {"type": ["string", "null"]},
-          "review_notes": {"type": ["string", "null"]},
-          "zitadel_sync_status": {"type": ["string", "null"], "enum": ["pending", "synced", "failed", null]},
-          "zitadel_sync_error": {"type": ["string", "null"]},
-          "created_at": {"type": "string", "format": "date-time"},
-          "reviewed_at": {"type": ["string", "null"], "format": "date-time"}
+          "justification": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "credentials": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "rejected",
+              "revoked"
+            ]
+          },
+          "reviewed_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "review_notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "zitadel_sync_status": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "enum": [
+              "pending",
+              "synced",
+              "failed",
+              null
+            ]
+          },
+          "zitadel_sync_error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "reviewed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
         },
-        "required": ["id", "zitadel_user_id", "user_email", "requested_role", "permissions", "status", "created_at"],
+        "required": [
+          "id",
+          "zitadel_user_id",
+          "user_email",
+          "requested_role",
+          "permissions",
+          "status",
+          "created_at"
+        ],
         "additionalProperties": false
       },
       "CreateAccessRequestBody": {
         "type": "object",
         "description": "Request body for submitting a new access request",
-        "required": ["requested_role", "permissions"],
+        "required": [
+          "requested_role",
+          "permissions"
+        ],
         "properties": {
           "requested_role": {
             "type": "string",
-            "enum": ["developer", "calendar_editor", "test_editor"],
+            "enum": [
+              "developer",
+              "calendar_editor",
+              "test_editor"
+            ],
             "description": "Role being requested"
           },
           "permissions": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/Permission"},
+            "items": {
+              "$ref": "#/components/schemas/Permission"
+            },
             "maxItems": 50,
             "description": "Array of permission entries requested"
           },
@@ -6310,7 +7117,9 @@
           },
           "current_roles": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "List of role names currently assigned to the user (e.g., \"developer\", \"calendar_editor\"). Empty when has_roles is false."
           },
           "pending_requests": {
@@ -6331,11 +7140,26 @@
           },
           "valid_roles": {
             "type": "array",
-            "items": {"type": "string", "enum": ["developer", "calendar_editor", "test_editor"]},
+            "items": {
+              "type": "string",
+              "enum": [
+                "developer",
+                "calendar_editor",
+                "test_editor"
+              ]
+            },
             "description": "The role names accepted by POST /auth/access-requests as the requested_role. Provided so clients don't hard-code the list."
           }
         },
-        "required": ["has_roles", "current_roles", "pending_requests", "approved_requests", "rejected_requests", "needs_access_request", "valid_roles"],
+        "required": [
+          "has_roles",
+          "current_roles",
+          "pending_requests",
+          "approved_requests",
+          "rejected_requests",
+          "needs_access_request",
+          "valid_roles"
+        ],
         "additionalProperties": false
       },
       "AccessRequestListResponse": {
@@ -6344,40 +7168,95 @@
         "properties": {
           "requests": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/AccessRequest"}
+            "items": {
+              "$ref": "#/components/schemas/AccessRequest"
+            }
           },
-          "count": {"type": "integer"}
+          "count": {
+            "type": "integer"
+          }
         },
-        "required": ["requests", "count"],
+        "required": [
+          "requests",
+          "count"
+        ],
         "additionalProperties": false
       },
       "PermissionTuple": {
         "type": "object",
         "description": "An OpenFGA relationship tuple representing a granted permission",
         "properties": {
-          "user": {"type": "string", "description": "User identifier (e.g., 'user:zitadel-id')"},
-          "relation": {"type": "string", "enum": ["admin", "viewer", "editor", "deleter"]},
-          "object": {"type": "string", "description": "Object identifier (e.g., 'national_calendar:IT')"}
+          "user": {
+            "type": "string",
+            "description": "User identifier (e.g., 'user:zitadel-id')"
+          },
+          "relation": {
+            "type": "string",
+            "enum": [
+              "admin",
+              "viewer",
+              "editor",
+              "deleter"
+            ]
+          },
+          "object": {
+            "type": "string",
+            "description": "Object identifier (e.g., 'national_calendar:IT')"
+          }
         },
-        "required": ["user", "relation", "object"],
+        "required": [
+          "user",
+          "relation",
+          "object"
+        ],
         "additionalProperties": false
       },
       "PermissionTupleInput": {
         "type": "object",
         "description": "Input for granting or revoking a permission",
         "properties": {
-          "user": {"type": "string", "description": "Zitadel user ID (with or without 'user:' prefix)"},
-          "object_type": {"type": "string", "enum": ["national_calendar", "diocesan_calendar", "wider_region", "test_definition"]},
-          "object_id": {"type": "string", "description": "Resource identifier (e.g., 'IT', 'BOSTON')"},
-          "relation": {"type": "string", "enum": ["admin", "viewer", "editor", "deleter"]}
+          "user": {
+            "type": "string",
+            "description": "Zitadel user ID (with or without 'user:' prefix)"
+          },
+          "object_type": {
+            "type": "string",
+            "enum": [
+              "national_calendar",
+              "diocesan_calendar",
+              "wider_region",
+              "test_definition"
+            ]
+          },
+          "object_id": {
+            "type": "string",
+            "description": "Resource identifier (e.g., 'IT', 'BOSTON')"
+          },
+          "relation": {
+            "type": "string",
+            "enum": [
+              "admin",
+              "viewer",
+              "editor",
+              "deleter"
+            ]
+          }
         },
-        "required": ["user", "object_type", "object_id", "relation"],
+        "required": [
+          "user",
+          "object_type",
+          "object_id",
+          "relation"
+        ],
         "additionalProperties": false
       },
       "AdminReviewRequestBody": {
         "type": "object",
         "properties": {
-          "notes": {"type": "string", "description": "Optional review notes"}
+          "notes": {
+            "type": "string",
+            "description": "Optional review notes"
+          }
         },
         "additionalProperties": false
       },
@@ -6385,114 +7264,268 @@
         "type": "object",
         "description": "Response from approving an access request",
         "properties": {
-          "success": {"type": "boolean"},
-          "message": {"type": "string"},
-          "role_assigned": {"type": "boolean"},
-          "tuples_created": {"type": "integer", "description": "Number of OpenFGA permission tuples created"},
-          "zitadel_error": {"type": ["string", "null"]},
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "role_assigned": {
+            "type": "boolean"
+          },
+          "tuples_created": {
+            "type": "integer",
+            "description": "Number of OpenFGA permission tuples created"
+          },
+          "zitadel_error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "tuple_errors": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Errors encountered while creating permission tuples"
           }
         },
-        "required": ["success", "message", "role_assigned", "tuples_created"],
+        "required": [
+          "success",
+          "message",
+          "role_assigned",
+          "tuples_created"
+        ],
         "additionalProperties": false
       },
       "AdminRevokeAccessRequestResponse": {
         "type": "object",
         "description": "Response from revoking an access request",
         "properties": {
-          "success": {"type": "boolean"},
-          "message": {"type": "string"},
-          "role_removed": {"type": "boolean"},
-          "tuples_deleted": {"type": "integer", "description": "Number of OpenFGA permission tuples deleted"},
-          "zitadel_error": {"type": ["string", "null"]},
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "role_removed": {
+            "type": "boolean"
+          },
+          "tuples_deleted": {
+            "type": "integer",
+            "description": "Number of OpenFGA permission tuples deleted"
+          },
+          "zitadel_error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "tuple_errors": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Errors encountered while deleting permission tuples"
           }
         },
-        "required": ["success", "message", "role_removed", "tuples_deleted"],
+        "required": [
+          "success",
+          "message",
+          "role_removed",
+          "tuples_deleted"
+        ],
         "additionalProperties": false
       },
       "AdminNotificationsResponse": {
         "type": "object",
         "properties": {
-          "pending_access_requests": {"type": "integer"},
-          "total": {"type": "integer"},
+          "pending_access_requests": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          },
           "items": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
-                "type": {"type": "string"},
-                "id": {"type": "string"},
-                "user_name": {"type": "string"},
-                "user_email": {"type": "string"},
-                "role": {"type": "string"},
-                "created_at": {"type": "string", "format": "date-time"},
-                "url": {"type": "string"}
+                "type": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                },
+                "user_name": {
+                  "type": "string"
+                },
+                "user_email": {
+                  "type": "string"
+                },
+                "role": {
+                  "type": "string"
+                },
+                "created_at": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "url": {
+                  "type": "string"
+                }
               },
-              "required": ["type", "id", "created_at"],
+              "required": [
+                "type",
+                "id",
+                "created_at"
+              ],
               "additionalProperties": false
             }
           }
         },
-        "required": ["pending_access_requests", "total", "items"],
+        "required": [
+          "pending_access_requests",
+          "total",
+          "items"
+        ],
         "additionalProperties": false
       },
       "UserGrant": {
         "type": "object",
         "properties": {
-          "grantId": {"type": "string"},
-          "roles": {"type": "array", "items": {"type": "string"}},
-          "state": {"type": ["integer", "null"], "description": "Grant state from identity provider"}
+          "grantId": {
+            "type": "string"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "state": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Grant state from identity provider"
+          }
         },
-        "required": ["grantId", "roles"],
+        "required": [
+          "grantId",
+          "roles"
+        ],
         "additionalProperties": false
       },
       "AdminUserWithRoles": {
         "type": "object",
         "properties": {
-          "userId": {"type": "string"},
-          "username": {"type": "string"},
-          "displayName": {"type": "string"},
-          "firstName": {"type": "string"},
-          "lastName": {"type": "string"},
-          "email": {"type": "string", "format": "email"},
-          "emailVerified": {"type": "boolean"},
-          "roles": {"type": "array", "items": {"type": "string"}},
-          "grants": {"type": "array", "items": {"$ref": "#/components/schemas/UserGrant"}}
+          "userId": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "emailVerified": {
+            "type": "boolean"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "grants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserGrant"
+            }
+          }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       },
       "AdminUserWithoutRoles": {
         "type": "object",
         "properties": {
-          "userId": {"type": "string"},
-          "username": {"type": "string"},
-          "displayName": {"type": "string"},
-          "firstName": {"type": "string"},
-          "lastName": {"type": "string"},
-          "email": {"type": "string", "format": "email"},
-          "emailVerified": {"type": "boolean"},
-          "roles": {"type": "array", "items": {"type": "string"}, "maxItems": 0},
-          "state": {"type": ["string", "null"], "description": "User state from identity provider (e.g., USER_STATE_ACTIVE)"}
+          "userId": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "emailVerified": {
+            "type": "boolean"
+          },
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 0
+          },
+          "state": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "User state from identity provider (e.g., USER_STATE_ACTIVE)"
+          }
         },
-        "required": ["userId"],
+        "required": [
+          "userId"
+        ],
         "additionalProperties": false
       },
       "PaginationMetadata": {
         "type": "object",
         "properties": {
-          "limit": {"type": "integer", "description": "Maximum number of results per page"},
-          "offset": {"type": "integer", "description": "Number of results skipped"},
-          "hasMore": {"type": "boolean", "description": "Whether more results exist beyond this page"}
+          "limit": {
+            "type": "integer",
+            "description": "Maximum number of results per page"
+          },
+          "offset": {
+            "type": "integer",
+            "description": "Number of results skipped"
+          },
+          "hasMore": {
+            "type": "boolean",
+            "description": "Whether more results exist beyond this page"
+          }
         },
-        "required": ["limit", "offset", "hasMore"],
+        "required": [
+          "limit",
+          "offset",
+          "hasMore"
+        ],
         "additionalProperties": false
       },
       "AdminUsersResponse": {
@@ -6500,59 +7533,171 @@
         "properties": {
           "usersWithRoles": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/AdminUserWithRoles"}
+            "items": {
+              "$ref": "#/components/schemas/AdminUserWithRoles"
+            }
           },
           "usersWithoutRoles": {
             "type": "array",
-            "items": {"$ref": "#/components/schemas/AdminUserWithoutRoles"}
+            "items": {
+              "$ref": "#/components/schemas/AdminUserWithoutRoles"
+            }
           },
-          "totalWithRoles": {"type": "integer"},
-          "totalWithoutRoles": {"type": "integer"},
-          "total": {"type": "integer", "description": "Total users returned in this response"},
-          "reportedTotal": {"type": "integer", "description": "Total user count reported by the identity provider"},
-          "pagination": {"$ref": "#/components/schemas/PaginationMetadata"}
+          "totalWithRoles": {
+            "type": "integer"
+          },
+          "totalWithoutRoles": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer",
+            "description": "Total users returned in this response"
+          },
+          "reportedTotal": {
+            "type": "integer",
+            "description": "Total user count reported by the identity provider"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMetadata"
+          }
         },
-        "required": ["usersWithRoles", "usersWithoutRoles", "totalWithRoles", "totalWithoutRoles", "total", "reportedTotal", "pagination"],
+        "required": [
+          "usersWithRoles",
+          "usersWithoutRoles",
+          "totalWithRoles",
+          "totalWithoutRoles",
+          "total",
+          "reportedTotal",
+          "pagination"
+        ],
         "additionalProperties": false
       },
       "SuccessResponse": {
         "type": "object",
         "properties": {
-          "success": {"type": "boolean"},
-          "message": {"type": "string"}
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          }
         },
-        "required": ["success", "message"],
+        "required": [
+          "success",
+          "message"
+        ],
         "additionalProperties": false
       },
       "Application": {
         "type": "object",
         "properties": {
-          "id": {"type": "string", "format": "uuid"},
-          "uuid": {"type": "string", "format": "uuid", "description": "Alias for id"},
-          "zitadel_user_id": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": ["string", "null"]},
-          "website": {"type": ["string", "null"], "format": "uri"},
-          "status": {"type": "string", "enum": ["pending", "approved", "rejected", "revoked"]},
-          "reviewed_by": {"type": ["string", "null"]},
-          "review_notes": {"type": ["string", "null"]},
-          "reviewed_at": {"type": ["string", "null"], "format": "date-time"},
-          "is_active": {"type": "boolean"},
-          "created_at": {"type": "string", "format": "date-time"},
-          "updated_at": {"type": "string", "format": "date-time"},
-          "user_name": {"type": ["string", "null"], "description": "Owner's display name (admin view only)"},
-          "user_email": {"type": ["string", "null"], "description": "Owner's email (admin view only)"}
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "uuid": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Alias for id"
+          },
+          "zitadel_user_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "website": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "uri"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "approved",
+              "rejected",
+              "revoked"
+            ]
+          },
+          "reviewed_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "review_notes": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "reviewed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "is_active": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "user_name": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Owner's display name (admin view only)"
+          },
+          "user_email": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Owner's email (admin view only)"
+          }
         },
-        "required": ["id", "zitadel_user_id", "name", "status", "is_active", "created_at", "updated_at"],
+        "required": [
+          "id",
+          "zitadel_user_id",
+          "name",
+          "status",
+          "is_active",
+          "created_at",
+          "updated_at"
+        ],
         "unevaluatedProperties": false
       },
       "ApplicationWithKeys": {
         "allOf": [
-          {"$ref": "#/components/schemas/Application"},
+          {
+            "$ref": "#/components/schemas/Application"
+          },
           {
             "type": "object",
             "properties": {
-              "keys": {"type": "array", "items": {"$ref": "#/components/schemas/ApiKey"}}
+              "keys": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ApiKey"
+                }
+              }
             }
           }
         ],
@@ -6561,47 +7706,129 @@
       "ApiKey": {
         "type": "object",
         "properties": {
-          "id": {"type": "string", "format": "uuid"},
-          "application_id": {"type": "string", "format": "uuid"},
-          "name": {"type": ["string", "null"]},
-          "key_prefix": {"type": "string", "description": "First 8 characters of the key for identification"},
-          "scope": {"type": "string", "enum": ["read", "write"]},
-          "rate_limit": {"type": "integer"},
-          "is_active": {"type": "boolean"},
-          "expires_at": {"type": ["string", "null"], "format": "date-time"},
-          "last_used_at": {"type": ["string", "null"], "format": "date-time"},
-          "created_at": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "application_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "key_prefix": {
+            "type": "string",
+            "description": "First 8 characters of the key for identification"
+          },
+          "scope": {
+            "type": "string",
+            "enum": [
+              "read",
+              "write"
+            ]
+          },
+          "rate_limit": {
+            "type": "integer"
+          },
+          "is_active": {
+            "type": "boolean"
+          },
+          "expires_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "last_used_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         },
-        "required": ["id", "application_id", "key_prefix", "scope", "rate_limit", "is_active", "created_at"],
+        "required": [
+          "id",
+          "application_id",
+          "key_prefix",
+          "scope",
+          "rate_limit",
+          "is_active",
+          "created_at"
+        ],
         "additionalProperties": false
       },
       "AdminApplicationsResponse": {
         "type": "object",
         "properties": {
-          "applications": {"type": "array", "items": {"$ref": "#/components/schemas/Application"}},
-          "total": {"type": "integer"},
-          "filter": {"type": ["string", "null"]}
+          "applications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Application"
+            }
+          },
+          "total": {
+            "type": "integer"
+          },
+          "filter": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
         },
-        "required": ["applications", "total"],
+        "required": [
+          "applications",
+          "total"
+        ],
         "additionalProperties": false
       },
       "AdminPendingApplicationsResponse": {
         "type": "object",
         "properties": {
-          "pending_applications": {"type": "array", "items": {"$ref": "#/components/schemas/Application"}},
-          "pending_count": {"type": "integer"}
+          "pending_applications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Application"
+            }
+          },
+          "pending_count": {
+            "type": "integer"
+          }
         },
-        "required": ["pending_applications", "pending_count"],
+        "required": [
+          "pending_applications",
+          "pending_count"
+        ],
         "additionalProperties": false
       },
       "AdminApplicationActionResponse": {
         "type": "object",
         "properties": {
-          "success": {"type": "boolean"},
-          "message": {"type": "string"},
-          "application": {"$ref": "#/components/schemas/Application"}
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "application": {
+            "$ref": "#/components/schemas/Application"
+          }
         },
-        "required": ["success", "message", "application"],
+        "required": [
+          "success",
+          "message",
+          "application"
+        ],
         "additionalProperties": false
       },
       "ApplicationsListResponse": {
@@ -6611,105 +7838,341 @@
             "type": "array",
             "items": {
               "allOf": [
-                {"$ref": "#/components/schemas/Application"},
-                {"type": "object", "properties": {"key_count": {"type": "integer"}}}
+                {
+                  "$ref": "#/components/schemas/Application"
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "key_count": {
+                      "type": "integer"
+                    }
+                  }
+                }
               ],
               "unevaluatedProperties": false
             }
           },
-          "total": {"type": "integer"}
+          "total": {
+            "type": "integer"
+          }
         },
-        "required": ["applications", "total"],
+        "required": [
+          "applications",
+          "total"
+        ],
         "additionalProperties": false
       },
       "CreateApplicationBody": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
-          "name": {"type": "string", "description": "Application name"},
-          "description": {"type": "string", "description": "Application description"},
-          "website": {"type": "string", "format": "uri", "description": "Application website URL"}
+          "name": {
+            "type": "string",
+            "description": "Application name"
+          },
+          "description": {
+            "type": "string",
+            "description": "Application description"
+          },
+          "website": {
+            "type": "string",
+            "format": "uri",
+            "description": "Application website URL"
+          }
         },
         "additionalProperties": false
       },
       "CreateApplicationResponse": {
         "type": "object",
         "properties": {
-          "success": {"type": "boolean"},
-          "message": {"type": "string"},
-          "application": {"$ref": "#/components/schemas/Application"}
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "application": {
+            "$ref": "#/components/schemas/Application"
+          }
         },
-        "required": ["success", "message", "application"],
+        "required": [
+          "success",
+          "message",
+          "application"
+        ],
         "additionalProperties": false
       },
       "UpdateApplicationBody": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "website": {"type": "string", "format": "uri"}
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "website": {
+            "type": "string",
+            "format": "uri"
+          }
         },
         "additionalProperties": false
       },
       "UpdateApplicationResponse": {
         "type": "object",
         "properties": {
-          "success": {"type": "boolean"},
-          "message": {"type": "string"},
-          "application": {"$ref": "#/components/schemas/Application"}
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "application": {
+            "$ref": "#/components/schemas/Application"
+          }
         },
-        "required": ["success", "message", "application"],
+        "required": [
+          "success",
+          "message",
+          "application"
+        ],
         "additionalProperties": false
       },
       "ResubmitApplicationResponse": {
         "type": "object",
         "properties": {
-          "success": {"type": "boolean"},
-          "message": {"type": "string"},
-          "application": {"$ref": "#/components/schemas/Application"}
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "application": {
+            "$ref": "#/components/schemas/Application"
+          }
         },
-        "required": ["success", "message", "application"],
+        "required": [
+          "success",
+          "message",
+          "application"
+        ],
         "additionalProperties": false
       },
       "ApiKeysListResponse": {
         "type": "object",
         "properties": {
-          "keys": {"type": "array", "items": {"$ref": "#/components/schemas/ApiKey"}},
-          "total": {"type": "integer"}
+          "keys": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiKey"
+            }
+          },
+          "total": {
+            "type": "integer"
+          }
         },
-        "required": ["keys", "total"],
+        "required": [
+          "keys",
+          "total"
+        ],
         "additionalProperties": false
       },
       "GenerateApiKeyBody": {
         "type": "object",
         "properties": {
-          "name": {"type": "string", "description": "Optional name for the API key"},
-          "scope": {"type": "string", "enum": ["read", "write"], "default": "read"},
-          "rate_limit": {"type": "integer", "description": "Rate limit per minute", "default": 1000},
-          "expires_at": {"type": "string", "format": "date-time", "description": "Optional expiration date"}
+          "name": {
+            "type": "string",
+            "description": "Optional name for the API key"
+          },
+          "scope": {
+            "type": "string",
+            "enum": [
+              "read",
+              "write"
+            ],
+            "default": "read"
+          },
+          "rate_limit": {
+            "type": "integer",
+            "description": "Rate limit per minute",
+            "default": 1000
+          },
+          "expires_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Optional expiration date"
+          }
         },
         "additionalProperties": false
       },
       "GenerateApiKeyResponse": {
         "type": "object",
         "properties": {
-          "success": {"type": "boolean"},
-          "message": {"type": "string"},
-          "key": {"type": "string", "description": "Plain text API key - only shown once"},
-          "record": {"$ref": "#/components/schemas/ApiKey"}
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string",
+            "description": "Plain text API key - only shown once"
+          },
+          "record": {
+            "$ref": "#/components/schemas/ApiKey"
+          }
         },
-        "required": ["success", "message", "key", "record"],
+        "required": [
+          "success",
+          "message",
+          "key",
+          "record"
+        ],
         "additionalProperties": false
       },
       "RotateApiKeyResponse": {
         "type": "object",
         "properties": {
-          "success": {"type": "boolean"},
-          "message": {"type": "string"},
-          "key": {"type": "string", "description": "New plain text API key - only shown once"},
-          "record": {"$ref": "#/components/schemas/ApiKey"}
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          },
+          "key": {
+            "type": "string",
+            "description": "New plain text API key - only shown once"
+          },
+          "record": {
+            "$ref": "#/components/schemas/ApiKey"
+          }
         },
-        "required": ["success", "message", "key", "record"],
+        "required": [
+          "success",
+          "message",
+          "key",
+          "record"
+        ],
+        "additionalProperties": false
+      },
+      "NotificationsSeenResponse": {
+        "type": "object",
+        "description": "Response from POST /auth/notifications/seen.",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "seen_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "success",
+          "seen_at"
+        ],
+        "additionalProperties": false
+      },
+      "UserNotification": {
+        "type": "object",
+        "description": "A single notification item in the authenticated user's inbox.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "access_request_reviewed"
+            ],
+            "description": "Discriminator for the notification kind."
+          },
+          "request_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "UUID of the underlying access_requests row."
+          },
+          "requested_role": {
+            "type": "string",
+            "description": "The role that was requested (e.g., 'calendar_editor')."
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "approved",
+              "rejected",
+              "revoked"
+            ],
+            "description": "Resolution status of the request."
+          },
+          "review_notes": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Free-text notes from the reviewing admin, if any."
+          },
+          "reviewed_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "RFC 3339 UTC timestamp of when the request was reviewed."
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Permission"
+            },
+            "description": "The permissions associated with the request."
+          },
+          "unread": {
+            "type": "boolean",
+            "description": "True if reviewed_at is more recent than the user's last_seen_at bookmark."
+          }
+        },
+        "required": [
+          "type",
+          "request_id",
+          "requested_role",
+          "status",
+          "review_notes",
+          "reviewed_at",
+          "permissions",
+          "unread"
+        ],
+        "additionalProperties": false
+      },
+      "UserNotificationsResponse": {
+        "type": "object",
+        "description": "Response from GET /auth/notifications — the inbox with unread badge metadata.",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UserNotification"
+            }
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "unread_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "last_seen_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "items",
+          "total",
+          "unread_count",
+          "last_seen_at"
+        ],
         "additionalProperties": false
       }
     },
@@ -6980,7 +8443,9 @@
             {
               "liturgical_event": {
                 "event_key": "ThanksgivingDay",
-                "color": ["white"],
+                "color": [
+                  "white"
+                ],
                 "grade": 3,
                 "strtotime": "fourth thursday of november",
                 "common": []
@@ -7011,9 +8476,13 @@
           },
           "metadata": {
             "nation": "US",
-            "locales": ["en_US"],
+            "locales": [
+              "en_US"
+            ],
             "wider_region": "Americas",
-            "missals": ["US_2011"]
+            "missals": [
+              "US_2011"
+            ]
           },
           "i18n": {
             "en_US": {
@@ -7030,9 +8499,13 @@
             {
               "liturgical_event": {
                 "event_key": "DedicationoftheCathedraloftheHolyCross",
-                "color": ["white"],
+                "color": [
+                  "white"
+                ],
                 "grade": 4,
-                "common": ["Dedication of a Church"],
+                "common": [
+                  "Dedication of a Church"
+                ],
                 "day": 8,
                 "month": 12
               },
@@ -7051,7 +8524,9 @@
             "diocese_id": "boston_us",
             "diocese_name": "Archdiocese of Boston (Massachusetts)",
             "nation": "US",
-            "locales": ["en_US"],
+            "locales": [
+              "en_US"
+            ],
             "timezone": "America/New_York"
           },
           "i18n": {
@@ -7069,9 +8544,13 @@
             {
               "liturgical_event": {
                 "event_key": "DedicationoftheBasilicaofStJohnLateran",
-                "color": ["white"],
+                "color": [
+                  "white"
+                ],
                 "grade": 6,
-                "common": ["Dedication of a Church"],
+                "common": [
+                  "Dedication of a Church"
+                ],
                 "day": 9,
                 "month": 11
               },
@@ -7090,7 +8569,9 @@
             "diocese_id": "romamo_it",
             "diocese_name": "Diocesi di Roma",
             "nation": "IT",
-            "locales": ["it_IT"],
+            "locales": [
+              "it_IT"
+            ],
             "timezone": "Europe/Rome"
           },
           "i18n": {
@@ -7252,7 +8733,9 @@
                   ]
                 }
               },
-              "required": ["success"]
+              "required": [
+                "success"
+              ]
             }
           }
         }

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -1079,6 +1079,112 @@
         }
       }
     },
+    "/auth/notifications": {
+      "get": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "getUserNotifications",
+        "summary": "Get the authenticated user's notification inbox",
+        "description": "Returns up to 50 most recent reviewed access-requests for the current user, with unread badge count and last-seen bookmark. Inbox items remain visible after marking-as-seen; only the unread flag and unread_count change.",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Inbox payload.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserNotificationsResponse"
+                }
+              }
+            },
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "no-store"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          }
+        }
+      }
+    },
+    "/auth/notifications/seen": {
+      "post": {
+        "tags": [
+          "Notifications"
+        ],
+        "operationId": "markNotificationsSeen",
+        "summary": "Mark the user's notification inbox as seen",
+        "description": "Upserts the user's bookmark so that last_notification_seen_at = NOW() (DB clock). Inbox itself is unchanged; only unread flags and unread_count flip on subsequent GETs.",
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Bookmark updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationsSeenResponse"
+                }
+              }
+            },
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string",
+                  "enum": [
+                    "no-store"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          }
+        }
+      }
+    },
     "/auth/access-requests": {
       "get": {
         "tags": [

--- a/phpunit_tests/Handlers/AbstractHandlerTestCase.php
+++ b/phpunit_tests/Handlers/AbstractHandlerTestCase.php
@@ -38,7 +38,7 @@ abstract class AbstractHandlerTestCase extends TestCase
     protected static ?PDO $pdo = null;
 
     /** @var array<int,string> */
-    protected const TABLES = ['api_keys', 'applications', 'access_requests', 'audit_log'];
+    protected const TABLES = ['api_keys', 'applications', 'access_requests', 'audit_log', 'user_notification_state'];
 
     /**
      * Subclasses set true when their tests need a working Postgres.

--- a/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
@@ -84,4 +84,131 @@ final class NotificationsHandlerTest extends AbstractHandlerTestCase
 
         self::assertSame(404, $response->getStatusCode());
     }
+
+    public function testPostSeenRequiresAuthentication(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+
+        ( new NotificationsHandler() )->handle(
+            $this->requestFor('POST', '/auth/notifications/seen', [], [])
+        );
+    }
+
+    public function testPostSeenInsertsBookmarkAndReturnsTimestamp(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/seen', [], []),
+                'zitadel-user-seen-1'
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/',
+            $body['seen_at']
+        );
+
+        $stmt = self::$pdo->prepare(
+            'SELECT COUNT(*) FROM user_notification_state WHERE user_id = :u'
+        );
+        $stmt->execute(['u' => 'zitadel-user-seen-1']);
+        self::assertSame(1, (int) $stmt->fetchColumn());
+    }
+
+    public function testPostSeenTwiceAdvancesTimestamp(): void
+    {
+        $h = new NotificationsHandler();
+
+        $resp1 = $h->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/seen', [], []),
+                'zitadel-user-seen-2'
+            )
+        );
+        $body1 = $this->decodeJsonBody($resp1);
+
+        usleep(1_100_000);
+
+        $resp2 = $h->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/seen', [], []),
+                'zitadel-user-seen-2'
+            )
+        );
+        $body2 = $this->decodeJsonBody($resp2);
+
+        self::assertGreaterThan($body1['seen_at'], $body2['seen_at']);
+    }
+
+    public function testPostSeenUnknownSubPathReturns404(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/bogus', [], []),
+                'zitadel-user-seen-3'
+            )
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testPostSeenAtBaseUrlReturns404(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications', [], []),
+                'zitadel-user-seen-4'
+            )
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+
+    public function testGetThenSeenThenGetFlipsUnreadFlag(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create(
+            'zitadel-user-rt-1',
+            'rt@example.test',
+            'RT',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $repo->approve($id, 'admin-x', null);
+
+        $h = new NotificationsHandler();
+
+        $body1 = $this->decodeJsonBody($h->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications'),
+                'zitadel-user-rt-1'
+            )
+        ));
+        self::assertSame(1, $body1['unread_count']);
+        self::assertTrue($body1['items'][0]['unread']);
+
+        usleep(1_100_000);
+
+        $h->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/auth/notifications/seen', [], []),
+                'zitadel-user-rt-1'
+            )
+        );
+
+        $body2 = $this->decodeJsonBody($h->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications'),
+                'zitadel-user-rt-1'
+            )
+        ));
+        self::assertSame(0, $body2['unread_count']);
+        self::assertFalse($body2['items'][0]['unread']);
+        self::assertSame(1, $body2['total']);
+    }
 }

--- a/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
@@ -169,6 +169,54 @@ final class NotificationsHandlerTest extends AbstractHandlerTestCase
         self::assertSame(404, $response->getStatusCode());
     }
 
+    public function testRejectsEmptyStringSub(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('Invalid authentication token');
+
+        $request = $this->requestFor('GET', '/auth/notifications')
+            ->withAttribute('oidc_user', ['sub' => '']);
+
+        ( new NotificationsHandler() )->handle($request);
+    }
+
+    public function testRejectsWhitespaceOnlySub(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('Invalid authentication token');
+
+        $request = $this->requestFor('GET', '/auth/notifications')
+            ->withAttribute('oidc_user', ['sub' => '   ']);
+
+        ( new NotificationsHandler() )->handle($request);
+    }
+
+    public function testRejectsMissingSub(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->expectExceptionMessage('Invalid authentication token');
+
+        // oidc_user without a 'sub' key — $userId resolves to null,
+        // triggering the !is_string($userId) branch.
+        $request = $this->requestFor('GET', '/auth/notifications')
+            ->withAttribute('oidc_user', ['email' => 'x@example.test']);
+
+        ( new NotificationsHandler() )->handle($request);
+    }
+
+    public function testHandlesOptionsPreflight(): void
+    {
+        $request  = $this->requestFor('OPTIONS', '/auth/notifications')
+            ->withHeader('Origin', 'https://example.test')
+            ->withHeader('Access-Control-Request-Method', 'GET');
+        $response = ( new NotificationsHandler() )->handle($request);
+
+        // Preflight should short-circuit before auth, so no UnauthorizedException
+        // is thrown. Status should be 2xx (typically 204 No Content).
+        self::assertLessThan(300, $response->getStatusCode());
+        self::assertGreaterThanOrEqual(200, $response->getStatusCode());
+    }
+
     public function testGetThenSeenThenGetFlipsUnreadFlag(): void
     {
         $repo = new AccessRequestRepository(self::$pdo);

--- a/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
@@ -217,6 +217,45 @@ final class NotificationsHandlerTest extends AbstractHandlerTestCase
         self::assertGreaterThanOrEqual(200, $response->getStatusCode());
     }
 
+    public function testUnknownHttpMethodReturns405(): void
+    {
+        // Method outside the RequestMethod enum (e.g. 'BANANA') makes
+        // RequestMethod::tryFrom return null; validateRequestMethod then
+        // throws a MethodNotAllowedException that surfaces as 405.
+        $this->expectException(\Throwable::class);
+
+        $request = $this->requestFor('BANANA', '/auth/notifications');
+
+        ( new NotificationsHandler() )->handle($request);
+    }
+
+    public function testExtractSubPathFallbackWhenApiBasePathUnset(): void
+    {
+        // The fallback branch in extractSubPath fires when API_BASE_PATH is
+        // absent or non-string. .env.local normally provides API_BASE_PATH=''
+        // so we have to temporarily unset it to exercise the fallback.
+        $originalEnv    = $_ENV['API_BASE_PATH'] ?? null;
+        $originalServer = $_SERVER['API_BASE_PATH'] ?? null;
+        unset($_ENV['API_BASE_PATH'], $_SERVER['API_BASE_PATH']);
+
+        try {
+            $response = ( new NotificationsHandler() )->handle(
+                $this->withOidcUser(
+                    $this->requestFor('GET', '/auth/notifications'),
+                    'zitadel-user-fallback'
+                )
+            );
+            self::assertSame(200, $response->getStatusCode());
+        } finally {
+            if ($originalEnv !== null) {
+                $_ENV['API_BASE_PATH'] = $originalEnv;
+            }
+            if ($originalServer !== null) {
+                $_SERVER['API_BASE_PATH'] = $originalServer;
+            }
+        }
+    }
+
     public function testGetThenSeenThenGetFlipsUnreadFlag(): void
     {
         $repo = new AccessRequestRepository(self::$pdo);

--- a/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers\Auth;
+
+use LiturgicalCalendar\Api\Handlers\Auth\NotificationsHandler;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+
+final class NotificationsHandlerTest extends AbstractHandlerTestCase
+{
+    protected static bool $requiresDatabase = true;
+
+    public function testGetInboxRequiresAuthentication(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+
+        ( new NotificationsHandler() )->handle(
+            $this->requestFor('GET', '/auth/notifications')
+        );
+    }
+
+    public function testGetInboxReturnsEmptyShapeForNewUser(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications'),
+                'zitadel-user-x'
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertSame([], $body['items']);
+        self::assertSame(0, $body['total']);
+        self::assertSame(0, $body['unread_count']);
+        self::assertSame('1970-01-01T00:00:00+00:00', $body['last_seen_at']);
+    }
+
+    public function testGetInboxReturnsReviewedItemsWithUnreadFlag(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create(
+            'zitadel-user-y',
+            'y@example.test',
+            'Y',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $repo->approve($id, 'admin-z', 'welcome');
+
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications'),
+                'zitadel-user-y'
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertCount(1, $body['items']);
+        self::assertSame($id, $body['items'][0]['request_id']);
+        self::assertSame('access_request_reviewed', $body['items'][0]['type']);
+        self::assertSame('approved', $body['items'][0]['status']);
+        self::assertSame('welcome', $body['items'][0]['review_notes']);
+        self::assertSame('calendar_editor', $body['items'][0]['requested_role']);
+        self::assertTrue($body['items'][0]['unread']);
+        self::assertSame(1, $body['total']);
+        self::assertSame(1, $body['unread_count']);
+    }
+
+    public function testGetInboxUnknownSubPathReturns404(): void
+    {
+        $response = ( new NotificationsHandler() )->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/auth/notifications/bogus'),
+                'zitadel-user-x'
+            )
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+    }
+}

--- a/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
+++ b/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Repositories\UserNotificationRepository;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+
+final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
+{
+    protected static bool $requiresDatabase = true;
+
+    private UserNotificationRepository $repo;
+    private AccessRequestRepository $accessReqRepo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo          = new UserNotificationRepository(self::$pdo);
+        $this->accessReqRepo = new AccessRequestRepository(self::$pdo);
+    }
+
+    public function testFetchInboxReturnsEmptyShapeWhenUserHasNoRequests(): void
+    {
+        $result = $this->repo->fetchInbox('zitadel-user-empty');
+
+        self::assertSame([], $result['items']);
+        self::assertSame(0, $result['total']);
+        self::assertSame(0, $result['unread_count']);
+        self::assertSame('1970-01-01T00:00:00+00:00', $result['last_seen_at']);
+    }
+
+    public function testFetchInboxExcludesPendingRequests(): void
+    {
+        $this->accessReqRepo->create(
+            'zitadel-user-a',
+            'a@example.test',
+            'User A',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        // Pending — no review yet.
+
+        $result = $this->repo->fetchInbox('zitadel-user-a');
+
+        self::assertSame([], $result['items']);
+        self::assertSame(0, $result['total']);
+        self::assertSame(0, $result['unread_count']);
+    }
+
+    public function testFetchInboxReturnsReviewedItemsAllUnreadWhenNoBookmark(): void
+    {
+        $id1 = $this->accessReqRepo->create(
+            'zitadel-user-b',
+            'b@example.test',
+            'User B',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $id2 = $this->accessReqRepo->create(
+            'zitadel-user-b',
+            'b@example.test',
+            'User B',
+            'developer',
+            [['object_type' => 'test_definition', 'object_id' => 'foo', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id1, 'admin-x', 'welcome');
+        $this->accessReqRepo->reject($id2, 'admin-x', 'denied');
+
+        $result = $this->repo->fetchInbox('zitadel-user-b');
+
+        self::assertCount(2, $result['items']);
+        self::assertSame(2, $result['total']);
+        self::assertSame(2, $result['unread_count']);
+        foreach ($result['items'] as $item) {
+            self::assertTrue($item['unread']);
+            self::assertSame('access_request_reviewed', $item['type']);
+            self::assertIsArray($item['permissions']);
+        }
+    }
+
+    public function testFetchInboxIsolatesUsers(): void
+    {
+        $idA = $this->accessReqRepo->create(
+            'zitadel-user-c',
+            'c@example.test',
+            'C',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $idB = $this->accessReqRepo->create(
+            'zitadel-user-d',
+            'd@example.test',
+            'D',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'FR', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($idA, 'admin-x', null);
+        $this->accessReqRepo->approve($idB, 'admin-x', null);
+
+        $resultC = $this->repo->fetchInbox('zitadel-user-c');
+        self::assertCount(1, $resultC['items']);
+        self::assertSame(1, $resultC['total']);
+    }
+
+    public function testFetchInboxRespectsLimit(): void
+    {
+        for ($i = 0; $i < 55; $i++) {
+            $id = $this->accessReqRepo->create(
+                'zitadel-user-e',
+                "e{$i}@example.test",
+                "E{$i}",
+                'developer',
+                [['object_type' => 'test_definition', 'object_id' => "obj-{$i}", 'relation' => 'editor']]
+            );
+            $this->accessReqRepo->approve($id, 'admin-x', null);
+        }
+
+        $result = $this->repo->fetchInbox('zitadel-user-e', limit: 50);
+
+        self::assertCount(50, $result['items']);
+        self::assertSame(55, $result['total']);
+        self::assertSame(55, $result['unread_count']);
+    }
+
+    public function testFetchInboxOrdersByReviewedAtDesc(): void
+    {
+        $id1 = $this->accessReqRepo->create(
+            'zitadel-user-f',
+            'f@example.test',
+            'F',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id1, 'admin-x', null);
+
+        usleep(1_100_000);
+
+        $id2 = $this->accessReqRepo->create(
+            'zitadel-user-f',
+            'f@example.test',
+            'F',
+            'developer',
+            [['object_type' => 'test_definition', 'object_id' => 't', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id2, 'admin-x', null);
+
+        $result = $this->repo->fetchInbox('zitadel-user-f');
+
+        self::assertSame($id2, $result['items'][0]['request_id']);
+        self::assertSame($id1, $result['items'][1]['request_id']);
+    }
+
+    public function testMarkSeenInsertsRowOnFirstCall(): void
+    {
+        $seenAt = $this->repo->markSeen('zitadel-user-g');
+
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/',
+            $seenAt
+        );
+
+        $stmt = self::$pdo->prepare(
+            'SELECT user_id FROM user_notification_state WHERE user_id = :u'
+        );
+        $stmt->execute(['u' => 'zitadel-user-g']);
+        self::assertSame('zitadel-user-g', $stmt->fetchColumn());
+    }
+
+    public function testMarkSeenAdvancesOnSecondCall(): void
+    {
+        $first = $this->repo->markSeen('zitadel-user-h');
+        usleep(1_100_000);
+        $second = $this->repo->markSeen('zitadel-user-h');
+
+        self::assertGreaterThan($first, $second);
+    }
+
+    public function testMarkSeenThenFetchInboxMarksItemsRead(): void
+    {
+        $id = $this->accessReqRepo->create(
+            'zitadel-user-i',
+            'i@example.test',
+            'I',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id, 'admin-x', null);
+
+        usleep(1_100_000);
+        $this->repo->markSeen('zitadel-user-i');
+
+        $result = $this->repo->fetchInbox('zitadel-user-i');
+        self::assertCount(1, $result['items']);
+        self::assertFalse($result['items'][0]['unread']);
+        self::assertSame(0, $result['unread_count']);
+        self::assertSame(1, $result['total']);
+    }
+
+    public function testFetchInboxDecodesPermissionsJsonb(): void
+    {
+        $id = $this->accessReqRepo->create(
+            'zitadel-user-j',
+            'j@example.test',
+            'J',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id, 'admin-x', null);
+
+        $result = $this->repo->fetchInbox('zitadel-user-j');
+
+        // assertEqualsCanonicalizing rather than assertSame because Postgres
+        // JSONB does not preserve key order — only the (de)normalized value
+        // shape is guaranteed.
+        self::assertEqualsCanonicalizing(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']],
+            $result['items'][0]['permissions']
+        );
+    }
+
+    public function testFetchInboxReturnsNullReviewNotes(): void
+    {
+        $id = $this->accessReqRepo->create(
+            'zitadel-user-k',
+            'k@example.test',
+            'K',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id, 'admin-x', null); // null notes
+
+        $result = $this->repo->fetchInbox('zitadel-user-k');
+
+        self::assertCount(1, $result['items']);
+        self::assertNull($result['items'][0]['review_notes']);
+    }
+
+    public function testFetchInboxIncludesRevokedStatus(): void
+    {
+        // The full reviewed-status matrix is approved | rejected | revoked.
+        // Verify all three appear in the inbox and are counted toward total
+        // and unread_count. Uses three distinct roles to avoid the partial
+        // unique index on (zitadel_user_id, requested_role) WHERE status =
+        // 'pending'.
+        $idApproved = $this->accessReqRepo->create(
+            'zitadel-user-revoked',
+            'r@example.test',
+            'R',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $idRejected = $this->accessReqRepo->create(
+            'zitadel-user-revoked',
+            'r@example.test',
+            'R',
+            'developer',
+            [['object_type' => 'test_definition', 'object_id' => 'foo', 'relation' => 'editor']]
+        );
+        $idRevoked  = $this->accessReqRepo->create(
+            'zitadel-user-revoked',
+            'r@example.test',
+            'R',
+            'test_editor',
+            [['object_type' => 'test_definition', 'object_id' => 'bar', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($idApproved, 'admin-x', null);
+        $this->accessReqRepo->reject($idRejected, 'admin-x', null);
+        // revoke() requires the row to be approved first (its WHERE clause).
+        $this->accessReqRepo->approve($idRevoked, 'admin-x', null);
+        $this->accessReqRepo->revoke($idRevoked, 'admin-x', null);
+
+        $result = $this->repo->fetchInbox('zitadel-user-revoked');
+
+        self::assertSame(3, $result['total']);
+        self::assertSame(3, $result['unread_count']);
+        $statuses = array_column($result['items'], 'status');
+        sort($statuses);
+        self::assertSame(['approved', 'rejected', 'revoked'], $statuses);
+    }
+}

--- a/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
+++ b/phpunit_tests/Repositories/UserNotificationRepositoryTest.php
@@ -125,6 +125,64 @@ final class UserNotificationRepositoryTest extends AbstractHandlerTestCase
         self::assertSame(55, $result['unread_count']);
     }
 
+    public function testFetchInboxClampsLimitAboveCap(): void
+    {
+        // Seed two items so the clamp's effect (cap at 50) is the only thing
+        // that could constrain the result; with 2 items and a caller-requested
+        // 999, we expect 2 returned (not an error, not the raw 999).
+        $id1 = $this->accessReqRepo->create(
+            'zitadel-user-clamp-hi',
+            'ch@example.test',
+            'CH',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $id2 = $this->accessReqRepo->create(
+            'zitadel-user-clamp-hi',
+            'ch@example.test',
+            'CH',
+            'developer',
+            [['object_type' => 'test_definition', 'object_id' => 'foo', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id1, 'admin-x', null);
+        $this->accessReqRepo->approve($id2, 'admin-x', null);
+
+        $result = $this->repo->fetchInbox('zitadel-user-clamp-hi', limit: 999);
+
+        self::assertCount(2, $result['items']);
+        self::assertSame(2, $result['total']);
+    }
+
+    public function testFetchInboxClampsNonPositiveLimitToOne(): void
+    {
+        // A caller-requested limit of 0 or negative is nonsensical; the
+        // repository clamps to 1 (defense in depth) rather than running a
+        // `LIMIT 0` query that returns no items.
+        $id1 = $this->accessReqRepo->create(
+            'zitadel-user-clamp-lo',
+            'cl@example.test',
+            'CL',
+            'calendar_editor',
+            [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]
+        );
+        $id2 = $this->accessReqRepo->create(
+            'zitadel-user-clamp-lo',
+            'cl@example.test',
+            'CL',
+            'developer',
+            [['object_type' => 'test_definition', 'object_id' => 'foo', 'relation' => 'editor']]
+        );
+        $this->accessReqRepo->approve($id1, 'admin-x', null);
+        $this->accessReqRepo->approve($id2, 'admin-x', null);
+
+        $result = $this->repo->fetchInbox('zitadel-user-clamp-lo', limit: 0);
+
+        self::assertCount(1, $result['items']);
+        // total is the window-function count over the FULL filtered set,
+        // so it still sees both items even though only 1 is paged in.
+        self::assertSame(2, $result['total']);
+    }
+
     public function testFetchInboxOrdersByReviewedAtDesc(): void
     {
         $id1 = $this->accessReqRepo->create(

--- a/phpunit_tests/Routes/Auth/NotificationsRoutesTest.php
+++ b/phpunit_tests/Routes/Auth/NotificationsRoutesTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Auth;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Integration tests for /auth/notifications.
+ *
+ * Requires a running API server, a configured database, and a Zitadel
+ * OIDC token (service account key file) for the token-requiring tests.
+ * Falls back to skipping cleanly when only a legacy JWT is available,
+ * since /auth/notifications is wired without legacy-JWT fallback in
+ * OidcAuthMiddleware.
+ */
+#[Group('slow')]
+final class NotificationsRoutesTest extends ApiTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        if (!self::isDatabaseConfigured()) {
+            self::markTestSkipped('Database not configured.');
+        }
+    }
+
+    /**
+     * Obtain a token that the OIDC middleware on /auth/notifications will
+     * accept. Returns null when no token can be obtained at all, or when
+     * the obtainable token is a legacy JWT that the OIDC middleware
+     * rejects (i.e. no Zitadel locally configured).
+     */
+    private function getAcceptableToken(): ?string
+    {
+        $token = self::getJwtToken();
+        if ($token === null) {
+            return null;
+        }
+
+        // Probe: if /auth/notifications rejects this token with 401, it's a
+        // legacy JWT and the OIDC middleware refuses it. The behavior-shape
+        // assertions need a token the middleware accepts, so signal skip.
+        $probe = self::$http->get('/auth/notifications', [
+            'headers' => array_merge(
+                self::authHeaders($token),
+                ['Accept' => 'application/json']
+            ),
+        ]);
+        if ($probe->getStatusCode() === 401) {
+            return null;
+        }
+
+        return $token;
+    }
+
+    public function testInboxRequiresAuth(): void
+    {
+        $response = self::$http->get('/auth/notifications', [
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+        self::assertSame(401, $response->getStatusCode());
+    }
+
+    public function testInboxReturnsExpectedShapeWithBearer(): void
+    {
+        $token = $this->getAcceptableToken();
+        if ($token === null) {
+            self::markTestSkipped('No OIDC-acceptable token obtainable (Zitadel not configured locally).');
+        }
+
+        $response = self::$http->get('/auth/notifications', [
+            'headers' => array_merge(
+                self::authHeaders($token),
+                ['Accept' => 'application/json']
+            ),
+        ]);
+        self::assertSame(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertArrayHasKey('items', $body);
+        self::assertArrayHasKey('total', $body);
+        self::assertArrayHasKey('unread_count', $body);
+        self::assertArrayHasKey('last_seen_at', $body);
+        self::assertIsArray($body['items']);
+        self::assertIsInt($body['total']);
+        self::assertIsInt($body['unread_count']);
+        self::assertSame('no-store', $response->getHeaderLine('Cache-Control'));
+    }
+
+    public function testPostSeenWithBearer(): void
+    {
+        $token = $this->getAcceptableToken();
+        if ($token === null) {
+            self::markTestSkipped('No OIDC-acceptable token obtainable (Zitadel not configured locally).');
+        }
+
+        $response = self::$http->post('/auth/notifications/seen', [
+            'headers' => array_merge(
+                self::authHeaders($token),
+                [
+                    'Accept'       => 'application/json',
+                    'Content-Type' => 'application/json',
+                ]
+            ),
+            'body'    => '{}',
+        ]);
+        self::assertSame(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertIsArray($body);
+        self::assertArrayHasKey('success', $body);
+        self::assertTrue($body['success']);
+        self::assertArrayHasKey('seen_at', $body);
+        self::assertIsString($body['seen_at']);
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+00:00$/',
+            $body['seen_at']
+        );
+    }
+
+    public function testGetSeenGetEndToEnd(): void
+    {
+        $token = $this->getAcceptableToken();
+        if ($token === null) {
+            self::markTestSkipped('No OIDC-acceptable token obtainable (Zitadel not configured locally).');
+        }
+
+        $getHeaders  = array_merge(
+            self::authHeaders($token),
+            ['Accept' => 'application/json']
+        );
+        $postHeaders = array_merge(
+            self::authHeaders($token),
+            [
+                'Accept'       => 'application/json',
+                'Content-Type' => 'application/json',
+            ]
+        );
+
+        self::$http->post('/auth/notifications/seen', [
+            'headers' => $postHeaders,
+            'body'    => '{}',
+        ]);
+        sleep(1);
+        $second = self::$http->get('/auth/notifications', ['headers' => $getHeaders]);
+        self::assertSame(200, $second->getStatusCode());
+
+        $body = json_decode((string) $second->getBody(), true);
+        self::assertIsArray($body);
+        self::assertArrayHasKey('unread_count', $body);
+        self::assertSame(0, $body['unread_count']);
+        self::assertArrayHasKey('items', $body);
+        self::assertIsArray($body['items']);
+        foreach ($body['items'] as $item) {
+            self::assertIsArray($item);
+            self::assertArrayHasKey('unread', $item);
+            self::assertFalse($item['unread']);
+        }
+    }
+}

--- a/phpunit_tests/Routes/Auth/NotificationsRoutesTest.php
+++ b/phpunit_tests/Routes/Auth/NotificationsRoutesTest.php
@@ -51,16 +51,18 @@ final class NotificationsRoutesTest extends ApiTestCase
             return null;
         }
 
-        // Probe: if /auth/notifications rejects this token with 401, it's a
-        // legacy JWT and the OIDC middleware refuses it. The behavior-shape
-        // assertions need a token the middleware accepts, so signal skip.
+        // Probe: only treat the token as usable if /auth/notifications
+        // accepts it with a 200. Any other status (401 legacy-JWT reject,
+        // 5xx transient failure, 406 Accept mismatch, etc.) means the
+        // behavior-shape tests can't run meaningfully — signal skip rather
+        // than letting downstream assertions fail with confusing diagnostics.
         $probe = self::$http->get('/auth/notifications', [
             'headers' => array_merge(
                 self::authHeaders($token),
                 ['Accept' => 'application/json']
             ),
         ]);
-        if ($probe->getStatusCode() === 401) {
+        if ($probe->getStatusCode() !== 200) {
             return null;
         }
 

--- a/phpunit_tests/Routes/Auth/NotificationsRoutesTest.php
+++ b/phpunit_tests/Routes/Auth/NotificationsRoutesTest.php
@@ -25,6 +25,17 @@ final class NotificationsRoutesTest extends ApiTestCase
         if (!self::isDatabaseConfigured()) {
             self::markTestSkipped('Database not configured.');
         }
+        // OidcAvailabilityMiddleware short-circuits with 503 when Zitadel
+        // envs aren't set on the running server. In that environment every
+        // request to /auth/notifications returns 503 regardless of auth,
+        // so neither the no-auth-401 assertion nor the token-flow tests
+        // can run meaningfully.
+        $probe = self::$http->get('/auth/notifications', [
+            'headers' => ['Accept' => 'application/json'],
+        ]);
+        if ($probe->getStatusCode() === 503) {
+            self::markTestSkipped('OIDC (Zitadel) not configured on the running server.');
+        }
     }
 
     /**

--- a/src/Handlers/Auth/NotificationsHandler.php
+++ b/src/Handlers/Auth/NotificationsHandler.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Auth;
+
+use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestContentType;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Repositories\UserNotificationRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * User notifications handler — issue #573.
+ *
+ * - GET  /auth/notifications        — Inbox + unread badge.
+ * - POST /auth/notifications/seen   — Mark inbox seen (bookmark).
+ *
+ * OIDC-gated via OidcAuthMiddleware (wired in Router.php). The user
+ * identifier is the Zitadel sub from oidc_user, which keys both the
+ * access_requests query and the user_notification_state row.
+ */
+final class NotificationsHandler extends AbstractHandler
+{
+    private const INBOX_LIMIT = 50;
+
+    private ?UserNotificationRepository $repository = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->allowedRequestMethods      = [RequestMethod::GET, RequestMethod::POST];
+        $this->allowedAcceptHeaders       = [AcceptHeader::JSON];
+        $this->allowedRequestContentTypes = [RequestContentType::JSON];
+        $this->allowCredentials           = true;
+    }
+
+    private function getRepository(): UserNotificationRepository
+    {
+        if ($this->repository === null) {
+            $this->repository = new UserNotificationRepository();
+        }
+        return $this->repository;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+
+        $method = RequestMethod::tryFrom($request->getMethod());
+
+        if ($method === null) {
+            $this->validateRequestMethod($request);
+        }
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime);
+        $response = $response->withHeader('Cache-Control', 'no-store');
+
+        /** @var array{sub?: string, email?: string, name?: string, preferred_username?: string, roles?: array<string>}|null $oidcUser */
+        $oidcUser = $request->getAttribute('oidc_user');
+        if ($oidcUser === null) {
+            throw new UnauthorizedException('Authentication required');
+        }
+        $userId = $oidcUser['sub'] ?? null;
+        if (!is_string($userId) || trim($userId) === '') {
+            throw new UnauthorizedException('Invalid authentication token');
+        }
+
+        $tail = $this->extractSubPath($request->getUri()->getPath());
+
+        if ($method === RequestMethod::GET && $tail === '') {
+            return $this->getInbox($response, $userId);
+        }
+
+        if ($method === RequestMethod::POST && $tail === 'seen') {
+            return $this->markSeen($response, $userId);
+        }
+
+        return $response->withStatus(StatusCode::NOT_FOUND->value, StatusCode::NOT_FOUND->reason());
+    }
+
+    private function getInbox(ResponseInterface $response, string $userId): ResponseInterface
+    {
+        if (!Connection::isConfigured()) {
+            throw new \RuntimeException('Database not configured');
+        }
+        return $this->encodeResponseBody(
+            $response,
+            $this->getRepository()->fetchInbox($userId, self::INBOX_LIMIT)
+        );
+    }
+
+    private function markSeen(ResponseInterface $response, string $userId): ResponseInterface
+    {
+        if (!Connection::isConfigured()) {
+            throw new \RuntimeException('Database not configured');
+        }
+        return $this->encodeResponseBody(
+            $response,
+            ['success' => true, 'seen_at' => $this->getRepository()->markSeen($userId)]
+        );
+    }
+
+    private function extractSubPath(string $path): string
+    {
+        $prefix = '/auth/notifications';
+        $base   = isset($_ENV['API_BASE_PATH']) && is_string($_ENV['API_BASE_PATH'])
+            ? rtrim($_ENV['API_BASE_PATH'], '/')
+            : '';
+        $needle = $base . $prefix;
+        $tail   = substr($path, strlen($needle));
+        return trim($tail, '/');
+    }
+}

--- a/src/Migrations/Version20260530140000.php
+++ b/src/Migrations/Version20260530140000.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Issue #573: user-facing notification bookmark.
+ *
+ * One row per Zitadel user, holding the last time they marked
+ * their notifications inbox as seen. Absence of a row is treated
+ * as "unseen since epoch" via the read path (no placeholder row
+ * is ever inserted on read).
+ */
+final class Version20260530140000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create user_notification_state table for issue #573';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE user_notification_state (
+                user_id                     VARCHAR(255) PRIMARY KEY,
+                last_notification_seen_at   TIMESTAMP NOT NULL DEFAULT TIMESTAMP 'epoch'
+            )
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('DROP TABLE IF EXISTS user_notification_state');
+    }
+}

--- a/src/Repositories/AccessRequestRepository.php
+++ b/src/Repositories/AccessRequestRepository.php
@@ -145,7 +145,7 @@ class AccessRequestRepository
             return null;
         }
 
-        return $this->decodePermissions($result);
+        return self::decodePermissions($result);
     }
 
     /**
@@ -614,7 +614,7 @@ class AccessRequestRepository
      * @param array<string, mixed> $row Database row
      * @return array<string, mixed> Row with permissions decoded
      */
-    private function decodePermissions(array $row): array
+    public static function decodePermissions(array $row): array
     {
         if (isset($row['permissions']) && is_string($row['permissions'])) {
             /** @var array<int, array{object_type: string, object_id: string, relation: string}>|null $decoded */
@@ -633,6 +633,6 @@ class AccessRequestRepository
      */
     private function decodePermissionsList(array $rows): array
     {
-        return array_map([$this, 'decodePermissions'], $rows);
+        return array_map([self::class, 'decodePermissions'], $rows);
     }
 }

--- a/src/Repositories/UserNotificationRepository.php
+++ b/src/Repositories/UserNotificationRepository.php
@@ -135,34 +135,29 @@ final class UserNotificationRepository
 
     /**
      * Narrow a scalar DB column value to int without violating PHPStan L10's
-     * cast-from-mixed rule. Postgres returns COUNT(*) OVER () as a numeric
-     * string by default; cast-after-validate is the canonical L10 pattern.
+     * cast-from-mixed rule. With PDO::ATTR_EMULATE_PREPARES=false (the project
+     * default — see Connection.php), pdo_pgsql returns COUNT(*) OVER () as a
+     * native PHP int, so a single is_int guard suffices.
      */
     private function toInt(mixed $value): int
     {
-        if (is_int($value)) {
-            return $value;
+        if (!is_int($value)) {
+            throw new \UnexpectedValueException('Expected int, got ' . gettype($value));
         }
-        if (is_string($value) && is_numeric($value)) {
-            return (int) $value;
-        }
-        throw new \UnexpectedValueException('Expected int-compatible scalar, got ' . gettype($value));
+        return $value;
     }
 
     /**
      * Narrow a scalar DB column value to string without violating PHPStan L10's
-     * cast-from-mixed rule. All columns we read here are either text-typed or
-     * UUID/timestamp (which the driver returns as strings).
+     * cast-from-mixed rule. All columns we read here are TEXT, VARCHAR, UUID,
+     * or TIMESTAMP — all of which pdo_pgsql returns as PHP strings.
      */
     private function toString(mixed $value): string
     {
-        if (is_string($value)) {
-            return $value;
+        if (!is_string($value)) {
+            throw new \UnexpectedValueException('Expected string, got ' . gettype($value));
         }
-        if (is_int($value) || is_float($value)) {
-            return (string) $value;
-        }
-        throw new \UnexpectedValueException('Expected string-compatible scalar, got ' . gettype($value));
+        return $value;
     }
 
     /**

--- a/src/Repositories/UserNotificationRepository.php
+++ b/src/Repositories/UserNotificationRepository.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Repositories;
+
+use LiturgicalCalendar\Api\Database\Connection;
+
+/**
+ * Repository for user-facing notification state and inbox queries.
+ *
+ * Backs the GET /auth/notifications and POST /auth/notifications/seen
+ * endpoints. Reads from access_requests (filtered to reviewed rows for
+ * the authenticated user) and reads/writes the user_notification_state
+ * bookmark table.
+ *
+ * The "no row yet = unseen since epoch" semantics are handled in the
+ * read path via a NULL → '1970-01-01' fallback. Reads never insert.
+ */
+final class UserNotificationRepository
+{
+    private const EPOCH         = '1970-01-01 00:00:00';
+    private const EPOCH_ISO8601 = '1970-01-01T00:00:00+00:00';
+
+    private \PDO $db;
+
+    public function __construct(?\PDO $db = null)
+    {
+        $this->db = $db ?? Connection::getInstance();
+    }
+
+    /**
+     * Fetch the user's inbox + unread badge metadata.
+     *
+     * @return array{
+     *     items: list<array{
+     *         type: string,
+     *         request_id: string,
+     *         requested_role: string,
+     *         status: string,
+     *         review_notes: ?string,
+     *         reviewed_at: string,
+     *         permissions: list<array{object_type: string, object_id: string, relation: string}>,
+     *         unread: bool
+     *     }>,
+     *     total: int,
+     *     unread_count: int,
+     *     last_seen_at: string
+     * }
+     */
+    public function fetchInbox(string $userId, int $limit = 50): array
+    {
+        // Statement A: bookmark (or epoch).
+        $stmt = $this->db->prepare(
+            'SELECT last_notification_seen_at FROM user_notification_state WHERE user_id = :uid'
+        );
+        $stmt->execute(['uid' => $userId]);
+        $lastSeenRaw = $stmt->fetchColumn();
+        $hasBookmark = is_string($lastSeenRaw);
+        $lastSeen    = $hasBookmark ? $lastSeenRaw : self::EPOCH;
+        $lastSeenIso = $hasBookmark ? $this->iso8601($lastSeen) : self::EPOCH_ISO8601;
+
+        // Statement B: items + window-function counts over the full filtered set.
+        $sql  = <<<'SQL'
+            SELECT
+                id,
+                requested_role,
+                status,
+                review_notes,
+                reviewed_at,
+                permissions,
+                (reviewed_at > :last_seen::timestamp) AS unread,
+                COUNT(*) OVER () AS total,
+                COUNT(*) FILTER (
+                    WHERE reviewed_at > :last_seen::timestamp
+                ) OVER () AS unread_count
+            FROM access_requests
+            WHERE zitadel_user_id = :uid
+              AND reviewed_at IS NOT NULL
+            ORDER BY reviewed_at DESC
+            LIMIT :limit
+        SQL;
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindValue(':uid', $userId);
+        $stmt->bindValue(':last_seen', $lastSeen);
+        $stmt->bindValue(':limit', $limit, \PDO::PARAM_INT);
+        $stmt->execute();
+        /** @var list<array<string, mixed>> $rows */
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        if ($rows === []) {
+            return [
+                'items'        => [],
+                'total'        => 0,
+                'unread_count' => 0,
+                'last_seen_at' => $lastSeenIso,
+            ];
+        }
+
+        $total       = $this->toInt($rows[0]['total']);
+        $unreadCount = $this->toInt($rows[0]['unread_count']);
+
+        $items = array_map(
+            function (array $row): array {
+                $decoded     = AccessRequestRepository::decodePermissions($row);
+                $rawPerms    = $decoded['permissions'] ?? [];
+                $perms       = is_array($rawPerms) ? array_values($rawPerms) : [];
+                $reviewNotes = $row['review_notes'] ?? null;
+                /** @var list<array{object_type: string, object_id: string, relation: string}> $perms */
+                return [
+                    'type'           => 'access_request_reviewed',
+                    'request_id'     => $this->toString($row['id']),
+                    'requested_role' => $this->toString($row['requested_role']),
+                    'status'         => $this->toString($row['status']),
+                    'review_notes'   => $reviewNotes === null ? null : $this->toString($reviewNotes),
+                    'reviewed_at'    => $this->iso8601($this->toString($row['reviewed_at'])),
+                    'permissions'    => $perms,
+                    'unread'         => (bool) ( $row['unread'] ?? false ),
+                ];
+            },
+            $rows
+        );
+
+        return [
+            'items'        => array_values($items),
+            'total'        => $total,
+            'unread_count' => $unreadCount,
+            'last_seen_at' => $lastSeenIso,
+        ];
+    }
+
+    /**
+     * Narrow a scalar DB column value to int without violating PHPStan L10's
+     * cast-from-mixed rule. Postgres returns COUNT(*) OVER () as a numeric
+     * string by default; cast-after-validate is the canonical L10 pattern.
+     */
+    private function toInt(mixed $value): int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+        if (is_string($value) && is_numeric($value)) {
+            return (int) $value;
+        }
+        throw new \UnexpectedValueException('Expected int-compatible scalar, got ' . gettype($value));
+    }
+
+    /**
+     * Narrow a scalar DB column value to string without violating PHPStan L10's
+     * cast-from-mixed rule. All columns we read here are either text-typed or
+     * UUID/timestamp (which the driver returns as strings).
+     */
+    private function toString(mixed $value): string
+    {
+        if (is_string($value)) {
+            return $value;
+        }
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+        throw new \UnexpectedValueException('Expected string-compatible scalar, got ' . gettype($value));
+    }
+
+    /**
+     * Mark the user's inbox as seen. Single source of truth for the
+     * timestamp is the database clock (NOW() in SQL, returned via
+     * RETURNING).
+     *
+     * @return string RFC 3339 UTC timestamp of the new bookmark.
+     */
+    public function markSeen(string $userId): string
+    {
+        $sql  = <<<'SQL'
+            INSERT INTO user_notification_state (user_id, last_notification_seen_at)
+            VALUES (:uid, NOW())
+            ON CONFLICT (user_id) DO UPDATE
+            SET last_notification_seen_at = EXCLUDED.last_notification_seen_at
+            RETURNING last_notification_seen_at
+        SQL;
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute(['uid' => $userId]);
+        $seen = $stmt->fetchColumn();
+        if (!is_string($seen)) {
+            throw new \RuntimeException('markSeen: RETURNING did not yield a timestamp string');
+        }
+        return $this->iso8601($seen);
+    }
+
+    /**
+     * Convert a Postgres TIMESTAMP (no TZ) string to RFC 3339 UTC.
+     *
+     * The DB stores wall-clock time in Europe/Vatican per the project
+     * convention; the wire format is always UTC.
+     */
+    private function iso8601(string $dbTimestamp): string
+    {
+        return ( new \DateTimeImmutable($dbTimestamp, new \DateTimeZone('Europe/Vatican')) )
+            ->setTimezone(new \DateTimeZone('UTC'))
+            ->format('Y-m-d\TH:i:sP');
+    }
+}

--- a/src/Repositories/UserNotificationRepository.php
+++ b/src/Repositories/UserNotificationRepository.php
@@ -50,6 +50,10 @@ final class UserNotificationRepository
      */
     public function fetchInbox(string $userId, int $limit = 50): array
     {
+        // Enforce the "up to 50" contract locally — defense in depth against
+        // callers that ask for an unbounded or non-positive page size.
+        $limit = max(1, min($limit, 50));
+
         // Statement A: bookmark (or epoch).
         $stmt = $this->db->prepare(
             'SELECT last_notification_seen_at FROM user_notification_state WHERE user_id = :uid'

--- a/src/Router.php
+++ b/src/Router.php
@@ -27,7 +27,8 @@ use LiturgicalCalendar\Api\Handlers\Auth\AccessRequestHandler;
 use LiturgicalCalendar\Api\Handlers\Auth\EmailVerificationHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\AccessRequestAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\ApplicationAdminHandler;
-use LiturgicalCalendar\Api\Handlers\Admin\NotificationsHandler;
+use LiturgicalCalendar\Api\Handlers\Admin\NotificationsHandler as AdminNotificationsHandler;
+use LiturgicalCalendar\Api\Handlers\Auth\NotificationsHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\PermissionAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\UsersHandler;
 use LiturgicalCalendar\Api\Handlers\ApplicationsHandler;
@@ -354,6 +355,12 @@ class Router
                         // POST /auth/email-verification/resend - Resend verification email
                         $emailVerificationHandler = new EmailVerificationHandler();
                         $this->handler            = $emailVerificationHandler;
+                    } elseif ($authRoute === 'notifications') {
+                        // User notifications routes (issue #573)
+                        // GET  /auth/notifications        - Inbox + unread badge
+                        // POST /auth/notifications/seen   - Mark inbox seen
+                        $notificationsHandler = new NotificationsHandler();
+                        $this->handler        = $notificationsHandler;
                     } else {
                         $this->response = new Response(StatusCode::NOT_FOUND->value, [], null, $this->request->getProtocolVersion(), StatusCode::NOT_FOUND->reason());
                         $this->emitResponse();
@@ -378,7 +385,7 @@ class Router
                     } elseif ($adminRoute === 'notifications') {
                         // Admin notifications route
                         // GET /admin/notifications - Get counts of pending items
-                        $notificationsHandler = new NotificationsHandler();
+                        $notificationsHandler = new AdminNotificationsHandler();
                         $this->handler        = $notificationsHandler;
                     } elseif ($adminRoute === 'users') {
                         // Admin users management routes
@@ -579,10 +586,10 @@ class Router
             $pipeline->pipe(new DeployTokenMiddleware());
         }
 
-        // Apply OIDC authentication for auth routes (access-requests, email-verification), admin, and applications
+        // Apply OIDC authentication for auth routes (access-requests, email-verification, notifications), admin, and applications
         // These routes need the oidc_user attribute set before the handler checks authentication
         if (
-            ( $route === 'auth' && count($requestPathParts) >= 1 && in_array($requestPathParts[0], ['access-requests', 'email-verification'], true) )
+            ( $route === 'auth' && count($requestPathParts) >= 1 && in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications'], true) )
             || $route === 'admin'
             || $route === 'applications'
         ) {


### PR DESCRIPTION
Closes #573.

Adds `GET /auth/notifications` (inbox + unread badge) and `POST /auth/notifications/seen` (mark-as-seen bookmark) so end users get in-app feedback on access-request review events.

## Design

Inbox + unread badge UX. Bookmark is the only mutable state (one row per Zitadel user in `user_notification_state`). All timestamps derive from `NOW()` in SQL — single source of truth.

See:
- Spec: `docs/superpowers/specs/2026-05-30-issue-573-user-notifications-design.md`
- Plan: `docs/superpowers/plans/2026-05-30-issue-573-user-notifications-plan.md`

## Endpoints

**`GET /auth/notifications`** → up to 50 most recent reviewed access-requests for the authenticated user, with `unread_count`, `total`, `last_seen_at`. Each item carries an `unread` boolean tagged against the bookmark. Items remain visible after marking-seen — only the unread flag flips.

**`POST /auth/notifications/seen`** → upsert via `INSERT ... ON CONFLICT (user_id) DO UPDATE ... RETURNING NOW()`. Returns `{ success: true, seen_at }`.

Both gated by `OidcAuthMiddleware::fromEnv()` (same gate as `/auth/access-requests`). Bearer or Cookie auth. `Cache-Control: no-store` on both 200 responses.

## Changes

| Layer | File | Notes |
|---|---|---|
| DB | `src/Migrations/Version20260530140000.php` | new |
| Repo | `src/Repositories/UserNotificationRepository.php` | new |
| Repo | `src/Repositories/AccessRequestRepository.php` | `decodePermissions` → `public static` (reused by new repo) |
| Handler | `src/Handlers/Auth/NotificationsHandler.php` | new |
| Router | `src/Router.php` | 4 surgical edits: imports, dispatch, OIDC gate |
| Tests | `phpunit_tests/Repositories/UserNotificationRepositoryTest.php` | 12 unit tests |
| Tests | `phpunit_tests/Handlers/Auth/NotificationsHandlerTest.php` | 10 unit tests |
| Tests | `phpunit_tests/Routes/Auth/NotificationsRoutesTest.php` | 4 `#[Group('slow')]` integration tests |
| Tests | `phpunit_tests/Handlers/AbstractHandlerTestCase.php` | added `user_notification_state` to truncate list |
| Docs | `jsondata/schemas/openapi.json` | 1 tag, 3 schemas, 2 paths |

## Tests

- **22** new unit tests, all green.
- **4** integration tests (server round-trip). Only the 401-without-auth case runs without an OIDC token; the other 3 skip cleanly in the absence of a Zitadel service account key.
- `composer test` (handler + repo subset): 243 tests, 3 failures — all pre-existing on `development`, unrelated to this PR.
- `composer analyse` (PHPStan L10): clean.
- `composer lint` (phpcs PSR-12): clean.
- `composer lint:openapi` (Redocly): clean.
- `composer lint:md` (markdownlint): clean.
- `composer parallel-lint`: 375 files, 0 syntax errors.

## Out of scope (deferred)

- Per-item delete / bulk clear UX (the spec discussed; inbox + unread badge handles the v1 UX).
- Push / WebSocket / email notification channels.
- Notification types beyond access-request reviews — `type` discriminator is in place for future expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authenticated notifications inbox (GET) with unread badge (up to 50 items) and POST to mark seen; endpoints honor no-store caching and handle CORS preflight.

* **Data**
  * New migration to persist per-user "last seen" notification state.

* **Tests**
  * Added unit and integration suites covering auth, payload shapes, unread→seen round-trip, 404/405 cases, and end-to-end flows.

* **Documentation**
  * Added design spec, implementation plan, and rollout/verification checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->