### PR TITLE
test: env-isolate the Zitadel/OpenFGA "not-configured" assertions (#619, #620)

### DIFF
--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -11,11 +11,14 @@ use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(AccessRequestAdminHandler::class)]
 final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 {
+    use EnvIsolationTrait;
+
     protected static bool $requiresDatabase = true;
 
     public function testOptionsPreflightSucceeds(): void
@@ -137,11 +140,15 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
         ]);
 
-        // Neither OpenFGA nor Zitadel envs are set in the test bootstrap, so
-        // both isConfigured() gates are false and the handler should still
-        // flip the DB status to approved without touching either service.
-        $response = ( new AccessRequestAdminHandler() )->handle(
-            $this->withOidcUser($this->requestFor('POST', '/admin/access-requests/' . $id . '/approve', [], ['notes' => 'ok']))
+        // Clear OpenFGA + Zitadel envs so both isConfigured() gates return
+        // false during the handler call. The bootstrap's safeLoad of
+        // .env.local would otherwise leak dev-stack credentials into this
+        // test on developer machines (see #619).
+        $response = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => ( new AccessRequestAdminHandler() )->handle(
+                $this->withOidcUser($this->requestFor('POST', '/admin/access-requests/' . $id . '/approve', [], ['notes' => 'ok']))
+            )
         );
 
         self::assertSame(200, $response->getStatusCode());

--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -183,15 +183,31 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
     public function testRevokeHappyPathWithoutFgaOrZitadel(): void
     {
         $repo = new AccessRequestRepository(self::$pdo);
-        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', []);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
         $repo->approve($id, 'admin');
 
-        $response = ( new AccessRequestAdminHandler() )->handle(
-            $this->withOidcUser($this->requestFor('POST', '/admin/access-requests/' . $id . '/revoke', [], []))
+        // Mirror testApproveHappyPathWithoutFgaOrZitadel — clear both gate's
+        // env vars so the handler hits the not-configured branch for each
+        // service. Seeding with a real permission (rather than the previous
+        // empty []) makes the "tuples_deleted=[]" assertion meaningful: an
+        // FGA-configured run would have tuples to delete; here it shouldn't
+        // even try.
+        $response = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => ( new AccessRequestAdminHandler() )->handle(
+                $this->withOidcUser($this->requestFor('POST', '/admin/access-requests/' . $id . '/revoke', [], []))
+            )
         );
 
+        self::assertSame(200, $response->getStatusCode());
         $body = $this->decodeJsonBody($response);
         self::assertTrue($body['success']);
+        self::assertFalse($body['role_removed']);
+        self::assertNull($body['zitadel_error']);
+        self::assertSame([], $body['tuples_deleted']);
+        self::assertSame([], $body['fga_errors']);
 
         $row = $repo->getById($id);
         self::assertNotNull($row);

--- a/phpunit_tests/Handlers/Admin/UsersHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/UsersHandlerTest.php
@@ -9,17 +9,22 @@ use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
 use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
- * UsersHandler hard-blocks when Zitadel isn't configured (the test env
- * doesn't set ZITADEL_* envs), so most of the listing/revoke code paths
- * can't be exercised here. These tests cover everything that runs before
- * the Zitadel gate.
+ * UsersHandler hard-blocks when Zitadel isn't configured, so most of the
+ * listing/revoke code paths can't be exercised here. These tests cover
+ * everything that runs before the Zitadel gate, plus the gate itself —
+ * the gate-assertion test uses {@see EnvIsolationTrait::withoutEnv()} to
+ * clear ZITADEL_* env vars (which the bootstrap may have loaded from
+ * .env.local on developer machines, see #620).
  */
 #[CoversClass(UsersHandler::class)]
 final class UsersHandlerTest extends AbstractHandlerTestCase
 {
+    use EnvIsolationTrait;
+
     public function testOptionsPreflightSucceeds(): void
     {
         $response = ( new UsersHandler() )->handle(
@@ -64,8 +69,8 @@ final class UsersHandlerTest extends AbstractHandlerTestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Zitadel service not configured');
 
-        ( new UsersHandler() )->handle(
+        $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => ( new UsersHandler() )->handle(
             $this->withOidcUser($this->requestFor('GET', '/admin/users'))
-        );
+        ));
     }
 }

--- a/phpunit_tests/Handlers/Auth/EmailVerificationHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/EmailVerificationHandlerTest.php
@@ -9,11 +9,14 @@ use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(EmailVerificationHandler::class)]
 final class EmailVerificationHandlerTest extends AbstractHandlerTestCase
 {
+    use EnvIsolationTrait;
+
     public function testOptionsPreflightSucceeds(): void
     {
         $response = ( new EmailVerificationHandler() )->handle(
@@ -66,14 +69,14 @@ final class EmailVerificationHandlerTest extends AbstractHandlerTestCase
 
     public function testZitadelNotConfiguredIsRuntimeError(): void
     {
-        // We don't set up Zitadel envs in the test bootstrap, so the handler
-        // should fail at the isConfigured() gate when reached.
+        // Bootstrap may load Zitadel envs from .env.local on dev machines,
+        // so clear them locally to reach the handler's isConfigured() gate.
         $request = $this->requestFor('POST', '/auth/email-verification/resend')
             ->withAttribute('oidc_user', ['sub' => 'user-123', 'email_verified' => false]);
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('Zitadel service not configured');
 
-        ( new EmailVerificationHandler() )->handle($request);
+        $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => ( new EmailVerificationHandler() )->handle($request));
     }
 }

--- a/phpunit_tests/Support/EnvIsolationTrait.php
+++ b/phpunit_tests/Support/EnvIsolationTrait.php
@@ -58,6 +58,12 @@ trait EnvIsolationTrait
      * Run `$fn` with `$vars` cleared from `$_ENV` and the process env table,
      * restoring originals on exit — even when `$fn` throws.
      *
+     * `$_ENV` and the process env table (read by `getenv()`) are independent;
+     * `putenv()` only writes the process table and array assignment to
+     * `$_ENV` only writes the superglobal. They can drift if code mutates
+     * one without the other. The trait snapshots both independently so the
+     * restore is exact even under that drift.
+     *
      * @template T
      * @param list<string>  $vars Env-var names to clear for the duration.
      * @param callable(): T $fn   The closure to run under the cleared env.
@@ -65,22 +71,30 @@ trait EnvIsolationTrait
      */
     protected function withoutEnv(array $vars, callable $fn): mixed
     {
-        $saved = [];
+        /** @var array<string, mixed>        $savedEnv    */
+        /** @var array<string, string|false> $savedGetenv */
+        $savedEnv    = [];
+        $savedGetenv = [];
         foreach ($vars as $k) {
-            $saved[$k] = array_key_exists($k, $_ENV) ? $_ENV[$k] : self::UNSET_SENTINEL;
+            $savedEnv[$k]    = array_key_exists($k, $_ENV) ? $_ENV[$k] : self::UNSET_SENTINEL;
+            $savedGetenv[$k] = getenv($k);
             unset($_ENV[$k]);
             putenv($k);
         }
         try {
             return $fn();
         } finally {
-            foreach ($saved as $k => $v) {
+            foreach ($savedEnv as $k => $v) {
                 if ($v === self::UNSET_SENTINEL) {
                     unset($_ENV[$k]);
-                    putenv($k);
                 } else {
                     $_ENV[$k] = $v;
-                    putenv($k . '=' . ( is_scalar($v) ? (string) $v : '' ));
+                }
+                $orig = $savedGetenv[$k];
+                if ($orig === false) {
+                    putenv($k);
+                } else {
+                    putenv($k . '=' . $orig);
                 }
             }
         }

--- a/phpunit_tests/Support/EnvIsolationTrait.php
+++ b/phpunit_tests/Support/EnvIsolationTrait.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+/**
+ * Per-test env-variable isolation helper.
+ *
+ * `phpunit_tests/bootstrap.php` loads `.env.local` into `$_ENV` via
+ * `Dotenv::createMutable(...)->safeLoad()`. On a developer machine running the
+ * docker-compose stack, `.env.local` typically holds real ZITADEL_* and
+ * OPENFGA_* credentials, which makes service `isConfigured()` gates return
+ * `true` during tests — leaking the dev environment into assertions that want
+ * to prove "service-X-is-not-configured" behavior.
+ *
+ * The trait exposes {@see withoutEnv()}: run a closure with the named env
+ * vars cleared from both `$_ENV` and the process env table, then restore the
+ * originals even if the closure throws. Per-test scope (not setUp/tearDown)
+ * because most tests in the affected classes legitimately rely on the
+ * configured state — only the "not-configured" assertion paths need it cleared.
+ *
+ * Closes #619, #620.
+ */
+trait EnvIsolationTrait
+{
+    /**
+     * Zitadel env vars consulted by `ZitadelService::isConfigured()`.
+     *
+     * @var list<string>
+     */
+    private const ZITADEL_ENV_VARS = [
+        'ZITADEL_ISSUER',
+        'ZITADEL_PROJECT_ID',
+        'ZITADEL_MACHINE_TOKEN',
+        'ZITADEL_INTERNAL_URL',
+    ];
+
+    /**
+     * OpenFGA env vars consulted by `OpenFgaClient::isConfigured()`.
+     *
+     * @var list<string>
+     */
+    private const OPENFGA_ENV_VARS = [
+        'OPENFGA_API_URL',
+        'OPENFGA_STORE_ID',
+        'OPENFGA_MODEL_ID',
+        'OPENFGA_API_TOKEN',
+    ];
+
+    /**
+     * Sentinel that survives string-typed restoration; distinguishes
+     * "originally absent" from "originally set to empty string".
+     */
+    private const UNSET_SENTINEL = "\0__env_isolation_unset__\0";
+
+    /**
+     * Run `$fn` with `$vars` cleared from `$_ENV` and the process env table,
+     * restoring originals on exit — even when `$fn` throws.
+     *
+     * @template T
+     * @param list<string>  $vars Env-var names to clear for the duration.
+     * @param callable(): T $fn   The closure to run under the cleared env.
+     * @return T The return value of `$fn`.
+     */
+    protected function withoutEnv(array $vars, callable $fn): mixed
+    {
+        $saved = [];
+        foreach ($vars as $k) {
+            $saved[$k] = array_key_exists($k, $_ENV) ? $_ENV[$k] : self::UNSET_SENTINEL;
+            unset($_ENV[$k]);
+            putenv($k);
+        }
+        try {
+            return $fn();
+        } finally {
+            foreach ($saved as $k => $v) {
+                if ($v === self::UNSET_SENTINEL) {
+                    unset($_ENV[$k]);
+                    putenv($k);
+                } else {
+                    $_ENV[$k] = $v;
+                    putenv($k . '=' . ( is_scalar($v) ? (string) $v : '' ));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #619.
Closes #620.

## Symptom

Three test failures on `development` for any developer running the docker-compose stack:

| Test | Expected | Actual |
|---|---|---|
| `AccessRequestAdminHandlerTest::testApproveHappyPathWithoutFgaOrZitadel` | `role_assigned=false`, `tuples_created=[]` | `role_assigned=true` (handler entered the Zitadel-configured branch) |
| `UsersHandlerTest::testZitadelNotConfiguredIsRuntimeError` | `RuntimeException('Zitadel service not configured')` | no exception thrown |
| `EmailVerificationHandlerTest::testZitadelNotConfiguredIsRuntimeError` | same | same |

## Root cause

Shared environmental leak — neither code nor test logic is wrong in isolation.

`phpunit_tests/bootstrap.php:40` does:

```php
$dotenv = Dotenv::createMutable($projectFolder, ['.env', '.env.local', '.env.development', ...], false);
$dotenv->safeLoad();
```

On a developer machine running the docker-compose stack, `.env.local` typically contains live `ZITADEL_*` (and `OPENFGA_*`) credentials so the dev API can talk to the dev Zitadel/OpenFGA containers. Those values bleed into `$_ENV` for every PHPUnit run, so `ZitadelService::isConfigured()` returns `true`:

```php
public static function isConfigured(): bool
{
    $issuer    = getenv('ZITADEL_ISSUER') ?: ( $_ENV['ZITADEL_ISSUER'] ?? '' );
    $projectId = getenv('ZITADEL_PROJECT_ID') ?: ( $_ENV['ZITADEL_PROJECT_ID'] ?? '' );
    $token     = getenv('ZITADEL_MACHINE_TOKEN') ?: ( $_ENV['ZITADEL_MACHINE_TOKEN'] ?? '' );
    return !empty($issuer) && !empty($projectId) && !empty($token);
}
```

Tests that assert "service-X-not-configured" behavior get the wrong branch.

**CI doesn't see this** because the workflow builds `.env.local` from `.env.example` (Zitadel commented out) + a handful of DB vars — so `isConfigured()` naturally returns `false` there. The failures are dev-environment-only, which is exactly why they sat unfixed.

The working pattern already in the codebase is `phpunit_tests/Services/ZitadelServiceTest::setUp/tearDown`, which save → unset → restore the four `ZITADEL_*` vars at class scope. That works there because that whole class is about an unconfigured Zitadel. Our affected handler-test classes have **mixed** needs — most tests legitimately depend on the configured state, only the gate-assertion tests need it cleared.

## Fix

New trait `phpunit_tests/Support/EnvIsolationTrait` (88 lines, self-contained):

- `ZITADEL_ENV_VARS` — the four vars `ZitadelService::isConfigured()` reads.
- `OPENFGA_ENV_VARS` — the four vars `OpenFgaClient::isConfigured()` reads.
- `withoutEnv(array $vars, callable $fn): mixed` — runs the closure with `$vars` cleared from both `$_ENV` and the process env table, with originals restored via `try { ... } finally { ... }`. The finally restores even when the closure throws (the `RuntimeException` case).

A sentinel string `\"\\0__env_isolation_unset__\\0\"` distinguishes \"originally absent\" from \"originally set to empty\" so restore is exact.

Applied to exactly the three drifted tests. Adjacent tests in the same classes are untouched.

## Verification

| Step | Result |
|---|---|
| 3 previously-failing tests | now pass (3/3, 12 assertions) |
| Full affected-class suite | 26/26 (no regression) |
| `phpunit_tests/Handlers/` + `phpunit_tests/Repositories/` | 251/251 (was 248/251) |
| `composer analyse` (PHPStan L10) | clean |
| `composer lint` (phpcs PSR-12) | clean |

## Defense in depth

The tests still use `expectException()` / `assertFalse()`, so any future handler regression — removing the throw, accidentally setting `role_assigned=true` with services unconfigured — would still be caught. The trait change adds an environment-isolation precondition; it doesn't weaken assertions.

## Out of scope (deferred)

A future improvement could move the isolation to a global PHPUnit listener that automatically clears all known service-config env vars before each test and restores after, with an `#[Attribute]` opt-in for tests that want the configured state. That's a bigger refactor and a different problem class — separate ticket if it ever becomes warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added per-test environment-variable isolation to PHPUnit tests to make configuration-dependent paths deterministic.
  * Updated handler tests to explicitly clear external-service env vars when exercising “not configured” and happy-path flows.
  * Extended assertions to verify downstream results are empty when external services are not configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->