### PR TITLE
feat(api): offset pagination on access-requests endpoints (#572)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-issue-572-access-requests-pagination-plan.md
+++ b/docs/superpowers/plans/2026-06-01-issue-572-access-requests-pagination-plan.md
@@ -1,0 +1,194 @@
+# Issue #572 — Implementation plan
+
+**Spec:** [2026-06-01-issue-572-access-requests-pagination-design.md](../specs/2026-06-01-issue-572-access-requests-pagination-design.md)
+**Branch:** `feature/issue-572-access-requests-pagination`
+**Date:** 2026-06-01
+
+Five tasks, each TDD: write failing tests → minimal change to pass → verify. Repository first
+because the handlers depend on its new shape; trait second because both handlers depend on it.
+
+## Task 1 — Repository: `getAll`/`getByUser` accept `$limit, $offset`; add `countAll`, `countByUser`
+
+### Step 1.1: Write 5 failing tests
+
+`phpunit_tests/Repositories/AccessRequestRepositoryTest.php` — add R1–R5 from spec §7 Layer A.
+
+Per the existing test file's patterns: each test inserts known rows, calls the method, asserts on
+the result. Use the same DB-fixture setup the file already has.
+
+### Step 1.2: Run — expect 5 failures
+
+```bash
+vendor/bin/phpunit phpunit_tests/Repositories/AccessRequestRepositoryTest.php
+```
+
+Failures expected: `getAll`/`getByUser` ignore extra args (no failure on call signature in PHP since
+extra args are silently dropped — but our test asserts on sliced result count, which will fail);
+`countAll`/`countByUser` don't exist → fatal.
+
+### Step 1.3: Modify `getAll()` — add `$limit, $offset`
+
+Append `LIMIT :limit OFFSET :offset` when both non-null. Bind with `PARAM_INT`. PDO's `execute([...])`
+binds everything as a string; for LIMIT/OFFSET we want integer-typed binds, so split prepare/bind/execute
+when paginating, keep the array-execute path when not.
+
+### Step 1.4: Modify `getByUser()` — same shape
+
+### Step 1.5: Add `countAll(?string $status = null): int`
+
+Same WHERE clause as `getAll`. Validate status if provided (mirror `getAll()`'s
+`InvalidArgumentException`).
+
+### Step 1.6: Add `countByUser(string $userId): int`
+
+`SELECT COUNT(*) FROM access_requests WHERE zitadel_user_id = :user_id`.
+
+### Step 1.7: Run — expect all pass
+
+```bash
+vendor/bin/phpunit phpunit_tests/Repositories/AccessRequestRepositoryTest.php
+```
+
+### Step 1.8: Verify existing tests still pass
+
+The default-arg back-compat is the existing behavior. Run the file fully.
+
+### Step 1.9: Commit
+
+`feat(repo): paginated getAll/getByUser + countAll/countByUser on AccessRequestRepository (#572)`
+
+## Task 2 — `OffsetPaginationTrait`
+
+### Step 2.1: Create `src/Handlers/Pagination/OffsetPaginationTrait.php`
+
+Body from spec §5. No tests — the trait is exercised via the two handlers' validation tests in
+Task 3 / Task 4. (A trait without a using class has no behavior to test in isolation; PHPStan/phpcs
+catches the structural issues.)
+
+### Step 2.2: Verify it compiles
+
+```bash
+composer parallel-lint  # catches syntax errors
+composer analyse        # catches type/PSR issues
+```
+
+### Step 2.3: Commit
+
+`feat(handlers): OffsetPaginationTrait for limit/offset parsing (#572)`
+
+## Task 3 — `AccessRequestHandler::listOwnRequests()` pagination
+
+### Step 3.1: Write 5 failing tests (H1–H5 from spec §7 Layer B)
+
+`phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php`. Use the same handler-test patterns
+already in the file (request mock, repository stub or real DB-backed depending on what existing
+tests do).
+
+### Step 3.2: Run — expect 5 failures
+
+### Step 3.3: Use the trait, modify `listOwnRequests()` body
+
+Add `use OffsetPaginationTrait;` to the class. Modify `listOwnRequests()` per spec §5. Update the
+single call site in `handle()` to pass `$request`.
+
+### Step 3.4: Run — expect all pass
+
+### Step 3.5: Run the full file — back-compat check
+
+Existing tests should keep passing. The envelope-shape assertions are the risk; if existing tests
+only check `requests` and `count` they'll pass; if they assert `additionalProperties: false`-style
+exact-match they'll need updating to include the new fields.
+
+### Step 3.6: Commit
+
+`feat(api): pagination on GET /auth/access-requests (#572)`
+
+## Task 4 — `AccessRequestAdminHandler::listRequests()` pagination
+
+### Step 4.1: Write 5 failing tests (A1–A5 from spec §7 Layer C)
+
+`phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php`.
+
+### Step 4.2: Run — expect 5 failures
+
+### Step 4.3: Use the trait, modify `listRequests()` body
+
+Add `use OffsetPaginationTrait;`. Modify per spec §5. Resource-admin path still applies
+`filterByAdminAccess` post-fetch; document the caveat in code comments matching OpenAPI.
+
+### Step 4.4: Run — expect all pass
+
+### Step 4.5: Run the full file — back-compat check
+
+### Step 4.6: Commit
+
+`feat(api): pagination on GET /admin/access-requests (#572)`
+
+## Task 5 — OpenAPI updates
+
+### Step 5.1: Add `LimitQueryParam` + `OffsetQueryParam` reusable parameter components
+
+Under `components.parameters`. If that key doesn't exist yet, create it.
+
+### Step 5.2: Reference them from both paths
+
+`/auth/access-requests` GET: add `parameters` array with two `$ref`s. `/admin/access-requests` GET:
+extend the existing `parameters` array.
+
+### Step 5.3: Extend `AccessRequestListResponse`
+
+Add `total`, `limit`, `offset`, `has_more` properties; update `required`; rewrite `description`.
+
+### Step 5.4: Add `firstPage` + `lastPage` examples to both 200 responses
+
+### Step 5.5: Lint
+
+```bash
+composer lint:openapi
+```
+
+Fix any Redocly warnings/errors.
+
+### Step 5.6: Commit
+
+`docs(openapi): document pagination on access-requests endpoints (#572)`
+
+## Task 6 — Final verification + PR
+
+### Step 6.1: Full test suite
+
+```bash
+composer test
+```
+
+### Step 6.2: Static analysis
+
+```bash
+composer analyse
+```
+
+### Step 6.3: Lint
+
+```bash
+composer lint
+composer lint:openapi
+composer parallel-lint
+```
+
+### Step 6.4: Self-review
+
+Walk the spec section by section; for each "the implementation does X" claim, find the line in the
+diff. Anything that's drifted from the spec gets a follow-up commit or an update to the spec.
+
+### Step 6.5: Push + open PR
+
+Branch: `feature/issue-572-access-requests-pagination`. Title:
+`feat(api): offset pagination on access-requests endpoints (#572)`. Body uses the same template as
+PR #623 (Design / Endpoint contract table / Changes table / Tests summary).
+
+PR targets `development`, not `stable`.
+
+## Done
+
+All five tasks green. Spec is honest about everything the PR ships. CodeRabbit gets the diff, we
+respond to its review feedback the same way #623 did.

--- a/docs/superpowers/specs/2026-06-01-issue-572-access-requests-pagination-design.md
+++ b/docs/superpowers/specs/2026-06-01-issue-572-access-requests-pagination-design.md
@@ -1,0 +1,517 @@
+# Issue #572 — Offset pagination for `GET /auth/access-requests` and `GET /admin/access-requests`
+
+**Status:** Design approved, ready for implementation plan.
+**Date:** 2026-06-01
+**Author:** John R. D'Orazio (with Claude Code)
+**Issue:** [#572](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/572)
+**Sibling:** [#565 / PR #623](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/623) — cursor pagination for `/admin/permissions`.
+
+## 1. Goal
+
+`GET /auth/access-requests` and `GET /admin/access-requests` currently return the full unpaginated set
+of `access_requests` rows. The admin endpoint accumulates `approved`/`rejected`/`revoked` rows
+indefinitely, so its response grows without bound. The user endpoint's per-user load is small in
+practice but is paginated for symmetry — same envelope, same client contract.
+
+This spec adds **offset-based** pagination (different from the cursor model used in #565 because the
+backing store is Postgres, where `COUNT(*)` and `LIMIT/OFFSET` are cheap and natural). The change
+spans three layers (repository → handler → OpenAPI) and keeps `AccessRequestListResponse` as a single
+shared schema between both endpoints, extended with pagination metadata.
+
+## 2. Endpoint contracts
+
+### Request
+
+Both endpoints accept the same two new query parameters:
+
+| Parameter | Type    | Default | Constraints     | Notes                                                          |
+| --------- | ------- | ------- | --------------- | -------------------------------------------------------------- |
+| `limit`   | integer | 100     | 1 ≤ limit ≤ 500 | **New** — max items per page.                                  |
+| `offset`  | integer | 0       | offset ≥ 0      | **New** — zero-based item index where this page starts.        |
+
+`GET /admin/access-requests` additionally retains its existing `status` filter (unchanged).
+
+### Response (200)
+
+```json
+{
+  "requests": [
+    { "id": "0e7…", "zitadel_user_id": "…", "user_email": "…", "requested_role": "calendar_editor",
+      "permissions": [{ "object_type": "national_calendar", "object_id": "IT", "relation": "editor" }],
+      "status": "pending", "created_at": "2026-05-30T12:00:00Z" }
+  ],
+  "count": 1,
+  "total": 137,
+  "limit": 100,
+  "offset": 0,
+  "has_more": true
+}
+```
+
+Final page has `has_more: false` and the last `count` items.
+
+| Field      | Semantics                                                                                                             |
+| ---------- | --------------------------------------------------------------------------------------------------------------------- |
+| `requests` | Items in this page, up to `limit`. Shape unchanged — array of `AccessRequest`.                                        |
+| `count`    | Number of items in this page (`requests.length`). May be **less than `limit`** on the last page or after admin-filter.|
+| `total`    | Total rows matching the same filter, ignoring `limit`/`offset`. Single source of truth for "how many altogether".     |
+| `limit`    | Echo of the effective `limit` (default 100 if omitted).                                                               |
+| `offset`   | Echo of the effective `offset` (default 0 if omitted).                                                                |
+| `has_more` | `(offset + count) < total`. False on the final page.                                                                  |
+
+### Error matrix
+
+| Condition                                           | Status | Source                                                                 |
+| --------------------------------------------------- | ------ | ---------------------------------------------------------------------- |
+| `limit` not a positive integer (non-digit, signed)  | 400    | Handler `ValidationException('limit must be a positive integer')`      |
+| `limit < 1` or `limit > 500`                        | 400    | Handler `ValidationException('limit must be between 1 and 500')`       |
+| `offset` not a non-negative integer (non-digit, -1) | 400    | Handler `ValidationException('offset must be a non-negative integer')` |
+| `status` not in enum (admin only)                   | 400    | Existing `ValidationException`                                         |
+| Auth missing / invalid                              | 401    | Existing OIDC / `UnauthorizedException`                                |
+| Caller not admin (admin endpoint)                   | 403    | Existing `ForbiddenException`                                          |
+
+## 3. Architecture
+
+```text
+Client request
+  GET /admin/access-requests?status=pending&limit=50&offset=100
+  ↓
+Router  (OIDC-gated, role-checked — unchanged)
+  ↓
+AccessRequestAdminHandler::listRequests()    ← src/Handlers/Admin/AccessRequestAdminHandler.php
+  ├─ parse limit (1..500, default 100)
+  ├─ parse offset (≥0, default 0)
+  ├─ existing status enum validation
+  ├─ global-admin path:    page = repo->getAll($status, $limit, $offset)
+  │                        total = repo->countAll($status)
+  └─ resource-admin path:  page = repo->getAll($status, $limit, $offset)
+                           total = repo->countAll($status)
+                           page = filterByAdminAccess(page, adminId)   ← OpenFGA check loop
+  ↓
+AccessRequestRepository                       ← src/Repositories/AccessRequestRepository.php
+  ├─ getAll(?string $status, ?int $limit=null, ?int $offset=null)
+  ├─ getByUser(string $userId, ?int $limit=null, ?int $offset=null)
+  ├─ countAll(?string $status = null)
+  └─ countByUser(string $userId)
+  ↓
+Postgres `access_requests`
+```
+
+```text
+Client request
+  GET /auth/access-requests?limit=20&offset=0
+  ↓
+Router  (OIDC-gated — unchanged)
+  ↓
+AccessRequestHandler::listOwnRequests()      ← src/Handlers/Auth/AccessRequestHandler.php
+  ├─ parse limit, offset (same helper)
+  ├─ page = repo->getByUser($userId, $limit, $offset)
+  └─ total = repo->countByUser($userId)
+```
+
+**Why offset, not cursor.** Postgres exposes `COUNT(*)` cheaply, so we can return an honest `total`
+and let clients render "page X of Y" UIs without a heuristic. Offset's downside (`OFFSET` walks rows
+on each page) is irrelevant at this volume: the access_requests table is bounded by user count and
+admin activity, not external traffic. If volume ever pushes `COUNT(*)` or `OFFSET` over budget,
+cursor migration is backward-compatible by adding `page_token` as an alternative to `offset` and
+making `total`/`has_more` honest while `offset` becomes a one-way ratchet — out of scope today
+(explicitly per the issue).
+
+**Why not split the response schema per endpoint.** `/auth/access-requests` and
+`/admin/access-requests` already share `AccessRequestListResponse`. The pagination envelope is
+identical on both — same fields, same semantics. Splitting would duplicate the schema for zero gain.
+
+**Resource-admin caveat (same as PR #623).** When `filterByAdminAccess()` post-filters a page on
+`/admin/access-requests`, the returned `count` may be smaller than `limit` and smaller than `total`.
+`total` reflects the SQL-level pre-filter count; `has_more` reflects the SQL paginator. Clients
+should keep paging until `has_more === false` even when individual pages come back short. Documented
+in the OpenAPI schema description — clients see the contract at the same layer they see the shape.
+
+## 4. `AccessRequestRepository` changes
+
+**File:** `src/Repositories/AccessRequestRepository.php`
+
+### `getAll()` — add optional `$limit, $offset`
+
+```php
+/**
+ * @param string|null $status Filter by status (pending, approved, rejected, revoked).
+ * @param int|null $limit Max rows to return; null = no LIMIT clause.
+ * @param int|null $offset Zero-based row offset; null = no OFFSET clause.
+ * @return array<int, array<string, mixed>>
+ * @throws \InvalidArgumentException If status is not a valid value.
+ */
+public function getAll(?string $status = null, ?int $limit = null, ?int $offset = null): array
+```
+
+Body sketch: same WHERE/ORDER BY as today, append `LIMIT :limit OFFSET :offset` when both are
+non-null. We pass them through `PDO::bindValue($key, $value, PDO::PARAM_INT)` rather than the
+`execute([...])` array form because PDO's prepared-statement array form binds everything as a
+string, which can confuse `LIMIT`/`OFFSET` parsing in Postgres.
+
+### `getByUser()` — same shape
+
+```php
+/**
+ * @param string $userId
+ * @param int|null $limit
+ * @param int|null $offset
+ * @return array<int, array<string, mixed>>
+ */
+public function getByUser(string $userId, ?int $limit = null, ?int $offset = null): array
+```
+
+### `countAll()` — new
+
+```php
+/**
+ * Count access requests matching an optional status filter.
+ *
+ * @param string|null $status
+ * @return int
+ * @throws \InvalidArgumentException If status is not a valid value.
+ */
+public function countAll(?string $status = null): int
+```
+
+Single `SELECT COUNT(*) FROM access_requests` with the same conditional WHERE clause as `getAll()`.
+
+### `countByUser()` — new
+
+```php
+/**
+ * Count access requests for a given user.
+ *
+ * @param string $userId
+ * @return int
+ */
+public function countByUser(string $userId): int
+```
+
+`SELECT COUNT(*) FROM access_requests WHERE zitadel_user_id = :user_id`.
+
+### Decision notes
+
+| Choice                                                      | Rationale                                                                                                              |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Optional `?int $limit/$offset`, default `null`              | Callers that don't paginate (e.g., `getStatus()`'s call to `getByUser()` for counting) keep their existing semantics.  |
+| `bindValue(..., PDO::PARAM_INT)` for LIMIT/OFFSET           | `execute([...])` binds as strings; Postgres rejects `LIMIT '100' OFFSET '0'` parameter forms in some configurations.   |
+| Separate `count*` methods (not a tuple return)              | `total` is independent of `limit`/`offset`. Two queries is honest. Caching is the handler's call if it ever matters.   |
+| Repository raises `InvalidArgumentException` on bad status  | Already does on `getAll()`; keep consistent in `countAll()`. Handler validates before calling, so this is defense.     |
+
+## 5. Handler changes
+
+### Shared: limit/offset parsing helpers
+
+Both handlers need the same `parseLimit()` and `parseOffset()` logic. PR #623 added `parseLimit()`
+to `PermissionAdminHandler`. To avoid copy-pasting three times (and the eventual drift), we'll
+introduce a small trait `Pagination/OffsetPaginationTrait` exposing `parseLimit()` and
+`parseOffset()` with shared constants:
+
+```php
+namespace LiturgicalCalendar\Api\Handlers\Pagination;
+
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+
+trait OffsetPaginationTrait
+{
+    private const DEFAULT_LIMIT = 100;
+    private const MAX_LIMIT     = 500;
+
+    private function parseLimit(mixed $raw): int
+    {
+        if ($raw === null || $raw === '') {
+            return self::DEFAULT_LIMIT;
+        }
+        if (!is_string($raw) || !ctype_digit($raw)) {
+            throw new ValidationException('limit must be a positive integer');
+        }
+        $limit = (int) $raw;
+        if ($limit < 1 || $limit > self::MAX_LIMIT) {
+            throw new ValidationException(sprintf('limit must be between 1 and %d', self::MAX_LIMIT));
+        }
+        return $limit;
+    }
+
+    private function parseOffset(mixed $raw): int
+    {
+        if ($raw === null || $raw === '') {
+            return 0;
+        }
+        if (!is_string($raw) || !ctype_digit($raw)) {
+            throw new ValidationException('offset must be a non-negative integer');
+        }
+        return (int) $raw;
+    }
+}
+```
+
+`ctype_digit` rejects signs, decimals, and non-ASCII digits — the same strict policy as PR #623.
+Constants are private to the trait (a trait is a code-injection mechanism, not a class), so
+constants land on the using class with the same visibility.
+
+**Not migrating `PermissionAdminHandler::parseLimit()` to the trait in this PR.** That handler
+shares the same `DEFAULT_LIMIT`/`MAX_LIMIT`/parsing logic, but its `parseLimit` is private and
+already shipped. Migrating it would be a noise-only refactor; the trait stands ready for adoption
+in a follow-up if a third pagination site appears. The DRY win waits for a third instance per the
+"rule of three".
+
+### `AccessRequestHandler::listOwnRequests()`
+
+```php
+private function listOwnRequests(
+    ServerRequestInterface $request,
+    ResponseInterface $response,
+    string $userId
+): ResponseInterface {
+    $params = $request->getQueryParams();
+    $limit  = $this->parseLimit($params['limit'] ?? null);
+    $offset = $this->parseOffset($params['offset'] ?? null);
+
+    $repo     = $this->getRepository();
+    $requests = $repo->getByUser($userId, $limit, $offset);
+    $total    = $repo->countByUser($userId);
+
+    return $this->encodeResponseBody($response, [
+        'requests' => $requests,
+        'count'    => count($requests),
+        'total'    => $total,
+        'limit'    => $limit,
+        'offset'   => $offset,
+        'has_more' => ($offset + count($requests)) < $total,
+    ]);
+}
+```
+
+Signature changes — the method now needs the request to read query params. The single caller
+(`handle()`) passes it through.
+
+### `AccessRequestAdminHandler::listRequests()`
+
+```php
+private function listRequests(
+    ServerRequestInterface $request,
+    ResponseInterface $response,
+    string $adminId,
+    bool $isGlobalAdmin
+): ResponseInterface {
+    $repo        = $this->getRepository();
+    $queryParams = $request->getQueryParams();
+
+    $statusFilter = isset($queryParams['status']) && is_string($queryParams['status'])
+        ? $queryParams['status']
+        : null;
+
+    if ($statusFilter !== null && !in_array($statusFilter, AccessRequestRepository::VALID_STATUSES, true)) {
+        throw new ValidationException(
+            sprintf('Invalid status. Valid values are: %s', implode(', ', AccessRequestRepository::VALID_STATUSES))
+        );
+    }
+
+    $limit  = $this->parseLimit($queryParams['limit']  ?? null);
+    $offset = $this->parseOffset($queryParams['offset'] ?? null);
+
+    $page  = $repo->getAll($statusFilter, $limit, $offset);
+    $total = $repo->countAll($statusFilter);
+
+    if (!$isGlobalAdmin) {
+        $page = $this->filterByAdminAccess($page, $adminId);
+    }
+
+    return $this->encodeResponseBody($response, [
+        'requests' => $page,
+        'count'    => count($page),
+        'total'    => $total,
+        'limit'    => $limit,
+        'offset'   => $offset,
+        'has_more' => ($offset + count($page)) < $total,
+    ]);
+}
+```
+
+Note: for resource admins, `count` ≤ raw page size, but `total` and `has_more` reflect the SQL-level
+paginator. Documented in OpenAPI.
+
+## 6. OpenAPI updates
+
+**File:** `jsondata/schemas/openapi.json`
+
+### Edit 1 — Add two query parameters to `paths["/auth/access-requests"].get.parameters`
+
+The path currently has no `parameters` block. Add one with `limit` and `offset`.
+
+### Edit 2 — Add two query parameters to `paths["/admin/access-requests"].get.parameters`
+
+Append `limit` and `offset` to the existing `parameters` list (which currently only has `status`).
+
+Reusable parameter components (`LimitQueryParam`, `OffsetQueryParam`) so both endpoints share the
+same definition — change defaults/bounds once, both endpoints update:
+
+```json
+"LimitQueryParam": {
+  "name": "limit",
+  "in": "query",
+  "required": false,
+  "description": "Maximum number of items to return in this page. Default 100, max 500.",
+  "schema": { "type": "integer", "minimum": 1, "maximum": 500, "default": 100 }
+},
+"OffsetQueryParam": {
+  "name": "offset",
+  "in": "query",
+  "required": false,
+  "description": "Zero-based offset of the first item to return. Default 0.",
+  "schema": { "type": "integer", "minimum": 0, "default": 0 }
+}
+```
+
+Both paths `$ref` these components.
+
+### Edit 3 — Extend `AccessRequestListResponse` with pagination fields
+
+```json
+"AccessRequestListResponse": {
+  "type": "object",
+  "description": "Offset-paginated page of access requests returned by GET /auth/access-requests and GET /admin/access-requests. When a resource admin (non-global) calls /admin/access-requests, `filterByAdminAccess` is applied to each page after fetching: `count` may be smaller than `limit`, and `total` reflects the pre-filter SQL count. Clients should page until `has_more` is false even if individual pages come back short.",
+  "properties": {
+    "requests": {
+      "type": "array",
+      "items": { "$ref": "#/components/schemas/AccessRequest" }
+    },
+    "count": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of items in this page. May be less than `limit` on the last page, or smaller still for resource admins after post-filtering."
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Total matching rows ignoring limit/offset. For resource admins on /admin/access-requests, this is the pre-filter SQL count."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 500,
+      "description": "Effective limit applied to this page (default 100 if not supplied)."
+    },
+    "offset": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Effective offset of the first item in this page (default 0 if not supplied)."
+    },
+    "has_more": {
+      "type": "boolean",
+      "description": "True iff (offset + count) < total. False on the final page."
+    }
+  },
+  "required": ["requests", "count", "total", "limit", "offset", "has_more"],
+  "additionalProperties": false
+}
+```
+
+Old `required: [requests, count]` becomes `required: [requests, count, total, limit, offset, has_more]`.
+
+### Edit 4 — Add `firstPage` + `lastPage` examples to both endpoints
+
+Same pattern as PR #623: each 200 response carries two examples illustrating mid-paginated and
+final-page envelopes. Helps human readers and tooling.
+
+### Lint
+
+`composer lint:openapi` must pass with zero errors. No 3.1-only features needed (no nullable union
+strings); the schema stays OpenAPI 3.0-clean.
+
+## 7. Tests
+
+Three layers. Targets follow PR #623's discipline: repository covered for new SQL paths, handlers
+covered for validation + envelope, no integration tests against a live DB beyond what already exists.
+
+### Layer A — `AccessRequestRepositoryTest`
+
+**5 new tests:**
+
+| #   | Test                                              | Verifies                                                                                |
+| --- | ------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| R1  | `testGetAllWithLimitAndOffsetReturnsSlice`        | Insert N>2 rows, call `getAll(null, 1, 1)`, assert correct row by created_at DESC.      |
+| R2  | `testGetByUserWithLimitAndOffsetReturnsSlice`     | Same pattern, user-scoped.                                                              |
+| R3  | `testCountAllMatchesGetAllSize`                   | Insert N rows, assert `countAll()` and `countAll('pending')` match SQL truth.           |
+| R4  | `testCountByUserMatchesGetByUserSize`             | `countByUser(userId)` matches the row count for that user.                              |
+| R5  | `testCountAllRejectsInvalidStatus`                | `countAll('bogus')` throws `InvalidArgumentException` (defense-in-depth).               |
+
+Existing tests for `getAll()` / `getByUser()` keep passing — default-args back-compat assertion.
+
+### Layer B — `AccessRequestHandlerTest` (user-facing endpoint)
+
+**5 new tests:**
+
+| #   | Test                                                 | Assertion                                                                              |
+| --- | ---------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| H1  | `testListOwnRequestsWithoutParamsReturnsFirstPage`   | Defaults: `limit=100, offset=0, total = total inserted, has_more=false`.               |
+| H2  | `testListOwnRequestsWithLimitAndOffset`              | `limit=1&offset=1` returns 1 item, correct envelope (`count=1, has_more=(2 < total)`). |
+| H3  | `testListOwnRequestsInvalidLimitIsValidationError`   | `limit=0`, `limit=501`, `limit=abc`, `limit=-1`, all → 400.                            |
+| H4  | `testListOwnRequestsInvalidOffsetIsValidationError`  | `offset=-1`, `offset=abc` → 400.                                                       |
+| H5  | `testListOwnRequestsHasMoreFalseOnLastPage`          | Page-3 of a 25-row, limit-10 dataset has `count=5, has_more=false`.                    |
+
+### Layer C — `AccessRequestAdminHandlerTest` (admin endpoint)
+
+**5 new tests:**
+
+| #   | Test                                                 | Assertion                                                            |
+| --- | ---------------------------------------------------- | -------------------------------------------------------------------- |
+| A1  | `testListRequestsWithoutPaginationDefaults`          | Defaults applied; envelope includes new fields.                      |
+| A2  | `testListRequestsWithLimitAndOffset`                 | Sliced page; envelope honest.                                        |
+| A3  | `testListRequestsInvalidLimitIsValidationError`      | `limit=0`, `limit=501`, `limit=abc`, `limit=-1` → 400.               |
+| A4  | `testListRequestsInvalidOffsetIsValidationError`     | `offset=-1`, `offset=abc` → 400.                                     |
+| A5  | `testListRequestsCombinesStatusFilterAndPagination`  | `status=pending&limit=2&offset=0` returns only pending, paginated.   |
+
+### Verification commands
+
+```bash
+vendor/bin/phpunit phpunit_tests/Repositories/AccessRequestRepositoryTest.php
+vendor/bin/phpunit phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php
+vendor/bin/phpunit phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+composer test                  # full unit suite
+composer analyse               # PHPStan L10
+composer lint                  # phpcs PSR-12
+composer lint:openapi          # Redocly
+composer parallel-lint         # php -l
+```
+
+## 8. Out of scope
+
+Per the issue:
+
+- **Cursor migration.** Offset is sufficient for this volume; cursor is a future option if `OFFSET`
+  ever becomes a hotspot. The envelope is forward-compatible because adding `page_token` later
+  doesn't conflict with `limit`/`offset`.
+- **Pagination of `/admin/permissions`** — shipped in PR #623 (cursor model).
+- **Pagination of `/admin/applications`** — separate decision, separate handler.
+- **Frontend UI changes** beyond basic compatibility (clients that ignore the new envelope fields
+  still get `requests` and `count` at the same paths).
+
+## 9. Files touched (summary)
+
+**Modified:**
+
+- `src/Repositories/AccessRequestRepository.php` — `getAll()` + `getByUser()` gain optional
+  `$limit, $offset`; new `countAll()` and `countByUser()` methods.
+- `src/Handlers/Auth/AccessRequestHandler.php` — `listOwnRequests()` reads query params, builds new
+  envelope; uses the trait.
+- `src/Handlers/Admin/AccessRequestAdminHandler.php` — `listRequests()` reads `limit`/`offset`,
+  builds new envelope; uses the trait.
+- `jsondata/schemas/openapi.json` — two reusable parameter components, two endpoints reference them,
+  `AccessRequestListResponse` gains pagination fields and updated `required`, examples on both
+  endpoints.
+- `phpunit_tests/Repositories/AccessRequestRepositoryTest.php` — 5 new tests.
+- `phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php` — 5 new tests.
+- `phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php` — 5 new tests.
+
+**Created:**
+
+- `src/Handlers/Pagination/OffsetPaginationTrait.php` — shared `parseLimit()` + `parseOffset()`.
+
+**Unchanged:**
+
+- `AccessRequest` component schema in OpenAPI (row shape is identical).
+- Router wiring, OIDC middleware, OpenFGA client.
+- `PermissionAdminHandler::parseLimit()` — left as-is; migrating it to the trait is a noise-only
+  refactor and the rule of three says wait for a third instance.

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -1200,14 +1200,78 @@
         ],
         "summary": "List user's own access requests",
         "operationId": "getUserAccessRequests",
-        "description": "Retrieve all access requests submitted by the authenticated user.",
+        "description": "Retrieve a paginated page of access requests submitted by the authenticated user. Default page size is 100; clients page via `limit` and `offset` and inspect `has_more` (or compare `offset + count` against `total`) to determine when to stop. Per-user volume is small in practice, but the envelope is uniform with /admin/access-requests for client simplicity.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/LimitQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetQueryParam"
+          }
+        ],
         "responses": {
           "200": {
-            "description": "OK: List of user's access requests",
+            "description": "OK: Paginated page of the user's access requests",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AccessRequestListResponse"
+                },
+                "examples": {
+                  "firstPage": {
+                    "summary": "First page (defaults)",
+                    "description": "Default request — no `limit` / `offset` supplied — returning the first page of the user's two access requests.",
+                    "value": {
+                      "requests": [
+                        {
+                          "id": "0e7c4f88-1111-4111-8111-111111111111",
+                          "zitadel_user_id": "user-alice",
+                          "user_email": "alice@example.test",
+                          "user_name": "Alice Example",
+                          "requested_role": "calendar_editor",
+                          "permissions": [
+                            {
+                              "object_type": "national_calendar",
+                              "object_id": "IT",
+                              "relation": "editor"
+                            }
+                          ],
+                          "justification": "I help maintain the IT calendar.",
+                          "status": "pending",
+                          "created_at": "2026-05-30T12:00:00Z"
+                        },
+                        {
+                          "id": "0e7c4f88-2222-4222-8222-222222222222",
+                          "zitadel_user_id": "user-alice",
+                          "user_email": "alice@example.test",
+                          "user_name": "Alice Example",
+                          "requested_role": "developer",
+                          "permissions": [],
+                          "status": "approved",
+                          "created_at": "2026-05-15T08:30:00Z",
+                          "reviewed_at": "2026-05-15T09:00:00Z",
+                          "reviewed_by": "admin"
+                        }
+                      ],
+                      "count": 2,
+                      "total": 2,
+                      "limit": 100,
+                      "offset": 0,
+                      "has_more": false
+                    }
+                  },
+                  "lastPage": {
+                    "summary": "Last page (has_more false)",
+                    "description": "Final page of a paginated traversal — `has_more` is false and clients can stop.",
+                    "value": {
+                      "requests": [],
+                      "count": 0,
+                      "total": 2,
+                      "limit": 100,
+                      "offset": 100,
+                      "has_more": false
+                    }
+                  }
                 }
               }
             }
@@ -1432,7 +1496,7 @@
         ],
         "summary": "List all access requests",
         "operationId": "adminListAccessRequests",
-        "description": "List all access requests with optional status filter. Requires admin role.",
+        "description": "List a paginated page of access requests with optional status filter. Default page size is 100; clients page via `limit` and `offset`, inspecting `has_more` (or comparing `offset + count` against `total`). Global admins see all rows. Resource admins see only requests over resources they administer — for those, the post-fetch filter may shrink the returned page below `limit`, but `total` and `has_more` reflect the pre-filter SQL paginator; clients should keep paging until `has_more` is false. Requires admin role.",
         "parameters": [
           {
             "name": "status",
@@ -1447,15 +1511,65 @@
                 "revoked"
               ]
             }
+          },
+          {
+            "$ref": "#/components/parameters/LimitQueryParam"
+          },
+          {
+            "$ref": "#/components/parameters/OffsetQueryParam"
           }
         ],
         "responses": {
           "200": {
-            "description": "OK: List of access requests",
+            "description": "OK: Paginated page of access requests",
             "content": {
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AccessRequestListResponse"
+                },
+                "examples": {
+                  "firstPage": {
+                    "summary": "First page (defaults)",
+                    "description": "Default admin listing — no `limit` / `offset` supplied — returning the first 100 of 137 pending and historical access requests.",
+                    "value": {
+                      "requests": [
+                        {
+                          "id": "0e7c4f88-3333-4333-8333-333333333333",
+                          "zitadel_user_id": "user-bob",
+                          "user_email": "bob@example.test",
+                          "user_name": "Bob Example",
+                          "requested_role": "calendar_editor",
+                          "permissions": [
+                            {
+                              "object_type": "national_calendar",
+                              "object_id": "US",
+                              "relation": "editor"
+                            }
+                          ],
+                          "justification": "I work on the US calendar.",
+                          "status": "pending",
+                          "created_at": "2026-05-31T11:00:00Z"
+                        }
+                      ],
+                      "count": 1,
+                      "total": 137,
+                      "limit": 100,
+                      "offset": 0,
+                      "has_more": true
+                    }
+                  },
+                  "lastPage": {
+                    "summary": "Last page (has_more false)",
+                    "description": "Final page reached: `offset + count == total`, so `has_more` is false and the client stops paging.",
+                    "value": {
+                      "requests": [],
+                      "count": 0,
+                      "total": 137,
+                      "limit": 100,
+                      "offset": 200,
+                      "has_more": false
+                    }
+                  }
                 }
               }
             }
@@ -7302,7 +7416,7 @@
       },
       "AccessRequestListResponse": {
         "type": "object",
-        "description": "List of access requests returned by GET /auth/access-requests and GET /admin/access-requests. Currently returns the full unpaginated set.",
+        "description": "Offset-paginated page of access requests returned by GET /auth/access-requests and GET /admin/access-requests. When a resource admin (non-global) calls /admin/access-requests, filterByAdminAccess is applied to each page after fetching: `count` may be smaller than `limit`, and `total` reflects the pre-filter SQL count. Clients should page until `has_more` is false even when individual pages come back short.",
         "properties": {
           "requests": {
             "type": "array",
@@ -7311,12 +7425,38 @@
             }
           },
           "count": {
-            "type": "integer"
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of items in this page. May be less than `limit` on the last page, or smaller still for resource admins after post-filtering."
+          },
+          "total": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Total matching rows ignoring limit/offset. For resource admins on /admin/access-requests, this is the pre-filter SQL count."
+          },
+          "limit": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 500,
+            "description": "Effective limit applied to this page (default 100 if not supplied)."
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Effective offset of the first item in this page (default 0 if not supplied)."
+          },
+          "has_more": {
+            "type": "boolean",
+            "description": "True iff (offset + count) < total. False on the final page."
           }
         },
         "required": [
           "requests",
-          "count"
+          "count",
+          "total",
+          "limit",
+          "offset",
+          "has_more"
         ],
         "additionalProperties": false
       },
@@ -8470,6 +8610,29 @@
         "description": "Identifier for a diocesan calendar",
         "schema": {
           "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+        }
+      },
+      "LimitQueryParam": {
+        "in": "query",
+        "name": "limit",
+        "required": false,
+        "description": "Maximum number of items to return in this page. Default 100, max 500.",
+        "schema": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 500,
+          "default": 100
+        }
+      },
+      "OffsetQueryParam": {
+        "in": "query",
+        "name": "offset",
+        "required": false,
+        "description": "Zero-based offset of the first item to return. Default 0.",
+        "schema": {
+          "type": "integer",
+          "minimum": 0,
+          "default": 0
         }
       }
     },

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -1276,6 +1276,9 @@
               }
             }
           },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
           "401": {
             "$ref": "#/components/responses/Unauthorized401"
           }
@@ -1530,7 +1533,7 @@
                 "examples": {
                   "firstPage": {
                     "summary": "First page (defaults)",
-                    "description": "Default admin listing — no `limit` / `offset` supplied — returning the first 100 of 137 pending and historical access requests.",
+                    "description": "Abbreviated sample of the first page returned by a default admin listing — no `limit` / `offset` supplied. `total: 137` and `count: 100` would be realistic over a populated table; only one representative `requests[]` entry is shown here to keep the doc readable. `has_more: true` because `offset + count < total`.",
                     "value": {
                       "requests": [
                         {
@@ -1551,7 +1554,7 @@
                           "created_at": "2026-05-31T11:00:00Z"
                         }
                       ],
-                      "count": 1,
+                      "count": 100,
                       "total": 137,
                       "limit": 100,
                       "offset": 0,
@@ -1573,6 +1576,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized401"
@@ -7447,7 +7453,7 @@
           },
           "has_more": {
             "type": "boolean",
-            "description": "True iff (offset + count) < total. False on the final page."
+            "description": "True iff more rows are available beyond this page. For global admins (and /auth/access-requests), equals `(offset + count) < total`. For non-global admins on /admin/access-requests this reflects the SQL paginator's state — `(offset + pre-filter SQL page size) < total` — rather than the post-filter `count`, so the client stops correctly on the final SQL page even when filterByAdminAccess trimmed it."
           }
         },
         "required": [

--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -13,6 +13,7 @@ use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
 use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(AccessRequestAdminHandler::class)]
 final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
@@ -224,6 +225,111 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 
         ( new AccessRequestAdminHandler() )->handle(
             $this->withOidcUser($this->requestFor('POST', '/admin/access-requests/' . $id . '/teleport', [], []))
+        );
+    }
+
+    // --- Pagination (issue #572) -----------------------------------------
+
+    public function testListRequestsWithoutPaginationDefaults(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $repo->create('user-a', 'a@x.test', null, 'developer', []);
+        $repo->create('user-b', 'b@x.test', null, 'developer', []);
+
+        $response = ( new AccessRequestAdminHandler() )->handle(
+            $this->withOidcUser($this->requestFor('GET', '/admin/access-requests'))
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertCount(2, $body['requests']);
+        self::assertSame(2, $body['count']);
+        self::assertSame(2, $body['total']);
+        self::assertSame(100, $body['limit']);
+        self::assertSame(0, $body['offset']);
+        self::assertFalse($body['has_more']);
+    }
+
+    public function testListRequestsWithLimitAndOffsetReturnsSlice(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $repo->create('user-a', 'a@x.test', null, 'developer', []);
+        usleep(2000);
+        $repo->create('user-b', 'b@x.test', null, 'developer', []);
+        usleep(2000);
+        $repo->create('user-c', 'c@x.test', null, 'developer', []);
+
+        $response = ( new AccessRequestAdminHandler() )->handle(
+            $this->withOidcUser($this->requestFor('GET', '/admin/access-requests?limit=1&offset=1'))
+        );
+
+        $body = $this->decodeJsonBody($response);
+        self::assertCount(1, $body['requests']);
+        self::assertSame(1, $body['count']);
+        self::assertSame(3, $body['total']);
+        self::assertSame(1, $body['limit']);
+        self::assertSame(1, $body['offset']);
+        self::assertTrue($body['has_more']); // 1 + 1 = 2 < 3
+    }
+
+    public function testListRequestsCombinesStatusFilterAndPagination(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $repo->create('user-a', 'a@x.test', null, 'developer', []); // pending
+        usleep(2000);
+        $repo->create('user-b', 'b@x.test', null, 'developer', []); // pending
+        usleep(2000);
+        $approved = $repo->create('user-c', 'c@x.test', null, 'developer', []);
+        $repo->approve($approved, 'someone'); // not pending — must not appear
+
+        $response = ( new AccessRequestAdminHandler() )->handle(
+            $this->withOidcUser($this->requestFor('GET', '/admin/access-requests?status=pending&limit=1&offset=0'))
+        );
+
+        $body = $this->decodeJsonBody($response);
+        self::assertCount(1, $body['requests']);
+        self::assertSame(1, $body['count']);
+        // total counts only matching (pending) rows, ignoring limit/offset.
+        self::assertSame(2, $body['total']);
+        self::assertTrue($body['has_more']); // 0 + 1 = 1 < 2
+        self::assertSame('pending', $body['requests'][0]['status']);
+    }
+
+    /** @return iterable<string, array{0:string,1:string}> */
+    public static function adminInvalidLimitProvider(): iterable
+    {
+        yield 'zero'        => ['limit=0', 'between 1 and 500'];
+        yield 'too-large'   => ['limit=501', 'between 1 and 500'];
+        yield 'non-numeric' => ['limit=abc', 'must be a positive integer'];
+        yield 'negative'    => ['limit=-1', 'must be a positive integer'];
+    }
+
+    #[DataProvider('adminInvalidLimitProvider')]
+    public function testListRequestsRejectsInvalidLimit(string $query, string $messageFragment): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage($messageFragment);
+
+        ( new AccessRequestAdminHandler() )->handle(
+            $this->withOidcUser($this->requestFor('GET', '/admin/access-requests?' . $query))
+        );
+    }
+
+    /** @return iterable<string, array{0:string}> */
+    public static function adminInvalidOffsetProvider(): iterable
+    {
+        yield 'negative'    => ['offset=-1'];
+        yield 'non-numeric' => ['offset=abc'];
+    }
+
+    #[DataProvider('adminInvalidOffsetProvider')]
+    public function testListRequestsRejectsInvalidOffset(string $query): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('offset must be a non-negative integer');
+
+        ( new AccessRequestAdminHandler() )->handle(
+            $this->withOidcUser($this->requestFor('GET', '/admin/access-requests?' . $query))
         );
     }
 }

--- a/phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php
@@ -12,6 +12,7 @@ use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 #[CoversClass(AccessRequestHandler::class)]
 final class AccessRequestHandlerTest extends AbstractHandlerTestCase
@@ -317,5 +318,115 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
         $row = $repo->getById($reqId);
         self::assertNotNull($row);
         self::assertSame('pending', $row['status']);
+    }
+
+    // --- Pagination (issue #572) -----------------------------------------
+
+    public function testListOwnRequestsWithoutParamsReturnsFirstPage(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $repo->create('user-alice', 'a@x.test', null, 'developer', []);
+        $repo->create('user-alice', 'a@x.test', null, 'calendar_editor', []);
+        $repo->create('user-bob', 'b@x.test', null, 'developer', []); // not Alice's
+
+        $request = $this->requestFor('GET', '/auth/access-requests')
+            ->withAttribute('oidc_user', $this->oidcUser());
+
+        $response = ( new AccessRequestHandler() )->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertCount(2, $body['requests']);
+        self::assertSame(2, $body['count']);
+        self::assertSame(2, $body['total']);
+        self::assertSame(100, $body['limit']);
+        self::assertSame(0, $body['offset']);
+        self::assertFalse($body['has_more']);
+    }
+
+    public function testListOwnRequestsWithLimitAndOffsetReturnsSlice(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        // Three Alice rows, ordered newest-to-oldest by created_at after inserts.
+        $repo->create('user-alice', 'a@x.test', null, 'developer', []);
+        usleep(2000);
+        $repo->create('user-alice', 'a@x.test', null, 'calendar_editor', []);
+        usleep(2000);
+        $repo->create('user-alice', 'a@x.test', null, 'test_editor', []);
+
+        $request = $this->requestFor('GET', '/auth/access-requests?limit=1&offset=1')
+            ->withAttribute('oidc_user', $this->oidcUser());
+
+        $response = ( new AccessRequestHandler() )->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertCount(1, $body['requests']);
+        self::assertSame(1, $body['count']);
+        self::assertSame(3, $body['total']);
+        self::assertSame(1, $body['limit']);
+        self::assertSame(1, $body['offset']);
+        self::assertTrue($body['has_more']); // offset(1) + count(1) = 2 < total(3)
+    }
+
+    public function testListOwnRequestsHasMoreFalseOnLastPage(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $repo->create('user-alice', 'a@x.test', null, 'developer', []);
+        usleep(2000);
+        $repo->create('user-alice', 'a@x.test', null, 'calendar_editor', []);
+        usleep(2000);
+        $repo->create('user-alice', 'a@x.test', null, 'test_editor', []);
+
+        // Page 2 of 2 with limit=2: offset=2, expect 1 row, has_more=false.
+        $request = $this->requestFor('GET', '/auth/access-requests?limit=2&offset=2')
+            ->withAttribute('oidc_user', $this->oidcUser());
+
+        $response = ( new AccessRequestHandler() )->handle($request);
+
+        $body = $this->decodeJsonBody($response);
+        self::assertSame(1, $body['count']);
+        self::assertSame(3, $body['total']);
+        self::assertFalse($body['has_more']);
+    }
+
+    /** @return iterable<string, array{0:string,1:string}> */
+    public static function invalidLimitProvider(): iterable
+    {
+        yield 'zero'         => ['limit=0', 'between 1 and 500'];
+        yield 'too-large'    => ['limit=501', 'between 1 and 500'];
+        yield 'non-numeric'  => ['limit=abc', 'must be a positive integer'];
+        yield 'negative'     => ['limit=-1', 'must be a positive integer'];
+    }
+
+    #[DataProvider('invalidLimitProvider')]
+    public function testListOwnRequestsRejectsInvalidLimit(string $query, string $messageFragment): void
+    {
+        $request = $this->requestFor('GET', '/auth/access-requests?' . $query)
+            ->withAttribute('oidc_user', $this->oidcUser());
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage($messageFragment);
+
+        ( new AccessRequestHandler() )->handle($request);
+    }
+
+    /** @return iterable<string, array{0:string}> */
+    public static function invalidOffsetProvider(): iterable
+    {
+        yield 'negative'    => ['offset=-1'];
+        yield 'non-numeric' => ['offset=abc'];
+    }
+
+    #[DataProvider('invalidOffsetProvider')]
+    public function testListOwnRequestsRejectsInvalidOffset(string $query): void
+    {
+        $request = $this->requestFor('GET', '/auth/access-requests?' . $query)
+            ->withAttribute('oidc_user', $this->oidcUser());
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('offset must be a non-negative integer');
+
+        ( new AccessRequestHandler() )->handle($request);
     }
 }

--- a/phpunit_tests/Repositories/AccessRequestRepositoryTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryTest.php
@@ -293,4 +293,93 @@ final class AccessRequestRepositoryTest extends RepositoryTestCase
         self::assertNotNull($pendingRow);
         self::assertCount(2, $pendingRow['permissions']);
     }
+
+    // --- Pagination (issue #572) -----------------------------------------
+
+    public function testGetAllWithLimitAndOffsetReturnsSlice(): void
+    {
+        // Three pending rows, ordered (oldest → newest) as $a, $b, $c.
+        // getAll() returns DESC by created_at, so the returned order is c, b, a.
+        $a = $this->repo->create('user-a', 'a@b.test', null, 'developer', []);
+        usleep(2000);
+        $b = $this->repo->create('user-b', 'b@b.test', null, 'developer', []);
+        usleep(2000);
+        $c = $this->repo->create('user-c', 'c@b.test', null, 'developer', []);
+
+        $firstTwo = $this->repo->getAll(null, 2, 0);
+        self::assertCount(2, $firstTwo);
+        self::assertSame($c, $firstTwo[0]['id']);
+        self::assertSame($b, $firstTwo[1]['id']);
+
+        $middle = $this->repo->getAll(null, 1, 1);
+        self::assertCount(1, $middle);
+        self::assertSame($b, $middle[0]['id']);
+
+        $last = $this->repo->getAll(null, 10, 2);
+        self::assertCount(1, $last);
+        self::assertSame($a, $last[0]['id']);
+
+        // Past-the-end offset returns an empty page.
+        self::assertCount(0, $this->repo->getAll(null, 10, 100));
+    }
+
+    public function testGetByUserWithLimitAndOffsetReturnsSlice(): void
+    {
+        // Same user, three rows, plus one for another user that must not leak in.
+        $a = $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+        usleep(2000);
+        $b = $this->repo->create('user-1', 'a@b.test', null, 'calendar_editor', []);
+        usleep(2000);
+        $c = $this->repo->create('user-1', 'a@b.test', null, 'test_editor', []);
+        $this->repo->create('user-2', 'b@b.test', null, 'developer', []);
+
+        $firstTwo = $this->repo->getByUser('user-1', 2, 0);
+        self::assertCount(2, $firstTwo);
+        self::assertSame($c, $firstTwo[0]['id']);
+        self::assertSame($b, $firstTwo[1]['id']);
+        foreach ($firstTwo as $row) {
+            self::assertSame('user-1', $row['zitadel_user_id']);
+        }
+
+        $middle = $this->repo->getByUser('user-1', 1, 1);
+        self::assertCount(1, $middle);
+        self::assertSame($b, $middle[0]['id']);
+
+        $last = $this->repo->getByUser('user-1', 10, 2);
+        self::assertCount(1, $last);
+        self::assertSame($a, $last[0]['id']);
+    }
+
+    public function testCountAllMatchesGetAllSize(): void
+    {
+        $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+        $approvedId = $this->repo->create('user-2', 'b@b.test', null, 'developer', []);
+        $this->repo->approve($approvedId, 'admin');
+        $rejectedId = $this->repo->create('user-3', 'c@b.test', null, 'developer', []);
+        $this->repo->reject($rejectedId, 'admin');
+
+        self::assertSame(3, $this->repo->countAll());
+        self::assertSame(1, $this->repo->countAll('pending'));
+        self::assertSame(1, $this->repo->countAll('approved'));
+        self::assertSame(1, $this->repo->countAll('rejected'));
+        self::assertSame(0, $this->repo->countAll('revoked'));
+    }
+
+    public function testCountByUserMatchesGetByUserSize(): void
+    {
+        $this->repo->create('user-1', 'a@b.test', null, 'developer', []);
+        $this->repo->create('user-1', 'a@b.test', null, 'calendar_editor', []);
+        $this->repo->create('user-2', 'b@b.test', null, 'developer', []);
+
+        self::assertSame(2, $this->repo->countByUser('user-1'));
+        self::assertSame(1, $this->repo->countByUser('user-2'));
+        self::assertSame(0, $this->repo->countByUser('user-nobody'));
+    }
+
+    public function testCountAllRejectsInvalidStatus(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->repo->countAll('weird');
+    }
 }

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -193,6 +193,15 @@ final class AccessRequestAdminHandler extends AbstractHandler
         $page  = $repo->getAll($statusFilter, $limit, $offset);
         $total = $repo->countAll($statusFilter);
 
+        // Snapshot the SQL page size BEFORE filterByAdminAccess shrinks the page.
+        // `has_more` must reflect the SQL paginator's state, not the filtered
+        // page count: when SQL returns its final page (sqlPageCount < limit so
+        // offset + sqlPageCount == total), the client should stop. If we used
+        // the post-filter count instead, a heavily-filtered final page would
+        // falsely advertise has_more=true and the client would fetch an empty
+        // next page.
+        $sqlPageCount = count($page);
+
         if (!$isGlobalAdmin) {
             $page = $this->filterByAdminAccess($page, $adminId);
         }
@@ -203,7 +212,7 @@ final class AccessRequestAdminHandler extends AbstractHandler
             'total'    => $total,
             'limit'    => $limit,
             'offset'   => $offset,
-            'has_more' => ( $offset + count($page) ) < $total,
+            'has_more' => ( $offset + $sqlPageCount ) < $total,
         ]);
     }
 

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Api\Handlers\Admin;
 
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Handlers\Pagination\OffsetPaginationTrait;
 use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
 use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
 use LiturgicalCalendar\Api\Http\Enum\RequestContentType;
@@ -39,6 +40,8 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 final class AccessRequestAdminHandler extends AbstractHandler
 {
+    use OffsetPaginationTrait;
+
     private ?AccessRequestRepository $repository = null;
     private ?OpenFgaClient $fgaClient            = null;
 
@@ -146,13 +149,24 @@ final class AccessRequestAdminHandler extends AbstractHandler
     }
 
     /**
-     * GET /admin/access-requests — List access requests.
+     * GET /admin/access-requests — List access requests, paginated.
      *
      * Global admins see all requests. Resource admins see only requests
-     * for resources they administer.
+     * for resources they administer (filterByAdminAccess is applied
+     * post-fetch to each page).
      *
      * Query parameters:
-     * - status: Filter by status (pending, approved, rejected, revoked). If omitted, returns all statuses.
+     *   - status: Filter by status (pending, approved, rejected, revoked).
+     *             If omitted, returns all statuses.
+     *   - limit:  Max items in this page (1..500, default 100).
+     *   - offset: Zero-based item index where this page starts (default 0).
+     *
+     * Note: when filterByAdminAccess is applied (non-global admin), the
+     * returned `count` may be smaller than `limit` and smaller than
+     * `total` — `total` reflects the pre-filter SQL count, `has_more`
+     * reflects the SQL paginator. Clients should keep paging until
+     * `has_more` is false even when individual pages come back short.
+     * Same caveat as PR #623's /admin/permissions endpoint.
      */
     private function listRequests(
         ServerRequestInterface $request,
@@ -167,28 +181,29 @@ final class AccessRequestAdminHandler extends AbstractHandler
             ? $queryParams['status']
             : null;
 
-        // Validate status if provided
         if ($statusFilter !== null && !in_array($statusFilter, AccessRequestRepository::VALID_STATUSES, true)) {
             throw new ValidationException(
                 sprintf('Invalid status. Valid values are: %s', implode(', ', AccessRequestRepository::VALID_STATUSES))
             );
         }
 
-        if ($isGlobalAdmin) {
-            $requests = $statusFilter !== null
-                ? $repo->getAll($statusFilter)
-                : $repo->getAll();
-        } else {
-            // Resource admins: get requests, then filter by admin access
-            $allRequests = $statusFilter !== null
-                ? $repo->getAll($statusFilter)
-                : $repo->getAll();
-            $requests    = $this->filterByAdminAccess($allRequests, $adminId);
+        $limit  = $this->parseLimit($queryParams['limit']   ?? null);
+        $offset = $this->parseOffset($queryParams['offset'] ?? null);
+
+        $page  = $repo->getAll($statusFilter, $limit, $offset);
+        $total = $repo->countAll($statusFilter);
+
+        if (!$isGlobalAdmin) {
+            $page = $this->filterByAdminAccess($page, $adminId);
         }
 
         return $this->encodeResponseBody($response, [
-            'requests' => $requests,
-            'count'    => count($requests),
+            'requests' => $page,
+            'count'    => count($page),
+            'total'    => $total,
+            'limit'    => $limit,
+            'offset'   => $offset,
+            'has_more' => ( $offset + count($page) ) < $total,
         ]);
     }
 

--- a/src/Handlers/Auth/AccessRequestHandler.php
+++ b/src/Handlers/Auth/AccessRequestHandler.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Api\Handlers\Auth;
 
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Handlers\Pagination\OffsetPaginationTrait;
 use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
 use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
 use LiturgicalCalendar\Api\Http\Enum\RequestContentType;
@@ -32,6 +33,7 @@ use Psr\Http\Message\ServerRequestInterface;
 final class AccessRequestHandler extends AbstractHandler
 {
     use AccessTokenTrait;
+    use OffsetPaginationTrait;
 
     /**
      * @var array<string>
@@ -138,7 +140,7 @@ final class AccessRequestHandler extends AbstractHandler
             return $this->getStatus($response, $oidcUser);
         }
 
-        return $this->listOwnRequests($response, $userId);
+        return $this->listOwnRequests($request, $response, $userId);
     }
 
     /**
@@ -291,13 +293,6 @@ final class AccessRequestHandler extends AbstractHandler
     }
 
     /**
-     * GET /auth/access-requests — List the user's own requests.
-     *
-     * @param ResponseInterface $response
-     * @param string $userId
-     * @return ResponseInterface
-     */
-    /**
      * POST /auth/access-requests/{id}/resubmit — Resubmit a rejected request.
      *
      * Allows the user to update their permissions and resubmit for review.
@@ -425,13 +420,35 @@ final class AccessRequestHandler extends AbstractHandler
         ]);
     }
 
-    private function listOwnRequests(ResponseInterface $response, string $userId): ResponseInterface
-    {
-        $requests = $this->getRepository()->getByUser($userId);
+    /**
+     * GET /auth/access-requests — List the user's own requests, paginated.
+     *
+     * Query params (validated via OffsetPaginationTrait):
+     *   - limit  (1..500, default 100)
+     *   - offset (>=0, default 0)
+     *
+     * Response envelope: requests[], count, total, limit, offset, has_more.
+     */
+    private function listOwnRequests(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        string $userId
+    ): ResponseInterface {
+        $params = $request->getQueryParams();
+        $limit  = $this->parseLimit($params['limit'] ?? null);
+        $offset = $this->parseOffset($params['offset'] ?? null);
+
+        $repo     = $this->getRepository();
+        $requests = $repo->getByUser($userId, $limit, $offset);
+        $total    = $repo->countByUser($userId);
 
         return $this->encodeResponseBody($response, [
             'requests' => $requests,
             'count'    => count($requests),
+            'total'    => $total,
+            'limit'    => $limit,
+            'offset'   => $offset,
+            'has_more' => ( $offset + count($requests) ) < $total,
         ]);
     }
 

--- a/src/Handlers/Pagination/OffsetPaginationTrait.php
+++ b/src/Handlers/Pagination/OffsetPaginationTrait.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Pagination;
+
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+
+/**
+ * Shared `limit` / `offset` query-param parsing for offset-paginated
+ * handlers.
+ *
+ * Used by `AccessRequestHandler::listOwnRequests()` and
+ * `AccessRequestAdminHandler::listRequests()` (issue #572).
+ *
+ * `PermissionAdminHandler::parseLimit()` (#623) duplicates the limit-parsing
+ * logic but is deliberately left in place — migrating its single private
+ * method to this trait is a noise-only refactor. The rule of three says wait
+ * for a third pagination site to need this; the trait is here ready when
+ * that happens.
+ *
+ * Both helpers use `ctype_digit` rather than `is_numeric` or `(int)` casts.
+ * `ctype_digit` rejects `-1`, `+1`, `1.5`, `1e2`, and any non-ASCII-digit
+ * characters; signed integers, decimals, and exponent forms all fail
+ * validation. Query params arrive from the wire as strings; leniency hides
+ * bugs.
+ */
+trait OffsetPaginationTrait
+{
+    /** Default page size when `limit` is absent or empty. */
+    private const DEFAULT_LIMIT = 100;
+
+    /** Hard ceiling on `limit`; values above this are 400 errors. */
+    private const MAX_LIMIT = 500;
+
+    /**
+     * Parse the `limit` query param.
+     *
+     * Returns DEFAULT_LIMIT when the param is absent or empty; throws
+     * ValidationException when present but non-numeric, signed, or out of
+     * the [1..MAX_LIMIT] range.
+     *
+     * @throws ValidationException
+     */
+    private function parseLimit(mixed $raw): int
+    {
+        if ($raw === null || $raw === '') {
+            return self::DEFAULT_LIMIT;
+        }
+        if (!is_string($raw) || !ctype_digit($raw)) {
+            throw new ValidationException('limit must be a positive integer');
+        }
+        $limit = (int) $raw;
+        if ($limit < 1 || $limit > self::MAX_LIMIT) {
+            throw new ValidationException(sprintf(
+                'limit must be between 1 and %d',
+                self::MAX_LIMIT
+            ));
+        }
+        return $limit;
+    }
+
+    /**
+     * Parse the `offset` query param.
+     *
+     * Returns 0 when the param is absent or empty; throws
+     * ValidationException when present but non-numeric or signed (negatives
+     * fail `ctype_digit`).
+     *
+     * @throws ValidationException
+     */
+    private function parseOffset(mixed $raw): int
+    {
+        if ($raw === null || $raw === '') {
+            return 0;
+        }
+        if (!is_string($raw) || !ctype_digit($raw)) {
+            throw new ValidationException('offset must be a non-negative integer');
+        }
+        return (int) $raw;
+    }
+}

--- a/src/Repositories/AccessRequestRepository.php
+++ b/src/Repositories/AccessRequestRepository.php
@@ -198,20 +198,32 @@ class AccessRequestRepository
     }
 
     /**
-     * Get all requests for a specific user.
+     * Get all requests for a specific user, with optional offset pagination.
      *
      * @param string $userId Zitadel user ID
-     * @return array<int, array<string, mixed>> List of requests
+     * @param int|null $limit Max rows to return; null = no LIMIT clause.
+     * @param int|null $offset Zero-based row offset; null = no OFFSET clause.
+     * @return array<int, array<string, mixed>> List of requests, newest first
      */
-    public function getByUser(string $userId): array
+    public function getByUser(string $userId, ?int $limit = null, ?int $offset = null): array
     {
-        $stmt = $this->db->prepare(
-            'SELECT * FROM access_requests
+        $sql = 'SELECT * FROM access_requests
              WHERE zitadel_user_id = :user_id
-             ORDER BY created_at DESC'
-        );
+             ORDER BY created_at DESC';
 
-        $stmt->execute(['user_id' => $userId]);
+        if ($limit !== null && $offset !== null) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
+
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindValue('user_id', $userId, PDO::PARAM_STR);
+        if ($limit !== null && $offset !== null) {
+            // PARAM_INT binds — PDO's execute([...]) form binds everything as
+            // a string, which can confuse Postgres's LIMIT/OFFSET parsing.
+            $stmt->bindValue('limit', $limit, PDO::PARAM_INT);
+            $stmt->bindValue('offset', $offset, PDO::PARAM_INT);
+        }
+        $stmt->execute();
 
         /** @var array<int, array<string, mixed>> $results */
         $results = $stmt->fetchAll();
@@ -241,38 +253,99 @@ class AccessRequestRepository
     }
 
     /**
-     * Get all access requests with optional status filter.
+     * Get all access requests with optional status filter and offset pagination.
      *
      * @param string|null $status Filter by status (pending, approved, rejected, revoked)
-     * @return array<int, array<string, mixed>> List of requests
+     * @param int|null $limit Max rows to return; null = no LIMIT clause.
+     * @param int|null $offset Zero-based row offset; null = no OFFSET clause.
+     * @return array<int, array<string, mixed>> List of requests, newest first
      * @throws \InvalidArgumentException If status is not a valid value
      */
-    public function getAll(?string $status = null): array
+    public function getAll(?string $status = null, ?int $limit = null, ?int $offset = null): array
     {
-        if ($status !== null) {
-            if (!in_array($status, self::VALID_STATUSES, true)) {
-                throw new \InvalidArgumentException(
-                    sprintf('Invalid status filter: %s. Valid values are: %s', $status, implode(', ', self::VALID_STATUSES))
-                );
-            }
-            $stmt = $this->db->prepare(
-                'SELECT * FROM access_requests
-                 WHERE status = :status
-                 ORDER BY created_at DESC'
+        if ($status !== null && !in_array($status, self::VALID_STATUSES, true)) {
+            throw new \InvalidArgumentException(
+                sprintf('Invalid status filter: %s. Valid values are: %s', $status, implode(', ', self::VALID_STATUSES))
             );
-            $stmt->execute(['status' => $status]);
-        } else {
-            $stmt = $this->db->prepare(
-                'SELECT * FROM access_requests
-                 ORDER BY created_at DESC'
-            );
-            $stmt->execute();
         }
+
+        $sql = 'SELECT * FROM access_requests';
+        if ($status !== null) {
+            $sql .= ' WHERE status = :status';
+        }
+        $sql .= ' ORDER BY created_at DESC';
+
+        if ($limit !== null && $offset !== null) {
+            $sql .= ' LIMIT :limit OFFSET :offset';
+        }
+
+        $stmt = $this->db->prepare($sql);
+        if ($status !== null) {
+            $stmt->bindValue('status', $status, PDO::PARAM_STR);
+        }
+        if ($limit !== null && $offset !== null) {
+            // PARAM_INT binds — PDO's execute([...]) form binds everything as
+            // a string, which can confuse Postgres's LIMIT/OFFSET parsing.
+            $stmt->bindValue('limit', $limit, PDO::PARAM_INT);
+            $stmt->bindValue('offset', $offset, PDO::PARAM_INT);
+        }
+        $stmt->execute();
 
         /** @var array<int, array<string, mixed>> $results */
         $results = $stmt->fetchAll();
 
         return $this->decodePermissionsList($results);
+    }
+
+    /**
+     * Count access requests matching an optional status filter.
+     *
+     * Companion to getAll() for pagination metadata.
+     *
+     * @param string|null $status Filter by status (pending, approved, rejected, revoked)
+     * @return int Total matching rows, ignoring limit/offset
+     * @throws \InvalidArgumentException If status is not a valid value
+     */
+    public function countAll(?string $status = null): int
+    {
+        if ($status !== null && !in_array($status, self::VALID_STATUSES, true)) {
+            throw new \InvalidArgumentException(
+                sprintf('Invalid status filter: %s. Valid values are: %s', $status, implode(', ', self::VALID_STATUSES))
+            );
+        }
+
+        $sql = 'SELECT COUNT(*) FROM access_requests';
+        if ($status !== null) {
+            $sql .= ' WHERE status = :status';
+        }
+
+        $stmt = $this->db->prepare($sql);
+        if ($status !== null) {
+            $stmt->bindValue('status', $status, PDO::PARAM_STR);
+        }
+        $stmt->execute();
+
+        $count = $stmt->fetchColumn();
+        return is_numeric($count) ? (int) $count : 0;
+    }
+
+    /**
+     * Count access requests for a given user.
+     *
+     * Companion to getByUser() for pagination metadata.
+     *
+     * @param string $userId Zitadel user ID
+     * @return int Total rows for this user, ignoring limit/offset
+     */
+    public function countByUser(string $userId): int
+    {
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) FROM access_requests WHERE zitadel_user_id = :user_id'
+        );
+        $stmt->execute(['user_id' => $userId]);
+
+        $count = $stmt->fetchColumn();
+        return is_numeric($count) ? (int) $count : 0;
     }
 
     /**

--- a/src/Repositories/AccessRequestRepository.php
+++ b/src/Repositories/AccessRequestRepository.php
@@ -211,16 +211,23 @@ class AccessRequestRepository
              WHERE zitadel_user_id = :user_id
              ORDER BY created_at DESC';
 
-        if ($limit !== null && $offset !== null) {
-            $sql .= ' LIMIT :limit OFFSET :offset';
+        // LIMIT and OFFSET are independent — either, both, or neither may be
+        // supplied. Matches the docstring promise that null = "omit the clause".
+        if ($limit !== null) {
+            $sql .= ' LIMIT :limit';
+        }
+        if ($offset !== null) {
+            $sql .= ' OFFSET :offset';
         }
 
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue('user_id', $userId, PDO::PARAM_STR);
-        if ($limit !== null && $offset !== null) {
-            // PARAM_INT binds — PDO's execute([...]) form binds everything as
+        if ($limit !== null) {
+            // PARAM_INT bind — PDO's execute([...]) form binds everything as
             // a string, which can confuse Postgres's LIMIT/OFFSET parsing.
             $stmt->bindValue('limit', $limit, PDO::PARAM_INT);
+        }
+        if ($offset !== null) {
             $stmt->bindValue('offset', $offset, PDO::PARAM_INT);
         }
         $stmt->execute();
@@ -275,18 +282,25 @@ class AccessRequestRepository
         }
         $sql .= ' ORDER BY created_at DESC';
 
-        if ($limit !== null && $offset !== null) {
-            $sql .= ' LIMIT :limit OFFSET :offset';
+        // LIMIT and OFFSET are independent — either, both, or neither may be
+        // supplied. Matches the docstring promise that null = "omit the clause".
+        if ($limit !== null) {
+            $sql .= ' LIMIT :limit';
+        }
+        if ($offset !== null) {
+            $sql .= ' OFFSET :offset';
         }
 
         $stmt = $this->db->prepare($sql);
         if ($status !== null) {
             $stmt->bindValue('status', $status, PDO::PARAM_STR);
         }
-        if ($limit !== null && $offset !== null) {
-            // PARAM_INT binds — PDO's execute([...]) form binds everything as
+        if ($limit !== null) {
+            // PARAM_INT bind — PDO's execute([...]) form binds everything as
             // a string, which can confuse Postgres's LIMIT/OFFSET parsing.
             $stmt->bindValue('limit', $limit, PDO::PARAM_INT);
+        }
+        if ($offset !== null) {
             $stmt->bindValue('offset', $offset, PDO::PARAM_INT);
         }
         $stmt->execute();


### PR DESCRIPTION
Closes #572.

Adds **offset-based** pagination to `GET /auth/access-requests` and `GET /admin/access-requests`. Different envelope from #623 (cursor) because the backing store is Postgres, not OpenFGA: `COUNT(*)` is cheap, so `total` can be honest and `has_more = (offset + count) < total`.

## Design

See:
- Spec: `docs/superpowers/specs/2026-06-01-issue-572-access-requests-pagination-design.md`
- Plan: `docs/superpowers/plans/2026-06-01-issue-572-access-requests-pagination-plan.md`

Defaults: `limit=100`, max 500; `offset=0`. Cursor migration explicitly out of scope per the issue. `AccessRequestListResponse` stays shared between both endpoints (same shape, just different filtering at the handler).

## Endpoint contract

```
GET /admin/access-requests?status=pending&limit=50&offset=100
GET /auth/access-requests?limit=20&offset=0
```

200 response:

```json
{
  "requests": [ /* AccessRequest[] */ ],
  "count": 50,
  "total": 137,
  "limit": 50,
  "offset": 100,
  "has_more": true
}
```

Final page: `count` ≤ `limit`, `has_more: false`. Validation errors (`limit < 1`, `limit > 500`, non-numeric/negative `limit`, negative/non-numeric `offset`) → 400 with explicit `ValidationException` messages.

## Changes

| Layer | File | Notes |
|---|---|---|
| Repository | `src/Repositories/AccessRequestRepository.php` | `getAll()` and `getByUser()` gain optional `?int $limit, ?int $offset` — append `LIMIT/OFFSET` when both non-null, `bindValue PARAM_INT` (execute-array binds strings, which can confuse Postgres). New `countAll(?status)` and `countByUser($userId)` for `total`. |
| Trait | `src/Handlers/Pagination/OffsetPaginationTrait.php` | New. Shared `parseLimit()` + `parseOffset()` with `DEFAULT_LIMIT=100`, `MAX_LIMIT=500`. `ctype_digit` rejects signed/decimal/non-ASCII. `PermissionAdminHandler::parseLimit()` (#623) deliberately not migrated — rule of three. |
| Handler | `src/Handlers/Auth/AccessRequestHandler.php` | `listOwnRequests()` reads query params, builds new envelope. |
| Handler | `src/Handlers/Admin/AccessRequestAdminHandler.php` | Same. Resource-admin path still applies `filterByAdminAccess` post-fetch; documented caveat (same as #623). |
| Docs | `jsondata/schemas/openapi.json` | Two reusable parameter components (`LimitQueryParam`, `OffsetQueryParam`); both endpoints `$ref` them. `AccessRequestListResponse` extended with `total`/`limit`/`offset`/`has_more`. `firstPage` + `lastPage` examples on both 200 responses. |
| Tests | `phpunit_tests/Repositories/AccessRequestRepositoryTest.php` | 5 new (R1–R5): slice ordering, count, count rejects bad status. |
| Tests | `phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php` | 5 new (H1–H5); 2 use `DataProvider` and expand to 6 cases. |
| Tests | `phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php` | 5 new (A1–A5); 2 use `DataProvider` and expand to 6 cases. |

## Tests

- **21** AccessRequestRepository tests (was 16), all green.
- **26** AccessRequestHandler tests (was 17), all green.
- **24** AccessRequestAdminHandler tests (was 15), all green.
- **86** tests in the four touched files together, all green.
- `composer analyse` (PHPStan L10): clean, 247 src files.
- `composer lint` (phpcs PSR-12): clean.
- `composer lint:openapi` (Redocly): clean.
- `composer parallel-lint`: 377 files, 0 syntax errors.
- `composer test` (full suite): 3 pre-existing rate-limiter flakes in `Routes/Readonly/CalendarTest.php` and `Handlers/Auth/LoginHandlerTest.php` (untouched files); reproduce on `origin/development`.

## Notable design decision

When the resource-admin path post-filters a page (`filterByAdminAccess`), the returned page may be shorter than `limit`. `total` reflects the SQL-level (pre-filter) count and `has_more` reflects the SQL paginator, so clients should keep paging until `has_more === false` even when individual pages come back short. Same shape as the caveat already documented in PR #623's `AdminListPermissionsResponse`. Captured in both the handler doc and the OpenAPI schema description.

## Out of scope (deferred)

- **Cursor migration.** Offset is sufficient at this volume; cursor is forward-compatible by adding `page_token` later. Explicitly out of scope per #572.
- **Pagination on `/admin/applications`.** Separate handler, separate decision.
- **Migrating `PermissionAdminHandler::parseLimit()` to the trait.** Rule of three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Access-request listing endpoints now support offset-based pagination with limit (1–500, default 100), offset, and paginated metadata (total, count, limit, offset, has_more). Admin listing preserves pre-filter total while post-filtering pages for non-global admins.

* **Documentation**
  * Added design, implementation plan, and updated API docs/examples describing pagination behavior and validation.

* **Tests**
  * New unit tests covering repository, auth, and admin pagination behaviors and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->