### PR TITLE
fix(tests): isolate rate-limit IP buckets + gettext state across reruns

### DIFF
--- a/phpunit_tests/LocaleDateFormatterTest.php
+++ b/phpunit_tests/LocaleDateFormatterTest.php
@@ -16,6 +16,33 @@ use IntlDateFormatter;
  */
 class LocaleDateFormatterTest extends TestCase
 {
+    /**
+     * Reset gettext state to a deterministic "no translations bound" baseline
+     * before each test.
+     *
+     * `LocaleDateFormatter::formatChristmasWeekdayName()` has hardcoded
+     * sprintf paths for Latin and Italian, but the English/French/default
+     * branch calls `_('%s - Christmas Weekday')` and inherits whatever the
+     * process-wide gettext state currently is. Production handlers
+     * (`CalendarHandler`, `EventsHandler`, `FerialEventNameGenerator`) call
+     * `setlocale + bindtextdomain('litcal') + textdomain('litcal')` and don't
+     * restore. When a prior test exercises one of those handlers with
+     * locale=it_IT, the Italian .mo catalog stays bound for the rest of the
+     * PHP process — and the English tests in this file then get back
+     * "%s - Giorno feriale di Natale" instead of the expected msgid fallback.
+     *
+     * Resetting to `LC_ALL=C` and the default `messages` textdomain (which
+     * this project never binds) means `_()` returns its msgid unchanged.
+     * Tests that assert hardcoded translations (Latin/Italian) are unaffected
+     * because those paths bypass gettext.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        \setlocale(LC_ALL, 'C');
+        \textdomain('messages');
+    }
+
     /* ========================= formatLocalizedDate Tests ========================= */
 
     /**

--- a/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
+++ b/phpunit_tests/Routes/Auth/LoginRateLimitTest.php
@@ -24,6 +24,15 @@ class LoginRateLimitTest extends ApiTestCase
      * test runner and a containerized API. The earlier reset-by-filesystem-delete
      * approach didn't work in containerized setups.
      *
+     * The hash mixes in `getmypid()` so the same test method picks a different
+     * IP on each PHP process. A bucket exhausted by one composer-test run no
+     * longer 429s the next run — the next run uses a different IP. (Within a
+     * single run, the PID is stable, so each test method's IP stays consistent
+     * across its own setUp/exhaustRateLimit/assertion calls.) Hashes still mod
+     * by 99 so the resulting octet stays in the 1-99 reservation; rare
+     * collisions across PID boundaries reduce the rerun-failure rate from
+     * 100% to ~1%.
+     *
      * Octet range 1-99 is reserved for per-method IPs so they never collide
      * with CalendarTest's bucket-rotation range (100-199) or ApiTestCase's
      * per-class range (200-254).
@@ -31,7 +40,8 @@ class LoginRateLimitTest extends ApiTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->testIp = '192.0.2.' . ( ( abs(crc32($this->name())) % 99 ) + 1 );
+        $hash         = crc32($this->name() . '|' . getmypid());
+        $this->testIp = '192.0.2.' . ( ( abs($hash) % 99 ) + 1 );
     }
 
     /**

--- a/phpunit_tests/Routes/Readonly/CalendarTest.php
+++ b/phpunit_tests/Routes/Readonly/CalendarTest.php
@@ -149,7 +149,15 @@ final class CalendarTest extends ApiTestCase
                     // a single IP's unauthenticated budget. 192.0.2.100-199 are reserved
                     // here for this bucket-rotation; ApiTestCase's per-class default is
                     // skipped because we're setting the header explicitly.
-                    $bucketIp = '192.0.2.' . ( 100 + intdiv($idx, 500) % 100 );
+                    //
+                    // The starting offset includes getmypid() so each composer-test run
+                    // walks the 100-IP range from a different position. The API key
+                    // rate-limit window is 1 hour and storage is file-backed inside the
+                    // litcal-api container; without the PID salt, two suite runs within
+                    // that window would touch the same buckets and trip 429s mid-run.
+                    // (The intdiv/%100 rotation between requests within a single run is
+                    // unchanged.)
+                    $bucketIp = '192.0.2.' . ( 100 + ( ( intdiv($idx, 500) + getmypid() ) % 100 ) );
                     yield self::$http
                         ->getAsync($request['uri'], [
                             'http_errors' => false,


### PR DESCRIPTION
Fixes three pre-existing test-isolation bugs that surface during full-suite re-runs on developer machines. All are test-only; no production code changes. Discovered while triaging the test output during work on #572 / PR #624 — none of the bugs are caused by that PR (the four touched test files are byte-identical to `origin/development` HEAD).

## Symptom (before)

`composer test` on a dev machine fails with 3–6 failures depending on how recently the suite was last run:

```
1) LoginRateLimitTest::testRateLimitingTriggeredAfterMaxAttempts
   Expected 401 on attempt 1 of 5 — got 429
2) LoginRateLimitTest::testSuccessfulLoginClearsRateLimit
   Expected 401 — got 429
3) CalendarTest::testGetCalendarSampleAllCalendars
   Expected HTTP 200 for /calendar/nation/VA/1970 — got 429: "Rate limit exceeded"
4) LocaleDateFormatterTest::testFormatChristmasWeekdayNameEnglish
   Expected "Monday - Christmas Weekday" — got "Monday - Giorno feriale di Natale"
5) LocaleDateFormatterTest::testChristmasWeekdayFullFlowEnglish
   Same shape (Italian fallback instead of English msgid)
```

After this PR: `composer test` is exit-0 reliably across consecutive runs.

## Three independent root causes

### 1. `LoginRateLimitTest` — per-test IP didn't include PID

`setUp()` computed `192.0.2.{abs(crc32(testName)) % 99 + 1}` — deterministic across `composer test` runs. The login rate-limiter keys on client IP with file-backed buckets in `/tmp/litcal_rate_limits/` (15-minute sliding window). `testRateLimitingTriggeredAfterMaxAttempts` makes 6 attempts by design vs the limit of 5; a single suite run leaves the bucket at the limit. Any rerun within 15 minutes started already 429'd, failing on "attempt 1 of 5".

**Fix:** mix `getmypid()` into the hash. Each `composer test` process gets a different IP per test method; exhausted buckets from prior runs no longer impact the current run. Hash still mods by 99 to stay in the 1–99 reservation; rerun-collision probability drops from 100% to ~1%.

Matches the established `ApiTestCase::$currentTestIp` pattern (line 45) which already includes PID.

### 2. `CalendarTest::testGetCalendarSampleAllCalendars` — bucket rotation deterministic across runs

The 80yr × ~25 calendar matrix produces ~2000 requests rotating across 100 reserved IPs (`192.0.2.100-199`), 500 requests per IP. Base bucket was `100 + intdiv($idx, 500) % 100` — so every run touched the same 4 buckets (100, 101, 102, 103). With the unauthenticated 1000/hr limit, two suite runs in an hour cumulated 1000 requests per bucket; the third request to a saturated bucket returned 429 mid-test.

**Fix:** shift the rotation by `getmypid()`. Each run walks the 100-IP range from a different starting point; two PIDs are very unlikely to land on overlapping 4-bucket windows.

### 3. `LocaleDateFormatterTest` — process-global gettext state leak

`LocaleDateFormatter::formatChristmasWeekdayName()` has hardcoded `sprintf` paths for Latin and Italian, but the English/French/default branch calls `_('%s - Christmas Weekday')` and inherits the process-wide gettext state. Production handlers (`CalendarHandler`, `EventsHandler`, `FerialEventNameGenerator`) call `setlocale + bindtextdomain('litcal') + textdomain('litcal')` and don't restore. When the test suite exercises one of those handlers with `locale=it_IT`, the Italian `.mo` catalog stays bound for the rest of the PHP process — so this file's English tests get `'%s - Giorno feriale di Natale'` instead of the expected msgid fallback.

The bug is invisible in:

- This file run in isolation (no prior test loaded gettext)
- CI containers that lack the `it_IT` system locale or the Italian `.mo` catalog

So it slips past CI but trips local developers running the full suite.

**Fix:** `setUp()` resets `setlocale(LC_ALL, 'C')` + `textdomain('messages')` (a domain this project never binds), giving each test method a deterministic baseline where `_()` returns its msgid unchanged. Latin and Italian tests are unaffected because they bypass gettext via hardcoded `sprintf`.

## Verification

Before fixes, running `composer test` twice in a 15-minute window: 5–6 failures.

After fixes, running `composer test` twice consecutively:

```
Tests: 1113, Assertions: 292211, PHPUnit Notices: 12, Skipped: 5.
```

- `composer test`: ✅ exit 0
- `composer analyse` (PHPStan L10): ✅ clean
- `composer lint` (phpcs PSR-12): ✅ clean
- `composer parallel-lint`: ✅ 376 files, 0 syntax errors

## Out of scope

- **12 `createMock` notices** in `OpenFgaAuthorizationMiddlewareTest` (7) and `LocaleDateFormatterTest` (5) — PHPUnit 12 strictness about mocks-without-expectations. Cosmetic; separate cleanup PR (swap `createMock()` → `createStub()` or add `#[AllowMockObjectsWithoutExpectations]`).
- **5 environmental skips** — 3 Zitadel (need a real OIDC token), 2 opcache (need `opcache.enable_cli=1`). Self-skip messages are correct and explicit; no code change needed.
- **The deeper architectural fix for #3** — `LocaleDateFormatter` should arguably set its own process locale in the constructor (the class is named for a locale but doesn't enforce it). Out of scope here; would touch production code and merits a separate design discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup to ensure deterministic execution environments and prevent test interference across runs
  * Enhanced test isolation for rate-limit and calendar tests using process-specific identifiers to reduce collisions during concurrent test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->