### PR TITLE
chore(tests): swap createMock to createStub for type-stub usages

### DIFF
--- a/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
+++ b/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
@@ -37,7 +37,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
 
     public function testThrowsUnauthorizedWhenNoOidcUser(): void
     {
-        $client     = $this->createMock(OpenFgaClient::class);
+        $client     = $this->createStub(OpenFgaClient::class);
         $middleware = new OpenFgaAuthorizationMiddleware($client, 'national_calendar');
 
         $request = new ServerRequest('PUT', '/data/nation/IT');
@@ -48,7 +48,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
 
     public function testThrowsUnauthorizedWhenNoSubClaim(): void
     {
-        $client     = $this->createMock(OpenFgaClient::class);
+        $client     = $this->createStub(OpenFgaClient::class);
         $middleware = new OpenFgaAuthorizationMiddleware($client, 'national_calendar');
 
         $request = ( new ServerRequest('PUT', '/data/nation/IT') )
@@ -179,7 +179,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
 
     public function testForCalendarDataMapsNationToNationalCalendar(): void
     {
-        $client     = $this->createMock(OpenFgaClient::class);
+        $client     = $this->createStub(OpenFgaClient::class);
         $middleware = OpenFgaAuthorizationMiddleware::forCalendarData($client, 'nation');
 
         $this->assertInstanceOf(OpenFgaAuthorizationMiddleware::class, $middleware);
@@ -187,7 +187,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
 
     public function testForCalendarDataMapsDioceseToDiocesanCalendar(): void
     {
-        $client     = $this->createMock(OpenFgaClient::class);
+        $client     = $this->createStub(OpenFgaClient::class);
         $middleware = OpenFgaAuthorizationMiddleware::forCalendarData($client, 'diocese');
 
         $this->assertInstanceOf(OpenFgaAuthorizationMiddleware::class, $middleware);
@@ -195,7 +195,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
 
     public function testForCalendarDataMapsWiderRegionToWiderRegion(): void
     {
-        $client     = $this->createMock(OpenFgaClient::class);
+        $client     = $this->createStub(OpenFgaClient::class);
         $middleware = OpenFgaAuthorizationMiddleware::forCalendarData($client, 'widerregion');
 
         $this->assertInstanceOf(OpenFgaAuthorizationMiddleware::class, $middleware);
@@ -203,7 +203,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
 
     public function testForCalendarDataReturnsNullForUnknownCategory(): void
     {
-        $client     = $this->createMock(OpenFgaClient::class);
+        $client     = $this->createStub(OpenFgaClient::class);
         $middleware = OpenFgaAuthorizationMiddleware::forCalendarData($client, 'unknown');
 
         $this->assertNull($middleware);
@@ -211,7 +211,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
 
     public function testForTestDefinitionCreatesMiddleware(): void
     {
-        $client     = $this->createMock(OpenFgaClient::class);
+        $client     = $this->createStub(OpenFgaClient::class);
         $middleware = OpenFgaAuthorizationMiddleware::forTestDefinition($client);
 
         $this->assertInstanceOf(OpenFgaAuthorizationMiddleware::class, $middleware);

--- a/phpunit_tests/LocaleDateFormatterTest.php
+++ b/phpunit_tests/LocaleDateFormatterTest.php
@@ -368,8 +368,8 @@ class LocaleDateFormatterTest extends TestCase
     {
         $formatter = new LocaleDateFormatter('it_IT');
 
-        // Inject a mock formatter that returns false
-        $mockFormatter = $this->createMock(IntlDateFormatter::class);
+        // Inject a stub formatter that returns false
+        $mockFormatter = $this->createStub(IntlDateFormatter::class);
         $mockFormatter->method('format')->willReturn(false);
         $formatter->setDayAndMonthFormatter($mockFormatter);
 
@@ -389,8 +389,8 @@ class LocaleDateFormatterTest extends TestCase
     {
         $formatter = new LocaleDateFormatter('it_IT');
 
-        // Inject a mock formatter that returns false
-        $mockFormatter = $this->createMock(IntlDateFormatter::class);
+        // Inject a stub formatter that returns false
+        $mockFormatter = $this->createStub(IntlDateFormatter::class);
         $mockFormatter->method('format')->willReturn(false);
         $formatter->setDayAndMonthFormatter($mockFormatter);
 
@@ -411,8 +411,8 @@ class LocaleDateFormatterTest extends TestCase
     {
         $formatter = new LocaleDateFormatter('fr_FR');
 
-        // Inject a mock formatter that returns false
-        $mockFormatter = $this->createMock(IntlDateFormatter::class);
+        // Inject a stub formatter that returns false
+        $mockFormatter = $this->createStub(IntlDateFormatter::class);
         $mockFormatter->method('format')->willReturn(false);
         $formatter->setDayOfTheWeekFormatter($mockFormatter);
 
@@ -471,7 +471,7 @@ class LocaleDateFormatterTest extends TestCase
     public function testSetDayAndMonthFormatterReturnsSelf(): void
     {
         $formatter     = new LocaleDateFormatter('en_US');
-        $mockFormatter = $this->createMock(IntlDateFormatter::class);
+        $mockFormatter = $this->createStub(IntlDateFormatter::class);
 
         $result = $formatter->setDayAndMonthFormatter($mockFormatter);
 
@@ -484,7 +484,7 @@ class LocaleDateFormatterTest extends TestCase
     public function testSetDayOfTheWeekFormatterReturnsSelf(): void
     {
         $formatter     = new LocaleDateFormatter('en_US');
-        $mockFormatter = $this->createMock(IntlDateFormatter::class);
+        $mockFormatter = $this->createStub(IntlDateFormatter::class);
 
         $result = $formatter->setDayOfTheWeekFormatter($mockFormatter);
 


### PR DESCRIPTION
Silences the 12 PHPUnit-12 notices about `createMock()` calls that never set expectations. All swaps are mechanical: `createMock()` → `createStub()` at sites that use the mock as a pure type stub (constructor argument with no method calls) or stub a return value via `->method()->willReturn()` without any `->expects()` expectation.

Independent of #624 and #625; branches off `development` so it can ship in any order.

## Why

PHPUnit 12 emits this notice whenever `createMock()` is used as a type stub:

> No expectations were configured for the mock object for X. Consider refactoring your test code to use a test stub instead. The `#[AllowMockObjectsWithoutExpectations]` attribute can be used to opt out of this check.

Two options: refactor to `createStub()` (the framework's recommended migration), or opt out with `#[AllowMockObjectsWithoutExpectations]`. All 12 sites here are genuinely stubs — none of them care about how (or whether) the code under test invokes the double — so `createStub()` is the right primitive. The opt-out attribute would just suppress the message without expressing intent.

PHPUnit 13 is likely to upgrade these notices to errors; doing this cleanup now keeps future upgrades trivial.

## Touched

| File | Sites | Use case |
|---|---|---|
| `phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php` | 7 | `OpenFgaClient` arguments to the middleware constructor / `forCalendarData` / `forTestDefinition` factories. 5 cases short-circuit before the middleware touches the client (no `oidc_user`, no `sub`, etc.); 2 cases assert on the returned middleware instance without invoking `process()`. |
| `phpunit_tests/LocaleDateFormatterTest.php` | 5 | `IntlDateFormatter` stubs passed to `setDayAndMonthFormatter` / `setDayOfTheWeekFormatter`. 3 fallback tests stub `->method('format')->willReturn(false)` (no expectations); 2 setter-return-self tests don't invoke any method on the stub. |

6 sites in `OpenFgaAuthorizationMiddlewareTest` use legitimate `->expects()` assertions and are intentionally left as `createMock()`.

## Verification

```text
Before:  PHPUnit Notices: 12
After:   PHPUnit Notices:  0
```

- The two touched test files together: **50 tests, 82 assertions, 0 notices, 0 failures.**
- `composer analyse` (PHPStan L10): clean on touched files.
- `composer lint` (phpcs PSR-12): clean.

## Pre-existing failures (unrelated)

A full-suite run on this branch will surface 3 failures inherited from `development`:

- `LocaleDateFormatterTest::testFormatChristmasWeekdayNameEnglish`
- `LocaleDateFormatterTest::testChristmasWeekdayFullFlowEnglish`
- `CalendarTest::testGetCalendarSampleAllCalendars`

These are the gettext-leak and rate-limit-rerun bugs fixed by **#625**. They will clear automatically once #625 merges (the two `LocaleDateFormatterTest` files modified by both PRs touch different lines/methods — no conflict expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for improved test isolation in authorization and date formatting test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->