### PR TITLE
feat(openfga): typed tuple-error exceptions + ListObjects in filterByAdminAccess (#567, #571)

### DIFF
--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Handlers\Admin;
 
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use LiturgicalCalendar\Api\Handlers\Admin\AccessRequestAdminHandler;
 use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
 use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -359,5 +365,275 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
         self::assertSame('failed', $row['zitadel_sync_status']);
         self::assertArrayHasKey('zitadel_sync_error', $row);
         self::assertSame('token expired', $row['zitadel_sync_error']);
+    }
+
+    // --- Fail-fast on OpenFGA tuple errors (issue #567) ------------------
+
+    /**
+     * Build a real OpenFgaClient backed by a Guzzle MockHandler that
+     * replays the queued HTTP responses. We construct the handler with
+     * this client injected, set the OPENFGA_* env vars so
+     * `OpenFgaClient::isConfigured()` returns true (otherwise the tuple-
+     * write loop is skipped), and undo both at the end of the test.
+     */
+    private function withMockOpenFgaClient(MockHandler $mock, callable $fn): mixed
+    {
+        $stack  = HandlerStack::create($mock);
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+
+        $savedEnv = [];
+        foreach (['OPENFGA_API_URL', 'OPENFGA_STORE_ID', 'OPENFGA_MODEL_ID'] as $name) {
+            $savedEnv[$name] = getenv($name);
+            putenv("{$name}=stub");
+            $_ENV[$name] = 'stub';
+        }
+
+        try {
+            return $fn($client);
+        } finally {
+            foreach ($savedEnv as $name => $original) {
+                if ($original === false) {
+                    putenv($name);
+                    unset($_ENV[$name]);
+                } else {
+                    putenv("{$name}={$original}");
+                    $_ENV[$name] = $original;
+                }
+            }
+        }
+    }
+
+    public function testApproveSucceedsWhenAllTupleWritesSucceed(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+            ['object_type' => 'diocesan_calendar', 'object_id' => 'romamo_it', 'relation' => 'viewer'],
+        ]);
+
+        $mock = new MockHandler([
+            new GuzzleResponse(200, [], '{}'), // tuple 1 write OK
+            new GuzzleResponse(200, [], '{}'), // tuple 2 write OK
+        ]);
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
+                $this->withOidcUser($this->requestFor(
+                    'POST',
+                    '/admin/access-requests/' . $id . '/approve',
+                    [],
+                    ['notes' => 'ok']
+                ))
+            )
+        ));
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertCount(2, $body['tuples_created']);
+        self::assertSame([], $body['fga_errors']);
+
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('approved', $row['status']);
+    }
+
+    public function testApproveTreatsDuplicateTupleAsBenign(): void
+    {
+        // Idempotent re-approval: one tuple already exists. The handler
+        // should treat that write as success, still mutate the DB, and
+        // return success: true.
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+
+        $mock = new MockHandler([
+            new GuzzleResponse(400, [], (string) json_encode([
+                'code'    => 'cannot_allow_duplicate_tuple',
+                'message' => 'cannot write duplicate tuple',
+            ])),
+        ]);
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
+                $this->withOidcUser($this->requestFor(
+                    'POST',
+                    '/admin/access-requests/' . $id . '/approve',
+                    [],
+                    ['notes' => 'retry']
+                ))
+            )
+        ));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertCount(1, $body['tuples_created']);
+        self::assertSame([], $body['fga_errors']);
+
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('approved', $row['status']);
+    }
+
+    public function testApproveBailsAndKeepsRequestPendingOnRealFgaError(): void
+    {
+        // Genuine OpenFGA failure (e.g. validation error). The handler must
+        // NOT mark the DB as approved — leaving it pending lets the admin
+        // retry once the underlying error is resolved.
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+
+        $mock = new MockHandler([
+            new GuzzleResponse(400, [], (string) json_encode([
+                'code'    => 'validation_error',
+                'message' => 'invalid relation for type',
+            ])),
+        ]);
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
+                $this->withOidcUser($this->requestFor(
+                    'POST',
+                    '/admin/access-requests/' . $id . '/approve',
+                    [],
+                    ['notes' => 'try']
+                ))
+            )
+        ));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertFalse($body['success']);
+        self::assertCount(1, $body['fga_errors']);
+        self::assertStringContainsString('Approval aborted', $body['message']);
+
+        // DB row must still be pending — the request was NOT approved.
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('pending', $row['status']);
+    }
+
+    public function testRevokeSucceedsWhenAllTupleDeletesSucceed(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+        $repo->approve($id, 'admin-bob');
+
+        $mock = new MockHandler([
+            new GuzzleResponse(200, [], '{}'), // delete OK
+        ]);
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
+                $this->withOidcUser($this->requestFor(
+                    'POST',
+                    '/admin/access-requests/' . $id . '/revoke',
+                    [],
+                    []
+                ))
+            )
+        ));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertCount(1, $body['tuples_deleted']);
+        self::assertSame([], $body['fga_errors']);
+
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('revoked', $row['status']);
+    }
+
+    public function testRevokeTreatsMissingTupleAsBenign(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+        $repo->approve($id, 'admin-bob');
+
+        $mock = new MockHandler([
+            new GuzzleResponse(400, [], (string) json_encode([
+                'code'    => 'cannot_allow_unknown_tuple_to_be_deleted',
+                'message' => 'cannot delete unknown tuple',
+            ])),
+        ]);
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
+                $this->withOidcUser($this->requestFor(
+                    'POST',
+                    '/admin/access-requests/' . $id . '/revoke',
+                    [],
+                    []
+                ))
+            )
+        ));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertCount(1, $body['tuples_deleted']);
+        self::assertSame([], $body['fga_errors']);
+
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('revoked', $row['status']);
+    }
+
+    public function testRevokeBailsAndKeepsRequestApprovedOnRealFgaError(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+        $repo->approve($id, 'admin-bob');
+
+        $mock = new MockHandler([
+            new GuzzleResponse(500, [], (string) json_encode([
+                'code'    => 'internal_error',
+                'message' => 'internal server error',
+            ])),
+        ]);
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
+                $this->withOidcUser($this->requestFor(
+                    'POST',
+                    '/admin/access-requests/' . $id . '/revoke',
+                    [],
+                    []
+                ))
+            )
+        ));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertFalse($body['success']);
+        self::assertCount(1, $body['fga_errors']);
+        self::assertStringContainsString('Revocation aborted', $body['message']);
+
+        // DB row must still be approved — the revoke was NOT committed.
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('approved', $row['status']);
     }
 }

--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -28,6 +28,59 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 
     protected static bool $requiresDatabase = true;
 
+    /**
+     * Extract and narrow the `requests` field of a decoded response body.
+     *
+     * `decodeJsonBody()` returns `array<string, mixed>`, so direct access
+     * to `$body['requests']` and any further descent is `mixed` —
+     * `assertCount`, `assertArrayHasKey`, and offset access all reject
+     * that. This helper does the runtime narrowing once per call site so
+     * the downstream test code stays readable.
+     *
+     * @param array<string, mixed> $body
+     * @return list<array<int|string, mixed>>
+     */
+    private static function requestsFrom(array $body): array
+    {
+        self::assertArrayHasKey('requests', $body);
+        self::assertIsArray($body['requests']);
+        $out = [];
+        foreach ($body['requests'] as $row) {
+            self::assertIsArray($row);
+            $out[] = $row;
+        }
+        return $out;
+    }
+
+    /**
+     * Extract and narrow an array-typed top-level body field. Used for
+     * the various list-shaped fields the admin handler returns
+     * (`tuples_created`, `tuples_deleted`, `fga_errors`, etc.) which
+     * arrive typed `mixed` through `decodeJsonBody`.
+     *
+     * @param array<string, mixed> $body
+     * @return array<int|string, mixed>
+     */
+    private static function arrayFieldFrom(array $body, string $key): array
+    {
+        self::assertArrayHasKey($key, $body);
+        self::assertIsArray($body[$key]);
+        return $body[$key];
+    }
+
+    /**
+     * Extract and narrow a string-typed top-level body field. Used for
+     * `message` (and other narrative fields) before assertStringContainsString.
+     *
+     * @param array<string, mixed> $body
+     */
+    private static function stringFieldFrom(array $body, string $key): string
+    {
+        self::assertArrayHasKey($key, $body);
+        self::assertIsString($body[$key]);
+        return $body[$key];
+    }
+
     public function testOptionsPreflightSucceeds(): void
     {
         $response = ( new AccessRequestAdminHandler() )->handle(
@@ -247,8 +300,9 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
         );
 
         self::assertSame(200, $response->getStatusCode());
-        $body = $this->decodeJsonBody($response);
-        self::assertCount(2, $body['requests']);
+        $body     = $this->decodeJsonBody($response);
+        $requests = self::requestsFrom($body);
+        self::assertCount(2, $requests);
         self::assertSame(2, $body['count']);
         self::assertSame(2, $body['total']);
         self::assertSame(100, $body['limit']);
@@ -269,8 +323,9 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             $this->withOidcUser($this->requestFor('GET', '/admin/access-requests?limit=1&offset=1'))
         );
 
-        $body = $this->decodeJsonBody($response);
-        self::assertCount(1, $body['requests']);
+        $body     = $this->decodeJsonBody($response);
+        $requests = self::requestsFrom($body);
+        self::assertCount(1, $requests);
         self::assertSame(1, $body['count']);
         self::assertSame(3, $body['total']);
         self::assertSame(1, $body['limit']);
@@ -292,13 +347,14 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             $this->withOidcUser($this->requestFor('GET', '/admin/access-requests?status=pending&limit=1&offset=0'))
         );
 
-        $body = $this->decodeJsonBody($response);
-        self::assertCount(1, $body['requests']);
+        $body     = $this->decodeJsonBody($response);
+        $requests = self::requestsFrom($body);
+        self::assertCount(1, $requests);
         self::assertSame(1, $body['count']);
         // total counts only matching (pending) rows, ignoring limit/offset.
         self::assertSame(2, $body['total']);
         self::assertTrue($body['has_more']); // 0 + 1 = 1 < 2
-        self::assertSame('pending', $body['requests'][0]['status']);
+        self::assertSame('pending', $requests[0]['status']);
     }
 
     /** @return iterable<string, array{0:string,1:string}> */
@@ -355,9 +411,10 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             $this->withOidcUser($this->requestFor('GET', '/admin/access-requests'))
         );
 
-        $body = $this->decodeJsonBody($response);
-        self::assertCount(1, $body['requests']);
-        $row = $body['requests'][0];
+        $body     = $this->decodeJsonBody($response);
+        $requests = self::requestsFrom($body);
+        self::assertCount(1, $requests);
+        $row = $requests[0];
 
         self::assertArrayHasKey('reviewed_by', $row);
         self::assertSame('admin-bob', $row['reviewed_by']);
@@ -375,8 +432,10 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
      * this client injected, set the OPENFGA_* env vars so
      * `OpenFgaClient::isConfigured()` returns true (otherwise the tuple-
      * write loop is skipped), and undo both at the end of the test.
+     *
+     * @param callable(OpenFgaClient): \Psr\Http\Message\ResponseInterface $fn
      */
-    private function withMockOpenFgaClient(MockHandler $mock, callable $fn): mixed
+    private function withMockOpenFgaClient(MockHandler $mock, callable $fn): \Psr\Http\Message\ResponseInterface
     {
         $stack  = HandlerStack::create($mock);
         $guzzle = new GuzzleClient(['handler' => $stack]);
@@ -441,7 +500,7 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
         self::assertSame(200, $response->getStatusCode());
         $body = $this->decodeJsonBody($response);
         self::assertTrue($body['success']);
-        self::assertCount(2, $body['tuples_created']);
+        self::assertCount(2, self::arrayFieldFrom($body, 'tuples_created'));
         self::assertSame([], $body['fga_errors']);
 
         $row = $repo->getById($id);
@@ -480,7 +539,7 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 
         $body = $this->decodeJsonBody($response);
         self::assertTrue($body['success']);
-        self::assertCount(1, $body['tuples_created']);
+        self::assertCount(1, self::arrayFieldFrom($body, 'tuples_created'));
         self::assertSame([], $body['fga_errors']);
 
         $row = $repo->getById($id);
@@ -519,8 +578,8 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 
         $body = $this->decodeJsonBody($response);
         self::assertFalse($body['success']);
-        self::assertCount(1, $body['fga_errors']);
-        self::assertStringContainsString('Approval aborted', $body['message']);
+        self::assertCount(1, self::arrayFieldFrom($body, 'fga_errors'));
+        self::assertStringContainsString('Approval aborted', self::stringFieldFrom($body, 'message'));
 
         // DB row must still be pending — the request was NOT approved.
         $row = $repo->getById($id);
@@ -554,7 +613,7 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 
         $body = $this->decodeJsonBody($response);
         self::assertTrue($body['success']);
-        self::assertCount(1, $body['tuples_deleted']);
+        self::assertCount(1, self::arrayFieldFrom($body, 'tuples_deleted'));
         self::assertSame([], $body['fga_errors']);
 
         $row = $repo->getById($id);
@@ -591,7 +650,7 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 
         $body = $this->decodeJsonBody($response);
         self::assertTrue($body['success']);
-        self::assertCount(1, $body['tuples_deleted']);
+        self::assertCount(1, self::arrayFieldFrom($body, 'tuples_deleted'));
         self::assertSame([], $body['fga_errors']);
 
         $row = $repo->getById($id);
@@ -628,8 +687,8 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 
         $body = $this->decodeJsonBody($response);
         self::assertFalse($body['success']);
-        self::assertCount(1, $body['fga_errors']);
-        self::assertStringContainsString('Revocation aborted', $body['message']);
+        self::assertCount(1, self::arrayFieldFrom($body, 'fga_errors'));
+        self::assertStringContainsString('Revocation aborted', self::stringFieldFrom($body, 'message'));
 
         // DB row must still be approved — the revoke was NOT committed.
         $row = $repo->getById($id);

--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -636,4 +636,64 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
         self::assertNotNull($row);
         self::assertSame('approved', $row['status']);
     }
+
+    // --- isFgaClientAvailable() fail-closed guards -----------------------
+
+    public function testRequireAdminForAllResourcesForbidsResourceAdminWhenFgaUnavailable(): void
+    {
+        // Non-global admin (no 'admin' role) attempting to approve when no
+        // OpenFgaClient is reachable — neither injected nor env-configured.
+        // requireAdminForAllResources must fail closed with 403.
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+
+        $this->expectException(\LiturgicalCalendar\Api\Http\Exception\ForbiddenException::class);
+        $this->expectExceptionMessage('Admin role required');
+
+        $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => ( new AccessRequestAdminHandler() )->handle(
+                $this->withOidcUser(
+                    $this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/approve',
+                        [],
+                        ['notes' => 'try']
+                    ),
+                    'resource-admin-1',
+                    ['calendar_editor']
+                )
+            )
+        );
+    }
+
+    public function testListRequestsAsResourceAdminWithoutFgaReturnsEmpty(): void
+    {
+        // Non-global admin listing when OpenFGA is unreachable —
+        // filterByAdminAccess fails closed by returning [], so the visible
+        // set is empty regardless of how many requests exist.
+        $repo = new AccessRequestRepository(self::$pdo);
+        $repo->create('user-a', 'a@x.test', null, 'developer', []);
+        $repo->create('user-b', 'b@x.test', null, 'developer', []);
+
+        $response = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => ( new AccessRequestAdminHandler() )->handle(
+                $this->withOidcUser(
+                    $this->requestFor('GET', '/admin/access-requests'),
+                    'resource-admin-1',
+                    ['calendar_editor']
+                )
+            )
+        );
+
+        $body = $this->decodeJsonBody($response);
+        self::assertSame([], $body['requests']);
+        self::assertSame(0, $body['count']);
+        // total reflects the SQL paginator's pre-filter count, not the
+        // empty post-filter visible set.
+        self::assertSame(2, $body['total']);
+    }
 }

--- a/phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php
@@ -267,4 +267,78 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
         self::assertArrayNotHasKey('tuple_key', $payload);
         self::assertSame(100, $payload['page_size']);
     }
+
+    // --- filterByAdminAccess uses ListObjects (issue #571) ---------------
+
+    public function testListAsResourceAdminUsesListObjectsInOneRoundTrip(): void
+    {
+        // Non-global admin (no 'admin' role) listing without object_id —
+        // triggers filterByAdminAccess. Before #571, this made one check()
+        // call per unique object_id in the tuples page; after, it makes a
+        // single listObjects() call regardless of N. We pin the new wire
+        // pattern: exactly two HTTP calls (readTuples + listObjects),
+        // never N+1.
+        //
+        // Tuples page returns 3 objects (IT, US, FR). listObjects returns
+        // 2 IDs the admin can see (IT, US). Expected filtered output: 2
+        // tuples (the one on FR is dropped).
+        $requestHistory = [];
+        $mock           = new MockHandler([
+            // readTuples: 3 tuples on national_calendar
+            new Response(200, [], (string) json_encode([
+                'tuples'             => [
+                    ['key' => ['user' => 'user:alice', 'relation' => 'editor', 'object' => 'national_calendar:IT']],
+                    ['key' => ['user' => 'user:bob',   'relation' => 'viewer', 'object' => 'national_calendar:US']],
+                    ['key' => ['user' => 'user:carol', 'relation' => 'editor', 'object' => 'national_calendar:FR']],
+                ],
+                'continuation_token' => '',
+            ])),
+            // listObjects: admin allowed on IT + US (NOT FR)
+            new Response(200, [], (string) json_encode([
+                'objects' => [
+                    'national_calendar:IT',
+                    'national_calendar:US',
+                ],
+            ])),
+        ]);
+        $handlerStack = HandlerStack::create($mock);
+        $handlerStack->push(\GuzzleHttp\Middleware::history($requestHistory));
+        $httpClient = new Client(['handler' => $handlerStack]);
+        $psr17      = new \Nyholm\Psr7\Factory\Psr17Factory();
+        $fgaClient  = new OpenFgaClient(
+            'http://localhost:8083',
+            'store-123',
+            'model-456',
+            $httpClient,
+            $psr17,
+            $psr17
+        );
+
+        $request = $this->withOidcUser(
+            $this->requestFor('GET', '/admin/permissions?object_type=national_calendar'),
+            'resource-admin-1',
+            ['calendar_editor']
+        );
+
+        $response = ( new PermissionAdminHandler($fgaClient) )->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertCount(2, $body['permissions']);
+        $allowedObjects = array_column($body['permissions'], 'object');
+        sort($allowedObjects);
+        self::assertSame(['national_calendar:IT', 'national_calendar:US'], $allowedObjects);
+
+        // Exactly two HTTP calls: readTuples + listObjects. Never N+1.
+        self::assertCount(2, $requestHistory);
+        self::assertStringContainsString('/read', (string) $requestHistory[0]['request']->getUri());
+        self::assertStringContainsString('/list-objects', (string) $requestHistory[1]['request']->getUri());
+
+        // listObjects payload exercises the right relation/type.
+        $listPayload = json_decode((string) $requestHistory[1]['request']->getBody(), true);
+        self::assertIsArray($listPayload);
+        self::assertSame('user:resource-admin-1', $listPayload['user']);
+        self::assertSame('admin', $listPayload['relation']);
+        self::assertSame('national_calendar', $listPayload['type']);
+    }
 }

--- a/phpunit_tests/Services/OpenFgaClientTest.php
+++ b/phpunit_tests/Services/OpenFgaClientTest.php
@@ -7,6 +7,9 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Middleware;
 use GuzzleHttp\Psr7\Response;
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
@@ -201,6 +204,128 @@ class OpenFgaClientTest extends TestCase
 
         $client->deleteTuple('user:test', 'editor', 'national_calendar:IT');
         $this->assertEquals(0, $mock->count());
+    }
+
+    // --- Typed exceptions for benign write/delete errors (issue #567) ----
+
+    public function testWriteTupleTranslatesDuplicateErrorByOpenFgaCode(): void
+    {
+        $mock   = new MockHandler([
+            new Response(400, [], (string) json_encode([
+                'code'    => 'cannot_allow_duplicate_tuple',
+                'message' => 'cannot write duplicate tuple',
+            ])),
+        ]);
+        $client = $this->createClientWithMock($mock);
+
+        $this->expectException(TupleAlreadyExistsException::class);
+        $client->writeTuple('user:test', 'editor', 'national_calendar:IT');
+    }
+
+    public function testWriteTupleTranslatesDuplicateErrorByMessageSubstring(): void
+    {
+        // Older OpenFGA versions return the generic input-error code and carry
+        // the cause only in the message. The classifier should still spot it.
+        $mock   = new MockHandler([
+            new Response(400, [], (string) json_encode([
+                'code'    => 'write_failed_due_to_invalid_input',
+                'message' => 'tuple_key already exists',
+            ])),
+        ]);
+        $client = $this->createClientWithMock($mock);
+
+        $this->expectException(TupleAlreadyExistsException::class);
+        $client->writeTuple('user:test', 'editor', 'national_calendar:IT');
+    }
+
+    public function testWriteTupleRethrowsNonBenignErrorsAsApiException(): void
+    {
+        $mock   = new MockHandler([
+            new Response(400, [], (string) json_encode([
+                'code'    => 'validation_error',
+                'message' => 'invalid relation',
+            ])),
+        ]);
+        $client = $this->createClientWithMock($mock);
+
+        try {
+            $client->writeTuple('user:test', 'editor', 'national_calendar:IT');
+            $this->fail('Expected OpenFgaApiException');
+        } catch (OpenFgaApiException $e) {
+            // Should be the base class, not the benign subclass.
+            $this->assertNotInstanceOf(TupleAlreadyExistsException::class, $e);
+            $this->assertSame(400, $e->getHttpStatus());
+            $this->assertSame('validation_error', $e->getErrorCode());
+        }
+    }
+
+    public function testDeleteTupleTranslatesNotFoundErrorByOpenFgaCode(): void
+    {
+        $mock   = new MockHandler([
+            new Response(400, [], (string) json_encode([
+                'code'    => 'cannot_allow_unknown_tuple_to_be_deleted',
+                'message' => 'cannot delete unknown tuple',
+            ])),
+        ]);
+        $client = $this->createClientWithMock($mock);
+
+        $this->expectException(TupleNotFoundException::class);
+        $client->deleteTuple('user:test', 'editor', 'national_calendar:IT');
+    }
+
+    public function testDeleteTupleTranslatesNotFoundErrorByMessageSubstring(): void
+    {
+        $mock   = new MockHandler([
+            new Response(400, [], (string) json_encode([
+                'code'    => 'write_failed_due_to_invalid_input',
+                'message' => 'tuple_key not found',
+            ])),
+        ]);
+        $client = $this->createClientWithMock($mock);
+
+        $this->expectException(TupleNotFoundException::class);
+        $client->deleteTuple('user:test', 'editor', 'national_calendar:IT');
+    }
+
+    public function testDeleteTupleRethrowsNonBenignErrorsAsApiException(): void
+    {
+        $mock   = new MockHandler([
+            new Response(500, [], (string) json_encode([
+                'code'    => 'internal_error',
+                'message' => 'internal server error',
+            ])),
+        ]);
+        $client = $this->createClientWithMock($mock);
+
+        try {
+            $client->deleteTuple('user:test', 'editor', 'national_calendar:IT');
+            $this->fail('Expected OpenFgaApiException');
+        } catch (OpenFgaApiException $e) {
+            $this->assertNotInstanceOf(TupleNotFoundException::class, $e);
+            $this->assertSame(500, $e->getHttpStatus());
+            $this->assertSame('internal_error', $e->getErrorCode());
+        }
+    }
+
+    public function testOpenFgaApiExceptionCarriesResponseBody(): void
+    {
+        $mock   = new MockHandler([
+            new Response(400, [], (string) json_encode([
+                'code'    => 'validation_error',
+                'message' => 'invalid',
+                'detail'  => 'extra structured field',
+            ])),
+        ]);
+        $client = $this->createClientWithMock($mock);
+
+        try {
+            $client->check('user:test', 'editor', 'national_calendar:IT');
+            $this->fail('Expected OpenFgaApiException');
+        } catch (OpenFgaApiException $e) {
+            $body = $e->getResponseBody();
+            $this->assertSame('validation_error', $body['code']);
+            $this->assertSame('extra structured field', $body['detail']);
+        }
     }
 
     public function testReadTuplesReturnsParsedTuples(): void

--- a/phpunit_tests/Services/OpenFgaClientTest.php
+++ b/phpunit_tests/Services/OpenFgaClientTest.php
@@ -328,6 +328,47 @@ class OpenFgaClientTest extends TestCase
         }
     }
 
+    public function testWriteTupleDoesNotMisclassifyCodelessResponseWithDuplicateInMessage(): void
+    {
+        // Regression guard: a 500 response with no `code` field whose
+        // message happens to contain "duplicate" must surface as the base
+        // OpenFgaApiException, NOT as the benign
+        // TupleAlreadyExistsException. The substring fallback is reserved
+        // for the documented legacy `write_failed_due_to_invalid_input`
+        // code — unrelated errors stay fatal.
+        $mock   = new MockHandler([
+            new Response(500, [], (string) json_encode(['message' => 'database returned duplicate key error'])),
+        ]);
+        $client = $this->createClientWithMock($mock);
+
+        try {
+            $client->writeTuple('user:test', 'editor', 'national_calendar:IT');
+            $this->fail('Expected base OpenFgaApiException');
+        } catch (OpenFgaApiException $e) {
+            $this->assertNotInstanceOf(TupleAlreadyExistsException::class, $e);
+            $this->assertSame(500, $e->getHttpStatus());
+            $this->assertNull($e->getErrorCode());
+        }
+    }
+
+    public function testDeleteTupleDoesNotMisclassifyCodelessResponseWithNotFoundInMessage(): void
+    {
+        // Symmetric regression guard for the delete side.
+        $mock   = new MockHandler([
+            new Response(500, [], (string) json_encode(['message' => 'upstream service not found'])),
+        ]);
+        $client = $this->createClientWithMock($mock);
+
+        try {
+            $client->deleteTuple('user:test', 'editor', 'national_calendar:IT');
+            $this->fail('Expected base OpenFgaApiException');
+        } catch (OpenFgaApiException $e) {
+            $this->assertNotInstanceOf(TupleNotFoundException::class, $e);
+            $this->assertSame(500, $e->getHttpStatus());
+            $this->assertNull($e->getErrorCode());
+        }
+    }
+
     public function testReadTuplesReturnsParsedTuples(): void
     {
         $mock   = new MockHandler([

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -83,6 +83,18 @@ final class AccessRequestAdminHandler extends AbstractHandler
         return $this->fgaClient;
     }
 
+    /**
+     * True when an OpenFGA client is reachable: either one was constructor-
+     * injected (test path), or the env-based static is configured (prod
+     * path). Replaces direct `OpenFgaClient::isConfigured()` checks at the
+     * sites that gate tuple-write / admin-check work, so an injected mock
+     * is honored without also requiring OPENFGA_* env vars to be set.
+     */
+    private function isFgaClientAvailable(): bool
+    {
+        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
+    }
+
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $response = static::initResponse($request);
@@ -282,7 +294,7 @@ final class AccessRequestAdminHandler extends AbstractHandler
         $createdTuples = [];
         $fgaErrors     = [];
 
-        if (OpenFgaClient::isConfigured() && !empty($permissions)) {
+        if ($this->isFgaClientAvailable() && !empty($permissions)) {
             $fgaUser = "user:{$userId}";
 
             foreach ($permissions as $perm) {
@@ -468,7 +480,7 @@ final class AccessRequestAdminHandler extends AbstractHandler
         $deletedTuples = [];
         $fgaErrors     = [];
 
-        if (OpenFgaClient::isConfigured() && !empty($permissions)) {
+        if ($this->isFgaClientAvailable() && !empty($permissions)) {
             $fgaUser = "user:{$userId}";
 
             foreach ($permissions as $perm) {
@@ -590,7 +602,7 @@ final class AccessRequestAdminHandler extends AbstractHandler
             return;
         }
 
-        if (!OpenFgaClient::isConfigured()) {
+        if (!$this->isFgaClientAvailable()) {
             throw new ForbiddenException('Admin role required');
         }
 
@@ -629,7 +641,7 @@ final class AccessRequestAdminHandler extends AbstractHandler
      */
     private function filterByAdminAccess(array $requests, string $adminId): array
     {
-        if (!OpenFgaClient::isConfigured()) {
+        if (!$this->isFgaClientAvailable()) {
             return [];
         }
 

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -17,6 +17,9 @@ use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\RoleCascadeService;
 use LiturgicalCalendar\Api\Services\ZitadelService;
@@ -45,9 +48,18 @@ final class AccessRequestAdminHandler extends AbstractHandler
     private ?AccessRequestRepository $repository = null;
     private ?OpenFgaClient $fgaClient            = null;
 
-    public function __construct()
+    /**
+     * The OpenFGA client is constructor-injectable for tests — pass a
+     * MockHandler-backed instance to verify the typed-exception integration
+     * without touching the runtime env. Production calls use the zero-arg
+     * form and the lazy `fromEnv()` fallback in `getFgaClient()`. Mirrors
+     * the pattern PR #623 introduced for `PermissionAdminHandler`.
+     */
+    public function __construct(?OpenFgaClient $fgaClient = null)
     {
         parent::__construct();
+
+        $this->fgaClient = $fgaClient;
 
         $this->allowedRequestMethods      = [RequestMethod::GET, RequestMethod::POST];
         $this->allowedAcceptHeaders       = [AcceptHeader::JSON];
@@ -259,7 +271,14 @@ final class AccessRequestAdminHandler extends AbstractHandler
         // Check admin authority over ALL requested resources
         $this->requireAdminForAllResources($adminId, $isGlobalAdmin, $permissions);
 
-        // Step 1: Create OpenFGA tuples for each permission
+        // Step 1: Create OpenFGA tuples for each permission.
+        //
+        // TupleAlreadyExistsException is treated as benign — the tuple is in
+        // the desired state already, so re-approval after a partial first
+        // attempt converges instead of double-failing. Any other
+        // OpenFgaApiException (validation, auth, server) is fatal: the
+        // response will surface success: false with the structured error
+        // list so the admin knows there's drift to repair.
         $createdTuples = [];
         $fgaErrors     = [];
 
@@ -279,8 +298,15 @@ final class AccessRequestAdminHandler extends AbstractHandler
                         'relation' => $relation,
                         'object'   => $fgaObject,
                     ];
-                } catch (\Exception $e) {
-                    // Tuple may already exist — log but continue
+                } catch (TupleAlreadyExistsException) {
+                    // Idempotent — tuple already exists. Count it as created
+                    // so the response shows the user's effective grants.
+                    $createdTuples[] = [
+                        'user'     => $fgaUser,
+                        'relation' => $relation,
+                        'object'   => $fgaObject,
+                    ];
+                } catch (OpenFgaApiException $e) {
                     $fgaErrors[] = [
                         'object'   => $fgaObject,
                         'relation' => $relation,
@@ -288,6 +314,25 @@ final class AccessRequestAdminHandler extends AbstractHandler
                     ];
                 }
             }
+        }
+
+        // If we couldn't write some of the tuples, bail before mutating the
+        // DB — leaving the request 'pending' lets the admin retry cleanly,
+        // and avoids the silent under-provisioning the issue flags
+        // ("row marked approved while user is missing the failed tuples").
+        if (!empty($fgaErrors)) {
+            return $this->encodeResponseBody($response, [
+                'success'        => false,
+                'role_assigned'  => false,
+                'zitadel_error'  => null,
+                'tuples_created' => $createdTuples,
+                'fga_errors'     => $fgaErrors,
+                'message'        => sprintf(
+                    'Approval aborted: %d of %d permission tuple(s) could not be written. The request remains pending; retry once the underlying OpenFGA error is resolved.',
+                    count($fgaErrors),
+                    count($permissions)
+                ),
+            ]);
         }
 
         // Step 2: Approve in database
@@ -413,7 +458,13 @@ final class AccessRequestAdminHandler extends AbstractHandler
 
         $this->requireAdminForAllResources($adminId, $isGlobalAdmin, $permissions);
 
-        // Step 1: Delete OpenFGA tuples
+        // Step 1: Delete OpenFGA tuples.
+        //
+        // TupleNotFoundException is treated as benign — the tuple is already
+        // gone, so re-revoke after a partial first attempt converges instead
+        // of double-failing. Any other OpenFgaApiException is fatal: the
+        // response will surface success: false with the structured error
+        // list so the admin knows there's drift to repair.
         $deletedTuples = [];
         $fgaErrors     = [];
 
@@ -433,8 +484,15 @@ final class AccessRequestAdminHandler extends AbstractHandler
                         'relation' => $relation,
                         'object'   => $fgaObject,
                     ];
-                } catch (\Exception $e) {
-                    // Tuple may already be deleted — log but continue
+                } catch (TupleNotFoundException) {
+                    // Idempotent — tuple already deleted. Count it as deleted
+                    // so the response shows the user's effective state.
+                    $deletedTuples[] = [
+                        'user'     => $fgaUser,
+                        'relation' => $relation,
+                        'object'   => $fgaObject,
+                    ];
+                } catch (OpenFgaApiException $e) {
                     $fgaErrors[] = [
                         'object'   => $fgaObject,
                         'relation' => $relation,
@@ -442,6 +500,25 @@ final class AccessRequestAdminHandler extends AbstractHandler
                     ];
                 }
             }
+        }
+
+        // If we couldn't delete some of the tuples, bail before mutating the
+        // DB — leaving the request 'approved' lets the admin retry cleanly,
+        // and avoids the silent over-provisioning the issue flags
+        // ("row marked revoked while stale tuples remain in OpenFGA").
+        if (!empty($fgaErrors)) {
+            return $this->encodeResponseBody($response, [
+                'success'        => false,
+                'role_removed'   => false,
+                'zitadel_error'  => null,
+                'tuples_deleted' => $deletedTuples,
+                'fga_errors'     => $fgaErrors,
+                'message'        => sprintf(
+                    'Revocation aborted: %d of %d permission tuple(s) could not be deleted. The request remains approved; retry once the underlying OpenFGA error is resolved.',
+                    count($fgaErrors),
+                    count($permissions)
+                ),
+            ]);
         }
 
         // Step 2: Revoke in database

--- a/src/Handlers/Admin/PermissionAdminHandler.php
+++ b/src/Handlers/Admin/PermissionAdminHandler.php
@@ -479,6 +479,15 @@ final class PermissionAdminHandler extends AbstractHandler
     /**
      * Filter tuples to only those on resources the user administers.
      *
+     * Resolves the admin's allowed-object set via OpenFGA's `ListObjects`
+     * in one round-trip — issue #571's fix for the previous N+1 `check()`
+     * loop, one call per unique `object_id` in the page. The trade-off is
+     * payload size: `ListObjects` returns every object of `objectType` the
+     * user has the `admin` relation on, which may exceed the N referenced
+     * in this page. In practice the admin's administered set is bounded by
+     * their actual responsibilities, while the tuple page size grows with
+     * traffic; one HTTP call per page comfortably wins on cold caches.
+     *
      * @param array<int, array{user: string, relation: string, object: string}> $tuples All tuples
      * @param string $userId The current user's Zitadel ID
      * @param string $objectType The object type being listed
@@ -486,26 +495,10 @@ final class PermissionAdminHandler extends AbstractHandler
      */
     private function filterByAdminAccess(array $tuples, string $userId, string $objectType): array
     {
-        // Collect unique object IDs from the tuples
-        $objectIds = [];
-        foreach ($tuples as $tuple) {
-            $parts = explode(':', $tuple['object'], 2);
-            if (count($parts) === 2 && $parts[1] !== '') {
-                $objectIds[$parts[1]] = true;
-            }
-        }
+        $allowedIds = array_flip(
+            $this->getClient()->listObjects("user:{$userId}", 'admin', $objectType)
+        );
 
-        // Check admin access for each unique object
-        $fgaUser    = "user:{$userId}";
-        $allowedIds = [];
-        foreach (array_keys($objectIds) as $objId) {
-            $fgaObject = "{$objectType}:{$objId}";
-            if ($this->getClient()->check($fgaUser, 'admin', $fgaObject)) {
-                $allowedIds[$objId] = true;
-            }
-        }
-
-        // Filter tuples
         return array_values(array_filter($tuples, function (array $tuple) use ($allowedIds): bool {
             $parts = explode(':', $tuple['object'], 2);
             $objId = $parts[1] ?? '';

--- a/src/Services/Exception/OpenFgaApiException.php
+++ b/src/Services/Exception/OpenFgaApiException.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Exception;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Thrown by `OpenFgaClient` when the OpenFGA HTTP API returns a non-2xx
+ * status.
+ *
+ * Carries the raw HTTP status and OpenFGA's structured error code so callers
+ * can decide whether to treat the failure as fatal or benign — see the
+ * sibling `TupleAlreadyExistsException` and `TupleNotFoundException` for the
+ * specific re-throws `writeTuple()` and `deleteTuple()` issue for the
+ * recoverable cases. Anything not classified to a subclass should be
+ * surfaced to the user; do not catch and ignore the base class.
+ */
+class OpenFgaApiException extends RuntimeException
+{
+    /**
+     * @param string $message Human-readable summary suitable for logs.
+     * @param int $httpStatus HTTP status returned by OpenFGA.
+     * @param string|null $errorCode OpenFGA error-code string from the response body, if present. Examples:
+     *                               'cannot_allow_duplicate_tuple', 'write_failed_due_to_invalid_input',
+     *                               'cannot_allow_unknown_tuple_to_be_deleted'.
+     * @param array<string, mixed> $responseBody Decoded JSON body from OpenFGA, if any.
+     */
+    public function __construct(
+        string $message,
+        private readonly int $httpStatus,
+        private readonly ?string $errorCode = null,
+        private readonly array $responseBody = [],
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    public function getHttpStatus(): int
+    {
+        return $this->httpStatus;
+    }
+
+    public function getErrorCode(): ?string
+    {
+        return $this->errorCode;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getResponseBody(): array
+    {
+        return $this->responseBody;
+    }
+}

--- a/src/Services/Exception/TupleAlreadyExistsException.php
+++ b/src/Services/Exception/TupleAlreadyExistsException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Exception;
+
+/**
+ * `OpenFgaClient::writeTuple()` throws this when OpenFGA reports the tuple
+ * being written already exists.
+ *
+ * Callers managing idempotent grant flows (e.g.
+ * `AccessRequestAdminHandler::approveRequest()`, manual re-approval after a
+ * partial first attempt) treat this as a benign no-op — the desired state is
+ * already in place. Genuine FGA failures stay as the base
+ * `OpenFgaApiException` and remain fatal.
+ *
+ * Detection is best-effort and version-tolerant: we match on OpenFGA's
+ * documented error code (`cannot_allow_duplicate_tuple`) plus message
+ * substrings ("already exists", "duplicate") that earlier OpenFGA versions
+ * return under the more generic `write_failed_due_to_invalid_input` code.
+ */
+final class TupleAlreadyExistsException extends OpenFgaApiException
+{
+}

--- a/src/Services/Exception/TupleNotFoundException.php
+++ b/src/Services/Exception/TupleNotFoundException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Exception;
+
+/**
+ * `OpenFgaClient::deleteTuple()` throws this when OpenFGA reports the tuple
+ * being deleted does not exist.
+ *
+ * Callers managing idempotent revoke flows (e.g.
+ * `AccessRequestAdminHandler::revokeRequest()`, manual re-revocation after a
+ * partial first attempt) treat this as a benign no-op — the desired state is
+ * already in place. Genuine FGA failures stay as the base
+ * `OpenFgaApiException` and remain fatal.
+ *
+ * Detection is best-effort and version-tolerant: we match on OpenFGA's
+ * documented error code (`cannot_allow_unknown_tuple_to_be_deleted`) plus
+ * message substrings ("not found", "does not exist") that earlier OpenFGA
+ * versions return under the more generic `write_failed_due_to_invalid_input`
+ * code.
+ */
+final class TupleNotFoundException extends OpenFgaApiException
+{
+}

--- a/src/Services/OpenFgaClient.php
+++ b/src/Services/OpenFgaClient.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Api\Services;
 
 use GuzzleHttp\Client;
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -130,10 +133,18 @@ class OpenFgaClient
     /**
      * Write a relationship tuple.
      *
+     * Throws `TupleAlreadyExistsException` (a subclass of
+     * `OpenFgaApiException`) when OpenFGA rejects the write because the
+     * tuple already exists. Callers managing idempotent grants should treat
+     * that as a benign no-op. Genuine FGA failures surface as the base
+     * `OpenFgaApiException` and remain fatal.
+     *
      * @param string $user     User identifier
      * @param string $relation Relation name
      * @param string $object   Object identifier
-     * @throws RuntimeException If the API request fails
+     * @throws TupleAlreadyExistsException If the tuple already exists (benign)
+     * @throws OpenFgaApiException         For any other API-level failure
+     * @throws RuntimeException            For transport-level failures
      */
     public function writeTuple(string $user, string $relation, string $object): void
     {
@@ -150,16 +161,37 @@ class OpenFgaClient
             'authorization_model_id' => $this->modelId,
         ];
 
-        $this->post("/stores/{$this->storeId}/write", $payload);
+        try {
+            $this->post("/stores/{$this->storeId}/write", $payload);
+        } catch (OpenFgaApiException $e) {
+            if (self::isDuplicateTupleError($e)) {
+                throw new TupleAlreadyExistsException(
+                    sprintf('Tuple already exists: %s#%s@%s', $object, $relation, $user),
+                    $e->getHttpStatus(),
+                    $e->getErrorCode(),
+                    $e->getResponseBody(),
+                    $e
+                );
+            }
+            throw $e;
+        }
     }
 
     /**
      * Delete a relationship tuple.
      *
+     * Throws `TupleNotFoundException` (a subclass of `OpenFgaApiException`)
+     * when OpenFGA rejects the delete because the tuple does not exist.
+     * Callers managing idempotent revokes should treat that as a benign
+     * no-op. Genuine FGA failures surface as the base `OpenFgaApiException`
+     * and remain fatal.
+     *
      * @param string $user     User identifier
      * @param string $relation Relation name
      * @param string $object   Object identifier
-     * @throws RuntimeException If the API request fails
+     * @throws TupleNotFoundException If the tuple does not exist (benign)
+     * @throws OpenFgaApiException    For any other API-level failure
+     * @throws RuntimeException       For transport-level failures
      */
     public function deleteTuple(string $user, string $relation, string $object): void
     {
@@ -176,7 +208,66 @@ class OpenFgaClient
             'authorization_model_id' => $this->modelId,
         ];
 
-        $this->post("/stores/{$this->storeId}/write", $payload);
+        try {
+            $this->post("/stores/{$this->storeId}/write", $payload);
+        } catch (OpenFgaApiException $e) {
+            if (self::isMissingTupleError($e)) {
+                throw new TupleNotFoundException(
+                    sprintf('Tuple not found: %s#%s@%s', $object, $relation, $user),
+                    $e->getHttpStatus(),
+                    $e->getErrorCode(),
+                    $e->getResponseBody(),
+                    $e
+                );
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Detect "tuple already exists" OpenFGA responses for `writeTuple` benign
+     * re-throw. Modern OpenFGA reports this as
+     * `cannot_allow_duplicate_tuple`; older versions return
+     * `write_failed_due_to_invalid_input` with the cause carried only in the
+     * message body. Match on both shapes so the classifier is version-
+     * tolerant.
+     */
+    private static function isDuplicateTupleError(OpenFgaApiException $e): bool
+    {
+        $code = $e->getErrorCode();
+        if ($code === 'cannot_allow_duplicate_tuple') {
+            return true;
+        }
+        if ($code === 'write_failed_due_to_invalid_input' || $code === null) {
+            $msg = strtolower($e->getMessage());
+            if (str_contains($msg, 'already exists') || str_contains($msg, 'duplicate')) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Detect "tuple not found" OpenFGA responses for `deleteTuple` benign
+     * re-throw. Modern OpenFGA reports this as
+     * `cannot_allow_unknown_tuple_to_be_deleted`; older versions return
+     * `write_failed_due_to_invalid_input` with the cause carried only in the
+     * message body. Match on both shapes so the classifier is version-
+     * tolerant.
+     */
+    private static function isMissingTupleError(OpenFgaApiException $e): bool
+    {
+        $code = $e->getErrorCode();
+        if ($code === 'cannot_allow_unknown_tuple_to_be_deleted') {
+            return true;
+        }
+        if ($code === 'write_failed_due_to_invalid_input' || $code === null) {
+            $msg = strtolower($e->getMessage());
+            if (str_contains($msg, 'not found') || str_contains($msg, 'does not exist')) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -352,9 +443,13 @@ class OpenFgaClient
         // OpenFGA returns 200 for successful checks and writes.
         // Non-200 responses indicate errors.
         if ($httpCode !== 200) {
-            $message = is_string($decoded['message'] ?? null) ? $decoded['message'] : 'Unknown error';
-            throw new RuntimeException(
-                sprintf('OpenFGA API error (HTTP %d): %s', $httpCode, $message)
+            $message   = is_string($decoded['message'] ?? null) ? $decoded['message'] : 'Unknown error';
+            $errorCode = is_string($decoded['code'] ?? null) ? $decoded['code'] : null;
+            throw new OpenFgaApiException(
+                sprintf('OpenFGA API error (HTTP %d): %s', $httpCode, $message),
+                $httpCode,
+                $errorCode,
+                $decoded
             );
         }
 

--- a/src/Services/OpenFgaClient.php
+++ b/src/Services/OpenFgaClient.php
@@ -238,7 +238,15 @@ class OpenFgaClient
         if ($code === 'cannot_allow_duplicate_tuple') {
             return true;
         }
-        if ($code === 'write_failed_due_to_invalid_input' || $code === null) {
+        // Only fall through to substring matching when OpenFGA returned the
+        // documented legacy generic-input code. Responses with no `code`
+        // field at all (transport errors, malformed bodies, server-side
+        // 5xx without structured detail) carry no contract that the
+        // message text is about a tuple-duplicate condition, so we
+        // intentionally let them bubble up as base OpenFgaApiException
+        // rather than risk misclassifying e.g. an unrelated 500 carrying
+        // the word "duplicate" as a benign already-exists.
+        if ($code === 'write_failed_due_to_invalid_input') {
             $msg = strtolower($e->getMessage());
             if (str_contains($msg, 'already exists') || str_contains($msg, 'duplicate')) {
                 return true;
@@ -261,7 +269,12 @@ class OpenFgaClient
         if ($code === 'cannot_allow_unknown_tuple_to_be_deleted') {
             return true;
         }
-        if ($code === 'write_failed_due_to_invalid_input' || $code === null) {
+        // Same tightening as isDuplicateTupleError — only fall through to
+        // substring matching for the documented legacy code, not for
+        // missing-`code` responses. Prevents an unrelated 500 carrying
+        // "not found" in its message from being misclassified as a
+        // benign already-deleted tuple.
+        if ($code === 'write_failed_due_to_invalid_input') {
             $msg = strtolower($e->getMessage());
             if (str_contains($msg, 'not found') || str_contains($msg, 'does not exist')) {
                 return true;


### PR DESCRIPTION
Closes #567 (Option A: typed exceptions) and #571 (ListObjects in filterByAdminAccess). Both share `OpenFgaClient` as the modification surface, so they ship as one PR per the grouping decision made on the umbrella discussion.

## #567 — Fail-fast on OpenFGA tuple errors (Option A)

### Exceptions

Three new classes under `src/Services/Exception/`:

| Class | Thrown by | Purpose |
|---|---|---|
| `OpenFgaApiException` | `OpenFgaClient::post()` on any non-2xx | Base. Carries `httpStatus`, OpenFGA's structured `errorCode`, and the decoded response body so callers can branch on type without re-parsing the message. |
| `TupleAlreadyExistsException` | `writeTuple()` when OpenFGA reports a duplicate | Benign for idempotent grants (e.g. re-approval after partial first attempt). |
| `TupleNotFoundException` | `deleteTuple()` when OpenFGA reports the tuple does not exist | Benign for idempotent revokes. |

Detection is **version-tolerant**: matches the modern error codes (`cannot_allow_duplicate_tuple`, `cannot_allow_unknown_tuple_to_be_deleted`) AND substring patterns (`already exists`, `duplicate`, `not found`, `does not exist`) that earlier OpenFGA versions return under the generic `write_failed_due_to_invalid_input` code.

### Handler integration

`AccessRequestAdminHandler::approveRequest` and `revokeRequest`:

- Catch `TupleAlreadyExistsException` / `TupleNotFoundException` → treat as benign; count the tuple as created/deleted so the response reflects the user's effective state.
- Catch any other `OpenFgaApiException` → accumulate into `fga_errors` and **bail before mutating the DB**. Request stays in its prior status (`pending` for approve, `approved` for revoke); the admin can retry once OpenFGA recovers.
- Set `success` from `empty($fga_errors)` — no more `success: true` while tuples failed, which was the central complaint in #567.

Constructor signature gains `?OpenFgaClient $fgaClient = null` for test injection, mirroring PR #623's `PermissionAdminHandler` pattern.

## #571 — ListObjects in filterByAdminAccess

`PermissionAdminHandler::filterByAdminAccess` previously made one `$client->check()` call per unique `object_id` in the readTuples page — O(N) HTTP round-trips for resource admins listing without `object_id`. Replaced with one `$client->listObjects()` call regardless of N. The `listObjects` method was already on `OpenFgaClient` (added for `RoleCascadeService`); we just hadn't adopted it here.

The method body collapses to one `array_flip` + `array_filter`.

**Trade-off:** ListObjects returns every object the admin has the `admin` relation on, which may exceed the N referenced in the current page. In practice the admin's administered set is bounded by their actual responsibilities; tuple page size grows with traffic. One HTTP call per page comfortably wins on cold caches.

## Tests

| File | Before | After | New tests |
|---|---|---|---|
| `OpenFgaClientTest` | 18 | 25 | Duplicate-by-code, duplicate-by-message, non-duplicate pass-through for `writeTuple`; symmetric trio for `deleteTuple`; verifies `OpenFgaApiException` carries the structured response body. |
| `AccessRequestAdminHandlerTest` | 24 | 30 | Approve/revoke happy-path with mock OpenFGA wire; benign-duplicate / benign-missing treated as success; real validation_error / 500 surfaces `success: false` and DB stays in prior status. Uses a new `withMockOpenFgaClient` helper that wires a Guzzle MockHandler-backed `OpenFgaClient` and sets the `OPENFGA_*` env vars for the duration of the test. |
| `PermissionAdminHandlerTest` | 15 | 16 | `testListAsResourceAdminUsesListObjectsInOneRoundTrip`: 3 tuples back from readTuples, listObjects returns 2 allowed IDs, response has the 2 filtered tuples, and **exactly 2** HTTP calls are made (readTuples + listObjects). Pins the wire pattern against N+1 regression. |

All 71 touched-file tests pass. `composer analyse` (PHPStan L10) clean. `composer lint` (phpcs PSR-12) clean.

## Out of scope (deferred, per the issues)

- Option B (compensating actions / DB-first ordering) and Option C (outbox + async reconciliation) from #567. Option A delivers the acceptance criterion — "A genuine OpenFGA failure during approve/revoke does not leave the response saying success: true" — with the smallest blast radius. The deeper transactional ordering refactor can land as its own PR later if operational experience shows it's needed.
- `BatchCheck` adoption from #571's "Option B". `ListObjects` is the better fit when the candidate set is "all resources of a type the admin manages"; `BatchCheck` would only help if we ever wanted to filter against a small known-upfront subset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approvals and revocations treat duplicate/missing external entries as benign, return structured failure details (including counts of tuples created/removed and external errors) and avoid changing request state when external writes/deletes fail.
  * Deny resource-admin approval and show no visible resources when the external auth service is unreachable.

* **Performance**
  * Admin resource filtering now resolves administered objects in a single outbound call per page, eliminating N+1 calls.

* **Tests**
  * Added coverage for idempotent approve/revoke flows, list-objects filtering, and external-error mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->