### PR TITLE
docs(deploy): .env.production.example for CatholicOS umbrella switch (#597)

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -74,8 +74,12 @@ OPENFGA_API_TOKEN=<OOB_DELIVERED>
 # 2. JWKS — what OidcAuthMiddleware uses to validate JWTs.
 #    curl -s https://auth.catholicdigitalcommons.org/oauth/v2/keys | jq
 
-# 3. OpenFGA store ping (replace <store-id> from handoff doc; needs the
-#    OOB-delivered key). 200 with the store body confirms auth works.
+# 3. OpenFGA store ping. The curl below uses shell expansion of
+#    $OPENFGA_API_TOKEN — either export it first
+#    (`export OPENFGA_API_TOKEN=<OOB-delivered-key>`) or substitute the
+#    literal value inline in the Authorization header. Also replace
+#    <store-id> with the value from the handoff doc. 200 with the store
+#    body confirms auth works.
 #    curl -s -H "Authorization: Bearer $OPENFGA_API_TOKEN" \
 #         https://authz.catholicdigitalcommons.org/stores/<store-id> | jq
 

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,84 @@
+##
+# Production environment template — point at the Catholic OS umbrella's shared
+# Zitadel + OpenFGA stack (issue #597).
+#
+# Usage:
+#   1. Copy this file to .env.production.
+#   2. Fill in <FROM_HANDOFF_DOC> values from
+#      https://github.com/CatholicOS/cdcf-infra/blob/main/auth/handoffs/liturgicalcalendar.md
+#   3. Receive OPENFGA_API_TOKEN out-of-band through an encrypted channel —
+#      it is NOT in the handoff doc and must NEVER be committed.
+#   4. Optionally generate ZITADEL_MACHINE_TOKEN in the umbrella Zitadel
+#      console under LiturgicalCalendar Org → Users → create machine user →
+#      Personal Access Tokens. Only needed if LitCal makes outbound Zitadel
+#      Management API calls (currently it does not, so leave unset).
+#
+# This file is a PRODUCTION OVERLAY. Settings not listed here inherit from
+# .env.example. Anything sensitive (tokens, secrets, hashes) lives only in
+# .env.production on the deployed host and is NEVER committed.
+##
+
+APP_ENV=production
+
+##
+# Zitadel — identity (umbrella production)
+##
+ZITADEL_ISSUER=https://auth.catholicdigitalcommons.org
+ZITADEL_PROJECT_ID=<FROM_HANDOFF_DOC>
+ZITADEL_CLIENT_ID=<FROM_HANDOFF_DOC>
+
+# Optional. Personal Access Token for the LiturgicalCalendar Org machine user.
+# Only required if LitCal makes outbound Zitadel Management API calls (currently
+# limited to RoleCascadeService when revoking roles end-to-end; if that flow is
+# not exercised in prod, leave unset and avoid generating the token).
+# ZITADEL_MACHINE_TOKEN=<OOB_DELIVERED>
+
+# Not used in the umbrella deployment — Zitadel is reached directly via
+# ZITADEL_ISSUER, not via a docker-network internal hostname.
+# ZITADEL_INTERNAL_URL=
+
+##
+# OpenFGA — authorization (umbrella production)
+##
+OPENFGA_API_URL=https://authz.catholicdigitalcommons.org
+OPENFGA_STORE_ID=<FROM_HANDOFF_DOC>
+OPENFGA_MODEL_ID=<FROM_HANDOFF_DOC>
+
+# The umbrella-wide bearer token for the OpenFGA HTTP API. Delivered through
+# an encrypted channel separate from the handoff doc. NEVER commit. The
+# umbrella refers to this as OPENFGA_PRESHARED_KEY; our code reads it as
+# OPENFGA_API_TOKEN.
+OPENFGA_API_TOKEN=<OOB_DELIVERED>
+
+##
+# Database, JWT, CORS, etc.
+#
+# These are NOT umbrella-controlled. Configure them per the rest of
+# .env.example and your hosting setup. Examples of common production-only
+# overrides:
+#   - JWT_SECRET                  (32+ chars, generated per-environment)
+#   - ADMIN_PASSWORD_HASH         (Argon2id, generated locally — required in prod)
+#   - CORS_ALLOWED_ORIGINS        (comma-separated; do NOT use '*' with cookies)
+#   - API_BASE_PATH               (e.g. /api/v5)
+#   - DB_HOST / DB_PORT / DB_NAME / DB_USER / DB_PASSWORD
+##
+
+##
+# Post-deploy verification (issue #597). Run these from the deployed host to
+# confirm the umbrella switch landed correctly.
+##
+
+# 1. OIDC discovery — anyone can hit this; confirms the issuer is reachable.
+#    curl -s https://auth.catholicdigitalcommons.org/.well-known/openid-configuration | jq
+
+# 2. JWKS — what OidcAuthMiddleware uses to validate JWTs.
+#    curl -s https://auth.catholicdigitalcommons.org/oauth/v2/keys | jq
+
+# 3. OpenFGA store ping (replace <store-id> from handoff doc; needs the
+#    OOB-delivered key). 200 with the store body confirms auth works.
+#    curl -s -H "Authorization: Bearer $OPENFGA_API_TOKEN" \
+#         https://authz.catholicdigitalcommons.org/stores/<store-id> | jq
+
+# 4. End-to-end: hit any authenticated LitCal endpoint with a fresh JWT and
+#    verify the OidcAuthMiddleware validates it against the umbrella's JWKS,
+#    and PermissionAdminHandler honours OpenFGA's tuples for the user.

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ vendor/*
 .env
 .env.*
 !.env.example
+!.env.production.example
 phpstan.neon
 !phpstan.neon.dist
 phpunit.xml


### PR DESCRIPTION
Closes #597.

Adds a checked-in production-overlay template so the cutover to the Catholic OS umbrella's shared Zitadel + OpenFGA stack is a copy + fill-in-the-blanks operation rather than a tribal-knowledge exercise. **No code changes** — per the issue, the umbrella switch is env-vars-only; `OidcAuthMiddleware` and `OpenFgaClient` keep working unchanged once the new endpoints are in place.

## What ships

### `.env.production.example` (new)

Per-deploy template with:

- **Hard-coded umbrella endpoints:** `ZITADEL_ISSUER=https://auth.catholicdigitalcommons.org`, `OPENFGA_API_URL=https://authz.catholicdigitalcommons.org`.
- **`<FROM_HANDOFF_DOC>` placeholders** for IDs that come from [the handoff doc](https://github.com/CatholicOS/cdcf-infra/blob/main/auth/handoffs/liturgicalcalendar.md): `ZITADEL_PROJECT_ID`, `ZITADEL_CLIENT_ID`, `OPENFGA_STORE_ID`, `OPENFGA_MODEL_ID`.
- **`<OOB_DELIVERED>` placeholder** for `OPENFGA_API_TOKEN`, delivered out-of-band through an encrypted channel. Note in-file that the umbrella refers to this as `OPENFGA_PRESHARED_KEY` — terminology differs between codebases; our code reads `OPENFGA_API_TOKEN`.
- **`ZITADEL_MACHINE_TOKEN` commented as optional** — only needed if outbound Zitadel Management API calls happen (currently limited to `RoleCascadeService`'s end-to-end revoke path).
- **"Not umbrella-controlled" reminder** for `JWT_SECRET`, `ADMIN_PASSWORD_HASH`, `CORS_ALLOWED_ORIGINS`, `API_BASE_PATH`, and DB credentials — those still need per-deployment values per `.env.example` + the `CLAUDE.md` fail-closed security rule (`ADMIN_PASSWORD_HASH` is required in `staging` / `production`).
- **Verification commands** from the issue body, commented inline so the ops-runbook reader can copy-paste them post-switch.

### `.gitignore`

One-line addition:

```text
!.env.production.example
```

Without this, the existing `.env.*` rule swallows the new file alongside `.env.production` itself; only `.env.example` had a negation before.

## Usage (mirrored at the top of the file)

```text
1. Copy this file to .env.production on the deployed host.
2. Fill in <FROM_HANDOFF_DOC> values from the handoff doc.
3. Set OPENFGA_API_TOKEN to the OOB-delivered preshared key.
4. (Optional) generate ZITADEL_MACHINE_TOKEN via the umbrella Zitadel console
   if Management API calls are needed.
```

## Out of scope (per the issue)

- Frontend SPA OIDC app — `LiturgicalCalendarFrontend`'s PKCE registration. Phase 2 follow-up.
- Test service account.
- Per-user role grants (done after first sign-in via the umbrella console).
- **The actual cutover** of the production deployment — operational task, needs the OOB token + access to the deployed host. This PR ships the template; cutover happens in the deploy runbook.

## Verification

The template is a docs artifact; nothing to run. Repository checks:

- `git check-ignore .env.production.example` → no longer ignored ✅
- No existing CI/test failures touched (`composer test`, `composer analyse`, `composer lint`, `composer lint:openapi` paths don't read this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a production environment configuration template with documented auth/authorization and OpenFGA placeholders, guidance to deliver sensitive tokens out-of-band, notes about inherited settings and common production overrides, plus post-deploy verification steps.
  * Adjusted version-control rules so the production configuration template is tracked alongside other example configs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->