### PR TITLE
feat(openfga): async reconciliation outbox (Options B+C follow-up to #567)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"137eaaf9-6c65-4aae-ad9f-bf436172805a","pid":20260,"procStart":"22279366","acquiredAt":1780198705970}

--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,16 @@ HTTPS_ENFORCEMENT=true
 # REDIS_PORT=6379
 
 ##
+# OpenFGA outbox reconciliation
+# Configures the Redis Streams-based reconciler for async tuple operations
+##
+REDIS_OUTBOX_STREAM=litcal:reconcile-stream
+REDIS_OUTBOX_GROUP=reconciler
+REDIS_OUTBOX_CONSUMER_NAME=          # default: hostname
+OUTBOX_MAX_ATTEMPTS=10
+OUTBOX_BACKSTOP_GRACE_SECONDS=60
+
+##
 # Docker Compose Port Configuration
 # These variables are read by docker-compose.yml for port mappings
 # All services are bound to 127.0.0.1 (localhost only)

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -3,22 +3,26 @@ project_name: "LiturgicalCalendarAPI"
 
 
 # list of languages for which language servers are started; choose from:
-#   al                  bash                clojure             cpp                 csharp
-#   csharp_omnisharp    dart                elixir              elm                 erlang
-#   fortran             fsharp              go                  groovy              haskell
-#   haxe                java                julia               kotlin              lua
-#   markdown
-#   matlab              nix                 pascal              perl                php
-#   php_phpactor        powershell          python              python_jedi         r
-#   rego                ruby                ruby_solargraph     rust                scala
-#   swift               terraform           toml                typescript          typescript_vts
-#   vue                 yaml                zig
+#   al                  angular             ansible             bash                clojure
+#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
+#   dart                elixir              elm                 erlang              fortran
+#   fsharp              go                  groovy              haskell             haxe
+#   hlsl                html                java                json                julia
+#   kotlin              lean4               lua                 luau                markdown
+#   matlab              msl                 nix                 ocaml               pascal
+#   perl                php                 php_phpactor        powershell          python
+#   python_jedi         python_ty           r                   rego                ruby
+#   ruby_solargraph     rust                scala               scss                solidity
+#   swift               systemverilog       terraform           toml                typescript
+#   typescript_vts      vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
+#   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
 #   Some languages require additional setup/installations.
@@ -66,54 +70,17 @@ read_only: false
 
 # list of tool names to exclude.
 # This extends the existing exclusions (e.g. from the global configuration)
-#
-# Below is the complete list of tools for convenience.
-# To make sure you have the latest list of tools, and to view their descriptions, 
-# execute `uv run scripts/print_tool_overview.py`.
-#
-#  * `activate_project`: Activates a project based on the project name or path.
-#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
-#  * `create_text_file`: Creates/overwrites a file in the project directory.
-#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
-#       for example by saying that the information retrieved from a memory file is no longer correct
-#       or no longer relevant for the project.
-#  * `edit_memory`: Replaces content matching a regular expression in a memory.
-#  * `execute_shell_command`: Executes a shell command.
-#  * `find_file`: Finds files in the given relative paths
-#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
-#  * `find_symbol`: Performs a global (or local) search using the language server backend.
-#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
-#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
-#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
-#       for clients that do not read the initial instructions when the MCP server is connected.
-#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
-#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
-#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
-#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
-#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
-#  * `read_file`: Reads a file within the project directory.
-#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
-#       is relevant to the current task. You can infer whether the information
-#       is relevant from the memory file name.
-#       You should not read the same memory file multiple times in the same conversation.
-#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
-#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
-#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
-#       For JB, we use a separate tool.
-#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
-#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
-#  * `safe_delete_symbol`:
-#  * `search_for_pattern`: Performs a search for a pattern in the project.
-#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
-#       The memory name should be meaningful.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 excluded_tools: []
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
 # This extends the existing inclusions (e.g. from the global configuration).
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
 # This cannot be combined with non-empty excluded_tools or included_optional_tools.
+# Find the list of tools here: https://oraios.github.io/serena/01-about/035_tools.html
 fixed_tools: []
 
 # list of mode names to that are always to be included in the set of active modes
@@ -124,11 +91,14 @@ fixed_tools: []
 # Set this to a list of mode names to always include the respective modes for this project.
 base_modes:
 
-# list of mode names that are to be activated by default.
-# The full set of modes to be activated is base_modes + default_modes.
-# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# list of mode names that are to be activated by default, overriding the setting in the global configuration.
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# If the setting is undefined/empty, the default_modes from the global configuration (serena_config.yml) apply.
 # Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# Therefore, you can set this to [] if you do not want the default modes defined in the global config to apply
+# for this project.
 # This setting can, in turn, be overridden by CLI parameters (--mode).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
@@ -139,6 +109,7 @@ initial_prompt: |
   - `return_type` query param is ONLY valid on `/calendar`. Do NOT propagate it to admin/auth or other routes.
   - Timezone is always `Europe/Vatican`; year range 1970-9999.
   - PHPStan level 10, PSR-12; pre-commit (CaptainHook) runs lint + lint:md. Never `--no-verify`.
+
 # time budget (seconds) per tool call for the retrieval of additional symbol information
 # such as docstrings or parameter information.
 # This overrides the corresponding setting in the global configuration; see the documentation there.
@@ -156,3 +127,19 @@ read_only_memory_patterns: []
 # Extends the list from the global configuration, merging the two lists.
 # Example: ["_archive/.*", "_episodes/.*"]
 ignored_memory_patterns: []
+
+# list of mode names to be activated additionally for this project, e.g. ["query-projects"]
+# The full set of modes to be activated is base_modes (from global config) + default_modes + added_modes.
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
+added_modes:
+
+# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# Paths can be absolute or relative to the project root.
+# Each folder is registered as an LSP workspace folder, enabling language servers to discover
+# symbols and references across package boundaries.
+# Currently supported for: TypeScript.
+# Example:
+#   additional_workspace_folders:
+#     - ../sibling-package
+#     - ../shared-lib
+additional_workspace_folders: []

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -422,15 +422,32 @@ Use `LoggerFactory::create()` to instantiate PSR-3 compliant Monolog loggers:
 
 **PHPUnit Tests:** `phpunit_tests/`
 
-- `ApiTestCase.php`: Base test class with common functionality
-- `Routes/`: Tests for each route handler
-- `Methods/`: HTTP method validation tests
-- `Enum/`: Enum behavior tests
+Test classes extend a layered base class depending on what surface they exercise. There is NOT a single "the" base class — use the one that matches the layer
+being tested:
+
+| Layer (path)     | Base class                   | When to use                                                                                                       |
+| ---------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `Routes/*`       | `ApiTestCase`                | Full HTTP-level integration tests. Hits the running API (Guzzle). Skipped when `localhost:8000` is unreachable.   |
+| `Handlers/*`     | `AbstractHandlerTestCase`    | In-process handler tests via direct `handle()` invocation. No HTTP server needed. 14+ existing tests follow this. |
+| `Repositories/*` | `RepositoryTestCase`         | PG-only repository tests. Auto-TRUNCATEs project tables; skipped when `DB_*` env unset. 6+ existing tests.        |
+| Pure-logic       | `PHPUnit\Framework\TestCase` | `Methods/`, `Enum/`, `Models/`, `Params/`, etc. — no I/O, extend the framework's `TestCase` directly.             |
+
+Rule of thumb: use the layered base whose surface you're actually exercising. A handler test that goes through `ApiTestCase` would unnecessarily require a running
+server; a route test that uses `AbstractHandlerTestCase` would bypass the Router and middleware pipeline.
+
+Other notable test infrastructure:
+
+- `phpunit_tests/Support/EnvIsolationTrait.php`: `withoutEnv(array $keys, callable $fn)` helper used by handler tests to exercise
+  "service not configured" branches without leaking host `.env.local` values into assertions.
+- `phpunit_tests/Services/OpenFgaClientTest.php`: pattern for `MockHandler`-backed `OpenFgaClient` (Guzzle `MockHandler` injected into
+  the HTTP client) — reused by every test that exercises FGA-calling code with mocked responses.
 
 **Test Groups:**
 
-- Regular tests: Fast validation tests
-- `@group slow`: Integration tests requiring API calls
+- Regular tests: Fast validation tests.
+- `@group slow`: Reserved for tests with **measurable** runtime cost — e.g., multi-year calendar calculations (`Routes/Readonly/TemporaleTest`), rate-limit
+  window waits (`Services/RateLimiterTest`), or full-schema-corpus validation (`Schemas/SchemaValidationTest`). Integration tests are NOT automatically slow:
+  most `Routes/*` tests run in < 200 ms and are excluded from `@group slow`.
 
 **Integrity Checks:**
 External web interface at [Liturgical-Calendar/UnitTestInterface](https://github.com/Liturgical-Calendar/UnitTestInterface) provides comprehensive calendar

--- a/bin/reconcile-outbox
+++ b/bin/reconcile-outbox
@@ -67,6 +67,7 @@ if ($mode === 'backstop') {
     $runner    = new BackstopRunner(
         $repo,
         $processor,
+        $pdo,
         graceSeconds: (int) ($_ENV['OUTBOX_BACKSTOP_GRACE_SECONDS'] ?? 60),
     );
     $processed = $runner->runOnce(limit: 200);

--- a/bin/reconcile-outbox
+++ b/bin/reconcile-outbox
@@ -60,7 +60,8 @@ $repo = new OutboxRepository($pdo);
 // and OPENFGA_MODEL_ID from the environment.
 $fga = OpenFgaClient::fromEnv();
 
-$processor = new OutboxProcessor($repo, $fga, (int) ($_ENV['OUTBOX_MAX_ATTEMPTS'] ?? 10));
+$maxAttempts = is_numeric($_ENV['OUTBOX_MAX_ATTEMPTS'] ?? null) ? (int) $_ENV['OUTBOX_MAX_ATTEMPTS'] : 10;
+$processor   = new OutboxProcessor($repo, $fga, $maxAttempts);
 
 if ($mode === 'backstop') {
     $runner    = new BackstopRunner(

--- a/bin/reconcile-outbox
+++ b/bin/reconcile-outbox
@@ -1,0 +1,101 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Subcommands:
+ *   consumer  — long-lived; systemd manages restart on failure
+ *   backstop  — one-shot scan; cron invokes every 5 min
+ *
+ * Both route through OutboxProcessor so the OpenFGA contact surface
+ * stays single-source.
+ */
+
+use Dotenv\Dotenv;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\BackstopRunner;
+use LiturgicalCalendar\Api\Services\Outbox\ConsumerLoop;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
+
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+if (file_exists($root . '/.env.local')) {
+    Dotenv::createImmutable($root, '.env.local')->safeLoad();
+} elseif (file_exists($root . '/.env')) {
+    Dotenv::createImmutable($root)->safeLoad();
+}
+
+$mode = $argv[1] ?? '';
+if ($mode !== 'consumer' && $mode !== 'backstop') {
+    fwrite(STDERR, "Usage: reconcile-outbox consumer|backstop\n");
+    exit(2);
+}
+
+// --- Build PDO ---
+$pdo = new PDO(
+    sprintf(
+        'pgsql:host=%s;port=%s;dbname=%s',
+        (string) ($_ENV['DB_HOST'] ?? 'localhost'),
+        (string) ($_ENV['DB_PORT'] ?? '5432'),
+        (string) ($_ENV['DB_NAME'] ?? ''),
+    ),
+    (string) ($_ENV['DB_USER'] ?? ''),
+    (string) ($_ENV['DB_PASSWORD'] ?? ''),
+    [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES   => false,
+    ],
+);
+$pdo->exec("SET timezone TO 'Europe/Vatican'");
+
+$repo = new OutboxRepository($pdo);
+
+// --- Build OpenFgaClient ---
+// OpenFgaClient::fromEnv() reads OPENFGA_API_URL, OPENFGA_STORE_ID,
+// and OPENFGA_MODEL_ID from the environment.
+$fga = OpenFgaClient::fromEnv();
+
+$processor = new OutboxProcessor($repo, $fga);
+
+if ($mode === 'backstop') {
+    $runner    = new BackstopRunner(
+        $repo,
+        $processor,
+        graceSeconds: (int) ($_ENV['OUTBOX_BACKSTOP_GRACE_SECONDS'] ?? 60),
+    );
+    $processed = $runner->runOnce(limit: 200);
+    fwrite(STDOUT, sprintf("backstop processed=%d\n", $processed));
+    exit(0);
+}
+
+// consumer mode
+if (!extension_loaded('redis')) {
+    fwrite(STDERR, "ext-redis is required for consumer mode but is not installed.\n");
+    exit(2);
+}
+$redis = new \Redis();
+if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+    $redis->connect((string) $_ENV['REDIS_SOCKET']);
+} else {
+    $redis->connect(
+        (string) ($_ENV['REDIS_HOST'] ?? '127.0.0.1'),
+        (int) ($_ENV['REDIS_PORT'] ?? 6379),
+    );
+}
+if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+    $redis->auth((string) $_ENV['REDIS_PASSWORD']);
+}
+
+$streamName   = (string) ($_ENV['REDIS_OUTBOX_STREAM']        ?? 'litcal:reconcile-stream');
+$groupName    = (string) ($_ENV['REDIS_OUTBOX_GROUP']         ?? 'reconciler');
+$consumerName = (string) ($_ENV['REDIS_OUTBOX_CONSUMER_NAME'] ?? (gethostname() ?: 'consumer'));
+
+$stream = new RedisStreamConsumer($redis, $streamName, $groupName, $consumerName);
+$loop   = new ConsumerLoop($stream, $processor, blockMs: 5000);
+
+$loop->run();

--- a/bin/reconcile-outbox
+++ b/bin/reconcile-outbox
@@ -60,7 +60,7 @@ $repo = new OutboxRepository($pdo);
 // and OPENFGA_MODEL_ID from the environment.
 $fga = OpenFgaClient::fromEnv();
 
-$processor = new OutboxProcessor($repo, $fga);
+$processor = new OutboxProcessor($repo, $fga, (int) ($_ENV['OUTBOX_MAX_ATTEMPTS'] ?? 10));
 
 if ($mode === 'backstop') {
     $runner    = new BackstopRunner(

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,8 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
+        "ext-pdo": "*",
+        "ext-pdo_pgsql": "*",
         "ext-simplexml": "*",
         "ext-xml": "*",
         "ext-zip": "*",
@@ -53,7 +55,9 @@
         "captainhook/hook-installer": "^1.0",
         "phpunit/phpunit": "^12.3@stable"
     },
-    "suggest": {},
+    "suggest": {
+        "ext-redis": "Required only for the long-lived `bin/reconcile-outbox consumer` (XREADGROUP) and best-effort outbox notifications. The backstop drains everything regardless when ext-redis is absent."
+    },
     "license": "Apache-2.0",
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -95,7 +95,9 @@
         "db:migrations:status": "@php bin/doctrine-migrations status",
         "db:migrations:generate": "@php bin/doctrine-migrations generate",
         "db:migrations:sync": "@php bin/doctrine-migrations sync-metadata-storage",
-        "db:migrations:mark-applied": "@php bin/doctrine-migrations version --add --all --no-interaction"
+        "db:migrations:mark-applied": "@php bin/doctrine-migrations version --add --all --no-interaction",
+        "reconciler:consumer": "@php bin/reconcile-outbox consumer",
+        "reconciler:backstop": "@php bin/reconcile-outbox backstop"
     },
     "config": {
         "allow-plugins": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "284f6b151019a350d2bb0f64a9bd64d4",
+    "content-hash": "778089c5927b031e4b1d56b9678474c1",
     "packages": [
         {
             "name": "doctrine/dbal",
@@ -406,12 +406,12 @@
             "version": "v7.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/firebase/php-jwt.git",
+                "url": "https://github.com/googleapis/php-jwt.git",
                 "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
+                "url": "https://api.github.com/repos/googleapis/php-jwt/zipball/47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "reference": "47ad26bab5e7c70ae8a6f08ed25ff83631121380",
                 "shasum": ""
             },
@@ -6529,10 +6529,12 @@
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
+        "ext-pdo": "*",
+        "ext-pdo_pgsql": "*",
         "ext-simplexml": "*",
         "ext-xml": "*",
         "ext-zip": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/deploy/cron/liturgical-calendar-backstop.cron
+++ b/deploy/cron/liturgical-calendar-backstop.cron
@@ -1,0 +1,5 @@
+# Liturgical Calendar OpenFGA outbox backstop — every 5 minutes.
+# Picks up rows older than the grace window that the consumer missed
+# (e.g. Redis was down or the API process died between PG commit and XADD).
+# Install: copy to /etc/cron.d/litcal-outbox-backstop and `systemctl restart cron`.
+*/5 * * * * litcal /usr/bin/php /opt/liturgical-calendar/bin/reconcile-outbox backstop >> /var/log/litcal-backstop.log 2>&1

--- a/deploy/cron/liturgical-calendar-backstop.cron
+++ b/deploy/cron/liturgical-calendar-backstop.cron
@@ -2,4 +2,9 @@
 # Picks up rows older than the grace window that the consumer missed
 # (e.g. Redis was down or the API process died between PG commit and XADD).
 # Install: copy to /etc/cron.d/litcal-outbox-backstop and `systemctl restart cron`.
-*/5 * * * * litcal /usr/bin/php /opt/liturgical-calendar/bin/reconcile-outbox backstop >> /var/log/litcal-backstop.log 2>&1
+#
+# Output is piped to `logger -t litcal-backstop` so stdout + stderr land in
+# syslog/journald without depending on a hard-coded /var/log path being
+# writable by the `litcal` user. View with:
+#   journalctl -t litcal-backstop --since '15 min ago'
+*/5 * * * * litcal /usr/bin/php /opt/liturgical-calendar/bin/reconcile-outbox backstop 2>&1 | /usr/bin/logger -t litcal-backstop

--- a/deploy/systemd/liturgical-calendar-reconciler.service
+++ b/deploy/systemd/liturgical-calendar-reconciler.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Liturgical Calendar OpenFGA outbox reconciler
+After=network-online.target postgresql.service redis-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=litcal
+Group=litcal
+WorkingDirectory=/opt/liturgical-calendar
+EnvironmentFile=/opt/liturgical-calendar/.env.local
+ExecStart=/usr/bin/php /opt/liturgical-calendar/bin/reconcile-outbox consumer
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=litcal-reconciler
+
+# Hardening (adjust per ops policy)
+ProtectSystem=full
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ops/openfga-outbox-runbook.md
+++ b/docs/ops/openfga-outbox-runbook.md
@@ -1,0 +1,102 @@
+# OpenFGA outbox — operator runbook
+
+## What this is
+
+The OpenFGA outbox (`openfga_outbox` table) holds every tuple write/delete the API has committed to perform. A
+systemd-managed consumer drains it via Redis Streams; a cron-driven backstop catches the cracks. Together they
+guarantee at-least-once application of tuple operations even across multi-minute network partitions.
+
+See `docs/superpowers/specs/2026-06-02-openfga-async-reconciliation-design.md` for the full design.
+
+## Install
+
+### 1. Apply the migration
+
+The `litcal-migrate` one-shot container handles this on `docker compose up -d --build`. Manual fallback:
+
+```bash
+composer db:migrate
+```
+
+### 2. Install the systemd unit
+
+```bash
+sudo cp deploy/systemd/liturgical-calendar-reconciler.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now liturgical-calendar-reconciler.service
+sudo systemctl status liturgical-calendar-reconciler.service
+```
+
+### 3. Install the cron backstop
+
+```bash
+sudo cp deploy/cron/liturgical-calendar-backstop.cron /etc/cron.d/litcal-outbox-backstop
+sudo systemctl restart cron
+```
+
+### 4. Confirm
+
+```bash
+curl -s http://localhost:8000/health | jq .openfga_outbox
+```
+
+Should return an object with all-zero counts on a fresh install.
+
+## Diagnostic queries
+
+```sql
+-- How deep is the queue right now?
+SELECT status, COUNT(*) FROM openfga_outbox GROUP BY status;
+
+-- What's the oldest unfinished work?
+SELECT id, operation, fga_user, fga_relation, fga_object, attempts,
+       last_error_code, EXTRACT(EPOCH FROM NOW() - created_at) AS age_s
+FROM openfga_outbox
+WHERE status IN ('pending', 'retrying')
+ORDER BY created_at ASC LIMIT 10;
+
+-- What's stuck in DLQ and why?
+SELECT id, operation, fga_user, fga_relation, fga_object, last_error, last_error_code
+FROM openfga_outbox
+WHERE status = 'failed_terminal'
+ORDER BY created_at DESC LIMIT 20;
+```
+
+## Common incidents
+
+### `oldest_pending_age_seconds` growing past 60s
+
+The consumer is wedged. Check `journalctl -u liturgical-calendar-reconciler.service --since '10 min ago'`. If it
+is crash-looping, you will see RestartSec=5 cycles. Common causes: Redis unreachable (consumer logs ERROR + exits;
+backstop still drains, just every 5 minutes); PG unreachable (handlers also fail, /health surfaces it).
+
+### Rows piling up in failed_terminal
+
+````bash
+curl -H "Authorization: Bearer $ADMIN_TOKEN" \
+  http://localhost:8000/admin/outbox?status=failed_terminal | jq .items
+````
+
+The `last_error_code` tells you why each row failed. Typical: `validation_error` (the API built a bad tuple — fix
+upstream), `auth_failure` (OpenFGA credentials wrong — fix env).
+
+After fixing the upstream issue:
+
+````bash
+# Retry one row:
+curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  http://localhost:8000/admin/outbox/42/retry
+````
+
+## Retention / pruning
+
+There is no automated prune in v1. The table grows by one row per tuple operation. For typical admin-action volume
+that is years before any concern. When it does become one:
+
+```sql
+DELETE FROM openfga_outbox
+WHERE status = 'succeeded'
+  AND completed_at < NOW() - INTERVAL '30 days';
+```
+
+Don't delete `failed_terminal` rows automatically — they are the audit trail for "what didn't apply".

--- a/docs/superpowers/plans/2026-06-02-openfga-async-reconciliation.md
+++ b/docs/superpowers/plans/2026-06-02-openfga-async-reconciliation.md
@@ -1,0 +1,3735 @@
+# OpenFGA async reconciliation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land Options B + C from issue #567 — a Postgres outbox + Redis Streams + systemd consumer + cron backstop
+that turns OpenFGA tuple writes/deletes from "best-effort during the request" into "eventually consistent with
+admin-visible DLQ".
+
+**Architecture:** Handler commits business state and outbox rows in one Postgres transaction. A sync fast path
+attempts OpenFGA inline. Failures (or process crashes) leave durable outbox rows that a systemd-managed consumer
+drains via Redis Streams, with a cron-driven backstop as the durability anchor. State machine in the outbox table is
+the idempotency anchor — re-running an operation on a terminal row is a no-op.
+
+**Tech Stack:** PHP 8.4+, Postgres (Doctrine migrations + PDO), Redis Streams (`ext-redis`), Guzzle for OpenFGA HTTP,
+PHPUnit, PHPStan L10, phpcs PSR-12.
+
+**Spec reference:** `docs/superpowers/specs/2026-06-02-openfga-async-reconciliation-design.md` (read this first if you
+have not already). All file paths, schema, response shapes, and behavior tables in this plan come from the spec —
+when something is ambiguous in the plan, the spec is canonical.
+
+**Branch:** `feature/openfga-async-reconciliation-design` (already created off `origin/development`).
+
+**Pre-requisites:**
+
+- `composer install` has been run on the host.
+- `docker compose up -d --build` brought Postgres + Zitadel + OpenFGA + Redis up and `litcal-migrate` applied all
+  prior migrations.
+- The host can reach `localhost:5432` (Postgres), `localhost:8083` (OpenFGA), `localhost:6379` (Redis).
+- `.env.local` has `DB_HOST`/`DB_PORT`/`DB_NAME`/`DB_USER`/`DB_PASSWORD` so `RepositoryTestCase` tests don't skip.
+
+---
+
+## File map
+
+### New files
+
+```text
+src/Migrations/Version<TIMESTAMP>.php             — DB migration (generated)
+src/Services/Outbox/OutboxOperation.php           — enum: write_tuple | delete_tuple
+src/Services/Outbox/OutboxStatus.php              — enum: pending | retrying | succeeded | failed_terminal
+src/Services/Outbox/OutboxDisposition.php         — enum: BENIGN_SUCCESS | RETRY | TERMINAL
+src/Services/Outbox/OutboxBackoff.php             — pure: secondsForAttempt(int): int
+src/Services/Outbox/OutboxClassifier.php          — pure: classify(\Throwable): OutboxDisposition
+src/Services/Outbox/OutboxRow.php                 — readonly value object for a row in transit
+src/Services/Outbox/OutboxProcessor.php           — orchestrates one row: attempt → classify → update
+src/Services/Outbox/OutboxNotifier.php            — best-effort \Redis::xAdd()
+src/Services/Outbox/RedisStreamConsumer.php       — XREADGROUP + XCLAIM loop primitive
+src/Services/Outbox/ConsumerLoop.php              — long-lived loop body (tick/run)
+src/Services/Outbox/BackstopRunner.php            — one-shot scan via OutboxRepository::pickupPending
+src/Repositories/OutboxRepository.php             — PDO repo for openfga_outbox
+src/Handlers/Admin/OutboxAdminHandler.php         — GET /admin/outbox, POST /admin/outbox/{id}/retry
+bin/reconcile-outbox                              — CLI entry: subcommands `consumer` and `backstop`
+deploy/systemd/liturgical-calendar-reconciler.service
+deploy/cron/liturgical-calendar-backstop.cron
+docs/ops/openfga-outbox-runbook.md
+phpunit_tests/Services/Outbox/OutboxBackoffTest.php
+phpunit_tests/Services/Outbox/OutboxClassifierTest.php
+phpunit_tests/Services/Outbox/OutboxProcessorTest.php
+phpunit_tests/Services/Outbox/OutboxNotifierTest.php
+phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
+phpunit_tests/Services/Outbox/BackstopRunnerTest.php
+phpunit_tests/Services/Outbox/ConsumerLoopTest.php
+phpunit_tests/Repositories/OutboxRepositoryTest.php
+phpunit_tests/Handlers/Admin/OutboxAdminHandlerTest.php
+```
+
+### Modified files
+
+```text
+src/Handlers/Admin/AccessRequestAdminHandler.php  — approve/revoke switch to outbox pattern
+src/Handlers/Admin/PermissionAdminHandler.php     — grant/revoke switch to outbox pattern
+src/Services/RoleCascadeService.php               — silent catch → outbox enqueue
+src/Router.php                                    — new /admin/outbox route
+src/Health.php                                    — openfga_outbox block in health output
+.env.example                                      — new keys
+composer.json                                     — reconciler:consumer/backstop scripts
+phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php  — new tests for outbox path
+phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php     — new tests for outbox path
+phpunit_tests/Repositories/RepositoryTestCase.php — add 'openfga_outbox' to TABLES const
+```
+
+---
+
+## Phase 0 — Bootstrap
+
+### Task 0: Verify branch and tooling
+
+**Files:**
+
+- Verify: `git rev-parse --abbrev-ref HEAD` returns `feature/openfga-async-reconciliation-design`
+
+- [ ] **Step 1: Confirm branch**
+
+Run: `git rev-parse --abbrev-ref HEAD`
+Expected output: `feature/openfga-async-reconciliation-design`
+
+- [ ] **Step 2: Confirm clean tooling**
+
+Run: `composer analyse && composer lint && composer test`
+Expected: all pass. (If `composer test` skips repository tests with "Postgres unreachable", run
+`docker compose up -d --build` first; see prerequisites at top of plan.)
+
+- [ ] **Step 3: Read the spec**
+
+Read `docs/superpowers/specs/2026-06-02-openfga-async-reconciliation-design.md` end-to-end before
+starting Phase 1.
+
+---
+
+## Phase 1 — Database schema
+
+### Task 1: Generate migration scaffold
+
+**Files:**
+
+- Create: `src/Migrations/Version<generated>.php` (`composer db:migrations:generate` will pick the timestamp)
+
+- [ ] **Step 1: Generate the migration**
+
+Run: `composer db:migrations:generate`
+Expected: prints `Generated new migration class to src/Migrations/Version<TIMESTAMP>.php`. Note the timestamp; use
+it in commit messages for this task.
+
+- [ ] **Step 2: Replace the scaffold**
+
+Open the generated file and replace its body with:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * OpenFGA async reconciliation outbox (Options B+C from issue #567).
+ *
+ * One row per OpenFGA tuple operation (write or delete) that the API has
+ * committed to perform. The handler inserts the row in the same Postgres
+ * transaction as the business write (e.g. access_requests.status = 'approved'),
+ * so commit atomicity gives us durable intent. A systemd consumer drains via
+ * Redis Streams on the fast path; a cron backstop catches the cracks.
+ */
+final class Version<TIMESTAMP> extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create openfga_outbox table for async reconciliation (issue #567 Options B+C)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql("CREATE TYPE outbox_op AS ENUM ('write_tuple', 'delete_tuple')");
+        $this->addSql("CREATE TYPE outbox_status AS ENUM ('pending', 'retrying', 'succeeded', 'failed_terminal')");
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE openfga_outbox (
+                id                BIGSERIAL    PRIMARY KEY,
+                operation         outbox_op    NOT NULL,
+                fga_user          TEXT         NOT NULL,
+                fga_relation      TEXT         NOT NULL,
+                fga_object        TEXT         NOT NULL,
+                status            outbox_status NOT NULL DEFAULT 'pending',
+                attempts          SMALLINT     NOT NULL DEFAULT 0,
+                next_attempt_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                last_error        TEXT         NULL,
+                last_error_code   TEXT         NULL,
+                metadata          JSONB        NOT NULL DEFAULT '{}'::jsonb,
+                created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                completed_at      TIMESTAMPTZ  NULL,
+
+                CONSTRAINT openfga_outbox_idempotency_unique
+                    UNIQUE ((metadata->>'idempotency_key'))
+            )
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX idx_outbox_pickup ON openfga_outbox (status, next_attempt_at)
+                WHERE status IN ('pending', 'retrying')
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX idx_outbox_dlq ON openfga_outbox (status, created_at)
+                WHERE status = 'failed_terminal'
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX idx_outbox_metadata_request ON openfga_outbox ((metadata->>'access_request_id'))
+                WHERE metadata ? 'access_request_id'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('DROP TABLE IF EXISTS openfga_outbox');
+        $this->addSql('DROP TYPE IF EXISTS outbox_status');
+        $this->addSql('DROP TYPE IF EXISTS outbox_op');
+    }
+}
+```
+
+Replace `<TIMESTAMP>` in the class name with the actual timestamp from Step 1.
+
+- [ ] **Step 3: Apply the migration**
+
+Run: `composer db:migrate`
+Expected output: `++ migrated (took <ms>, used <KB> memory)` for the new version. Migration status shows it as
+applied.
+
+- [ ] **Step 4: Sanity-check the schema**
+
+Run: `psql "$DATABASE_URL" -c "\d openfga_outbox"` (or use Adminer at `localhost:8081`).
+Expected: table exists with all columns, three indexes (`idx_outbox_pickup`, `idx_outbox_dlq`,
+`idx_outbox_metadata_request`), one unique constraint.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Migrations/Version*.php
+git commit -m "feat(outbox): create openfga_outbox table
+
+One row per OpenFGA tuple operation. Atomically committed with the
+business write; drained by the consumer (Redis Streams) and the cron
+backstop. Partial indexes on (status, next_attempt_at) keep the pickup
+hot path tight; UNIQUE constraint on metadata->>'idempotency_key' makes
+re-issued handler calls a no-op insert.
+
+Part of issue #567 Options B+C."
+```
+
+---
+
+## Phase 2 — Pure types and logic (TDD)
+
+### Task 2: OutboxOperation enum
+
+**Files:**
+
+- Create: `src/Services/Outbox/OutboxOperation.php`
+
+- [ ] **Step 1: Write the file**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * The two OpenFGA tuple operations the outbox tracks.
+ *
+ * Values match the `outbox_op` Postgres enum from
+ * Version<TIMESTAMP> migration.
+ */
+enum OutboxOperation: string
+{
+    case WRITE_TUPLE  = 'write_tuple';
+    case DELETE_TUPLE = 'delete_tuple';
+}
+```
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `vendor/bin/parallel-lint src/Services/Outbox/OutboxOperation.php`
+Expected: `No syntax error found`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Services/Outbox/OutboxOperation.php
+git commit -m "feat(outbox): add OutboxOperation enum"
+```
+
+### Task 3: OutboxStatus enum
+
+**Files:**
+
+- Create: `src/Services/Outbox/OutboxStatus.php`
+
+- [ ] **Step 1: Write the file**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * Outbox row lifecycle states.
+ *
+ * Values match the `outbox_status` Postgres enum. State transitions:
+ *
+ *   pending → succeeded
+ *   pending → retrying → retrying → ... → succeeded
+ *   retrying → failed_terminal (attempts == 10 on transient, OR any 4xx classified TERMINAL)
+ *   failed_terminal → pending (admin retry via POST /admin/outbox/{id}/retry)
+ *
+ * `succeeded` and `failed_terminal` are terminal unless the admin retry
+ * endpoint resets the row back to `pending`.
+ */
+enum OutboxStatus: string
+{
+    case PENDING         = 'pending';
+    case RETRYING        = 'retrying';
+    case SUCCEEDED       = 'succeeded';
+    case FAILED_TERMINAL = 'failed_terminal';
+}
+```
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `vendor/bin/parallel-lint src/Services/Outbox/OutboxStatus.php`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Services/Outbox/OutboxStatus.php
+git commit -m "feat(outbox): add OutboxStatus enum"
+```
+
+### Task 4: OutboxDisposition enum
+
+**Files:**
+
+- Create: `src/Services/Outbox/OutboxDisposition.php`
+
+- [ ] **Step 1: Write the file**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * What OutboxClassifier::classify decided about an exception.
+ *
+ * The processor consults this to decide whether to mark the row
+ * succeeded, schedule a retry, or mark it failed_terminal.
+ */
+enum OutboxDisposition
+{
+    case BENIGN_SUCCESS;  // TupleAlreadyExists on write, TupleNotFound on delete
+    case RETRY;           // 5xx, 429, network — schedule with backoff
+    case TERMINAL;        // 4xx validation/auth — no retry, surface in DLQ
+}
+```
+
+- [ ] **Step 2: Verify it parses**
+
+Run: `vendor/bin/parallel-lint src/Services/Outbox/OutboxDisposition.php`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Services/Outbox/OutboxDisposition.php
+git commit -m "feat(outbox): add OutboxDisposition enum"
+```
+
+### Task 5: OutboxBackoff — pure backoff function (TDD)
+
+**Files:**
+
+- Create: `src/Services/Outbox/OutboxBackoff.php`
+- Test: `phpunit_tests/Services/Outbox/OutboxBackoffTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OutboxBackoff::class)]
+final class OutboxBackoffTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{int, int}>
+     */
+    public static function backoffCases(): iterable
+    {
+        yield 'attempt 1 → 1s'   => [1, 1];
+        yield 'attempt 2 → 2s'   => [2, 2];
+        yield 'attempt 3 → 4s'   => [3, 4];
+        yield 'attempt 4 → 8s'   => [4, 8];
+        yield 'attempt 5 → 16s'  => [5, 16];
+        yield 'attempt 6 → 32s'  => [6, 32];
+        yield 'attempt 7 → 64s'  => [7, 64];
+        yield 'attempt 8 → 128s' => [8, 128];
+        yield 'attempt 9 → 256s' => [9, 256];
+        yield 'attempt 10 → 512s' => [10, 512];
+        yield 'attempts past cap stay at 512s' => [99, 512];
+    }
+
+    #[DataProvider('backoffCases')]
+    public function testSecondsForAttempt(int $attempts, int $expectedSeconds): void
+    {
+        self::assertSame($expectedSeconds, OutboxBackoff::secondsForAttempt($attempts));
+    }
+
+    public function testZeroAttemptsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        OutboxBackoff::secondsForAttempt(0);
+    }
+
+    public function testNegativeAttemptsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        OutboxBackoff::secondsForAttempt(-1);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/OutboxBackoffTest.php`
+Expected: FAIL with `Error: Class "LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff" not found`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * Exponential backoff for outbox retries.
+ *
+ * Schedule: 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s, 512s — capped at
+ * 2^9 = 512s. Total budget across 10 attempts: ~17 minutes.
+ *
+ * Pure function. Lives in its own file for testability and so the
+ * schedule is editable in one place without touching the processor.
+ */
+final class OutboxBackoff
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param int $attempts The new attempt count (just incremented), 1..n.
+     */
+    public static function secondsForAttempt(int $attempts): int
+    {
+        if ($attempts < 1) {
+            throw new \InvalidArgumentException('attempts must be >= 1');
+        }
+
+        return 1 << min($attempts - 1, 9);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/OutboxBackoffTest.php`
+Expected: PASS, 12 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Services/Outbox/OutboxBackoff.php phpunit_tests/Services/Outbox/OutboxBackoffTest.php
+git commit -m "feat(outbox): exponential backoff (1s..512s, 10 attempts)"
+```
+
+### Task 6: OutboxClassifier (TDD)
+
+**Files:**
+
+- Create: `src/Services/Outbox/OutboxClassifier.php`
+- Test: `phpunit_tests/Services/Outbox/OutboxClassifierTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxClassifier;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OutboxClassifier::class)]
+final class OutboxClassifierTest extends TestCase
+{
+    public function testTupleAlreadyExistsIsBenign(): void
+    {
+        $e = new TupleAlreadyExistsException('already exists', 400, 'cannot_allow_duplicate_tuple');
+        self::assertSame(OutboxDisposition::BENIGN_SUCCESS, OutboxClassifier::classify($e));
+    }
+
+    public function testTupleNotFoundIsBenign(): void
+    {
+        $e = new TupleNotFoundException('not found', 400, 'cannot_allow_unknown_tuple_to_be_deleted');
+        self::assertSame(OutboxDisposition::BENIGN_SUCCESS, OutboxClassifier::classify($e));
+    }
+
+    public function testValidationErrorIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('invalid input', 400, 'validation_error');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testInvalidInputFormatIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('bad format', 400, 'invalid_input_format');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testTypeNotFoundIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('no such type', 400, 'type_not_found');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testRelationNotFoundIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('no such relation', 400, 'relation_not_found');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testAuthFailureIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('auth failure', 401, 'auth_failure');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testUnauthenticatedIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('unauthenticated', 401, 'unauthenticated');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testRateLimitedIsRetry(): void
+    {
+        $e = new OpenFgaApiException('rate-limited', 429, null);
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+
+    public function test500IsRetry(): void
+    {
+        $e = new OpenFgaApiException('server error', 500, null);
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+
+    public function test503IsRetry(): void
+    {
+        $e = new OpenFgaApiException('unavailable', 503, null);
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+
+    public function testGenericRuntimeExceptionIsRetry(): void
+    {
+        // Network errors surface as \RuntimeException (Guzzle ConnectException) or similar.
+        $e = new \RuntimeException('connection refused');
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+
+    public function testUnknownErrorCodeIsRetry(): void
+    {
+        // Safe default: anything we don't recognize gets retried.
+        $e = new OpenFgaApiException('mystery', 418, 'i_am_a_teapot');
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/OutboxClassifierTest.php`
+Expected: FAIL — `OutboxClassifier` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
+
+/**
+ * Stateless classifier that decides what to do with an exception raised
+ * by an OpenFGA call inside OutboxProcessor.
+ *
+ * The mapping is canonical — every branch in OutboxProcessor consults
+ * this. New OpenFGA error codes get a new test in OutboxClassifierTest
+ * and a new arm in classify().
+ */
+final class OutboxClassifier
+{
+    /**
+     * Error codes we recognize as admin-input bugs (no retry).
+     *
+     * Validation errors, type/relation lookups failing, auth failures —
+     * retrying these 9 more times wastes work and pollutes metrics.
+     *
+     * @var list<string>
+     */
+    private const TERMINAL_CODES = [
+        'validation_error',
+        'invalid_input_format',
+        'type_not_found',
+        'relation_not_found',
+        'auth_failure',
+        'unauthenticated',
+    ];
+
+    private function __construct()
+    {
+    }
+
+    public static function classify(\Throwable $e): OutboxDisposition
+    {
+        if ($e instanceof TupleAlreadyExistsException || $e instanceof TupleNotFoundException) {
+            return OutboxDisposition::BENIGN_SUCCESS;
+        }
+
+        if ($e instanceof OpenFgaApiException) {
+            $code = $e->getErrorCode();
+            if ($code !== null && in_array($code, self::TERMINAL_CODES, true)) {
+                return OutboxDisposition::TERMINAL;
+            }
+            // 429 / 5xx / unknown errorCode → retry.
+            return OutboxDisposition::RETRY;
+        }
+
+        // Network errors, unexpected RuntimeException, anything else — retry.
+        // The 10-attempt budget keeps us from looping forever on bugs.
+        return OutboxDisposition::RETRY;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/OutboxClassifierTest.php`
+Expected: PASS, 13 tests.
+
+- [ ] **Step 5: Static analysis**
+
+Run: `composer analyse -- src/Services/Outbox/OutboxClassifier.php`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/Outbox/OutboxClassifier.php phpunit_tests/Services/Outbox/OutboxClassifierTest.php
+git commit -m "feat(outbox): error classifier (benign/retry/terminal)"
+```
+
+---
+
+## Phase 3 — Repository
+
+### Task 7: OutboxRow value object
+
+**Files:**
+
+- Create: `src/Services/Outbox/OutboxRow.php`
+
+- [ ] **Step 1: Write the file**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * Readonly snapshot of one openfga_outbox row in transit between
+ * OutboxRepository and OutboxProcessor.
+ *
+ * Repository hydrates these from PG; processor reads them, performs the
+ * OpenFGA call, then calls back into the repository to update the
+ * underlying row. The row object itself does not mutate — re-read after
+ * an update to see the new state.
+ */
+final class OutboxRow
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly int $id,
+        public readonly OutboxOperation $operation,
+        public readonly string $fgaUser,
+        public readonly string $fgaRelation,
+        public readonly string $fgaObject,
+        public readonly OutboxStatus $status,
+        public readonly int $attempts,
+        public readonly \DateTimeImmutable $nextAttemptAt,
+        public readonly ?string $lastError,
+        public readonly ?string $lastErrorCode,
+        public readonly array $metadata,
+        public readonly \DateTimeImmutable $createdAt,
+        public readonly ?\DateTimeImmutable $completedAt,
+    ) {
+    }
+}
+```
+
+- [ ] **Step 2: Parse-check**
+
+Run: `vendor/bin/parallel-lint src/Services/Outbox/OutboxRow.php`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Services/Outbox/OutboxRow.php
+git commit -m "feat(outbox): OutboxRow readonly value object"
+```
+
+### Task 8: Add openfga_outbox to RepositoryTestCase truncation list
+
+**Files:**
+
+- Modify: `phpunit_tests/Repositories/RepositoryTestCase.php` — the `TABLES` const
+
+- [ ] **Step 1: Edit the TABLES const**
+
+Find:
+
+```php
+protected const TABLES = ['api_keys', 'applications', 'access_requests', 'audit_log'];
+```
+
+Replace with:
+
+```php
+protected const TABLES = ['api_keys', 'applications', 'access_requests', 'audit_log', 'openfga_outbox'];
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add phpunit_tests/Repositories/RepositoryTestCase.php
+git commit -m "test(outbox): truncate openfga_outbox between repository tests"
+```
+
+### Task 9: OutboxRepository::insertBatch + idempotency (TDD)
+
+**Files:**
+
+- Create: `src/Repositories/OutboxRepository.php`
+- Test: `phpunit_tests/Repositories/OutboxRepositoryTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(OutboxRepository::class)]
+final class OutboxRepositoryTest extends RepositoryTestCase
+{
+    private OutboxRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new OutboxRepository(self::$pdo);
+    }
+
+    /**
+     * @return list<array{operation: OutboxOperation, fga_user: string, fga_relation: string, fga_object: string, idempotency_key: string, metadata: array<string,mixed>}>
+     */
+    private function samplePayload(): array
+    {
+        return [
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:alice',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => 'access_request:r1:write_tuple:user:alice:editor:national_calendar:IT',
+                'metadata'        => ['access_request_id' => 'r1', 'admin_user' => 'admin:bob'],
+            ],
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:alice',
+                'fga_relation'    => 'viewer',
+                'fga_object'      => 'diocesan_calendar:romamo_it',
+                'idempotency_key' => 'access_request:r1:write_tuple:user:alice:viewer:diocesan_calendar:romamo_it',
+                'metadata'        => ['access_request_id' => 'r1', 'admin_user' => 'admin:bob'],
+            ],
+        ];
+    }
+
+    public function testInsertBatchReturnsRowIds(): void
+    {
+        $ids = $this->repo->insertBatch($this->samplePayload());
+
+        self::assertCount(2, $ids);
+        self::assertContainsOnly('int', $ids);
+        self::assertGreaterThan(0, $ids[0]);
+        self::assertGreaterThan(0, $ids[1]);
+        self::assertNotSame($ids[0], $ids[1]);
+    }
+
+    public function testInsertBatchIsIdempotentOnDuplicateKey(): void
+    {
+        $firstIds  = $this->repo->insertBatch($this->samplePayload());
+        // Re-insert the same payload — same idempotency keys, no new rows.
+        $secondIds = $this->repo->insertBatch($this->samplePayload());
+
+        // Same IDs returned both times.
+        self::assertSame($firstIds, $secondIds);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: FAIL — `OutboxRepository` not found.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Repositories;
+
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxRow;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
+use PDO;
+
+/**
+ * PDO repository for the openfga_outbox table.
+ *
+ * Sole writer of outbox rows. Hot path is insertBatch (called inside the
+ * handler's tx with the business write) and pickupPending (the consumer
+ * and backstop both call this).
+ */
+final class OutboxRepository
+{
+    public function __construct(private readonly PDO $db)
+    {
+    }
+
+    /**
+     * Insert a batch of outbox rows, idempotent on idempotency_key.
+     *
+     * Returns the row IDs in the same order as the input payload.
+     *
+     * @param list<array{
+     *     operation: OutboxOperation,
+     *     fga_user: string,
+     *     fga_relation: string,
+     *     fga_object: string,
+     *     idempotency_key: string,
+     *     metadata: array<string, mixed>
+     * }> $rows
+     * @return list<int>
+     */
+    public function insertBatch(array $rows): array
+    {
+        if (empty($rows)) {
+            return [];
+        }
+
+        $ids = [];
+        $insert = $this->db->prepare(<<<'SQL'
+            INSERT INTO openfga_outbox (operation, fga_user, fga_relation, fga_object, metadata)
+            VALUES (:operation, :fga_user, :fga_relation, :fga_object, :metadata::jsonb)
+            ON CONFLICT ((metadata->>'idempotency_key')) DO NOTHING
+            RETURNING id
+        SQL);
+
+        $select = $this->db->prepare(<<<'SQL'
+            SELECT id FROM openfga_outbox WHERE metadata->>'idempotency_key' = :key
+        SQL);
+
+        foreach ($rows as $row) {
+            // The idempotency_key must live inside the metadata JSONB so the
+            // expression UNIQUE index catches conflicts.
+            $metadata                    = $row['metadata'];
+            $metadata['idempotency_key'] = $row['idempotency_key'];
+
+            $insert->execute([
+                ':operation'    => $row['operation']->value,
+                ':fga_user'     => $row['fga_user'],
+                ':fga_relation' => $row['fga_relation'],
+                ':fga_object'   => $row['fga_object'],
+                ':metadata'     => json_encode($metadata, JSON_THROW_ON_ERROR),
+            ]);
+
+            $insertedId = $insert->fetchColumn();
+            if ($insertedId !== false) {
+                $ids[] = (int) $insertedId;
+                continue;
+            }
+
+            // Conflict path — the row already exists. Look up its ID.
+            $select->execute([':key' => $row['idempotency_key']]);
+            $existingId = $select->fetchColumn();
+            if ($existingId === false) {
+                throw new \RuntimeException(sprintf(
+                    'OutboxRepository::insertBatch: conflict on key %s but row not found',
+                    $row['idempotency_key']
+                ));
+            }
+            $ids[] = (int) $existingId;
+        }
+
+        return $ids;
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Repositories/OutboxRepository.php phpunit_tests/Repositories/OutboxRepositoryTest.php
+git commit -m "feat(outbox): repository.insertBatch with idempotency"
+```
+
+### Task 10: OutboxRepository::getById (TDD)
+
+**Files:**
+
+- Modify: `src/Repositories/OutboxRepository.php`
+- Modify: `phpunit_tests/Repositories/OutboxRepositoryTest.php`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `OutboxRepositoryTest`:
+
+```php
+    public function testGetByIdHydratesAllFields(): void
+    {
+        [$id1, ] = $this->repo->insertBatch($this->samplePayload());
+
+        $row = $this->repo->getById($id1);
+
+        self::assertNotNull($row);
+        self::assertSame($id1, $row->id);
+        self::assertSame(OutboxOperation::WRITE_TUPLE, $row->operation);
+        self::assertSame('user:alice', $row->fgaUser);
+        self::assertSame('editor', $row->fgaRelation);
+        self::assertSame('national_calendar:IT', $row->fgaObject);
+        self::assertSame(OutboxStatus::PENDING, $row->status);
+        self::assertSame(0, $row->attempts);
+        self::assertNull($row->lastError);
+        self::assertNull($row->lastErrorCode);
+        self::assertSame('r1', $row->metadata['access_request_id']);
+        self::assertNull($row->completedAt);
+    }
+
+    public function testGetByIdReturnsNullForMissingRow(): void
+    {
+        self::assertNull($this->repo->getById(999999));
+    }
+```
+
+Add the `use` statements at the top of the test file for `OutboxStatus`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: FAIL on the two new methods — `getById` not defined.
+
+- [ ] **Step 3: Add the method**
+
+Add to `OutboxRepository`:
+
+```php
+    public function getById(int $id): ?OutboxRow
+    {
+        $stmt = $this->db->prepare(<<<'SQL'
+            SELECT id, operation, fga_user, fga_relation, fga_object,
+                   status, attempts, next_attempt_at, last_error, last_error_code,
+                   metadata, created_at, completed_at
+            FROM openfga_outbox
+            WHERE id = :id
+        SQL);
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+        return $this->hydrate($row);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): OutboxRow
+    {
+        $metadataJson = is_string($row['metadata']) ? $row['metadata'] : '{}';
+        /** @var array<string, mixed> $metadata */
+        $metadata = json_decode($metadataJson, true, flags: JSON_THROW_ON_ERROR);
+
+        return new OutboxRow(
+            id: (int) $row['id'],
+            operation: OutboxOperation::from((string) $row['operation']),
+            fgaUser: (string) $row['fga_user'],
+            fgaRelation: (string) $row['fga_relation'],
+            fgaObject: (string) $row['fga_object'],
+            status: OutboxStatus::from((string) $row['status']),
+            attempts: (int) $row['attempts'],
+            nextAttemptAt: new \DateTimeImmutable((string) $row['next_attempt_at']),
+            lastError: $row['last_error'] !== null ? (string) $row['last_error'] : null,
+            lastErrorCode: $row['last_error_code'] !== null ? (string) $row['last_error_code'] : null,
+            metadata: $metadata,
+            createdAt: new \DateTimeImmutable((string) $row['created_at']),
+            completedAt: $row['completed_at'] !== null ? new \DateTimeImmutable((string) $row['completed_at']) : null,
+        );
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Repositories/OutboxRepository.php phpunit_tests/Repositories/OutboxRepositoryTest.php
+git commit -m "feat(outbox): repository.getById with row hydration"
+```
+
+### Task 11: OutboxRepository::markSucceeded, markRetryable, markFailedTerminal (TDD)
+
+**Files:**
+
+- Modify: `src/Repositories/OutboxRepository.php`
+- Modify: `phpunit_tests/Repositories/OutboxRepositoryTest.php`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `OutboxRepositoryTest`:
+
+```php
+    public function testMarkSucceededSetsTerminalStateAndCompletedAt(): void
+    {
+        [$id, ] = $this->repo->insertBatch($this->samplePayload());
+
+        $this->repo->markSucceeded($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::SUCCEEDED, $row->status);
+        self::assertNotNull($row->completedAt);
+    }
+
+    public function testMarkSucceededOnAlreadyTerminalIsNoOp(): void
+    {
+        [$id, ] = $this->repo->insertBatch($this->samplePayload());
+        $this->repo->markSucceeded($id);
+        $firstCompleted = $this->repo->getById($id)?->completedAt;
+
+        // Sleep 1 second so completed_at would observably change if a second call rewrote it.
+        sleep(1);
+        $this->repo->markSucceeded($id);
+
+        $secondCompleted = $this->repo->getById($id)?->completedAt;
+        self::assertEquals($firstCompleted, $secondCompleted, 'completed_at must not change on second markSucceeded');
+    }
+
+    public function testMarkRetryableIncrementsAttemptsAndSchedulesNext(): void
+    {
+        [$id, ] = $this->repo->insertBatch($this->samplePayload());
+        $nextAt = (new \DateTimeImmutable('now'))->modify('+8 seconds');
+
+        $this->repo->markRetryable($id, attempts: 3, nextAttemptAt: $nextAt, lastError: 'OpenFGA 503', lastErrorCode: null);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::RETRYING, $row->status);
+        self::assertSame(3, $row->attempts);
+        self::assertSame('OpenFGA 503', $row->lastError);
+        self::assertEqualsWithDelta(
+            $nextAt->getTimestamp(),
+            $row->nextAttemptAt->getTimestamp(),
+            1.0,
+            'next_attempt_at within 1s of requested',
+        );
+    }
+
+    public function testMarkFailedTerminalIsSticky(): void
+    {
+        [$id, ] = $this->repo->insertBatch($this->samplePayload());
+
+        $this->repo->markFailedTerminal($id, lastError: 'validation_error', lastErrorCode: 'validation_error');
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::FAILED_TERMINAL, $row->status);
+        self::assertSame('validation_error', $row->lastErrorCode);
+
+        // Subsequent markRetryable on a terminal row must NOT downgrade it.
+        $this->repo->markRetryable($id, attempts: 4, nextAttemptAt: new \DateTimeImmutable(), lastError: 'late retry', lastErrorCode: null);
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(
+            OutboxStatus::FAILED_TERMINAL,
+            $row->status,
+            'markRetryable must not overwrite a terminal status',
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests — they must fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: FAIL on the four new methods.
+
+- [ ] **Step 3: Add the methods**
+
+Add to `OutboxRepository`:
+
+```php
+    public function markSucceeded(int $id): void
+    {
+        // Guard against terminal-status downgrades: only mark succeeded if currently
+        // in a non-terminal state. Re-applying succeeded is a no-op (completed_at preserved).
+        $stmt = $this->db->prepare(<<<'SQL'
+            UPDATE openfga_outbox
+            SET status = 'succeeded',
+                completed_at = COALESCE(completed_at, NOW())
+            WHERE id = :id AND status IN ('pending', 'retrying', 'succeeded')
+        SQL);
+        $stmt->execute([':id' => $id]);
+    }
+
+    public function markRetryable(
+        int $id,
+        int $attempts,
+        \DateTimeImmutable $nextAttemptAt,
+        string $lastError,
+        ?string $lastErrorCode,
+    ): void {
+        // Only transition out of pending/retrying. A failed_terminal row must
+        // stay terminal — admin retry has its own path (resetForRetry).
+        $stmt = $this->db->prepare(<<<'SQL'
+            UPDATE openfga_outbox
+            SET status = 'retrying',
+                attempts = :attempts,
+                next_attempt_at = :next_attempt_at,
+                last_error = :last_error,
+                last_error_code = :last_error_code
+            WHERE id = :id AND status IN ('pending', 'retrying')
+        SQL);
+        $stmt->execute([
+            ':id'              => $id,
+            ':attempts'        => $attempts,
+            ':next_attempt_at' => $nextAttemptAt->format('Y-m-d H:i:sP'),
+            ':last_error'      => $lastError,
+            ':last_error_code' => $lastErrorCode,
+        ]);
+    }
+
+    public function markFailedTerminal(int $id, string $lastError, ?string $lastErrorCode): void
+    {
+        $stmt = $this->db->prepare(<<<'SQL'
+            UPDATE openfga_outbox
+            SET status = 'failed_terminal',
+                last_error = :last_error,
+                last_error_code = :last_error_code,
+                completed_at = NOW()
+            WHERE id = :id AND status IN ('pending', 'retrying')
+        SQL);
+        $stmt->execute([
+            ':id'              => $id,
+            ':last_error'      => $lastError,
+            ':last_error_code' => $lastErrorCode,
+        ]);
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Repositories/OutboxRepository.php phpunit_tests/Repositories/OutboxRepositoryTest.php
+git commit -m "feat(outbox): markSucceeded/markRetryable/markFailedTerminal with terminal stickiness"
+```
+
+### Task 12: OutboxRepository::pickupPending with FOR UPDATE SKIP LOCKED (TDD)
+
+**Files:**
+
+- Modify: `src/Repositories/OutboxRepository.php`
+- Modify: `phpunit_tests/Repositories/OutboxRepositoryTest.php`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append to `OutboxRepositoryTest`:
+
+```php
+    public function testPickupPendingReturnsOnlyEligibleRows(): void
+    {
+        $ids = $this->repo->insertBatch($this->samplePayload());
+        $this->repo->markSucceeded($ids[0]); // exclude succeeded
+        $this->repo->markFailedTerminal($ids[1], 'x', null); // exclude failed_terminal
+
+        $picked = $this->repo->pickupPending(limit: 10, now: new \DateTimeImmutable());
+
+        self::assertSame([], $picked, 'no eligible rows after both are terminal');
+    }
+
+    public function testPickupPendingRespectsNextAttemptAt(): void
+    {
+        [$id] = $this->repo->insertBatch([$this->samplePayload()[0]]);
+
+        // Schedule the next attempt 60 seconds into the future.
+        $this->repo->markRetryable(
+            $id,
+            attempts: 1,
+            nextAttemptAt: (new \DateTimeImmutable())->modify('+60 seconds'),
+            lastError: 'transient',
+            lastErrorCode: null,
+        );
+
+        $tooEarly = $this->repo->pickupPending(limit: 10, now: new \DateTimeImmutable());
+        self::assertSame([], $tooEarly);
+
+        // Far-future cutoff should pick it up.
+        $picked = $this->repo->pickupPending(limit: 10, now: (new \DateTimeImmutable())->modify('+120 seconds'));
+        self::assertCount(1, $picked);
+        self::assertSame($id, $picked[0]->id);
+    }
+
+    /**
+     * Two concurrent transactions must each get distinct rows
+     * thanks to FOR UPDATE SKIP LOCKED. This is the load-bearing
+     * concurrency test for the consumer + backstop topology.
+     */
+    public function testPickupPendingSkipLockedSeparatesConcurrentRunners(): void
+    {
+        $ids = $this->repo->insertBatch($this->samplePayload()); // 2 rows
+
+        // Open a second PDO connection — both share the same Postgres DB.
+        $other = new \PDO(
+            (string) self::$pdo->getAttribute(\PDO::ATTR_CONNECTION_STATUS),
+            (string) ( $_ENV['DB_USER'] ?? '' ),
+            (string) ( $_ENV['DB_PASSWORD'] ?? '' ),
+            [
+                \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+                \PDO::ATTR_EMULATE_PREPARES   => false,
+            ],
+        );
+        $other->exec("SET timezone TO 'Europe/Vatican'");
+        $otherRepo = new OutboxRepository($other);
+
+        // Both runners attempt to pick up; SKIP LOCKED must give each one a distinct row.
+        self::$pdo->beginTransaction();
+        $picked1 = $this->repo->pickupPending(limit: 10, now: new \DateTimeImmutable());
+
+        $other->beginTransaction();
+        $picked2 = $otherRepo->pickupPending(limit: 10, now: new \DateTimeImmutable());
+
+        self::$pdo->commit();
+        $other->commit();
+
+        $idsPicked = array_merge(
+            array_map(static fn ($r) => $r->id, $picked1),
+            array_map(static fn ($r) => $r->id, $picked2),
+        );
+        sort($idsPicked);
+        sort($ids);
+        self::assertSame($ids, $idsPicked, 'two transactions must collectively pick up every row exactly once');
+        self::assertCount(1, $picked1);
+        self::assertCount(1, $picked2);
+    }
+```
+
+NOTE on the second-PDO setup: `RepositoryTestCase` exposes `DB_HOST` etc. via `self::env()`. If your local DSN
+construction differs from `pgsql:host=...;port=...;dbname=...`, mirror what `RepositoryTestCase::setUpBeforeClass`
+builds — the simplest fix is to add a `protected static function makeSecondPdo(): \PDO` to `RepositoryTestCase`
+that reuses the env reading and returns a fresh connection, then call that here. Do that refactor if/when the
+inline DSN feels awkward; it's not required for v1.
+
+- [ ] **Step 2: Run tests — they must fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: FAIL on `pickupPending`.
+
+- [ ] **Step 3: Add the method**
+
+Add to `OutboxRepository`:
+
+```php
+    /**
+     * Pick up rows ready for the consumer / backstop to process.
+     *
+     * Uses FOR UPDATE SKIP LOCKED so concurrent runners don't collide:
+     * each runner gets a distinct slice of the eligible rows. Caller is
+     * responsible for COMMIT/ROLLBACK of the surrounding transaction
+     * (the lock is held until the runner finishes processing or rolls
+     * back).
+     *
+     * @return list<OutboxRow>
+     */
+    public function pickupPending(int $limit, \DateTimeImmutable $now): array
+    {
+        $stmt = $this->db->prepare(<<<'SQL'
+            SELECT id, operation, fga_user, fga_relation, fga_object,
+                   status, attempts, next_attempt_at, last_error, last_error_code,
+                   metadata, created_at, completed_at
+            FROM openfga_outbox
+            WHERE status IN ('pending', 'retrying')
+              AND next_attempt_at <= :now
+            ORDER BY next_attempt_at ASC, id ASC
+            LIMIT :limit
+            FOR UPDATE SKIP LOCKED
+        SQL);
+        $stmt->bindValue(':now', $now->format('Y-m-d H:i:sP'), PDO::PARAM_STR);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        $rows = [];
+        while (($r = $stmt->fetch(PDO::FETCH_ASSOC)) !== false) {
+            $rows[] = $this->hydrate($r);
+        }
+        return $rows;
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Repositories/OutboxRepository.php phpunit_tests/Repositories/OutboxRepositoryTest.php
+git commit -m "feat(outbox): repository.pickupPending with FOR UPDATE SKIP LOCKED"
+```
+
+### Task 13: OutboxRepository::resetForRetry + countByStatus (TDD)
+
+**Files:**
+
+- Modify: `src/Repositories/OutboxRepository.php`
+- Modify: `phpunit_tests/Repositories/OutboxRepositoryTest.php`
+
+- [ ] **Step 1: Add the failing tests**
+
+```php
+    public function testResetForRetryClearsAttemptsAndStatus(): void
+    {
+        [$id] = $this->repo->insertBatch([$this->samplePayload()[0]]);
+        $this->repo->markFailedTerminal($id, 'validation_error', 'validation_error');
+
+        $changed = $this->repo->resetForRetry($id);
+
+        self::assertTrue($changed, 'resetForRetry must return true when a row was reset');
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::PENDING, $row->status);
+        self::assertSame(0, $row->attempts);
+        self::assertNull($row->lastError);
+        self::assertNull($row->lastErrorCode);
+        self::assertNull($row->completedAt);
+    }
+
+    public function testResetForRetryReturnsFalseForNonTerminalRow(): void
+    {
+        [$id] = $this->repo->insertBatch([$this->samplePayload()[0]]);
+        // Row is still 'pending' — admin retry must refuse.
+        $changed = $this->repo->resetForRetry($id);
+        self::assertFalse($changed);
+    }
+
+    public function testCountByStatusBucketsAllFour(): void
+    {
+        $ids = $this->repo->insertBatch($this->samplePayload());
+        $this->repo->markSucceeded($ids[0]);
+        $this->repo->markFailedTerminal($ids[1], 'x', null);
+
+        $counts = $this->repo->countByStatus();
+
+        self::assertSame(0, $counts['pending'] ?? 0);
+        self::assertSame(0, $counts['retrying'] ?? 0);
+        self::assertSame(1, $counts['succeeded'] ?? 0);
+        self::assertSame(1, $counts['failed_terminal'] ?? 0);
+    }
+```
+
+- [ ] **Step 2: Verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: FAIL on the three new methods.
+
+- [ ] **Step 3: Add the methods**
+
+```php
+    /**
+     * Reset a failed_terminal row back to pending so the consumer/backstop
+     * will retry it. Only failed_terminal rows are eligible — admin retry on
+     * a pending/retrying row is a 409 from the handler.
+     *
+     * Returns true if a row was reset; false if the row was not in
+     * failed_terminal state.
+     */
+    public function resetForRetry(int $id): bool
+    {
+        $stmt = $this->db->prepare(<<<'SQL'
+            UPDATE openfga_outbox
+            SET status = 'pending',
+                attempts = 0,
+                last_error = NULL,
+                last_error_code = NULL,
+                completed_at = NULL,
+                next_attempt_at = NOW()
+            WHERE id = :id AND status = 'failed_terminal'
+        SQL);
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() === 1;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function countByStatus(): array
+    {
+        $stmt = $this->db->query(<<<'SQL'
+            SELECT status::text AS status, COUNT(*)::int AS n
+            FROM openfga_outbox
+            GROUP BY status
+        SQL);
+        $out = [];
+        if ($stmt !== false) {
+            /** @var array{status: string, n: int} $r */
+            foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+                $out[$r['status']] = $r['n'];
+            }
+        }
+        return $out;
+    }
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/OutboxRepositoryTest.php`
+Expected: PASS, 14 tests.
+
+- [ ] **Step 5: Static analysis**
+
+Run: `composer analyse -- src/Repositories/OutboxRepository.php`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Repositories/OutboxRepository.php phpunit_tests/Repositories/OutboxRepositoryTest.php
+git commit -m "feat(outbox): repository.resetForRetry and countByStatus"
+```
+
+---
+
+## Phase 4 — Processor
+
+### Task 14: OutboxProcessor (TDD, the core orchestration)
+
+**Files:**
+
+- Create: `src/Services/Outbox/OutboxProcessor.php`
+- Create: `phpunit_tests/Services/Outbox/OutboxProcessorTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+This test uses `MockHandler`-backed `OpenFgaClient` (the pattern from `OpenFgaClientTest` established in PR #628)
+plus a real `OutboxRepository` against the test Postgres.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(OutboxProcessor::class)]
+final class OutboxProcessorTest extends RepositoryTestCase
+{
+    private OutboxRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new OutboxRepository(self::$pdo);
+    }
+
+    private function makeClient(MockHandler $mock): OpenFgaClient
+    {
+        $psr17 = new Psr17Factory();
+        return new OpenFgaClient(
+            'http://localhost:8083',
+            'store-123',
+            'model-456',
+            new Client(['handler' => HandlerStack::create($mock)]),
+            $psr17,
+            $psr17,
+        );
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function seedOneWrite(): array
+    {
+        return $this->repo->insertBatch([
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:alice',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => 'k-' . bin2hex(random_bytes(4)),
+                'metadata'        => ['access_request_id' => 'r1'],
+            ],
+        ]);
+    }
+
+    public function testProcessOneSuccessMarksSucceeded(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $mock = new MockHandler([new Response(200, [], '')]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $disp = $proc->processOne($id);
+
+        self::assertSame(OutboxDisposition::BENIGN_SUCCESS->name, $disp->name === OutboxDisposition::BENIGN_SUCCESS->name ? $disp->name : $disp->name);
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::SUCCEEDED, $row->status);
+    }
+
+    public function testProcessOneTransientSchedulesRetryWithCorrectBackoff(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $mock = new MockHandler([
+            new Response(503, [], (string) json_encode(['code' => 'temporarily_unavailable', 'message' => 'try again'])),
+        ]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::RETRYING, $row->status);
+        self::assertSame(1, $row->attempts);
+        $delta = $row->nextAttemptAt->getTimestamp() - (new \DateTimeImmutable())->getTimestamp();
+        self::assertGreaterThanOrEqual(0, $delta);
+        self::assertLessThanOrEqual(2, $delta, 'attempts=1 should schedule ~1s ahead');
+    }
+
+    public function testProcessOneValidationErrorMarksTerminalOnFirstAttempt(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $mock = new MockHandler([
+            new Response(400, [], (string) json_encode(['code' => 'validation_error', 'message' => 'bad type'])),
+        ]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::FAILED_TERMINAL, $row->status);
+        self::assertSame('validation_error', $row->lastErrorCode);
+    }
+
+    public function test10thAttemptOnTransientMarksTerminal(): void
+    {
+        [$id] = $this->seedOneWrite();
+        // Pre-set the row to attempts=9 and retrying so this call is the 10th.
+        $this->repo->markRetryable(
+            $id,
+            attempts: 9,
+            nextAttemptAt: new \DateTimeImmutable('-1 second'),
+            lastError: 'prior transient',
+            lastErrorCode: null,
+        );
+        $mock = new MockHandler([new Response(503, [], '')]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(
+            OutboxStatus::FAILED_TERMINAL,
+            $row->status,
+            '10th attempt on transient must transition to failed_terminal',
+        );
+    }
+
+    public function testProcessOneBenignAlreadyExistsCountsAsSuccess(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $mock = new MockHandler([
+            new Response(400, [], (string) json_encode([
+                'code'    => 'cannot_allow_duplicate_tuple',
+                'message' => 'tuple already exists',
+            ])),
+        ]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::SUCCEEDED, $row->status);
+    }
+
+    public function testProcessOneOnTerminalRowIsNoOp(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $this->repo->markSucceeded($id);
+        $mock = new MockHandler([]); // No OpenFGA call should be made.
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        // Should not throw despite MockHandler being empty.
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::SUCCEEDED, $row->status);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/OutboxProcessorTest.php`
+Expected: FAIL — `OutboxProcessor` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+
+/**
+ * Single point of contact between the outbox and OpenFGA.
+ *
+ * Called from three places: the handler's sync fast path (after the
+ * surrounding tx has committed), the consumer's XREADGROUP loop, and
+ * the cron backstop's pickupPending scan. They all use the same
+ * processOne() so classification, retry scheduling, and status
+ * transitions live in exactly one file.
+ *
+ * processOne() is idempotent on terminal rows — re-running on a
+ * succeeded or failed_terminal row is a no-op.
+ */
+final class OutboxProcessor
+{
+    private const MAX_ATTEMPTS = 10;
+
+    public function __construct(
+        private readonly OutboxRepository $repo,
+        private readonly OpenFgaClient $client,
+    ) {
+    }
+
+    public function processOne(int $rowId): OutboxDisposition
+    {
+        $row = $this->repo->getById($rowId);
+        if ($row === null) {
+            // Row was deleted between pickup and processOne — nothing to do.
+            return OutboxDisposition::BENIGN_SUCCESS;
+        }
+
+        if ($row->status === OutboxStatus::SUCCEEDED || $row->status === OutboxStatus::FAILED_TERMINAL) {
+            // Idempotency anchor — re-running on a terminal row no-ops.
+            return OutboxDisposition::BENIGN_SUCCESS;
+        }
+
+        try {
+            $this->invoke($row);
+            $this->repo->markSucceeded($row->id);
+            return OutboxDisposition::BENIGN_SUCCESS;
+        } catch (\Throwable $e) {
+            $disposition = OutboxClassifier::classify($e);
+            $code        = $e instanceof OpenFgaApiException ? $e->getErrorCode() : null;
+            $message     = $e->getMessage();
+
+            switch ($disposition) {
+                case OutboxDisposition::BENIGN_SUCCESS:
+                    // TupleAlreadyExists / TupleNotFound — counts as success.
+                    $this->repo->markSucceeded($row->id);
+                    return OutboxDisposition::BENIGN_SUCCESS;
+
+                case OutboxDisposition::TERMINAL:
+                    $this->repo->markFailedTerminal($row->id, $message, $code);
+                    return OutboxDisposition::TERMINAL;
+
+                case OutboxDisposition::RETRY:
+                    $newAttempts = $row->attempts + 1;
+                    if ($newAttempts >= self::MAX_ATTEMPTS) {
+                        // Last attempt failed transiently — terminal.
+                        $this->repo->markFailedTerminal($row->id, $message, $code);
+                        return OutboxDisposition::TERMINAL;
+                    }
+                    $delay = OutboxBackoff::secondsForAttempt($newAttempts);
+                    $next  = (new \DateTimeImmutable())->modify("+{$delay} seconds");
+                    $this->repo->markRetryable($row->id, $newAttempts, $next, $message, $code);
+                    return OutboxDisposition::RETRY;
+            }
+        }
+    }
+
+    /**
+     * Convenience alias used by handlers in the sync fast path.
+     *
+     * Same semantics as processOne — separate method to make the call
+     * site read as "sync attempt" rather than "any-context attempt".
+     */
+    public function processSync(int $rowId): OutboxDisposition
+    {
+        return $this->processOne($rowId);
+    }
+
+    private function invoke(OutboxRow $row): void
+    {
+        match ($row->operation) {
+            OutboxOperation::WRITE_TUPLE  => $this->client->writeTuple($row->fgaUser, $row->fgaRelation, $row->fgaObject),
+            OutboxOperation::DELETE_TUPLE => $this->client->deleteTuple($row->fgaUser, $row->fgaRelation, $row->fgaObject),
+        };
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/OutboxProcessorTest.php`
+Expected: PASS, 6 tests.
+
+- [ ] **Step 5: Static analysis**
+
+Run: `composer analyse -- src/Services/Outbox/OutboxProcessor.php`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/Outbox/OutboxProcessor.php phpunit_tests/Services/Outbox/OutboxProcessorTest.php
+git commit -m "feat(outbox): OutboxProcessor — single point of OpenFGA contact"
+```
+
+---
+
+## Phase 5 — Redis layer
+
+### Task 15: OutboxNotifier (TDD, best-effort XADD)
+
+**Files:**
+
+- Create: `src/Services/Outbox/OutboxNotifier.php`
+- Create: `phpunit_tests/Services/Outbox/OutboxNotifierTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OutboxNotifier::class)]
+final class OutboxNotifierTest extends TestCase
+{
+    public function testNotifyXAddsToStream(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xAdd')
+            ->with(
+                self::equalTo('litcal:reconcile-stream'),
+                self::equalTo('*'),
+                self::callback(static function (array $payload): bool {
+                    return ( $payload['row_id'] ?? null ) === '42' && ( $payload['op'] ?? null ) === 'write_tuple';
+                }),
+            )
+            ->willReturn('1234567890-0');
+
+        $notifier = new OutboxNotifier($redis, 'litcal:reconcile-stream');
+        $notifier->notify(42, 'write_tuple');
+    }
+
+    public function testNotifyOnRedisExceptionDoesNotPropagate(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xAdd')
+            ->willThrowException(new \RedisException('connection refused'));
+
+        $notifier = new OutboxNotifier($redis, 'litcal:reconcile-stream');
+
+        // Must NOT throw — the outbox row is durable in PG; the backstop will pick it up.
+        $notifier->notify(42, 'write_tuple');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testNotifyWithNullRedisIsNoOp(): void
+    {
+        $notifier = new OutboxNotifier(null, 'litcal:reconcile-stream');
+        $notifier->notify(42, 'write_tuple');
+        $this->addToAssertionCount(1);
+    }
+}
+```
+
+- [ ] **Step 2: Verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/OutboxNotifierTest.php`
+Expected: FAIL — `OutboxNotifier` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Best-effort XADD to the reconcile stream.
+ *
+ * Never throws to the caller — the outbox row is durable in PG, and the
+ * cron backstop is the safety net. Logging at WARNING is sufficient
+ * signal that something is off; the system continues to function.
+ *
+ * Pass null \Redis to disable (e.g. in environments without Redis).
+ */
+final class OutboxNotifier
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly ?\Redis $redis,
+        private readonly string $streamName,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function notify(int $outboxId, string $operation): void
+    {
+        if ($this->redis === null) {
+            return;
+        }
+
+        try {
+            $this->redis->xAdd(
+                $this->streamName,
+                '*',
+                [
+                    'row_id' => (string) $outboxId,
+                    'op'     => $operation,
+                ],
+            );
+        } catch (\RedisException $e) {
+            $this->logger->warning('outbox.redis.notify_failed', [
+                'row_id' => $outboxId,
+                'op'     => $operation,
+                'error'  => $e->getMessage(),
+            ]);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/OutboxNotifierTest.php`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Services/Outbox/OutboxNotifier.php phpunit_tests/Services/Outbox/OutboxNotifierTest.php
+git commit -m "feat(outbox): OutboxNotifier — best-effort XADD to reconcile stream"
+```
+
+### Task 16: RedisStreamConsumer (TDD, mocked Redis)
+
+**Files:**
+
+- Create: `src/Services/Outbox/RedisStreamConsumer.php`
+- Create: `phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php`
+
+- [ ] **Step 1: Write the failing test (mocked Redis)**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RedisStreamConsumer::class)]
+final class RedisStreamConsumerTest extends TestCase
+{
+    public function testEnsureGroupCreatesGroupIfMissing(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xGroup')
+            ->with('CREATE', 'litcal:reconcile-stream', 'reconciler', '$', true)
+            ->willReturn(true);
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->ensureGroup();
+    }
+
+    public function testEnsureGroupIgnoresBusygroup(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xGroup')
+            ->willThrowException(new \RedisException('BUSYGROUP Consumer Group name already exists'));
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->ensureGroup();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEnsureGroupReraisesOtherErrors(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xGroup')
+            ->willThrowException(new \RedisException('WRONGTYPE'));
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $this->expectException(\RedisException::class);
+        $this->expectExceptionMessage('WRONGTYPE');
+        $consumer->ensureGroup();
+    }
+
+    public function testReadOneInvokesCallbackWithRowIdAndAcks(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->method('xReadGroup')->willReturn([
+            'litcal:reconcile-stream' => [
+                '1700000000-0' => ['row_id' => '42', 'op' => 'write_tuple'],
+            ],
+        ]);
+        $redis->expects(self::once())
+            ->method('xAck')
+            ->with('litcal:reconcile-stream', 'reconciler', ['1700000000-0'])
+            ->willReturn(1);
+
+        $captured = null;
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(
+            blockMs: 5000,
+            process: function (int $rowId) use (&$captured): void { $captured = $rowId; },
+        );
+
+        self::assertSame(42, $captured);
+    }
+
+    public function testReadOneReturnsWithoutAckOnEmptyRead(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        // Empty arrays come back from xReadGroup on timeout / no messages.
+        $redis->method('xReadGroup')->willReturn([]);
+        $redis->expects(self::never())->method('xAck');
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(blockMs: 100, process: function (int $rowId): void {});
+        $this->addToAssertionCount(1);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php`
+Expected: FAIL — `RedisStreamConsumer` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Thin wrapper around \Redis XREADGROUP + XACK for the consumer loop.
+ *
+ * Lives in its own class so the consumer's domain logic (look up the
+ * outbox row, invoke OutboxProcessor) doesn't get tangled with Redis
+ * Streams plumbing, and so we can unit-test by mocking \Redis.
+ */
+final class RedisStreamConsumer
+{
+    private const CLAIM_IDLE_MS = 30_000;
+
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly \Redis $redis,
+        private readonly string $streamName,
+        private readonly string $groupName,
+        private readonly string $consumerName,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Idempotent. BUSYGROUP errors mean the group already exists; that's fine.
+     */
+    public function ensureGroup(): void
+    {
+        try {
+            $this->redis->xGroup('CREATE', $this->streamName, $this->groupName, '$', true);
+        } catch (\RedisException $e) {
+            if (str_contains($e->getMessage(), 'BUSYGROUP')) {
+                return;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Read one message (or batch) from the stream and invoke $process
+     * with the row_id field. XACK on success.
+     *
+     * Stale pending entries (idle > CLAIM_IDLE_MS) are reclaimed first
+     * via XCLAIM so a new consumer can finish work a previous consumer
+     * crashed mid-flight.
+     *
+     * @param callable(int): void $process
+     */
+    public function readOnce(int $blockMs, callable $process): void
+    {
+        // First, try to claim anything stale from another consumer.
+        $this->claimStale($process);
+
+        /** @var array<string, array<string, array<string, string>>> $batch */
+        $batch = $this->redis->xReadGroup(
+            $this->groupName,
+            $this->consumerName,
+            [$this->streamName => '>'],
+            1,
+            $blockMs,
+        );
+
+        $messages = $batch[$this->streamName] ?? [];
+        if (empty($messages)) {
+            return;
+        }
+
+        $ackIds = [];
+        foreach ($messages as $msgId => $payload) {
+            $rowId = isset($payload['row_id']) ? (int) $payload['row_id'] : 0;
+            if ($rowId <= 0) {
+                $this->logger->warning('outbox.consumer.bad_message', ['msg_id' => $msgId, 'payload' => $payload]);
+                $ackIds[] = $msgId;
+                continue;
+            }
+            try {
+                $process($rowId);
+                $ackIds[] = $msgId;
+            } catch (\Throwable $e) {
+                // Leave the message in the PEL; XCLAIM on the next pass picks it up.
+                $this->logger->error('outbox.consumer.process_failed', [
+                    'msg_id' => $msgId,
+                    'row_id' => $rowId,
+                    'error'  => $e->getMessage(),
+                ]);
+            }
+        }
+
+        if (!empty($ackIds)) {
+            $this->redis->xAck($this->streamName, $this->groupName, $ackIds);
+        }
+    }
+
+    /**
+     * @param callable(int): void $process
+     */
+    private function claimStale(callable $process): void
+    {
+        // XPENDING + XCLAIM for messages idle longer than CLAIM_IDLE_MS.
+        /** @var array<int, array{0: string, 1: string, 2: int, 3: int}>|false $pending */
+        $pending = $this->redis->xPending($this->streamName, $this->groupName);
+        if ($pending === false || empty($pending)) {
+            return;
+        }
+        // xPending without an idle filter returns summary form; we need detail form.
+        // Use $0 / $1 sentinels from ['-', '+'] to enumerate.
+        /** @var array<int, array{0: string, 1: string, 2: int, 3: int}>|false $detail */
+        $detail = $this->redis->xPending(
+            $this->streamName,
+            $this->groupName,
+            '-',
+            '+',
+            100,
+        );
+        if ($detail === false || !is_array($detail) || !isset($detail[0]) || !is_array($detail[0])) {
+            return;
+        }
+
+        $staleIds = [];
+        foreach ($detail as $entry) {
+            if (!is_array($entry) || count($entry) < 4) {
+                continue;
+            }
+            // entry: [msgId, consumer, idle_ms, deliveries]
+            $idleMs = (int) $entry[2];
+            if ($idleMs >= self::CLAIM_IDLE_MS) {
+                $staleIds[] = (string) $entry[0];
+            }
+        }
+
+        if (empty($staleIds)) {
+            return;
+        }
+
+        /** @var array<string, array<string, string>>|false $claimed */
+        $claimed = $this->redis->xClaim(
+            $this->streamName,
+            $this->groupName,
+            $this->consumerName,
+            self::CLAIM_IDLE_MS,
+            $staleIds,
+        );
+        if ($claimed === false || empty($claimed)) {
+            return;
+        }
+
+        $ackIds = [];
+        foreach ($claimed as $msgId => $payload) {
+            $rowId = isset($payload['row_id']) ? (int) $payload['row_id'] : 0;
+            $this->logger->warning('outbox.consumer.xclaim', [
+                'msg_id'   => $msgId,
+                'row_id'   => $rowId,
+                'idle_ms'  => self::CLAIM_IDLE_MS,
+            ]);
+            if ($rowId <= 0) {
+                $ackIds[] = $msgId;
+                continue;
+            }
+            try {
+                $process($rowId);
+                $ackIds[] = $msgId;
+            } catch (\Throwable) {
+                // leave it pending; next pass retries.
+            }
+        }
+
+        if (!empty($ackIds)) {
+            $this->redis->xAck($this->streamName, $this->groupName, $ackIds);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Services/Outbox/RedisStreamConsumer.php phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
+git commit -m "feat(outbox): RedisStreamConsumer with XREADGROUP + XCLAIM stale reclaim"
+```
+
+---
+
+## Phase 6 — Runners + CLI
+
+### Task 17: BackstopRunner (TDD)
+
+**Files:**
+
+- Create: `src/Services/Outbox/BackstopRunner.php`
+- Create: `phpunit_tests/Services/Outbox/BackstopRunnerTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\BackstopRunner;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(BackstopRunner::class)]
+final class BackstopRunnerTest extends RepositoryTestCase
+{
+    public function testRunOnceProcessesEligibleRowsAndIgnoresGraceWindow(): void
+    {
+        $repo  = new OutboxRepository(self::$pdo);
+        $psr17 = new Psr17Factory();
+        $mock  = new MockHandler([
+            new Response(200, [], ''),
+            new Response(200, [], ''),
+        ]);
+        $client = new OpenFgaClient(
+            'http://localhost:8083',
+            'store-123',
+            'model-456',
+            new Client(['handler' => HandlerStack::create($mock)]),
+            $psr17,
+            $psr17,
+        );
+        $processor = new OutboxProcessor($repo, $client);
+
+        // Two ancient pending rows (eligible for backstop after 60s grace).
+        $ids = $repo->insertBatch([
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:a',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => 'k1-' . bin2hex(random_bytes(4)),
+                'metadata'        => [],
+            ],
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:b',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:US',
+                'idempotency_key' => 'k2-' . bin2hex(random_bytes(4)),
+                'metadata'        => [],
+            ],
+        ]);
+
+        $runner    = new BackstopRunner($repo, $processor, graceSeconds: 0);
+        $processed = $runner->runOnce(limit: 100);
+
+        self::assertSame(2, $processed);
+        self::assertSame(OutboxStatus::SUCCEEDED, $repo->getById($ids[0])?->status);
+        self::assertSame(OutboxStatus::SUCCEEDED, $repo->getById($ids[1])?->status);
+    }
+
+    public function testRunOnceRespectsGraceWindow(): void
+    {
+        $repo  = new OutboxRepository(self::$pdo);
+        $psr17 = new Psr17Factory();
+        $mock  = new MockHandler([]);
+        $client = new OpenFgaClient(
+            'http://localhost:8083',
+            'store-123',
+            'model-456',
+            new Client(['handler' => HandlerStack::create($mock)]),
+            $psr17,
+            $psr17,
+        );
+        $processor = new OutboxProcessor($repo, $client);
+
+        $repo->insertBatch([[
+            'operation'       => OutboxOperation::WRITE_TUPLE,
+            'fga_user'        => 'user:c',
+            'fga_relation'    => 'editor',
+            'fga_object'      => 'national_calendar:FR',
+            'idempotency_key' => 'k3-' . bin2hex(random_bytes(4)),
+            'metadata'        => [],
+        ]]);
+
+        $runner    = new BackstopRunner($repo, $processor, graceSeconds: 60);
+        $processed = $runner->runOnce(limit: 100);
+
+        self::assertSame(0, $processed, 'row is too fresh — under the 60s grace window');
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/BackstopRunnerTest.php`
+Expected: FAIL — `BackstopRunner` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+
+/**
+ * One-shot scan of openfga_outbox for the cron backstop.
+ *
+ * Picks up rows older than the grace window (default 60s — the consumer
+ * gets first crack), processes them via OutboxProcessor, exits.
+ *
+ * The grace window is the durability buffer: the consumer's XREADGROUP
+ * wake-up is sub-second on the happy path, so the backstop should only
+ * see rows where Redis lost the XADD or the consumer is dead.
+ */
+final class BackstopRunner
+{
+    public function __construct(
+        private readonly OutboxRepository $repo,
+        private readonly OutboxProcessor $processor,
+        private readonly int $graceSeconds = 60,
+    ) {
+    }
+
+    public function runOnce(int $limit = 100): int
+    {
+        $cutoff = (new \DateTimeImmutable())->modify("-{$this->graceSeconds} seconds");
+        $rows   = $this->repo->pickupPending($limit, $cutoff);
+
+        foreach ($rows as $row) {
+            $this->processor->processOne($row->id);
+        }
+
+        return count($rows);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/BackstopRunnerTest.php`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Services/Outbox/BackstopRunner.php phpunit_tests/Services/Outbox/BackstopRunnerTest.php
+git commit -m "feat(outbox): BackstopRunner — cron-driven scan with grace window"
+```
+
+### Task 18: ConsumerLoop (TDD, mocked Redis)
+
+**Files:**
+
+- Create: `src/Services/Outbox/ConsumerLoop.php`
+- Create: `phpunit_tests/Services/Outbox/ConsumerLoopTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Outbox\ConsumerLoop;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConsumerLoop::class)]
+final class ConsumerLoopTest extends TestCase
+{
+    public function testTickEnsuresGroupOnceAndDelegatesToConsumer(): void
+    {
+        $consumer = $this->createMock(RedisStreamConsumer::class);
+        $consumer->expects(self::once())->method('ensureGroup');
+        $consumer->expects(self::exactly(3))
+            ->method('readOnce')
+            ->with(5000, self::isType('callable'));
+
+        $processor = $this->createMock(OutboxProcessor::class);
+
+        $loop = new ConsumerLoop($consumer, $processor, blockMs: 5000);
+        $loop->tick();
+        $loop->tick();
+        $loop->tick();
+    }
+
+    public function testTickPassesRowIdToProcessor(): void
+    {
+        $consumer = $this->createMock(RedisStreamConsumer::class);
+        $consumer->method('readOnce')->willReturnCallback(
+            static function (int $blockMs, callable $process): void {
+                $process(42);
+            },
+        );
+
+        $processor = $this->createMock(OutboxProcessor::class);
+        $processor->expects(self::once())->method('processOne')->with(42);
+
+        $loop = new ConsumerLoop($consumer, $processor, blockMs: 5000);
+        $loop->tick();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/ConsumerLoopTest.php`
+Expected: FAIL — `ConsumerLoop` not found.
+
+- [ ] **Step 3: Write the implementation**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * Long-lived consumer loop body.
+ *
+ * tick() does one readOnce + process cycle (the unit-testable part).
+ * run() is the outer while (true), excluded from coverage. Splitting
+ * keeps the test pyramid honest.
+ */
+final class ConsumerLoop
+{
+    private bool $groupEnsured = false;
+
+    public function __construct(
+        private readonly RedisStreamConsumer $consumer,
+        private readonly OutboxProcessor $processor,
+        private readonly int $blockMs = 5000,
+    ) {
+    }
+
+    public function tick(): void
+    {
+        if (!$this->groupEnsured) {
+            $this->consumer->ensureGroup();
+            $this->groupEnsured = true;
+        }
+        $this->consumer->readOnce(
+            $this->blockMs,
+            function (int $rowId): void {
+                $this->processor->processOne($rowId);
+            },
+        );
+    }
+
+    public function run(): never
+    {
+        // Forever. systemd restarts on crash.
+        while (true) { // @phpstan-ignore-line — infinite loop is intentional
+            $this->tick();
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/Outbox/ConsumerLoopTest.php`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Services/Outbox/ConsumerLoop.php phpunit_tests/Services/Outbox/ConsumerLoopTest.php
+git commit -m "feat(outbox): ConsumerLoop — tick (testable) + run (forever)"
+```
+
+### Task 19: bin/reconcile-outbox CLI
+
+**Files:**
+
+- Create: `bin/reconcile-outbox`
+- Modify: `composer.json`
+
+- [ ] **Step 1: Write the CLI**
+
+```php
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Subcommands:
+ *   consumer  — long-lived; systemd manages restart on failure
+ *   backstop  — one-shot scan; cron invokes every 5 min
+ *
+ * Both routes through OutboxProcessor so the OpenFGA contact surface
+ * stays single-source.
+ */
+
+use Dotenv\Dotenv;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\BackstopRunner;
+use LiturgicalCalendar\Api\Services\Outbox\ConsumerLoop;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
+
+// Locate the project root via composer.json — same pattern as public/index.php.
+$root = dirname(__DIR__);
+require $root . '/vendor/autoload.php';
+
+if (file_exists($root . '/.env.local')) {
+    Dotenv::createImmutable($root, '.env.local')->safeLoad();
+} elseif (file_exists($root . '/.env')) {
+    Dotenv::createImmutable($root)->safeLoad();
+}
+
+$mode = $argv[1] ?? '';
+if ($mode !== 'consumer' && $mode !== 'backstop') {
+    fwrite(STDERR, "Usage: reconcile-outbox consumer|backstop\n");
+    exit(2);
+}
+
+// --- Build dependencies ---
+
+$pdo = new PDO(
+    sprintf(
+        'pgsql:host=%s;port=%s;dbname=%s',
+        $_ENV['DB_HOST'] ?? 'localhost',
+        $_ENV['DB_PORT'] ?? '5432',
+        $_ENV['DB_NAME'] ?? '',
+    ),
+    (string) ( $_ENV['DB_USER'] ?? '' ),
+    (string) ( $_ENV['DB_PASSWORD'] ?? '' ),
+    [
+        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+        PDO::ATTR_EMULATE_PREPARES   => false,
+    ],
+);
+$pdo->exec("SET timezone TO 'Europe/Vatican'");
+
+$repo      = new OutboxRepository($pdo);
+$fga       = OpenFgaClient::fromEnv();   // Use the existing static factory.
+$processor = new OutboxProcessor($repo, $fga);
+
+if ($mode === 'backstop') {
+    $runner    = new BackstopRunner($repo, $processor, graceSeconds: (int) ( $_ENV['OUTBOX_BACKSTOP_GRACE_SECONDS'] ?? 60 ));
+    $processed = $runner->runOnce(limit: 200);
+    fwrite(STDOUT, sprintf("backstop processed=%d\n", $processed));
+    exit(0);
+}
+
+// consumer mode
+$redis = new \Redis();
+if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+    $redis->connect((string) $_ENV['REDIS_SOCKET']);
+} else {
+    $redis->connect(
+        (string) ( $_ENV['REDIS_HOST'] ?? '127.0.0.1' ),
+        (int) ( $_ENV['REDIS_PORT'] ?? 6379 ),
+    );
+}
+if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+    $redis->auth((string) $_ENV['REDIS_PASSWORD']);
+}
+
+$streamName   = (string) ( $_ENV['REDIS_OUTBOX_STREAM']        ?? 'litcal:reconcile-stream' );
+$groupName    = (string) ( $_ENV['REDIS_OUTBOX_GROUP']         ?? 'reconciler' );
+$consumerName = (string) ( $_ENV['REDIS_OUTBOX_CONSUMER_NAME'] ?? gethostname() );
+
+$stream = new RedisStreamConsumer($redis, $streamName, $groupName, $consumerName);
+$loop   = new ConsumerLoop($stream, $processor, blockMs: 5000);
+
+$loop->run();
+```
+
+NOTE: If `OpenFgaClient::fromEnv()` does not exist (verify with `grep -n 'fromEnv' src/Services/OpenFgaClient.php`),
+construct the client inline using `getenv('OPENFGA_API_URL')` etc., mirroring how the existing handlers do it.
+
+- [ ] **Step 2: Make it executable**
+
+Run: `chmod +x bin/reconcile-outbox`
+
+- [ ] **Step 3: Add composer scripts**
+
+In `composer.json`, find the `"scripts"` block and add:
+
+```json
+        "reconciler:consumer": "@php bin/reconcile-outbox consumer",
+        "reconciler:backstop": "@php bin/reconcile-outbox backstop"
+```
+
+- [ ] **Step 4: Smoke-test the backstop (no rows is OK)**
+
+Run: `composer reconciler:backstop`
+Expected: `backstop processed=0` (or processed=N if you happen to have rows around).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bin/reconcile-outbox composer.json
+git commit -m "feat(outbox): bin/reconcile-outbox CLI (consumer + backstop subcommands)"
+```
+
+---
+
+## Phase 7 — Handler integration
+
+### Task 20: Refactor AccessRequestAdminHandler::approveRequest (TDD)
+
+**Files:**
+
+- Modify: `src/Handlers/Admin/AccessRequestAdminHandler.php`
+- Modify: `phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php`
+
+This task is the largest single behavioral change in the plan. Read the current `approveRequest` carefully before
+making changes (lines ~258-395 of `AccessRequestAdminHandler.php`). The new structure:
+
+```text
+  BEGIN tx
+    repo.approve(requestId, adminId, notes)            ── current behavior
+    outbox.insertBatch(rows)                           ── new
+  COMMIT
+  foreach row: OutboxProcessor::processSync(row)       ── new
+  OutboxNotifier::notify(row_id, op) for any still-pending row
+  return response with outbox_pending / outbox_failed / outbox_ids
+```
+
+- [ ] **Step 1: Add a failing integration test**
+
+Append to `AccessRequestAdminHandlerTest`:
+
+```php
+    public function testApproveCommitsOutboxRowsAtomicallyWithDbWrite(): void
+    {
+        // Seed a pending request with two permissions.
+        $requestId = $this->seedPendingRequest('user:alice', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+            ['object_type' => 'national_calendar', 'object_id' => 'US', 'relation' => 'viewer'],
+        ]);
+
+        // OpenFGA mock: first call 503, second call 200. So one outbox row stays
+        // 'retrying', the other goes to 'succeeded' on the fast path.
+        $mock = new MockHandler([
+            new \GuzzleHttp\Psr7\Response(503, [], ''),
+            new \GuzzleHttp\Psr7\Response(200, [], ''),
+        ]);
+        $handler = $this->makeHandlerWithMockFga($mock);
+
+        $response = $this->callApprove($handler, $requestId);
+        $body     = json_decode((string) $response->getBody(), true);
+
+        self::assertTrue($body['success']);
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(2, $body['outbox_ids']);
+
+        // Verify the row that stayed pending has the right state.
+        $outboxRepo = new \LiturgicalCalendar\Api\Repositories\OutboxRepository(self::$pdo);
+        $stmt       = self::$pdo->prepare(
+            "SELECT status::text AS status FROM openfga_outbox
+             WHERE metadata->>'access_request_id' = :rid ORDER BY id"
+        );
+        $stmt->execute([':rid' => $requestId]);
+        /** @var list<array{status: string}> $rows */
+        $rows = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        self::assertSame(['retrying', 'succeeded'], array_column($rows, 'status'));
+    }
+
+    public function testApproveIsIdempotentOnReissue(): void
+    {
+        $requestId = $this->seedPendingRequest('user:alice', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+        $mock = new MockHandler([
+            new \GuzzleHttp\Psr7\Response(200, [], ''),
+            // Second call (if it happened, which it shouldn't): no response queued.
+        ]);
+        $handler = $this->makeHandlerWithMockFga($mock);
+
+        $r1 = json_decode((string) $this->callApprove($handler, $requestId)->getBody(), true);
+
+        // Second invocation of the same request — must not throw, must produce same outbox_ids.
+        $mock2    = new MockHandler([]);
+        $handler2 = $this->makeHandlerWithMockFga($mock2);
+        $r2       = json_decode((string) $this->callApprove($handler2, $requestId)->getBody(), true);
+
+        self::assertSame($r1['outbox_ids'], $r2['outbox_ids'], 'idempotency key must collapse second insert to same row IDs');
+    }
+```
+
+You will need helper methods on the test class for `seedPendingRequest`, `makeHandlerWithMockFga`, `callApprove`. If
+`AccessRequestAdminHandlerTest` already has analogous helpers from #628, reuse them; otherwise pattern them after
+the existing `withMockOpenFgaClient` helper added in PR #628 (`grep -n withMockOpenFgaClient phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php`).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php --filter testApproveCommits`
+Expected: FAIL — `outbox_pending` doesn't exist in response.
+
+- [ ] **Step 3: Refactor approveRequest**
+
+In `AccessRequestAdminHandler::approveRequest`, replace the body **after the
+`$this->requireAdminForAllResources(...)` line** through the end of the OpenFGA loop with the outbox pattern. Keep
+the rest of the method (validation, Zitadel sync) intact.
+
+Replace (current code from `// Step 1: Create OpenFGA tuples` down to and including the `if (!empty($fgaErrors)) {
+return ... }` block that bails before DB mutation, **plus** the `// Step 2: Approve in database` block):
+
+```php
+        // ----- Outbox-backed step 1+2 (Options B+C from #567 design) -----
+        $repository = $this->getRepository();
+        $outboxRepo = $this->getOutboxRepository();
+        $notifier   = $this->getOutboxNotifier();
+
+        if (empty($permissions)) {
+            // No tuples to write — just approve.
+            if (!$repository->approve($requestId, $adminId, $notes)) {
+                throw new ValidationException('Failed to approve request');
+            }
+            $outboxRows = [];
+        } else {
+            $outboxRows = [];
+            self::$pdo->beginTransaction();
+            try {
+                if (!$repository->approve($requestId, $adminId, $notes)) {
+                    throw new ValidationException('Failed to approve request');
+                }
+                $payload = [];
+                foreach ($permissions as $perm) {
+                    $objectType = (string) ( $perm['object_type'] ?? '' );
+                    $objectId   = (string) ( $perm['object_id']   ?? '' );
+                    $relation   = (string) ( $perm['relation']    ?? '' );
+                    $fgaUser    = "user:{$userId}";
+                    $fgaObject  = "{$objectType}:{$objectId}";
+                    $payload[]  = [
+                        'operation'       => OutboxOperation::WRITE_TUPLE,
+                        'fga_user'        => $fgaUser,
+                        'fga_relation'    => $relation,
+                        'fga_object'      => $fgaObject,
+                        'idempotency_key' => sprintf(
+                            'access_request:%s:write_tuple:%s:%s:%s',
+                            $requestId, $fgaUser, $relation, $fgaObject,
+                        ),
+                        'metadata'        => [
+                            'access_request_id' => $requestId,
+                            'admin_user'        => "user:{$adminId}",
+                        ],
+                    ];
+                }
+                $rowIds = $outboxRepo->insertBatch($payload);
+                self::$pdo->commit();
+            } catch (\Throwable $e) {
+                self::$pdo->rollBack();
+                throw $e;
+            }
+
+            // ----- Sync fast path: attempt each tuple inline -----
+            $processor = $this->getOutboxProcessor();
+            $outboxRows = [];
+            foreach ($rowIds as $rowId) {
+                $disp        = $processor->processSync($rowId);
+                $current     = $outboxRepo->getById($rowId);
+                $outboxRows[] = [
+                    'id'         => $rowId,
+                    'disposition'=> $disp->name,
+                    'status'     => $current?->status->value ?? 'unknown',
+                ];
+                // If the sync attempt left the row pending/retrying, nudge Redis so the
+                // consumer wakes immediately rather than waiting for the cron backstop.
+                if ($current !== null && in_array($current->status, [OutboxStatus::PENDING, OutboxStatus::RETRYING], true)) {
+                    $notifier->notify($rowId, OutboxOperation::WRITE_TUPLE->value);
+                }
+            }
+        }
+
+        $outboxIds      = array_map(static fn ($r): int => (int) $r['id'], $outboxRows);
+        $outboxPending  = count(array_filter($outboxRows, static fn ($r): bool => $r['status'] === 'retrying' || $r['status'] === 'pending'));
+        $outboxFailed   = count(array_filter($outboxRows, static fn ($r): bool => $r['status'] === 'failed_terminal'));
+        $tuplesCreated  = [];
+        foreach ($outboxRows as $r) {
+            if ($r['status'] === 'succeeded') {
+                // Hydrate the human-readable tuple for back-compat with the response shape.
+                $row = $outboxRepo->getById((int) $r['id']);
+                if ($row !== null) {
+                    $tuplesCreated[] = [
+                        'user'     => $row->fgaUser,
+                        'relation' => $row->fgaRelation,
+                        'object'   => $row->fgaObject,
+                    ];
+                }
+            }
+        }
+```
+
+Then update the response body so it includes `outbox_pending`, `outbox_failed`, `outbox_ids` and adjusts the
+`message` based on those counts. The `success` field stays `true` (DB committed). Existing Zitadel sync block stays
+unchanged after this point.
+
+- [ ] **Step 4: Add the dependency-injection slots**
+
+Add these properties + getters near the top of `AccessRequestAdminHandler`:
+
+```php
+    private ?OutboxRepository $outboxRepository = null;
+    private ?OutboxNotifier   $outboxNotifier   = null;
+    private ?OutboxProcessor  $outboxProcessor  = null;
+
+    public function setOutboxDependencies(
+        OutboxRepository $repo,
+        OutboxNotifier $notifier,
+        OutboxProcessor $processor,
+    ): void {
+        $this->outboxRepository = $repo;
+        $this->outboxNotifier   = $notifier;
+        $this->outboxProcessor  = $processor;
+    }
+
+    private function getOutboxRepository(): OutboxRepository { /* lazy build from $this->pdo */ }
+    private function getOutboxNotifier(): OutboxNotifier     { /* lazy build from REDIS_* env */ }
+    private function getOutboxProcessor(): OutboxProcessor   { /* lazy build from repo + getFgaClient() */ }
+```
+
+Implement the lazy builders to mirror the existing `getFgaClient()` pattern (factory + env reads). Test injection
+uses `setOutboxDependencies`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php`
+Expected: PASS, including the two new tests + all pre-existing tests for approve.
+
+- [ ] **Step 6: PHPStan**
+
+Run: `composer analyse -- src/Handlers/Admin/AccessRequestAdminHandler.php`
+Expected: clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Handlers/Admin/AccessRequestAdminHandler.php phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+git commit -m "feat(outbox): wire approveRequest through the outbox pattern"
+```
+
+### Task 21: Refactor AccessRequestAdminHandler::revokeRequest
+
+Mirror Task 20 for `revokeRequest`. Key differences:
+
+- `operation: OutboxOperation::DELETE_TUPLE` instead of WRITE_TUPLE.
+- The benign exception is `TupleNotFoundException` instead of `TupleAlreadyExistsException` — already handled by
+  the classifier; no handler change.
+- Response field names are `tuples_removed`, `outbox_pending`, `outbox_failed`, `outbox_ids`.
+
+Write two tests symmetric to Task 20's: `testRevokeCommitsOutboxRowsAtomicallyWithDbWrite` and
+`testRevokeIsIdempotentOnReissue`. Then refactor.
+
+- [ ] **Step 1: Add the two tests**
+
+(Symmetric to Task 20; substitute `revoke` for `approve` and `delete_tuple` for `write_tuple`.)
+
+- [ ] **Step 2: Verify they fail**
+
+- [ ] **Step 3: Refactor `revokeRequest` analogously**
+
+Use the same outbox pattern as Task 20.
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: PHPStan**
+
+Run: `composer analyse -- src/Handlers/Admin/AccessRequestAdminHandler.php`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Handlers/Admin/AccessRequestAdminHandler.php phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+git commit -m "feat(outbox): wire revokeRequest through the outbox pattern"
+```
+
+### Task 22: Refactor PermissionAdminHandler::grantPermission and revokePermission
+
+Mirror the same outbox pattern in `PermissionAdminHandler`. The structure is simpler than
+`AccessRequestAdminHandler` because there's no `access_requests` row to coordinate with — the outbox row is the
+durable record of intent.
+
+- [ ] **Step 1: Read the current grantPermission and revokePermission**
+
+Run: `grep -n "function grantPermission\|function revokePermission" src/Handlers/Admin/PermissionAdminHandler.php`
+Read both methods in their entirety before modifying.
+
+- [ ] **Step 2: Add two failing tests in PermissionAdminHandlerTest**
+
+For `grantPermission`: `testGrantPersistsOutboxRowAndAppliesViaSyncFastPath` and
+`testGrantIsIdempotentOnReissue`. Pattern after Task 20.
+
+- [ ] **Step 3: Verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php --filter testGrant`
+
+- [ ] **Step 4: Refactor grantPermission and revokePermission**
+
+Apply the same outbox pattern. The idempotency key for ad-hoc grants uses `permission_grant` as the namespace prefix
+(no access_request_id available):
+
+```text
+permission_grant:{adminId}:{operation}:{user}:{relation}:{object}
+```
+
+Metadata field: `'admin_user' => "user:{$adminId}"`, no `access_request_id`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php`
+Expected: PASS.
+
+- [ ] **Step 6: PHPStan**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Handlers/Admin/PermissionAdminHandler.php phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php
+git commit -m "feat(outbox): wire grant/revokePermission through the outbox pattern"
+```
+
+### Task 23: Refactor RoleCascadeService silent catch → outbox enqueue
+
+**Files:**
+
+- Modify: `src/Services/RoleCascadeService.php`
+- Modify: `phpunit_tests/Services/RoleCascadeServiceTest.php` (if it exists; otherwise create it)
+
+The current code (around `src/Services/RoleCascadeService.php:134`) silently catches OpenFGA `deleteTuple` failures
+and logs WARNING. Replace the catch body so the failure becomes an outbox row.
+
+- [ ] **Step 1: Add a failing test**
+
+If `RoleCascadeServiceTest` does not exist, create it; pattern after `OutboxProcessorTest` (real PG + MockHandler
+OpenFgaClient). Test name: `testCascadeRevokeEnqueuesOutboxRowOnFgaTransientFailure`.
+
+The test:
+
+1. Seeds an existing tuple.
+2. Mocks OpenFGA to return 503 on `deleteTuple`.
+3. Calls the cascade revoke method.
+4. Asserts that an `openfga_outbox` row exists with `operation = delete_tuple`, the correct user/relation/object,
+   and `status = pending`.
+
+- [ ] **Step 2: Verify the test fails**
+
+- [ ] **Step 3: Modify RoleCascadeService**
+
+Inject `OutboxRepository` + `OutboxNotifier` (mirror the existing constructor pattern; `RoleCascadeService::fromEnv`
+should construct them). In the catch block currently logging WARNING, replace with:
+
+```php
+catch (OpenFgaApiException $e) {
+    $disp = OutboxClassifier::classify($e);
+    if ($disp === OutboxDisposition::BENIGN_SUCCESS) {
+        // Already gone — nothing to enqueue.
+        continue;
+    }
+    $idempotencyKey = sprintf(
+        'role_cascade:%s:%s:delete_tuple:user:%s:%s:%s',
+        $userId,
+        $role,
+        $userId, // fga_user
+        $relation,
+        $fgaObject,
+    );
+    $ids = $this->outboxRepo->insertBatch([[
+        'operation'       => OutboxOperation::DELETE_TUPLE,
+        'fga_user'        => "user:{$userId}",
+        'fga_relation'    => $relation,
+        'fga_object'      => $fgaObject,
+        'idempotency_key' => $idempotencyKey,
+        'metadata'        => [
+            'role_cascade_user' => $userId,
+            'role_cascade_role' => $role,
+        ],
+    ]]);
+    foreach ($ids as $rowId) {
+        $this->outboxNotifier->notify($rowId, OutboxOperation::DELETE_TUPLE->value);
+    }
+}
+```
+
+Keep the WARNING log alongside, with `outbox_row_ids` added to the structured payload, so audit trails don't
+regress.
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/RoleCascadeServiceTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: PHPStan**
+
+Run: `composer analyse -- src/Services/RoleCascadeService.php`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Services/RoleCascadeService.php phpunit_tests/Services/RoleCascadeServiceTest.php
+git commit -m "feat(outbox): RoleCascadeService transient FGA failures enqueue outbox rows"
+```
+
+---
+
+## Phase 8 — Admin endpoint
+
+### Task 24: OutboxAdminHandler (TDD)
+
+**Files:**
+
+- Create: `src/Handlers/Admin/OutboxAdminHandler.php`
+- Create: `phpunit_tests/Handlers/Admin/OutboxAdminHandlerTest.php`
+
+Pattern after `PermissionAdminHandler` for handler structure and auth-guard wiring.
+
+- [ ] **Step 1: Write failing tests**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers\Admin;
+
+use LiturgicalCalendar\Api\Handlers\Admin\OutboxAdminHandler;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(OutboxAdminHandler::class)]
+final class OutboxAdminHandlerTest extends RepositoryTestCase
+{
+    public function testGetWithStatusFilterReturnsMatchingRows(): void
+    {
+        $repo = new OutboxRepository(self::$pdo);
+        $ids  = $repo->insertBatch([
+            [
+                'operation' => OutboxOperation::WRITE_TUPLE,
+                'fga_user' => 'user:a', 'fga_relation' => 'editor', 'fga_object' => 'national_calendar:IT',
+                'idempotency_key' => 'k1', 'metadata' => [],
+            ],
+            [
+                'operation' => OutboxOperation::WRITE_TUPLE,
+                'fga_user' => 'user:b', 'fga_relation' => 'editor', 'fga_object' => 'national_calendar:US',
+                'idempotency_key' => 'k2', 'metadata' => [],
+            ],
+        ]);
+        $repo->markFailedTerminal($ids[0], 'validation_error', 'validation_error');
+
+        // (Construct handler with admin auth bypassed for the test — mirror PermissionAdminHandlerTest's auth wiring.)
+        $handler  = $this->makeHandlerWithAdminAuth();
+        $response = $handler->handle($this->makeRequest('GET', '/admin/outbox?status=failed_terminal'));
+        $body     = json_decode((string) $response->getBody(), true);
+
+        self::assertSame(1, $body['count']);
+        self::assertSame($ids[0], $body['rows'][0]['id']);
+        self::assertSame('failed_terminal', $body['rows'][0]['status']);
+    }
+
+    public function testGetSummaryReturnsCountsPerStatus(): void { /* … */ }
+    public function testPostRetryResetsFailedTerminalToPending(): void { /* … */ }
+    public function testPostRetryReturns409ForNonTerminalRow(): void { /* … */ }
+}
+```
+
+Fill in `testGetSummaryReturnsCountsPerStatus`, `testPostRetryResetsFailedTerminalToPending`, and
+`testPostRetryReturns409ForNonTerminalRow` following the same pattern.
+
+- [ ] **Step 2: Verify they fail**
+
+- [ ] **Step 3: Write the handler**
+
+Implement `OutboxAdminHandler`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Admin;
+
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * GET  /admin/outbox?status=…&access_request_id=…&summary=1
+ * POST /admin/outbox/{id}/retry
+ *
+ * Admin-only — same JWT + role guard the other Admin handlers use.
+ */
+final class OutboxAdminHandler extends AbstractHandler
+{
+    private ?OutboxRepository $repository = null;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->allowedMethods = [RequestMethod::GET, RequestMethod::POST];
+    }
+
+    public function setRepository(OutboxRepository $repo): void
+    {
+        $this->repository = $repo;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->requireAdmin($request);  // Or your existing equivalent.
+        $method = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::GET) {
+            return $this->handleGet($request);
+        }
+        return $this->handlePost($request);
+    }
+
+    private function handleGet(ServerRequestInterface $request): ResponseInterface { /* implement: list, summary */ }
+    private function handlePost(ServerRequestInterface $request): ResponseInterface { /* implement: retry */ }
+}
+```
+
+Implement `handleGet`:
+
+- Read `$_GET['status']`, `$_GET['access_request_id']`, `$_GET['summary']`, `$_GET['limit']`, `$_GET['offset']`.
+- If `summary=1`, return `countByStatus()` plus `oldest_pending_age_seconds` (run a small SQL: `SELECT EXTRACT(EPOCH FROM
+  NOW() - MIN(created_at)) FROM openfga_outbox WHERE status IN ('pending','retrying')`).
+- Otherwise build a SELECT with the supplied filters and the standard limit/offset pagination (default
+  limit 50, max 200 — pattern after `AccessRequestAdminHandler::listForAdmin` for the pagination envelope shape).
+
+Implement `handlePost`:
+
+- Extract `{id}` from the path.
+- Call `$repo->resetForRetry($id)`.
+- If true, return 200 with the new row state.
+- If false, return 409 with `{"error": "Row is not in failed_terminal state"}`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Admin/OutboxAdminHandlerTest.php`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: PHPStan**
+
+Run: `composer analyse -- src/Handlers/Admin/OutboxAdminHandler.php`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Handlers/Admin/OutboxAdminHandler.php phpunit_tests/Handlers/Admin/OutboxAdminHandlerTest.php
+git commit -m "feat(outbox): OutboxAdminHandler — GET list/summary, POST retry"
+```
+
+### Task 25: Wire OutboxAdminHandler into Router
+
+**Files:**
+
+- Modify: `src/Router.php`
+
+- [ ] **Step 1: Add the route arm**
+
+In `Router::route()`'s `case 'admin':` block (around lines 373-420), add a new `elseif` arm after the existing
+`applications` arm:
+
+```php
+                    } elseif ($adminRoute === 'outbox') {
+                        // Admin outbox management routes
+                        // GET  /admin/outbox?status=…&summary=…   - List/summary
+                        // POST /admin/outbox/{id}/retry            - Reset terminal row to pending
+                        $outboxAdminHandler = new OutboxAdminHandler();
+                        $this->handler      = $outboxAdminHandler;
+                    }
+```
+
+Add the corresponding `use` import at the top of `Router.php`.
+
+- [ ] **Step 2: Smoke-test the route**
+
+Start the API (`composer start` if not running), then:
+
+```bash
+# Without admin auth — expect 401/403:
+curl -i http://localhost:8000/admin/outbox?summary=1
+```
+
+Expected: non-200, with the same auth-failure shape the other admin endpoints produce.
+
+(Authenticated test happens in the OutboxAdminHandlerTest harness.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Router.php
+git commit -m "feat(outbox): wire /admin/outbox routes into Router"
+```
+
+---
+
+## Phase 9 — Health
+
+### Task 26: Health endpoint adds openfga_outbox block
+
+**Files:**
+
+- Modify: `src/Health.php`
+
+- [ ] **Step 1: Read Health.php to find the right insertion point**
+
+Run: `grep -n "function\|return\|\$result\[" src/Health.php | head -30`
+
+Find where the health output is assembled (likely a method that builds an array which gets returned/JSON-encoded).
+Add a new top-level key `openfga_outbox` to that array.
+
+- [ ] **Step 2: Add the outbox block builder**
+
+```php
+    /**
+     * @return array{
+     *   pending: int,
+     *   retrying: int,
+     *   succeeded: int,
+     *   failed_terminal: int,
+     *   oldest_pending_age_seconds: int,
+     *   consumer: array{redis_reachable: bool, stream_name: string, group_name: string, pending_entries: int, oldest_pel_idle_seconds: int}
+     * }
+     */
+    private function buildOutboxStats(): array
+    {
+        $counts = [
+            'pending'         => 0,
+            'retrying'        => 0,
+            'succeeded'       => 0,
+            'failed_terminal' => 0,
+        ];
+        $oldestAge = 0;
+
+        try {
+            $pdo = $this->getPdo();  // existing pattern from Health.php
+            $stmt = $pdo->query(<<<'SQL'
+                SELECT status::text AS status, COUNT(*)::int AS n
+                FROM openfga_outbox
+                GROUP BY status
+            SQL);
+            if ($stmt !== false) {
+                /** @var array{status: string, n: int} $r */
+                foreach ($stmt->fetchAll(\PDO::FETCH_ASSOC) as $r) {
+                    $counts[$r['status']] = $r['n'];
+                }
+            }
+
+            $ageStmt = $pdo->query(<<<'SQL'
+                SELECT COALESCE(EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::int, 0) AS age
+                FROM openfga_outbox
+                WHERE status IN ('pending', 'retrying')
+            SQL);
+            if ($ageStmt !== false) {
+                $oldestAge = (int) $ageStmt->fetchColumn();
+            }
+        } catch (\PDOException) {
+            // PG unreachable — surface zeroes; health endpoint will mark DB unhealthy separately.
+        }
+
+        $consumer = [
+            'redis_reachable'        => false,
+            'stream_name'            => (string) ( $_ENV['REDIS_OUTBOX_STREAM'] ?? 'litcal:reconcile-stream' ),
+            'group_name'             => (string) ( $_ENV['REDIS_OUTBOX_GROUP']  ?? 'reconciler' ),
+            'pending_entries'        => 0,
+            'oldest_pel_idle_seconds' => 0,
+        ];
+        $redis = $this->getRedis();  // existing Health.php pattern
+        if ($redis !== null) {
+            try {
+                $info = $redis->xInfo('GROUPS', $consumer['stream_name']);
+                $consumer['redis_reachable'] = true;
+                if (is_array($info)) {
+                    foreach ($info as $group) {
+                        if (is_array($group) && ( $group['name'] ?? null ) === $consumer['group_name']) {
+                            $consumer['pending_entries'] = (int) ( $group['pending'] ?? 0 );
+                        }
+                    }
+                }
+                // Oldest PEL idle: XPENDING returns it as element [3] of the summary.
+                $pel = $redis->xPending($consumer['stream_name'], $consumer['group_name']);
+                if (is_array($pel) && isset($pel[2]) && is_numeric($pel[2])) {
+                    // xPending in summary form: [count, minId, maxId, consumers]; use Redis TIME to compute idle.
+                    // For simplicity here, leave oldest_pel_idle_seconds at 0 unless we want a detail call.
+                }
+            } catch (\Throwable) {
+                $consumer['redis_reachable'] = false;
+            }
+        }
+
+        return [
+            'pending'                    => $counts['pending'],
+            'retrying'                   => $counts['retrying'],
+            'succeeded'                  => $counts['succeeded'],
+            'failed_terminal'            => $counts['failed_terminal'],
+            'oldest_pending_age_seconds' => $oldestAge,
+            'consumer'                   => $consumer,
+        ];
+    }
+```
+
+Then plug `$result['openfga_outbox'] = $this->buildOutboxStats();` into the health-response assembly site.
+
+NOTE: `getPdo()` and `getRedis()` are placeholder names — use whatever existing accessors `Health.php` already has
+(grep for the connection setup; the file already manages both PDO and \Redis with APCu fallback).
+
+- [ ] **Step 2: Smoke-test**
+
+```bash
+curl -s http://localhost:8000/health | jq .openfga_outbox
+```
+
+Expected: an object with all the keys, all zeros for a freshly-migrated DB.
+
+- [ ] **Step 3: PHPStan**
+
+Run: `composer analyse -- src/Health.php`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Health.php
+git commit -m "feat(outbox): /health surfaces openfga_outbox block"
+```
+
+---
+
+## Phase 10 — Deployment artifacts + .env + docs
+
+### Task 27: systemd unit file
+
+**Files:**
+
+- Create: `deploy/systemd/liturgical-calendar-reconciler.service`
+
+- [ ] **Step 1: Write the unit file**
+
+```ini
+[Unit]
+Description=Liturgical Calendar OpenFGA outbox reconciler
+After=network-online.target postgresql.service redis-server.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=litcal
+Group=litcal
+WorkingDirectory=/opt/liturgical-calendar
+EnvironmentFile=/opt/liturgical-calendar/.env.local
+ExecStart=/usr/bin/php /opt/liturgical-calendar/bin/reconcile-outbox consumer
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=litcal-reconciler
+
+# Hardening (adjust as your ops policy dictates).
+ProtectSystem=full
+PrivateTmp=true
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add deploy/systemd/liturgical-calendar-reconciler.service
+git commit -m "feat(outbox): systemd unit file for the reconciler consumer"
+```
+
+### Task 28: cron entry
+
+**Files:**
+
+- Create: `deploy/cron/liturgical-calendar-backstop.cron`
+
+- [ ] **Step 1: Write the cron entry**
+
+```text
+# Liturgical Calendar OpenFGA outbox backstop — every 5 minutes.
+# Picks up rows older than the grace window that the consumer missed
+# (e.g. Redis was down or the API process died between PG commit and XADD).
+# Install: copy to /etc/cron.d/litcal-outbox-backstop and `systemctl restart cron`.
+*/5 * * * * litcal /usr/bin/php /opt/liturgical-calendar/bin/reconcile-outbox backstop >> /var/log/litcal-backstop.log 2>&1
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add deploy/cron/liturgical-calendar-backstop.cron
+git commit -m "feat(outbox): cron entry for the reconciler backstop"
+```
+
+### Task 29: Operator runbook
+
+**Files:**
+
+- Create: `docs/ops/openfga-outbox-runbook.md`
+
+- [ ] **Step 1: Write the runbook**
+
+```markdown
+# OpenFGA outbox — operator runbook
+
+## What this is
+
+The OpenFGA outbox (`openfga_outbox` table) holds every tuple write/delete the API has committed to perform.
+A systemd-managed consumer drains it via Redis Streams; a cron-driven backstop catches the cracks. Together they
+guarantee at-least-once application of tuple operations even across multi-minute network partitions.
+
+See `docs/superpowers/specs/2026-06-02-openfga-async-reconciliation-design.md` for the full design.
+
+## Install
+
+### 1. Apply the migration
+
+The `litcal-migrate` one-shot container handles this on `docker compose up -d --build`. Manual fallback:
+
+\`\`\`bash
+composer db:migrate
+\`\`\`
+
+### 2. Install the systemd unit
+
+\`\`\`bash
+sudo cp deploy/systemd/liturgical-calendar-reconciler.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now liturgical-calendar-reconciler.service
+sudo systemctl status liturgical-calendar-reconciler.service
+\`\`\`
+
+### 3. Install the cron backstop
+
+\`\`\`bash
+sudo cp deploy/cron/liturgical-calendar-backstop.cron /etc/cron.d/litcal-outbox-backstop
+sudo systemctl restart cron
+\`\`\`
+
+### 4. Confirm
+
+\`\`\`bash
+curl -s http://localhost:8000/health | jq .openfga_outbox
+\`\`\`
+
+Should return an object with all-zero counts on a fresh install.
+
+## Diagnostic queries
+
+\`\`\`sql
+-- How deep is the queue right now?
+SELECT status, COUNT(*) FROM openfga_outbox GROUP BY status;
+
+-- What's the oldest unfinished work?
+SELECT id, operation, fga_user, fga_relation, fga_object, attempts,
+       last_error_code, EXTRACT(EPOCH FROM NOW() - created_at) AS age_s
+FROM openfga_outbox
+WHERE status IN ('pending', 'retrying')
+ORDER BY created_at ASC LIMIT 10;
+
+-- What's stuck in DLQ and why?
+SELECT id, operation, fga_user, fga_relation, fga_object, last_error, last_error_code
+FROM openfga_outbox
+WHERE status = 'failed_terminal'
+ORDER BY created_at DESC LIMIT 20;
+\`\`\`
+
+## Common incidents
+
+### `oldest_pending_age_seconds` growing past 60s
+
+The consumer is wedged. Check `journalctl -u liturgical-calendar-reconciler.service --since '10 min ago'`. If it's
+crash-looping, you'll see RestartSec=5 cycles. Common causes: Redis unreachable (consumer logs ERROR + exits;
+backstop still drains, just every 5 minutes); PG unreachable (handlers also fail, /health surfaces it).
+
+### Rows piling up in failed_terminal
+
+\`\`\`bash
+curl -H "Authorization: Bearer $ADMIN_TOKEN" \\
+  http://localhost:8000/admin/outbox?status=failed_terminal | jq .rows
+\`\`\`
+
+The `last_error_code` tells you why each row failed. Typical: `validation_error` (the API built a bad tuple — fix
+upstream), `auth_failure` (OpenFGA credentials wrong — fix env).
+
+After fixing the upstream issue:
+
+\`\`\`bash
+# Retry one row:
+curl -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \\
+  http://localhost:8000/admin/outbox/42/retry
+\`\`\`
+
+## Retention / pruning
+
+There is no automated prune in v1. The table grows by one row per tuple operation. For typical admin-action volume
+that is years before any concern. When it does become one:
+
+\`\`\`sql
+DELETE FROM openfga_outbox
+WHERE status = 'succeeded'
+  AND completed_at < NOW() - INTERVAL '30 days';
+\`\`\`
+
+Don't delete `failed_terminal` rows automatically — they are the audit trail for "what didn't apply".
+```
+
+- [ ] **Step 2: Lint the runbook**
+
+Run: `composer lint:md -- docs/ops/openfga-outbox-runbook.md`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/ops/openfga-outbox-runbook.md
+git commit -m "docs(outbox): operator runbook for systemd + cron deployment"
+```
+
+### Task 30: .env.example additions
+
+**Files:**
+
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add the keys**
+
+Append (near the existing `REDIS_*` block):
+
+```dotenv
+# OpenFGA outbox reconciliation
+REDIS_OUTBOX_STREAM=litcal:reconcile-stream
+REDIS_OUTBOX_GROUP=reconciler
+REDIS_OUTBOX_CONSUMER_NAME=          # default: hostname
+OUTBOX_MAX_ATTEMPTS=10
+OUTBOX_BACKSTOP_GRACE_SECONDS=60
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .env.example
+git commit -m "docs(outbox): document reconciler env vars in .env.example"
+```
+
+---
+
+## Phase 11 — Final verification
+
+### Task 31: Whole-suite quality gates
+
+- [ ] **Step 1: Full test run**
+
+Run: `composer test`
+Expected: all tests pass; no skipped tests beyond pre-existing skips (e.g. `@group needs-redis` if you opted out
+locally).
+
+- [ ] **Step 2: PHPStan L10**
+
+Run: `composer analyse`
+Expected: no errors.
+
+- [ ] **Step 3: phpcs PSR-12**
+
+Run: `composer lint`
+Expected: no errors.
+
+- [ ] **Step 4: Markdown lint**
+
+Run: `composer lint:md`
+Expected: no errors.
+
+- [ ] **Step 5: Migration apply/rollback round-trip**
+
+Run: `composer db:migrate && composer db:migrations:execute --down <Version<TIMESTAMP>> && composer db:migrate`
+Expected: the new migration's `down()` cleanly drops the table + enums; `up()` re-applies cleanly.
+
+- [ ] **Step 6: End-to-end smoke**
+
+With `composer start` running:
+
+```bash
+# 1. Approve a pending access request (replace IDs with real ones from your seed data).
+curl -s -X POST -H "Authorization: Bearer $ADMIN_TOKEN" \
+  http://localhost:8000/admin/access-requests/$REQ_ID/approve \
+  -H 'Content-Type: application/json' -d '{}' | jq
+
+# 2. Verify outbox rows landed.
+psql -c "SELECT id, status, fga_user, fga_relation, fga_object FROM openfga_outbox ORDER BY id DESC LIMIT 5"
+
+# 3. Verify the systemd consumer (if installed) drained them.
+# 4. Otherwise verify the backstop drains:
+composer reconciler:backstop
+```
+
+- [ ] **Step 7: Push the branch**
+
+```bash
+git push -u origin feature/openfga-async-reconciliation-design
+```
+
+- [ ] **Step 8: Open PR**
+
+Use `gh pr create --base development` with the body summarizing the spec + which acceptance criteria are met. Link
+to the spec doc.
+
+---
+
+## Self-review checklist (for the implementer before declaring complete)
+
+- All steps in all tasks are checked off.
+- `composer test` passes (no new skips).
+- `composer analyse` clean (PHPStan L10).
+- `composer lint` clean (phpcs PSR-12).
+- `composer lint:md` clean.
+- The new migration has both `up()` and `down()` and the round-trip works.
+- `/health` surfaces the `openfga_outbox` block with all expected keys.
+- A real approve/revoke through the running API creates outbox rows in PG and (if Redis is up + consumer is
+  running) drains them within a second.
+- `/admin/outbox?status=failed_terminal` returns the right shape.
+- `POST /admin/outbox/{id}/retry` resets a `failed_terminal` row.
+- The systemd unit + cron entry are in `deploy/` (not actually installed by CI — operator's job).
+- The runbook exists at `docs/ops/openfga-outbox-runbook.md`.

--- a/docs/superpowers/specs/2026-06-02-openfga-async-reconciliation-design.md
+++ b/docs/superpowers/specs/2026-06-02-openfga-async-reconciliation-design.md
@@ -1,0 +1,523 @@
+# OpenFGA async reconciliation — Options B + C follow-up to issue #567
+
+**Status:** Design approved, ready for implementation plan.
+**Date:** 2026-06-02
+**Author:** John R. D'Orazio (with Claude Code)
+**Predecessor:** Issue [#567](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/567) Option A
+shipped in PR [#628](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/628) — typed `OpenFgaApiException`
+hierarchy + fail-fast in approve/revoke flows.
+**Related issues:** [#571](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/571) (ListObjects in
+`filterByAdminAccess`, shipped in #628), [#630](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/630)
+(tracking issue for future metrics framework).
+
+## 1. Context
+
+PR #628 closed the most pressing failure mode in OpenFGA tuple writes/deletes: the handler no longer returns
+`success: true` when an OpenFGA call fails outright (Option A). What remains, from the same issue's "Pick one (or
+layer them)" framing:
+
+- **Option B — Compensating actions.** Mutate DB first (single source of truth for "this approval has been committed"),
+  then call OpenFGA. On FGA failure, attempt a compensating action.
+- **Option C — Outbox / async reconciliation.** Persist the intent in an outbox table inside the DB transaction, then
+  reconcile to OpenFGA asynchronously with retry. Heaviest lift, most operationally robust under partial-network
+  failures.
+
+This spec lands B and C **layered together in one PR**, because designing the contracts in isolation would either (a)
+make B's compensation logic dead code once C arrives, or (b) leave C without the synchronous fast path that keeps the
+common case sub-millisecond. The combined design is the smallest correct one.
+
+### Why not B alone
+
+Compensation requires the OpenFGA write to be reversible inside the request lifetime. A network partition that lasts
+longer than the request's wall-clock budget (e.g., HTTP gateway timeouts of 30s) leaves the admin with a 5xx response
+even though the DB write committed. Compensation alone trades silent under-provisioning for noisy partial-success — an
+improvement, but not the durable convergence the issue asks for.
+
+### Why not C alone
+
+Pure-async writes (every approve returns "queued") shift the latency cost onto every admin action, even when OpenFGA
+is healthy. For the 99% case where the OpenFGA call would succeed in 5ms, making admins wait for the reconciler to
+drain is operationally absurd. The hybrid (sync fast-path + async fallback) is strictly better.
+
+## 2. Goals and non-goals
+
+### Goals
+
+1. **Atomicity:** the business write (`access_requests.status = 'approved'`) and the "OpenFGA needs to know about
+   this" intent commit in a single Postgres transaction. Either both happen or neither does.
+2. **Convergence:** every DB-committed approve/revoke eventually applies in OpenFGA, even across multi-minute network
+   partitions, process crashes, or Redis outages.
+3. **Visibility:** admins see, in the response body and via `/admin/outbox`, the per-tuple status of each request's
+   side effects.
+4. **Operational legibility:** a single number (`oldest_pending_age_seconds`) tells on-call whether the system is
+   reconciling.
+5. **No silent failures.** Validation-error 4xx surfaces in the DLQ on first attempt; transient 5xx retries
+   ~17 minutes before joining it.
+
+### Non-goals
+
+- **Zitadel role-sync** stays on its existing `access_requests.zitadel_sync_status` column. Migrating it into the
+  outbox is a candidate future use of this pattern but is explicitly deferred (per #567's out-of-scope note).
+- **Distributed transactions** across PG + OpenFGA + Zitadel are not in scope. At-least-once with idempotent
+  reconciliation is what we ship.
+- **Metrics framework.** Reconciliation health is surfaced via `/health` only. A real metrics layer is tracked in
+  #630 and ships when more signals justify it.
+- **Multi-consumer scale.** One consumer + one cron backstop is the v1 topology. The schema is laid out so adding a
+  `lease_until` column later is trivial, but YAGNI for the current admin-action volume.
+
+## 3. Architecture
+
+Three new components, four modified components, one new DB table.
+
+```text
+┌─────────────────────────────────────────────────────────────────────────┐
+│ HTTP request: PATCH /access-requests/{id}/approve                       │
+└──────────────────────────────────┬──────────────────────────────────────┘
+                                   ▼
+       ┌──────────────────────────────────────────────────────────┐
+       │ AccessRequestAdminHandler::approveRequest (MODIFIED)     │
+       │  BEGIN tx                                                │
+       │    repo.approve()                  ◄── DB business write │
+       │    outbox.insertBatch(tuples)      ◄── outbox rows       │
+       │  COMMIT                                                  │
+       │  ────── fast path (sync attempt) ──────                  │
+       │  foreach row: OutboxProcessor::processSync(row)          │
+       │    → marks row succeeded / retrying / failed_terminal    │
+       │  XADD reconcile-stream (best effort, fire-and-forget)    │
+       │  return response (per-tuple state from in-memory rows)   │
+       └────────────────────┬─────────────────────────────────────┘
+                            │
+                            ▼
+       ┌──────────────────────────────────────────────────────────┐
+       │ Redis Stream: litcal:reconcile-stream                    │
+       │   consumer group: reconciler                             │
+       └────────────────────┬─────────────────────────────────────┘
+                            │ XREADGROUP BLOCK 5000
+                            ▼
+       ┌──────────────────────────────────────────────────────────┐
+       │ bin/reconcile-outbox consumer (NEW, systemd service)     │
+       │   loop:                                                  │
+       │     XCLAIM stale PEL entries (idle > 30s)                │
+       │     msg ← XREADGROUP                                     │
+       │     OutboxProcessor::processOne(row_id)                  │
+       │     XACK                                                 │
+       └──────────────────────────────────────────────────────────┘
+
+       ┌──────────────────────────────────────────────────────────┐
+       │ bin/reconcile-outbox backstop (NEW, cron every 5 min)    │
+       │   SELECT * FROM openfga_outbox                           │
+       │     WHERE status IN ('pending', 'retrying')              │
+       │       AND next_attempt_at ≤ NOW() - INTERVAL '60 seconds'│
+       │     FOR UPDATE SKIP LOCKED                               │
+       │   foreach row: OutboxProcessor::processOne(row_id)       │
+       │   (catches "DB committed but XADD never fired")          │
+       └──────────────────────────────────────────────────────────┘
+
+       ┌──────────────────────────────────────────────────────────┐
+       │ OutboxAdminHandler (NEW)                                 │
+       │   GET  /admin/outbox?status=…&access_request_id=…        │
+       │   GET  /admin/outbox?summary=1                           │
+       │   POST /admin/outbox/{id}/retry                          │
+       └──────────────────────────────────────────────────────────┘
+```
+
+### Invariants
+
+| Invariant                               | How it's enforced                                                                                             |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Postgres is the source of truth.        | All work derives from `openfga_outbox` rows. Redis Stream is a latency optimization.                          |
+| Atomicity of business write and intent. | `BEGIN ... INSERT access_requests ... INSERT openfga_outbox ... COMMIT` is one transaction.                   |
+| At-least-once application.              | Consumer's PEL + backstop's `pickupPending()` together ensure every row is eventually attempted.              |
+| No double-apply.                        | `SELECT FOR UPDATE` + state machine. Terminal rows no-op when re-processed.                                   |
+| Graceful degradation.                   | Redis unreachable → handler skips XADD, logs WARNING, backstop drains within 5 min. PG durability unaffected. |
+
+## 4. Data flow — four scenarios
+
+### Scenario A — Happy path (OpenFGA healthy, Redis healthy)
+
+```text
+t=0ms     PG BEGIN
+t=0ms     repo.approve(requestId, adminId, notes)           ─┐
+t=1ms     outbox.insertBatch(rows)  ── status='pending'      ├── one tx
+t=2ms     PG COMMIT                                          ─┘
+t=3ms     XADD reconcile-stream * row_id=… op=write_tuple …  (best effort)
+t=4ms     fga.writeTuple()  →  OK
+t=4ms     outbox.markSucceeded(row_id)  ── status='succeeded'
+t=5ms     respond {success: true, tuples_created: [...], outbox_pending: 0}
+```
+
+The consumer wakes immediately on XREADGROUP, `SELECT FOR UPDATE`s the row, finds `status='succeeded'`, XACKs without
+acting. No double-apply.
+
+### Scenario B — Fast path fails on a transient (OpenFGA returns 503)
+
+```text
+t=0–3ms   same as Scenario A through XADD
+t=4ms     fga.writeTuple()  →  OpenFgaApiException(httpStatus=503)
+t=4ms     outbox.markRetryable(row_id, attempts=1, next_attempt_at=NOW()+1s, ...)
+t=5ms     respond {success: true,
+                   outbox_pending: 3,
+                   message: "Approval recorded; 3 of 5 permissions queued for retry"}
+
+t≈1005ms  consumer XCLAIMs the row (idle > backoff window) OR backstop wakes first
+          OutboxProcessor::processOne retries fga.writeTuple() → OK
+          outbox.markSucceeded()
+```
+
+Admin sees `success: true` plus an explicit deferral count. No need to retry the API call.
+
+### Scenario C — API process dies between PG COMMIT and XADD
+
+```text
+t=0ms     PG BEGIN, business write, outbox.insertBatch
+t=2ms     PG COMMIT (durable)
+t=3ms     PHP-FPM worker dies — XADD never executes
+          
+t=300s    cron fires bin/reconcile-outbox backstop
+          SELECT outbox WHERE status IN ('pending','retrying')
+            AND next_attempt_at ≤ NOW() - INTERVAL '60 seconds'
+          finds the orphan rows, processes them, markSucceeded
+```
+
+The admin's HTTP request hung up with a 5xx. They re-issue the request: `repo.approve()` is idempotent on
+`access_requests.status`, `outbox.insertBatch()` is idempotent on `metadata->>'idempotency_key'` (§5). The re-issued
+request returns the now-converged state. **No work lost. No double-apply.**
+
+### Scenario D — OpenFGA outage longer than the retry budget
+
+```text
+t=0–4ms   same as Scenario B
+[consumer + backstop alternate: 1s, 2s, 4s, 8s, ..., 512s — total ~17 min]
+t≈17min   10th attempt fails — outbox.markFailedTerminal(row_id, last_error="…")
+```
+
+Admin discovers via `/admin/outbox?status=failed_terminal` or `/health`'s `failed_terminal` count. Remediation: fix
+OpenFGA, then `POST /admin/outbox/{id}/retry` (resets to `pending`, attempts=0, gets a fresh 10-attempt budget).
+
+## 5. Outbox schema and state machine
+
+### Migration
+
+```sql
+-- src/Migrations/Version<TIMESTAMP>.php  (filename generated via `composer db:migrations:generate`)
+
+CREATE TYPE outbox_op AS ENUM ('write_tuple', 'delete_tuple');
+CREATE TYPE outbox_status AS ENUM ('pending', 'retrying', 'succeeded', 'failed_terminal');
+
+CREATE TABLE openfga_outbox (
+    id                BIGSERIAL    PRIMARY KEY,
+    operation         outbox_op    NOT NULL,
+    fga_user          TEXT         NOT NULL,
+    fga_relation      TEXT         NOT NULL,
+    fga_object        TEXT         NOT NULL,
+    status            outbox_status NOT NULL DEFAULT 'pending',
+    attempts          SMALLINT     NOT NULL DEFAULT 0,
+    next_attempt_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    last_error        TEXT         NULL,
+    last_error_code   TEXT         NULL,
+    metadata          JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    completed_at      TIMESTAMPTZ  NULL,
+
+    CONSTRAINT openfga_outbox_idempotency_unique
+        UNIQUE ((metadata->>'idempotency_key'))
+);
+
+CREATE INDEX idx_outbox_pickup ON openfga_outbox (status, next_attempt_at)
+    WHERE status IN ('pending', 'retrying');
+
+CREATE INDEX idx_outbox_dlq ON openfga_outbox (status, created_at)
+    WHERE status = 'failed_terminal';
+
+CREATE INDEX idx_outbox_metadata_request ON openfga_outbox ((metadata->>'access_request_id'))
+    WHERE metadata ? 'access_request_id';
+```
+
+### Schema notes
+
+| Choice                                       | Rationale                                                                                                                                                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `BIGSERIAL` not UUID                         | Internal ID only; smaller index, natural ordering by insert time.                                                                                                                                |
+| Partial indexes on `(status, …)`             | Terminal rows are excluded from the pickup index; index stays tight forever even at high cumulative volume.                                                                                      |
+| UNIQUE on `metadata->>'idempotency_key'`     | Handler-built deterministic key (`"access_request:{id}:write_tuple:{user}:{relation}:{object}"`) makes `insertBatch()` safe to call twice with `ON CONFLICT DO NOTHING`.                         |
+| `last_error_code` separate from `last_error` | OpenFGA's structured `errorCode` drives retry classification; keeping it separate from the human message makes the consumer's branching legible and queryable.                                   |
+| `metadata` JSONB                             | Stores `access_request_id`, `admin_user`, etc. — provenance info, not domain attributes of the operation. Future extension (e.g., Zitadel) can grow new metadata keys without schema migrations. |
+
+### State machine
+
+```text
+                       ┌───────────────────────────────────────────┐
+                       │                                           │
+                       ▼                                           │
+                  ┌─────────┐  fga.op() succeeds OR benign      ┌─────────────┐
+   handler        │ pending │ ────────────────────────────────► │  succeeded  │
+   inserts ─────► │ att=0   │                                   │ (terminal)  │
+                  └────┬────┘                                   └─────────────┘
+                       │
+                       │ fga.op() throws OpenFgaApiException(5xx | network | 429)
+                       │ → attempts++, next_attempt_at = NOW() + backoff(attempts)
+                       ▼
+                  ┌──────────┐
+                  │ retrying │ ◄──┐
+                  │ att=1..9 │    │ next attempt fires (XREADGROUP or backstop)
+                  └────┬─────┘    │ → transient again
+                       │──────────┘
+                       │
+                       │ attempts == 10 AND transient again
+                       │   OR  any attempt throws validation_error 4xx
+                       ▼
+                  ┌─────────────────┐
+                  │ failed_terminal │
+                  │ (terminal)      │ ◄──── POST /admin/outbox/{id}/retry
+                  └─────────────────┘       resets to pending, attempts=0
+```
+
+### Backoff schedule
+
+```php
+private static function backoffSeconds(int $attempts): int
+{
+    // attempts is the NEW count (just incremented), 1..10.
+    // 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s, 512s — ~17 min total budget.
+    return 1 << min($attempts - 1, 9);
+}
+```
+
+### Classification table
+
+`OutboxClassifier::classify(\Throwable $e): OutboxDisposition` returns one of `BENIGN_SUCCESS`, `RETRY`, `TERMINAL`:
+
+| Signal                                                                                      | Disposition            |
+| ------------------------------------------------------------------------------------------- | ---------------------- |
+| `TupleAlreadyExistsException`                                                               | `BENIGN_SUCCESS`       |
+| `TupleNotFoundException`                                                                    | `BENIGN_SUCCESS`       |
+| `errorCode IN (validation_error, invalid_input_format, type_not_found, relation_not_found)` | `TERMINAL`             |
+| `errorCode IN (auth_failure, unauthenticated)`                                              | `TERMINAL`             |
+| `httpStatus == 429`                                                                         | `RETRY`                |
+| `httpStatus >= 500`                                                                         | `RETRY`                |
+| Network error (no httpStatus)                                                               | `RETRY`                |
+| Anything else                                                                               | `RETRY` (safe default) |
+
+## 6. Components
+
+### New files
+
+| Path                                                                                      | Purpose                                                                                                                                                                                                                                                         |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/Migrations/Version<TIMESTAMP>.php` (generated via `composer db:migrations:generate`) | Creates `openfga_outbox` table, enums, partial indexes.                                                                                                                                                                                                         |
+| `src/Repositories/OutboxRepository.php`                                                   | `insertBatch`, `markSucceeded`, `markRetryable`, `markFailedTerminal`, `pickupPending`, `getById`, `countByStatus`, `resetForRetry`.                                                                                                                            |
+| `src/Services/Outbox/OutboxClassifier.php`                                                | Stateless: `classify(\Throwable $e): OutboxDisposition`.                                                                                                                                                                                                        |
+| `src/Services/Outbox/OutboxDisposition.php`                                               | Enum: `BENIGN_SUCCESS`, `RETRY`, `TERMINAL`.                                                                                                                                                                                                                    |
+| `src/Services/Outbox/OutboxProcessor.php`                                                 | Shared processing logic. Takes one outbox row, attempts OpenFGA op, dispatches to classifier, updates row, returns disposition. Called by both fast-path inline attempt and consumer/backstop. **Single point of OpenFGA contact** for request and async paths. |
+| `src/Services/Outbox/OutboxNotifier.php`                                                  | Wraps `\Redis::xAdd()`. `notify(int $outboxId, string $operation): void` — best-effort, never throws to caller. Reuses `Health.php` connection pattern.                                                                                                         |
+| `src/Services/Outbox/RedisStreamConsumer.php`                                             | Reusable loop: `consume(callable $process, int $blockMs = 5000): void`. XREADGROUP, XCLAIM stale PEL entries, XACK. Pure infrastructure.                                                                                                                        |
+| `src/Services/Outbox/ConsumerLoop.php`                                                    | Long-lived loop body invoked by the consumer binary. `tick()` does one read+process cycle (the testable unit); `run()` is the outer `while (true)`.                                                                                                             |
+| `src/Services/Outbox/BackstopRunner.php`                                                  | One-shot scan invoked by the backstop binary. `runOnce()` does the FOR UPDATE SKIP LOCKED + foreach process cycle and exits.                                                                                                                                    |
+| `bin/reconcile-outbox`                                                                    | CLI entry point. Subcommands `consumer` and `backstop`. Thin wrapper over `ConsumerLoop::run()` and `BackstopRunner::runOnce()`.                                                                                                                                |
+| `src/Handlers/Admin/OutboxAdminHandler.php`                                               | `GET /admin/outbox?status=…&access_request_id=…&summary=1`, `POST /admin/outbox/{id}/retry`.                                                                                                                                                                    |
+| `deploy/systemd/liturgical-calendar-reconciler.service`                                   | Example unit: `ExecStart=php /path/bin/reconcile-outbox consumer`, `Restart=on-failure`, `RestartSec=5`, runs as app user.                                                                                                                                      |
+| `deploy/cron/liturgical-calendar-backstop.cron`                                           | Example cron: `*/5 * * * * appuser php /path/bin/reconcile-outbox backstop`.                                                                                                                                                                                    |
+| `docs/ops/openfga-outbox-runbook.md`                                                      | Operator runbook: install systemd unit, install cron, diagnostic SQL, retention guidance.                                                                                                                                                                       |
+| `phpunit_tests/Repositories/OutboxRepositoryTest.php`                                     | Insert dedup, pickup ordering + SKIP LOCKED, status transitions, terminal stickiness.                                                                                                                                                                           |
+| `phpunit_tests/Services/Outbox/OutboxClassifierTest.php`                                  | One test per classification table row.                                                                                                                                                                                                                          |
+| `phpunit_tests/Services/Outbox/OutboxProcessorTest.php`                                   | Happy path, transient retry with correct backoff, terminal-on-validation, benign already-exists/not-found, 10th attempt → terminal, no-op on already-terminal rows.                                                                                             |
+| `phpunit_tests/Services/Outbox/BackstopRunnerTest.php`                                    | `runOnce()` picks up only rows past the grace window, processes them via OutboxProcessor.                                                                                                                                                                       |
+| `phpunit_tests/Services/Outbox/ConsumerLoopTest.php`                                      | `tick()` against a mocked Redis: reads, processes, acks. Real-Redis variant gated behind `@group needs-redis`.                                                                                                                                                  |
+| `phpunit_tests/Handlers/Admin/OutboxAdminHandlerTest.php`                                 | List/summary/retry endpoints, auth guards.                                                                                                                                                                                                                      |
+
+### Modified files
+
+| Path                                               | Changes                                                                                                                                                                                                                                                                                                                                                                                                     |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/Handlers/Admin/AccessRequestAdminHandler.php` | `approveRequest()` and `revokeRequest()` switch to the outbox pattern. PG tx wraps `repo.approve/revoke` + `outbox.insertBatch`. After commit, loop calls `OutboxProcessor::processSync()` per row, then XADD via `OutboxNotifier`. Response body grows `outbox_pending`, `outbox_failed`, `outbox_ids`. `fga_errors` preserved for back-compat. Constructor gains `?OutboxRepository` + `?OutboxNotifier`. |
+| `src/Handlers/Admin/PermissionAdminHandler.php`    | `grantPermission()` and `revokePermission()` get the same treatment — per #567's note that typed-error work was a prerequisite for this handler.                                                                                                                                                                                                                                                            |
+| `src/Services/RoleCascadeService.php`              | The silent best-effort `try/catch` around `deleteTuple` (currently logs WARNING and moves on) replaces its catch with an outbox enqueue on transient failures. Cascade caller stays synchronous; only the per-tuple failure path goes async.                                                                                                                                                                |
+| `src/Router.php`                                   | Two new routes behind existing admin JWT middleware: `GET /admin/outbox`, `POST /admin/outbox/{id}/retry`.                                                                                                                                                                                                                                                                                                  |
+| `src/Health.php`                                   | Adds `openfga_outbox` block: `pending`, `retrying`, `failed_terminal`, `oldest_pending_age_seconds`, and a `consumer` sub-block with `redis_reachable`, `pending_entries`, `oldest_pel_idle_seconds`.                                                                                                                                                                                                       |
+| `.env.example`                                     | New keys: `REDIS_OUTBOX_STREAM=litcal:reconcile-stream`, `REDIS_OUTBOX_GROUP=reconciler`, `REDIS_OUTBOX_CONSUMER_NAME=` (default = hostname), `OUTBOX_MAX_ATTEMPTS=10`, `OUTBOX_BACKSTOP_GRACE_SECONDS=60`.                                                                                                                                                                                                 |
+| `composer.json`                                    | New scripts: `reconciler:consumer`, `reconciler:backstop` for local dev parity with systemd/cron.                                                                                                                                                                                                                                                                                                           |
+
+### Notable non-changes
+
+- **`OpenFgaClient` is untouched.** Typed exceptions from #628 are consumed, not extended.
+- **No new dependencies.** `ext-redis`, `ext-pdo_pgsql`, Doctrine migrations — all already present.
+- **No changes to Zitadel sync.** Out of scope per #567.
+
+### Response shape
+
+Approve/revoke and permission grant/revoke handlers return:
+
+```json
+{
+  "success": true,
+  "role_assigned": true,
+  "zitadel_error": null,
+  "tuples_created": [{ "user": "...", "relation": "...", "object": "..." }],
+  "outbox_pending": 0,
+  "outbox_failed": 0,
+  "outbox_ids": [42, 43, 44],
+  "fga_errors": [],
+  "message": "Access request approved; permissions granted."
+}
+```
+
+`success` is `true` whenever the DB write committed, regardless of OpenFGA status. The `outbox_*` fields tell the
+admin what happened to the side effects. This is a deliberate semantic shift from #628: with the outbox in place, the
+DB write IS the commitment, and OpenFGA application is a tracked side effect.
+
+When `outbox_pending > 0`, the message becomes `"… N of M permissions queued for retry (OpenFGA was temporarily
+unavailable)."`. When `outbox_failed > 0`, additionally `"… N permissions require admin review:
+/admin/outbox?status=failed_terminal."`.
+
+## 7. Error handling — the edges
+
+| Failure                                                     | Behavior                                                                                                                                                | Safety argument                                                                                                                        |
+| ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Redis unreachable at XADD                                   | `OutboxNotifier` catches `\RedisException`, logs WARNING, returns void.                                                                                 | Outbox row is durable in PG; backstop drains within 5 min.                                                                             |
+| Redis unreachable in consumer                               | Consumer logs ERROR, exits 1; systemd cycles.                                                                                                           | Backstop continues to drain via PG.                                                                                                    |
+| Consumer group does not exist                               | `XGROUP CREATE litcal:reconcile-stream reconciler $ MKSTREAM` on startup; BUSYGROUP ignored.                                                            | Idempotent setup; no manual pre-step.                                                                                                  |
+| PG fault between business write and outbox insert           | Whole `BEGIN ... COMMIT` rolls back.                                                                                                                    | Atomicity is the contract.                                                                                                             |
+| PG unreachable in consumer/backstop                         | Logs ERROR, exits 1; systemd cycles.                                                                                                                    | Handlers commit DB + return responses unaffected; reconciliation stalls until PG returns. State machine resumes from current `status`. |
+| Consumer crashes mid-process (after PG update, before XACK) | Next pass XCLAIMs the message; `processOne` sees row in terminal state, no-ops, XACKs.                                                                  | State machine is the idempotency anchor.                                                                                               |
+| Consumer crashes between OpenFGA call and PG update         | Next pass retries OpenFGA op. Write → `TupleAlreadyExistsException` (benign). Delete → `TupleNotFoundException` (benign).                               | This is exactly what #567's typed exceptions enable.                                                                                   |
+| Two runners pick the same row simultaneously                | `SELECT FOR UPDATE` serializes; second runner re-checks status, no-ops if terminal.                                                                     | PG row lock is the serialization point. Backstop's 60s grace window makes the race vanishingly rare.                                   |
+| Validation error 4xx from OpenFGA                           | `OutboxClassifier` returns `TERMINAL`; row marked `failed_terminal` on first attempt.                                                                   | Retrying 4xx 9 more times wastes work and pollutes metrics.                                                                            |
+| OpenFGA returns 429                                         | Classified as RETRY; backoff schedule self-throttles.                                                                                                   | If sustained, revisit (honor `Retry-After`). Not premature in v1.                                                                      |
+| Idempotency-key collision on retry                          | `INSERT ... ON CONFLICT (metadata->>'idempotency_key') DO NOTHING RETURNING id`; for duplicate keys, `insertBatch` falls back to `SELECT id WHERE ...`. | Makes the handler safe to re-invoke.                                                                                                   |
+| Admin retries a non-failed row                              | 409 Conflict. Only `failed_terminal` is retryable via the admin endpoint.                                                                               | Avoids counter desync with in-flight processing.                                                                                       |
+| Stale PEL entries from dead consumer                        | `XCLAIM` (or `XAUTOCLAIM`) reassigns messages idle > 30s on each loop iteration.                                                                        | At-least-once guarantee depends on this.                                                                                               |
+
+## 8. Observability
+
+### `/health` adds an `openfga_outbox` block
+
+```json
+{
+  "openfga_outbox": {
+    "pending": 0,
+    "retrying": 0,
+    "failed_terminal": 0,
+    "oldest_pending_age_seconds": 0,
+    "consumer": {
+      "redis_reachable": true,
+      "stream_name": "litcal:reconcile-stream",
+      "group_name": "reconciler",
+      "pending_entries": 0,
+      "oldest_pel_idle_seconds": 0
+    }
+  }
+}
+```
+
+The two operational signals that matter most:
+
+- `oldest_pending_age_seconds` — sustained growth past ~60s means the consumer is wedged. Single number to alert on.
+- `oldest_pel_idle_seconds` — sustained growth past ~30s means the consumer is alive but not XACK'ing (different
+  failure mode).
+
+### `/admin/outbox`
+
+| Query                           | Returns                                                                                       |
+| ------------------------------- | --------------------------------------------------------------------------------------------- |
+| `?status=failed_terminal`       | DLQ list with `last_error`/`last_error_code`.                                                 |
+| `?access_request_id={uuid}`     | All rows for one approve/revoke — the operationally important one.                            |
+| `?summary=1`                    | Counts per status + oldest age. Same data as `/health` for ops without health-scraping.       |
+| `POST /admin/outbox/{id}/retry` | Resets one `failed_terminal` row to `pending`, attempts=0. Returns 409 for non-terminal rows. |
+
+Pagination follows the existing access-requests pattern (limit/offset, default 50, max 200).
+
+### Logging discipline
+
+| Level   | Site                                       | Shape                                                                           |
+| ------- | ------------------------------------------ | ------------------------------------------------------------------------------- |
+| INFO    | OutboxProcessor succeeded a row            | `outbox.row.succeeded id=42 op=write_tuple user=… attempts=1`                   |
+| INFO    | OutboxProcessor marked terminal            | `outbox.row.failed_terminal id=42 attempts=10 last_error_code=validation_error` |
+| WARNING | OutboxNotifier XADD failed                 | `outbox.redis.notify_failed row_ids=[42,43] error="…"`                          |
+| WARNING | OutboxProcessor scheduled retry            | `outbox.row.retry_scheduled id=42 attempts=3 next_attempt_at=… error_code=…`    |
+| WARNING | RedisStreamConsumer XCLAIM'd stale message | `outbox.consumer.xclaim id=42 idle_ms=45000 from_consumer=…`                    |
+| ERROR   | RedisStreamConsumer lost Redis             | `outbox.consumer.redis_lost error="…" — exiting for systemd restart`            |
+| ERROR   | OutboxProcessor couldn't update PG row     | `outbox.processor.pg_update_failed id=42 error="…"`                             |
+
+Uses the existing `LoggerFactory` from `src/Http/Logs/`.
+
+### Audit trail
+
+The `openfga_outbox` table is the durable record of every tuple grant/revoke that ever passed through the API.
+Substantial improvement over today's scattered log lines. Retention defaults to "keep everything" until the table
+becomes a real concern; pruning SQL is documented in the runbook (a one-shot `DELETE FROM openfga_outbox WHERE
+status = 'succeeded' AND completed_at < NOW() - INTERVAL '30 days'`). Automated pruning, if needed, ships as a separate
+append-only migration — never folded into `init-db.sql`.
+
+## 9. Testing strategy
+
+Five testing layers. The codebase already has the infrastructure for all of them.
+
+### Layer 1 — Pure logic
+
+`OutboxClassifierTest` (one test per classification row) and a parametric `backoffSeconds()` test. Fast, deterministic.
+
+### Layer 2 — Repository (PG only)
+
+`OutboxRepositoryTest` uses the existing test-DB-with-rollback fixture pattern from `AccessRequestRepositoryTest`. The
+load-bearing test: `testPickupPendingHonorsForUpdateSkipLocked()` — two concurrent transactions must get distinct
+rows.
+
+### Layer 3 — Processor (PG + mocked OpenFGA)
+
+`OutboxProcessorTest` uses `MockHandler`-backed `OpenFgaClient` (the pattern from `OpenFgaClientTest` established
+in PR #628). Load-bearing test: `testProcessSync10thAttemptOnTransientMarksFailedTerminal()` pins the retry budget.
+
+### Layer 4 — Handler integration (PG + mocked OpenFGA + mocked Redis)
+
+Additions to `AccessRequestAdminHandlerTest` and `PermissionAdminHandlerTest`. Load-bearing tests:
+
+- `testApproveCommitsAtomicallyOrNotAtAll()` — PG fault between `repo.approve` and `outbox.insertBatch` rolls back
+  both.
+- `testApproveIsIdempotentOnReissue()` — same request twice → same outbox row IDs, no duplicate rows.
+- `testApproveSucceedsEvenWhenRedisNotifyFails()` — `OutboxNotifier` throwing does not affect the response.
+
+### Layer 5 — Runner classes (BackstopRunner, ConsumerLoop)
+
+- `BackstopRunnerTest::runOnce()` against a real PG: only rows past the grace window are picked up and processed.
+- `ConsumerLoopTest::tick()` against a mocked Redis (default) and a real Redis (`@group needs-redis`, opt-in).
+
+The binaries' outer `while (true)` and CLI arg parsing are excluded from coverage and trusted to be obvious.
+
+### Not tested
+
+- systemd unit behavior (Restart, RestartSec) — operational, manually verified.
+- cron-driven invocation — same.
+- XADD-to-process latency — not a correctness concern; add only if we adopt a sub-second-reconciliation SLO.
+
+### Quality gates (same as #628)
+
+- `composer test` clean.
+- `composer analyse` (PHPStan L10) clean.
+- `composer lint` (phpcs PSR-12) clean.
+- `composer parallel-lint` clean.
+- `composer db:migrate` applies cleanly in CI.
+
+## 10. Out of scope / future work
+
+| Item                                          | Why deferred                                                                                                                               |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| Zitadel role-sync moves into the outbox       | Out of scope per #567. Pattern is designed to extend (op enum + metadata JSONB) but Zitadel has its own `zitadel_sync_status` story today. |
+| Automated pruning of `succeeded` rows         | Premature optimization. Runbook documents the SQL; ship automation only when table size becomes a real concern.                            |
+| Bulk admin retry (`/retry-all`)               | YAGNI. Single-row retry covers v1. Admins can script bulk via `GET /admin/outbox?status=failed_terminal` + per-row POST.                   |
+| `lease_until` column for multi-consumer scale | YAGNI. One consumer + one backstop is sufficient for admin-action volume. Trivial to add later.                                            |
+| Metrics framework (Prometheus / StatsD)       | Tracked in #630. Separate design pass when more signals justify it.                                                                        |
+| `Retry-After` header honoring for 429s        | Premature optimization until we observe sustained 429s. Exponential backoff already self-throttles.                                        |
+| Frontend UI for the DLQ                       | JSON endpoint suffices for v1 ops. Cosmetic; separate concern in `LiturgicalCalendarFrontend`.                                             |
+
+## 11. References
+
+- Predecessor PR: [#628](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/628) — typed exceptions +
+  ListObjects.
+- Originating issue: [#567](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/567) — Options A/B/C
+  framing.
+- Sibling issue: [#571](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/571) — ListObjects in
+  `filterByAdminAccess` (shipped in #628).
+- Tracking issue: [#630](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/630) — future metrics
+  framework.
+- Original CR thread: [PR #555 discussion_r3197872349](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/555#discussion_r3197872349).
+- CLAUDE.md schema-authority rule: migrations are append-only, never folded into `init-db.sql`.

--- a/phpunit_tests/Handlers/AbstractHandlerTestCase.php
+++ b/phpunit_tests/Handlers/AbstractHandlerTestCase.php
@@ -38,7 +38,7 @@ abstract class AbstractHandlerTestCase extends TestCase
     protected static ?PDO $pdo = null;
 
     /** @var array<int,string> */
-    protected const TABLES = ['api_keys', 'applications', 'access_requests', 'audit_log', 'user_notification_state'];
+    protected const TABLES = ['api_keys', 'applications', 'access_requests', 'audit_log', 'user_notification_state', 'openfga_outbox'];
 
     /**
      * Subclasses set true when their tests need a working Postgres.

--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -226,6 +226,15 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
         $row = $repo->getById($id);
         self::assertNotNull($row);
         self::assertSame('approved', $row['status']);
+
+        // FGA-unavailable + non-empty permissions: outbox rows are still
+        // persisted so the backstop can drain them when FGA comes back.
+        // Mirror of testRevokeHappyPathWithoutFgaOrZitadel.
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(1, $body['outbox_ids']);
+        self::assertCount(1, $body['fga_errors']);
+        self::assertSame('pending', $body['fga_errors'][0]['status']);
     }
 
     public function testRejectHappyPath(): void

--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -17,6 +17,7 @@ use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
@@ -646,22 +647,33 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             new GuzzleResponse(200, [], '{}'), // delete OK
         ]);
 
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
         $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
             $mock,
-            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
-                $this->withOidcUser($this->requestFor(
-                    'POST',
-                    '/admin/access-requests/' . $id . '/revoke',
-                    [],
-                    []
-                ))
-            )
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/revoke',
+                        [],
+                        []
+                    ))
+                );
+            }
         ));
 
         $body = $this->decodeJsonBody($response);
         self::assertTrue($body['success']);
         self::assertCount(1, self::arrayFieldFrom($body, 'tuples_deleted'));
         self::assertSame([], $body['fga_errors']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(1, self::arrayFieldFrom($body, 'outbox_ids'));
 
         $row = $repo->getById($id);
         self::assertNotNull($row);
@@ -670,6 +682,9 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 
     public function testRevokeTreatsMissingTupleAsBenign(): void
     {
+        // TupleNotFoundException (cannot_allow_unknown_tuple_to_be_deleted) is
+        // classified as BENIGN_SUCCESS by OutboxClassifier — the row lands in
+        // 'succeeded' state and appears in tuples_deleted (idempotent re-revoke).
         $repo = new AccessRequestRepository(self::$pdo);
         $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
             ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
@@ -683,30 +698,46 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             ])),
         ]);
 
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
         $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
             $mock,
-            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
-                $this->withOidcUser($this->requestFor(
-                    'POST',
-                    '/admin/access-requests/' . $id . '/revoke',
-                    [],
-                    []
-                ))
-            )
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/revoke',
+                        [],
+                        []
+                    ))
+                );
+            }
         ));
 
         $body = $this->decodeJsonBody($response);
         self::assertTrue($body['success']);
+        // BENIGN_SUCCESS → counted in tuples_deleted (idempotent — tuple already gone).
         self::assertCount(1, self::arrayFieldFrom($body, 'tuples_deleted'));
         self::assertSame([], $body['fga_errors']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
 
         $row = $repo->getById($id);
         self::assertNotNull($row);
         self::assertSame('revoked', $row['status']);
     }
 
-    public function testRevokeBailsAndKeepsRequestApprovedOnRealFgaError(): void
+    public function testRevokeCommitsDbAndSurfacesTransientOutboxFailureOnFgaError(): void
     {
+        // A 500 (transient / retryable) from OpenFGA. Under the outbox pattern:
+        // - The DB IS committed (revoked) — success: true.
+        // - The outbox row ends up in 'retrying' state.
+        // - outbox_pending == 1 and fga_errors carries the structured error.
+        // - The cron backstop or async consumer will retry the deletion.
         $repo = new AccessRequestRepository(self::$pdo);
         $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
             ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
@@ -720,27 +751,44 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             ])),
         ]);
 
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
         $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
             $mock,
-            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
-                $this->withOidcUser($this->requestFor(
-                    'POST',
-                    '/admin/access-requests/' . $id . '/revoke',
-                    [],
-                    []
-                ))
-            )
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/revoke',
+                        [],
+                        []
+                    ))
+                );
+            }
         ));
 
         $body = $this->decodeJsonBody($response);
-        self::assertFalse($body['success']);
+        // DB committed → success: true (outbox pattern — mirrors approveRequest semantics).
+        self::assertTrue($body['success']);
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
         self::assertCount(1, self::arrayFieldFrom($body, 'fga_errors'));
-        self::assertStringContainsString('Revocation aborted', self::stringFieldFrom($body, 'message'));
 
-        // DB row must still be approved — the revoke was NOT committed.
+        // DB row IS revoked — the outbox captures the failure, not the DB transaction.
         $row = $repo->getById($id);
         self::assertNotNull($row);
-        self::assertSame('approved', $row['status']);
+        self::assertSame('revoked', $row['status']);
+
+        // Verify the outbox row itself is in retrying state.
+        $outboxIds = self::arrayFieldFrom($body, 'outbox_ids');
+        self::assertCount(1, $outboxIds);
+        $outboxRow = $outboxRepo->getById((int) $outboxIds[0]);
+        self::assertNotNull($outboxRow);
+        self::assertSame(OutboxStatus::RETRYING, $outboxRow->status);
     }
 
     // --- isFgaClientAvailable() fail-closed guards -----------------------
@@ -946,6 +994,152 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
                     $this->withOidcUser($this->requestFor(
                         'POST',
                         '/admin/access-requests/' . $id . '/approve',
+                        [],
+                        []
+                    ))
+                );
+            }
+        ));
+    }
+
+    // --- Outbox pattern (Task 21: revokeRequest) --------------------------
+
+    public function testRevokeCommitsOutboxRowsAtomicallyWithDbWrite(): void
+    {
+        // Two permissions: first call returns 503 (transient — RETRY → retrying),
+        // second call returns 200 (success → succeeded). After the sync fast path:
+        // - success: true (DB committed)
+        // - outbox_pending: 1 (the retrying row)
+        // - outbox_failed: 0
+        // - outbox_ids: 2 entries
+        // Both outbox rows have operation 'delete_tuple'.
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+            ['object_type' => 'diocesan_calendar', 'object_id' => 'roma_it', 'relation' => 'viewer'],
+        ]);
+        $repo->approve($id, 'admin-bob');
+
+        $mock = new MockHandler([
+            new GuzzleResponse(503, [], ''),   // tuple 1: transient → RETRY
+            new GuzzleResponse(200, [], '{}'), // tuple 2: OK → BENIGN_SUCCESS
+        ]);
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/revoke',
+                        [],
+                        []
+                    ))
+                );
+            }
+        ));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(2, self::arrayFieldFrom($body, 'outbox_ids'));
+
+        // DB row is revoked (commit happened before the FGA sync attempt).
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('revoked', $row['status']);
+
+        // Outbox rows: one retrying, one succeeded — both delete_tuple.
+        $outboxIds = self::arrayFieldFrom($body, 'outbox_ids');
+        $statuses  = [];
+        foreach ($outboxIds as $rowId) {
+            $outboxRow = $outboxRepo->getById((int) $rowId);
+            self::assertNotNull($outboxRow);
+            $statuses[] = $outboxRow->status->value;
+            self::assertSame(OutboxOperation::DELETE_TUPLE, $outboxRow->operation);
+        }
+        sort($statuses);
+        self::assertSame([OutboxStatus::RETRYING->value, OutboxStatus::SUCCEEDED->value], $statuses);
+    }
+
+    public function testRevokeIsIdempotentOnReissue(): void
+    {
+        // Verify idempotency_key collapse for delete_tuple rows.
+        $outboxRepo     = new OutboxRepository(self::$pdo);
+        $idempotencyKey = 'access_request:test-uuid:delete_tuple:user:alice:editor:national_calendar:IT';
+
+        $rows = [
+            [
+                'operation'       => OutboxOperation::DELETE_TUPLE,
+                'fga_user'        => 'user:alice',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => $idempotencyKey,
+                'metadata'        => ['access_request_id' => 'test-uuid'],
+            ],
+        ];
+
+        $firstIds  = $outboxRepo->insertBatch($rows);
+        $secondIds = $outboxRepo->insertBatch($rows); // same key → same row
+
+        self::assertSame(
+            $firstIds,
+            $secondIds,
+            'idempotency_key must collapse second insert to same row IDs'
+        );
+
+        // Handler-level: re-revoking an already-revoked request must be rejected
+        // with a ValidationException (status is no longer 'approved').
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+        $repo->approve($id, 'admin-bob');
+
+        $notifier = new OutboxNotifier(null, 'litcal:reconcile-stream');
+        $mock1    = new MockHandler([new GuzzleResponse(200, [], '{}')]);
+
+        // First revoke succeeds.
+        $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock1,
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/revoke',
+                        [],
+                        []
+                    ))
+                );
+            }
+        ));
+
+        // Second revoke on the same (now 'revoked') request must be rejected.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Cannot revoke a request with status: revoked');
+
+        $mock2 = new MockHandler([]);
+
+        $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock2,
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/revoke',
                         [],
                         []
                     ))

--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -14,7 +14,11 @@ use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
 use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -485,16 +489,24 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             new GuzzleResponse(200, [], '{}'), // tuple 2 write OK
         ]);
 
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
         $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
             $mock,
-            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
-                $this->withOidcUser($this->requestFor(
-                    'POST',
-                    '/admin/access-requests/' . $id . '/approve',
-                    [],
-                    ['notes' => 'ok']
-                ))
-            )
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/approve',
+                        [],
+                        ['notes' => 'ok']
+                    ))
+                );
+            }
         ));
 
         self::assertSame(200, $response->getStatusCode());
@@ -502,6 +514,9 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
         self::assertTrue($body['success']);
         self::assertCount(2, self::arrayFieldFrom($body, 'tuples_created'));
         self::assertSame([], $body['fga_errors']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(2, self::arrayFieldFrom($body, 'outbox_ids'));
 
         $row = $repo->getById($id);
         self::assertNotNull($row);
@@ -510,9 +525,9 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
 
     public function testApproveTreatsDuplicateTupleAsBenign(): void
     {
-        // Idempotent re-approval: one tuple already exists. The handler
-        // should treat that write as success, still mutate the DB, and
-        // return success: true.
+        // Idempotent re-approval: one tuple already exists. The outbox processor
+        // classifies TupleAlreadyExistsException as BENIGN_SUCCESS, so the row
+        // ends up in 'succeeded' state. The DB is mutated and success is true.
         $repo = new AccessRequestRepository(self::$pdo);
         $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
             ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
@@ -525,33 +540,47 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             ])),
         ]);
 
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
         $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
             $mock,
-            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
-                $this->withOidcUser($this->requestFor(
-                    'POST',
-                    '/admin/access-requests/' . $id . '/approve',
-                    [],
-                    ['notes' => 'retry']
-                ))
-            )
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/approve',
+                        [],
+                        ['notes' => 'retry']
+                    ))
+                );
+            }
         ));
 
         $body = $this->decodeJsonBody($response);
         self::assertTrue($body['success']);
+        // BENIGN_SUCCESS → goes into tuples_created (row is succeeded in outbox).
         self::assertCount(1, self::arrayFieldFrom($body, 'tuples_created'));
         self::assertSame([], $body['fga_errors']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
 
         $row = $repo->getById($id);
         self::assertNotNull($row);
         self::assertSame('approved', $row['status']);
     }
 
-    public function testApproveBailsAndKeepsRequestPendingOnRealFgaError(): void
+    public function testApproveCommitsDbAndSurfacesTerminalOutboxFailureOnRealFgaError(): void
     {
-        // Genuine OpenFGA failure (e.g. validation error). The handler must
-        // NOT mark the DB as approved — leaving it pending lets the admin
-        // retry once the underlying error is resolved.
+        // Genuine terminal OpenFGA failure (e.g. validation_error 400 with a
+        // known-terminal error code). Under the outbox pattern:
+        // - The DB IS committed (approved) — success: true.
+        // - The outbox row ends up in 'failed_terminal' state.
+        // - outbox_failed == 1 and fga_errors carries the structured error.
+        // - The admin can retry the outbox row via the outbox retry endpoint.
         $repo = new AccessRequestRepository(self::$pdo);
         $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
             ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
@@ -564,27 +593,45 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             ])),
         ]);
 
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
         $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
             $mock,
-            fn(OpenFgaClient $client) => ( new AccessRequestAdminHandler($client) )->handle(
-                $this->withOidcUser($this->requestFor(
-                    'POST',
-                    '/admin/access-requests/' . $id . '/approve',
-                    [],
-                    ['notes' => 'try']
-                ))
-            )
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/approve',
+                        [],
+                        ['notes' => 'try']
+                    ))
+                );
+            }
         ));
 
         $body = $this->decodeJsonBody($response);
-        self::assertFalse($body['success']);
+        // DB committed → success: true (deliberate semantic shift from #628).
+        self::assertTrue($body['success']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(1, $body['outbox_failed']);
         self::assertCount(1, self::arrayFieldFrom($body, 'fga_errors'));
-        self::assertStringContainsString('Approval aborted', self::stringFieldFrom($body, 'message'));
+        self::assertStringContainsString('failed terminally', self::stringFieldFrom($body, 'message'));
 
-        // DB row must still be pending — the request was NOT approved.
+        // DB row IS approved — the outbox captures the failure, not the DB transaction.
         $row = $repo->getById($id);
         self::assertNotNull($row);
-        self::assertSame('pending', $row['status']);
+        self::assertSame('approved', $row['status']);
+
+        // Verify the outbox row itself is in failed_terminal state.
+        $outboxIds = self::arrayFieldFrom($body, 'outbox_ids');
+        self::assertCount(1, $outboxIds);
+        $outboxRow = $outboxRepo->getById((int) $outboxIds[0]);
+        self::assertNotNull($outboxRow);
+        self::assertSame(OutboxStatus::FAILED_TERMINAL, $outboxRow->status);
     }
 
     public function testRevokeSucceedsWhenAllTupleDeletesSucceed(): void
@@ -754,5 +801,156 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
         // total reflects the SQL paginator's pre-filter count, not the
         // empty post-filter visible set.
         self::assertSame(2, $body['total']);
+    }
+
+    // --- Outbox pattern (Task 20: issue #567 Options B+C) ----------------
+
+    public function testApproveCommitsOutboxRowsAtomicallyWithDbWrite(): void
+    {
+        // Two permissions: first call returns 503 (transient — RETRY → retrying),
+        // second call returns 200 (success → succeeded). After the sync fast path:
+        // - success: true (DB committed)
+        // - outbox_pending: 1 (the retrying row)
+        // - outbox_failed: 0
+        // - outbox_ids: 2 entries
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+            ['object_type' => 'diocesan_calendar', 'object_id' => 'roma_it', 'relation' => 'viewer'],
+        ]);
+
+        $mock = new MockHandler([
+            new GuzzleResponse(503, [], ''), // tuple 1: transient → RETRY
+            new GuzzleResponse(200, [], '{}'), // tuple 2: OK → BENIGN_SUCCESS
+        ]);
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/approve',
+                        [],
+                        ['notes' => 'ok']
+                    ))
+                );
+            }
+        ));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(2, self::arrayFieldFrom($body, 'outbox_ids'));
+
+        // Verify the DB row is approved.
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('approved', $row['status']);
+
+        // Verify the outbox row statuses: one retrying, one succeeded.
+        $outboxIds = self::arrayFieldFrom($body, 'outbox_ids');
+        $statuses  = [];
+        foreach ($outboxIds as $rowId) {
+            $outboxRow = $outboxRepo->getById((int) $rowId);
+            self::assertNotNull($outboxRow);
+            $statuses[] = $outboxRow->status->value;
+        }
+        sort($statuses);
+        self::assertSame([OutboxStatus::RETRYING->value, OutboxStatus::SUCCEEDED->value], $statuses);
+    }
+
+    public function testApproveIsIdempotentOnReissue(): void
+    {
+        // First approval: all tuples succeed → outbox rows in 'succeeded'.
+        // Second approval of the same request: repo.approve() returns false
+        // (status is already 'approved'), so the handler throws ValidationException.
+        // This test therefore verifies that the idempotency_key in insertBatch
+        // collapses duplicate inserts to the same row IDs when the first call
+        // succeeded and the second call cannot re-enter the approval flow.
+        //
+        // To test the actual idempotency_key collapse, we directly call insertBatch
+        // twice on the outbox repo with the same key and assert same IDs are returned.
+        $outboxRepo     = new OutboxRepository(self::$pdo);
+        $idempotencyKey = 'access_request:test-uuid:write_tuple:user:alice:editor:national_calendar:IT';
+
+        $rows = [
+            [
+                'operation'       => \LiturgicalCalendar\Api\Services\Outbox\OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:alice',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => $idempotencyKey,
+                'metadata'        => ['access_request_id' => 'test-uuid'],
+            ],
+        ];
+
+        $firstIds  = $outboxRepo->insertBatch($rows);
+        $secondIds = $outboxRepo->insertBatch($rows); // same key → same row
+
+        self::assertSame(
+            $firstIds,
+            $secondIds,
+            'idempotency_key must collapse second insert to same row IDs'
+        );
+
+        // Now verify the handler-level idempotency: re-approving an already-approved
+        // request must be rejected with a ValidationException (not crash or duplicate rows).
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+
+        $mock1 = new MockHandler([new GuzzleResponse(200, [], '{}')]);
+
+        $notifier = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        // First approval succeeds.
+        $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock1,
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/approve',
+                        [],
+                        []
+                    ))
+                );
+            }
+        ));
+
+        // Second approval on the same (now 'approved') request must be rejected.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('Cannot approve a request with status: approved');
+
+        $mock2 = new MockHandler([]);
+
+        $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock2,
+            function (OpenFgaClient $client) use ($id, $outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new AccessRequestAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/access-requests/' . $id . '/approve',
+                        [],
+                        []
+                    ))
+                );
+            }
+        ));
     }
 }

--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -253,12 +253,10 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
         ]);
         $repo->approve($id, 'admin');
 
-        // Mirror testApproveHappyPathWithoutFgaOrZitadel — clear both gate's
-        // env vars so the handler hits the not-configured branch for each
-        // service. Seeding with a real permission (rather than the previous
-        // empty []) makes the "tuples_deleted=[]" assertion meaningful: an
-        // FGA-configured run would have tuples to delete; here it shouldn't
-        // even try.
+        // When FGA is unavailable the handler MUST still create outbox rows
+        // for the delete operations — they're durable in PG and the cron
+        // backstop will drain them once FGA comes back. The earlier
+        // contract (drop the work) silently left stale tuples behind.
         $response = $this->withoutEnv(
             array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
             fn() => ( new AccessRequestAdminHandler() )->handle(
@@ -271,12 +269,21 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
         self::assertTrue($body['success']);
         self::assertFalse($body['role_removed']);
         self::assertNull($body['zitadel_error']);
-        self::assertSame([], $body['tuples_deleted']);
-        self::assertSame([], $body['fga_errors']);
-
+        // DB revoke happened atomically with the outbox insert.
         $row = $repo->getById($id);
         self::assertNotNull($row);
         self::assertSame('revoked', $row['status']);
+
+        // The delete is queued for the backstop. tuples_deleted stays empty
+        // (sync attempt was skipped because FGA is unavailable); the row
+        // shows up as outbox_pending and outbox_ids carries its ID so the
+        // admin can follow up via /admin/outbox.
+        self::assertSame([], $body['tuples_deleted']);
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(1, $body['outbox_ids']);
+        self::assertCount(1, $body['fga_errors']);
+        self::assertSame('pending', $body['fga_errors'][0]['status']);
     }
 
     public function testUnknownActionIsValidationError(): void

--- a/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/AccessRequestAdminHandlerTest.php
@@ -1163,4 +1163,145 @@ final class AccessRequestAdminHandlerTest extends AbstractHandlerTestCase
             }
         ));
     }
+
+    // -----------------------------------------------------------------------
+    // Empty-permissions fast path — exercises the early-return branch in
+    // both approveRequest and revokeRequest where no tuples are written/
+    // deleted and the outbox is bypassed entirely. Closes the bulk of the
+    // uncovered lines in the no-perms branch (lines ~373-390 / ~666-694
+    // per the coverage report).
+    // -----------------------------------------------------------------------
+
+    public function testApproveWithEmptyPermissionsTakesFastPathWithNoOutboxRows(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-fast', 'fast@x.test', null, 'developer', []);
+
+        $response = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => ( new AccessRequestAdminHandler() )->handle(
+                $this->withOidcUser($this->requestFor('POST', '/admin/access-requests/' . $id . '/approve', [], ['notes' => 'ok']))
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        // No permissions ⇒ no outbox rows ⇒ no fga_errors entries.
+        self::assertSame([], $body['tuples_created']);
+        self::assertSame([], $body['fga_errors']);
+        self::assertSame([], $body['outbox_ids']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+
+        // DB row is now approved.
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('approved', $row['status']);
+
+        // Outbox is empty (the fast path never inserts when permissions=[]).
+        $outboxCount = (int) self::$pdo->query("SELECT COUNT(*) FROM openfga_outbox WHERE metadata->>'access_request_id' = " . self::$pdo->quote($id))->fetchColumn();
+        self::assertSame(0, $outboxCount, 'fast path must not insert outbox rows');
+    }
+
+    public function testRevokeWithEmptyPermissionsTakesFastPathWithNoOutboxRows(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-fast', 'fast@x.test', null, 'developer', []);
+        $repo->approve($id, 'admin');
+
+        $response = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => ( new AccessRequestAdminHandler() )->handle(
+                $this->withOidcUser($this->requestFor('POST', '/admin/access-requests/' . $id . '/revoke', [], []))
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame([], $body['tuples_deleted']);
+        self::assertSame([], $body['fga_errors']);
+        self::assertSame([], $body['outbox_ids']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+
+        $row = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame('revoked', $row['status']);
+
+        $outboxCount = (int) self::$pdo->query("SELECT COUNT(*) FROM openfga_outbox WHERE metadata->>'access_request_id' = " . self::$pdo->quote($id))->fetchColumn();
+        self::assertSame(0, $outboxCount, 'fast path must not insert outbox rows');
+    }
+
+    // -----------------------------------------------------------------------
+    // approvalMessage / revocationMessage variants — exercise the deferral
+    // and failure-suffix branches that the existing happy-path tests don't
+    // touch (lines ~879-908 per the coverage report).
+    // -----------------------------------------------------------------------
+
+    public function testApprovalMessageIncludesBothDeferredAndFailedSuffix(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        // Two permissions: one will get a 503 (transient → deferred), one
+        // will get a validation_error 400 (terminal → failed).
+        $id = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+            ['object_type' => 'national_calendar', 'object_id' => 'US', 'relation' => 'editor'],
+        ]);
+
+        $mock = new MockHandler([
+            new \GuzzleHttp\Psr7\Response(503, [], ''),
+            new \GuzzleHttp\Psr7\Response(400, [], (string) json_encode(['code' => 'validation_error', 'message' => 'bad type'])),
+        ]);
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            function (OpenFgaClient $client) use ($id): \Psr\Http\Message\ResponseInterface {
+                $handler = new AccessRequestAdminHandler($client);
+                return $handler->handle($this->withOidcUser(
+                    $this->requestFor('POST', '/admin/access-requests/' . $id . '/approve', [], ['notes' => 'ok'])
+                ));
+            }
+        ));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(1, $body['outbox_failed']);
+        self::assertStringContainsString('deferred for async delivery', $body['message']);
+        self::assertStringContainsString('failed terminally', $body['message']);
+    }
+
+    public function testRevocationMessageIncludesBothDeferredAndFailedSuffix(): void
+    {
+        $repo = new AccessRequestRepository(self::$pdo);
+        $id   = $repo->create('user-a', 'a@x.test', null, 'developer', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+            ['object_type' => 'national_calendar', 'object_id' => 'US', 'relation' => 'editor'],
+        ]);
+        $repo->approve($id, 'admin');
+
+        $mock = new MockHandler([
+            new \GuzzleHttp\Psr7\Response(503, [], ''),
+            new \GuzzleHttp\Psr7\Response(400, [], (string) json_encode(['code' => 'validation_error', 'message' => 'bad type'])),
+        ]);
+
+        $response = $this->withoutEnv(self::ZITADEL_ENV_VARS, fn() => $this->withMockOpenFgaClient(
+            $mock,
+            function (OpenFgaClient $client) use ($id): \Psr\Http\Message\ResponseInterface {
+                $handler = new AccessRequestAdminHandler($client);
+                return $handler->handle($this->withOidcUser(
+                    $this->requestFor('POST', '/admin/access-requests/' . $id . '/revoke', [], [])
+                ));
+            }
+        ));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(1, $body['outbox_failed']);
+        self::assertStringContainsString('deferred for async deletion', $body['message']);
+        self::assertStringContainsString('failed terminally', $body['message']);
+    }
 }

--- a/phpunit_tests/Handlers/Admin/OutboxAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/OutboxAdminHandlerTest.php
@@ -220,4 +220,22 @@ final class OutboxAdminHandlerTest extends AbstractHandlerTestCase
         self::assertArrayHasKey('error', $body);
         self::assertStringContainsStringIgnoringCase('failed_terminal', (string) $body['error']);
     }
+
+    // -----------------------------------------------------------------------
+    // Test 5: POST retry returns 404 for missing row
+    // -----------------------------------------------------------------------
+
+    public function testPostRetryReturns404ForMissingRow(): void
+    {
+        $response = $this->makeHandler()->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', '/admin/outbox/999999/retry')
+            )
+        );
+
+        self::assertSame(404, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('error', $body);
+        self::assertStringContainsStringIgnoringCase('not found', (string) $body['error']);
+    }
 }

--- a/phpunit_tests/Handlers/Admin/OutboxAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/OutboxAdminHandlerTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers\Admin;
+
+use LiturgicalCalendar\Api\Handlers\Admin\OutboxAdminHandler;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Integration tests for OutboxAdminHandler.
+ *
+ * Exercises the two sub-routes:
+ *   GET  /admin/outbox?status=...&summary=...&limit=...&offset=...
+ *   POST /admin/outbox/{id}/retry
+ *
+ * All four tests require Postgres (openfga_outbox table).
+ * Auth is satisfied by attaching an oidc_user attribute directly on the
+ * PSR-7 request (same pattern as PermissionAdminHandlerTest / AbstractHandlerTestCase).
+ */
+#[CoversClass(OutboxAdminHandler::class)]
+final class OutboxAdminHandlerTest extends AbstractHandlerTestCase
+{
+    protected static bool $requiresDatabase = true;
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Insert a single outbox row directly via SQL and return its ID.
+     * Bypasses OutboxRepository::insertBatch (which enforces idempotency_key
+     * uniqueness) so tests can seed arbitrary statuses quickly.
+     */
+    private function insertOutboxRow(
+        string $status = 'pending',
+        string $operation = 'write_tuple',
+        ?string $lastError = null,
+        ?string $accessRequestId = null
+    ): int {
+        $metadata = ['admin_user' => 'user:test-admin'];
+        if ($accessRequestId !== null) {
+            $metadata['access_request_id'] = $accessRequestId;
+        }
+
+        $stmt = self::$pdo->prepare(<<<'SQL'
+            INSERT INTO openfga_outbox
+                (operation, fga_user, fga_relation, fga_object, status, last_error, metadata)
+            VALUES
+                (:operation, 'user:alice', 'editor', 'national_calendar:IT', :status::outbox_status, :last_error, :metadata::jsonb)
+            RETURNING id
+        SQL);
+        $stmt->execute([
+            ':operation'  => $operation,
+            ':status'     => $status,
+            ':last_error' => $lastError,
+            ':metadata'   => json_encode($metadata, JSON_THROW_ON_ERROR),
+        ]);
+        return (int) $stmt->fetchColumn();
+    }
+
+    private function makeHandler(): OutboxAdminHandler
+    {
+        return new OutboxAdminHandler(new OutboxRepository(self::$pdo));
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 1: GET list with status filter
+    // -----------------------------------------------------------------------
+
+    public function testGetWithStatusFilterReturnsMatchingRows(): void
+    {
+        // Seed rows in different statuses
+        $this->insertOutboxRow('pending');
+        $this->insertOutboxRow('pending');
+        $this->insertOutboxRow('retrying');
+        $failedId1 = $this->insertOutboxRow('failed_terminal', 'write_tuple', 'FGA error', null);
+        $failedId2 = $this->insertOutboxRow('failed_terminal', 'delete_tuple', 'timeout', null);
+        $this->insertOutboxRow('succeeded');
+
+        $response = $this->makeHandler()->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/admin/outbox?status=failed_terminal')
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+
+        // Envelope shape
+        self::assertArrayHasKey('items', $body);
+        self::assertArrayHasKey('total', $body);
+        self::assertArrayHasKey('count', $body);
+        self::assertArrayHasKey('limit', $body);
+        self::assertArrayHasKey('offset', $body);
+        self::assertArrayHasKey('has_more', $body);
+
+        // Only failed_terminal rows come back
+        self::assertSame(2, $body['total']);
+        self::assertSame(2, $body['count']);
+        self::assertFalse($body['has_more']);
+
+        self::assertIsArray($body['items']);
+        $returnedIds = array_column($body['items'], 'id');
+        sort($returnedIds);
+        self::assertContains($failedId1, $returnedIds);
+        self::assertContains($failedId2, $returnedIds);
+
+        // Each row has the expected fields
+        $firstItem = $body['items'][0];
+        self::assertArrayHasKey('id', $firstItem);
+        self::assertArrayHasKey('operation', $firstItem);
+        self::assertArrayHasKey('fga_user', $firstItem);
+        self::assertArrayHasKey('fga_relation', $firstItem);
+        self::assertArrayHasKey('fga_object', $firstItem);
+        self::assertArrayHasKey('status', $firstItem);
+        self::assertArrayHasKey('attempts', $firstItem);
+        self::assertArrayHasKey('last_error', $firstItem);
+        self::assertArrayHasKey('metadata', $firstItem);
+        self::assertArrayHasKey('created_at', $firstItem);
+
+        // All returned rows must be in failed_terminal status
+        foreach ($body['items'] as $item) {
+            self::assertSame('failed_terminal', $item['status']);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 2: GET summary returns counts per status
+    // -----------------------------------------------------------------------
+
+    public function testGetSummaryReturnsCountsPerStatus(): void
+    {
+        // Seed: 2 pending, 1 retrying, 3 succeeded, 1 failed_terminal
+        $this->insertOutboxRow('pending');
+        $this->insertOutboxRow('pending');
+        $this->insertOutboxRow('retrying');
+        $this->insertOutboxRow('succeeded');
+        $this->insertOutboxRow('succeeded');
+        $this->insertOutboxRow('succeeded');
+        $this->insertOutboxRow('failed_terminal', 'write_tuple', 'error');
+
+        $response = $this->makeHandler()->handle(
+            $this->withOidcUser(
+                $this->requestFor('GET', '/admin/outbox?summary=1')
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+
+        self::assertArrayHasKey('counts', $body);
+        self::assertIsArray($body['counts']);
+
+        $counts = $body['counts'];
+        self::assertArrayHasKey('pending', $counts);
+        self::assertArrayHasKey('retrying', $counts);
+        self::assertArrayHasKey('succeeded', $counts);
+        self::assertArrayHasKey('failed_terminal', $counts);
+
+        self::assertSame(2, $counts['pending']);
+        self::assertSame(1, $counts['retrying']);
+        self::assertSame(3, $counts['succeeded']);
+        self::assertSame(1, $counts['failed_terminal']);
+
+        // oldest_pending_age_seconds must be present and >= 0
+        self::assertArrayHasKey('oldest_pending_age_seconds', $body);
+        self::assertIsInt($body['oldest_pending_age_seconds']);
+        self::assertGreaterThanOrEqual(0, $body['oldest_pending_age_seconds']);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 3: POST retry resets failed_terminal to pending
+    // -----------------------------------------------------------------------
+
+    public function testPostRetryResetsFailedTerminalToPending(): void
+    {
+        $id = $this->insertOutboxRow('failed_terminal', 'write_tuple', 'FGA unreachable');
+
+        $response = $this->makeHandler()->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', "/admin/outbox/{$id}/retry")
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('success', $body);
+        self::assertTrue($body['success']);
+
+        // Verify via repository that the row is back to pending with reset fields
+        $repo = new OutboxRepository(self::$pdo);
+        $row  = $repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::PENDING, $row->status);
+        self::assertSame(0, $row->attempts);
+        self::assertNull($row->lastError);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 4: POST retry returns 409 for non-terminal row
+    // -----------------------------------------------------------------------
+
+    public function testPostRetryReturns409ForNonTerminalRow(): void
+    {
+        $id = $this->insertOutboxRow('pending');
+
+        $response = $this->makeHandler()->handle(
+            $this->withOidcUser(
+                $this->requestFor('POST', "/admin/outbox/{$id}/retry")
+            )
+        );
+
+        self::assertSame(409, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('error', $body);
+        self::assertStringContainsStringIgnoringCase('failed_terminal', (string) $body['error']);
+    }
+}

--- a/phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php
@@ -5,15 +5,24 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Handlers\Admin;
 
 use GuzzleHttp\Client;
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use LiturgicalCalendar\Api\Handlers\Admin\PermissionAdminHandler;
 use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
@@ -26,6 +35,70 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(PermissionAdminHandler::class)]
 final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
 {
+    use EnvIsolationTrait;
+
+    protected static bool $requiresDatabase = true;
+
+    /**
+     * Build a real OpenFgaClient backed by a Guzzle MockHandler that
+     * replays the queued HTTP responses. We set the OPENFGA_* env vars so
+     * `OpenFgaClient::isConfigured()` returns true (otherwise the outbox
+     * fast-path's getClient() call would hit the env gate), and undo both
+     * at the end of the test. Mirrors the pattern in AccessRequestAdminHandlerTest.
+     *
+     * @param callable(OpenFgaClient): \Psr\Http\Message\ResponseInterface $fn
+     */
+    private function withMockOpenFgaClient(MockHandler $mock, callable $fn): \Psr\Http\Message\ResponseInterface
+    {
+        $stack  = HandlerStack::create($mock);
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+
+        $savedEnv = [];
+        foreach (['OPENFGA_API_URL', 'OPENFGA_STORE_ID', 'OPENFGA_MODEL_ID'] as $name) {
+            $savedEnv[$name] = getenv($name);
+            putenv("{$name}=stub");
+            $_ENV[$name] = 'stub';
+        }
+
+        try {
+            return $fn($client);
+        } finally {
+            foreach ($savedEnv as $name => $original) {
+                if ($original === false) {
+                    putenv($name);
+                    unset($_ENV[$name]);
+                } else {
+                    putenv("{$name}={$original}");
+                    $_ENV[$name] = $original;
+                }
+            }
+        }
+    }
+
+    /**
+     * Extract and narrow an array-typed top-level body field (same helper
+     * as in AccessRequestAdminHandlerTest, duplicated to keep tests self-contained).
+     *
+     * @param array<string, mixed> $body
+     * @return array<int|string, mixed>
+     */
+    private static function arrayFieldFrom(array $body, string $key): array
+    {
+        self::assertArrayHasKey($key, $body);
+        self::assertIsArray($body[$key]);
+        return $body[$key];
+    }
+
     public function testOptionsPreflightSucceeds(): void
     {
         $response = ( new PermissionAdminHandler() )->handle(
@@ -340,5 +413,400 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
         self::assertSame('user:resource-admin-1', $listPayload['user']);
         self::assertSame('admin', $listPayload['relation']);
         self::assertSame('national_calendar', $listPayload['type']);
+    }
+
+    // --- Outbox pattern: grantPermission (Task 22) -----------------------
+
+    public function testGrantPersistsOutboxRowAndAppliesViaSyncFastPath(): void
+    {
+        // Global admin granting a permission. FGA returns 200. After the
+        // outbox sync fast path the outbox row must be in 'succeeded' state
+        // and the response shape must include outbox counters.
+        $mock = new MockHandler([
+            new GuzzleResponse(200, [], '{}'), // writeTuple OK
+        ]);
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $response = $this->withMockOpenFgaClient(
+            $mock,
+            function (OpenFgaClient $client) use ($outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new PermissionAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/permissions',
+                        [],
+                        [
+                            'user'        => 'user-alice',
+                            'object_type' => 'national_calendar',
+                            'object_id'   => 'IT',
+                            'relation'    => 'editor',
+                        ]
+                    ))
+                );
+            }
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(1, self::arrayFieldFrom($body, 'outbox_ids'));
+
+        // Verify outbox row was created and marked succeeded.
+        $outboxIds = self::arrayFieldFrom($body, 'outbox_ids');
+        $outboxRow = $outboxRepo->getById((int) $outboxIds[0]);
+        self::assertNotNull($outboxRow);
+        self::assertSame(OutboxStatus::SUCCEEDED, $outboxRow->status);
+        self::assertSame(OutboxOperation::WRITE_TUPLE, $outboxRow->operation);
+    }
+
+    public function testGrantIsIdempotentOnReissue(): void
+    {
+        // Two sequential grant calls for the same tuple from the same admin
+        // must collapse to the same outbox row IDs (idempotency_key).
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $requestBody = [
+            'user'        => 'user-alice',
+            'object_type' => 'national_calendar',
+            'object_id'   => 'IT',
+            'relation'    => 'editor',
+        ];
+
+        $mock1 = new MockHandler([new GuzzleResponse(200, [], '{}')]);
+        $body1 = $this->withMockOpenFgaClient(
+            $mock1,
+            function (OpenFgaClient $client) use ($outboxRepo, $notifier, $requestBody): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new PermissionAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor('POST', '/admin/permissions', [], $requestBody))
+                );
+            }
+        );
+
+        $mock2 = new MockHandler([new GuzzleResponse(200, [], '{}')]);
+        $body2 = $this->withMockOpenFgaClient(
+            $mock2,
+            function (OpenFgaClient $client) use ($outboxRepo, $notifier, $requestBody): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new PermissionAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor('POST', '/admin/permissions', [], $requestBody))
+                );
+            }
+        );
+
+        $ids1 = self::arrayFieldFrom($this->decodeJsonBody($body1), 'outbox_ids');
+        $ids2 = self::arrayFieldFrom($this->decodeJsonBody($body2), 'outbox_ids');
+
+        self::assertSame(
+            $ids1,
+            $ids2,
+            'idempotency_key must collapse second grant to same outbox row IDs'
+        );
+    }
+
+    public function testGrantSurfacesTransientFailureAsOutboxPending(): void
+    {
+        // FGA returns 503 (transient). The outbox row must end up in 'retrying'
+        // state and outbox_pending must be 1.
+        $mock = new MockHandler([
+            new GuzzleResponse(503, [], ''), // transient → RETRY
+        ]);
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $response = $this->withMockOpenFgaClient(
+            $mock,
+            function (OpenFgaClient $client) use ($outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new PermissionAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/permissions',
+                        [],
+                        [
+                            'user'        => 'user-alice',
+                            'object_type' => 'national_calendar',
+                            'object_id'   => 'IT',
+                            'relation'    => 'editor',
+                        ]
+                    ))
+                );
+            }
+        );
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+
+        $outboxIds = self::arrayFieldFrom($body, 'outbox_ids');
+        $outboxRow = $outboxRepo->getById((int) $outboxIds[0]);
+        self::assertNotNull($outboxRow);
+        self::assertSame(OutboxStatus::RETRYING, $outboxRow->status);
+    }
+
+    public function testGrantTreatsDuplicateTupleAsBenignSuccess(): void
+    {
+        // FGA returns 400 with cannot_allow_duplicate_tuple (already exists).
+        // OutboxClassifier must classify this as BENIGN_SUCCESS — the row ends
+        // up in 'succeeded' state and outbox_pending/failed are both 0.
+        $mock = new MockHandler([
+            new GuzzleResponse(400, [], (string) json_encode([
+                'code'    => 'cannot_allow_duplicate_tuple',
+                'message' => 'cannot write duplicate tuple',
+            ])),
+        ]);
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $response = $this->withMockOpenFgaClient(
+            $mock,
+            function (OpenFgaClient $client) use ($outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                $processor = new OutboxProcessor($outboxRepo, $client);
+                $handler   = new PermissionAdminHandler($client);
+                $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                return $handler->handle(
+                    $this->withOidcUser($this->requestFor(
+                        'POST',
+                        '/admin/permissions',
+                        [],
+                        [
+                            'user'        => 'user-alice',
+                            'object_type' => 'national_calendar',
+                            'object_id'   => 'IT',
+                            'relation'    => 'editor',
+                        ]
+                    ))
+                );
+            }
+        );
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(1, self::arrayFieldFrom($body, 'tuples_created'));
+    }
+
+    // --- Outbox pattern: revokePermission (Task 22) ----------------------
+
+    public function testRevokePersistsOutboxRowAndAppliesViaSyncFastPath(): void
+    {
+        // Global admin revoking a permission. FGA returns 200. After the
+        // outbox sync fast path the outbox row must be in 'succeeded' state.
+        $mock = new MockHandler([
+            new GuzzleResponse(200, [], '{}'), // deleteTuple OK
+        ]);
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $response = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => $this->withMockOpenFgaClient(
+                $mock,
+                function (OpenFgaClient $client) use ($outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                    $processor = new OutboxProcessor($outboxRepo, $client);
+                    $handler   = new PermissionAdminHandler($client);
+                    $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                    return $handler->handle(
+                        $this->withOidcUser($this->requestFor(
+                            'DELETE',
+                            '/admin/permissions',
+                            [],
+                            [
+                                'user'        => 'user-alice',
+                                'object_type' => 'national_calendar',
+                                'object_id'   => 'IT',
+                                'relation'    => 'editor',
+                            ]
+                        ))
+                    );
+                }
+            )
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        self::assertCount(1, self::arrayFieldFrom($body, 'outbox_ids'));
+        self::assertCount(1, self::arrayFieldFrom($body, 'tuples_deleted'));
+
+        // Verify outbox row was created and marked succeeded with delete_tuple operation.
+        $outboxIds = self::arrayFieldFrom($body, 'outbox_ids');
+        $outboxRow = $outboxRepo->getById((int) $outboxIds[0]);
+        self::assertNotNull($outboxRow);
+        self::assertSame(OutboxStatus::SUCCEEDED, $outboxRow->status);
+        self::assertSame(OutboxOperation::DELETE_TUPLE, $outboxRow->operation);
+    }
+
+    public function testRevokeSurfacesTransientFailureAsOutboxPending(): void
+    {
+        // FGA returns 503 (transient). The outbox row must end up in 'retrying'
+        // state and outbox_pending must be 1. success must still be true
+        // (the outbox row committed to the DB before the sync attempt).
+        $mock = new MockHandler([
+            new GuzzleResponse(503, [], ''), // transient → RETRY
+        ]);
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $response = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => $this->withMockOpenFgaClient(
+                $mock,
+                function (OpenFgaClient $client) use ($outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                    $processor = new OutboxProcessor($outboxRepo, $client);
+                    $handler   = new PermissionAdminHandler($client);
+                    $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                    return $handler->handle(
+                        $this->withOidcUser($this->requestFor(
+                            'DELETE',
+                            '/admin/permissions',
+                            [],
+                            [
+                                'user'        => 'user-alice',
+                                'object_type' => 'national_calendar',
+                                'object_id'   => 'IT',
+                                'relation'    => 'editor',
+                            ]
+                        ))
+                    );
+                }
+            )
+        );
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(1, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+
+        $outboxIds = self::arrayFieldFrom($body, 'outbox_ids');
+        $outboxRow = $outboxRepo->getById((int) $outboxIds[0]);
+        self::assertNotNull($outboxRow);
+        self::assertSame(OutboxStatus::RETRYING, $outboxRow->status);
+    }
+
+    public function testRevokeTreatsMissingTupleAsBenignSuccess(): void
+    {
+        // FGA returns 400 with cannot_allow_unknown_tuple_to_be_deleted
+        // (tuple not found — already gone). OutboxClassifier must classify this
+        // as BENIGN_SUCCESS — the row ends up in 'succeeded' state.
+        $mock = new MockHandler([
+            new GuzzleResponse(400, [], (string) json_encode([
+                'code'    => 'cannot_allow_unknown_tuple_to_be_deleted',
+                'message' => 'cannot delete unknown tuple',
+            ])),
+        ]);
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $response = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => $this->withMockOpenFgaClient(
+                $mock,
+                function (OpenFgaClient $client) use ($outboxRepo, $notifier): \Psr\Http\Message\ResponseInterface {
+                    $processor = new OutboxProcessor($outboxRepo, $client);
+                    $handler   = new PermissionAdminHandler($client);
+                    $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                    return $handler->handle(
+                        $this->withOidcUser($this->requestFor(
+                            'DELETE',
+                            '/admin/permissions',
+                            [],
+                            [
+                                'user'        => 'user-alice',
+                                'object_type' => 'national_calendar',
+                                'object_id'   => 'IT',
+                                'relation'    => 'editor',
+                            ]
+                        ))
+                    );
+                }
+            )
+        );
+
+        $body = $this->decodeJsonBody($response);
+        self::assertTrue($body['success']);
+        self::assertSame(0, $body['outbox_pending']);
+        self::assertSame(0, $body['outbox_failed']);
+        // BENIGN_SUCCESS → counted in tuples_deleted (idempotent — tuple already gone).
+        self::assertCount(1, self::arrayFieldFrom($body, 'tuples_deleted'));
+    }
+
+    public function testRevokeIsIdempotentOnReissue(): void
+    {
+        // Two sequential revoke calls for the same tuple from the same admin
+        // must collapse to the same outbox row IDs (idempotency_key).
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $notifier   = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        $requestBody = [
+            'user'        => 'user-alice',
+            'object_type' => 'national_calendar',
+            'object_id'   => 'IT',
+            'relation'    => 'editor',
+        ];
+
+        $mock1 = new MockHandler([new GuzzleResponse(200, [], '{}')]);
+        $body1 = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => $this->withMockOpenFgaClient(
+                $mock1,
+                function (OpenFgaClient $client) use ($outboxRepo, $notifier, $requestBody): \Psr\Http\Message\ResponseInterface {
+                    $processor = new OutboxProcessor($outboxRepo, $client);
+                    $handler   = new PermissionAdminHandler($client);
+                    $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                    return $handler->handle(
+                        $this->withOidcUser($this->requestFor('DELETE', '/admin/permissions', [], $requestBody))
+                    );
+                }
+            )
+        );
+
+        $mock2 = new MockHandler([new GuzzleResponse(200, [], '{}')]);
+        $body2 = $this->withoutEnv(
+            array_merge(self::ZITADEL_ENV_VARS, self::OPENFGA_ENV_VARS),
+            fn() => $this->withMockOpenFgaClient(
+                $mock2,
+                function (OpenFgaClient $client) use ($outboxRepo, $notifier, $requestBody): \Psr\Http\Message\ResponseInterface {
+                    $processor = new OutboxProcessor($outboxRepo, $client);
+                    $handler   = new PermissionAdminHandler($client);
+                    $handler->setOutboxDependencies($outboxRepo, $notifier, $processor);
+                    return $handler->handle(
+                        $this->withOidcUser($this->requestFor('DELETE', '/admin/permissions', [], $requestBody))
+                    );
+                }
+            )
+        );
+
+        $ids1 = self::arrayFieldFrom($this->decodeJsonBody($body1), 'outbox_ids');
+        $ids2 = self::arrayFieldFrom($this->decodeJsonBody($body2), 'outbox_ids');
+
+        self::assertSame(
+            $ids1,
+            $ids2,
+            'idempotency_key must collapse second revoke to same outbox row IDs'
+        );
     }
 }

--- a/phpunit_tests/Handlers/Ops/HealthHandlerTest.php
+++ b/phpunit_tests/Handlers/Ops/HealthHandlerTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers\Ops;
+
+use LiturgicalCalendar\Api\Handlers\Ops\HealthHandler;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(HealthHandler::class)]
+final class HealthHandlerTest extends AbstractHandlerTestCase
+{
+    use EnvIsolationTrait;
+
+    /**
+     * The endpoint hits openfga_outbox; we want the test DB so the count
+     * branch in buildOutboxStats() is exercised.
+     */
+    protected static bool $requiresDatabase = true;
+
+    public function testGetReturns200WithExpectedShape(): void
+    {
+        $response = ( new HealthHandler() )->handle(
+            $this->requestFor('GET', '/health', [], [])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/json; charset=utf-8', $response->getHeaderLine('Content-Type'));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertSame('ok', $body['status']);
+        self::assertSame('reachable', $body['database']);
+
+        self::assertArrayHasKey('openfga_outbox', $body);
+        $outbox = $body['openfga_outbox'];
+        self::assertSame(0, $outbox['pending']);
+        self::assertSame(0, $outbox['retrying']);
+        self::assertSame(0, $outbox['succeeded']);
+        self::assertSame(0, $outbox['failed_terminal']);
+        self::assertSame(0, $outbox['oldest_pending_age_seconds']);
+        self::assertArrayHasKey('consumer', $outbox);
+
+        $consumer = $outbox['consumer'];
+        self::assertArrayHasKey('redis_reachable', $consumer);
+        self::assertIsBool($consumer['redis_reachable']);
+        self::assertSame('litcal:reconcile-stream', $consumer['stream_name']);
+        self::assertSame('reconciler', $consumer['group_name']);
+        self::assertIsInt($consumer['pending_entries']);
+        self::assertIsInt($consumer['oldest_pel_idle_seconds']);
+    }
+
+    public function testGetReturnsNotConfiguredWhenDbEnvAbsent(): void
+    {
+        // Clear DB_* env vars so Connection::isConfigured() returns false.
+        $response = $this->withoutEnv(
+            ['DB_HOST', 'DB_PORT', 'DB_NAME', 'DB_USER', 'DB_PASSWORD'],
+            fn() => ( new HealthHandler() )->handle(
+                $this->requestFor('GET', '/health', [], [])
+            )
+        );
+
+        $body = $this->decodeJsonBody($response);
+        self::assertSame('ok', $body['status'], 'no DB configured is not a degraded state');
+        self::assertSame('not_configured', $body['database']);
+        // The outbox block still ships with zero counts (no DB to read).
+        self::assertSame(0, $body['openfga_outbox']['pending']);
+    }
+
+    public function testPostReturns405(): void
+    {
+        $this->expectException(MethodNotAllowedException::class);
+
+        ( new HealthHandler() )->handle(
+            $this->requestFor('POST', '/health', [], [])
+        );
+    }
+}

--- a/phpunit_tests/HealthOutboxStatsTest.php
+++ b/phpunit_tests/HealthOutboxStatsTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Targeted coverage for Health::buildOutboxStats, the static helper that
+ * powers the /health endpoint's openfga_outbox block. The Redis side of
+ * the helper is exercised live (best-effort — relies on ext-redis being
+ * loaded); the PG side is exercised against real rows.
+ */
+#[CoversClass(Health::class)]
+final class HealthOutboxStatsTest extends RepositoryTestCase
+{
+    public function testStatsReportsZeroOnEmptyOutbox(): void
+    {
+        $stats = Health::buildOutboxStats();
+
+        self::assertSame(0, $stats['pending']);
+        self::assertSame(0, $stats['retrying']);
+        self::assertSame(0, $stats['succeeded']);
+        self::assertSame(0, $stats['failed_terminal']);
+        self::assertSame(0, $stats['oldest_pending_age_seconds']);
+
+        self::assertArrayHasKey('consumer', $stats);
+        self::assertSame('litcal:reconcile-stream', $stats['consumer']['stream_name']);
+        self::assertSame('reconciler', $stats['consumer']['group_name']);
+    }
+
+    public function testStatsBucketsRowsPerStatusAndReportsOldestAge(): void
+    {
+        self::assertNotNull(self::$pdo);
+        $repo = new OutboxRepository(self::$pdo);
+
+        $ids = $repo->insertBatch([
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:a',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => 'h1-' . bin2hex(random_bytes(4)),
+                'metadata'        => [],
+            ],
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:b',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:US',
+                'idempotency_key' => 'h2-' . bin2hex(random_bytes(4)),
+                'metadata'        => [],
+            ],
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:c',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:FR',
+                'idempotency_key' => 'h3-' . bin2hex(random_bytes(4)),
+                'metadata'        => [],
+            ],
+        ]);
+        // One stays pending, one becomes succeeded, one becomes failed_terminal.
+        $repo->markSucceeded($ids[1]);
+        $repo->markFailedTerminal($ids[2], 'validation_error', 'validation_error');
+
+        $stats = Health::buildOutboxStats();
+
+        self::assertSame(1, $stats['pending']);
+        self::assertSame(1, $stats['succeeded']);
+        self::assertSame(1, $stats['failed_terminal']);
+        // oldest_pending_age_seconds is computed from created_at, which the
+        // migration default-sets to NOW(). Brand-new rows are < 1s old; an
+        // age value of 0 or 1 is both acceptable.
+        self::assertGreaterThanOrEqual(0, $stats['oldest_pending_age_seconds']);
+        self::assertLessThanOrEqual(5, $stats['oldest_pending_age_seconds'], 'fresh rows must show a small age');
+    }
+
+    public function testStatsConsumerStreamNameHonorsEnv(): void
+    {
+        $originalStream = $_ENV['REDIS_OUTBOX_STREAM'] ?? null;
+        $originalGroup  = $_ENV['REDIS_OUTBOX_GROUP'] ?? null;
+        try {
+            $_ENV['REDIS_OUTBOX_STREAM'] = 'custom:stream:name';
+            $_ENV['REDIS_OUTBOX_GROUP']  = 'custom-group';
+
+            $stats = Health::buildOutboxStats();
+
+            self::assertSame('custom:stream:name', $stats['consumer']['stream_name']);
+            self::assertSame('custom-group', $stats['consumer']['group_name']);
+        } finally {
+            if ($originalStream === null) {
+                unset($_ENV['REDIS_OUTBOX_STREAM']);
+            } else {
+                $_ENV['REDIS_OUTBOX_STREAM'] = $originalStream;
+            }
+            if ($originalGroup === null) {
+                unset($_ENV['REDIS_OUTBOX_GROUP']);
+            } else {
+                $_ENV['REDIS_OUTBOX_GROUP'] = $originalGroup;
+            }
+        }
+    }
+}

--- a/phpunit_tests/Repositories/OutboxRepositoryTest.php
+++ b/phpunit_tests/Repositories/OutboxRepositoryTest.php
@@ -200,16 +200,18 @@ final class OutboxRepositoryTest extends RepositoryTestCase
     {
         $ids = $this->repo->insertBatch($this->samplePayload()); // 2 rows
 
-        // Open a second PDO connection to the same DB.
-        $other = new \PDO(
-            sprintf(
-                'pgsql:host=%s;port=%s;dbname=%s',
-                (string) ( $_ENV['DB_HOST'] ?? 'localhost' ),
-                (string) ( $_ENV['DB_PORT'] ?? '5432' ),
-                (string) ( $_ENV['DB_NAME'] ?? '' ),
-            ),
-            (string) ( $_ENV['DB_USER'] ?? '' ),
-            (string) ( $_ENV['DB_PASSWORD'] ?? '' ),
+        // Open a second PDO connection to the same DB. Use the same env
+        // resolution the base class uses (env array first, getenv fallback)
+        // so this works in CI where DB_* may live only in getenv().
+        $host     = self::env('DB_HOST') ?? 'localhost';
+        $port     = self::env('DB_PORT') ?? '5432';
+        $name     = self::env('DB_NAME') ?? '';
+        $user     = self::env('DB_USER') ?? '';
+        $password = self::env('DB_PASSWORD') ?? '';
+        $other    = new \PDO(
+            sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $name),
+            $user,
+            $password,
             [
                 \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
                 \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
@@ -220,15 +222,27 @@ final class OutboxRepositoryTest extends RepositoryTestCase
         $otherRepo = new OutboxRepository($other);
 
         // Both runners start a tx and call pickupPending with limit: 1;
-        // SKIP LOCKED must give each one a distinct row.
-        self::$pdo->beginTransaction();
-        $picked1 = $this->repo->pickupPending(limit: 1, now: new \DateTimeImmutable());
+        // SKIP LOCKED must give each one a distinct row. Wrap in try/finally
+        // so a mid-test assertion failure can't leave open transactions on
+        // the shared connections — those would cascade into TRUNCATE failures
+        // in the next test's setUp.
+        try {
+            self::$pdo->beginTransaction();
+            $picked1 = $this->repo->pickupPending(limit: 1, now: new \DateTimeImmutable());
 
-        $other->beginTransaction();
-        $picked2 = $otherRepo->pickupPending(limit: 1, now: new \DateTimeImmutable());
+            $other->beginTransaction();
+            $picked2 = $otherRepo->pickupPending(limit: 1, now: new \DateTimeImmutable());
 
-        self::$pdo->commit();
-        $other->commit();
+            self::$pdo->commit();
+            $other->commit();
+        } finally {
+            if (self::$pdo->inTransaction()) {
+                self::$pdo->rollBack();
+            }
+            if ($other->inTransaction()) {
+                $other->rollBack();
+            }
+        }
 
         $idsPicked = array_merge(
             array_map(static fn ($r): int => $r->id, $picked1),

--- a/phpunit_tests/Repositories/OutboxRepositoryTest.php
+++ b/phpunit_tests/Repositories/OutboxRepositoryTest.php
@@ -279,4 +279,27 @@ final class OutboxRepositoryTest extends RepositoryTestCase
         self::assertSame(1, $counts['succeeded'] ?? 0);
         self::assertSame(1, $counts['failed_terminal'] ?? 0);
     }
+
+    public function testMarkRetryableRoundtripsMicrosecondPrecision(): void
+    {
+        [$id]   = $this->repo->insertBatch([$this->samplePayload()[0]]);
+        $nextAt = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', '2026-06-02 12:34:56.123456');
+        self::assertInstanceOf(\DateTimeImmutable::class, $nextAt);
+
+        $this->repo->markRetryable(
+            $id,
+            attempts: 1,
+            nextAttemptAt: $nextAt,
+            lastError: 'transient',
+            lastErrorCode: null,
+        );
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(
+            $nextAt->format('u'),
+            $row->nextAttemptAt->format('u'),
+            'next_attempt_at microseconds must survive the write/read roundtrip',
+        );
+    }
 }

--- a/phpunit_tests/Repositories/OutboxRepositoryTest.php
+++ b/phpunit_tests/Repositories/OutboxRepositoryTest.php
@@ -90,4 +90,72 @@ final class OutboxRepositoryTest extends RepositoryTestCase
     {
         self::assertNull($this->repo->getById(999999));
     }
+
+    public function testMarkSucceededSetsTerminalStateAndCompletedAt(): void
+    {
+        [$id] = $this->repo->insertBatch($this->samplePayload());
+
+        $this->repo->markSucceeded($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::SUCCEEDED, $row->status);
+        self::assertNotNull($row->completedAt);
+    }
+
+    public function testMarkSucceededOnAlreadyTerminalIsNoOp(): void
+    {
+        [$id] = $this->repo->insertBatch($this->samplePayload());
+        $this->repo->markSucceeded($id);
+        $firstCompleted = $this->repo->getById($id)?->completedAt;
+
+        // Sleep 1 second so completed_at would observably change if a second call rewrote it.
+        sleep(1);
+        $this->repo->markSucceeded($id);
+
+        $secondCompleted = $this->repo->getById($id)?->completedAt;
+        self::assertEquals($firstCompleted, $secondCompleted, 'completed_at must not change on second markSucceeded');
+    }
+
+    public function testMarkRetryableIncrementsAttemptsAndSchedulesNext(): void
+    {
+        [$id]   = $this->repo->insertBatch($this->samplePayload());
+        $nextAt = ( new \DateTimeImmutable('now') )->modify('+8 seconds');
+
+        $this->repo->markRetryable($id, attempts: 3, nextAttemptAt: $nextAt, lastError: 'OpenFGA 503', lastErrorCode: null);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::RETRYING, $row->status);
+        self::assertSame(3, $row->attempts);
+        self::assertSame('OpenFGA 503', $row->lastError);
+        self::assertEqualsWithDelta(
+            $nextAt->getTimestamp(),
+            $row->nextAttemptAt->getTimestamp(),
+            1.0,
+            'next_attempt_at within 1s of requested',
+        );
+    }
+
+    public function testMarkFailedTerminalIsSticky(): void
+    {
+        [$id] = $this->repo->insertBatch($this->samplePayload());
+
+        $this->repo->markFailedTerminal($id, lastError: 'validation_error', lastErrorCode: 'validation_error');
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::FAILED_TERMINAL, $row->status);
+        self::assertSame('validation_error', $row->lastErrorCode);
+
+        // Subsequent markRetryable on a terminal row must NOT downgrade it.
+        $this->repo->markRetryable($id, attempts: 4, nextAttemptAt: new \DateTimeImmutable(), lastError: 'late retry', lastErrorCode: null);
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(
+            OutboxStatus::FAILED_TERMINAL,
+            $row->status,
+            'markRetryable must not overwrite a terminal status',
+        );
+    }
 }

--- a/phpunit_tests/Repositories/OutboxRepositoryTest.php
+++ b/phpunit_tests/Repositories/OutboxRepositoryTest.php
@@ -158,4 +158,86 @@ final class OutboxRepositoryTest extends RepositoryTestCase
             'markRetryable must not overwrite a terminal status',
         );
     }
+
+    public function testPickupPendingReturnsOnlyEligibleRows(): void
+    {
+        $ids = $this->repo->insertBatch($this->samplePayload());
+        $this->repo->markSucceeded($ids[0]); // exclude succeeded
+        $this->repo->markFailedTerminal($ids[1], 'x', null); // exclude failed_terminal
+
+        $picked = $this->repo->pickupPending(limit: 10, now: new \DateTimeImmutable());
+
+        self::assertSame([], $picked, 'no eligible rows after both are terminal');
+    }
+
+    public function testPickupPendingRespectsNextAttemptAt(): void
+    {
+        [$id] = $this->repo->insertBatch([$this->samplePayload()[0]]);
+
+        // Schedule the next attempt 60 seconds into the future.
+        $this->repo->markRetryable(
+            $id,
+            attempts: 1,
+            nextAttemptAt: ( new \DateTimeImmutable() )->modify('+60 seconds'),
+            lastError: 'transient',
+            lastErrorCode: null,
+        );
+
+        $tooEarly = $this->repo->pickupPending(limit: 10, now: new \DateTimeImmutable());
+        self::assertSame([], $tooEarly);
+
+        // Far-future cutoff should pick it up.
+        $picked = $this->repo->pickupPending(limit: 10, now: ( new \DateTimeImmutable() )->modify('+120 seconds'));
+        self::assertCount(1, $picked);
+        self::assertSame($id, $picked[0]->id);
+    }
+
+    /**
+     * Two concurrent transactions must each get distinct rows
+     * thanks to FOR UPDATE SKIP LOCKED. Load-bearing for consumer + backstop topology.
+     */
+    public function testPickupPendingSkipLockedSeparatesConcurrentRunners(): void
+    {
+        $ids = $this->repo->insertBatch($this->samplePayload()); // 2 rows
+
+        // Open a second PDO connection to the same DB.
+        $other = new \PDO(
+            sprintf(
+                'pgsql:host=%s;port=%s;dbname=%s',
+                (string) ( $_ENV['DB_HOST'] ?? 'localhost' ),
+                (string) ( $_ENV['DB_PORT'] ?? '5432' ),
+                (string) ( $_ENV['DB_NAME'] ?? '' ),
+            ),
+            (string) ( $_ENV['DB_USER'] ?? '' ),
+            (string) ( $_ENV['DB_PASSWORD'] ?? '' ),
+            [
+                \PDO::ATTR_ERRMODE            => \PDO::ERRMODE_EXCEPTION,
+                \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
+                \PDO::ATTR_EMULATE_PREPARES   => false,
+            ],
+        );
+        $other->exec("SET timezone TO 'Europe/Vatican'");
+        $otherRepo = new OutboxRepository($other);
+
+        // Both runners start a tx and call pickupPending with limit: 1;
+        // SKIP LOCKED must give each one a distinct row.
+        self::$pdo->beginTransaction();
+        $picked1 = $this->repo->pickupPending(limit: 1, now: new \DateTimeImmutable());
+
+        $other->beginTransaction();
+        $picked2 = $otherRepo->pickupPending(limit: 1, now: new \DateTimeImmutable());
+
+        self::$pdo->commit();
+        $other->commit();
+
+        $idsPicked = array_merge(
+            array_map(static fn ($r): int => $r->id, $picked1),
+            array_map(static fn ($r): int => $r->id, $picked2),
+        );
+        sort($idsPicked);
+        sort($ids);
+        self::assertSame($ids, $idsPicked, 'two transactions must collectively pick up every row exactly once');
+        self::assertCount(1, $picked1);
+        self::assertCount(1, $picked2);
+    }
 }

--- a/phpunit_tests/Repositories/OutboxRepositoryTest.php
+++ b/phpunit_tests/Repositories/OutboxRepositoryTest.php
@@ -240,4 +240,43 @@ final class OutboxRepositoryTest extends RepositoryTestCase
         self::assertCount(1, $picked1);
         self::assertCount(1, $picked2);
     }
+
+    public function testResetForRetryClearsAttemptsAndStatus(): void
+    {
+        [$id] = $this->repo->insertBatch([$this->samplePayload()[0]]);
+        $this->repo->markFailedTerminal($id, 'validation_error', 'validation_error');
+
+        $changed = $this->repo->resetForRetry($id);
+
+        self::assertTrue($changed, 'resetForRetry must return true when a row was reset');
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::PENDING, $row->status);
+        self::assertSame(0, $row->attempts);
+        self::assertNull($row->lastError);
+        self::assertNull($row->lastErrorCode);
+        self::assertNull($row->completedAt);
+    }
+
+    public function testResetForRetryReturnsFalseForNonTerminalRow(): void
+    {
+        [$id] = $this->repo->insertBatch([$this->samplePayload()[0]]);
+        // Row is still 'pending' — admin retry must refuse.
+        $changed = $this->repo->resetForRetry($id);
+        self::assertFalse($changed);
+    }
+
+    public function testCountByStatusBucketsAllFour(): void
+    {
+        $ids = $this->repo->insertBatch($this->samplePayload());
+        $this->repo->markSucceeded($ids[0]);
+        $this->repo->markFailedTerminal($ids[1], 'x', null);
+
+        $counts = $this->repo->countByStatus();
+
+        self::assertSame(0, $counts['pending'] ?? 0);
+        self::assertSame(0, $counts['retrying'] ?? 0);
+        self::assertSame(1, $counts['succeeded'] ?? 0);
+        self::assertSame(1, $counts['failed_terminal'] ?? 0);
+    }
 }

--- a/phpunit_tests/Repositories/OutboxRepositoryTest.php
+++ b/phpunit_tests/Repositories/OutboxRepositoryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(OutboxRepository::class)]
+final class OutboxRepositoryTest extends RepositoryTestCase
+{
+    private OutboxRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new OutboxRepository(self::$pdo);
+    }
+
+    /**
+     * @return list<array{operation: OutboxOperation, fga_user: string, fga_relation: string, fga_object: string, idempotency_key: string, metadata: array<string,mixed>}>
+     */
+    private function samplePayload(): array
+    {
+        return [
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:alice',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => 'access_request:r1:write_tuple:user:alice:editor:national_calendar:IT',
+                'metadata'        => ['access_request_id' => 'r1', 'admin_user' => 'admin:bob'],
+            ],
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:alice',
+                'fga_relation'    => 'viewer',
+                'fga_object'      => 'diocesan_calendar:romamo_it',
+                'idempotency_key' => 'access_request:r1:write_tuple:user:alice:viewer:diocesan_calendar:romamo_it',
+                'metadata'        => ['access_request_id' => 'r1', 'admin_user' => 'admin:bob'],
+            ],
+        ];
+    }
+
+    public function testInsertBatchReturnsRowIds(): void
+    {
+        $ids = $this->repo->insertBatch($this->samplePayload());
+
+        self::assertCount(2, $ids);
+        self::assertContainsOnlyInt($ids);
+        self::assertGreaterThan(0, $ids[0]);
+        self::assertGreaterThan(0, $ids[1]);
+        self::assertNotSame($ids[0], $ids[1]);
+    }
+
+    public function testInsertBatchIsIdempotentOnDuplicateKey(): void
+    {
+        $firstIds = $this->repo->insertBatch($this->samplePayload());
+        // Re-insert the same payload — same idempotency keys, no new rows.
+        $secondIds = $this->repo->insertBatch($this->samplePayload());
+
+        // Same IDs returned both times.
+        self::assertSame($firstIds, $secondIds);
+    }
+}

--- a/phpunit_tests/Repositories/OutboxRepositoryTest.php
+++ b/phpunit_tests/Repositories/OutboxRepositoryTest.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Tests\Repositories;
 
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(OutboxRepository::class)]
@@ -63,5 +64,30 @@ final class OutboxRepositoryTest extends RepositoryTestCase
 
         // Same IDs returned both times.
         self::assertSame($firstIds, $secondIds);
+    }
+
+    public function testGetByIdHydratesAllFields(): void
+    {
+        [$id1] = $this->repo->insertBatch($this->samplePayload());
+
+        $row = $this->repo->getById($id1);
+
+        self::assertNotNull($row);
+        self::assertSame($id1, $row->id);
+        self::assertSame(OutboxOperation::WRITE_TUPLE, $row->operation);
+        self::assertSame('user:alice', $row->fgaUser);
+        self::assertSame('editor', $row->fgaRelation);
+        self::assertSame('national_calendar:IT', $row->fgaObject);
+        self::assertSame(OutboxStatus::PENDING, $row->status);
+        self::assertSame(0, $row->attempts);
+        self::assertNull($row->lastError);
+        self::assertNull($row->lastErrorCode);
+        self::assertSame('r1', $row->metadata['access_request_id']);
+        self::assertNull($row->completedAt);
+    }
+
+    public function testGetByIdReturnsNullForMissingRow(): void
+    {
+        self::assertNull($this->repo->getById(999999));
     }
 }

--- a/phpunit_tests/Repositories/OutboxRepositoryTest.php
+++ b/phpunit_tests/Repositories/OutboxRepositoryTest.php
@@ -300,6 +300,10 @@ final class OutboxRepositoryTest extends RepositoryTestCase
         $nextAt = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s.u', '2026-06-02 12:34:56.123456');
         self::assertInstanceOf(\DateTimeImmutable::class, $nextAt);
 
+        // ----- list() coverage -----
+        // Seeded below by the trailing tests; reset is fine since each test
+        // gets a fresh TRUNCATE via RepositoryTestCase.
+
         $this->repo->markRetryable(
             $id,
             attempts: 1,
@@ -315,5 +319,95 @@ final class OutboxRepositoryTest extends RepositoryTestCase
             $row->nextAttemptAt->format('u'),
             'next_attempt_at microseconds must survive the write/read roundtrip',
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // list() — used by OutboxAdminHandler::handleGet for the paginated list
+    // surface. Exercises both filter dimensions and pagination.
+    // -----------------------------------------------------------------------
+
+    /**
+     * @return list<int>
+     */
+    private function seedThreeMixedRows(): array
+    {
+        // Same `access_request_id` for first two, third has a different one.
+        return $this->repo->insertBatch([
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:a',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => 'list-k1-' . bin2hex(random_bytes(4)),
+                'metadata'        => ['access_request_id' => 'r-A'],
+            ],
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:b',
+                'fga_relation'    => 'viewer',
+                'fga_object'      => 'national_calendar:US',
+                'idempotency_key' => 'list-k2-' . bin2hex(random_bytes(4)),
+                'metadata'        => ['access_request_id' => 'r-A'],
+            ],
+            [
+                'operation'       => OutboxOperation::DELETE_TUPLE,
+                'fga_user'        => 'user:c',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:FR',
+                'idempotency_key' => 'list-k3-' . bin2hex(random_bytes(4)),
+                'metadata'        => ['access_request_id' => 'r-B'],
+            ],
+        ]);
+    }
+
+    public function testListWithoutFiltersReturnsAllRowsAndTotal(): void
+    {
+        $this->seedThreeMixedRows();
+
+        $page = $this->repo->list(status: null, accessRequestId: null, limit: 100, offset: 0);
+
+        self::assertSame(3, $page['total']);
+        self::assertCount(3, $page['rows']);
+    }
+
+    public function testListWithStatusFilterReturnsMatchingRowsOnly(): void
+    {
+        $ids = $this->seedThreeMixedRows();
+        $this->repo->markFailedTerminal($ids[0], 'validation_error', 'validation_error');
+
+        $page = $this->repo->list(status: 'failed_terminal', accessRequestId: null, limit: 100, offset: 0);
+
+        self::assertSame(1, $page['total']);
+        self::assertCount(1, $page['rows']);
+        self::assertSame($ids[0], $page['rows'][0]->id);
+        self::assertSame(OutboxStatus::FAILED_TERMINAL, $page['rows'][0]->status);
+    }
+
+    public function testListWithAccessRequestIdFilterReturnsMatchingRowsOnly(): void
+    {
+        $this->seedThreeMixedRows();
+
+        $page = $this->repo->list(status: null, accessRequestId: 'r-A', limit: 100, offset: 0);
+
+        self::assertSame(2, $page['total']);
+        self::assertCount(2, $page['rows']);
+        foreach ($page['rows'] as $row) {
+            self::assertSame('r-A', $row->metadata['access_request_id']);
+        }
+    }
+
+    public function testListRespectsLimitAndOffset(): void
+    {
+        $this->seedThreeMixedRows();
+
+        // total is still 3 regardless of pagination
+        $page = $this->repo->list(status: null, accessRequestId: null, limit: 2, offset: 0);
+        self::assertSame(3, $page['total']);
+        self::assertCount(2, $page['rows']);
+
+        // offset 2 → just the last row
+        $page = $this->repo->list(status: null, accessRequestId: null, limit: 2, offset: 2);
+        self::assertSame(3, $page['total']);
+        self::assertCount(1, $page['rows']);
     }
 }

--- a/phpunit_tests/Repositories/RepositoryTestCase.php
+++ b/phpunit_tests/Repositories/RepositoryTestCase.php
@@ -92,7 +92,13 @@ abstract class RepositoryTestCase extends TestCase
 
     private static ?string $skipReason = null;
 
-    private static function env(string $name): ?string
+    /**
+     * Resolve a DB env var. Subclasses that need to open a second PDO
+     * connection should reuse this rather than reading $_ENV directly,
+     * so the resolution rules (env array first, getenv() fallback) stay
+     * consistent with setUpBeforeClass().
+     */
+    protected static function env(string $name): ?string
     {
         if (isset($_ENV[$name]) && $_ENV[$name] !== '') {
             return (string) $_ENV[$name];

--- a/phpunit_tests/Repositories/RepositoryTestCase.php
+++ b/phpunit_tests/Repositories/RepositoryTestCase.php
@@ -31,7 +31,7 @@ abstract class RepositoryTestCase extends TestCase
     protected static ?PDO $pdo = null;
 
     /** @var array<int,string> Tables truncated before each test, in any order — CASCADE handles FKs. */
-    protected const TABLES = ['api_keys', 'applications', 'access_requests', 'audit_log'];
+    protected const TABLES = ['api_keys', 'applications', 'access_requests', 'audit_log', 'openfga_outbox'];
 
     public static function setUpBeforeClass(): void
     {

--- a/phpunit_tests/Routes/Readonly/HealthTest.php
+++ b/phpunit_tests/Routes/Readonly/HealthTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Readonly;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+/**
+ * Integration tests for the `/health` route — verifies that the Router
+ * wires HealthHandler under the unauthenticated public path and that
+ * the response shape monitoring tooling depends on stays intact.
+ *
+ * The handler's own contract is exercised by HealthHandlerTest (in-process
+ * handle() against AbstractHandlerTestCase). This test complements that by
+ * asserting the live HTTP path through the Router + rate-limit middleware
+ * — the surface load balancers and uptime checks actually hit.
+ */
+final class HealthTest extends ApiTestCase
+{
+    public function testGetHealthReturnsJsonWithExpectedShape(): void
+    {
+        $response = self::$http->get('/health');
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertStringStartsWith('application/json', $response->getHeaderLine('Content-Type'));
+
+        /** @var array{status: string, database: string, openfga_outbox: array<string, mixed>} $body */
+        $body = json_decode((string) $response->getBody(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('ok', $body['status']);
+        // Either 'reachable' (PG up + configured) or 'not_configured' is
+        // acceptable depending on the dev environment running the suite.
+        $this->assertContains($body['database'], ['reachable', 'not_configured']);
+
+        $this->assertArrayHasKey('openfga_outbox', $body);
+        $outbox = $body['openfga_outbox'];
+        $this->assertIsInt($outbox['pending']);
+        $this->assertIsInt($outbox['retrying']);
+        $this->assertIsInt($outbox['succeeded']);
+        $this->assertIsInt($outbox['failed_terminal']);
+        $this->assertIsInt($outbox['oldest_pending_age_seconds']);
+
+        $this->assertArrayHasKey('consumer', $outbox);
+        $this->assertArrayHasKey('redis_reachable', $outbox['consumer']);
+        $this->assertIsBool($outbox['consumer']['redis_reachable']);
+    }
+
+    public function testNonGetVerbReturns405(): void
+    {
+        // POST is not allowed on /health; the handler restricts to GET via
+        // allowedRequestMethods. Disable Guzzle's http_errors so we can
+        // inspect the 4xx response directly instead of catching an
+        // exception.
+        $response = self::$http->request('POST', '/health', ['http_errors' => false]);
+        $this->assertSame(405, $response->getStatusCode());
+    }
+}

--- a/phpunit_tests/Services/Outbox/BackstopRunnerTest.php
+++ b/phpunit_tests/Services/Outbox/BackstopRunnerTest.php
@@ -12,7 +12,9 @@ use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\Outbox\BackstopRunner;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessorInterface;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
 use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
 use Nyholm\Psr7\Factory\Psr17Factory;
@@ -99,5 +101,44 @@ final class BackstopRunnerTest extends RepositoryTestCase
         $processed = $runner->runOnce(limit: 100);
 
         self::assertSame(0, $processed, 'row is too fresh — under the 60s grace window');
+    }
+
+    public function testRunOnceRollsBackAndRethrowsWhenProcessorThrows(): void
+    {
+        self::assertNotNull(self::$pdo);
+        $repo = new OutboxRepository(self::$pdo);
+
+        $repo->insertBatch([
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:x',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:ES',
+                'idempotency_key' => 'rollback-' . bin2hex(random_bytes(4)),
+                'metadata'        => [],
+            ],
+        ]);
+
+        // Processor stub that always throws — exercises the try/catch in
+        // runOnce(): the surrounding tx must be rolled back, and the
+        // exception must propagate so the cron job exits non-zero.
+        // createStub (not createMock) because we don't assert call counts;
+        // PHPUnit 12 emits a notice when createMock has no expectations.
+        $processor = $this->createStub(OutboxProcessorInterface::class);
+        $processor->method('processOne')->willThrowException(new \RuntimeException('processor blew up'));
+
+        $runner = new BackstopRunner($repo, $processor, self::$pdo, graceSeconds: 0);
+
+        try {
+            $runner->runOnce(limit: 100);
+            self::fail('Expected the runner to rethrow the processor exception');
+        } catch (\RuntimeException $e) {
+            self::assertSame('processor blew up', $e->getMessage());
+        }
+
+        // After the failed runOnce, the connection must NOT be left in a
+        // transaction — that would cascade into TRUNCATE failures in the
+        // next test's setUp.
+        self::assertFalse(self::$pdo->inTransaction(), 'BackstopRunner must roll back its tx before re-raising');
     }
 }

--- a/phpunit_tests/Services/Outbox/BackstopRunnerTest.php
+++ b/phpunit_tests/Services/Outbox/BackstopRunnerTest.php
@@ -60,7 +60,7 @@ final class BackstopRunnerTest extends RepositoryTestCase
             ],
         ]);
 
-        $runner    = new BackstopRunner($repo, $processor, graceSeconds: 0);
+        $runner    = new BackstopRunner($repo, $processor, self::$pdo, graceSeconds: 0);
         $processed = $runner->runOnce(limit: 100);
 
         self::assertSame(2, $processed);
@@ -95,7 +95,7 @@ final class BackstopRunnerTest extends RepositoryTestCase
             ]
         ]);
 
-        $runner    = new BackstopRunner($repo, $processor, graceSeconds: 60);
+        $runner    = new BackstopRunner($repo, $processor, self::$pdo, graceSeconds: 60);
         $processed = $runner->runOnce(limit: 100);
 
         self::assertSame(0, $processed, 'row is too fresh — under the 60s grace window');

--- a/phpunit_tests/Services/Outbox/BackstopRunnerTest.php
+++ b/phpunit_tests/Services/Outbox/BackstopRunnerTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\BackstopRunner;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(BackstopRunner::class)]
+final class BackstopRunnerTest extends RepositoryTestCase
+{
+    public function testRunOnceProcessesEligibleRowsAndIgnoresGraceWindow(): void
+    {
+        self::assertNotNull(self::$pdo);
+        $repo      = new OutboxRepository(self::$pdo);
+        $psr17     = new Psr17Factory();
+        $mock      = new MockHandler([
+            new Response(200, [], ''),
+            new Response(200, [], ''),
+        ]);
+        $client    = new OpenFgaClient(
+            'http://localhost:8083',
+            'store-123',
+            'model-456',
+            new Client(['handler' => HandlerStack::create($mock)]),
+            $psr17,
+            $psr17,
+        );
+        $processor = new OutboxProcessor($repo, $client);
+
+        // Two ancient pending rows (eligible for backstop after 0s grace).
+        $ids = $repo->insertBatch([
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:a',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => 'k1-' . bin2hex(random_bytes(4)),
+                'metadata'        => [],
+            ],
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:b',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:US',
+                'idempotency_key' => 'k2-' . bin2hex(random_bytes(4)),
+                'metadata'        => [],
+            ],
+        ]);
+
+        $runner    = new BackstopRunner($repo, $processor, graceSeconds: 0);
+        $processed = $runner->runOnce(limit: 100);
+
+        self::assertSame(2, $processed);
+        self::assertSame(OutboxStatus::SUCCEEDED, $repo->getById($ids[0])?->status);
+        self::assertSame(OutboxStatus::SUCCEEDED, $repo->getById($ids[1])?->status);
+    }
+
+    public function testRunOnceRespectsGraceWindow(): void
+    {
+        self::assertNotNull(self::$pdo);
+        $repo      = new OutboxRepository(self::$pdo);
+        $psr17     = new Psr17Factory();
+        $mock      = new MockHandler([]);
+        $client    = new OpenFgaClient(
+            'http://localhost:8083',
+            'store-123',
+            'model-456',
+            new Client(['handler' => HandlerStack::create($mock)]),
+            $psr17,
+            $psr17,
+        );
+        $processor = new OutboxProcessor($repo, $client);
+
+        $repo->insertBatch([
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:c',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:FR',
+                'idempotency_key' => 'k3-' . bin2hex(random_bytes(4)),
+                'metadata'        => [],
+            ]
+        ]);
+
+        $runner    = new BackstopRunner($repo, $processor, graceSeconds: 60);
+        $processed = $runner->runOnce(limit: 100);
+
+        self::assertSame(0, $processed, 'row is too fresh — under the 60s grace window');
+    }
+}

--- a/phpunit_tests/Services/Outbox/ConsumerLoopTest.php
+++ b/phpunit_tests/Services/Outbox/ConsumerLoopTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Outbox\ConsumerLoop;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessorInterface;
+use LiturgicalCalendar\Api\Services\Outbox\StreamConsumerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConsumerLoop::class)]
+final class ConsumerLoopTest extends TestCase
+{
+    public function testTickEnsuresGroupOnceAndDelegatesToConsumer(): void
+    {
+        $consumer = $this->createMock(StreamConsumerInterface::class);
+        $consumer->expects(self::once())->method('ensureGroup');
+        $consumer->expects(self::exactly(3))
+            ->method('readOnce')
+            ->with(5000, self::isCallable());
+
+        // No expectations on processor in this test — use stub to avoid notice.
+        $processor = $this->createStub(OutboxProcessorInterface::class);
+
+        $loop = new ConsumerLoop($consumer, $processor, blockMs: 5000);
+        $loop->tick();
+        $loop->tick();
+        $loop->tick();
+    }
+
+    public function testTickPassesRowIdToProcessor(): void
+    {
+        // No expectations on consumer beyond behavior — use stub to avoid notice.
+        $consumer = $this->createStub(StreamConsumerInterface::class);
+        $consumer->method('readOnce')->willReturnCallback(
+            static function (int $blockMs, callable $process): void {
+                $process(42);
+            },
+        );
+
+        $processor = $this->createMock(OutboxProcessorInterface::class);
+        $processor->expects(self::once())
+            ->method('processOne')
+            ->with(42)
+            ->willReturn(OutboxDisposition::BENIGN_SUCCESS);
+
+        $loop = new ConsumerLoop($consumer, $processor, blockMs: 5000);
+        $loop->tick();
+    }
+}

--- a/phpunit_tests/Services/Outbox/OutboxBackoffTest.php
+++ b/phpunit_tests/Services/Outbox/OutboxBackoffTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OutboxBackoff::class)]
+final class OutboxBackoffTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{int, int}>
+     */
+    public static function backoffCases(): iterable
+    {
+        yield 'attempt 1 → 1s'   => [1, 1];
+        yield 'attempt 2 → 2s'   => [2, 2];
+        yield 'attempt 3 → 4s'   => [3, 4];
+        yield 'attempt 4 → 8s'   => [4, 8];
+        yield 'attempt 5 → 16s'  => [5, 16];
+        yield 'attempt 6 → 32s'  => [6, 32];
+        yield 'attempt 7 → 64s'  => [7, 64];
+        yield 'attempt 8 → 128s' => [8, 128];
+        yield 'attempt 9 → 256s' => [9, 256];
+        yield 'attempt 10 → 512s' => [10, 512];
+        yield 'attempts past cap stay at 512s' => [99, 512];
+    }
+
+    #[DataProvider('backoffCases')]
+    public function testSecondsForAttempt(int $attempts, int $expectedSeconds): void
+    {
+        self::assertSame($expectedSeconds, OutboxBackoff::secondsForAttempt($attempts));
+    }
+
+    public function testZeroAttemptsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        OutboxBackoff::secondsForAttempt(0);
+    }
+
+    public function testNegativeAttemptsThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        OutboxBackoff::secondsForAttempt(-1);
+    }
+}

--- a/phpunit_tests/Services/Outbox/OutboxClassifierTest.php
+++ b/phpunit_tests/Services/Outbox/OutboxClassifierTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxClassifier;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OutboxClassifier::class)]
+final class OutboxClassifierTest extends TestCase
+{
+    public function testTupleAlreadyExistsIsBenign(): void
+    {
+        $e = new TupleAlreadyExistsException('already exists', 400, 'cannot_allow_duplicate_tuple');
+        self::assertSame(OutboxDisposition::BENIGN_SUCCESS, OutboxClassifier::classify($e));
+    }
+
+    public function testTupleNotFoundIsBenign(): void
+    {
+        $e = new TupleNotFoundException('not found', 400, 'cannot_allow_unknown_tuple_to_be_deleted');
+        self::assertSame(OutboxDisposition::BENIGN_SUCCESS, OutboxClassifier::classify($e));
+    }
+
+    public function testValidationErrorIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('invalid input', 400, 'validation_error');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testInvalidInputFormatIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('bad format', 400, 'invalid_input_format');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testTypeNotFoundIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('no such type', 400, 'type_not_found');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testRelationNotFoundIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('no such relation', 400, 'relation_not_found');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testAuthFailureIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('auth failure', 401, 'auth_failure');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testUnauthenticatedIsTerminal(): void
+    {
+        $e = new OpenFgaApiException('unauthenticated', 401, 'unauthenticated');
+        self::assertSame(OutboxDisposition::TERMINAL, OutboxClassifier::classify($e));
+    }
+
+    public function testRateLimitedIsRetry(): void
+    {
+        $e = new OpenFgaApiException('rate-limited', 429, null);
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+
+    public function test500IsRetry(): void
+    {
+        $e = new OpenFgaApiException('server error', 500, null);
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+
+    public function test503IsRetry(): void
+    {
+        $e = new OpenFgaApiException('unavailable', 503, null);
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+
+    public function testGenericRuntimeExceptionIsRetry(): void
+    {
+        // Network errors surface as \RuntimeException (Guzzle ConnectException) or similar.
+        $e = new \RuntimeException('connection refused');
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+
+    public function testUnknownErrorCodeIsRetry(): void
+    {
+        // Safe default: anything we don't recognize gets retried.
+        $e = new OpenFgaApiException('mystery', 418, 'i_am_a_teapot');
+        self::assertSame(OutboxDisposition::RETRY, OutboxClassifier::classify($e));
+    }
+}

--- a/phpunit_tests/Services/Outbox/OutboxNotifierTest.php
+++ b/phpunit_tests/Services/Outbox/OutboxNotifierTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(OutboxNotifier::class)]
+final class OutboxNotifierTest extends TestCase
+{
+    public function testNotifyXAddsToStream(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xAdd')
+            ->with(
+                self::equalTo('litcal:reconcile-stream'),
+                self::equalTo('*'),
+                self::callback(static function (array $payload): bool {
+                    return ( $payload['row_id'] ?? null ) === '42' && ( $payload['op'] ?? null ) === 'write_tuple';
+                }),
+            )
+            ->willReturn('1234567890-0');
+
+        $notifier = new OutboxNotifier($redis, 'litcal:reconcile-stream');
+        $notifier->notify(42, 'write_tuple');
+    }
+
+    public function testNotifyOnRedisExceptionDoesNotPropagate(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xAdd')
+            ->willThrowException(new \RedisException('connection refused'));
+
+        $notifier = new OutboxNotifier($redis, 'litcal:reconcile-stream');
+
+        // Must NOT throw — the outbox row is durable in PG; the backstop will pick it up.
+        $notifier->notify(42, 'write_tuple');
+        $this->addToAssertionCount(1);
+    }
+
+    public function testNotifyWithNullRedisIsNoOp(): void
+    {
+        $notifier = new OutboxNotifier(null, 'litcal:reconcile-stream');
+        $notifier->notify(42, 'write_tuple');
+        $this->addToAssertionCount(1);
+    }
+}

--- a/phpunit_tests/Services/Outbox/OutboxProcessorTest.php
+++ b/phpunit_tests/Services/Outbox/OutboxProcessorTest.php
@@ -136,6 +136,32 @@ final class OutboxProcessorTest extends RepositoryTestCase
         );
     }
 
+    public function testCustomMaxAttemptsConfigurable(): void
+    {
+        [$id] = $this->seedOneWrite();
+        // Pre-set the row to attempts=2 so this call is the 3rd attempt.
+        $this->repo->markRetryable(
+            $id,
+            attempts: 2,
+            nextAttemptAt: new \DateTimeImmutable('-1 second'),
+            lastError: 'prior transient',
+            lastErrorCode: null,
+        );
+        $mock = new MockHandler([new Response(503, [], '')]);
+        // Processor with maxAttempts=3: the 3rd attempt (attempts=2 → newAttempts=3 >= 3) must go terminal.
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock), maxAttempts: 3);
+
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(
+            OutboxStatus::FAILED_TERMINAL,
+            $row->status,
+            'custom maxAttempts=3 must cause failed_terminal on the 3rd attempt',
+        );
+    }
+
     public function testProcessOneBenignAlreadyExistsCountsAsSuccess(): void
     {
         [$id] = $this->seedOneWrite();

--- a/phpunit_tests/Services/Outbox/OutboxProcessorTest.php
+++ b/phpunit_tests/Services/Outbox/OutboxProcessorTest.php
@@ -84,15 +84,21 @@ final class OutboxProcessorTest extends RepositoryTestCase
         ]);
         $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
 
+        // Capture the timestamp BEFORE processing so the delta is computed
+        // against a stable reference rather than a fresh now() that races
+        // the wall clock (the original was flaky in slow CI).
+        $before = new \DateTimeImmutable();
         $proc->processOne($id);
 
         $row = $this->repo->getById($id);
         self::assertNotNull($row);
         self::assertSame(OutboxStatus::RETRYING, $row->status);
         self::assertSame(1, $row->attempts);
-        $delta = $row->nextAttemptAt->getTimestamp() - ( new \DateTimeImmutable() )->getTimestamp();
-        self::assertGreaterThanOrEqual(0, $delta);
-        self::assertLessThanOrEqual(2, $delta, 'attempts=1 should schedule ~1s ahead');
+        $delta = $row->nextAttemptAt->getTimestamp() - $before->getTimestamp();
+        // attempts=1 schedules +1s from "now during processing"; tolerate
+        // up to 5s for slow CI without making the test useless.
+        self::assertGreaterThanOrEqual(1, $delta, 'attempts=1 must schedule at least 1s after processing started');
+        self::assertLessThanOrEqual(5, $delta, 'attempts=1 schedules ~1s ahead (5s slack for slow CI)');
     }
 
     public function testProcessOneValidationErrorMarksTerminalOnFirstAttempt(): void

--- a/phpunit_tests/Services/Outbox/OutboxProcessorTest.php
+++ b/phpunit_tests/Services/Outbox/OutboxProcessorTest.php
@@ -200,4 +200,32 @@ final class OutboxProcessorTest extends RepositoryTestCase
         self::assertNotNull($row);
         self::assertSame(OutboxStatus::SUCCEEDED, $row->status);
     }
+
+    public function testProcessOneOnRetryingRowWithFutureNextAttemptIsNoOp(): void
+    {
+        // Pin the RETRYING + future-next-attempt guard: if XCLAIM-from-PEL
+        // hands us a row that another runner already rescheduled, we must
+        // honor the backoff rather than firing the OpenFGA call early.
+        [$id] = $this->seedOneWrite();
+        $this->repo->markRetryable(
+            $id,
+            attempts: 2,
+            nextAttemptAt: ( new \DateTimeImmutable('now', new \DateTimeZone('Europe/Vatican')) )->modify('+5 minutes'),
+            lastError: 'transient earlier',
+            lastErrorCode: null,
+        );
+
+        // MockHandler with no queued responses — if processOne tries to call
+        // OpenFGA, the test will fail with "No more handlers in stack".
+        $mock = new MockHandler([]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $disp = $proc->processOne($id);
+
+        self::assertSame(OutboxDisposition::BENIGN_SUCCESS, $disp, 'RETRYING + future next_attempt_at must short-circuit to BENIGN_SUCCESS');
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::RETRYING, $row->status, 'row must stay RETRYING — no transition triggered');
+        self::assertSame(2, $row->attempts, 'attempts must NOT increment on a skipped pass');
+    }
 }

--- a/phpunit_tests/Services/Outbox/OutboxProcessorTest.php
+++ b/phpunit_tests/Services/Outbox/OutboxProcessorTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(OutboxProcessor::class)]
+final class OutboxProcessorTest extends RepositoryTestCase
+{
+    private OutboxRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // parent::setUp() calls markTestSkipped() when $pdo is null,
+        // so reaching this line guarantees a live connection.
+        self::assertNotNull(self::$pdo, 'PDO connection must be available after parent::setUp()');
+        $this->repo = new OutboxRepository(self::$pdo);
+    }
+
+    private function makeClient(MockHandler $mock): OpenFgaClient
+    {
+        $psr17 = new Psr17Factory();
+        return new OpenFgaClient(
+            'http://localhost:8083',
+            'store-123',
+            'model-456',
+            new Client(['handler' => HandlerStack::create($mock)]),
+            $psr17,
+            $psr17,
+        );
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function seedOneWrite(): array
+    {
+        return $this->repo->insertBatch([
+            [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => 'user:alice',
+                'fga_relation'    => 'editor',
+                'fga_object'      => 'national_calendar:IT',
+                'idempotency_key' => 'k-' . bin2hex(random_bytes(4)),
+                'metadata'        => ['access_request_id' => 'r1'],
+            ],
+        ]);
+    }
+
+    public function testProcessOneSuccessMarksSucceeded(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $mock = new MockHandler([new Response(200, [], '')]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $disp = $proc->processOne($id);
+
+        self::assertSame(OutboxDisposition::BENIGN_SUCCESS, $disp);
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::SUCCEEDED, $row->status);
+    }
+
+    public function testProcessOneTransientSchedulesRetryWithCorrectBackoff(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $mock = new MockHandler([
+            new Response(503, [], (string) json_encode(['code' => 'temporarily_unavailable', 'message' => 'try again'])),
+        ]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::RETRYING, $row->status);
+        self::assertSame(1, $row->attempts);
+        $delta = $row->nextAttemptAt->getTimestamp() - ( new \DateTimeImmutable() )->getTimestamp();
+        self::assertGreaterThanOrEqual(0, $delta);
+        self::assertLessThanOrEqual(2, $delta, 'attempts=1 should schedule ~1s ahead');
+    }
+
+    public function testProcessOneValidationErrorMarksTerminalOnFirstAttempt(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $mock = new MockHandler([
+            new Response(400, [], (string) json_encode(['code' => 'validation_error', 'message' => 'bad type'])),
+        ]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::FAILED_TERMINAL, $row->status);
+        self::assertSame('validation_error', $row->lastErrorCode);
+    }
+
+    public function test10thAttemptOnTransientMarksTerminal(): void
+    {
+        [$id] = $this->seedOneWrite();
+        // Pre-set the row to attempts=9 and retrying so this call is the 10th.
+        $this->repo->markRetryable(
+            $id,
+            attempts: 9,
+            nextAttemptAt: new \DateTimeImmutable('-1 second'),
+            lastError: 'prior transient',
+            lastErrorCode: null,
+        );
+        $mock = new MockHandler([new Response(503, [], '')]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(
+            OutboxStatus::FAILED_TERMINAL,
+            $row->status,
+            '10th attempt on transient must transition to failed_terminal',
+        );
+    }
+
+    public function testProcessOneBenignAlreadyExistsCountsAsSuccess(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $mock = new MockHandler([
+            new Response(400, [], (string) json_encode([
+                'code'    => 'cannot_allow_duplicate_tuple',
+                'message' => 'tuple already exists',
+            ])),
+        ]);
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::SUCCEEDED, $row->status);
+    }
+
+    public function testProcessOneOnTerminalRowIsNoOp(): void
+    {
+        [$id] = $this->seedOneWrite();
+        $this->repo->markSucceeded($id);
+        $mock = new MockHandler([]); // No OpenFGA call should be made.
+        $proc = new OutboxProcessor($this->repo, $this->makeClient($mock));
+
+        // Should not throw despite MockHandler being empty.
+        $proc->processOne($id);
+
+        $row = $this->repo->getById($id);
+        self::assertNotNull($row);
+        self::assertSame(OutboxStatus::SUCCEEDED, $row->status);
+    }
+}

--- a/phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
+++ b/phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
@@ -16,7 +16,7 @@ final class RedisStreamConsumerTest extends TestCase
         $redis = $this->createMock(\Redis::class);
         $redis->expects(self::once())
             ->method('xGroup')
-            ->with('CREATE', 'litcal:reconcile-stream', 'reconciler', '$', true)
+            ->with('CREATE', 'litcal:reconcile-stream', 'reconciler', '0', true)
             ->willReturn(true);
 
         $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');

--- a/phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
+++ b/phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
@@ -85,4 +85,122 @@ final class RedisStreamConsumerTest extends TestCase
         });
         $this->addToAssertionCount(1);
     }
+
+    public function testClaimStaleSkipsWhenPelIsEmpty(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        // First xPending call (summary form, no PEL entries).
+        $redis->method('xPending')->willReturn(false);
+        // Empty xReadGroup → no main-loop work either; just verifies the
+        // early-exit from claimStale doesn't crash.
+        $redis->method('xReadGroup')->willReturn([]);
+        $redis->expects(self::never())->method('xClaim');
+        $redis->expects(self::never())->method('xAck');
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(blockMs: 100, process: function (int $rowId): void {
+        });
+        $this->addToAssertionCount(1);
+    }
+
+    public function testClaimStaleXClaimsAndAcksIdleMessages(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        // Summary form: non-empty so the detail-form call proceeds.
+        // Detail form: one stale entry idle 45_000ms > the 30_000 threshold.
+        $redis->method('xPending')->willReturnOnConsecutiveCalls(
+            [1, '1700000000-0', '1700000000-0', [['consumer-x', '1']]],     // summary form
+            [['1700000000-0', 'consumer-x', 45_000, 1]],                    // detail form
+        );
+        $redis->expects(self::once())
+            ->method('xClaim')
+            ->willReturn([
+                '1700000000-0' => ['row_id' => '99', 'op' => 'write_tuple'],
+            ]);
+        // No new XREADGROUP messages.
+        $redis->method('xReadGroup')->willReturn([]);
+        // xAck must fire for the claimed-and-processed message.
+        $redis->expects(self::once())
+            ->method('xAck')
+            ->with('litcal:reconcile-stream', 'reconciler', ['1700000000-0'])
+            ->willReturn(1);
+
+        $captured = null;
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(
+            blockMs: 100,
+            process: function (int $rowId) use (&$captured): void {
+                $captured = $rowId;
+            },
+        );
+
+        self::assertSame(99, $captured);
+    }
+
+    public function testClaimStaleSkipsClaimsForFreshEntries(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->method('xPending')->willReturnOnConsecutiveCalls(
+            [1, '1700000000-0', '1700000000-0', [['consumer-x', '1']]],     // summary
+            [['1700000000-0', 'consumer-x', 5_000, 1]],                     // 5s idle — fresh
+        );
+        // 5s < 30s threshold → no XCLAIM.
+        $redis->expects(self::never())->method('xClaim');
+        $redis->method('xReadGroup')->willReturn([]);
+        $redis->expects(self::never())->method('xAck');
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(blockMs: 100, process: function (int $rowId): void {
+        });
+        $this->addToAssertionCount(1);
+    }
+
+    public function testReadOnceAcksBadMessageWithMissingRowIdWithoutInvokingCallback(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->method('xPending')->willReturn(false);
+        $redis->method('xReadGroup')->willReturn([
+            'litcal:reconcile-stream' => [
+                '1700000000-0' => ['op' => 'write_tuple'], // missing row_id
+            ],
+        ]);
+        // Bad message must still be acked so it doesn't loop forever in the PEL.
+        $redis->expects(self::once())
+            ->method('xAck')
+            ->with('litcal:reconcile-stream', 'reconciler', ['1700000000-0'])
+            ->willReturn(1);
+
+        $callbackCalled = false;
+        $consumer       = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(
+            blockMs: 100,
+            process: function (int $rowId) use (&$callbackCalled): void {
+                $callbackCalled = true;
+            },
+        );
+
+        self::assertFalse($callbackCalled, 'callback must NOT fire for malformed message');
+    }
+
+    public function testReadOnceLeavesBadProcessThrowInPel(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->method('xPending')->willReturn(false);
+        $redis->method('xReadGroup')->willReturn([
+            'litcal:reconcile-stream' => [
+                '1700000000-0' => ['row_id' => '7', 'op' => 'write_tuple'],
+            ],
+        ]);
+        // Process throws → no xAck (message stays in PEL for next pass).
+        $redis->expects(self::never())->method('xAck');
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(
+            blockMs: 100,
+            process: function (int $rowId): void {
+                throw new \RuntimeException('boom');
+            },
+        );
+        $this->addToAssertionCount(1);
+    }
 }

--- a/phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
+++ b/phpunit_tests/Services/Outbox/RedisStreamConsumerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RedisStreamConsumer::class)]
+final class RedisStreamConsumerTest extends TestCase
+{
+    public function testEnsureGroupCreatesGroupIfMissing(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xGroup')
+            ->with('CREATE', 'litcal:reconcile-stream', 'reconciler', '$', true)
+            ->willReturn(true);
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->ensureGroup();
+    }
+
+    public function testEnsureGroupIgnoresBusygroup(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xGroup')
+            ->willThrowException(new \RedisException('BUSYGROUP Consumer Group name already exists'));
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->ensureGroup();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEnsureGroupReraisesOtherErrors(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->expects(self::once())
+            ->method('xGroup')
+            ->willThrowException(new \RedisException('WRONGTYPE'));
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $this->expectException(\RedisException::class);
+        $this->expectExceptionMessage('WRONGTYPE');
+        $consumer->ensureGroup();
+    }
+
+    public function testReadOneInvokesCallbackWithRowIdAndAcks(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        $redis->method('xReadGroup')->willReturn([
+            'litcal:reconcile-stream' => [
+                '1700000000-0' => ['row_id' => '42', 'op' => 'write_tuple'],
+            ],
+        ]);
+        $redis->expects(self::once())
+            ->method('xAck')
+            ->with('litcal:reconcile-stream', 'reconciler', ['1700000000-0'])
+            ->willReturn(1);
+
+        $captured = null;
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(
+            blockMs: 5000,
+            process: function (int $rowId) use (&$captured): void {
+                $captured = $rowId;
+            },
+        );
+
+        self::assertSame(42, $captured);
+    }
+
+    public function testReadOneReturnsWithoutAckOnEmptyRead(): void
+    {
+        $redis = $this->createMock(\Redis::class);
+        // Empty arrays come back from xReadGroup on timeout / no messages.
+        $redis->method('xReadGroup')->willReturn([]);
+        $redis->expects(self::never())->method('xAck');
+
+        $consumer = new RedisStreamConsumer($redis, 'litcal:reconcile-stream', 'reconciler', 'consumer-1');
+        $consumer->readOnce(blockMs: 100, process: function (int $rowId): void {
+        });
+        $this->addToAssertionCount(1);
+    }
+}

--- a/phpunit_tests/Services/RoleCascadeServiceOutboxTest.php
+++ b/phpunit_tests/Services/RoleCascadeServiceOutboxTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
+use LiturgicalCalendar\Api\Services\RoleCascadeService;
+use LiturgicalCalendar\Api\Services\ZitadelService;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Integration tests for RoleCascadeService's outbox-enqueue behaviour on FGA
+ * deleteTuple failures. These tests require a live Postgres connection and are
+ * automatically skipped when the DB is unavailable (CI supplies it; local devs
+ * can do the same — see RepositoryTestCase for the skip logic).
+ */
+#[CoversClass(RoleCascadeService::class)]
+final class RoleCascadeServiceOutboxTest extends RepositoryTestCase
+{
+    private function service(
+        OpenFgaClient $fga,
+        AccessRequestRepository $repo,
+        OutboxRepository $outboxRepo,
+    ): RoleCascadeService {
+        // OutboxNotifier with null Redis — no stream publish, but PG insert still happens.
+        $notifier = new OutboxNotifier(null, 'litcal:reconcile-stream');
+
+        return new RoleCascadeService(
+            $fga,
+            $this->createStub(ZitadelService::class),
+            $repo,
+            null,
+            $outboxRepo,
+            $notifier,
+        );
+    }
+
+    /**
+     * When deleteTuple throws a transient 503 (OutboxClassifier → RETRY), the
+     * service must insert a pending openfga_outbox row and return an empty
+     * deleted list (the failing tuple is not counted as deleted).
+     */
+    public function testCascadeRevokeEnqueuesOutboxRowOnFgaTransientFailure(): void
+    {
+        $fga = $this->createStub(OpenFgaClient::class);
+        // 'test_editor' role: first relation (admin) returns one object, rest empty.
+        $fga->method('listObjects')
+            ->willReturnCallback(static function (string $user, string $relation): array {
+                return $relation === 'admin' ? ['t1'] : [];
+            });
+        $fga->method('deleteTuple')
+            ->willThrowException(new OpenFgaApiException('Service Unavailable', 503));
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $repo       = $this->createStub(AccessRequestRepository::class);
+
+        $svc     = $this->service($fga, $repo, $outboxRepo);
+        $deleted = $svc->cascadeTupleRevokeForRole('u1', 'test_editor');
+
+        // The failing tuple is not counted as deleted.
+        self::assertSame([], $deleted);
+
+        // One pending outbox row must exist for the failed delete.
+        $stmt = self::$pdo->query(
+            "SELECT operation, fga_user, fga_relation, fga_object, status,
+                    metadata->>'role_cascade_user' AS cascade_user,
+                    metadata->>'role_cascade_role' AS cascade_role
+             FROM openfga_outbox
+             WHERE fga_user = 'user:u1'
+               AND fga_relation = 'admin'
+               AND fga_object = 'test_definition:t1'"
+        );
+        $rows = $stmt !== false ? $stmt->fetchAll() : [];
+
+        self::assertCount(1, $rows, 'Expected exactly one outbox row for the failed deleteTuple');
+        self::assertSame('delete_tuple', $rows[0]['operation']);
+        self::assertSame('pending', $rows[0]['status']);
+        self::assertSame('u1', $rows[0]['cascade_user']);
+        self::assertSame('test_editor', $rows[0]['cascade_role']);
+    }
+
+    /**
+     * When deleteTuple throws a TupleNotFoundException (BENIGN_SUCCESS), no outbox
+     * row must be inserted — the tuple was already gone, cascade is consistent.
+     */
+    public function testCascadeRevokeSkipsOutboxEnqueueOnBenignFgaFailure(): void
+    {
+        $fga = $this->createStub(OpenFgaClient::class);
+        $fga->method('listObjects')
+            ->willReturnCallback(static function (string $user, string $relation): array {
+                return $relation === 'admin' ? ['t1'] : [];
+            });
+        $fga->method('deleteTuple')
+            ->willThrowException(new TupleNotFoundException('not found', 404));
+
+        $outboxRepo = new OutboxRepository(self::$pdo);
+        $repo       = $this->createStub(AccessRequestRepository::class);
+
+        $svc     = $this->service($fga, $repo, $outboxRepo);
+        $deleted = $svc->cascadeTupleRevokeForRole('u1', 'test_editor');
+
+        // Benign failure: tuple already gone, so nothing to record.
+        self::assertSame([], $deleted);
+
+        // No outbox row must have been inserted.
+        $stmt  = self::$pdo->query('SELECT COUNT(*) FROM openfga_outbox');
+        $count = $stmt !== false ? (int) $stmt->fetchColumn() : -1;
+        self::assertSame(0, $count, 'BENIGN_SUCCESS must not enqueue any outbox row');
+    }
+}

--- a/phpunit_tests/Services/RoleCascadeServiceTest.php
+++ b/phpunit_tests/Services/RoleCascadeServiceTest.php
@@ -167,6 +167,9 @@ final class RoleCascadeServiceTest extends TestCase
 
     public function testCascadeTupleRevokeForRoleSwallowsDeleteFailures(): void
     {
+        // deleteTuple throws a generic Throwable (classified as RETRY).
+        // With no outboxRepo injected the nullsafe insertBatch call is a no-op,
+        // but cascadeRevokeByRole must still run and no tuples are recorded.
         $fga = $this->createStub(OpenFgaClient::class);
         $fga->method('listObjects')->willReturn(['t1']);
         $fga->method('deleteTuple')

--- a/phpunit_tests/bootstrap.php
+++ b/phpunit_tests/bootstrap.php
@@ -35,6 +35,13 @@ if (null === $autoloaderPath) {
 
 require_once $autoloaderPath;
 
+// Load Redis stubs when ext-redis is not installed (CI / dev environments
+// without the extension). The stub file is guarded by class_exists() so it
+// is safe to include unconditionally — in production the real extension wins.
+if (!extension_loaded('redis')) {
+    require_once dirname(__DIR__) . '/stubs/Redis.php';
+}
+
 use Dotenv\Dotenv;
 
 $dotenv = Dotenv::createMutable($projectFolder, ['.env', '.env.local', '.env.development', '.env.staging', '.env.production'], false);

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -18,8 +18,6 @@ use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
-use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
-use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
@@ -618,11 +616,24 @@ final class AccessRequestAdminHandler extends AbstractHandler
     /**
      * POST /admin/access-requests/{id}/revoke — Revoke a previously approved request.
      *
-     * Flow:
+     * Flow (outbox pattern, mirrors approveRequest):
      * 1. Validate request exists and is approved
-     * 2. Delete all OpenFGA tuples
-     * 3. Remove Zitadel role
-     * 4. Update DB status to revoked
+     * 2. Check admin has authority (global admin OR resource admin for ALL requested resources)
+     * 3. If permissions is empty: revoke in DB and return immediately
+     * 4. Otherwise:
+     *    a. PG BEGIN
+     *       - repo.revoke(requestId, adminId, notes)
+     *       - outbox.insertBatch(rows) — one row per permission, idempotency_key ensures
+     *         that re-revoking the same request collapses to the same outbox row IDs
+     *    b. PG COMMIT
+     *    c. For each outbox row: processor.processSync(), then notifier.notify() when
+     *       row is still in a non-terminal state (pending/retrying)
+     * 5. Sync role cascade to Zitadel (unchanged)
+     * 6. Return response with success=true (whenever DB committed), plus outbox counters
+     *
+     * `success` is true whenever the DB commit succeeded. Tuple deletion failures
+     * surface via outbox_pending / outbox_failed / fga_errors rather than aborting
+     * the entire revocation.
      */
     private function revokeRequest(
         ResponseInterface $response,
@@ -655,85 +666,158 @@ final class AccessRequestAdminHandler extends AbstractHandler
 
         $this->requireAdminForAllResources($adminId, $isGlobalAdmin, $permissions);
 
-        // Step 1: Delete OpenFGA tuples.
-        //
-        // TupleNotFoundException is treated as benign — the tuple is already
-        // gone, so re-revoke after a partial first attempt converges instead
-        // of double-failing. Any other OpenFgaApiException is fatal: the
-        // response will surface success: false with the structured error
-        // list so the admin knows there's drift to repair.
-        $deletedTuples = [];
-        $fgaErrors     = [];
-
-        if ($this->isFgaClientAvailable() && !empty($permissions)) {
-            $fgaUser = "user:{$userId}";
-
-            foreach ($permissions as $perm) {
-                $objectType = $perm['object_type'] ?? '';
-                $objectId   = $perm['object_id'] ?? '';
-                $relation   = $perm['relation'] ?? '';
-                $fgaObject  = "{$objectType}:{$objectId}";
-
-                try {
-                    $this->getFgaClient()->deleteTuple($fgaUser, $relation, $fgaObject);
-                    $deletedTuples[] = [
-                        'user'     => $fgaUser,
-                        'relation' => $relation,
-                        'object'   => $fgaObject,
-                    ];
-                } catch (TupleNotFoundException) {
-                    // Idempotent — tuple already deleted. Count it as deleted
-                    // so the response shows the user's effective state.
-                    $deletedTuples[] = [
-                        'user'     => $fgaUser,
-                        'relation' => $relation,
-                        'object'   => $fgaObject,
-                    ];
-                } catch (OpenFgaApiException $e) {
-                    $fgaErrors[] = [
-                        'object'   => $fgaObject,
-                        'relation' => $relation,
-                        'error'    => $e->getMessage(),
-                    ];
-                }
+        // Fast path: no permissions to delete — just revoke in DB and return.
+        if (empty($permissions) || !$this->isFgaClientAvailable()) {
+            $revoked = $repo->revoke($requestId, $adminId, $notes);
+            if (!$revoked) {
+                throw new NotFoundException('Request not found or not in approved status');
             }
-        }
 
-        // If we couldn't delete some of the tuples, bail before mutating the
-        // DB — leaving the request 'approved' lets the admin retry cleanly,
-        // and avoids the silent over-provisioning the issue flags
-        // ("row marked revoked while stale tuples remain in OpenFGA").
-        if (!empty($fgaErrors)) {
+            [$roleRemoved, $zitadelError] = $this->syncZitadelRoleRevoke($repo, $requestId, $userId, $requestedRole);
+
             return $this->encodeResponseBody($response, [
-                'success'        => false,
-                'role_removed'   => false,
-                'zitadel_error'  => null,
-                'tuples_deleted' => $deletedTuples,
-                'fga_errors'     => $fgaErrors,
-                'message'        => sprintf(
-                    'Revocation aborted: %d of %d permission tuple(s) could not be deleted. The request remains approved; retry once the underlying OpenFGA error is resolved.',
-                    count($fgaErrors),
-                    count($permissions)
-                ),
+                'success'        => true,
+                'role_removed'   => $roleRemoved,
+                'zitadel_error'  => $zitadelError,
+                'tuples_deleted' => [],
+                'fga_errors'     => [],
+                'outbox_ids'     => [],
+                'outbox_pending' => 0,
+                'outbox_failed'  => 0,
+                'message'        => $this->revocationMessage($roleRemoved, $zitadelError, 0, 0),
             ]);
         }
 
-        // Step 2: Revoke in database
-        $revoked = $repo->revoke($requestId, $adminId, $notes);
-        if (!$revoked) {
-            throw new NotFoundException('Request not found or not in approved status');
+        // Step 1: Build outbox rows — one per permission tuple.
+        $fgaUser    = "user:{$userId}";
+        $outboxRows = [];
+        foreach ($permissions as $perm) {
+            $objectType = is_string($perm['object_type'] ?? null) ? $perm['object_type'] : '';
+            $objectId   = is_string($perm['object_id'] ?? null) ? $perm['object_id'] : '';
+            $relation   = is_string($perm['relation'] ?? null) ? $perm['relation'] : '';
+            $fgaObject  = "{$objectType}:{$objectId}";
+
+            // Idempotency key: scoped to this access request + the specific tuple,
+            // so re-revoking the same request after a partial first attempt collapses
+            // to the same row rather than inserting a duplicate.
+            $idempotencyKey = "access_request:{$requestId}:delete_tuple:{$fgaUser}:{$relation}:{$fgaObject}";
+
+            $outboxRows[] = [
+                'operation'       => OutboxOperation::DELETE_TUPLE,
+                'fga_user'        => $fgaUser,
+                'fga_relation'    => $relation,
+                'fga_object'      => $fgaObject,
+                'idempotency_key' => $idempotencyKey,
+                'metadata'        => ['access_request_id' => $requestId],
+            ];
         }
 
-        // Step 3: Conditionally remove role from Zitadel.
-        // Cascade rule: only revoke the role if the user has zero remaining
-        // tuples in the role's scope. Other access_requests may still grant
-        // tuples for the same role — revoking unconditionally would strip
-        // those legitimate grants.
+        // Step 2: Atomically revoke in DB + insert outbox rows in one PG transaction.
+        $pdo    = Connection::getInstance();
+        $outbox = $this->getOutboxRepository();
+
+        $pdo->beginTransaction();
+        try {
+            $revoked = $repo->revoke($requestId, $adminId, $notes);
+            if (!$revoked) {
+                $pdo->rollBack();
+                throw new NotFoundException('Request not found or not in approved status');
+            }
+            $outboxIds = $outbox->insertBatch($outboxRows);
+            $pdo->commit();
+        } catch (\Throwable $e) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            throw $e;
+        }
+
+        // Step 3: Sync fast path — attempt each outbox row immediately.
+        // Rows that fail (transient errors) stay in 'retrying' state and will be
+        // picked up by the cron backstop. Rows that fail terminally (4xx validation)
+        // are marked 'failed_terminal' and surface in outbox_failed.
+        $processor = $this->getOutboxProcessor();
+        $notifier  = $this->getOutboxNotifier();
+
+        /** @var list<array{id: int, disposition: string, status: string}> $outboxResult */
+        $outboxResult  = [];
+        $deletedTuples = [];
+        $fgaErrors     = [];
+
+        foreach ($outboxIds as $rowId) {
+            $disposition = $processor->processSync($rowId);
+            $current     = $outbox->getById($rowId);
+            $statusValue = $current !== null ? $current->status->value : OutboxStatus::PENDING->value;
+
+            $outboxResult[] = [
+                'id'          => $rowId,
+                'disposition' => $disposition->name,
+                'status'      => $statusValue,
+            ];
+
+            if ($disposition === OutboxDisposition::BENIGN_SUCCESS) {
+                // Row is in succeeded state (or was already succeeded idempotently).
+                $deletedTuples[] = [
+                    'user'     => $current !== null ? $current->fgaUser     : $fgaUser,
+                    'relation' => $current !== null ? $current->fgaRelation : '',
+                    'object'   => $current !== null ? $current->fgaObject   : '',
+                ];
+            } else {
+                // RETRY or TERMINAL — surface in fga_errors for back-compat.
+                $fgaErrors[] = [
+                    'outbox_id' => $rowId,
+                    'status'    => $statusValue,
+                    'error'     => $current !== null ? ( $current->lastError ?? 'unknown' ) : 'unknown',
+                ];
+            }
+
+            // Notify the async consumer if the row is still non-terminal.
+            if (
+                $current !== null
+                && in_array($current->status, [OutboxStatus::PENDING, OutboxStatus::RETRYING], true)
+            ) {
+                $notifier->notify($rowId, OutboxOperation::DELETE_TUPLE->value);
+            }
+        }
+
+        $outboxPending = count(array_filter($outboxResult, static fn($r) => $r['status'] === OutboxStatus::RETRYING->value || $r['status'] === OutboxStatus::PENDING->value));
+        $outboxFailed  = count(array_filter($outboxResult, static fn($r) => $r['status'] === OutboxStatus::FAILED_TERMINAL->value));
+
+        // Step 4: Conditionally remove role from Zitadel (unchanged)
+        [$roleRemoved, $zitadelError] = $this->syncZitadelRoleRevoke($repo, $requestId, $userId, $requestedRole);
+
+        return $this->encodeResponseBody($response, [
+            'success'        => true,
+            'role_removed'   => $roleRemoved,
+            'zitadel_error'  => $zitadelError,
+            'tuples_deleted' => $deletedTuples,
+            'fga_errors'     => $fgaErrors,
+            'outbox_ids'     => $outboxIds,
+            'outbox_pending' => $outboxPending,
+            'outbox_failed'  => $outboxFailed,
+            'message'        => $this->revocationMessage($roleRemoved, $zitadelError, $outboxPending, $outboxFailed),
+        ]);
+    }
+
+    /**
+     * Sync a Zitadel role revocation (cascade) after DB revoke.
+     *
+     * Extracted to avoid duplicating the same try/catch in the fast-path and
+     * the outbox-path branches of revokeRequest.
+     *
+     * @return array{0: bool, 1: string|null}  [roleRemoved, zitadelError]
+     */
+    private function syncZitadelRoleRevoke(
+        AccessRequestRepository $repo,
+        string $requestId,
+        string $userId,
+        string $requestedRole,
+    ): array {
         $roleRemoved  = false;
         $zitadelError = null;
 
         if (ZitadelService::isConfigured()) {
-            if (empty($userId) || empty($requestedRole)) {
+            if ($userId === '' || $requestedRole === '') {
                 $zitadelError = 'Missing user ID or role in revoked request';
                 $repo->updateZitadelSyncStatus($requestId, 'failed', $zitadelError);
             } else {
@@ -751,20 +835,52 @@ final class AccessRequestAdminHandler extends AbstractHandler
             }
         }
 
-        return $this->encodeResponseBody($response, [
-            'success'        => true,
-            'role_removed'   => $roleRemoved,
-            'zitadel_error'  => $zitadelError,
-            'tuples_deleted' => $deletedTuples,
-            'fga_errors'     => $fgaErrors,
-            'message'        => $roleRemoved
-                ? 'Access revoked, role removed (no remaining permissions in scope) and permissions deleted'
-                : ( $zitadelError !== null
-                    ? 'Access revoked but Zitadel sync failed (will retry)'
-                    : ( ZitadelService::isConfigured()
-                        ? 'Access revoked, permissions deleted; role retained (other in-scope permissions remain)'
-                        : 'Access revoked (Zitadel not configured)' ) ),
-        ]);
+        return [$roleRemoved, $zitadelError];
+    }
+
+    /**
+     * Build the human-readable revocation message, incorporating outbox deferral/failure notes.
+     */
+    private function revocationMessage(
+        bool $roleRemoved,
+        ?string $zitadelError,
+        int $outboxPending,
+        int $outboxFailed,
+    ): string {
+        $base = $roleRemoved
+            ? 'Access revoked, role removed (no remaining permissions in scope) and permissions deleted'
+            : ( $zitadelError !== null
+                ? 'Access revoked but Zitadel sync failed (will retry)'
+                : ( ZitadelService::isConfigured()
+                    ? 'Access revoked, permissions deleted; role retained (other in-scope permissions remain)'
+                    : 'Access revoked (Zitadel not configured)' ) );
+
+        if ($outboxPending > 0 && $outboxFailed > 0) {
+            return sprintf(
+                '%s; %d permission tuple(s) deferred for async deletion, %d failed terminally (check outbox)',
+                $base,
+                $outboxPending,
+                $outboxFailed,
+            );
+        }
+
+        if ($outboxPending > 0) {
+            return sprintf(
+                '%s; %d permission tuple(s) deferred for async deletion',
+                $base,
+                $outboxPending,
+            );
+        }
+
+        if ($outboxFailed > 0) {
+            return sprintf(
+                '%s; %d permission tuple(s) failed terminally (check outbox)',
+                $base,
+                $outboxFailed,
+            );
+        }
+
+        return $base;
     }
 
     /**

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -366,7 +366,10 @@ final class AccessRequestAdminHandler extends AbstractHandler
         $this->requireAdminForAllResources($adminId, $isGlobalAdmin, $permissions);
 
         // Fast path: no permissions to write — just approve in DB and return.
-        if (empty($permissions) || !$this->isFgaClientAvailable()) {
+        // (FGA-unavailable does NOT short-circuit here: the outbox rows are
+        // still persisted below so the backstop can drain them once FGA
+        // comes back. Skipping that would silently lose tuple writes.)
+        if (empty($permissions)) {
             $approved = $repo->approve($requestId, $adminId, $notes);
             if (!$approved) {
                 throw new ValidationException('Failed to approve request');
@@ -435,8 +438,13 @@ final class AccessRequestAdminHandler extends AbstractHandler
         // Rows that fail (transient errors) stay in 'retrying' state and will be
         // picked up by the cron backstop. Rows that fail terminally (4xx validation)
         // are marked 'failed_terminal' and surface in outbox_failed.
-        $processor = $this->getOutboxProcessor();
-        $notifier  = $this->getOutboxNotifier();
+        //
+        // When FGA is unavailable we skip the inline attempt — the rows are
+        // already durable in PG and the backstop will pick them up once the
+        // client is reachable. Notifier XADD is still best-effort.
+        $fgaAvailable = $this->isFgaClientAvailable();
+        $processor    = $fgaAvailable ? $this->getOutboxProcessor() : null;
+        $notifier     = $this->getOutboxNotifier();
 
         /** @var list<array{id: int, disposition: string, status: string}> $outboxResult */
         $outboxResult  = [];
@@ -444,7 +452,9 @@ final class AccessRequestAdminHandler extends AbstractHandler
         $fgaErrors     = [];
 
         foreach ($outboxIds as $rowId) {
-            $disposition = $processor->processSync($rowId);
+            $disposition = $processor !== null
+                ? $processor->processSync($rowId)
+                : OutboxDisposition::RETRY;
             $current     = $outbox->getById($rowId);
             $statusValue = $current !== null ? $current->status->value : OutboxStatus::PENDING->value;
 
@@ -674,7 +684,11 @@ final class AccessRequestAdminHandler extends AbstractHandler
         $this->requireAdminForAllResources($adminId, $isGlobalAdmin, $permissions);
 
         // Fast path: no permissions to delete — just revoke in DB and return.
-        if (empty($permissions) || !$this->isFgaClientAvailable()) {
+        // (FGA-unavailable does NOT short-circuit here: the outbox delete
+        // rows are still persisted below so the backstop can drain them
+        // once FGA comes back. Skipping that would silently leave stale
+        // tuples in OpenFGA after the DB row was revoked.)
+        if (empty($permissions)) {
             $revoked = $repo->revoke($requestId, $adminId, $notes);
             if (!$revoked) {
                 throw new NotFoundException('Request not found or not in approved status');
@@ -743,8 +757,13 @@ final class AccessRequestAdminHandler extends AbstractHandler
         // Rows that fail (transient errors) stay in 'retrying' state and will be
         // picked up by the cron backstop. Rows that fail terminally (4xx validation)
         // are marked 'failed_terminal' and surface in outbox_failed.
-        $processor = $this->getOutboxProcessor();
-        $notifier  = $this->getOutboxNotifier();
+        //
+        // When FGA is unavailable we skip the inline attempt — the rows are
+        // already durable in PG and the backstop will pick them up once the
+        // client is reachable.
+        $fgaAvailable = $this->isFgaClientAvailable();
+        $processor    = $fgaAvailable ? $this->getOutboxProcessor() : null;
+        $notifier     = $this->getOutboxNotifier();
 
         /** @var list<array{id: int, disposition: string, status: string}> $outboxResult */
         $outboxResult  = [];
@@ -752,7 +771,9 @@ final class AccessRequestAdminHandler extends AbstractHandler
         $fgaErrors     = [];
 
         foreach ($outboxIds as $rowId) {
-            $disposition = $processor->processSync($rowId);
+            $disposition = $processor !== null
+                ? $processor->processSync($rowId)
+                : OutboxDisposition::RETRY;
             $current     = $outbox->getById($rowId);
             $statusValue = $current !== null ? $current->status->value : OutboxStatus::PENDING->value;
 

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -142,10 +142,13 @@ final class AccessRequestAdminHandler extends AbstractHandler
     private function getOutboxProcessor(): OutboxProcessor
     {
         if ($this->outboxProcessor === null) {
+            $maxAttempts           = is_numeric($_ENV['OUTBOX_MAX_ATTEMPTS'] ?? null)
+                ? (int) $_ENV['OUTBOX_MAX_ATTEMPTS']
+                : 10;
             $this->outboxProcessor = new OutboxProcessor(
                 $this->getOutboxRepository(),
                 $this->getFgaClient(),
-                (int) ( $_ENV['OUTBOX_MAX_ATTEMPTS'] ?? 10 ),
+                $maxAttempts,
             );
         }
         return $this->outboxProcessor;

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -142,7 +142,11 @@ final class AccessRequestAdminHandler extends AbstractHandler
     private function getOutboxProcessor(): OutboxProcessor
     {
         if ($this->outboxProcessor === null) {
-            $this->outboxProcessor = new OutboxProcessor($this->getOutboxRepository(), $this->getFgaClient());
+            $this->outboxProcessor = new OutboxProcessor(
+                $this->getOutboxRepository(),
+                $this->getFgaClient(),
+                (int) ( $_ENV['OUTBOX_MAX_ATTEMPTS'] ?? 10 ),
+            );
         }
         return $this->outboxProcessor;
     }

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -17,10 +17,15 @@ use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
-use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
 use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
 use LiturgicalCalendar\Api\Services\RoleCascadeService;
 use LiturgicalCalendar\Api\Services\ZitadelService;
 use Psr\Http\Message\ResponseInterface;
@@ -47,6 +52,9 @@ final class AccessRequestAdminHandler extends AbstractHandler
 
     private ?AccessRequestRepository $repository = null;
     private ?OpenFgaClient $fgaClient            = null;
+    private ?OutboxRepository $outboxRepository  = null;
+    private ?OutboxNotifier $outboxNotifier      = null;
+    private ?OutboxProcessor $outboxProcessor    = null;
 
     /**
      * The OpenFGA client is constructor-injectable for tests — pass a
@@ -67,6 +75,20 @@ final class AccessRequestAdminHandler extends AbstractHandler
         $this->allowCredentials           = true;
     }
 
+    /**
+     * Inject outbox dependencies — primarily for tests (avoids real Redis / env).
+     * Production calls use the lazy getters below, which build from env vars.
+     */
+    public function setOutboxDependencies(
+        OutboxRepository $repo,
+        OutboxNotifier $notifier,
+        OutboxProcessor $processor,
+    ): void {
+        $this->outboxRepository = $repo;
+        $this->outboxNotifier   = $notifier;
+        $this->outboxProcessor  = $processor;
+    }
+
     private function getRepository(): AccessRequestRepository
     {
         if ($this->repository === null) {
@@ -81,6 +103,50 @@ final class AccessRequestAdminHandler extends AbstractHandler
             $this->fgaClient = OpenFgaClient::fromEnv();
         }
         return $this->fgaClient;
+    }
+
+    private function getOutboxRepository(): OutboxRepository
+    {
+        if ($this->outboxRepository === null) {
+            $this->outboxRepository = new OutboxRepository(Connection::getInstance());
+        }
+        return $this->outboxRepository;
+    }
+
+    private function getOutboxNotifier(): OutboxNotifier
+    {
+        if ($this->outboxNotifier === null) {
+            $redis = null;
+            if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
+                try {
+                    $redis = new \Redis();
+                    if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+                        $redis->connect((string) $_ENV['REDIS_SOCKET']);
+                    } else {
+                        $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
+                        $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
+                        $redis->connect($redisHost, $redisPort);
+                    }
+                    if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+                        $redis->auth((string) $_ENV['REDIS_PASSWORD']);
+                    }
+                } catch (\Throwable) {
+                    $redis = null; // Best-effort; fall back to PG-only durability.
+                }
+            }
+            $redisStream          = is_string($_ENV['REDIS_OUTBOX_STREAM'] ?? null) ? $_ENV['REDIS_OUTBOX_STREAM'] : 'litcal:reconcile-stream';
+            $streamName           = $redisStream;
+            $this->outboxNotifier = new OutboxNotifier($redis, $streamName);
+        }
+        return $this->outboxNotifier;
+    }
+
+    private function getOutboxProcessor(): OutboxProcessor
+    {
+        if ($this->outboxProcessor === null) {
+            $this->outboxProcessor = new OutboxProcessor($this->getOutboxRepository(), $this->getFgaClient());
+        }
+        return $this->outboxProcessor;
     }
 
     /**
@@ -243,13 +309,24 @@ final class AccessRequestAdminHandler extends AbstractHandler
     /**
      * POST /admin/access-requests/{id}/approve — Approve access request.
      *
-     * Flow:
+     * Flow (outbox pattern):
      * 1. Validate request exists and is pending
      * 2. Check admin has authority (global admin OR resource admin for ALL requested resources)
-     * 3. Create OpenFGA tuples first (for each permission in the array)
-     * 4. Assign Zitadel role
-     * 5. Update DB status to approved
-     * 6. Track Zitadel sync status
+     * 3. If permissions is empty: approve in DB and return immediately
+     * 4. Otherwise:
+     *    a. PG BEGIN
+     *       - repo.approve(requestId, adminId, notes)
+     *       - outbox.insertBatch(rows) — one row per permission, idempotency_key ensures
+     *         that re-approving the same request collapses to the same outbox row IDs
+     *    b. PG COMMIT
+     *    c. For each outbox row: processor.processSync(), then notifier.notify() when
+     *       row is still in a non-terminal state (pending/retrying)
+     * 5. Sync role to Zitadel (unchanged)
+     * 6. Return response with success=true (whenever DB committed), plus outbox counters
+     *
+     * `success` is true whenever the DB commit succeeded — this is the deliberate
+     * semantic shift from #628. Tuple delivery failures surface via outbox_pending /
+     * outbox_failed / fga_errors rather than aborting the entire approval.
      */
     private function approveRequest(
         ResponseInterface $response,
@@ -283,82 +360,158 @@ final class AccessRequestAdminHandler extends AbstractHandler
         // Check admin authority over ALL requested resources
         $this->requireAdminForAllResources($adminId, $isGlobalAdmin, $permissions);
 
-        // Step 1: Create OpenFGA tuples for each permission.
-        //
-        // TupleAlreadyExistsException is treated as benign — the tuple is in
-        // the desired state already, so re-approval after a partial first
-        // attempt converges instead of double-failing. Any other
-        // OpenFgaApiException (validation, auth, server) is fatal: the
-        // response will surface success: false with the structured error
-        // list so the admin knows there's drift to repair.
-        $createdTuples = [];
-        $fgaErrors     = [];
-
-        if ($this->isFgaClientAvailable() && !empty($permissions)) {
-            $fgaUser = "user:{$userId}";
-
-            foreach ($permissions as $perm) {
-                $objectType = $perm['object_type'] ?? '';
-                $objectId   = $perm['object_id'] ?? '';
-                $relation   = $perm['relation'] ?? '';
-                $fgaObject  = "{$objectType}:{$objectId}";
-
-                try {
-                    $this->getFgaClient()->writeTuple($fgaUser, $relation, $fgaObject);
-                    $createdTuples[] = [
-                        'user'     => $fgaUser,
-                        'relation' => $relation,
-                        'object'   => $fgaObject,
-                    ];
-                } catch (TupleAlreadyExistsException) {
-                    // Idempotent — tuple already exists. Count it as created
-                    // so the response shows the user's effective grants.
-                    $createdTuples[] = [
-                        'user'     => $fgaUser,
-                        'relation' => $relation,
-                        'object'   => $fgaObject,
-                    ];
-                } catch (OpenFgaApiException $e) {
-                    $fgaErrors[] = [
-                        'object'   => $fgaObject,
-                        'relation' => $relation,
-                        'error'    => $e->getMessage(),
-                    ];
-                }
+        // Fast path: no permissions to write — just approve in DB and return.
+        if (empty($permissions) || !$this->isFgaClientAvailable()) {
+            $approved = $repo->approve($requestId, $adminId, $notes);
+            if (!$approved) {
+                throw new ValidationException('Failed to approve request');
             }
-        }
 
-        // If we couldn't write some of the tuples, bail before mutating the
-        // DB — leaving the request 'pending' lets the admin retry cleanly,
-        // and avoids the silent under-provisioning the issue flags
-        // ("row marked approved while user is missing the failed tuples").
-        if (!empty($fgaErrors)) {
+            [$roleAssigned, $zitadelError] = $this->syncZitadelRole($repo, $requestId, $userId, $requestedRole);
+
             return $this->encodeResponseBody($response, [
-                'success'        => false,
-                'role_assigned'  => false,
-                'zitadel_error'  => null,
-                'tuples_created' => $createdTuples,
-                'fga_errors'     => $fgaErrors,
-                'message'        => sprintf(
-                    'Approval aborted: %d of %d permission tuple(s) could not be written. The request remains pending; retry once the underlying OpenFGA error is resolved.',
-                    count($fgaErrors),
-                    count($permissions)
-                ),
+                'success'        => true,
+                'role_assigned'  => $roleAssigned,
+                'zitadel_error'  => $zitadelError,
+                'tuples_created' => [],
+                'fga_errors'     => [],
+                'outbox_ids'     => [],
+                'outbox_pending' => 0,
+                'outbox_failed'  => 0,
+                'message'        => $this->approvalMessage($roleAssigned, $zitadelError, 0, 0),
             ]);
         }
 
-        // Step 2: Approve in database
-        $approved = $repo->approve($requestId, $adminId, $notes);
-        if (!$approved) {
-            throw new ValidationException('Failed to approve request');
+        // Step 1: Build outbox rows — one per permission tuple.
+        $fgaUser    = "user:{$userId}";
+        $outboxRows = [];
+        foreach ($permissions as $perm) {
+            $objectType = is_string($perm['object_type'] ?? null) ? $perm['object_type'] : '';
+            $objectId   = is_string($perm['object_id'] ?? null) ? $perm['object_id'] : '';
+            $relation   = is_string($perm['relation'] ?? null) ? $perm['relation'] : '';
+            $fgaObject  = "{$objectType}:{$objectId}";
+
+            // Idempotency key: scoped to this access request + the specific tuple,
+            // so re-approving the same request after a partial first attempt collapses
+            // to the same row rather than inserting a duplicate.
+            $idempotencyKey = "access_request:{$requestId}:write_tuple:{$fgaUser}:{$relation}:{$fgaObject}";
+
+            $outboxRows[] = [
+                'operation'       => OutboxOperation::WRITE_TUPLE,
+                'fga_user'        => $fgaUser,
+                'fga_relation'    => $relation,
+                'fga_object'      => $fgaObject,
+                'idempotency_key' => $idempotencyKey,
+                'metadata'        => ['access_request_id' => $requestId],
+            ];
         }
 
-        // Step 3: Sync role to Zitadel
+        // Step 2: Atomically approve in DB + insert outbox rows in one PG transaction.
+        $pdo    = Connection::getInstance();
+        $outbox = $this->getOutboxRepository();
+
+        $pdo->beginTransaction();
+        try {
+            $approved = $repo->approve($requestId, $adminId, $notes);
+            if (!$approved) {
+                $pdo->rollBack();
+                throw new ValidationException('Failed to approve request');
+            }
+            $outboxIds = $outbox->insertBatch($outboxRows);
+            $pdo->commit();
+        } catch (\Throwable $e) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            throw $e;
+        }
+
+        // Step 3: Sync fast path — attempt each outbox row immediately.
+        // Rows that fail (transient errors) stay in 'retrying' state and will be
+        // picked up by the cron backstop. Rows that fail terminally (4xx validation)
+        // are marked 'failed_terminal' and surface in outbox_failed.
+        $processor = $this->getOutboxProcessor();
+        $notifier  = $this->getOutboxNotifier();
+
+        /** @var list<array{id: int, disposition: string, status: string}> $outboxResult */
+        $outboxResult  = [];
+        $createdTuples = [];
+        $fgaErrors     = [];
+
+        foreach ($outboxIds as $rowId) {
+            $disposition = $processor->processSync($rowId);
+            $current     = $outbox->getById($rowId);
+            $statusValue = $current !== null ? $current->status->value : OutboxStatus::PENDING->value;
+
+            $outboxResult[] = [
+                'id'          => $rowId,
+                'disposition' => $disposition->name,
+                'status'      => $statusValue,
+            ];
+
+            if ($disposition === OutboxDisposition::BENIGN_SUCCESS) {
+                // Row is in succeeded state (or was already succeeded idempotently).
+                $createdTuples[] = [
+                    'user'     => $current !== null ? $current->fgaUser     : $fgaUser,
+                    'relation' => $current !== null ? $current->fgaRelation : '',
+                    'object'   => $current !== null ? $current->fgaObject   : '',
+                ];
+            } else {
+                // RETRY or TERMINAL — surface in fga_errors for back-compat.
+                $fgaErrors[] = [
+                    'outbox_id' => $rowId,
+                    'status'    => $statusValue,
+                    'error'     => $current !== null ? ( $current->lastError ?? 'unknown' ) : 'unknown',
+                ];
+            }
+
+            // Notify the async consumer if the row is still non-terminal.
+            if (
+                $current !== null
+                && in_array($current->status, [OutboxStatus::PENDING, OutboxStatus::RETRYING], true)
+            ) {
+                $notifier->notify($rowId, OutboxOperation::WRITE_TUPLE->value);
+            }
+        }
+
+        $outboxPending = count(array_filter($outboxResult, static fn($r) => $r['status'] === OutboxStatus::RETRYING->value || $r['status'] === OutboxStatus::PENDING->value));
+        $outboxFailed  = count(array_filter($outboxResult, static fn($r) => $r['status'] === OutboxStatus::FAILED_TERMINAL->value));
+
+        // Step 4: Sync role to Zitadel (unchanged)
+        [$roleAssigned, $zitadelError] = $this->syncZitadelRole($repo, $requestId, $userId, $requestedRole);
+
+        return $this->encodeResponseBody($response, [
+            'success'        => true,
+            'role_assigned'  => $roleAssigned,
+            'zitadel_error'  => $zitadelError,
+            'tuples_created' => $createdTuples,
+            'fga_errors'     => $fgaErrors,
+            'outbox_ids'     => $outboxIds,
+            'outbox_pending' => $outboxPending,
+            'outbox_failed'  => $outboxFailed,
+            'message'        => $this->approvalMessage($roleAssigned, $zitadelError, $outboxPending, $outboxFailed),
+        ]);
+    }
+
+    /**
+     * Sync a Zitadel role assignment after DB approval.
+     *
+     * Extracted to avoid duplicating the same try/catch in the fast-path and
+     * the outbox-path branches of approveRequest.
+     *
+     * @return array{0: bool, 1: string|null}  [roleAssigned, zitadelError]
+     */
+    private function syncZitadelRole(
+        AccessRequestRepository $repo,
+        string $requestId,
+        string $userId,
+        string $requestedRole,
+    ): array {
         $roleAssigned = false;
         $zitadelError = null;
 
         if (ZitadelService::isConfigured()) {
-            if (empty($userId) || empty($requestedRole)) {
+            if ($userId === '' || $requestedRole === '') {
                 $zitadelError = 'Missing user ID or role in approved request';
                 $repo->updateZitadelSyncStatus($requestId, 'failed', $zitadelError);
             } else {
@@ -377,18 +530,50 @@ final class AccessRequestAdminHandler extends AbstractHandler
             }
         }
 
-        return $this->encodeResponseBody($response, [
-            'success'        => true,
-            'role_assigned'  => $roleAssigned,
-            'zitadel_error'  => $zitadelError,
-            'tuples_created' => $createdTuples,
-            'fga_errors'     => $fgaErrors,
-            'message'        => $roleAssigned
-                ? 'Access request approved, role assigned and permissions granted'
-                : ( $zitadelError !== null
-                    ? 'Access request approved but Zitadel sync failed (will retry)'
-                    : 'Access request approved (Zitadel not configured)' ),
-        ]);
+        return [$roleAssigned, $zitadelError];
+    }
+
+    /**
+     * Build the human-readable approval message, incorporating outbox deferral/failure notes.
+     */
+    private function approvalMessage(
+        bool $roleAssigned,
+        ?string $zitadelError,
+        int $outboxPending,
+        int $outboxFailed,
+    ): string {
+        $base = $roleAssigned
+            ? 'Access request approved, role assigned and permissions granted'
+            : ( $zitadelError !== null
+                ? 'Access request approved but Zitadel sync failed (will retry)'
+                : 'Access request approved (Zitadel not configured)' );
+
+        if ($outboxPending > 0 && $outboxFailed > 0) {
+            return sprintf(
+                '%s; %d permission tuple(s) deferred for async delivery, %d failed terminally (check outbox)',
+                $base,
+                $outboxPending,
+                $outboxFailed,
+            );
+        }
+
+        if ($outboxPending > 0) {
+            return sprintf(
+                '%s; %d permission tuple(s) deferred for async delivery',
+                $base,
+                $outboxPending,
+            );
+        }
+
+        if ($outboxFailed > 0) {
+            return sprintf(
+                '%s; %d permission tuple(s) failed terminally (check outbox)',
+                $base,
+                $outboxFailed,
+            );
+        }
+
+        return $base;
     }
 
     /**

--- a/src/Handlers/Admin/OutboxAdminHandler.php
+++ b/src/Handlers/Admin/OutboxAdminHandler.php
@@ -15,6 +15,7 @@ use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxRow;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -36,12 +37,14 @@ final class OutboxAdminHandler extends AbstractHandler
     private const MAX_LIMIT     = 200;
 
     private ?OutboxRepository $repository;
+    private ?OutboxNotifier $notifier;
 
-    public function __construct(?OutboxRepository $repository = null)
+    public function __construct(?OutboxRepository $repository = null, ?OutboxNotifier $notifier = null)
     {
         parent::__construct();
 
         $this->repository = $repository;
+        $this->notifier   = $notifier;
 
         $this->allowedRequestMethods      = [RequestMethod::GET, RequestMethod::POST];
         $this->allowedAcceptHeaders       = [AcceptHeader::JSON];
@@ -55,6 +58,41 @@ final class OutboxAdminHandler extends AbstractHandler
             $this->repository = new OutboxRepository(Connection::getInstance());
         }
         return $this->repository;
+    }
+
+    /**
+     * Lazy notifier — falls back to null \Redis when ext-redis is absent or
+     * REDIS_* env vars are missing. OutboxNotifier::notify is best-effort
+     * either way: the row is durable in PG, the backstop is the safety net.
+     */
+    private function getNotifier(): OutboxNotifier
+    {
+        if ($this->notifier !== null) {
+            return $this->notifier;
+        }
+        $redis = null;
+        if (extension_loaded('redis')) {
+            try {
+                $r = new \Redis();
+                if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+                    $r->connect((string) $_ENV['REDIS_SOCKET']);
+                } elseif (isset($_ENV['REDIS_HOST']) && is_string($_ENV['REDIS_HOST']) && $_ENV['REDIS_HOST'] !== '') {
+                    $port = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
+                    $r->connect($_ENV['REDIS_HOST'], $port);
+                }
+                if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+                    $r->auth($_ENV['REDIS_PASSWORD']);
+                }
+                $redis = $r;
+            } catch (\Throwable) {
+                $redis = null;
+            }
+        }
+        $stream         = isset($_ENV['REDIS_OUTBOX_STREAM']) && is_string($_ENV['REDIS_OUTBOX_STREAM']) && $_ENV['REDIS_OUTBOX_STREAM'] !== ''
+            ? $_ENV['REDIS_OUTBOX_STREAM']
+            : 'litcal:reconcile-stream';
+        $this->notifier = new OutboxNotifier($redis, $stream);
+        return $this->notifier;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -219,6 +257,13 @@ final class OutboxAdminHandler extends AbstractHandler
         // the return type to OutboxRow here because the null-guard above
         // (404 return) eliminates the null branch for this $id.
         $updatedRow = $repo->getById($id);
+
+        // Wake the consumer so it picks up the reset row immediately rather
+        // than waiting for the next cron backstop run (best-effort; the
+        // notifier swallows Redis errors and the backstop is the backstop).
+        // PHPStan correctly narrows $updatedRow to non-null after the 404
+        // guard above + the successful resetForRetry — no null check needed.
+        $this->getNotifier()->notify($id, $updatedRow->operation->value);
 
         return $this->encodeResponseBody($response, [
             'success' => true,

--- a/src/Handlers/Admin/OutboxAdminHandler.php
+++ b/src/Handlers/Admin/OutboxAdminHandler.php
@@ -1,0 +1,272 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Admin;
+
+use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestContentType;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxRow;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Outbox Admin Handler — inspection and retry management.
+ *
+ * Provides endpoints for monitoring and operating on the OpenFGA outbox:
+ *
+ * - GET  /admin/outbox                — List rows (optional filters: status, access_request_id, limit, offset)
+ * - GET  /admin/outbox?summary=1      — Summarise counts per status + oldest pending age
+ * - POST /admin/outbox/{id}/retry     — Reset a failed_terminal row back to pending
+ *
+ * Access control: global admins (Zitadel "admin" role) only.
+ */
+final class OutboxAdminHandler extends AbstractHandler
+{
+    private const DEFAULT_LIMIT = 50;
+    private const MAX_LIMIT     = 200;
+
+    private ?OutboxRepository $repository;
+
+    public function __construct(?OutboxRepository $repository = null)
+    {
+        parent::__construct();
+
+        $this->repository = $repository;
+
+        $this->allowedRequestMethods      = [RequestMethod::GET, RequestMethod::POST];
+        $this->allowedAcceptHeaders       = [AcceptHeader::JSON];
+        $this->allowedRequestContentTypes = [RequestContentType::JSON];
+        $this->allowCredentials           = true;
+    }
+
+    private function getRepository(): OutboxRepository
+    {
+        if ($this->repository === null) {
+            $this->repository = new OutboxRepository(Connection::getInstance());
+        }
+        return $this->repository;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+        $method   = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime)
+            ->withHeader('Cache-Control', 'no-store');
+
+        // Authentication guard
+        /** @var array{sub?: string, roles?: array<string>}|null $oidcUser */
+        $oidcUser = $request->getAttribute('oidc_user');
+
+        if ($oidcUser === null) {
+            throw new UnauthorizedException('Authentication required');
+        }
+
+        $userId = $oidcUser['sub'] ?? null;
+        if (!is_string($userId) || trim($userId) === '') {
+            throw new UnauthorizedException('Invalid authentication token');
+        }
+
+        if (!OidcAuthMiddleware::isAdmin($oidcUser)) {
+            throw new UnauthorizedException('Admin role required');
+        }
+
+        // Route on method and path segments
+        $path      = $request->getUri()->getPath();
+        $pathParts = array_values(array_filter(explode('/', trim($path, '/'))));
+
+        // POST /admin/outbox/{id}/retry
+        // pathParts: ['admin', 'outbox', '{id}', 'retry']
+        if (
+            $method === RequestMethod::POST
+            && count($pathParts) === 4
+            && $pathParts[3] === 'retry'
+        ) {
+            $rawId = $pathParts[2];
+            if (!ctype_digit($rawId) || (int) $rawId < 1) {
+                throw new ValidationException('Invalid outbox row id');
+            }
+            return $this->handleRetry($request, $response, (int) $rawId);
+        }
+
+        // GET /admin/outbox?...
+        if ($method === RequestMethod::GET) {
+            return $this->handleGet($request, $response);
+        }
+
+        // Fallback — should not be reachable given allowedRequestMethods
+        throw new ValidationException('Unsupported request');
+    }
+
+    // -----------------------------------------------------------------------
+    // GET handler
+    // -----------------------------------------------------------------------
+
+    private function handleGet(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $params = $request->getQueryParams();
+
+        // ?summary=1 — return counts per status + oldest pending age
+        $summaryRaw = $params['summary'] ?? null;
+        if ($summaryRaw !== null && $summaryRaw !== '' && $summaryRaw !== '0') {
+            return $this->handleSummary($response);
+        }
+
+        // List with optional filters and pagination
+        $statusRaw          = isset($params['status']) && is_string($params['status']) ? $params['status'] : null;
+        $accessRequestIdRaw = isset($params['access_request_id']) && is_string($params['access_request_id'])
+            ? $params['access_request_id']
+            : null;
+
+        $limit  = $this->parseLimit($params['limit'] ?? null);
+        $offset = $this->parseOffset($params['offset'] ?? null);
+
+        if ($statusRaw !== null) {
+            $validStatuses = ['pending', 'retrying', 'succeeded', 'failed_terminal'];
+            if (!in_array($statusRaw, $validStatuses, true)) {
+                throw new ValidationException(
+                    sprintf('Invalid status. Valid values: %s', implode(', ', $validStatuses))
+                );
+            }
+        }
+
+        $repo   = $this->getRepository();
+        $result = $repo->list($statusRaw, $accessRequestIdRaw, $limit, $offset);
+
+        $rows = array_map(
+            static fn(OutboxRow $r): array => self::rowToArray($r),
+            $result['rows']
+        );
+
+        $total   = $result['total'];
+        $count   = count($rows);
+        $hasMore = ( $offset + $count ) < $total;
+
+        return $this->encodeResponseBody($response, [
+            'items'    => $rows,
+            'count'    => $count,
+            'total'    => $total,
+            'limit'    => $limit,
+            'offset'   => $offset,
+            'has_more' => $hasMore,
+        ]);
+    }
+
+    private function handleSummary(ResponseInterface $response): ResponseInterface
+    {
+        $repo   = $this->getRepository();
+        $counts = $repo->countByStatus();
+
+        // Ensure all four statuses are always present in the response, defaulting to 0.
+        $normalised = [
+            'pending'         => $counts['pending']        ?? 0,
+            'retrying'        => $counts['retrying']       ?? 0,
+            'succeeded'       => $counts['succeeded']      ?? 0,
+            'failed_terminal' => $counts['failed_terminal'] ?? 0,
+        ];
+
+        $oldestAge = $repo->oldestPendingAgeSeconds();
+
+        return $this->encodeResponseBody($response, [
+            'counts'                     => $normalised,
+            'oldest_pending_age_seconds' => $oldestAge,
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // POST /admin/outbox/{id}/retry
+    // -----------------------------------------------------------------------
+
+    private function handleRetry(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        int $id
+    ): ResponseInterface {
+        $repo  = $this->getRepository();
+        $reset = $repo->resetForRetry($id);
+
+        if (!$reset) {
+            // Row doesn't exist or is not in failed_terminal state
+            return $this->encodeResponseBody($response, ['error' => 'Row must be in failed_terminal state to retry; if the row does not exist, check the id.'], StatusCode::CONFLICT);
+        }
+
+        $row = $repo->getById($id);
+
+        return $this->encodeResponseBody($response, [
+            'success' => true,
+            'id'      => $id,
+            'row'     => $row !== null ? self::rowToArray($row) : null,
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * @return array<string, mixed>
+     */
+    private static function rowToArray(OutboxRow $row): array
+    {
+        return [
+            'id'              => $row->id,
+            'operation'       => $row->operation->value,
+            'fga_user'        => $row->fgaUser,
+            'fga_relation'    => $row->fgaRelation,
+            'fga_object'      => $row->fgaObject,
+            'status'          => $row->status->value,
+            'attempts'        => $row->attempts,
+            'next_attempt_at' => $row->nextAttemptAt->format(\DateTimeInterface::ATOM),
+            'last_error'      => $row->lastError,
+            'last_error_code' => $row->lastErrorCode,
+            'metadata'        => $row->metadata,
+            'created_at'      => $row->createdAt->format(\DateTimeInterface::ATOM),
+            'completed_at'    => $row->completedAt?->format(\DateTimeInterface::ATOM),
+        ];
+    }
+
+    private function parseLimit(mixed $raw): int
+    {
+        if ($raw === null || $raw === '') {
+            return self::DEFAULT_LIMIT;
+        }
+        if (!is_string($raw) || !ctype_digit($raw)) {
+            throw new ValidationException('limit must be a positive integer');
+        }
+        $limit = (int) $raw;
+        if ($limit < 1 || $limit > self::MAX_LIMIT) {
+            throw new ValidationException(sprintf('limit must be between 1 and %d', self::MAX_LIMIT));
+        }
+        return $limit;
+    }
+
+    private function parseOffset(mixed $raw): int
+    {
+        if ($raw === null || $raw === '') {
+            return 0;
+        }
+        if (!is_string($raw) || !ctype_digit($raw)) {
+            throw new ValidationException('offset must be a non-negative integer');
+        }
+        return (int) $raw;
+    }
+}

--- a/src/Handlers/Admin/OutboxAdminHandler.php
+++ b/src/Handlers/Admin/OutboxAdminHandler.php
@@ -201,12 +201,18 @@ final class OutboxAdminHandler extends AbstractHandler
         ResponseInterface $response,
         int $id
     ): ResponseInterface {
-        $repo  = $this->getRepository();
+        $repo = $this->getRepository();
+
+        // Distinguish missing row (404) from non-terminal row (409).
+        if ($repo->getById($id) === null) {
+            return $this->encodeResponseBody($response, ['error' => 'Outbox row not found', 'id' => $id], StatusCode::NOT_FOUND);
+        }
+
         $reset = $repo->resetForRetry($id);
 
         if (!$reset) {
-            // Row doesn't exist or is not in failed_terminal state
-            return $this->encodeResponseBody($response, ['error' => 'Row must be in failed_terminal state to retry; if the row does not exist, check the id.'], StatusCode::CONFLICT);
+            // Row exists but is not in failed_terminal state.
+            return $this->encodeResponseBody($response, ['error' => 'Row must be in failed_terminal state to retry'], StatusCode::CONFLICT);
         }
 
         $row = $repo->getById($id);

--- a/src/Handlers/Admin/OutboxAdminHandler.php
+++ b/src/Handlers/Admin/OutboxAdminHandler.php
@@ -215,12 +215,15 @@ final class OutboxAdminHandler extends AbstractHandler
             return $this->encodeResponseBody($response, ['error' => 'Row must be in failed_terminal state to retry'], StatusCode::CONFLICT);
         }
 
-        $row = $repo->getById($id);
+        // Re-fetch to return the updated row shape. PHPStan correctly narrows
+        // the return type to OutboxRow here because the null-guard above
+        // (404 return) eliminates the null branch for this $id.
+        $updatedRow = $repo->getById($id);
 
         return $this->encodeResponseBody($response, [
             'success' => true,
             'id'      => $id,
-            'row'     => $row !== null ? self::rowToArray($row) : null,
+            'row'     => self::rowToArray($updatedRow),
         ]);
     }
 

--- a/src/Handlers/Admin/PermissionAdminHandler.php
+++ b/src/Handlers/Admin/PermissionAdminHandler.php
@@ -152,10 +152,13 @@ final class PermissionAdminHandler extends AbstractHandler
     private function getOutboxProcessor(): OutboxProcessor
     {
         if ($this->outboxProcessor === null) {
+            $maxAttempts           = is_numeric($_ENV['OUTBOX_MAX_ATTEMPTS'] ?? null)
+                ? (int) $_ENV['OUTBOX_MAX_ATTEMPTS']
+                : 10;
             $this->outboxProcessor = new OutboxProcessor(
                 $this->getOutboxRepository(),
                 $this->getClient(),
-                (int) ( $_ENV['OUTBOX_MAX_ATTEMPTS'] ?? 10 ),
+                $maxAttempts,
             );
         }
         return $this->outboxProcessor;

--- a/src/Handlers/Admin/PermissionAdminHandler.php
+++ b/src/Handlers/Admin/PermissionAdminHandler.php
@@ -152,7 +152,11 @@ final class PermissionAdminHandler extends AbstractHandler
     private function getOutboxProcessor(): OutboxProcessor
     {
         if ($this->outboxProcessor === null) {
-            $this->outboxProcessor = new OutboxProcessor($this->getOutboxRepository(), $this->getClient());
+            $this->outboxProcessor = new OutboxProcessor(
+                $this->getOutboxRepository(),
+                $this->getClient(),
+                (int) ( $_ENV['OUTBOX_MAX_ATTEMPTS'] ?? 10 ),
+            );
         }
         return $this->outboxProcessor;
     }

--- a/src/Handlers/Admin/PermissionAdminHandler.php
+++ b/src/Handlers/Admin/PermissionAdminHandler.php
@@ -16,7 +16,13 @@ use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
 use LiturgicalCalendar\Api\Services\RoleCascadeService;
 use LiturgicalCalendar\Api\Services\ZitadelService;
 use Psr\Http\Message\ResponseInterface;
@@ -62,7 +68,10 @@ final class PermissionAdminHandler extends AbstractHandler
     private const DEFAULT_LIMIT = 100;
     private const MAX_LIMIT     = 500;
 
-    private ?OpenFgaClient $fgaClient = null;
+    private ?OpenFgaClient $fgaClient           = null;
+    private ?OutboxRepository $outboxRepository = null;
+    private ?OutboxNotifier $outboxNotifier     = null;
+    private ?OutboxProcessor $outboxProcessor   = null;
     private LoggerInterface $logger;
 
     public function __construct(?OpenFgaClient $client = null)
@@ -88,6 +97,64 @@ final class PermissionAdminHandler extends AbstractHandler
             $this->fgaClient = OpenFgaClient::fromEnv();
         }
         return $this->fgaClient;
+    }
+
+    /**
+     * Inject outbox dependencies — primarily for tests (avoids real Redis / env).
+     * Production calls use the lazy getters below, which build from env vars.
+     */
+    public function setOutboxDependencies(
+        OutboxRepository $repo,
+        OutboxNotifier $notifier,
+        OutboxProcessor $processor,
+    ): void {
+        $this->outboxRepository = $repo;
+        $this->outboxNotifier   = $notifier;
+        $this->outboxProcessor  = $processor;
+    }
+
+    private function getOutboxRepository(): OutboxRepository
+    {
+        if ($this->outboxRepository === null) {
+            $this->outboxRepository = new OutboxRepository(Connection::getInstance());
+        }
+        return $this->outboxRepository;
+    }
+
+    private function getOutboxNotifier(): OutboxNotifier
+    {
+        if ($this->outboxNotifier === null) {
+            $redis = null;
+            if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
+                try {
+                    $redis = new \Redis();
+                    if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+                        $redis->connect((string) $_ENV['REDIS_SOCKET']);
+                    } else {
+                        $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
+                        $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
+                        $redis->connect($redisHost, $redisPort);
+                    }
+                    if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+                        $redis->auth((string) $_ENV['REDIS_PASSWORD']);
+                    }
+                } catch (\Throwable) {
+                    $redis = null; // Best-effort; fall back to PG-only durability.
+                }
+            }
+            $redisStream          = is_string($_ENV['REDIS_OUTBOX_STREAM'] ?? null) ? $_ENV['REDIS_OUTBOX_STREAM'] : 'litcal:reconcile-stream';
+            $streamName           = $redisStream;
+            $this->outboxNotifier = new OutboxNotifier($redis, $streamName);
+        }
+        return $this->outboxNotifier;
+    }
+
+    private function getOutboxProcessor(): OutboxProcessor
+    {
+        if ($this->outboxProcessor === null) {
+            $this->outboxProcessor = new OutboxProcessor($this->getOutboxRepository(), $this->getClient());
+        }
+        return $this->outboxProcessor;
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
@@ -311,6 +378,19 @@ final class PermissionAdminHandler extends AbstractHandler
      *   - object_type: string (required) — e.g., "national_calendar"
      *   - object_id: string (required) — e.g., "IT"
      *   - relation: string (required) — "admin", "viewer", "editor", or "deleter"
+     *
+     * Flow (outbox pattern):
+     * 1. Validate and authorize
+     * 2. PG BEGIN
+     *    - outbox.insertBatch([row]) — one row, idempotency_key ensures
+     *      re-granting the same tuple collapses to the same outbox row ID
+     * 3. PG COMMIT
+     * 4. processor.processSync(), then notifier.notify() when row is still non-terminal
+     * 5. Return response with success=true, plus outbox counters
+     *
+     * `success` is true whenever the DB commit succeeded. Tuple delivery
+     * failures surface via outbox_pending / outbox_failed rather than
+     * aborting the grant.
      */
     private function grantPermission(
         ServerRequestInterface $request,
@@ -334,21 +414,92 @@ final class PermissionAdminHandler extends AbstractHandler
         $fgaUser   = $this->normalizeUser($user);
         $fgaObject = "{$objectType}:{$objectId}";
 
+        // Idempotency key: scoped to the admin + the specific tuple, so
+        // re-granting the same permission collapses to the same outbox row ID.
+        $idempotencyKey = "permission_grant:{$userId}:write_tuple:{$fgaUser}:{$relation}:{$fgaObject}";
+
+        $outboxRow = [
+            'operation'       => OutboxOperation::WRITE_TUPLE,
+            'fga_user'        => $fgaUser,
+            'fga_relation'    => $relation,
+            'fga_object'      => $fgaObject,
+            'idempotency_key' => $idempotencyKey,
+            'metadata'        => ['admin_user' => "user:{$userId}"],
+        ];
+
+        // Atomically insert the outbox row in a PG transaction for durability
+        // before any sync fast-path is attempted.
+        $pdo    = Connection::getInstance();
+        $outbox = $this->getOutboxRepository();
+
+        $pdo->beginTransaction();
         try {
-            $this->getClient()->writeTuple($fgaUser, $relation, $fgaObject);
-        } catch (\RuntimeException $e) {
-            // Treat "tuple already exists" as success (idempotent grant)
-            if (!str_contains($e->getMessage(), 'cannot write a tuple which already exists')) {
-                throw $e;
+            $outboxIds = $outbox->insertBatch([$outboxRow]);
+            $pdo->commit();
+        } catch (\Throwable $e) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            throw $e;
+        }
+
+        // Sync fast path — attempt the outbox row immediately.
+        $processor = $this->getOutboxProcessor();
+        $notifier  = $this->getOutboxNotifier();
+
+        /** @var list<array{id: int, disposition: string, status: string}> $outboxResult */
+        $outboxResult  = [];
+        $createdTuples = [];
+        $fgaErrors     = [];
+
+        foreach ($outboxIds as $rowId) {
+            $disposition = $processor->processSync($rowId);
+            $current     = $outbox->getById($rowId);
+            $statusValue = $current !== null ? $current->status->value : OutboxStatus::PENDING->value;
+
+            $outboxResult[] = [
+                'id'          => $rowId,
+                'disposition' => $disposition->name,
+                'status'      => $statusValue,
+            ];
+
+            if ($disposition === OutboxDisposition::BENIGN_SUCCESS) {
+                $createdTuples[] = [
+                    'user'     => $current !== null ? $current->fgaUser     : $fgaUser,
+                    'relation' => $current !== null ? $current->fgaRelation : '',
+                    'object'   => $current !== null ? $current->fgaObject   : '',
+                ];
+            } else {
+                $fgaErrors[] = [
+                    'outbox_id' => $rowId,
+                    'status'    => $statusValue,
+                    'error'     => $current !== null ? ( $current->lastError ?? 'unknown' ) : 'unknown',
+                ];
+            }
+
+            // Notify the async consumer if the row is still non-terminal.
+            if (
+                $current !== null
+                && in_array($current->status, [OutboxStatus::PENDING, OutboxStatus::RETRYING], true)
+            ) {
+                $notifier->notify($rowId, OutboxOperation::WRITE_TUPLE->value);
             }
         }
 
+        $outboxPending = count(array_filter($outboxResult, static fn($r) => $r['status'] === OutboxStatus::RETRYING->value || $r['status'] === OutboxStatus::PENDING->value));
+        $outboxFailed  = count(array_filter($outboxResult, static fn($r) => $r['status'] === OutboxStatus::FAILED_TERMINAL->value));
+
         return $this->encodeResponseBody($response, [
-            'success'  => true,
-            'message'  => 'Permission granted',
-            'user'     => $fgaUser,
-            'relation' => $relation,
-            'object'   => $fgaObject,
+            'success'        => true,
+            'message'        => 'Permission granted',
+            'user'           => $fgaUser,
+            'relation'       => $relation,
+            'object'         => $fgaObject,
+            'tuples_created' => $createdTuples,
+            'fga_errors'     => $fgaErrors,
+            'outbox_ids'     => $outboxIds,
+            'outbox_pending' => $outboxPending,
+            'outbox_failed'  => $outboxFailed,
         ]);
     }
 
@@ -360,6 +511,20 @@ final class PermissionAdminHandler extends AbstractHandler
      *   - object_type: string (required)
      *   - object_id: string (required)
      *   - relation: string (required)
+     *
+     * Flow (outbox pattern, mirrors grantPermission):
+     * 1. Validate and authorize
+     * 2. PG BEGIN
+     *    - outbox.insertBatch([row]) — one row, idempotency_key ensures
+     *      re-revoking the same tuple collapses to the same outbox row ID
+     * 3. PG COMMIT
+     * 4. processor.processSync(), then notifier.notify() when row is still non-terminal
+     * 5. DB sync and role cascade (non-fatal post-commit work)
+     * 6. Return response with success=true, plus outbox counters
+     *
+     * `success` is true whenever the DB commit succeeded. Tuple deletion
+     * failures surface via outbox_pending / outbox_failed rather than
+     * aborting the revoke.
      */
     private function revokePermission(
         ServerRequestInterface $request,
@@ -383,17 +548,84 @@ final class PermissionAdminHandler extends AbstractHandler
         $fgaUser   = $this->normalizeUser($user);
         $fgaObject = "{$objectType}:{$objectId}";
 
+        // Idempotency key: scoped to the admin + the specific tuple, so
+        // re-revoking the same permission collapses to the same outbox row ID.
+        $idempotencyKey = "permission_revoke:{$userId}:delete_tuple:{$fgaUser}:{$relation}:{$fgaObject}";
+
+        $outboxRow = [
+            'operation'       => OutboxOperation::DELETE_TUPLE,
+            'fga_user'        => $fgaUser,
+            'fga_relation'    => $relation,
+            'fga_object'      => $fgaObject,
+            'idempotency_key' => $idempotencyKey,
+            'metadata'        => ['admin_user' => "user:{$userId}"],
+        ];
+
+        // Atomically insert the outbox row in a PG transaction for durability
+        // before any sync fast-path is attempted.
+        $pdo    = Connection::getInstance();
+        $outbox = $this->getOutboxRepository();
+
+        $pdo->beginTransaction();
         try {
-            $this->getClient()->deleteTuple($fgaUser, $relation, $fgaObject);
-        } catch (\RuntimeException $e) {
-            // Treat "tuple not found" as success (idempotent revoke)
-            if (!str_contains($e->getMessage(), 'cannot delete a tuple which does not exist')) {
-                throw $e;
+            $outboxIds = $outbox->insertBatch([$outboxRow]);
+            $pdo->commit();
+        } catch (\Throwable $e) {
+            if ($pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            throw $e;
+        }
+
+        // Sync fast path — attempt the outbox row immediately.
+        $processor = $this->getOutboxProcessor();
+        $notifier  = $this->getOutboxNotifier();
+
+        /** @var list<array{id: int, disposition: string, status: string}> $outboxResult */
+        $outboxResult  = [];
+        $deletedTuples = [];
+        $fgaErrors     = [];
+
+        foreach ($outboxIds as $rowId) {
+            $disposition = $processor->processSync($rowId);
+            $current     = $outbox->getById($rowId);
+            $statusValue = $current !== null ? $current->status->value : OutboxStatus::PENDING->value;
+
+            $outboxResult[] = [
+                'id'          => $rowId,
+                'disposition' => $disposition->name,
+                'status'      => $statusValue,
+            ];
+
+            if ($disposition === OutboxDisposition::BENIGN_SUCCESS) {
+                $deletedTuples[] = [
+                    'user'     => $current !== null ? $current->fgaUser     : $fgaUser,
+                    'relation' => $current !== null ? $current->fgaRelation : '',
+                    'object'   => $current !== null ? $current->fgaObject   : '',
+                ];
+            } else {
+                $fgaErrors[] = [
+                    'outbox_id' => $rowId,
+                    'status'    => $statusValue,
+                    'error'     => $current !== null ? ( $current->lastError ?? 'unknown' ) : 'unknown',
+                ];
+            }
+
+            // Notify the async consumer if the row is still non-terminal.
+            if (
+                $current !== null
+                && in_array($current->status, [OutboxStatus::PENDING, OutboxStatus::RETRYING], true)
+            ) {
+                $notifier->notify($rowId, OutboxOperation::DELETE_TUPLE->value);
             }
         }
 
+        $outboxPending = count(array_filter($outboxResult, static fn($r) => $r['status'] === OutboxStatus::RETRYING->value || $r['status'] === OutboxStatus::PENDING->value));
+        $outboxFailed  = count(array_filter($outboxResult, static fn($r) => $r['status'] === OutboxStatus::FAILED_TERMINAL->value));
+
         // Keep access_requests DB in sync: remove this permission from
-        // any approved access request for this user
+        // any approved access request for this user. This is a best-effort
+        // post-commit sync; failures here are non-fatal.
         $bareUserId = str_starts_with($fgaUser, 'user:')
             ? substr($fgaUser, 5)
             : $fgaUser;
@@ -406,8 +638,8 @@ final class PermissionAdminHandler extends AbstractHandler
         // Cascade: if this delete leaves any of the user's currently-held roles
         // with zero in-scope tuples, revoke the role too. Only check roles whose
         // scope includes the deleted tuple's object_type — others can't have
-        // been affected. Failures here are non-fatal: the tuple delete already
-        // succeeded.
+        // been affected. Failures here are non-fatal: the outbox row already
+        // committed.
         $cascadedRoles = [];
         if (ZitadelService::isConfigured() && OpenFgaClient::isConfigured()) {
             try {
@@ -427,15 +659,22 @@ final class PermissionAdminHandler extends AbstractHandler
             }
         }
 
+        $message = empty($cascadedRoles)
+            ? 'Permission revoked'
+            : 'Permission revoked; cascaded role(s) revoked: ' . implode(', ', $cascadedRoles);
+
         return $this->encodeResponseBody($response, [
             'success'        => true,
-            'message'        => empty($cascadedRoles)
-                ? 'Permission revoked'
-                : 'Permission revoked; cascaded role(s) revoked: ' . implode(', ', $cascadedRoles),
+            'message'        => $message,
             'user'           => $fgaUser,
             'relation'       => $relation,
             'object'         => $fgaObject,
             'cascaded_roles' => $cascadedRoles,
+            'tuples_deleted' => $deletedTuples,
+            'fga_errors'     => $fgaErrors,
+            'outbox_ids'     => $outboxIds,
+            'outbox_pending' => $outboxPending,
+            'outbox_failed'  => $outboxFailed,
         ]);
     }
 

--- a/src/Handlers/Ops/HealthHandler.php
+++ b/src/Handlers/Ops/HealthHandler.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Ops;
+
+use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Health;
+use Nyholm\Psr7\Response;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * HTTP GET /health
+ *
+ * Returns a JSON object summarising the operational health of the API,
+ * including the openfga_outbox block for observability of the async
+ * OpenFGA reconciliation subsystem.
+ *
+ * This endpoint is unauthenticated and publicly accessible so that
+ * monitoring infrastructure (load-balancers, uptime checks, etc.) can
+ * poll it without credentials.
+ */
+final class HealthHandler extends AbstractHandler
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $this->validateRequestMethod($request);
+
+        $result = [
+            'status'         => 'ok',
+            'database'       => Connection::isConfigured() ? 'configured' : 'not_configured',
+            'openfga_outbox' => Health::buildOutboxStats(),
+        ];
+
+        $body = json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+        if ($body === false) {
+            $body = '{"status":"error","message":"Failed to encode health response"}';
+        }
+
+        return new Response(
+            200,
+            ['Content-Type' => 'application/json; charset=utf-8'],
+            $body
+        );
+    }
+}

--- a/src/Handlers/Ops/HealthHandler.php
+++ b/src/Handlers/Ops/HealthHandler.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Api\Handlers\Ops;
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Handlers\AbstractHandler;
 use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
 use Nyholm\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -20,22 +21,44 @@ use Psr\Http\Message\ServerRequestInterface;
  *
  * This endpoint is unauthenticated and publicly accessible so that
  * monitoring infrastructure (load-balancers, uptime checks, etc.) can
- * poll it without credentials.
+ * poll it without credentials. It is GET-only — non-GET requests get a
+ * 405 from validateRequestMethod().
  */
 final class HealthHandler extends AbstractHandler
 {
     public function __construct()
     {
         parent::__construct();
+        // GET-only; any other verb is a 405. The default allowed-methods
+        // list is permissive (all verbs); restrict it here so monitoring
+        // clients get a stable contract.
+        $this->allowedRequestMethods = [RequestMethod::GET];
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
         $this->validateRequestMethod($request);
 
+        // Active DB probe: if PG is configured, run a 1-row SELECT to
+        // verify we can actually reach it. Without this the endpoint's
+        // "database" field would always read "configured" even when PG is
+        // down, masking outages from monitoring infrastructure.
+        $dbStatus = 'not_configured';
+        $overall  = 'ok';
+        if (Connection::isConfigured()) {
+            try {
+                $pdo = Connection::getInstance();
+                $pdo->query('SELECT 1');
+                $dbStatus = 'reachable';
+            } catch (\Throwable) {
+                $dbStatus = 'unreachable';
+                $overall  = 'degraded';
+            }
+        }
+
         $result = [
-            'status'         => 'ok',
-            'database'       => Connection::isConfigured() ? 'configured' : 'not_configured',
+            'status'         => $overall,
+            'database'       => $dbStatus,
             'openfga_outbox' => Health::buildOutboxStats(),
         ];
 
@@ -44,8 +67,11 @@ final class HealthHandler extends AbstractHandler
             $body = '{"status":"error","message":"Failed to encode health response"}';
         }
 
+        // 503 on degraded so load balancers / uptime checks fail fast.
+        $statusCode = $overall === 'ok' ? 200 : 503;
+
         return new Response(
-            200,
+            $statusCode,
             ['Content-Type' => 'application/json; charset=utf-8'],
             $body
         );

--- a/src/Health.php
+++ b/src/Health.php
@@ -1914,6 +1914,16 @@ class Health implements MessageComponentInterface
                             }
                         }
                     }
+                    // Populate oldest_pel_idle_seconds via the xPending detail form.
+                    // Response shape: list of [msgId, consumer, idle_ms, deliveries].
+                    try {
+                        $pel = $redis->xPending($streamName, $groupName, '-', '+', 1);
+                        if (is_array($pel) && count($pel) > 0 && is_array($pel[0]) && isset($pel[0][2]) && is_numeric($pel[0][2])) {
+                            $consumer['oldest_pel_idle_seconds'] = intdiv((int) $pel[0][2], 1000);
+                        }
+                    } catch (\Throwable) {
+                        // Best-effort — don't let a secondary Redis call break the health response.
+                    }
                 }
             } catch (\Throwable) {
                 $consumer['redis_reachable'] = false;

--- a/src/Health.php
+++ b/src/Health.php
@@ -14,6 +14,7 @@ use React\Promise\Deferred;
 use React\Promise\PromiseInterface;
 use React\Filesystem\Factory;
 use React\EventLoop\Loop;
+use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Enum\ICSErrorLevel;
 use LiturgicalCalendar\Api\Enum\LitSchema;
 use LiturgicalCalendar\Api\Enum\Route;
@@ -22,6 +23,7 @@ use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use Symfony\Component\Yaml\Yaml;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
@@ -1810,6 +1812,122 @@ class Health implements MessageComponentInterface
                 return null;
         }
         return null;
+    }
+
+    /**
+     * Build the openfga_outbox block for the HTTP /health endpoint.
+     *
+     * Fetches PG-side status counts and oldest-pending age from OutboxRepository,
+     * and Redis-side consumer group info via xInfo GROUPS.
+     *
+     * Designed to be called from HealthHandler (HTTP context), which is why it is
+     * public static — the Redis connection here is a short-lived probe, independent
+     * of the WebSocket server's cached self::$redis.
+     *
+     * @return array{
+     *   pending: int,
+     *   retrying: int,
+     *   succeeded: int,
+     *   failed_terminal: int,
+     *   oldest_pending_age_seconds: int,
+     *   consumer: array{
+     *     redis_reachable: bool,
+     *     stream_name: string,
+     *     group_name: string,
+     *     pending_entries: int,
+     *     oldest_pel_idle_seconds: int
+     *   }
+     * }
+     */
+    public static function buildOutboxStats(): array
+    {
+        $counts    = [
+            'pending'         => 0,
+            'retrying'        => 0,
+            'succeeded'       => 0,
+            'failed_terminal' => 0,
+        ];
+        $oldestAge = 0;
+
+        if (Connection::isConfigured()) {
+            try {
+                $repo      = new OutboxRepository(Connection::getInstance());
+                $rawCounts = $repo->countByStatus();
+                foreach ($rawCounts as $status => $n) {
+                    if (array_key_exists($status, $counts)) {
+                        $counts[$status] = $n;
+                    }
+                }
+                $oldestAge = $repo->oldestPendingAgeSeconds();
+            } catch (\Throwable) {
+                // PG unreachable — leave zeros; the health endpoint's DB section surfaces the failure.
+            }
+        }
+
+        $streamName = isset($_ENV['REDIS_OUTBOX_STREAM']) && is_string($_ENV['REDIS_OUTBOX_STREAM'])
+            ? $_ENV['REDIS_OUTBOX_STREAM']
+            : 'litcal:reconcile-stream';
+        $groupName  = isset($_ENV['REDIS_OUTBOX_GROUP']) && is_string($_ENV['REDIS_OUTBOX_GROUP'])
+            ? $_ENV['REDIS_OUTBOX_GROUP']
+            : 'reconciler';
+
+        $consumer = [
+            'redis_reachable'         => false,
+            'stream_name'             => $streamName,
+            'group_name'              => $groupName,
+            'pending_entries'         => 0,
+            'oldest_pel_idle_seconds' => 0,
+        ];
+
+        if (extension_loaded('redis')) {
+            try {
+                $redis       = new \Redis();
+                $redisSocket = isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET'])
+                    ? $_ENV['REDIS_SOCKET']
+                    : null;
+                if ($redisSocket !== null && $redisSocket !== '') {
+                    $connected = $redis->connect($redisSocket, 0, 2.0);
+                } else {
+                    $redisHost = isset($_ENV['REDIS_HOST']) && is_string($_ENV['REDIS_HOST'])
+                        ? $_ENV['REDIS_HOST']
+                        : '127.0.0.1';
+                    $redisPort = isset($_ENV['REDIS_PORT']) && is_numeric($_ENV['REDIS_PORT'])
+                        ? (int) $_ENV['REDIS_PORT']
+                        : 6379;
+                    $connected = $redis->connect($redisHost, $redisPort, 2.0);
+                }
+                if ($connected) {
+                    $redisPassword = isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD'])
+                        ? $_ENV['REDIS_PASSWORD']
+                        : null;
+                    if ($redisPassword !== null && $redisPassword !== '') {
+                        $redis->auth($redisPassword);
+                    }
+                    $redis->ping();
+                    $consumer['redis_reachable'] = true;
+                    $info                        = $redis->xInfo('GROUPS', $streamName);
+                    if (is_array($info)) {
+                        foreach ($info as $group) {
+                            if (is_array($group) && ( $group['name'] ?? null ) === $groupName) {
+                                $pending                     = $group['pending'] ?? 0;
+                                $consumer['pending_entries'] = is_numeric($pending) ? (int) $pending : 0;
+                            }
+                        }
+                    }
+                }
+            } catch (\Throwable) {
+                $consumer['redis_reachable'] = false;
+            }
+        }
+
+        return [
+            'pending'                    => $counts['pending'],
+            'retrying'                   => $counts['retrying'],
+            'succeeded'                  => $counts['succeeded'],
+            'failed_terminal'            => $counts['failed_terminal'],
+            'oldest_pending_age_seconds' => $oldestAge,
+            'consumer'                   => $consumer,
+        ];
     }
 
     /**

--- a/src/Migrations/Version20260602202504.php
+++ b/src/Migrations/Version20260602202504.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * OpenFGA async reconciliation outbox (Options B+C from issue #567).
+ *
+ * One row per OpenFGA tuple operation (write or delete) that the API has
+ * committed to perform. The handler inserts the row in the same Postgres
+ * transaction as the business write (e.g. access_requests.status = 'approved'),
+ * so commit atomicity gives us durable intent. A systemd consumer drains via
+ * Redis Streams on the fast path; a cron backstop catches the cracks.
+ */
+final class Version20260602202504 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create openfga_outbox table for async reconciliation (issue #567 Options B+C)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql("CREATE TYPE outbox_op AS ENUM ('write_tuple', 'delete_tuple')");
+        $this->addSql("CREATE TYPE outbox_status AS ENUM ('pending', 'retrying', 'succeeded', 'failed_terminal')");
+
+        $this->addSql(<<<'SQL'
+            CREATE TABLE openfga_outbox (
+                id                BIGSERIAL    PRIMARY KEY,
+                operation         outbox_op    NOT NULL,
+                fga_user          TEXT         NOT NULL,
+                fga_relation      TEXT         NOT NULL,
+                fga_object        TEXT         NOT NULL,
+                status            outbox_status NOT NULL DEFAULT 'pending',
+                attempts          SMALLINT     NOT NULL DEFAULT 0,
+                next_attempt_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                last_error        TEXT         NULL,
+                last_error_code   TEXT         NULL,
+                metadata          JSONB        NOT NULL DEFAULT '{}'::jsonb,
+                created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+                completed_at      TIMESTAMPTZ  NULL
+            )
+        SQL);
+
+        // Deliberately a standalone UNIQUE INDEX rather than an inline CONSTRAINT ... UNIQUE
+        // inside CREATE TABLE: Doctrine DBAL mis-parses the double-parenthesis expression form
+        // "(metadata->>'idempotency_key')" when it appears as an inline table constraint.
+        // Postgres enforces uniqueness identically either way.
+        // To reverse: use  DROP INDEX openfga_outbox_idempotency_unique
+        //             NOT  ALTER TABLE openfga_outbox DROP CONSTRAINT openfga_outbox_idempotency_unique
+        $this->addSql(<<<'SQL'
+            CREATE UNIQUE INDEX openfga_outbox_idempotency_unique
+                ON openfga_outbox ((metadata->>'idempotency_key'))
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX idx_outbox_pickup ON openfga_outbox (status, next_attempt_at)
+                WHERE status IN ('pending', 'retrying')
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX idx_outbox_dlq ON openfga_outbox (status, created_at)
+                WHERE status = 'failed_terminal'
+        SQL);
+
+        $this->addSql(<<<'SQL'
+            CREATE INDEX idx_outbox_metadata_request ON openfga_outbox ((metadata->>'access_request_id'))
+                WHERE metadata ?? 'access_request_id'
+        SQL);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        // Drop indexes explicitly before the table for auditability and symmetry with up().
+        // (DROP TABLE would cascade them automatically, but explicit reversal is clearer.)
+        // The unique index is an INDEX, not a CONSTRAINT — use DROP INDEX, not DROP CONSTRAINT.
+        $this->addSql('DROP INDEX IF EXISTS openfga_outbox_idempotency_unique');
+        $this->addSql('DROP INDEX IF EXISTS idx_outbox_pickup');
+        $this->addSql('DROP INDEX IF EXISTS idx_outbox_dlq');
+        $this->addSql('DROP INDEX IF EXISTS idx_outbox_metadata_request');
+        $this->addSql('DROP TABLE IF EXISTS openfga_outbox');
+        // Drop enum types in reverse-declaration order (outbox_status declared after outbox_op).
+        $this->addSql('DROP TYPE IF EXISTS outbox_status');
+        $this->addSql('DROP TYPE IF EXISTS outbox_op');
+    }
+}

--- a/src/Repositories/OutboxRepository.php
+++ b/src/Repositories/OutboxRepository.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Repositories;
+
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use PDO;
+
+/**
+ * PDO repository for the openfga_outbox table.
+ *
+ * Sole writer of outbox rows. Hot path is insertBatch (called inside the
+ * handler's tx with the business write) and pickupPending (the consumer
+ * and backstop both call this).
+ */
+final class OutboxRepository
+{
+    public function __construct(private readonly PDO $db)
+    {
+    }
+
+    /**
+     * Insert a batch of outbox rows, idempotent on idempotency_key.
+     *
+     * Returns the row IDs in the same order as the input payload.
+     *
+     * @param list<array{
+     *     operation: OutboxOperation,
+     *     fga_user: string,
+     *     fga_relation: string,
+     *     fga_object: string,
+     *     idempotency_key: string,
+     *     metadata: array<string, mixed>
+     * }> $rows
+     * @return list<int>
+     */
+    public function insertBatch(array $rows): array
+    {
+        if (empty($rows)) {
+            return [];
+        }
+
+        $ids = [];
+
+        $insert = $this->db->prepare(<<<'SQL'
+            INSERT INTO openfga_outbox (operation, fga_user, fga_relation, fga_object, metadata)
+            VALUES (:operation, :fga_user, :fga_relation, :fga_object, :metadata::jsonb)
+            ON CONFLICT ((metadata->>'idempotency_key')) DO NOTHING
+            RETURNING id
+        SQL);
+
+        $select = $this->db->prepare(<<<'SQL'
+            SELECT id FROM openfga_outbox WHERE metadata->>'idempotency_key' = :key
+        SQL);
+
+        foreach ($rows as $row) {
+            // The idempotency_key must live inside the metadata JSONB so the
+            // expression UNIQUE index catches conflicts.
+            $metadata                    = $row['metadata'];
+            $metadata['idempotency_key'] = $row['idempotency_key'];
+
+            $insert->execute([
+                ':operation'    => $row['operation']->value,
+                ':fga_user'     => $row['fga_user'],
+                ':fga_relation' => $row['fga_relation'],
+                ':fga_object'   => $row['fga_object'],
+                ':metadata'     => json_encode($metadata, JSON_THROW_ON_ERROR),
+            ]);
+
+            $insertedId = $insert->fetchColumn();
+            if ($insertedId !== false) {
+                $ids[] = (int) $insertedId;
+                continue;
+            }
+
+            // Conflict path — the row already exists. Look up its ID.
+            $select->execute([':key' => $row['idempotency_key']]);
+            $existingId = $select->fetchColumn();
+            if ($existingId === false) {
+                throw new \RuntimeException(sprintf(
+                    'OutboxRepository::insertBatch: conflict on key %s but row not found',
+                    $row['idempotency_key']
+                ));
+            }
+            $ids[] = (int) $existingId;
+        }
+
+        return $ids;
+    }
+}

--- a/src/Repositories/OutboxRepository.php
+++ b/src/Repositories/OutboxRepository.php
@@ -201,6 +201,50 @@ final class OutboxRepository
     }
 
     /**
+     * Reset a failed_terminal row back to pending so the consumer/backstop
+     * will retry it. Only failed_terminal rows are eligible — admin retry on
+     * a pending/retrying row is a 409 from the handler.
+     *
+     * Returns true if a row was reset; false if the row was not in
+     * failed_terminal state.
+     */
+    public function resetForRetry(int $id): bool
+    {
+        $stmt = $this->db->prepare(<<<'SQL'
+            UPDATE openfga_outbox
+            SET status = 'pending',
+                attempts = 0,
+                last_error = NULL,
+                last_error_code = NULL,
+                completed_at = NULL,
+                next_attempt_at = NOW()
+            WHERE id = :id AND status = 'failed_terminal'
+        SQL);
+        $stmt->execute([':id' => $id]);
+        return $stmt->rowCount() === 1;
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    public function countByStatus(): array
+    {
+        $stmt = $this->db->query(<<<'SQL'
+            SELECT status::text AS status, COUNT(*)::int AS n
+            FROM openfga_outbox
+            GROUP BY status
+        SQL);
+        $out  = [];
+        if ($stmt !== false) {
+            /** @var array{status: string, n: int} $r */
+            foreach ($stmt->fetchAll(PDO::FETCH_ASSOC) as $r) {
+                $out[$r['status']] = $r['n'];
+            }
+        }
+        return $out;
+    }
+
+    /**
      * @param array<string, mixed> $row
      */
     private function hydrate(array $row): OutboxRow

--- a/src/Repositories/OutboxRepository.php
+++ b/src/Repositories/OutboxRepository.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Api\Repositories;
 
 use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxRow;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
 use PDO;
 
 /**
@@ -87,5 +89,48 @@ final class OutboxRepository
         }
 
         return $ids;
+    }
+
+    public function getById(int $id): ?OutboxRow
+    {
+        $stmt = $this->db->prepare(<<<'SQL'
+            SELECT id, operation, fga_user, fga_relation, fga_object,
+                   status, attempts, next_attempt_at, last_error, last_error_code,
+                   metadata, created_at, completed_at
+            FROM openfga_outbox
+            WHERE id = :id
+        SQL);
+        $stmt->execute([':id' => $id]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if ($row === false) {
+            return null;
+        }
+        return $this->hydrate($row);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function hydrate(array $row): OutboxRow
+    {
+        $metadataJson = is_string($row['metadata']) ? $row['metadata'] : '{}';
+        /** @var array<string, mixed> $metadata */
+        $metadata = json_decode($metadataJson, true, flags: JSON_THROW_ON_ERROR);
+
+        return new OutboxRow(
+            id: (int) $row['id'],
+            operation: OutboxOperation::from((string) $row['operation']),
+            fgaUser: (string) $row['fga_user'],
+            fgaRelation: (string) $row['fga_relation'],
+            fgaObject: (string) $row['fga_object'],
+            status: OutboxStatus::from((string) $row['status']),
+            attempts: (int) $row['attempts'],
+            nextAttemptAt: new \DateTimeImmutable((string) $row['next_attempt_at']),
+            lastError: $row['last_error'] !== null ? (string) $row['last_error'] : null,
+            lastErrorCode: $row['last_error_code'] !== null ? (string) $row['last_error_code'] : null,
+            metadata: $metadata,
+            createdAt: new \DateTimeImmutable((string) $row['created_at']),
+            completedAt: $row['completed_at'] !== null ? new \DateTimeImmutable((string) $row['completed_at']) : null,
+        );
     }
 }

--- a/src/Repositories/OutboxRepository.php
+++ b/src/Repositories/OutboxRepository.php
@@ -105,6 +105,7 @@ final class OutboxRepository
         if ($row === false) {
             return null;
         }
+        /** @var array<string, mixed> $row */
         return $this->hydrate($row);
     }
 
@@ -195,6 +196,7 @@ final class OutboxRepository
 
         $rows = [];
         while (( $r = $stmt->fetch(PDO::FETCH_ASSOC) ) !== false) {
+            /** @var array<string, mixed> $r */
             $rows[] = $this->hydrate($r);
         }
         return $rows;
@@ -253,20 +255,45 @@ final class OutboxRepository
         /** @var array<string, mixed> $metadata */
         $metadata = json_decode($metadataJson, true, flags: JSON_THROW_ON_ERROR);
 
+        /** @var int|string $id */
+        $id = $row['id'];
+        /** @var string $operation */
+        $operation = $row['operation'];
+        /** @var string $fgaUser */
+        $fgaUser = $row['fga_user'];
+        /** @var string $fgaRelation */
+        $fgaRelation = $row['fga_relation'];
+        /** @var string $fgaObject */
+        $fgaObject = $row['fga_object'];
+        /** @var string $status */
+        $status = $row['status'];
+        /** @var int|string $attempts */
+        $attempts = $row['attempts'];
+        /** @var string $nextAttemptAt */
+        $nextAttemptAt = $row['next_attempt_at'];
+        /** @var string|null $lastError */
+        $lastError = $row['last_error'];
+        /** @var string|null $lastErrorCode */
+        $lastErrorCode = $row['last_error_code'];
+        /** @var string $createdAt */
+        $createdAt = $row['created_at'];
+        /** @var string|null $completedAt */
+        $completedAt = $row['completed_at'];
+
         return new OutboxRow(
-            id: (int) $row['id'],
-            operation: OutboxOperation::from((string) $row['operation']),
-            fgaUser: (string) $row['fga_user'],
-            fgaRelation: (string) $row['fga_relation'],
-            fgaObject: (string) $row['fga_object'],
-            status: OutboxStatus::from((string) $row['status']),
-            attempts: (int) $row['attempts'],
-            nextAttemptAt: new \DateTimeImmutable((string) $row['next_attempt_at']),
-            lastError: $row['last_error'] !== null ? (string) $row['last_error'] : null,
-            lastErrorCode: $row['last_error_code'] !== null ? (string) $row['last_error_code'] : null,
+            id: (int) $id,
+            operation: OutboxOperation::from($operation),
+            fgaUser: $fgaUser,
+            fgaRelation: $fgaRelation,
+            fgaObject: $fgaObject,
+            status: OutboxStatus::from($status),
+            attempts: (int) $attempts,
+            nextAttemptAt: new \DateTimeImmutable($nextAttemptAt),
+            lastError: $lastError,
+            lastErrorCode: $lastErrorCode,
             metadata: $metadata,
-            createdAt: new \DateTimeImmutable((string) $row['created_at']),
-            completedAt: $row['completed_at'] !== null ? new \DateTimeImmutable((string) $row['completed_at']) : null,
+            createdAt: new \DateTimeImmutable($createdAt),
+            completedAt: $completedAt !== null ? new \DateTimeImmutable($completedAt) : null,
         );
     }
 }

--- a/src/Repositories/OutboxRepository.php
+++ b/src/Repositories/OutboxRepository.php
@@ -108,6 +108,63 @@ final class OutboxRepository
         return $this->hydrate($row);
     }
 
+    public function markSucceeded(int $id): void
+    {
+        // Guard against terminal-status downgrades: only mark succeeded if currently
+        // in a non-terminal state. Re-applying succeeded is a no-op (completed_at preserved).
+        $stmt = $this->db->prepare(<<<'SQL'
+            UPDATE openfga_outbox
+            SET status = 'succeeded',
+                completed_at = COALESCE(completed_at, NOW())
+            WHERE id = :id AND status IN ('pending', 'retrying', 'succeeded')
+        SQL);
+        $stmt->execute([':id' => $id]);
+    }
+
+    public function markRetryable(
+        int $id,
+        int $attempts,
+        \DateTimeImmutable $nextAttemptAt,
+        string $lastError,
+        ?string $lastErrorCode,
+    ): void {
+        // Only transition out of pending/retrying. A failed_terminal row must
+        // stay terminal — admin retry has its own path (resetForRetry).
+        $stmt = $this->db->prepare(<<<'SQL'
+            UPDATE openfga_outbox
+            SET status = 'retrying',
+                attempts = :attempts,
+                next_attempt_at = :next_attempt_at,
+                last_error = :last_error,
+                last_error_code = :last_error_code
+            WHERE id = :id AND status IN ('pending', 'retrying')
+        SQL);
+        $stmt->execute([
+            ':id'              => $id,
+            ':attempts'        => $attempts,
+            ':next_attempt_at' => $nextAttemptAt->format('Y-m-d H:i:sP'),
+            ':last_error'      => $lastError,
+            ':last_error_code' => $lastErrorCode,
+        ]);
+    }
+
+    public function markFailedTerminal(int $id, string $lastError, ?string $lastErrorCode): void
+    {
+        $stmt = $this->db->prepare(<<<'SQL'
+            UPDATE openfga_outbox
+            SET status = 'failed_terminal',
+                last_error = :last_error,
+                last_error_code = :last_error_code,
+                completed_at = NOW()
+            WHERE id = :id AND status IN ('pending', 'retrying')
+        SQL);
+        $stmt->execute([
+            ':id'              => $id,
+            ':last_error'      => $lastError,
+            ':last_error_code' => $lastErrorCode,
+        ]);
+    }
+
     /**
      * @param array<string, mixed> $row
      */

--- a/src/Repositories/OutboxRepository.php
+++ b/src/Repositories/OutboxRepository.php
@@ -166,6 +166,41 @@ final class OutboxRepository
     }
 
     /**
+     * Pick up rows ready for the consumer / backstop to process.
+     *
+     * Uses FOR UPDATE SKIP LOCKED so concurrent runners don't collide:
+     * each runner gets a distinct slice of the eligible rows. Caller is
+     * responsible for COMMIT/ROLLBACK of the surrounding transaction
+     * (the lock is held until the runner finishes processing or rolls
+     * back).
+     *
+     * @return list<OutboxRow>
+     */
+    public function pickupPending(int $limit, \DateTimeImmutable $now): array
+    {
+        $stmt = $this->db->prepare(<<<'SQL'
+            SELECT id, operation, fga_user, fga_relation, fga_object,
+                   status, attempts, next_attempt_at, last_error, last_error_code,
+                   metadata, created_at, completed_at
+            FROM openfga_outbox
+            WHERE status IN ('pending', 'retrying')
+              AND next_attempt_at <= :now
+            ORDER BY next_attempt_at ASC, id ASC
+            LIMIT :limit
+            FOR UPDATE SKIP LOCKED
+        SQL);
+        $stmt->bindValue(':now', $now->format('Y-m-d H:i:s.uP'), PDO::PARAM_STR);
+        $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $stmt->execute();
+
+        $rows = [];
+        while (( $r = $stmt->fetch(PDO::FETCH_ASSOC) ) !== false) {
+            $rows[] = $this->hydrate($r);
+        }
+        return $rows;
+    }
+
+    /**
      * @param array<string, mixed> $row
      */
     private function hydrate(array $row): OutboxRow

--- a/src/Repositories/OutboxRepository.php
+++ b/src/Repositories/OutboxRepository.php
@@ -248,7 +248,11 @@ final class OutboxRepository
               AND (:access_request_id_null OR metadata->>'access_request_id' = :access_request_id_val)
         SQL);
         $countStmt->bindValue(':status_null', $status === null, PDO::PARAM_BOOL);
-        $countStmt->bindValue(':status_val', $status ?? '', PDO::PARAM_STR);
+        // Bind a valid enum literal even when not filtering by status: PG
+        // evaluates `::outbox_status` at plan time, so passing '' would
+        // trip "invalid input value for enum outbox_status" before the
+        // `:status_null OR ...` short-circuit ever runs at row time.
+        $countStmt->bindValue(':status_val', $status ?? 'pending', PDO::PARAM_STR);
         $countStmt->bindValue(':access_request_id_null', $accessRequestId === null, PDO::PARAM_BOOL);
         $countStmt->bindValue(':access_request_id_val', $accessRequestId ?? '', PDO::PARAM_STR);
         $countStmt->execute();
@@ -266,7 +270,8 @@ final class OutboxRepository
             LIMIT :limit OFFSET :offset
         SQL);
         $dataStmt->bindValue(':status_null', $status === null, PDO::PARAM_BOOL);
-        $dataStmt->bindValue(':status_val', $status ?? '', PDO::PARAM_STR);
+        // See countStmt above — placeholder must be a valid enum value.
+        $dataStmt->bindValue(':status_val', $status ?? 'pending', PDO::PARAM_STR);
         $dataStmt->bindValue(':access_request_id_null', $accessRequestId === null, PDO::PARAM_BOOL);
         $dataStmt->bindValue(':access_request_id_val', $accessRequestId ?? '', PDO::PARAM_STR);
         $dataStmt->bindValue(':limit', $limit, PDO::PARAM_INT);

--- a/src/Repositories/OutboxRepository.php
+++ b/src/Repositories/OutboxRepository.php
@@ -143,7 +143,7 @@ final class OutboxRepository
         $stmt->execute([
             ':id'              => $id,
             ':attempts'        => $attempts,
-            ':next_attempt_at' => $nextAttemptAt->format('Y-m-d H:i:sP'),
+            ':next_attempt_at' => $nextAttemptAt->format('Y-m-d H:i:s.uP'),
             ':last_error'      => $lastError,
             ':last_error_code' => $lastErrorCode,
         ]);

--- a/src/Repositories/OutboxRepository.php
+++ b/src/Repositories/OutboxRepository.php
@@ -227,6 +227,79 @@ final class OutboxRepository
     }
 
     /**
+     * List outbox rows with optional filters and offset pagination.
+     *
+     * @return array{rows: list<OutboxRow>, total: int}
+     */
+    public function list(
+        ?string $status,
+        ?string $accessRequestId,
+        int $limit,
+        int $offset,
+    ): array {
+        // Count query.
+        // We use two parameters for the status filter to avoid PostgreSQL's
+        // "could not determine data type of parameter" ambiguity when the same
+        // placeholder appears in both `IS NULL` and a cast expression.
+        $countStmt = $this->db->prepare(<<<'SQL'
+            SELECT COUNT(*)::int AS total
+            FROM openfga_outbox
+            WHERE (:status_null OR status = :status_val::outbox_status)
+              AND (:access_request_id_null OR metadata->>'access_request_id' = :access_request_id_val)
+        SQL);
+        $countStmt->bindValue(':status_null', $status === null, PDO::PARAM_BOOL);
+        $countStmt->bindValue(':status_val', $status ?? '', PDO::PARAM_STR);
+        $countStmt->bindValue(':access_request_id_null', $accessRequestId === null, PDO::PARAM_BOOL);
+        $countStmt->bindValue(':access_request_id_val', $accessRequestId ?? '', PDO::PARAM_STR);
+        $countStmt->execute();
+        $total = (int) $countStmt->fetchColumn();
+
+        // Data query — same split-param trick.
+        $dataStmt = $this->db->prepare(<<<'SQL'
+            SELECT id, operation, fga_user, fga_relation, fga_object,
+                   status, attempts, next_attempt_at, last_error, last_error_code,
+                   metadata, created_at, completed_at
+            FROM openfga_outbox
+            WHERE (:status_null OR status = :status_val::outbox_status)
+              AND (:access_request_id_null OR metadata->>'access_request_id' = :access_request_id_val)
+            ORDER BY id DESC
+            LIMIT :limit OFFSET :offset
+        SQL);
+        $dataStmt->bindValue(':status_null', $status === null, PDO::PARAM_BOOL);
+        $dataStmt->bindValue(':status_val', $status ?? '', PDO::PARAM_STR);
+        $dataStmt->bindValue(':access_request_id_null', $accessRequestId === null, PDO::PARAM_BOOL);
+        $dataStmt->bindValue(':access_request_id_val', $accessRequestId ?? '', PDO::PARAM_STR);
+        $dataStmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+        $dataStmt->bindValue(':offset', $offset, PDO::PARAM_INT);
+        $dataStmt->execute();
+
+        $rows = [];
+        while (( $r = $dataStmt->fetch(PDO::FETCH_ASSOC) ) !== false) {
+            /** @var array<string, mixed> $r */
+            $rows[] = $this->hydrate($r);
+        }
+
+        return ['rows' => $rows, 'total' => $total];
+    }
+
+    /**
+     * Return the age in seconds of the oldest pending/retrying row, or 0 when none.
+     */
+    public function oldestPendingAgeSeconds(): int
+    {
+        $stmt = $this->db->query(<<<'SQL'
+            SELECT COALESCE(EXTRACT(EPOCH FROM (NOW() - MIN(created_at)))::int, 0)
+            FROM openfga_outbox
+            WHERE status IN ('pending', 'retrying')
+        SQL);
+        if ($stmt === false) {
+            return 0;
+        }
+        $val = $stmt->fetchColumn();
+        return is_numeric($val) ? (int) $val : 0;
+    }
+
+    /**
      * @return array<string, int>
      */
     public function countByStatus(): array

--- a/src/Router.php
+++ b/src/Router.php
@@ -28,6 +28,7 @@ use LiturgicalCalendar\Api\Handlers\Auth\EmailVerificationHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\AccessRequestAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\ApplicationAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\NotificationsHandler as AdminNotificationsHandler;
+use LiturgicalCalendar\Api\Handlers\Admin\OutboxAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Auth\NotificationsHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\PermissionAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\UsersHandler;
@@ -411,6 +412,12 @@ class Router
                         // POST /admin/applications/{uuid}/revoke - Revoke an approved application
                         $applicationAdminHandler = new ApplicationAdminHandler();
                         $this->handler           = $applicationAdminHandler;
+                    } elseif ($adminRoute === 'outbox') {
+                        // Admin outbox management routes
+                        // GET  /admin/outbox?status=…&summary=…  - List/summary
+                        // POST /admin/outbox/{id}/retry           - Reset failed_terminal row to pending
+                        $outboxAdminHandler = new OutboxAdminHandler();
+                        $this->handler      = $outboxAdminHandler;
                     } else {
                         $this->response = new Response(StatusCode::NOT_FOUND->value, [], null, $this->request->getProtocolVersion(), StatusCode::NOT_FOUND->reason());
                         $this->emitResponse();

--- a/src/Router.php
+++ b/src/Router.php
@@ -33,6 +33,7 @@ use LiturgicalCalendar\Api\Handlers\Auth\NotificationsHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\PermissionAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\UsersHandler;
 use LiturgicalCalendar\Api\Handlers\ApplicationsHandler;
+use LiturgicalCalendar\Api\Handlers\Ops\HealthHandler;
 use LiturgicalCalendar\Api\Handlers\Ops\MigrateHandler;
 use LiturgicalCalendar\Api\Handlers\Ops\OpcacheResetHandler;
 use LiturgicalCalendar\Api\Http\Enum\StatusCode;
@@ -538,6 +539,11 @@ class Router
                 }
                 $this->handler = $temporaleHandler;
                 break;
+            case 'health':
+                $healthHandler = new HealthHandler();
+                $healthHandler->setAllowedRequestMethods([RequestMethod::GET]);
+                $this->handler = $healthHandler;
+                break;
             case '_ops':
                 if (count($requestPathParts) === 1 && $requestPathParts[0] === 'migrate') {
                     $migrateHandler = new MigrateHandler();
@@ -569,7 +575,8 @@ class Router
         $pipeline->pipe(new JsonBodyParserMiddleware());
 
         // Apply API key validation and rate limiting for public API routes
-        if (!in_array($route, ['auth', 'admin', 'applications', '_ops'], true)) {
+        // health is unauthenticated monitoring endpoint — exclude from key/rate checks
+        if (!in_array($route, ['auth', 'admin', 'applications', '_ops', 'health'], true)) {
             if (Connection::isConfigured()) {
                 $pipeline->pipe(new ApiKeyMiddleware(
                     new \LiturgicalCalendar\Api\Repositories\ApiKeyRepository(),

--- a/src/Router.php
+++ b/src/Router.php
@@ -574,9 +574,13 @@ class Router
         // Parse JSON request bodies into getParsedBody() for all routes
         $pipeline->pipe(new JsonBodyParserMiddleware());
 
-        // Apply API key validation and rate limiting for public API routes
-        // health is unauthenticated monitoring endpoint — exclude from key/rate checks
-        if (!in_array($route, ['auth', 'admin', 'applications', '_ops', 'health'], true)) {
+        // Apply API key validation and rate limiting for public API routes.
+        // /health is an unauthenticated monitoring endpoint — exclude it from
+        // the API-key check but KEEP IP-based rate limiting, because /health
+        // touches openfga_outbox and PG on every request; without rate
+        // limiting an unauthenticated flood could exhaust DB capacity.
+        $skipAuthRoutes = ['auth', 'admin', 'applications', '_ops', 'health'];
+        if (!in_array($route, $skipAuthRoutes, true)) {
             if (Connection::isConfigured()) {
                 $pipeline->pipe(new ApiKeyMiddleware(
                     new \LiturgicalCalendar\Api\Repositories\ApiKeyRepository(),
@@ -588,6 +592,9 @@ class Router
                 // Apply IP-only rate limiting for unauthenticated requests.
                 $pipeline->pipe(ApiKeyRateLimitMiddleware::fromEnv());
             }
+        } elseif ($route === 'health') {
+            // /health still needs IP-based throttling — see comment above.
+            $pipeline->pipe(ApiKeyRateLimitMiddleware::fromEnv());
         }
 
         // Apply HTTPS enforcement middleware for auth, admin, and applications routes in production

--- a/src/Services/Outbox/BackstopRunner.php
+++ b/src/Services/Outbox/BackstopRunner.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+
+/**
+ * One-shot scan of openfga_outbox for the cron backstop.
+ *
+ * Picks up rows older than the grace window (default 60s — the consumer
+ * gets first crack), processes them via OutboxProcessor, exits.
+ *
+ * The grace window is the durability buffer: the consumer's XREADGROUP
+ * wake-up is sub-second on the happy path, so the backstop should only
+ * see rows where Redis lost the XADD or the consumer is dead.
+ */
+final class BackstopRunner
+{
+    public function __construct(
+        private readonly OutboxRepository $repo,
+        private readonly OutboxProcessor $processor,
+        private readonly int $graceSeconds = 60,
+    ) {
+    }
+
+    public function runOnce(int $limit = 100): int
+    {
+        $cutoff = ( new \DateTimeImmutable() )->modify("-{$this->graceSeconds} seconds");
+        $rows   = $this->repo->pickupPending($limit, $cutoff);
+
+        foreach ($rows as $row) {
+            $this->processor->processOne($row->id);
+        }
+
+        return count($rows);
+    }
+}

--- a/src/Services/Outbox/BackstopRunner.php
+++ b/src/Services/Outbox/BackstopRunner.php
@@ -10,7 +10,7 @@ use LiturgicalCalendar\Api\Repositories\OutboxRepository;
  * One-shot scan of openfga_outbox for the cron backstop.
  *
  * Picks up rows older than the grace window (default 60s — the consumer
- * gets first crack), processes them via OutboxProcessor, exits.
+ * gets first crack), processes them via OutboxProcessorInterface, exits.
  *
  * The grace window is the durability buffer: the consumer's XREADGROUP
  * wake-up is sub-second on the happy path, so the backstop should only
@@ -20,7 +20,7 @@ final class BackstopRunner
 {
     public function __construct(
         private readonly OutboxRepository $repo,
-        private readonly OutboxProcessor $processor,
+        private readonly OutboxProcessorInterface $processor,
         private readonly int $graceSeconds = 60,
     ) {
     }

--- a/src/Services/Outbox/BackstopRunner.php
+++ b/src/Services/Outbox/BackstopRunner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Api\Services\Outbox;
 
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use PDO;
 
 /**
  * One-shot scan of openfga_outbox for the cron backstop.
@@ -21,17 +22,35 @@ final class BackstopRunner
     public function __construct(
         private readonly OutboxRepository $repo,
         private readonly OutboxProcessorInterface $processor,
+        private readonly PDO $pdo,
         private readonly int $graceSeconds = 60,
     ) {
     }
 
     public function runOnce(int $limit = 100): int
     {
-        $cutoff = ( new \DateTimeImmutable() )->modify("-{$this->graceSeconds} seconds");
-        $rows   = $this->repo->pickupPending($limit, $cutoff);
+        // FOR UPDATE SKIP LOCKED inside pickupPending only holds locks for
+        // the lifetime of the surrounding transaction. Without an explicit
+        // tx the locks would be released immediately by PG's autocommit,
+        // defeating the SKIP LOCKED guarantee (concurrent runners could
+        // double-process). Wrap pickup + processing in one tx so the row
+        // locks survive across processOne() for every picked row.
+        // Timezone pinned to Europe/Vatican per the project-wide convention.
+        $cutoff = ( new \DateTimeImmutable('now', new \DateTimeZone('Europe/Vatican')) )
+            ->modify("-{$this->graceSeconds} seconds");
 
-        foreach ($rows as $row) {
-            $this->processor->processOne($row->id);
+        $this->pdo->beginTransaction();
+        try {
+            $rows = $this->repo->pickupPending($limit, $cutoff);
+            foreach ($rows as $row) {
+                $this->processor->processOne($row->id);
+            }
+            $this->pdo->commit();
+        } catch (\Throwable $e) {
+            if ($this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
+            throw $e;
         }
 
         return count($rows);

--- a/src/Services/Outbox/ConsumerLoop.php
+++ b/src/Services/Outbox/ConsumerLoop.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * Long-lived consumer loop body.
+ *
+ * tick() does one readOnce + process cycle (the unit-testable part).
+ * run() is the outer while (true), excluded from coverage. Splitting
+ * keeps the test pyramid honest.
+ */
+final class ConsumerLoop
+{
+    private bool $groupEnsured = false;
+
+    public function __construct(
+        private readonly StreamConsumerInterface $consumer,
+        private readonly OutboxProcessorInterface $processor,
+        private readonly int $blockMs = 5000,
+    ) {
+    }
+
+    public function tick(): void
+    {
+        if (!$this->groupEnsured) {
+            $this->consumer->ensureGroup();
+            $this->groupEnsured = true;
+        }
+        $this->consumer->readOnce(
+            $this->blockMs,
+            function (int $rowId): void {
+                $this->processor->processOne($rowId);
+            },
+        );
+    }
+
+    /**
+     * Forever. systemd restarts on crash.
+     *
+     * @codeCoverageIgnore
+     */
+    public function run(): never
+    {
+        while (true) {
+            $this->tick();
+        }
+    }
+}

--- a/src/Services/Outbox/OutboxBackoff.php
+++ b/src/Services/Outbox/OutboxBackoff.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * Exponential backoff for outbox retries.
+ *
+ * Schedule: 1s, 2s, 4s, 8s, 16s, 32s, 64s, 128s, 256s, 512s — capped at
+ * 2^9 = 512s. Total budget across 10 attempts: ~17 minutes.
+ *
+ * Pure function. Lives in its own file for testability and so the
+ * schedule is editable in one place without touching the processor.
+ */
+final class OutboxBackoff
+{
+    private function __construct()
+    {
+    }
+
+    /**
+     * @param int $attempts The new attempt count (just incremented), 1..n.
+     */
+    public static function secondsForAttempt(int $attempts): int
+    {
+        if ($attempts < 1) {
+            throw new \InvalidArgumentException('attempts must be >= 1');
+        }
+
+        return 1 << min($attempts - 1, 9);
+    }
+}

--- a/src/Services/Outbox/OutboxClassifier.php
+++ b/src/Services/Outbox/OutboxClassifier.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
+
+/**
+ * Stateless classifier that decides what to do with an exception raised
+ * by an OpenFGA call inside OutboxProcessor.
+ *
+ * The mapping is canonical — every branch in OutboxProcessor consults
+ * this. New OpenFGA error codes get a new test in OutboxClassifierTest
+ * and a new arm in classify().
+ */
+final class OutboxClassifier
+{
+    /**
+     * Error codes we recognize as admin-input bugs (no retry).
+     *
+     * Validation errors, type/relation lookups failing, auth failures —
+     * retrying these 9 more times wastes work and pollutes metrics.
+     *
+     * @var list<string>
+     */
+    private const TERMINAL_CODES = [
+        'validation_error',
+        'invalid_input_format',
+        'type_not_found',
+        'relation_not_found',
+        'auth_failure',
+        'unauthenticated',
+    ];
+
+    private function __construct()
+    {
+    }
+
+    public static function classify(\Throwable $e): OutboxDisposition
+    {
+        if ($e instanceof TupleAlreadyExistsException || $e instanceof TupleNotFoundException) {
+            return OutboxDisposition::BENIGN_SUCCESS;
+        }
+
+        if ($e instanceof OpenFgaApiException) {
+            $code = $e->getErrorCode();
+            if ($code !== null && in_array($code, self::TERMINAL_CODES, true)) {
+                return OutboxDisposition::TERMINAL;
+            }
+            return OutboxDisposition::RETRY;
+        }
+
+        return OutboxDisposition::RETRY;
+    }
+}

--- a/src/Services/Outbox/OutboxDisposition.php
+++ b/src/Services/Outbox/OutboxDisposition.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * What OutboxClassifier::classify decided about an exception.
+ *
+ * The processor consults this to decide whether to mark the row
+ * succeeded, schedule a retry, or mark it failed_terminal.
+ */
+enum OutboxDisposition
+{
+    case BENIGN_SUCCESS;  // TupleAlreadyExists on write, TupleNotFound on delete
+    case RETRY;           // 5xx, 429, network — schedule with backoff
+    case TERMINAL;        // 4xx validation/auth — no retry, surface in DLQ
+}

--- a/src/Services/Outbox/OutboxNotifier.php
+++ b/src/Services/Outbox/OutboxNotifier.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Best-effort XADD to the reconcile stream.
+ *
+ * Never throws to the caller — the outbox row is durable in PG, and the
+ * cron backstop is the safety net. Logging at WARNING is sufficient
+ * signal that something is off; the system continues to function.
+ *
+ * Pass null \Redis to disable (e.g. in environments without Redis).
+ */
+final class OutboxNotifier
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly ?\Redis $redis,
+        private readonly string $streamName,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    public function notify(int $outboxId, string $operation): void
+    {
+        if ($this->redis === null) {
+            return;
+        }
+
+        try {
+            $this->redis->xAdd(
+                $this->streamName,
+                '*',
+                [
+                    'row_id' => (string) $outboxId,
+                    'op'     => $operation,
+                ],
+            );
+        } catch (\RedisException $e) {
+            $this->logger->warning('outbox.redis.notify_failed', [
+                'row_id' => $outboxId,
+                'op'     => $operation,
+                'error'  => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/src/Services/Outbox/OutboxOperation.php
+++ b/src/Services/Outbox/OutboxOperation.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * The two OpenFGA tuple operations the outbox tracks.
+ *
+ * Values match the `outbox_op` Postgres enum from
+ * Version20260602202504 migration.
+ */
+enum OutboxOperation: string
+{
+    case WRITE_TUPLE  = 'write_tuple';
+    case DELETE_TUPLE = 'delete_tuple';
+}

--- a/src/Services/Outbox/OutboxProcessor.php
+++ b/src/Services/Outbox/OutboxProcessor.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+
+/**
+ * Single point of contact between the outbox and OpenFGA.
+ *
+ * Called from three places: the handler's sync fast path (after the
+ * surrounding tx has committed), the consumer's XREADGROUP loop, and
+ * the cron backstop's pickupPending scan. They all use the same
+ * processOne() so classification, retry scheduling, and status
+ * transitions live in exactly one file.
+ *
+ * processOne() is idempotent on terminal rows — re-running on a
+ * succeeded or failed_terminal row is a no-op.
+ */
+final class OutboxProcessor
+{
+    private const MAX_ATTEMPTS = 10;
+
+    public function __construct(
+        private readonly OutboxRepository $repo,
+        private readonly OpenFgaClient $client,
+    ) {
+    }
+
+    public function processOne(int $rowId): OutboxDisposition
+    {
+        $row = $this->repo->getById($rowId);
+        if ($row === null) {
+            // Row was deleted between pickup and processOne — nothing to do.
+            return OutboxDisposition::BENIGN_SUCCESS;
+        }
+
+        if ($row->status === OutboxStatus::SUCCEEDED || $row->status === OutboxStatus::FAILED_TERMINAL) {
+            // Idempotency anchor — re-running on a terminal row no-ops.
+            return OutboxDisposition::BENIGN_SUCCESS;
+        }
+
+        try {
+            $this->invoke($row);
+            $this->repo->markSucceeded($row->id);
+            return OutboxDisposition::BENIGN_SUCCESS;
+        } catch (\Throwable $e) {
+            $disposition = OutboxClassifier::classify($e);
+            $code        = $e instanceof OpenFgaApiException ? $e->getErrorCode() : null;
+            $message     = $e->getMessage();
+
+            switch ($disposition) {
+                case OutboxDisposition::BENIGN_SUCCESS:
+                    $this->repo->markSucceeded($row->id);
+                    return OutboxDisposition::BENIGN_SUCCESS;
+
+                case OutboxDisposition::TERMINAL:
+                    $this->repo->markFailedTerminal($row->id, $message, $code);
+                    return OutboxDisposition::TERMINAL;
+
+                case OutboxDisposition::RETRY:
+                    $newAttempts = $row->attempts + 1;
+                    if ($newAttempts >= self::MAX_ATTEMPTS) {
+                        $this->repo->markFailedTerminal($row->id, $message, $code);
+                        return OutboxDisposition::TERMINAL;
+                    }
+                    $delay = OutboxBackoff::secondsForAttempt($newAttempts);
+                    $next  = ( new \DateTimeImmutable() )->modify("+{$delay} seconds");
+                    $this->repo->markRetryable($row->id, $newAttempts, $next, $message, $code);
+                    return OutboxDisposition::RETRY;
+            }
+        }
+    }
+
+    /**
+     * Convenience alias used by handlers in the sync fast path.
+     *
+     * Same semantics as processOne — separate method to make the call
+     * site read as "sync attempt" rather than "any-context attempt".
+     */
+    public function processSync(int $rowId): OutboxDisposition
+    {
+        return $this->processOne($rowId);
+    }
+
+    private function invoke(OutboxRow $row): void
+    {
+        match ($row->operation) {
+            OutboxOperation::WRITE_TUPLE  => $this->client->writeTuple($row->fgaUser, $row->fgaRelation, $row->fgaObject),
+            OutboxOperation::DELETE_TUPLE => $this->client->deleteTuple($row->fgaUser, $row->fgaRelation, $row->fgaObject),
+        };
+    }
+}

--- a/src/Services/Outbox/OutboxProcessor.php
+++ b/src/Services/Outbox/OutboxProcessor.php
@@ -22,12 +22,14 @@ use LiturgicalCalendar\Api\Services\OpenFgaClient;
  */
 final class OutboxProcessor implements OutboxProcessorInterface
 {
-    private const MAX_ATTEMPTS = 10;
+    private readonly int $maxAttempts;
 
     public function __construct(
         private readonly OutboxRepository $repo,
         private readonly OpenFgaClient $client,
+        int $maxAttempts = 10,
     ) {
+        $this->maxAttempts = $maxAttempts;
     }
 
     public function processOne(int $rowId): OutboxDisposition
@@ -63,7 +65,7 @@ final class OutboxProcessor implements OutboxProcessorInterface
 
                 case OutboxDisposition::RETRY:
                     $newAttempts = $row->attempts + 1;
-                    if ($newAttempts >= self::MAX_ATTEMPTS) {
+                    if ($newAttempts >= $this->maxAttempts) {
                         $this->repo->markFailedTerminal($row->id, $message, $code);
                         return OutboxDisposition::TERMINAL;
                     }

--- a/src/Services/Outbox/OutboxProcessor.php
+++ b/src/Services/Outbox/OutboxProcessor.php
@@ -45,6 +45,19 @@ final class OutboxProcessor implements OutboxProcessorInterface
             return OutboxDisposition::BENIGN_SUCCESS;
         }
 
+        // If the row is in RETRYING and its scheduled next attempt is still
+        // in the future, honor the backoff window. The backstop's
+        // pickupPending() already filters on next_attempt_at, but the
+        // consumer's XCLAIM-from-PEL path can hand us a row whose retry
+        // was just rescheduled by another runner; don't bypass the schedule.
+        // Vatican TZ to match the repo's storage convention.
+        if ($row->status === OutboxStatus::RETRYING) {
+            $now = new \DateTimeImmutable('now', new \DateTimeZone('Europe/Vatican'));
+            if ($row->nextAttemptAt > $now) {
+                return OutboxDisposition::BENIGN_SUCCESS;
+            }
+        }
+
         try {
             $this->invoke($row);
             $this->repo->markSucceeded($row->id);
@@ -70,7 +83,8 @@ final class OutboxProcessor implements OutboxProcessorInterface
                         return OutboxDisposition::TERMINAL;
                     }
                     $delay = OutboxBackoff::secondsForAttempt($newAttempts);
-                    $next  = ( new \DateTimeImmutable() )->modify("+{$delay} seconds");
+                    $next  = ( new \DateTimeImmutable('now', new \DateTimeZone('Europe/Vatican')) )
+                        ->modify("+{$delay} seconds");
                     $this->repo->markRetryable($row->id, $newAttempts, $next, $message, $code);
                     return OutboxDisposition::RETRY;
             }

--- a/src/Services/Outbox/OutboxProcessor.php
+++ b/src/Services/Outbox/OutboxProcessor.php
@@ -20,7 +20,7 @@ use LiturgicalCalendar\Api\Services\OpenFgaClient;
  * processOne() is idempotent on terminal rows — re-running on a
  * succeeded or failed_terminal row is a no-op.
  */
-final class OutboxProcessor
+final class OutboxProcessor implements OutboxProcessorInterface
 {
     private const MAX_ATTEMPTS = 10;
 

--- a/src/Services/Outbox/OutboxProcessorInterface.php
+++ b/src/Services/Outbox/OutboxProcessorInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+interface OutboxProcessorInterface
+{
+    public function processOne(int $rowId): OutboxDisposition;
+}

--- a/src/Services/Outbox/OutboxRow.php
+++ b/src/Services/Outbox/OutboxRow.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * Readonly snapshot of one openfga_outbox row in transit between
+ * OutboxRepository and OutboxProcessor.
+ *
+ * Repository hydrates these from PG; processor reads them, performs the
+ * OpenFGA call, then calls back into the repository to update the
+ * underlying row. The row object itself does not mutate — re-read after
+ * an update to see the new state.
+ */
+final class OutboxRow
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public readonly int $id,
+        public readonly OutboxOperation $operation,
+        public readonly string $fgaUser,
+        public readonly string $fgaRelation,
+        public readonly string $fgaObject,
+        public readonly OutboxStatus $status,
+        public readonly int $attempts,
+        public readonly \DateTimeImmutable $nextAttemptAt,
+        public readonly ?string $lastError,
+        public readonly ?string $lastErrorCode,
+        public readonly array $metadata,
+        public readonly \DateTimeImmutable $createdAt,
+        public readonly ?\DateTimeImmutable $completedAt,
+    ) {
+    }
+}

--- a/src/Services/Outbox/OutboxStatus.php
+++ b/src/Services/Outbox/OutboxStatus.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+/**
+ * Outbox row lifecycle states.
+ *
+ * Values match the `outbox_status` Postgres enum. State transitions:
+ *
+ *   pending → succeeded
+ *   pending → retrying → retrying → ... → succeeded
+ *   retrying → failed_terminal (attempts == 10 on transient, OR any 4xx classified TERMINAL)
+ *   failed_terminal → pending (admin retry via POST /admin/outbox/{id}/retry)
+ *
+ * `succeeded` and `failed_terminal` are terminal unless the admin retry
+ * endpoint resets the row back to `pending`.
+ */
+enum OutboxStatus: string
+{
+    case PENDING         = 'pending';
+    case RETRYING        = 'retrying';
+    case SUCCEEDED       = 'succeeded';
+    case FAILED_TERMINAL = 'failed_terminal';
+}

--- a/src/Services/Outbox/RedisStreamConsumer.php
+++ b/src/Services/Outbox/RedisStreamConsumer.php
@@ -36,7 +36,13 @@ final class RedisStreamConsumer implements StreamConsumerInterface
     public function ensureGroup(): void
     {
         try {
-            $this->redis->xGroup('CREATE', $this->streamName, $this->groupName, '$', true);
+            // Start ID '0' (not '$') so the group can read any pre-existing
+            // messages still on the stream when the consumer first starts.
+            // The DB outbox is the source of truth — re-delivering an old
+            // message is safe (the row is already terminal or already due,
+            // and processOne handles both idempotently). '$' would silently
+            // drop messages added before the consumer first started.
+            $this->redis->xGroup('CREATE', $this->streamName, $this->groupName, '0', true);
         } catch (\RedisException $e) {
             if (str_contains($e->getMessage(), 'BUSYGROUP')) {
                 return;

--- a/src/Services/Outbox/RedisStreamConsumer.php
+++ b/src/Services/Outbox/RedisStreamConsumer.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Thin wrapper around \Redis XREADGROUP + XACK for the consumer loop.
+ *
+ * Lives in its own class so the consumer's domain logic (look up the
+ * outbox row, invoke OutboxProcessor) doesn't get tangled with Redis
+ * Streams plumbing, and so we can unit-test by mocking \Redis.
+ */
+final class RedisStreamConsumer
+{
+    private const CLAIM_IDLE_MS = 30_000;
+
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly \Redis $redis,
+        private readonly string $streamName,
+        private readonly string $groupName,
+        private readonly string $consumerName,
+        ?LoggerInterface $logger = null,
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Idempotent. BUSYGROUP errors mean the group already exists; that's fine.
+     */
+    public function ensureGroup(): void
+    {
+        try {
+            $this->redis->xGroup('CREATE', $this->streamName, $this->groupName, '$', true);
+        } catch (\RedisException $e) {
+            if (str_contains($e->getMessage(), 'BUSYGROUP')) {
+                return;
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Read one message (or batch) from the stream and invoke $process
+     * with the row_id field. XACK on success.
+     *
+     * Stale pending entries (idle > CLAIM_IDLE_MS) are reclaimed first
+     * via XCLAIM so a new consumer can finish work a previous consumer
+     * crashed mid-flight.
+     *
+     * @param callable(int): void $process
+     */
+    public function readOnce(int $blockMs, callable $process): void
+    {
+        // First, try to claim anything stale from another consumer.
+        $this->claimStale($process);
+
+        /** @var array<string, array<string, array<string, string>>>|false $batch */
+        $batch = $this->redis->xReadGroup(
+            $this->groupName,
+            $this->consumerName,
+            [$this->streamName => '>'],
+            1,
+            $blockMs,
+        );
+
+        $messages = is_array($batch) ? ( $batch[$this->streamName] ?? [] ) : [];
+        if (empty($messages)) {
+            return;
+        }
+
+        $ackIds = [];
+        foreach ($messages as $msgId => $payload) {
+            $rowId = isset($payload['row_id']) ? (int) $payload['row_id'] : 0;
+            if ($rowId <= 0) {
+                $this->logger->warning('outbox.consumer.bad_message', ['msg_id' => $msgId, 'payload' => $payload]);
+                $ackIds[] = $msgId;
+                continue;
+            }
+            try {
+                $process($rowId);
+                $ackIds[] = $msgId;
+            } catch (\Throwable $e) {
+                // Leave the message in the PEL; XCLAIM on the next pass picks it up.
+                $this->logger->error('outbox.consumer.process_failed', [
+                    'msg_id' => $msgId,
+                    'row_id' => $rowId,
+                    'error'  => $e->getMessage(),
+                ]);
+            }
+        }
+
+        if (!empty($ackIds)) {
+            $this->redis->xAck($this->streamName, $this->groupName, $ackIds);
+        }
+    }
+
+    /**
+     * @param callable(int): void $process
+     */
+    private function claimStale(callable $process): void
+    {
+        // Summary form: xPending(stream, group) — returns false or summary array.
+        // phpstan-ignore-next-line — ext-redis stubs aren't precise enough for the dual-shape return
+        $pending = $this->redis->xPending($this->streamName, $this->groupName);
+        if ($pending === false || !is_array($pending) || empty($pending)) {
+            return;
+        }
+
+        // Detail form: xPending(stream, group, start, end, count) — returns per-message list.
+        // phpstan-ignore-next-line — ext-redis stubs aren't precise enough for the dual-shape return
+        $detail = $this->redis->xPending(
+            $this->streamName,
+            $this->groupName,
+            '-',
+            '+',
+            100,
+        );
+        if ($detail === false || !is_array($detail) || !isset($detail[0]) || !is_array($detail[0])) {
+            return;
+        }
+
+        $staleIds = [];
+        foreach ($detail as $entry) {
+            if (!is_array($entry) || count($entry) < 4) {
+                continue;
+            }
+            // $entry = [msgId, consumerName, idleMs, deliveryCount] per Redis XPENDING detail format.
+            $msgId  = $entry[0];
+            $idleMs = $entry[2];
+            if (!is_string($msgId) || !is_int($idleMs)) {
+                continue;
+            }
+            if ($idleMs >= self::CLAIM_IDLE_MS) {
+                $staleIds[] = $msgId;
+            }
+        }
+
+        if (empty($staleIds)) {
+            return;
+        }
+
+        /** @var array<string, array<string, string>>|false $claimed */
+        $claimed = $this->redis->xClaim(
+            $this->streamName,
+            $this->groupName,
+            $this->consumerName,
+            self::CLAIM_IDLE_MS,
+            $staleIds,
+        );
+        if ($claimed === false || empty($claimed)) {
+            return;
+        }
+
+        $ackIds = [];
+        foreach ($claimed as $msgId => $payload) {
+            $rowId = isset($payload['row_id']) ? (int) $payload['row_id'] : 0;
+            $this->logger->warning('outbox.consumer.xclaim', [
+                'msg_id'  => $msgId,
+                'row_id'  => $rowId,
+                'idle_ms' => self::CLAIM_IDLE_MS,
+            ]);
+            if ($rowId <= 0) {
+                $ackIds[] = $msgId;
+                continue;
+            }
+            try {
+                $process($rowId);
+                $ackIds[] = $msgId;
+            } catch (\Throwable) {
+                // leave it pending; next pass retries.
+            }
+        }
+
+        if (!empty($ackIds)) {
+            $this->redis->xAck($this->streamName, $this->groupName, $ackIds);
+        }
+    }
+}

--- a/src/Services/Outbox/RedisStreamConsumer.php
+++ b/src/Services/Outbox/RedisStreamConsumer.php
@@ -158,6 +158,10 @@ final class RedisStreamConsumer implements StreamConsumerInterface
             $this->consumerName,
             self::CLAIM_IDLE_MS,
             $staleIds,
+            // CI's ext-redis requires the options array even when empty —
+            // newer phpredis builds reject the 5-arg form. [] keeps the
+            // default behavior (no JUSTID/FORCE/IDLE/RETRYCOUNT).
+            [],
         );
         if ($claimed === false || empty($claimed)) {
             return;

--- a/src/Services/Outbox/RedisStreamConsumer.php
+++ b/src/Services/Outbox/RedisStreamConsumer.php
@@ -14,7 +14,7 @@ use Psr\Log\NullLogger;
  * outbox row, invoke OutboxProcessor) doesn't get tangled with Redis
  * Streams plumbing, and so we can unit-test by mocking \Redis.
  */
-final class RedisStreamConsumer
+final class RedisStreamConsumer implements StreamConsumerInterface
 {
     private const CLAIM_IDLE_MS = 30_000;
 

--- a/src/Services/Outbox/StreamConsumerInterface.php
+++ b/src/Services/Outbox/StreamConsumerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Outbox;
+
+interface StreamConsumerInterface
+{
+    public function ensureGroup(): void;
+
+    /**
+     * @param callable(int): void $process
+     */
+    public function readOnce(int $blockMs, callable $process): void;
+}

--- a/src/Services/RoleCascadeService.php
+++ b/src/Services/RoleCascadeService.php
@@ -4,7 +4,14 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Services;
 
+use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\Exception\OpenFgaApiException;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxClassifier;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxDisposition;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
+use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -23,7 +30,9 @@ class RoleCascadeService
         private OpenFgaClient $fga,
         private ZitadelService $zitadel,
         private AccessRequestRepository $repo,
-        private ?LoggerInterface $logger = null
+        private ?LoggerInterface $logger = null,
+        private ?OutboxRepository $outboxRepo = null,
+        private ?OutboxNotifier $outboxNotifier = null,
     ) {
     }
 
@@ -32,11 +41,33 @@ class RoleCascadeService
      */
     public static function fromEnv(?LoggerInterface $logger = null): self
     {
+        $redis = null;
+        if (extension_loaded('redis') && ( isset($_ENV['REDIS_HOST']) || isset($_ENV['REDIS_SOCKET']) )) {
+            try {
+                $redis = new \Redis();
+                if (isset($_ENV['REDIS_SOCKET']) && is_string($_ENV['REDIS_SOCKET']) && $_ENV['REDIS_SOCKET'] !== '') {
+                    $redis->connect((string) $_ENV['REDIS_SOCKET']);
+                } else {
+                    $redisHost = is_string($_ENV['REDIS_HOST'] ?? null) ? $_ENV['REDIS_HOST'] : '127.0.0.1';
+                    $redisPort = is_numeric($_ENV['REDIS_PORT'] ?? null) ? (int) $_ENV['REDIS_PORT'] : 6379;
+                    $redis->connect($redisHost, $redisPort);
+                }
+                if (isset($_ENV['REDIS_PASSWORD']) && is_string($_ENV['REDIS_PASSWORD']) && $_ENV['REDIS_PASSWORD'] !== '') {
+                    $redis->auth((string) $_ENV['REDIS_PASSWORD']);
+                }
+            } catch (\Throwable) {
+                $redis = null; // Best-effort; fall back to PG-only durability.
+            }
+        }
+        $streamName = is_string($_ENV['REDIS_OUTBOX_STREAM'] ?? null) ? $_ENV['REDIS_OUTBOX_STREAM'] : 'litcal:reconcile-stream';
+
         return new self(
             OpenFgaClient::fromEnv(),
             ZitadelService::fromEnv($logger),
             new AccessRequestRepository(),
-            $logger
+            $logger,
+            new OutboxRepository(Connection::getInstance()),
+            new OutboxNotifier($redis, $streamName, $logger),
         );
     }
 
@@ -131,13 +162,55 @@ class RoleCascadeService
                             'object'   => $fgaObject,
                         ];
                     } catch (\Throwable $e) {
-                        $this->logger?->warning('RoleCascadeService: deleteTuple failed during cascade', [
-                            'user_id'  => $userId,
-                            'role'     => $role,
-                            'relation' => $relation,
-                            'object'   => $fgaObject,
-                            'error'    => $e->getMessage(),
-                        ]);
+                        $disp = OutboxClassifier::classify($e);
+                        if ($disp === OutboxDisposition::BENIGN_SUCCESS) {
+                            // Tuple already gone — cascade is already consistent.
+                            $this->logger?->info('RoleCascadeService: deleteTuple benign during cascade', [
+                                'user_id'  => $userId,
+                                'role'     => $role,
+                                'relation' => $relation,
+                                'object'   => $fgaObject,
+                            ]);
+                            continue;
+                        }
+
+                        $idempotencyKey = sprintf(
+                            'role_cascade:%s:%s:delete_tuple:%s:%s:%s',
+                            $userId,
+                            $role,
+                            $fgaUser,
+                            $relation,
+                            $fgaObject,
+                        );
+                        $ids            = $this->outboxRepo?->insertBatch([
+                            [
+                                'operation'       => OutboxOperation::DELETE_TUPLE,
+                                'fga_user'        => $fgaUser,
+                                'fga_relation'    => $relation,
+                                'fga_object'      => $fgaObject,
+                                'idempotency_key' => $idempotencyKey,
+                                'metadata'        => [
+                                    'idempotency_key'   => $idempotencyKey,
+                                    'role_cascade_user' => $userId,
+                                    'role_cascade_role' => $role,
+                                ],
+                            ]
+                        ]) ?? [];
+                        foreach ($ids as $rowId) {
+                            $this->outboxNotifier?->notify($rowId, OutboxOperation::DELETE_TUPLE->value);
+                        }
+                        $this->logger?->warning(
+                            'RoleCascadeService: deleteTuple failed during cascade — outbox enqueued',
+                            [
+                                'user_id'        => $userId,
+                                'role'           => $role,
+                                'relation'       => $relation,
+                                'object'         => $fgaObject,
+                                'outbox_row_ids' => $ids,
+                                'error_code'     => $e instanceof OpenFgaApiException ? $e->getErrorCode() : null,
+                                'error'          => $e->getMessage(),
+                            ]
+                        );
                     }
                 }
             }

--- a/stubs/Redis.php
+++ b/stubs/Redis.php
@@ -93,11 +93,12 @@ if (!class_exists(\Redis::class)) {
         }
 
         /**
-         * @param string        $key
-         * @param string        $group
-         * @param string        $consumer
-         * @param int           $minIdleMs
-         * @param array<string> $ids
+         * @param string                $key
+         * @param string                $group
+         * @param string                $consumer
+         * @param int                   $minIdleMs
+         * @param array<string>         $ids
+         * @param array<string, mixed>  $options
          * @return array<string, array<string, string>>|false
          */
         public function xClaim(
@@ -106,6 +107,7 @@ if (!class_exists(\Redis::class)) {
             string $consumer,
             int $minIdleMs,
             array $ids,
+            array $options = [],
         ): array|false {
             return false;
         }

--- a/stubs/Redis.php
+++ b/stubs/Redis.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Minimal Redis stubs for static analysis and unit testing in environments
+ * where ext-redis is not installed.
+ *
+ * These declarations are only loaded when the \Redis class does not already
+ * exist (i.e. when ext-redis is absent). In production the extension provides
+ * the real class; here we just need enough surface for PHPStan L10 and
+ * PHPUnit's createMock(\Redis::class) to work.
+ */
+
+declare(strict_types=1);
+
+if (!class_exists(\Redis::class)) {
+    class Redis
+    {
+        /**
+         * @param array<string, string> $fields
+         * @return string|false
+         */
+        public function xAdd(string $key, string $id, array $fields): string|false
+        {
+            return false;
+        }
+
+        /**
+         * @param string                    $operation  CREATE | SETID | DESTROY | DELCONSUMER
+         * @param string                    $key
+         * @param string                    $group
+         * @param string|int                $msgId
+         * @param bool                      $mkStream
+         * @return bool
+         */
+        public function xGroup(
+            string $operation,
+            string $key,
+            string $group,
+            string|int $msgId = '$',
+            bool $mkStream = false,
+        ): bool {
+            return false;
+        }
+
+        /**
+         * @param string                    $group
+         * @param string                    $consumer
+         * @param array<string, string>     $streams    keys = stream name, values = last-id
+         * @param int                       $count
+         * @param int|null                  $blockMs
+         * @return array<string, array<string, array<string, string>>>|false
+         */
+        public function xReadGroup(
+            string $group,
+            string $consumer,
+            array $streams,
+            int $count = 1,
+            ?int $blockMs = null,
+        ): array|false {
+            return false;
+        }
+
+        /**
+         * @param string        $key
+         * @param string        $group
+         * @param array<string> $ids
+         * @return int|false
+         */
+        public function xAck(string $key, string $group, array $ids): int|false
+        {
+            return false;
+        }
+
+        /**
+         * Summary form (2 args): returns array{0: int, 1: string, 2: string, 3: int}|false
+         * Detail form (5 args): returns array<int, array{0: string, 1: string, 2: int, 3: int}>|false
+         *
+         * @param string      $key
+         * @param string      $group
+         * @param string|null $start
+         * @param string|null $end
+         * @param int|null    $count
+         * @return array<int|string, mixed>|false
+         */
+        public function xPending(
+            string $key,
+            string $group,
+            ?string $start = null,
+            ?string $end = null,
+            ?int $count = null,
+        ): array|false {
+            return false;
+        }
+
+        /**
+         * @param string        $key
+         * @param string        $group
+         * @param string        $consumer
+         * @param int           $minIdleMs
+         * @param array<string> $ids
+         * @return array<string, array<string, string>>|false
+         */
+        public function xClaim(
+            string $key,
+            string $group,
+            string $consumer,
+            int $minIdleMs,
+            array $ids,
+        ): array|false {
+            return false;
+        }
+    }
+}
+
+if (!class_exists(\RedisException::class)) {
+    class RedisException extends \RuntimeException
+    {
+    }
+}


### PR DESCRIPTION
Closes the Options B and C work from issue #567. Lands the spec, the implementation plan, and the 37 implementation commits as one PR per the design's "B and C share a single coherent design" decision.

## What this delivers

A Postgres outbox + Redis Streams + systemd consumer + cron backstop that turns OpenFGA tuple writes/deletes from "best-effort during the request" into "eventually consistent with admin-visible DLQ".

### Architecture

```
HTTP request → handler (PG tx wraps DB write + outbox.insertBatch)
            → sync fast-path: OutboxProcessor::processSync per row
            → XADD to Redis Stream for any still-pending row
            
systemd ↔ ConsumerLoop ↔ RedisStreamConsumer ↔ OutboxProcessor (XREADGROUP, sub-second reconciliation)
cron    → bin/reconcile-outbox backstop → BackstopRunner → OutboxProcessor (every 5 min, picks up cracks)
admin   → GET /admin/outbox?status=… | ?summary=1 | POST /admin/outbox/{id}/retry
ops     → GET /health → openfga_outbox block (counts, oldest_pending_age, consumer.redis_reachable, oldest_pel_idle)
```

### Invariants

- **Atomicity:** handler's PG transaction wraps `repo.write` + `outbox.insertBatch`. Either both commit or neither.
- **Idempotency:** deterministic handler-built keys + UNIQUE index on `metadata->>'idempotency_key'` + `ON CONFLICT DO NOTHING`. Reissuing the same approve/revoke returns the same outbox row IDs.
- **Terminal-status stickiness:** all four UPDATE mutations include `WHERE … AND status IN (…)` guards. `markRetryable` cannot downgrade a `failed_terminal` row.
- **At-least-once:** SKIP LOCKED + consumer PEL + backstop together guarantee every row is eventually attempted.
- **Graceful degradation:** Redis unreachable → handler skips XADD (logged WARNING); backstop drains within 5 min. PG durability unaffected.

### Retry policy

Exponential backoff 1s → 2s → 4s → … → 512s, capped at 2^9. Max 10 attempts (~17 min budget) before a row goes `failed_terminal`. Validation 4xx is terminal on first attempt. Benign duplicates (`TupleAlreadyExistsException` / `TupleNotFoundException`) count as success.

### Semantic shift from #628

`success: true` now means **DB committed** rather than **all sync FGA work succeeded**. New fields `outbox_pending`, `outbox_failed`, `outbox_ids` carry the side-effect state; the `message` field carries the warning when reconciliation is deferred. Pre-existing tests that asserted `success: false` on transient FGA failures were updated to reflect the new contract.

## Files

**New** (~30): migration, `OutboxOperation`/`OutboxStatus`/`OutboxDisposition` enums, `OutboxBackoff`, `OutboxClassifier`, `OutboxRow`, `OutboxRepository`, `OutboxProcessor` (+ `OutboxProcessorInterface`), `OutboxNotifier`, `RedisStreamConsumer` (+ `StreamConsumerInterface`), `ConsumerLoop`, `BackstopRunner`, `bin/reconcile-outbox`, `OutboxAdminHandler`, `HealthHandler`, `Handlers/Ops/`, deploy artifacts (systemd unit + cron + runbook), tests for every layer.

**Modified:** `AccessRequestAdminHandler` (approve + revoke refactored), `PermissionAdminHandler` (grant + revoke refactored), `RoleCascadeService` (silent catch → outbox enqueue), `Router` (`/admin/outbox` and `/health` routes), `Health.php` (outbox stats), `.env.example`, `composer.json`.

## Test plan

- [x] `composer test` — 1235 tests / 5 pre-existing skips / no new skips
- [x] `composer analyse` — PHPStan L10 clean (267 files)
- [x] `composer lint` — phpcs PSR-12 clean
- [x] `composer lint:md` — markdown lint clean
- [x] `composer reconciler:backstop` — end-to-end CLI works
- [x] Migration up/down roundtrip — verified
- [ ] Reviewer: deploy the systemd unit + cron on staging and verify the consumer drains a real approve into OpenFGA

## Process trail

- Spec: `docs/superpowers/specs/2026-06-02-openfga-async-reconciliation-design.md`
- Plan: `docs/superpowers/plans/2026-06-02-openfga-async-reconciliation.md`
- Final whole-branch review (opus): Approved with 5 Important items, all addressed in commits 270117df / 625076b9 / b2689829 / 4742d15c / 77f03f63 / 3cc05e8f.
- Tracking issue opened during brainstorming: #630 (future metrics framework — out of scope for this PR).

## Out of scope (per spec §10)

- Zitadel role-sync moving into the outbox (its `zitadel_sync_status` column stays).
- Automated pruning of `succeeded` rows (runbook documents the SQL; ship automation only when table size warrants).
- Bulk `/retry-all` endpoint (single-row retry covers v1).
- `lease_until` column for multi-consumer scale (YAGNI; trivial to add later).
- Metrics framework (tracked in #630).
- `Retry-After` header honoring for 429s (premature until observed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Health endpoint with DB + outbox status; admin endpoint to list/summary/retry outbox rows
  * Async OpenFGA reconciliation: consumer loop, Redis-stream notifications, cron backstop, CLI entrypoint and systemd service

* **Documentation**
  * Operator runbook and design doc with install, diagnostics, and troubleshooting

* **Tests**
  * Extensive test coverage for outbox pipeline, consumer, processor, notifier, classifier, backoff, handlers, and health

* **Chores**
  * Example env vars for reconciliation, composer scripts and extension suggestions, Redis stub for CI/dev
<!-- end of auto-generated comment: release notes by coderabbit.ai -->