### PR TITLE
fix(ics): don't 503 the calendar when GitHub release lookup fails

### DIFF
--- a/phpunit_tests/Handlers/CalendarHandlerTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerTest.php
@@ -109,4 +109,39 @@ final class CalendarHandlerTest extends AbstractHandlerTestCase
         $this->makeHandler(['nation', 'ZZ', '2025'])
             ->handle($this->requestFor('GET', '/calendar/nation/ZZ/2025', ['Accept-Language' => 'la']));
     }
+
+    /**
+     * On a successful GitHub release lookup, the release object is passed
+     * through unchanged to supply the ICS CREATED timestamp.
+     */
+    public function testResolveIcalReleaseObjectReturnsReleaseOnSuccess(): void
+    {
+        $release = (object) ['published_at' => '2024-01-01T00:00:00Z', 'tag_name' => 'v9.9.9'];
+        $infoObj = (object) ['status' => 'success', 'obj' => $release];
+
+        $result = ( new \ReflectionMethod(CalendarHandler::class, 'resolveIcalReleaseObject') )
+            ->invoke($this->makeHandler(), $infoObj);
+
+        self::assertSame($release, $result, 'A successful lookup must return the GitHub release object unchanged');
+    }
+
+    /**
+     * When the GitHub release lookup fails (e.g. api.github.com rate-limits the
+     * server), ICS generation must not 503: it falls back to the current UTC
+     * time so produceIcal can still emit a valid CREATED line.
+     */
+    public function testResolveIcalReleaseObjectFallsBackToUtcNowOnError(): void
+    {
+        $infoObj = (object) ['status' => 'error', 'message' => '403 rate limit exceeded'];
+
+        $result = ( new \ReflectionMethod(CalendarHandler::class, 'resolveIcalReleaseObject') )
+            ->invoke($this->makeHandler(), $infoObj);
+
+        self::assertIsString($result->published_at);
+        self::assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/',
+            $result->published_at,
+            'Fallback published_at must be an RFC3339 UTC timestamp for the ICS CREATED field'
+        );
+    }
 }

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4471,17 +4471,21 @@ final class CalendarHandler extends AbstractHandler
                 $infoObj = $this->getGithubReleaseInfo();
                 if ($infoObj->status === 'success') {
                     /** @var GitHubReleaseInfoSuccess $infoObj */
-                    $responseBody = $this->produceIcal($SerializeableLitCal, $infoObj->obj);
+                    $releaseObj = $infoObj->obj;
                 } else {
-                    // if we cannot get the latest release info, we return an error
-                    // and we do not produce the iCal file
+                    // The GitHub release lookup supplies only the per-event ICS
+                    // CREATED timestamp, which is non-essential metadata. When
+                    // GitHub is unreachable or rate-limited (HTTP 403), don't make
+                    // the entire calendar unavailable (503) — fall back to the
+                    // current UTC time and log a warning so the ICS still renders.
                     /** @var GitHubReleaseInfoError $infoObj */
-                    $message = sprintf(
-                        _('Error receiving or parsing info from GitHub about latest release: %s.'),
-                        $infoObj->message
-                    );
-                    throw new ServiceUnavailableException($message);
+                    $logger = LoggerFactory::create('calendar', null, 30, false, true, false);
+                    $logger->warning('GitHub release info unavailable; using fallback timestamp for ICS CREATED', [
+                        'reason' => $infoObj->message,
+                    ]);
+                    $releaseObj = (object) ['published_at' => gmdate('Y-m-d\TH:i:s\Z')];
                 }
+                $responseBody = $this->produceIcal($SerializeableLitCal, $releaseObj);
                 break;
             default:
                 $responseBody = json_encode($SerializeableLitCal, JSON_THROW_ON_ERROR);

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4363,6 +4363,35 @@ final class CalendarHandler extends AbstractHandler
 
 
     /**
+     * Resolve the GitHub release object whose `published_at` becomes each ICS
+     * VEVENT's CREATED timestamp.
+     *
+     * The release lookup is non-essential metadata: when it failed (GitHub
+     * unreachable or rate-limited with HTTP 403), it must not take the whole
+     * calendar down with a 503. Fall back to the current UTC time and log a
+     * warning so the ICS still renders.
+     *
+     * @param GitHubReleaseInfoSuccess|GitHubReleaseInfoError $infoObj result of {@see self::getGithubReleaseInfo()}
+     * @return \stdClass an object exposing a `published_at` string for {@see self::produceIcal()}
+     */
+    private function resolveIcalReleaseObject(\stdClass $infoObj): \stdClass
+    {
+        if ($infoObj->status === 'success') {
+            /** @var GitHubReleaseInfoSuccess $infoObj */
+            return $infoObj->obj;
+        }
+
+        /** @var GitHubReleaseInfoError $infoObj */
+        $logger = LoggerFactory::create('calendar', null, 30, false, true, false);
+        $logger->warning('GitHub release info unavailable; using fallback timestamp for ICS CREATED', [
+            'reason' => $infoObj->message,
+        ]);
+
+        return (object) ['published_at' => gmdate('Y-m-d\TH:i:s\Z')];
+    }
+
+
+    /**
      * This function generates the response for the requested Liturgical Calendar.
      *
      * Depending on the value of $this->CalendarParams->ReturnType, it will either return a JSON object,
@@ -4468,23 +4497,7 @@ final class CalendarHandler extends AbstractHandler
                 }
                 break;
             case ReturnTypeParam::ICS:
-                $infoObj = $this->getGithubReleaseInfo();
-                if ($infoObj->status === 'success') {
-                    /** @var GitHubReleaseInfoSuccess $infoObj */
-                    $releaseObj = $infoObj->obj;
-                } else {
-                    // The GitHub release lookup supplies only the per-event ICS
-                    // CREATED timestamp, which is non-essential metadata. When
-                    // GitHub is unreachable or rate-limited (HTTP 403), don't make
-                    // the entire calendar unavailable (503) — fall back to the
-                    // current UTC time and log a warning so the ICS still renders.
-                    /** @var GitHubReleaseInfoError $infoObj */
-                    $logger = LoggerFactory::create('calendar', null, 30, false, true, false);
-                    $logger->warning('GitHub release info unavailable; using fallback timestamp for ICS CREATED', [
-                        'reason' => $infoObj->message,
-                    ]);
-                    $releaseObj = (object) ['published_at' => gmdate('Y-m-d\TH:i:s\Z')];
-                }
+                $releaseObj   = $this->resolveIcalReleaseObject($this->getGithubReleaseInfo());
                 $responseBody = $this->produceIcal($SerializeableLitCal, $releaseObj);
                 break;
             default:


### PR DESCRIPTION
## Problem

Two intermittent CI failures, both rooted in the same external dependency — the API's unauthenticated call to `api.github.com/.../releases/latest`:

1. `Routes/Readonly/CalendarTest::testGetCalendarReturnsIcal` — returned **503** instead of 200 when GitHub responded `403 rate limit exceeded` (shared CI runner IPs hit GitHub's 60-req/hr unauthenticated limit).
2. `WebSocket/ValidateCalendarTest::testIcsHappyPathEmitsThreeSuccessMessages` — timed out with `Read timed out waiting for 2 more byte(s)`.

### Why they're the same bug

The ICS branch of `CalendarHandler` threw `ServiceUnavailableException` (503) whenever `getGithubReleaseInfo()` failed. But that release info is used **only** to populate each `VEVENT`'s `CREATED:` timestamp (`produceIcal`, line ~4872) — non-essential metadata. 503-ing the whole calendar for it is disproportionate.

The WS test fetches `/calendar?return_type=ICS` through `Health.php`'s `cachedGet`. When that endpoint 503'd, the validator couldn't parse the error body as ICS, emitted only 2 frames (`file-exists` ✓, decode ✗) instead of 3, and the test blocked waiting for the never-sent third frame until its 30 s read timeout.

## Fix

When the GitHub release lookup fails, **fall back to the current UTC time** (logging a warning) and still render the ICS, instead of throwing 503:

```php
} else {
    /** @var GitHubReleaseInfoError $infoObj */
    $logger = LoggerFactory::create('calendar', null, 30, false, true, false);
    $logger->warning('GitHub release info unavailable; using fallback timestamp for ICS CREATED', [
        'reason' => $infoObj->message,
    ]);
    $releaseObj = (object) ['published_at' => gmdate('Y-m-d\TH:i:s\Z')];
}
$responseBody = $this->produceIcal($SerializeableLitCal, $releaseObj);
```

This is a production-resilience improvement (a calendar should not be unavailable because GitHub is rate-limited) and removes the only 503 path in ICS generation, fixing both flakes.

## Verification

- `phpcs` ✓, `parallel-lint` ✓, **PHPStan level 10 ✓**.
- No test expects a 503 from this path (`testGetCalendarReturnsIcal` expects 200).
- Note: the flakes are non-deterministic (depend on GitHub rate-limiting the runner), so a single green CI run can't *prove* the fix — but it eliminates the failure path entirely.

## Follow-up (not in this PR)

Authenticating the GitHub call with `GITHUB_TOKEN` in CI would also reduce how often the limit is hit (1000 req/hr authenticated). Worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)