### PR TITLE
feat(fga): general_roman_calendar object type + write-route enforcement

### DIFF
--- a/docs/superpowers/plans/2026-06-20-general-roman-calendar-object-type.md
+++ b/docs/superpowers/plans/2026-06-20-general-roman-calendar-object-type.md
@@ -1,0 +1,1006 @@
+# General Roman Calendar Object Type — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended)
+> or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax
+> for tracking.
+
+**Goal:** Add a `general_roman_calendar` OpenFGA object type (five enumerated object IDs) so Calendar
+Editors can be granted edit rights on the Temporale, the Editio Typica Sanctorale editions, and the
+Decrees — and enforce it on the `temporale`, `missals`, and `decrees` write routes.
+
+**Architecture:** The API (`LiturgicalCalendarAPI`) is authoritative: it owns the FGA model, the
+object-type/ID validation, and the per-route enforcement. The frontend (`LiturgicalCalendarFrontend`)
+mirrors the FGA model byte-for-byte and exposes the new type in its grant and access-request UIs.
+Phase A (API) lands first; Phase B (frontend) lands after.
+
+**Tech Stack:** PHP 8.4 (PSR-7/15), OpenFGA, PHPUnit (`phpunit_tests/`), vanilla ES6 JS + Bootstrap (frontend), gettext i18n.
+
+**Spec:** `docs/superpowers/specs/2026-06-20-general-roman-calendar-object-type-design.md`
+
+## Global Constraints
+
+- New object type string: `general_roman_calendar` (exact).
+- The five valid object IDs (exact): `temporale`, `EDITIO_TYPICA_1970`, `EDITIO_TYPICA_2002`, `EDITIO_TYPICA_2008`, `decrees`.
+- Relations unchanged: `admin`, `viewer`, `editor`, `deleter`. Write→relation map: `PUT`/`PATCH`→`editor`, `DELETE`→`deleter`.
+- Roles allowed to hold the new type: `calendar_editor` and `developer` only.
+- The two `scripts/openfga-model.json` files (API + frontend) MUST remain byte-identical.
+- Admin role bypasses all FGA checks (existing behavior — do not change).
+- Only `PUT`/`PATCH`/`DELETE` are gated (matches existing `data`/`tests` behavior); `POST` is out of scope.
+- PHP: PSR-12, short arrays, 4-space indent. Run `composer lint:fix` before committing; never use `--no-verify`.
+- API branch: `feat/general-roman-calendar-object-type` (off `development`, already created). Frontend branch: create `feat/general-roman-calendar-object-type` off `development`.
+
+---
+
+## Phase A — API (`LiturgicalCalendarAPI`)
+
+Work on branch `feat/general-roman-calendar-object-type`. All paths in Phase A are relative to the
+`LiturgicalCalendarAPI` repo root. Run a single test with `vendor/bin/phpunit phpunit_tests/Path/To/Test.php`.
+
+### Task A1: Add `general_roman_calendar` to the FGA model
+
+**Files:**
+
+- Modify: `scripts/openfga-model.json`
+- Test: `phpunit_tests/Services/OpenFgaModelTest.php` (create)
+
+**Interfaces:**
+
+- Produces: a `general_roman_calendar` type definition with relations `admin/viewer/editor/deleter`, each `directly_related_user_types: [{ "type": "user" }]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+
+final class OpenFgaModelTest extends TestCase
+{
+    /** @return array<string, mixed> */
+    private function loadModel(): array
+    {
+        $json = file_get_contents(__DIR__ . '/../../scripts/openfga-model.json');
+        self::assertIsString($json);
+        $model = json_decode($json, true);
+        self::assertIsArray($model);
+        return $model;
+    }
+
+    public function testGeneralRomanCalendarTypeExistsWithStandardRelations(): void
+    {
+        $model = $this->loadModel();
+        $types = [];
+        foreach ($model['type_definitions'] as $def) {
+            $types[$def['type']] = $def;
+        }
+
+        self::assertArrayHasKey('general_roman_calendar', $types);
+        $grc = $types['general_roman_calendar'];
+        foreach (['admin', 'viewer', 'editor', 'deleter'] as $relation) {
+            self::assertArrayHasKey($relation, $grc['relations']);
+            self::assertSame(
+                [['type' => 'user']],
+                $grc['metadata']['relations'][$relation]['directly_related_user_types']
+            );
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/OpenFgaModelTest.php`
+Expected: FAIL — `Failed asserting that an array has the key 'general_roman_calendar'`.
+
+- [ ] **Step 3: Add the type to the model**
+
+In `scripts/openfga-model.json`, add this object to the `type_definitions` array (after `test_definition`):
+
+```json
+    {
+      "type": "general_roman_calendar",
+      "relations": {
+        "admin": { "this": {} },
+        "viewer": { "this": {} },
+        "editor": { "this": {} },
+        "deleter": { "this": {} }
+      },
+      "metadata": {
+        "relations": {
+          "admin":   { "directly_related_user_types": [{ "type": "user" }] },
+          "viewer":  { "directly_related_user_types": [{ "type": "user" }] },
+          "editor":  { "directly_related_user_types": [{ "type": "user" }] },
+          "deleter": { "directly_related_user_types": [{ "type": "user" }] }
+        }
+      }
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/OpenFgaModelTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/openfga-model.json phpunit_tests/Services/OpenFgaModelTest.php
+git commit -m "feat(fga): add general_roman_calendar object type to model"
+```
+
+---
+
+### Task A2: Repository — object type, role map, and object-ID validation
+
+**Files:**
+
+- Modify: `src/Repositories/AccessRequestRepository.php:47` (VALID_OBJECT_TYPES), `:56` (ROLE_OBJECT_TYPES)
+- Test: `phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php` (create)
+
+**Interfaces:**
+
+- Produces:
+  - `AccessRequestRepository::VALID_OBJECT_TYPES` now contains `general_roman_calendar`.
+  - `AccessRequestRepository::ROLE_OBJECT_TYPES['calendar_editor']` and `['developer']` contain `general_roman_calendar`.
+  - `AccessRequestRepository::GRC_OBJECT_IDS` — `array<int,string>` of the five valid IDs.
+  - `AccessRequestRepository::isValidObjectIdForType(string $objectType, string $objectId): bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use PHPUnit\Framework\TestCase;
+
+final class AccessRequestRepositoryConstantsTest extends TestCase
+{
+    public function testGeneralRomanCalendarIsAValidObjectType(): void
+    {
+        self::assertContains('general_roman_calendar', AccessRequestRepository::VALID_OBJECT_TYPES);
+    }
+
+    public function testCalendarEditorAndDeveloperCanHoldGeneralRomanCalendar(): void
+    {
+        self::assertContains('general_roman_calendar', AccessRequestRepository::ROLE_OBJECT_TYPES['calendar_editor']);
+        self::assertContains('general_roman_calendar', AccessRequestRepository::ROLE_OBJECT_TYPES['developer']);
+        self::assertNotContains('general_roman_calendar', AccessRequestRepository::ROLE_OBJECT_TYPES['test_editor']);
+    }
+
+    public function testGrcObjectIdValidation(): void
+    {
+        foreach (['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees'] as $id) {
+            self::assertTrue(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', $id));
+        }
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', 'EDITIO_TYPICA_1971'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', ''));
+        // Other types keep free-form ids (non-empty)
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('national_calendar', 'IT'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('national_calendar', ''));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php`
+Expected: FAIL — `general_roman_calendar` not found / `isValidObjectIdForType` undefined.
+
+- [ ] **Step 3: Update constants and add the helper**
+
+In `src/Repositories/AccessRequestRepository.php`, change line 47 to:
+
+```php
+    public const VALID_OBJECT_TYPES = ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition', 'general_roman_calendar'];
+```
+
+Change the `ROLE_OBJECT_TYPES` constant (line ~56) to:
+
+```php
+    public const ROLE_OBJECT_TYPES = [
+        'developer'       => ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition', 'general_roman_calendar'],
+        'calendar_editor' => ['national_calendar', 'diocesan_calendar', 'wider_region', 'general_roman_calendar'],
+        'test_editor'     => ['test_definition'],
+    ];
+```
+
+Immediately after the `VALID_RELATIONS` constant (line ~42) add:
+
+```php
+    /**
+     * The fixed, enumerated set of object IDs valid for the general_roman_calendar type.
+     *
+     * @var array<int, string>
+     */
+    public const GRC_OBJECT_IDS = ['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees'];
+```
+
+Add this static method to the class (e.g. just below the constructor):
+
+```php
+    /**
+     * Validate an object_id for a given object_type.
+     *
+     * general_roman_calendar uses a fixed enumerated id set; all other types accept any
+     * non-empty id (the resource itself is validated downstream by the handler).
+     */
+    public static function isValidObjectIdForType(string $objectType, string $objectId): bool
+    {
+        if ($objectType === 'general_roman_calendar') {
+            return in_array($objectId, self::GRC_OBJECT_IDS, true);
+        }
+
+        return $objectId !== '';
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Repositories/AccessRequestRepository.php phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
+git commit -m "feat(fga): allow general_roman_calendar tuples in repository constants"
+```
+
+---
+
+### Task A3: Middleware — fixed object IDs + GRC/missals factories
+
+**Files:**
+
+- Modify: `src/Http/Middleware/OpenFgaAuthorizationMiddleware.php`
+- Test: `phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php` (extend existing)
+
+**Interfaces:**
+
+- Consumes: `RomanMissal::isLatinMissal(string): bool` (`src/Enum/RomanMissal.php`).
+- Produces:
+  - constructor 4th param `?string $fixedObjectId = null`; when set, it is used as the object id instead of a request attribute.
+  - `OpenFgaAuthorizationMiddleware::forGeneralRomanCalendar(OpenFgaClient $client, string $objectId): self`
+  - `OpenFgaAuthorizationMiddleware::forMissals(OpenFgaClient $client, string $missalId): self`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php`. These verify the FGA object string
+each factory checks. Use the existing test's helpers for building a request/handler and a fake/mock
+`OpenFgaClient`; the assertions below capture the `check()` arguments.
+
+```php
+public function testForGeneralRomanCalendarChecksFixedObjectId(): void
+{
+    $client = $this->createMock(\LiturgicalCalendar\Api\Services\OpenFgaClient::class);
+    $client->expects($this->once())
+        ->method('check')
+        ->with('user:abc', 'editor', 'general_roman_calendar:temporale')
+        ->willReturn(true);
+
+    $mw      = \LiturgicalCalendar\Api\Http\Middleware\OpenFgaAuthorizationMiddleware::forGeneralRomanCalendar($client, 'temporale');
+    $request = $this->makeRequest('PUT', ['sub' => 'abc', 'roles' => ['calendar_editor']]);
+    $mw->process($request, $this->passthroughHandler());
+}
+
+public function testForMissalsEditioTypicaChecksGeneralRomanCalendar(): void
+{
+    $client = $this->createMock(\LiturgicalCalendar\Api\Services\OpenFgaClient::class);
+    $client->expects($this->once())
+        ->method('check')
+        ->with('user:abc', 'editor', 'general_roman_calendar:EDITIO_TYPICA_2002')
+        ->willReturn(true);
+
+    $mw      = \LiturgicalCalendar\Api\Http\Middleware\OpenFgaAuthorizationMiddleware::forMissals($client, 'EDITIO_TYPICA_2002');
+    $request = $this->makeRequest('PATCH', ['sub' => 'abc', 'roles' => ['calendar_editor']]);
+    $mw->process($request, $this->passthroughHandler());
+}
+
+public function testForMissalsNationalChecksNationalCalendarByPrefix(): void
+{
+    $client = $this->createMock(\LiturgicalCalendar\Api\Services\OpenFgaClient::class);
+    $client->expects($this->once())
+        ->method('check')
+        ->with('user:abc', 'editor', 'national_calendar:IT')
+        ->willReturn(true);
+
+    $mw      = \LiturgicalCalendar\Api\Http\Middleware\OpenFgaAuthorizationMiddleware::forMissals($client, 'IT_1983');
+    $request = $this->makeRequest('PUT', ['sub' => 'abc', 'roles' => ['calendar_editor']]);
+    $mw->process($request, $this->passthroughHandler());
+}
+```
+
+> Note: `makeRequest()` and `passthroughHandler()` are helper names — reuse the equivalents already
+> present in this test file (it already builds requests with the `oidc_user` attribute and a
+> pass-through handler). If they have different names, call the existing ones.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php`
+Expected: FAIL — `forGeneralRomanCalendar`/`forMissals` undefined.
+
+- [ ] **Step 3: Implement the middleware changes**
+
+Add the import near the top of `src/Http/Middleware/OpenFgaAuthorizationMiddleware.php`:
+
+```php
+use LiturgicalCalendar\Api\Enum\RomanMissal;
+```
+
+Add a property alongside the other private properties:
+
+```php
+    /**
+     * When non-null, this fixed object id is used instead of a request attribute.
+     */
+    private ?string $fixedObjectId;
+```
+
+Replace the constructor with:
+
+```php
+    public function __construct(
+        OpenFgaClient $client,
+        string $objectType,
+        string $resourceIdAttribute = 'calendar_id',
+        ?string $fixedObjectId = null
+    ) {
+        $this->client              = $client;
+        $this->objectType          = $objectType;
+        $this->resourceIdAttribute = $resourceIdAttribute;
+        $this->fixedObjectId       = $fixedObjectId;
+    }
+```
+
+Replace `extractResourceId()` with:
+
+```php
+    private function extractResourceId(ServerRequestInterface $request): ?string
+    {
+        if ($this->fixedObjectId !== null) {
+            return $this->fixedObjectId;
+        }
+
+        $value = $request->getAttribute($this->resourceIdAttribute);
+        if ($value !== null && ( is_string($value) || is_int($value) )) {
+            return (string) $value;
+        }
+
+        return null;
+    }
+```
+
+Add the two factories next to `forTestDefinition()`:
+
+```php
+    /**
+     * Create middleware for a General Roman Calendar sub-resource with a fixed object id
+     * (e.g. "temporale" or "decrees").
+     */
+    public static function forGeneralRomanCalendar(OpenFgaClient $client, string $objectId): self
+    {
+        return new self($client, 'general_roman_calendar', 'calendar_id', $objectId);
+    }
+
+    /**
+     * Create middleware for a missal write.
+     *
+     * Editio Typica (Latin) missals are General Roman Calendar Sanctorale sub-resources;
+     * national/regional missals follow the owning national calendar's grants (id prefix).
+     */
+    public static function forMissals(OpenFgaClient $client, string $missalId): self
+    {
+        if (RomanMissal::isLatinMissal($missalId)) {
+            return new self($client, 'general_roman_calendar', 'calendar_id', $missalId);
+        }
+
+        $nation = explode('_', $missalId)[0];
+        return new self($client, 'national_calendar', 'calendar_id', $nation);
+    }
+```
+
+Update the class docblock object-type list to mention `temporale`/`missals`/`decrees` → `general_roman_calendar` / `national_calendar` (documentation only).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php`
+Expected: PASS (all, including pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Http/Middleware/OpenFgaAuthorizationMiddleware.php phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
+git commit -m "feat(fga): GRC + missals authorization middleware factories"
+```
+
+---
+
+### Task A4: Router — guard temporale, missals, decrees
+
+**Files:**
+
+- Modify: `src/Router.php:631` (protected-route list), `src/Router.php:676-705` (`configureAuthorizationPipeline`)
+- Test: `phpunit_tests/Http/RouterAuthorizationTest.php` (create) — or extend an existing Router test if present.
+
+**Interfaces:**
+
+- Consumes: `OpenFgaAuthorizationMiddleware::forGeneralRomanCalendar`, `::forMissals` (Task A3); `AuthorizationMiddleware::forCalendarEditor()` (existing).
+
+- [ ] **Step 1: Write the failing test**
+
+Verify the protected-route gate now includes `missals` and `decrees`. The simplest robust assertion is
+behavioral: a `PATCH /decrees/...` with no auth token returns 401 (auth middleware now applied) instead
+of reaching the handler. If the repo already has a Router test harness, add a case there; otherwise create:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+
+final class RouterAuthorizationTest extends TestCase
+{
+    /**
+     * The set of routes that require auth for write methods must include the
+     * General Roman Calendar write routes.
+     */
+    public function testProtectedWriteRoutesIncludeGrcRoutes(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../src/Router.php');
+        self::assertIsString($src);
+        // Guard list literal must contain all five route names.
+        self::assertMatchesRegularExpression(
+            "/in_array\\(\\s*\\\$route,\\s*\\['data',\\s*'tests',\\s*'temporale',\\s*'missals',\\s*'decrees'\\]/",
+            $src
+        );
+        // temporale must no longer be admin-only.
+        self::assertStringNotContainsString("// Temporale requires admin role", $src);
+    }
+}
+```
+
+> This is a guard-rail (static) test because Router wiring is hard to exercise in isolation. The real
+> authorization behavior is covered by Task A3's middleware tests; an end-to-end check is added in
+> Phase A verification (Task A7).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Http/RouterAuthorizationTest.php`
+Expected: FAIL — guard list does not yet contain `missals`/`decrees`.
+
+- [ ] **Step 3: Update the Router**
+
+Change the protected-route condition (line ~631) to:
+
+```php
+            in_array($route, ['data', 'tests', 'temporale', 'missals', 'decrees'], true)
+```
+
+In `configureAuthorizationPipeline()`, replace the `temporale` branch (lines ~702-705) with the following three branches:
+
+```php
+        } elseif ($route === 'temporale') {
+            $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
+            if ($oidcAvailable && $fgaClient !== null) {
+                $pipeline->pipe(OpenFgaAuthorizationMiddleware::forGeneralRomanCalendar($fgaClient, 'temporale'));
+            }
+        } elseif ($route === 'decrees') {
+            $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
+            if ($oidcAvailable && $fgaClient !== null) {
+                $pipeline->pipe(OpenFgaAuthorizationMiddleware::forGeneralRomanCalendar($fgaClient, 'decrees'));
+            }
+        } elseif ($route === 'missals') {
+            $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
+            if ($oidcAvailable && $fgaClient !== null && count($requestPathParts) >= 1) {
+                $pipeline->pipe(OpenFgaAuthorizationMiddleware::forMissals($fgaClient, $requestPathParts[0]));
+            }
+        }
+```
+
+- [ ] **Step 4: Run test + full suite to verify**
+
+Run: `vendor/bin/phpunit phpunit_tests/Http/RouterAuthorizationTest.php`
+Expected: PASS.
+Run: `composer test:quick`
+Expected: PASS (no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Router.php phpunit_tests/Http/RouterAuthorizationTest.php
+git commit -m "feat(fga): enforce GRC editor on temporale, missals, decrees routes"
+```
+
+---
+
+### Task A5: AccessRequestHandler — accept GRC in request submission/approval
+
+**Files:**
+
+- Modify: `src/Handlers/Auth/AccessRequestHandler.php:41` (VALID_OBJECT_TYPES), `:208-233` (submit validation), `:371-395` (approve validation)
+- Test: `phpunit_tests/Handlers/Auth/AccessRequestHandlerValidationTest.php` (create), or extend an existing AccessRequestHandler test.
+
+**Interfaces:**
+
+- Consumes: `AccessRequestRepository::isValidObjectIdForType()` (Task A2).
+
+- [ ] **Step 1: Write the failing test**
+
+Add focused tests that a `general_roman_calendar` permission with a valid id is accepted and with an
+invalid id is rejected. Mirror the existing AccessRequestHandler test setup (request body → handler →
+response). Example assertions on the validation path:
+
+```php
+public function testGrcPermissionWithValidObjectIdIsAccepted(): void
+{
+    $perms = [['object_type' => 'general_roman_calendar', 'object_id' => 'temporale', 'relation' => 'editor']];
+    self::assertTrue($this->submitIsAccepted('calendar_editor', $perms));
+}
+
+public function testGrcPermissionWithInvalidObjectIdIsRejected(): void
+{
+    $perms = [['object_type' => 'general_roman_calendar', 'object_id' => 'EDITIO_TYPICA_1971', 'relation' => 'editor']];
+    self::assertFalse($this->submitIsAccepted('calendar_editor', $perms));
+}
+```
+
+> `submitIsAccepted()` is a helper to write against the handler's existing entry point (it returns true
+> on 2xx, false on a `ValidationException`/4xx). Use the existing test harness's request builder.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Auth/AccessRequestHandlerValidationTest.php`
+Expected: FAIL — GRC type rejected as invalid object_type.
+
+- [ ] **Step 3: Implement**
+
+Add `'general_roman_calendar'` to the `VALID_OBJECT_TYPES` constant (line ~41):
+
+```php
+    private const VALID_OBJECT_TYPES = [
+        'national_calendar',
+        'diocesan_calendar',
+        'wider_region',
+        'test_definition',
+        'general_roman_calendar',
+    ];
+```
+
+In the submit-validation loop, after the `object_id === ''` check (line ~233), add:
+
+```php
+            if (!AccessRequestRepository::isValidObjectIdForType($objectType, $objectId)) {
+                throw new ValidationException(
+                    sprintf(
+                        'permissions[%d].object_id "%s" is invalid for object_type "%s". Valid ids: %s',
+                        $index,
+                        $objectId,
+                        $objectType,
+                        implode(', ', AccessRequestRepository::GRC_OBJECT_IDS)
+                    )
+                );
+            }
+```
+
+In the approve-validation loop, after the `in_array($objType, ...)` check (line ~385), add the same guard using the local names `$objType` / `$objId`:
+
+```php
+            if (!AccessRequestRepository::isValidObjectIdForType($objType, $objId)) {
+                throw new ValidationException(sprintf(
+                    'permissions[%d].object_id "%s" is invalid for object_type "%s". Valid ids: %s',
+                    $index,
+                    $objId,
+                    $objType,
+                    implode(', ', AccessRequestRepository::GRC_OBJECT_IDS)
+                ));
+            }
+```
+
+Ensure `use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;` is imported (it likely already is; add if missing).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Auth/AccessRequestHandlerValidationTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Handlers/Auth/AccessRequestHandler.php phpunit_tests/Handlers/Auth/AccessRequestHandlerValidationTest.php
+git commit -m "feat(fga): validate GRC object ids in access request handler"
+```
+
+---
+
+### Task A6: PermissionAdminHandler — accept GRC in admin grants
+
+**Files:**
+
+- Modify: `src/Handlers/Admin/PermissionAdminHandler.php:54` (VALID_OBJECT_TYPES), `:816-834` (`validateTupleParams`)
+- Test: `phpunit_tests/Handlers/Admin/PermissionAdminHandlerValidationTest.php` (create) or extend the existing admin handler test.
+
+**Interfaces:**
+
+- Consumes: `AccessRequestRepository::isValidObjectIdForType()` (Task A2).
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+public function testGrantGrcTupleWithValidIdPasses(): void
+{
+    self::assertTrue($this->tupleParamsValid('user:abc', 'general_roman_calendar', 'decrees', 'editor'));
+}
+
+public function testGrantGrcTupleWithInvalidIdFails(): void
+{
+    self::assertFalse($this->tupleParamsValid('user:abc', 'general_roman_calendar', 'nonsense', 'editor'));
+}
+```
+
+> `tupleParamsValid()` is a helper that calls the handler's grant validation (or `validateTupleParams`
+> via the public grant entry point) and returns true unless a `ValidationException` is thrown.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Admin/PermissionAdminHandlerValidationTest.php`
+Expected: FAIL — GRC type invalid.
+
+- [ ] **Step 3: Implement**
+
+Add `'general_roman_calendar'` to `VALID_OBJECT_TYPES` (line ~54):
+
+```php
+    private const VALID_OBJECT_TYPES = [
+        'national_calendar',
+        'diocesan_calendar',
+        'wider_region',
+        'test_definition',
+        'general_roman_calendar',
+    ];
+```
+
+In `validateTupleParams()`, after the `$objectId === ''` check (line ~824), add:
+
+```php
+        if (!AccessRequestRepository::isValidObjectIdForType($objectType, $objectId)) {
+            throw new ValidationException(
+                sprintf(
+                    'Invalid object_id "%s" for object_type "%s". Valid ids: %s',
+                    $objectId,
+                    $objectType,
+                    implode(', ', AccessRequestRepository::GRC_OBJECT_IDS)
+                )
+            );
+        }
+```
+
+Add `use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;` if not already imported.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/Admin/PermissionAdminHandlerValidationTest.php`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Handlers/Admin/PermissionAdminHandler.php phpunit_tests/Handlers/Admin/PermissionAdminHandlerValidationTest.php
+git commit -m "feat(fga): validate GRC object ids in permission admin handler"
+```
+
+---
+
+### Task A7: Phase A verification + static analysis
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run full quality gates**
+
+```bash
+composer parallel-lint
+composer lint
+composer analyse
+composer test
+```
+
+Expected: all pass. Fix any phpcs issues with `composer lint:fix`.
+
+- [ ] **Step 2: Apply the model to a running OpenFGA store (manual/integration)**
+
+In an environment with OpenFGA running, run the model-update script and confirm the new type is present:
+
+```bash
+./scripts/setup-openfga.sh
+```
+
+Expected: the script writes the updated authorization model containing `general_roman_calendar`.
+
+- [ ] **Step 3: Manual end-to-end smoke (documented, optional in CI)**
+
+Grant `editor` on `general_roman_calendar:temporale` to a test user, obtain their token, and confirm
+`PATCH /temporale/...` succeeds while a user without the grant gets 403. Record the result in the PR
+description.
+
+- [ ] **Step 4: Open the API PR**
+
+```bash
+git push -u origin feat/general-roman-calendar-object-type
+gh pr create --base development --title "feat(fga): general_roman_calendar object type + enforcement" --body "Implements docs/superpowers/specs/2026-06-20-general-roman-calendar-object-type-design.md (API side)."
+```
+
+---
+
+## Phase B — Frontend (`LiturgicalCalendarFrontend`)
+
+Start only after the API PR is merged (the model must exist server-side). All Phase B paths are relative
+to the `LiturgicalCalendarFrontend` repo root. Create branch `feat/general-roman-calendar-object-type`
+off `development`. Verify JS with `node --check <file>` and PHP with `composer lint`.
+
+### Task B1: Mirror the FGA model (byte-identical)
+
+**Files:**
+
+- Modify: `scripts/openfga-model.json`
+
+- [ ] **Step 1: Copy the model from the API repo**
+
+```bash
+cp ../LiturgicalCalendarAPI/scripts/openfga-model.json scripts/openfga-model.json
+```
+
+- [ ] **Step 2: Verify byte-identical**
+
+Run: `diff -q ../LiturgicalCalendarAPI/scripts/openfga-model.json scripts/openfga-model.json`
+Expected: no output (identical).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/openfga-model.json
+git commit -m "feat(fga): mirror general_roman_calendar in frontend openfga model"
+```
+
+---
+
+### Task B2: Admin grant UI — option, display name, object-id dropdown
+
+**Files:**
+
+- Modify: `admin-permissions.php:287` (object-type `<select>`), `:371` (i18n display-name map)
+- Modify: `assets/js/admin-permissions.js:53-57` (`objectTypeNames`), object-id field handling (~lines 32-33, 258-274)
+
+**Interfaces:**
+
+- Consumes: `config.i18n.generalRomanCalendar` (added in this task).
+
+- [ ] **Step 1: Add the option + i18n in `admin-permissions.php`**
+
+After the `test_definition` `<option>` (line ~287) add:
+
+```php
+                            <option value="general_roman_calendar"><?php echo htmlspecialchars(_('General Roman Calendar'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'); ?></option>
+```
+
+In the JS config `i18n` block, after `testDefinition:` (line ~371) add:
+
+```php
+                generalRomanCalendar: <?php echo json_encode(_('General Roman Calendar')); ?>,
+```
+
+- [ ] **Step 2: Update `assets/js/admin-permissions.js`**
+
+Add to the `objectTypeNames` map (after `test_definition`, line ~57):
+
+```javascript
+        'general_roman_calendar': config.i18n.generalRomanCalendar,
+```
+
+Add a module-level constant near the top of the file (after the element refs at lines ~32-33):
+
+```javascript
+    // Fixed object-id choices for the singleton-ish General Roman Calendar type.
+    const GRC_OBJECT_IDS = [
+        { id: 'temporale',          label: config.i18n.grcTemporale },
+        { id: 'EDITIO_TYPICA_1970', label: config.i18n.grcSanctorale1970 },
+        { id: 'EDITIO_TYPICA_2002', label: config.i18n.grcSanctorale2002 },
+        { id: 'EDITIO_TYPICA_2008', label: config.i18n.grcSanctorale2008 },
+        { id: 'decrees',            label: config.i18n.grcDecrees },
+    ];
+
+    // Swap the free-text Object ID input for a <select> when GRC is selected, and back otherwise.
+    function syncObjectIdField(objectType) {
+        const current = document.getElementById('grantObjectId');
+        if (objectType === 'general_roman_calendar') {
+            if (current.tagName === 'SELECT') {
+                return;
+            }
+            const select = document.createElement('select');
+            select.className = 'form-select';
+            select.id = 'grantObjectId';
+            select.required = true;
+            for (const opt of GRC_OBJECT_IDS) {
+                const o = document.createElement('option');
+                o.value = opt.id;
+                o.textContent = opt.label;
+                select.appendChild(o);
+            }
+            current.replaceWith(select);
+        } else if (current.tagName === 'SELECT') {
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.className = 'form-control';
+            input.id = 'grantObjectId';
+            input.required = true;
+            input.placeholder = config.i18n.enterObjectId || '';
+            current.replaceWith(input);
+        }
+    }
+
+    grantObjectType.addEventListener('change', (e) => syncObjectIdField(e.target.value));
+```
+
+> The grant submit handler (line ~270) reads `document.getElementById('grantObjectId').value` — because
+> the swap keeps the same `id`, no change is needed there. Confirm the reset logic (line ~258-259) still
+> works: after reset, call `syncObjectIdField('')` to restore the text input.
+
+In the reset block (line ~258), add after `grantObjectType.value = '';`:
+
+```javascript
+        syncObjectIdField('');
+```
+
+- [ ] **Step 3: Add the new i18n strings to `admin-permissions.php` config**
+
+In the same `i18n` block add:
+
+```php
+                grcTemporale: <?php echo json_encode(_('Temporale')); ?>,
+                grcSanctorale1970: <?php echo json_encode(_('Sanctorale — Editio Typica 1970')); ?>,
+                grcSanctorale2002: <?php echo json_encode(_('Sanctorale — Editio Typica 2002')); ?>,
+                grcSanctorale2008: <?php echo json_encode(_('Sanctorale — Editio Typica 2008')); ?>,
+                grcDecrees: <?php echo json_encode(_('Decrees of the Dicastery for Divine Worship')); ?>,
+                enterObjectId: <?php echo json_encode(_('Enter object ID...')); ?>,
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `node --check assets/js/admin-permissions.js`
+Expected: no syntax errors.
+Run: `composer lint`
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add admin-permissions.php assets/js/admin-permissions.js
+git commit -m "feat(ui): grant General Roman Calendar permissions in admin UI"
+```
+
+---
+
+### Task B3: Access-request UI — role→type map, display name, object-id dropdown
+
+**Files:**
+
+- Modify: `assets/js/permission-requests.js:50-53` (`objectTypeNames`), `:82-84` (`roleObjectTypes`), object-id field handling
+- Modify: `permission-requests.php` and `request-access.php` (i18n config strings for the new labels)
+
+**Interfaces:**
+
+- Consumes: the same `config.i18n.generalRomanCalendar` + GRC id labels, provided by `permission-requests.php` / `request-access.php`.
+
+- [ ] **Step 1: Update `assets/js/permission-requests.js`**
+
+Add to `objectTypeNames` (after `test_definition`, line ~53):
+
+```javascript
+        'general_roman_calendar': config.i18n.generalRomanCalendar,
+```
+
+Update `roleObjectTypes` (lines ~82-84) to:
+
+```javascript
+        'calendar_editor': ['national_calendar', 'diocesan_calendar', 'wider_region', 'general_roman_calendar'],
+        'test_editor': ['test_definition'],
+        'developer': ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition', 'general_roman_calendar']
+```
+
+Apply the same `GRC_OBJECT_IDS` + object-id-field-swap approach as Task B2, scoped to the per-row
+object-id control used in this form (match the existing element ids/classes this file already uses when
+it builds a permission row). When the row's object type is `general_roman_calendar`, render a `<select>`
+of the five ids; otherwise the existing input.
+
+- [ ] **Step 2: Add i18n strings in `permission-requests.php` and `request-access.php`**
+
+In each file's JS i18n config object, add the same six keys as Task B2 Step 3 (`generalRomanCalendar`,
+`grcTemporale`, `grcSanctorale1970`, `grcSanctorale2002`, `grcSanctorale2008`, `grcDecrees`). Use the
+existing `_()` + `json_encode` pattern already in those files.
+
+- [ ] **Step 3: Verify**
+
+Run: `node --check assets/js/permission-requests.js`
+Expected: no syntax errors.
+Run: `composer lint`
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add assets/js/permission-requests.js permission-requests.php request-access.php
+git commit -m "feat(ui): request General Roman Calendar access in request flows"
+```
+
+---
+
+### Task B4: i18n extraction + Phase B verification
+
+**Files:**
+
+- Modify: `i18n/` gettext catalogs (regenerated)
+
+- [ ] **Step 1: Extract/update translation strings**
+
+Run the project's gettext extraction (matching how this repo updates `.pot`/`.po`; commonly):
+
+```bash
+composer lint:md:fix >/dev/null 2>&1 || true
+# Extract translatable strings (use the repo's documented command if different):
+find . -path ./vendor -prune -o -name '*.php' -print | xargs xgettext --from-code=UTF-8 -k_ -o i18n/messages.pot 2>/dev/null || true
+```
+
+Confirm the new msgids appear in the catalog: `General Roman Calendar`, `Temporale`,
+`Sanctorale — Editio Typica 1970/2002/2008`, and `Decrees of the Dicastery for Divine Worship`.
+If the project uses Weblate, leave `.po` value updates to Weblate and only commit the `.pot`/source
+string additions.
+
+- [ ] **Step 2: Run quality gates**
+
+```bash
+composer parallel-lint
+composer lint
+yarn typecheck
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Manual UI smoke**
+
+With the API (Phase A) deployed: open `admin-permissions.php` and select **General Roman Calendar** as
+Object Type. Confirm the Object ID field becomes a dropdown of the five labels, grant `editor` on
+`Temporale` to a test user, and confirm the tuple appears in the list. Repeat a request in
+`request-access.php` as a calendar_editor.
+
+- [ ] **Step 4: Commit + open PR**
+
+```bash
+git add i18n/
+git commit -m "chore(i18n): add General Roman Calendar permission strings"
+git push -u origin feat/general-roman-calendar-object-type
+gh pr create --base development --title "feat(ui): general_roman_calendar object type (frontend)" --body "Mirror of the API GRC object type; implements the frontend portion of docs/superpowers/specs/2026-06-20-general-roman-calendar-object-type-design.md (in the API repo)."
+```
+
+---
+
+## Self-Review notes (for the implementer)
+
+- **Three object-type lists** exist in the API (`AccessRequestRepository`, `AccessRequestHandler`,
+  `PermissionAdminHandler`) — Tasks A2/A5/A6 update all three. They are intentionally kept separate
+  (existing pattern); a future consolidation is out of scope.
+- **Cascade** (`RoleCascadeService`) needs no change: it discovers object ids via OpenFGA `listObjects`
+  over `ROLE_OBJECT_TYPES`, so adding GRC to that map (Task A2) is sufficient.
+- **Naming consistency:** the factory `forGeneralRomanCalendar`, helper `isValidObjectIdForType`,
+  constant `GRC_OBJECT_IDS`, and i18n keys (`generalRomanCalendar`, `grcTemporale`,
+  `grcSanctorale1970/2002/2008`, `grcDecrees`) are used identically across all tasks referencing them.
+- **POST** writes to `missals`/`decrees` remain ungated (matches existing `data`/`tests` behavior —
+  only PUT/PATCH/DELETE are gated). If POST creation must be gated, that is a separate follow-up.

--- a/docs/superpowers/plans/2026-06-20-general-roman-calendar-object-type.md
+++ b/docs/superpowers/plans/2026-06-20-general-roman-calendar-object-type.md
@@ -563,19 +563,17 @@ public function testGrcPermissionWithInvalidObjectIdIsRejected(): void
 Run: `vendor/bin/phpunit phpunit_tests/Handlers/Auth/AccessRequestHandlerValidationTest.php`
 Expected: FAIL — GRC type rejected as invalid object_type.
 
-- [ ] **Step 3: Implement**
+- [ ] **Step 3: Implement (consolidate object-type list onto the repository constant)**
 
-Add `'general_roman_calendar'` to the `VALID_OBJECT_TYPES` constant (line ~41):
+Per the consolidation decision, do NOT add a fifth entry to a private copy. Instead, remove this
+handler's private `VALID_OBJECT_TYPES` constant (lines ~41-46) entirely and point every usage at the
+single authoritative source `AccessRequestRepository::VALID_OBJECT_TYPES` (updated in Task A2).
 
-```php
-    private const VALID_OBJECT_TYPES = [
-        'national_calendar',
-        'diocesan_calendar',
-        'wider_region',
-        'test_definition',
-        'general_roman_calendar',
-    ];
-```
+- Delete the `private const VALID_OBJECT_TYPES = [ ... ];` declaration.
+- Replace each `self::VALID_OBJECT_TYPES` reference in this file (the submit loop ~line 218 and the
+  approve loop ~line 379) with `AccessRequestRepository::VALID_OBJECT_TYPES`.
+- Leave the private `VALID_RELATIONS` constant unchanged (relations are not part of this consolidation).
+- Ensure `use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;` is imported.
 
 In the submit-validation loop, after the `object_id === ''` check (line ~233), add:
 
@@ -607,7 +605,7 @@ In the approve-validation loop, after the `in_array($objType, ...)` check (line 
             }
 ```
 
-Ensure `use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;` is imported (it likely already is; add if missing).
+(`AccessRequestRepository` is already imported per the consolidation step above.)
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -656,19 +654,17 @@ public function testGrantGrcTupleWithInvalidIdFails(): void
 Run: `vendor/bin/phpunit phpunit_tests/Handlers/Admin/PermissionAdminHandlerValidationTest.php`
 Expected: FAIL — GRC type invalid.
 
-- [ ] **Step 3: Implement**
+- [ ] **Step 3: Implement (consolidate object-type list onto the repository constant)**
 
-Add `'general_roman_calendar'` to `VALID_OBJECT_TYPES` (line ~54):
+Per the consolidation decision, remove this handler's private `VALID_OBJECT_TYPES` constant
+(lines ~54-59) entirely and point every usage at `AccessRequestRepository::VALID_OBJECT_TYPES`
+(updated in Task A2).
 
-```php
-    private const VALID_OBJECT_TYPES = [
-        'national_calendar',
-        'diocesan_calendar',
-        'wider_region',
-        'test_definition',
-        'general_roman_calendar',
-    ];
-```
+- Delete the `private const VALID_OBJECT_TYPES = [ ... ];` declaration.
+- Replace each `self::VALID_OBJECT_TYPES` reference in this file (the list-filter validation ~line 330
+  and `validateTupleParams` ~line 816) with `AccessRequestRepository::VALID_OBJECT_TYPES`.
+- Leave the private `VALID_RELATIONS` constant unchanged.
+- Ensure `use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;` is imported.
 
 In `validateTupleParams()`, after the `$objectId === ''` check (line ~824), add:
 
@@ -685,7 +681,7 @@ In `validateTupleParams()`, after the `$objectId === ''` check (line ~824), add:
         }
 ```
 
-Add `use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;` if not already imported.
+(`AccessRequestRepository` is already imported per the consolidation step above.)
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -994,9 +990,10 @@ gh pr create --base development --title "feat(ui): general_roman_calendar object
 
 ## Self-Review notes (for the implementer)
 
-- **Three object-type lists** exist in the API (`AccessRequestRepository`, `AccessRequestHandler`,
-  `PermissionAdminHandler`) — Tasks A2/A5/A6 update all three. They are intentionally kept separate
-  (existing pattern); a future consolidation is out of scope.
+- **Object-type list consolidation:** the API previously had three duplicated `VALID_OBJECT_TYPES`
+  lists (`AccessRequestRepository`, `AccessRequestHandler`, `PermissionAdminHandler`). Per the
+  consolidation decision, Task A2 keeps the authoritative copy on `AccessRequestRepository`, and
+  Tasks A5/A6 delete the two handler-private copies and reference the repository constant instead.
 - **Cascade** (`RoleCascadeService`) needs no change: it discovers object ids via OpenFGA `listObjects`
   over `ROLE_OBJECT_TYPES`, so adding GRC to that map (Task A2) is sufficient.
 - **Naming consistency:** the factory `forGeneralRomanCalendar`, helper `isValidObjectIdForType`,

--- a/docs/superpowers/specs/2026-06-20-general-roman-calendar-object-type-design.md
+++ b/docs/superpowers/specs/2026-06-20-general-roman-calendar-object-type-design.md
@@ -1,0 +1,172 @@
+# Design: `general_roman_calendar` Object Type for Calendar Editor Permissions
+
+- **Date:** 2026-06-20
+- **Status:** Draft (awaiting review)
+- **Repos affected:** `LiturgicalCalendarAPI` (authoritative), `LiturgicalCalendarFrontend` (mirror/UI)
+- **Related:** OpenFGA fine-grained authorization (`OpenFgaAuthorizationMiddleware`, `AccessRequestRepository`, `RoleCascadeService`)
+
+## 1. Background
+
+The permission system models editable resources as OpenFGA **object types**, each with the relations
+`admin / viewer / editor / deleter`. Today the types are:
+
+| Object type         | Object ID                | Write route guarded                         |
+|---------------------|--------------------------|---------------------------------------------|
+| `national_calendar` | nation code (e.g. `IT`)  | `/data/nation/{id}`                         |
+| `diocesan_calendar` | diocese id               | `/data/diocese/{id}`                        |
+| `wider_region`      | region name              | `/data/widerregion/{id}`                    |
+| `test_definition`   | test id                  | `/tests/{id}`                               |
+
+`VALID_OBJECT_TYPES` / `ROLE_OBJECT_TYPES` live in `AccessRequestRepository`; the FGA model is in
+`scripts/openfga-model.json` (byte-identical copy in the Frontend repo); enforcement is wired per-route
+in `Router::configureAuthorizationPipeline()` via `OpenFgaAuthorizationMiddleware`.
+
+There is currently **no object type for the General Roman Calendar** (the base, universal calendar). Its
+editable sub-resources are reached through routes that are either over-restricted or unguarded:
+
+- `temporale` (PUT/PATCH/DELETE) — guarded by **admin-only** (`AuthorizationMiddleware::forAdmin()`).
+- `missals` (PUT/PATCH/DELETE) — **not** in the authenticated/authorized route set at all.
+- `decrees` (PUT/PATCH/DELETE) — **not** in the authenticated/authorized route set at all.
+
+## 2. Goals
+
+1. Add a new object type **`general_roman_calendar`** usable in Calendar Editor permission tuples.
+2. A user with `editor` on the relevant `general_roman_calendar` object may edit:
+   - the **Temporale**,
+   - the **Sanctorale** of the Editio Typica editions (1970, 2002, 2008),
+   - the **Decrees of the Dicastery for Divine Worship**.
+3. Wire real enforcement on the `temporale`, `missals`, and `decrees` write routes.
+4. Make national/regional missals (non-Editio-Typica) follow the **existing `national_calendar` grants**.
+
+## 3. Non-goals
+
+- Per-diocese or per-wider-region missals (none exist today).
+- A management UI redesign — we extend the existing grant / request-access flows only.
+- Changing the relation set (`admin/viewer/editor/deleter` is reused unchanged).
+
+## 4. Design decisions (confirmed)
+
+### 4.1 One object type, enumerated object IDs
+
+`general_roman_calendar` is **not** a singleton and **not** free-text. It has a **fixed, enumerated set of
+five object IDs**, each mapping to one editable sub-resource:
+
+| UI label                                      | Object ID (FGA)        | Write route / target                          |
+|-----------------------------------------------|------------------------|-----------------------------------------------|
+| Temporale                                     | `temporale`            | `/temporale` (PUT/PATCH/DELETE)               |
+| Sanctorale — Editio Typica 1970               | `EDITIO_TYPICA_1970`   | `/missals/EDITIO_TYPICA_1970`                 |
+| Sanctorale — Editio Typica 2002               | `EDITIO_TYPICA_2002`   | `/missals/EDITIO_TYPICA_2002`                 |
+| Sanctorale — Editio Typica 2008               | `EDITIO_TYPICA_2008`   | `/missals/EDITIO_TYPICA_2008`                 |
+| Decrees of the Dicastery for Divine Worship   | `decrees`              | `/decrees` (PUT/PATCH/DELETE)                 |
+
+The Sanctorale object IDs **reuse the `RomanMissal` edition identifiers verbatim**, so the `missals` write
+route can use its path parameter directly as the FGA object ID with no translation layer. Editions 1971/1975
+are excluded — they have no Sanctorale data file (`getSanctoraleFileName()` is `false`).
+
+A new constant `AccessRequestRepository::GRC_OBJECT_IDS` enumerates the five valid IDs; grant/request
+validation rejects any `general_roman_calendar` tuple whose object ID is not in this set.
+
+### 4.2 Roles
+
+`general_roman_calendar` is added to the allowed object types for:
+
+- `calendar_editor` (per the requirement), and
+- `developer` (which already holds every object type; keeps it a superset).
+
+`test_editor` is unaffected.
+
+### 4.3 Enforcement — route dispatch
+
+`PUT/PATCH → editor`, `DELETE → deleter` (existing `RELATION_MAP`).
+
+- **`temporale`** route: replace `forAdmin()` with `forCalendarEditor()` **+** FGA check
+  `editor`/`deleter` on `general_roman_calendar:temporale`. (Loosens from admin-only.)
+- **`decrees`** route: add to the authenticated+authorized route set; `forCalendarEditor()` **+** FGA check
+  on `general_roman_calendar:decrees`. (Newly guarded.)
+- **`missals`** route: add to the authenticated+authorized route set; `forCalendarEditor()` **+** a
+  **dispatch by missal id**:
+  - if `RomanMissal::isLatinMissal($missalId)` (Editio Typica) → object type `general_roman_calendar`,
+    object id = `$missalId` (must be one of the three enumerated editions, else 403/404);
+  - otherwise (national missal, e.g. `IT_1983`) → object type `national_calendar`, object id =
+    the owning nation = `explode('_', $missalId)[0]`.
+
+This makes national missals follow the **same grant** as the national calendar itself: `editor` on
+`national_calendar:IT` authorizes editing both `/data/nation/IT` and `/missals/IT_1983`, `/missals/IT_2020`
+(the ids found under that nation's `metadata.missals`). Admin users continue to bypass all FGA checks.
+
+### 4.4 Object ID → nation resolution
+
+The owning nation of a national missal is the id prefix (`IT_1983 → IT`), which is exactly how
+`RomanMissal::produceMetadata()` already derives a missal's `region`. The authoritative cross-check is the
+nation's `metadata.missals` array (e.g. `IT.json → metadata.missals: ["IT_1983","IT_2020"]`). The middleware
+uses the prefix for the FGA object id; resolution does not require loading every national calendar.
+
+## 5. Detailed changes
+
+### 5.1 API — `LiturgicalCalendarAPI` (authoritative; lands first)
+
+1. **`scripts/openfga-model.json`** — add a `general_roman_calendar` type definition mirroring the existing
+   types (relations `admin/viewer/editor/deleter`, each `directly_related_user_types: [{ "type": "user" }]`).
+2. **`src/Repositories/AccessRequestRepository.php`**
+   - add `'general_roman_calendar'` to `VALID_OBJECT_TYPES`;
+   - add it to `ROLE_OBJECT_TYPES['calendar_editor']` and `ROLE_OBJECT_TYPES['developer']`;
+   - add `public const GRC_OBJECT_IDS = ['temporale','EDITIO_TYPICA_1970','EDITIO_TYPICA_2002','EDITIO_TYPICA_2008','decrees'];`
+   - enforce, in tuple validation, that a `general_roman_calendar` object id ∈ `GRC_OBJECT_IDS`.
+3. **`src/Http/Middleware/OpenFgaAuthorizationMiddleware.php`**
+   - add a `forGeneralRomanCalendar($client, $fixedObjectId)` factory (for `temporale` / `decrees`);
+   - add a `forMissals($client)` factory whose `objectType`/`objectId` are resolved per request from the
+     missal id (ET → `general_roman_calendar:<edition>`, national → `national_calendar:<nation>`).
+   - (Implementation note: this is the first route whose object **type** is dynamic; either generalize the
+     middleware to accept a resolver closure, or add a dedicated missals middleware. Decide in the plan.)
+4. **`src/Router.php`**
+   - extend the protected-route guard (currently `['data','tests','temporale']`) to include
+     `'missals'` and `'decrees'`;
+   - in `configureAuthorizationPipeline()` add `missals` and `decrees` branches and change the `temporale`
+     branch from `forAdmin()` to `forCalendarEditor()` + FGA, per §4.3;
+   - set the resource-id request attribute(s) the middleware reads.
+5. **`src/Services/RoleCascadeService.php`** — verify it cascades correctly for an object type whose object
+   IDs are an enumerated set (it iterates `ROLE_OBJECT_TYPES[$role]`); add GRC handling if it assumes
+   free-form ids.
+6. **Tests** — middleware dispatch (temporale/decrees/ET-missal/national-missal/unknown-missal), validation
+   of `GRC_OBJECT_IDS`, role-object-type mapping, and a cascade test.
+
+### 5.2 Frontend — `LiturgicalCalendarFrontend` (mirror + UI; lands after API)
+
+1. **`scripts/openfga-model.json`** — keep byte-identical with the API copy.
+2. **`admin-permissions.php`** — add a `general_roman_calendar` `<option>` to `#grantObjectType`; add its
+   display name to the i18n map.
+3. **`assets/js/admin-permissions.js`** — when `general_roman_calendar` is selected, replace the free-text
+   `#grantObjectId` input with a **dropdown** of the five enumerated IDs (label → id per §4.1); restore the
+   free-text input for other types.
+4. **`permission-requests.php`** and **`request-access.php`** — add `general_roman_calendar` to the
+   `calendar_editor` role's object types, with the enumerated object-id choices.
+5. **i18n** — add the new display strings (object type label + five object-id labels) to the gettext catalog.
+
+## 6. Validation rules
+
+- A `general_roman_calendar` tuple is valid only if object id ∈ `GRC_OBJECT_IDS`.
+- On the `missals` write route, a Latin/Editio-Typica missal id outside the three Sanctorale editions
+  (e.g. `EDITIO_TYPICA_1971`) is rejected (no editable Sanctorale).
+- A national missal id with no resolvable nation prefix is rejected.
+
+## 7. Rollout / sequencing
+
+1. API PR (model + validation + enforcement + tests) → targets `LiturgicalCalendarAPI` `development`.
+2. After the API model is deployed, run the OpenFGA model-update script (`scripts/setup-openfga.sh`) so the
+   running store learns the new type before tuples are written.
+3. Frontend PR (mirror model + UI) → targets `LiturgicalCalendarFrontend` `development`.
+
+The model files in the two repos must remain byte-identical (existing invariant).
+
+## 8. Risks
+
+- **Behavior change on `temporale`:** existing admin-only editing is loosened to calendar_editor + FGA. Admins
+  retain access (FGA bypass), so this is strictly additive for non-admin editors.
+- **Newly guarded `missals`/`decrees`:** writes that were previously unauthenticated now require a token and
+  the right grant. If any internal tooling wrote to these routes unauthenticated, it must be updated.
+- **Dynamic object type on `missals`:** the middleware must resolve type+id per request; covered by tests.
+
+## 9. Open questions
+
+None blocking. The only implementation choice deferred to the plan is the exact mechanism for the dynamic
+`missals` middleware (resolver closure vs dedicated subclass).

--- a/phpunit_tests/Handlers/Admin/PermissionAdminHandlerValidationTest.php
+++ b/phpunit_tests/Handlers/Admin/PermissionAdminHandlerValidationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers\Admin;
+
+use LiturgicalCalendar\Api\Handlers\Admin\PermissionAdminHandler;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Validation tests for PermissionAdminHandler — object-id constraints for
+ * the general_roman_calendar object type.
+ *
+ * These tests exercise the grant entry point (POST /admin/permissions) as a
+ * global admin so that `requireResourceAdmin` is bypassed and validation is
+ * the only gate before the outbox/FGA path is attempted.
+ *
+ * `tupleParamsValid()` returns false on ValidationException, true otherwise
+ * (downstream DB/FGA errors are non-fatal for the assertion in question).
+ */
+#[CoversClass(PermissionAdminHandler::class)]
+final class PermissionAdminHandlerValidationTest extends AbstractHandlerTestCase
+{
+    /**
+     * Dispatch POST /admin/permissions as a global admin with the given tuple
+     * fields. Returns true unless a ValidationException is thrown; any
+     * downstream (DB / FGA) error is caught and treated as "validation passed".
+     */
+    private function tupleParamsValid(
+        string $user,
+        string $objectType,
+        string $objectId,
+        string $relation
+    ): bool {
+        try {
+            ( new PermissionAdminHandler() )->handle(
+                $this->withOidcUser($this->requestFor('POST', '/admin/permissions', [], [
+                    'user'        => $user,
+                    'object_type' => $objectType,
+                    'object_id'   => $objectId,
+                    'relation'    => $relation,
+                ]))
+            );
+        } catch (ValidationException) {
+            return false;
+        } catch (\Throwable) {
+            // Downstream (DB / FGA) error — validation passed.
+        }
+        return true;
+    }
+
+    public function testGrantGrcTupleWithValidIdPasses(): void
+    {
+        self::assertTrue($this->tupleParamsValid('user:abc', 'general_roman_calendar', 'decrees', 'editor'));
+    }
+
+    public function testGrantGrcTupleWithInvalidIdFails(): void
+    {
+        self::assertFalse($this->tupleParamsValid('user:abc', 'general_roman_calendar', 'nonsense', 'editor'));
+    }
+}

--- a/phpunit_tests/Handlers/Admin/PermissionAdminHandlerValidationTest.php
+++ b/phpunit_tests/Handlers/Admin/PermissionAdminHandlerValidationTest.php
@@ -60,4 +60,9 @@ final class PermissionAdminHandlerValidationTest extends AbstractHandlerTestCase
     {
         self::assertFalse($this->tupleParamsValid('user:abc', 'general_roman_calendar', 'nonsense', 'editor'));
     }
+
+    public function testGrantTupleWithInvalidObjectTypeFails(): void
+    {
+        self::assertFalse($this->tupleParamsValid('user:abc', 'not_a_real_type', 'temporale', 'editor'));
+    }
 }

--- a/phpunit_tests/Handlers/Auth/AccessRequestHandlerValidationTest.php
+++ b/phpunit_tests/Handlers/Auth/AccessRequestHandlerValidationTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers\Auth;
+
+use LiturgicalCalendar\Api\Handlers\Auth\AccessRequestHandler;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Focused tests that a general_roman_calendar permission with a valid id is accepted
+ * and with an invalid id is rejected, exercising the GRC object-id validation
+ * added in both the submit and resubmit paths of AccessRequestHandler.
+ */
+#[CoversClass(AccessRequestHandler::class)]
+final class AccessRequestHandlerValidationTest extends AbstractHandlerTestCase
+{
+    protected static bool $requiresDatabase = true;
+
+    /** @return array<string, mixed> */
+    private function oidcUser(): array
+    {
+        return [
+            'sub'   => 'user-grc-test',
+            'email' => 'grc@x.test',
+            'name'  => 'GRC Tester',
+            'roles' => [],
+        ];
+    }
+
+    /**
+     * Submit an access request and return true on 2xx, false on ValidationException / 4xx.
+     *
+     * @param string $role
+     * @param array<int, array{object_type: string, object_id: string, relation: string}> $perms
+     */
+    private function submitIsAccepted(string $role, array $perms): bool
+    {
+        try {
+            $request = $this->requestFor(
+                'POST',
+                '/auth/access-requests',
+                [],
+                [
+                    'requested_role' => $role,
+                    'permissions'    => $perms,
+                    'justification'  => 'GRC access test',
+                ]
+            )->withAttribute('oidc_user', $this->oidcUser());
+
+            $response = ( new AccessRequestHandler() )->handle($request);
+            return $response->getStatusCode() >= 200 && $response->getStatusCode() < 300;
+        } catch (ValidationException) {
+            return false;
+        }
+    }
+
+    // ── submit path ──────────────────────────────────────────────────────────
+
+    public function testGrcPermissionWithValidObjectIdIsAccepted(): void
+    {
+        $perms = [['object_type' => 'general_roman_calendar', 'object_id' => 'temporale', 'relation' => 'editor']];
+        self::assertTrue($this->submitIsAccepted('calendar_editor', $perms));
+    }
+
+    public function testGrcPermissionWithInvalidObjectIdIsRejected(): void
+    {
+        $perms = [['object_type' => 'general_roman_calendar', 'object_id' => 'EDITIO_TYPICA_1971', 'relation' => 'editor']];
+        self::assertFalse($this->submitIsAccepted('calendar_editor', $perms));
+    }
+
+    /** All valid GRC object ids must be accepted (each with a distinct user to avoid the duplicate-pending guard). */
+    public function testAllValidGrcObjectIdsAreAccepted(): void
+    {
+        foreach (AccessRequestRepository::GRC_OBJECT_IDS as $i => $validId) {
+            $oidcUser = [
+                'sub'   => 'user-grc-' . $i,
+                'email' => 'grc' . $i . '@x.test',
+                'name'  => 'GRC Tester ' . $i,
+                'roles' => [],
+            ];
+
+            try {
+                $request = $this->requestFor(
+                    'POST',
+                    '/auth/access-requests',
+                    [],
+                    [
+                        'requested_role' => 'calendar_editor',
+                        'permissions'    => [['object_type' => 'general_roman_calendar', 'object_id' => $validId, 'relation' => 'editor']],
+                        'justification'  => 'GRC access test',
+                    ]
+                )->withAttribute('oidc_user', $oidcUser);
+
+                $response = ( new AccessRequestHandler() )->handle($request);
+                $accepted = $response->getStatusCode() >= 200 && $response->getStatusCode() < 300;
+            } catch (ValidationException) {
+                $accepted = false;
+            }
+
+            self::assertTrue(
+                $accepted,
+                sprintf('Expected valid GRC object_id "%s" to be accepted', $validId)
+            );
+        }
+    }
+
+    // ── resubmit path ────────────────────────────────────────────────────────
+
+    public function testResubmitGrcWithValidObjectIdIsAccepted(): void
+    {
+        // Seed a rejected request so resubmit has something to work with.
+        $repo  = new AccessRequestRepository(self::$pdo);
+        $reqId = $repo->create('user-grc-test', 'grc@x.test', null, 'calendar_editor', []);
+        $repo->reject($reqId, 'admin');
+
+        $request = $this->requestFor(
+            'POST',
+            '/auth/access-requests/' . $reqId . '/resubmit',
+            [],
+            [
+                'permissions' => [
+                    ['object_type' => 'general_roman_calendar', 'object_id' => 'temporale', 'relation' => 'editor'],
+                ],
+            ]
+        )->withAttribute('oidc_user', $this->oidcUser());
+
+        $response = ( new AccessRequestHandler() )->handle($request);
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testResubmitGrcWithInvalidObjectIdIsRejected(): void
+    {
+        $repo  = new AccessRequestRepository(self::$pdo);
+        $reqId = $repo->create('user-grc-test', 'grc@x.test', null, 'calendar_editor', []);
+        $repo->reject($reqId, 'admin');
+
+        $request = $this->requestFor(
+            'POST',
+            '/auth/access-requests/' . $reqId . '/resubmit',
+            [],
+            [
+                'permissions' => [
+                    ['object_type' => 'general_roman_calendar', 'object_id' => 'EDITIO_TYPICA_1971', 'relation' => 'editor'],
+                ],
+            ]
+        )->withAttribute('oidc_user', $this->oidcUser());
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/object_id.*EDITIO_TYPICA_1971.*invalid.*general_roman_calendar/i');
+
+        ( new AccessRequestHandler() )->handle($request);
+    }
+}

--- a/phpunit_tests/Handlers/Auth/AccessRequestHandlerValidationTest.php
+++ b/phpunit_tests/Handlers/Auth/AccessRequestHandlerValidationTest.php
@@ -154,4 +154,27 @@ final class AccessRequestHandlerValidationTest extends AbstractHandlerTestCase
 
         ( new AccessRequestHandler() )->handle($request);
     }
+
+    public function testResubmitWithInvalidObjectTypeIsRejected(): void
+    {
+        $repo  = new AccessRequestRepository(self::$pdo);
+        $reqId = $repo->create('user-grc-test', 'grc@x.test', null, 'calendar_editor', []);
+        $repo->reject($reqId, 'admin');
+
+        $request = $this->requestFor(
+            'POST',
+            '/auth/access-requests/' . $reqId . '/resubmit',
+            [],
+            [
+                'permissions' => [
+                    ['object_type' => 'not_a_real_type', 'object_id' => 'temporale', 'relation' => 'editor'],
+                ],
+            ]
+        )->withAttribute('oidc_user', $this->oidcUser());
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/object_type.*is invalid/i');
+
+        ( new AccessRequestHandler() )->handle($request);
+    }
 }

--- a/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
+++ b/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
@@ -234,4 +234,52 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
         $response = $middleware->process($request, $this->nextHandler);
         $this->assertEquals(200, $response->getStatusCode());
     }
+
+    public function testForGeneralRomanCalendarChecksFixedObjectId(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->once())
+            ->method('check')
+            ->with('user:abc', 'editor', 'general_roman_calendar:temporale')
+            ->willReturn(true);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forGeneralRomanCalendar($client, 'temporale');
+        $request    = ( new ServerRequest('PUT', '/temporale') )
+            ->withAttribute('oidc_user', ['sub' => 'abc', 'roles' => ['calendar_editor']]);
+
+        $response = $middleware->process($request, $this->nextHandler);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testForMissalsEditioTypicaChecksGeneralRomanCalendar(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->once())
+            ->method('check')
+            ->with('user:abc', 'editor', 'general_roman_calendar:EDITIO_TYPICA_2002')
+            ->willReturn(true);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forMissals($client, 'EDITIO_TYPICA_2002');
+        $request    = ( new ServerRequest('PATCH', '/missals/EDITIO_TYPICA_2002') )
+            ->withAttribute('oidc_user', ['sub' => 'abc', 'roles' => ['calendar_editor']]);
+
+        $response = $middleware->process($request, $this->nextHandler);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testForMissalsNationalChecksNationalCalendarByPrefix(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->once())
+            ->method('check')
+            ->with('user:abc', 'editor', 'national_calendar:IT')
+            ->willReturn(true);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forMissals($client, 'IT_1983');
+        $request    = ( new ServerRequest('PUT', '/missals/IT_1983') )
+            ->withAttribute('oidc_user', ['sub' => 'abc', 'roles' => ['calendar_editor']]);
+
+        $response = $middleware->process($request, $this->nextHandler);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
 }

--- a/phpunit_tests/Http/RouterAuthorizationTest.php
+++ b/phpunit_tests/Http/RouterAuthorizationTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http;
+
+use PHPUnit\Framework\TestCase;
+
+final class RouterAuthorizationTest extends TestCase
+{
+    /**
+     * The set of routes that require auth for write methods must include the
+     * General Roman Calendar write routes.
+     */
+    public function testProtectedWriteRoutesIncludeGrcRoutes(): void
+    {
+        $src = file_get_contents(__DIR__ . '/../../src/Router.php');
+        self::assertIsString($src);
+        // Guard list literal must contain all five route names.
+        self::assertMatchesRegularExpression(
+            "/in_array\\(\\s*\\\$route,\\s*\\['data',\\s*'tests',\\s*'temporale',\\s*'missals',\\s*'decrees'\\]/",
+            $src
+        );
+        // temporale must no longer be admin-only.
+        self::assertStringNotContainsString('// Temporale requires admin role', $src);
+    }
+}

--- a/phpunit_tests/Http/RouterPipelineTest.php
+++ b/phpunit_tests/Http/RouterPipelineTest.php
@@ -245,4 +245,34 @@ final class RouterPipelineTest extends TestCase
         self::assertSame('general_roman_calendar', $this->getPrivateProp($fgaMw, 'objectType'));
         self::assertSame('EDITIO_TYPICA_2002', $this->getPrivateProp($fgaMw, 'fixedObjectId'));
     }
+
+    public function testMissalsWithoutIdRequiresAdminAndSkipsFga(): void
+    {
+        $router   = $this->routerWithoutConstructor();
+        $pipeline = $this->emptyPipeline();
+
+        // A collection-level write (no missal id) cannot be resource-authorized, so it must
+        // fail closed to admin rather than fall back to calendar_editor + no FGA check.
+        $this->callConfigurePipeline($router, $pipeline, 'missals', []);
+
+        $queue = $this->getQueue($pipeline);
+
+        $authMw = null;
+        foreach ($queue as $mw) {
+            if ($mw instanceof AuthorizationMiddleware) {
+                $authMw = $mw;
+                break;
+            }
+        }
+        self::assertNotNull($authMw, 'Expected an AuthorizationMiddleware for an id-less missals write');
+        self::assertSame('admin', $this->getPrivateProp($authMw, 'requiredRole'));
+
+        foreach ($queue as $mw) {
+            self::assertNotInstanceOf(
+                OpenFgaAuthorizationMiddleware::class,
+                $mw,
+                'No fine-grained FGA middleware should be added when the missal id is absent'
+            );
+        }
+    }
 }

--- a/phpunit_tests/Http/RouterPipelineTest.php
+++ b/phpunit_tests/Http/RouterPipelineTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Http;
+
+use LiturgicalCalendar\Api\Http\Middleware\AuthorizationMiddleware;
+use LiturgicalCalendar\Api\Http\Middleware\OpenFgaAuthorizationMiddleware;
+use LiturgicalCalendar\Api\Http\Server\MiddlewarePipeline;
+use LiturgicalCalendar\Api\Router;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * Covers the temporale / decrees / missals branches in the private
+ * Router::configureAuthorizationPipeline() method.
+ *
+ * We use reflection to:
+ *   1. Instantiate Router without its constructor side-effects.
+ *   2. Call the private method directly.
+ *   3. Inspect the MiddlewarePipeline's internal middleware queue.
+ *
+ * Environment variables are set before each test and restored after so
+ * that other tests are not polluted.
+ */
+#[CoversClass(Router::class)]
+final class RouterPipelineTest extends TestCase
+{
+    /** @var array<string, string|false> */
+    private array $savedEnv = [];
+
+    private const ENV_VARS = [
+        'ZITADEL_ISSUER'    => 'https://issuer.example',
+        'ZITADEL_CLIENT_ID' => 'test-client-id',
+        'OPENFGA_API_URL'   => 'http://fga.example',
+        'OPENFGA_STORE_ID'  => '01ABC',
+        'OPENFGA_MODEL_ID'  => '01DEF',
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Save current values (getenv returns false when unset)
+        foreach (array_keys(self::ENV_VARS) as $name) {
+            $this->savedEnv[$name] = getenv($name);
+        }
+
+        // Inject fake values so isConfigured() / isOidcConfigured() return true
+        // and fromEnv() constructs without throwing (just builds a Guzzle client object)
+        foreach (self::ENV_VARS as $name => $value) {
+            putenv("{$name}={$value}");
+            $_ENV[$name] = $value;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->savedEnv as $name => $previous) {
+            if ($previous === false) {
+                putenv($name);             // unset the env var
+                unset($_ENV[$name]);
+            } else {
+                putenv("{$name}={$previous}");
+                $_ENV[$name] = $previous;
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────
+
+    /**
+     * Build a Router instance without calling the constructor.
+     */
+    private function routerWithoutConstructor(): Router
+    {
+        return ( new ReflectionClass(Router::class) )->newInstanceWithoutConstructor();
+    }
+
+    /**
+     * Build a MiddlewarePipeline with a no-op default handler.
+     */
+    private function emptyPipeline(): MiddlewarePipeline
+    {
+        $noop = new class () implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(200);
+            }
+        };
+
+        return new MiddlewarePipeline($noop);
+    }
+
+    /**
+     * Call the private configureAuthorizationPipeline method via reflection.
+     *
+     * @param array<int, string> $pathParts
+     */
+    private function callConfigurePipeline(
+        Router $router,
+        MiddlewarePipeline $pipeline,
+        string $route,
+        array $pathParts
+    ): void {
+        $method = new ReflectionMethod(Router::class, 'configureAuthorizationPipeline');
+        $method->invoke($router, $pipeline, $route, $pathParts);
+    }
+
+    /**
+     * Extract the private middlewareQueue from a MiddlewarePipeline.
+     *
+     * @return list<object>
+     */
+    private function getQueue(MiddlewarePipeline $pipeline): array
+    {
+        $prop = ( new ReflectionClass(MiddlewarePipeline::class) )->getProperty('middlewareQueue');
+        /** @var list<object> */
+        return $prop->getValue($pipeline);
+    }
+
+    /**
+     * Extract a named private property from an object via reflection.
+     */
+    private function getPrivateProp(object $obj, string $propName): mixed
+    {
+        $prop = ( new ReflectionClass($obj) )->getProperty($propName);
+        return $prop->getValue($obj);
+    }
+
+    // ── tests: temporale ─────────────────────────────────────────────────────
+
+    public function testTemporaleAddsCalendarEditorMiddleware(): void
+    {
+        $router   = $this->routerWithoutConstructor();
+        $pipeline = $this->emptyPipeline();
+
+        $this->callConfigurePipeline($router, $pipeline, 'temporale', []);
+
+        $queue = $this->getQueue($pipeline);
+        $types = array_map('get_class', $queue);
+
+        self::assertContains(AuthorizationMiddleware::class, $types, 'Expected AuthorizationMiddleware in pipeline');
+    }
+
+    public function testTemporaleAddsOpenFgaMiddlewareForGeneralRomanCalendar(): void
+    {
+        $router   = $this->routerWithoutConstructor();
+        $pipeline = $this->emptyPipeline();
+
+        $this->callConfigurePipeline($router, $pipeline, 'temporale', []);
+
+        $queue = $this->getQueue($pipeline);
+        $fgaMw = null;
+        foreach ($queue as $mw) {
+            if ($mw instanceof OpenFgaAuthorizationMiddleware) {
+                $fgaMw = $mw;
+                break;
+            }
+        }
+
+        self::assertNotNull($fgaMw, 'Expected OpenFgaAuthorizationMiddleware in pipeline for temporale');
+        self::assertSame('general_roman_calendar', $this->getPrivateProp($fgaMw, 'objectType'));
+        self::assertSame('temporale', $this->getPrivateProp($fgaMw, 'fixedObjectId'));
+    }
+
+    // ── tests: decrees ───────────────────────────────────────────────────────
+
+    public function testDecreesAddsCalendarEditorMiddleware(): void
+    {
+        $router   = $this->routerWithoutConstructor();
+        $pipeline = $this->emptyPipeline();
+
+        $this->callConfigurePipeline($router, $pipeline, 'decrees', []);
+
+        $queue = $this->getQueue($pipeline);
+        $types = array_map('get_class', $queue);
+
+        self::assertContains(AuthorizationMiddleware::class, $types, 'Expected AuthorizationMiddleware in pipeline');
+    }
+
+    public function testDecreesAddsOpenFgaMiddlewareForGeneralRomanCalendar(): void
+    {
+        $router   = $this->routerWithoutConstructor();
+        $pipeline = $this->emptyPipeline();
+
+        $this->callConfigurePipeline($router, $pipeline, 'decrees', []);
+
+        $queue = $this->getQueue($pipeline);
+        $fgaMw = null;
+        foreach ($queue as $mw) {
+            if ($mw instanceof OpenFgaAuthorizationMiddleware) {
+                $fgaMw = $mw;
+                break;
+            }
+        }
+
+        self::assertNotNull($fgaMw, 'Expected OpenFgaAuthorizationMiddleware in pipeline for decrees');
+        self::assertSame('general_roman_calendar', $this->getPrivateProp($fgaMw, 'objectType'));
+        self::assertSame('decrees', $this->getPrivateProp($fgaMw, 'fixedObjectId'));
+    }
+
+    // ── tests: missals ───────────────────────────────────────────────────────
+
+    public function testMissalsAddsCalendarEditorMiddleware(): void
+    {
+        $router   = $this->routerWithoutConstructor();
+        $pipeline = $this->emptyPipeline();
+
+        // Pass a Latin Editio Typica missal ID as the first path part
+        $this->callConfigurePipeline($router, $pipeline, 'missals', ['EDITIO_TYPICA_2002']);
+
+        $queue = $this->getQueue($pipeline);
+        $types = array_map('get_class', $queue);
+
+        self::assertContains(AuthorizationMiddleware::class, $types, 'Expected AuthorizationMiddleware in pipeline');
+    }
+
+    public function testMissalsAddsOpenFgaMiddlewareForLatinMissal(): void
+    {
+        $router   = $this->routerWithoutConstructor();
+        $pipeline = $this->emptyPipeline();
+
+        // EDITIO_TYPICA_2002 is a Latin missal → general_roman_calendar object type
+        $this->callConfigurePipeline($router, $pipeline, 'missals', ['EDITIO_TYPICA_2002']);
+
+        $queue = $this->getQueue($pipeline);
+        $fgaMw = null;
+        foreach ($queue as $mw) {
+            if ($mw instanceof OpenFgaAuthorizationMiddleware) {
+                $fgaMw = $mw;
+                break;
+            }
+        }
+
+        self::assertNotNull($fgaMw, 'Expected OpenFgaAuthorizationMiddleware in pipeline for missals');
+        self::assertSame('general_roman_calendar', $this->getPrivateProp($fgaMw, 'objectType'));
+        self::assertSame('EDITIO_TYPICA_2002', $this->getPrivateProp($fgaMw, 'fixedObjectId'));
+    }
+}

--- a/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use PHPUnit\Framework\TestCase;
+
+final class AccessRequestRepositoryConstantsTest extends TestCase
+{
+    public function testGeneralRomanCalendarIsAValidObjectType(): void
+    {
+        self::assertContains('general_roman_calendar', AccessRequestRepository::VALID_OBJECT_TYPES);
+    }
+
+    public function testCalendarEditorAndDeveloperCanHoldGeneralRomanCalendar(): void
+    {
+        self::assertContains('general_roman_calendar', AccessRequestRepository::ROLE_OBJECT_TYPES['calendar_editor']);
+        self::assertContains('general_roman_calendar', AccessRequestRepository::ROLE_OBJECT_TYPES['developer']);
+        self::assertNotContains('general_roman_calendar', AccessRequestRepository::ROLE_OBJECT_TYPES['test_editor']);
+    }
+
+    public function testGrcObjectIdValidation(): void
+    {
+        foreach (['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees'] as $id) {
+            self::assertTrue(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', $id));
+        }
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', 'EDITIO_TYPICA_1971'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', ''));
+        // Other types keep free-form ids (non-empty)
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('national_calendar', 'IT'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('national_calendar', ''));
+    }
+}

--- a/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
@@ -23,7 +23,14 @@ final class AccessRequestRepositoryConstantsTest extends TestCase
 
     public function testGrcObjectIdValidation(): void
     {
-        foreach (['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees'] as $id) {
+        // Independently pin the exact set of valid ids, so this test fails if the
+        // production constant gains, loses, or reorders an entry.
+        self::assertSame(
+            ['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees'],
+            AccessRequestRepository::GRC_OBJECT_IDS
+        );
+
+        foreach (AccessRequestRepository::GRC_OBJECT_IDS as $id) {
             self::assertTrue(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', $id));
         }
         self::assertFalse(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', 'EDITIO_TYPICA_1971'));

--- a/phpunit_tests/Services/OpenFgaModelTest.php
+++ b/phpunit_tests/Services/OpenFgaModelTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use PHPUnit\Framework\TestCase;
+
+class OpenFgaModelTest extends TestCase
+{
+    /** @return array<string, mixed> */
+    private function loadModel(): array
+    {
+        $json = file_get_contents(__DIR__ . '/../../scripts/openfga-model.json');
+        self::assertIsString($json);
+        $model = json_decode($json, true);
+        self::assertIsArray($model);
+        return $model;
+    }
+
+    public function testGeneralRomanCalendarTypeExistsWithStandardRelations(): void
+    {
+        $model = $this->loadModel();
+        $types = [];
+        foreach ($model['type_definitions'] as $def) {
+            $types[$def['type']] = $def;
+        }
+
+        self::assertArrayHasKey('general_roman_calendar', $types);
+        $grc = $types['general_roman_calendar'];
+        foreach (['admin', 'viewer', 'editor', 'deleter'] as $relation) {
+            self::assertArrayHasKey($relation, $grc['relations']);
+            self::assertSame(
+                [['type' => 'user']],
+                $grc['metadata']['relations'][$relation]['directly_related_user_types']
+            );
+        }
+    }
+}

--- a/scripts/openfga-model.json
+++ b/scripts/openfga-model.json
@@ -56,6 +56,23 @@
       }
     },
     {
+      "type": "general_roman_calendar",
+      "relations": {
+        "admin": { "this": {} },
+        "viewer": { "this": {} },
+        "editor": { "this": {} },
+        "deleter": { "this": {} }
+      },
+      "metadata": {
+        "relations": {
+          "admin":   { "directly_related_user_types": [{ "type": "user" }] },
+          "viewer":  { "directly_related_user_types": [{ "type": "user" }] },
+          "editor":  { "directly_related_user_types": [{ "type": "user" }] },
+          "deleter": { "directly_related_user_types": [{ "type": "user" }] }
+        }
+      }
+    },
+    {
       "type": "test_definition",
       "relations": {
         "admin": { "this": {} },

--- a/src/Handlers/Admin/PermissionAdminHandler.php
+++ b/src/Handlers/Admin/PermissionAdminHandler.php
@@ -47,18 +47,6 @@ use Psr\Log\LoggerInterface;
 final class PermissionAdminHandler extends AbstractHandler
 {
     /**
-     * Valid OpenFGA object types that can be managed.
-     *
-     * @var array<string>
-     */
-    private const VALID_OBJECT_TYPES = [
-        'national_calendar',
-        'diocesan_calendar',
-        'wider_region',
-        'test_definition',
-    ];
-
-    /**
      * Valid OpenFGA relations.
      *
      * @var array<string>
@@ -327,9 +315,9 @@ final class PermissionAdminHandler extends AbstractHandler
             throw new ValidationException('Resource admins must specify object_type filter');
         }
 
-        if ($objectType !== '' && !in_array($objectType, self::VALID_OBJECT_TYPES, true)) {
+        if ($objectType !== '' && !in_array($objectType, AccessRequestRepository::VALID_OBJECT_TYPES, true)) {
             throw new ValidationException(
-                sprintf('Invalid object_type. Valid types: %s', implode(', ', self::VALID_OBJECT_TYPES))
+                sprintf('Invalid object_type. Valid types: %s', implode(', ', AccessRequestRepository::VALID_OBJECT_TYPES))
             );
         }
 
@@ -813,14 +801,25 @@ final class PermissionAdminHandler extends AbstractHandler
             throw new ValidationException('Missing required parameter: object_type');
         }
 
-        if (!in_array($objectType, self::VALID_OBJECT_TYPES, true)) {
+        if (!in_array($objectType, AccessRequestRepository::VALID_OBJECT_TYPES, true)) {
             throw new ValidationException(
-                sprintf('Invalid object_type "%s". Valid types: %s', $objectType, implode(', ', self::VALID_OBJECT_TYPES))
+                sprintf('Invalid object_type "%s". Valid types: %s', $objectType, implode(', ', AccessRequestRepository::VALID_OBJECT_TYPES))
             );
         }
 
         if ($objectId === '') {
             throw new ValidationException('Missing required parameter: object_id');
+        }
+
+        if (!AccessRequestRepository::isValidObjectIdForType($objectType, $objectId)) {
+            throw new ValidationException(
+                sprintf(
+                    'Invalid object_id "%s" for object_type "%s". Valid ids: %s',
+                    $objectId,
+                    $objectType,
+                    implode(', ', AccessRequestRepository::GRC_OBJECT_IDS)
+                )
+            );
         }
 
         if ($relation === '') {

--- a/src/Handlers/Auth/AccessRequestHandler.php
+++ b/src/Handlers/Auth/AccessRequestHandler.php
@@ -38,16 +38,6 @@ final class AccessRequestHandler extends AbstractHandler
     /**
      * @var array<string>
      */
-    private const VALID_OBJECT_TYPES = [
-        'national_calendar',
-        'diocesan_calendar',
-        'wider_region',
-        'test_definition',
-    ];
-
-    /**
-     * @var array<string>
-     */
     private const VALID_RELATIONS = ['admin', 'viewer', 'editor', 'deleter'];
 
     /**
@@ -59,6 +49,7 @@ final class AccessRequestHandler extends AbstractHandler
         'national_calendar',
         'diocesan_calendar',
         'wider_region',
+        'general_roman_calendar',
     ];
 
     private ?AccessRequestRepository $repository = null;
@@ -215,13 +206,13 @@ final class AccessRequestHandler extends AbstractHandler
                 );
             }
 
-            if (!in_array($objectType, self::VALID_OBJECT_TYPES, true)) {
+            if (!in_array($objectType, AccessRequestRepository::VALID_OBJECT_TYPES, true)) {
                 throw new ValidationException(
                     sprintf(
                         'permissions[%d].object_type "%s" is invalid. Valid types: %s',
                         $index,
                         $objectType,
-                        implode(', ', self::VALID_OBJECT_TYPES)
+                        implode(', ', AccessRequestRepository::VALID_OBJECT_TYPES)
                     )
                 );
             }
@@ -229,6 +220,18 @@ final class AccessRequestHandler extends AbstractHandler
             if ($objectId === '') {
                 throw new ValidationException(
                     sprintf('permissions[%d].object_id is required', $index)
+                );
+            }
+
+            if (!AccessRequestRepository::isValidObjectIdForType($objectType, $objectId)) {
+                throw new ValidationException(
+                    sprintf(
+                        'permissions[%d].object_id "%s" is invalid for object_type "%s". Valid ids: %s',
+                        $index,
+                        $objectId,
+                        $objectType,
+                        implode(', ', AccessRequestRepository::GRC_OBJECT_IDS)
+                    )
                 );
             }
 
@@ -376,12 +379,22 @@ final class AccessRequestHandler extends AbstractHandler
                 throw new ValidationException('Each permission requires object_type, object_id, and relation');
             }
 
-            if (!in_array($objType, self::VALID_OBJECT_TYPES, true)) {
+            if (!in_array($objType, AccessRequestRepository::VALID_OBJECT_TYPES, true)) {
                 throw new ValidationException(sprintf(
                     'permissions[%d].object_type "%s" is invalid. Valid types: %s',
                     $index,
                     $objType,
-                    implode(', ', self::VALID_OBJECT_TYPES)
+                    implode(', ', AccessRequestRepository::VALID_OBJECT_TYPES)
+                ));
+            }
+
+            if (!AccessRequestRepository::isValidObjectIdForType($objType, $objId)) {
+                throw new ValidationException(sprintf(
+                    'permissions[%d].object_id "%s" is invalid for object_type "%s". Valid ids: %s',
+                    $index,
+                    $objId,
+                    $objType,
+                    implode(', ', AccessRequestRepository::GRC_OBJECT_IDS)
                 ));
             }
 

--- a/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
+++ b/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Http\Middleware;
 
+use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
@@ -24,10 +25,13 @@ use Psr\Http\Server\RequestHandlerInterface;
  *   DELETE     → "deleter" relation
  *
  * Object types:
- *   /data/nation/{id}      → national_calendar:{id}
+ *   /data/nation/{id}       → national_calendar:{id}
  *   /data/diocese/{id}      → diocesan_calendar:{id}
  *   /data/widerregion/{id}  → wider_region:{id}
  *   /tests/{id}             → test_definition:{id}
+ *   /temporale, /decrees    → general_roman_calendar:{fixedId}
+ *   /missals/{editio_typica}→ general_roman_calendar:{missalId}
+ *   /missals/{national}     → national_calendar:{nation}
  */
 final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
 {
@@ -65,14 +69,21 @@ final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
      */
     private string $resourceIdAttribute;
 
+    /**
+     * When non-null, this fixed object id is used instead of a request attribute.
+     */
+    private ?string $fixedObjectId;
+
     public function __construct(
         OpenFgaClient $client,
         string $objectType,
-        string $resourceIdAttribute = 'calendar_id'
+        string $resourceIdAttribute = 'calendar_id',
+        ?string $fixedObjectId = null
     ) {
         $this->client              = $client;
         $this->objectType          = $objectType;
         $this->resourceIdAttribute = $resourceIdAttribute;
+        $this->fixedObjectId       = $fixedObjectId;
     }
 
     /**
@@ -145,9 +156,16 @@ final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
 
     /**
      * Extract the resource ID from the request.
+     *
+     * When a fixed object id was supplied at construction time it is returned
+     * immediately; otherwise the value is read from the named request attribute.
      */
     private function extractResourceId(ServerRequestInterface $request): ?string
     {
+        if ($this->fixedObjectId !== null) {
+            return $this->fixedObjectId;
+        }
+
         $value = $request->getAttribute($this->resourceIdAttribute);
         if ($value !== null && ( is_string($value) || is_int($value) )) {
             return (string) $value;
@@ -185,5 +203,38 @@ final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
     public static function forTestDefinition(OpenFgaClient $client): self
     {
         return new self($client, 'test_definition', 'test_id');
+    }
+
+    /**
+     * Create middleware for a General Roman Calendar sub-resource with a fixed object id
+     * (e.g. "temporale" or "decrees").
+     *
+     * @param OpenFgaClient $client   The OpenFGA client
+     * @param string        $objectId Fixed object id (e.g. "temporale")
+     * @return self Configured middleware
+     */
+    public static function forGeneralRomanCalendar(OpenFgaClient $client, string $objectId): self
+    {
+        return new self($client, 'general_roman_calendar', 'calendar_id', $objectId);
+    }
+
+    /**
+     * Create middleware for a missal write.
+     *
+     * Editio Typica (Latin) missals are General Roman Calendar Sanctorale sub-resources;
+     * national/regional missals follow the owning national calendar's grants (id prefix).
+     *
+     * @param OpenFgaClient $client   The OpenFGA client
+     * @param string        $missalId The missal identifier (e.g. "EDITIO_TYPICA_2002" or "IT_1983")
+     * @return self Configured middleware
+     */
+    public static function forMissals(OpenFgaClient $client, string $missalId): self
+    {
+        if (RomanMissal::isLatinMissal($missalId)) {
+            return new self($client, 'general_roman_calendar', 'calendar_id', $missalId);
+        }
+
+        $nation = explode('_', $missalId)[0];
+        return new self($client, 'national_calendar', 'calendar_id', $nation);
     }
 }

--- a/src/Repositories/AccessRequestRepository.php
+++ b/src/Repositories/AccessRequestRepository.php
@@ -42,9 +42,16 @@ class AccessRequestRepository
     public const VALID_RELATIONS = ['admin', 'viewer', 'editor', 'deleter'];
 
     /**
+     * The fixed, enumerated set of object IDs valid for the general_roman_calendar type.
+     *
+     * @var array<int, string>
+     */
+    public const GRC_OBJECT_IDS = ['temporale', 'EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'decrees'];
+
+    /**
      * Valid OpenFGA object types on permission tuples.
      */
-    public const VALID_OBJECT_TYPES = ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition'];
+    public const VALID_OBJECT_TYPES = ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition', 'general_roman_calendar'];
 
     /**
      * Object types each role is permitted to hold tuples for. Used by RoleCascadeService
@@ -54,14 +61,29 @@ class AccessRequestRepository
      * @var array<string, array<int, string>>
      */
     public const ROLE_OBJECT_TYPES = [
-        'developer'       => ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition'],
-        'calendar_editor' => ['national_calendar', 'diocesan_calendar', 'wider_region'],
+        'developer'       => ['national_calendar', 'diocesan_calendar', 'wider_region', 'test_definition', 'general_roman_calendar'],
+        'calendar_editor' => ['national_calendar', 'diocesan_calendar', 'wider_region', 'general_roman_calendar'],
         'test_editor'     => ['test_definition'],
     ];
 
     public function __construct(?PDO $db = null)
     {
         $this->db = $db ?? Connection::getInstance();
+    }
+
+    /**
+     * Validate an object_id for a given object_type.
+     *
+     * general_roman_calendar uses a fixed enumerated id set; all other types accept any
+     * non-empty id (the resource itself is validated downstream by the handler).
+     */
+    public static function isValidObjectIdForType(string $objectType, string $objectId): bool
+    {
+        if ($objectType === 'general_roman_calendar') {
+            return in_array($objectId, self::GRC_OBJECT_IDS, true);
+        }
+
+        return $objectId !== '';
     }
 
     /**

--- a/src/Router.php
+++ b/src/Router.php
@@ -710,9 +710,18 @@ class Router
                 $pipeline->pipe(OpenFgaAuthorizationMiddleware::forGeneralRomanCalendar($fgaClient, 'decrees'));
             }
         } elseif ($route === 'missals') {
-            $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
-            if ($oidcAvailable && $fgaClient !== null && count($requestPathParts) >= 1) {
-                $pipeline->pipe(OpenFgaAuthorizationMiddleware::forMissals($fgaClient, $requestPathParts[0]));
+            // The missal id identifies the resource being authorized. With an id, gate by
+            // calendar_editor + fine-grained FGA (Editio Typica -> general_roman_calendar,
+            // national missal -> national_calendar). Without an id (a collection-level write,
+            // e.g. creating a new missal) no resource-level check is possible, so fail closed
+            // to admin rather than falling back to role-only authorization.
+            if (count($requestPathParts) >= 1) {
+                $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
+                if ($oidcAvailable && $fgaClient !== null) {
+                    $pipeline->pipe(OpenFgaAuthorizationMiddleware::forMissals($fgaClient, $requestPathParts[0]));
+                }
+            } else {
+                $pipeline->pipe(AuthorizationMiddleware::forAdmin());
             }
         }
     }

--- a/src/Router.php
+++ b/src/Router.php
@@ -628,7 +628,7 @@ class Router
 
         // Apply authentication middleware for protected routes
         if (
-            in_array($route, ['data', 'tests', 'temporale'], true)
+            in_array($route, ['data', 'tests', 'temporale', 'missals', 'decrees'], true)
             && in_array($this->request->getMethod(), [RequestMethod::PUT->value, RequestMethod::PATCH->value, RequestMethod::DELETE->value], true)
         ) {
             // Use OIDC (Zitadel) authentication if configured (with legacy JWT fallback),
@@ -700,8 +700,20 @@ class Router
                 $pipeline->pipe(OpenFgaAuthorizationMiddleware::forTestDefinition($fgaClient));
             }
         } elseif ($route === 'temporale') {
-            // Temporale requires admin role (General Roman Calendar)
-            $pipeline->pipe(AuthorizationMiddleware::forAdmin());
+            $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
+            if ($oidcAvailable && $fgaClient !== null) {
+                $pipeline->pipe(OpenFgaAuthorizationMiddleware::forGeneralRomanCalendar($fgaClient, 'temporale'));
+            }
+        } elseif ($route === 'decrees') {
+            $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
+            if ($oidcAvailable && $fgaClient !== null) {
+                $pipeline->pipe(OpenFgaAuthorizationMiddleware::forGeneralRomanCalendar($fgaClient, 'decrees'));
+            }
+        } elseif ($route === 'missals') {
+            $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
+            if ($oidcAvailable && $fgaClient !== null && count($requestPathParts) >= 1) {
+                $pipeline->pipe(OpenFgaAuthorizationMiddleware::forMissals($fgaClient, $requestPathParts[0]));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Adds a new OpenFGA object type **`general_roman_calendar`** so Calendar Editors can be granted edit rights on the base/universal calendar's sub-resources, and wires real authorization onto the corresponding write routes.

Implements the API (Phase A) of the design spec:
`docs/superpowers/specs/2026-06-20-general-roman-calendar-object-type-design.md`
(Plan: `docs/superpowers/plans/2026-06-20-general-roman-calendar-object-type.md`.)

The frontend mirror + grant/request UI (Phase B) is a **separate follow-up branch**, to be opened once this merges (the OpenFGA model must exist server-side first).

## What changed

- **FGA model** (`scripts/openfga-model.json`): new `general_roman_calendar` type with the standard `admin/viewer/editor/deleter` relations.
- **`AccessRequestRepository`**: `general_roman_calendar` added to `VALID_OBJECT_TYPES` and to `ROLE_OBJECT_TYPES` for `calendar_editor` + `developer`; new `GRC_OBJECT_IDS` constant + `isValidObjectIdForType()` helper. This is now the **single authoritative** object-type list — the two handlers' private duplicates were removed and repointed here (consolidation).
- **`OpenFgaAuthorizationMiddleware`**: optional fixed-object-id support; `forGeneralRomanCalendar()` and `forMissals()` factories. `forMissals()` dispatches Editio-Typica editions → `general_roman_calendar:<edition>` and national missals → `national_calendar:<nation-prefix>` (e.g. `IT_1983` → `national_calendar:IT`).
- **`Router`**: `temporale`/`missals`/`decrees` added to the protected write routes; `temporale` changed from admin-only to `calendar_editor` + FGA editor check; `missals`/`decrees` newly gated.
- **Validation**: GRC tuples restricted to the five object IDs (`temporale`, `EDITIO_TYPICA_1970`, `EDITIO_TYPICA_2002`, `EDITIO_TYPICA_2008`, `decrees`) at the access-request submit/approve and admin-grant entry points.

## Object IDs

| Sub-resource | Object ID |
|---|---|
| Temporale | `temporale` |
| Sanctorale — Editio Typica 1970 | `EDITIO_TYPICA_1970` |
| Sanctorale — Editio Typica 2002 | `EDITIO_TYPICA_2002` |
| Sanctorale — Editio Typica 2008 | `EDITIO_TYPICA_2008` |
| Decrees of the Dicastery for Divine Worship | `decrees` |

## Testing

- New/extended PHPUnit tests for the model, repository constants + validation, both middleware factories, the Router wiring, and both handlers' GRC validation.
- `composer parallel-lint`, `composer lint` (phpcs), `composer analyse` (PHPStan level 10): all clean.
- `composer test:quick`: 1222 tests pass; the only 12 errors are integration tests that require a live API server on `localhost:8000` (environmental, pre-existing).

## Reviewer notes / caveats

- **`missals` and `decrees` write handlers are currently 405 "Not yet implemented" stubs** — the enforcement added here is forward-looking and active for `temporale` (the only live write handler today).
- **`temporale`** loosens from admin-only to `calendar_editor` + FGA; admins still bypass FGA, so this is additive for non-admin editors. When OIDC/FGA is not configured, the fine-grained gate is skipped (as on the existing `data` route).
- **`developer`-only** users (without the `calendar_editor` role) are gated out at the route's `forCalendarEditor()` check — identical to the existing `data` route.
- Deferred non-blocking nits: the static `RouterAuthorizationTest` could assert `forAdmin` absence directly; `CALENDAR_OBJECT_TYPES` and the GRC-ids error message are future consolidation candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced granular permission control for Calendar Editor role with fixed enumerated resources (including temporale, multiple Editio Typica editions, and decrees)
  * Enhanced authorization model for liturgical calendar editing with fine-grained per-resource access control

* **Tests**
  * Added validation tests for permission handling of new calendar resources and object identifiers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->