### PR TITLE
feat(api): scoped admin-review endpoints for resource-admins

### DIFF
--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -1569,7 +1569,7 @@
         ],
         "summary": "List all access requests",
         "operationId": "adminListAccessRequests",
-        "description": "List a paginated page of access requests with optional status filter. Default page size is 100; clients page via `limit` and `offset`, inspecting `has_more` (or comparing `offset + count` against `total`). Global admins see all rows. Resource admins see only requests over resources they administer \u2014 for those, the post-fetch filter may shrink the returned page below `limit`, but `total` and `has_more` reflect the pre-filter SQL paginator; clients should keep paging until `has_more` is false. Requires admin role.",
+        "description": "List a paginated page of access requests with optional status filter. Default page size is 100; clients page via `limit` and `offset`, inspecting `has_more` (or comparing `offset + count` against `total`). Global admins see all rows. Resource admins see only requests over resources they administer \u2014 for those, the post-fetch filter may shrink the returned page below `limit`, but `total` and `has_more` reflect the pre-filter SQL paginator; clients should keep paging until `has_more` is false. Requires either the global admin role or OpenFGA resource-admin access; resource admins receive role-based filtered results.",
         "parameters": [
           {
             "name": "status",

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -1079,6 +1079,48 @@
         }
       }
     },
+    "/auth/admin-scopes": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get the caller's admin scopes",
+        "operationId": "authAdminScopes",
+        "description": "Returns whether the authenticated user is a global admin or an OpenFGA resource-admin, together with the list of objects they administer. Returns HTTP 200 with `is_global_admin=false` and an empty `admin_scopes` array when the user holds no admin relation at all. Response is not cacheable (`Cache-Control: no-store`).",
+        "responses": {
+          "200": {
+            "description": "OK: Admin scope information",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string",
+                  "example": "no-store"
+                },
+                "description": "Always set to `no-store` to prevent caching of auth state."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminScopesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          }
+        }
+      }
+    },
     "/auth/notifications": {
       "get": {
         "tags": [
@@ -1220,7 +1262,7 @@
                 "examples": {
                   "firstPage": {
                     "summary": "First page (defaults)",
-                    "description": "Default request — no `limit` / `offset` supplied — returning the first page of the user's two access requests.",
+                    "description": "Default request \u2014 no `limit` / `offset` supplied \u2014 returning the first page of the user's two access requests.",
                     "value": {
                       "requests": [
                         {
@@ -1261,7 +1303,7 @@
                   },
                   "lastPage": {
                     "summary": "Last page (has_more false)",
-                    "description": "Final page of the requester's listing: `offset + count == total`, so `has_more` is false and the client stops paging. With `total: 2` and the default `limit: 100`, the first page already exhausts the dataset — this example is the same shape as `firstPage` for that reason.",
+                    "description": "Final page of the requester's listing: `offset + count == total`, so `has_more` is false and the client stops paging. With `total: 2` and the default `limit: 100`, the first page already exhausts the dataset \u2014 this example is the same shape as `firstPage` for that reason.",
                     "value": {
                       "requests": [
                         {
@@ -1426,7 +1468,7 @@
         ],
         "summary": "Resubmit a rejected access request",
         "operationId": "resubmitAccessRequest",
-        "description": "Resubmit a previously rejected access request with updated permissions (and optionally an updated justification). Only the user who created the request may resubmit it, and only when its current status is `rejected` — the request transitions back to `pending` for admin re-review. The role originally requested cannot be changed; create a new request via POST /auth/access-requests for a different role. Permissions in the body are validated identically to POST /auth/access-requests (object_type and relation must match the same enums; role-permission consistency is enforced).",
+        "description": "Resubmit a previously rejected access request with updated permissions (and optionally an updated justification). Only the user who created the request may resubmit it, and only when its current status is `rejected` \u2014 the request transitions back to `pending` for admin re-review. The role originally requested cannot be changed; create a new request via POST /auth/access-requests for a different role. Permissions in the body are validated identically to POST /auth/access-requests (object_type and relation must match the same enums; role-permission consistency is enforced).",
         "parameters": [
           {
             "name": "id",
@@ -1527,7 +1569,7 @@
         ],
         "summary": "List all access requests",
         "operationId": "adminListAccessRequests",
-        "description": "List a paginated page of access requests with optional status filter. Default page size is 100; clients page via `limit` and `offset`, inspecting `has_more` (or comparing `offset + count` against `total`). Global admins see all rows. Resource admins see only requests over resources they administer — for those, the post-fetch filter may shrink the returned page below `limit`, but `total` and `has_more` reflect the pre-filter SQL paginator; clients should keep paging until `has_more` is false. Requires admin role.",
+        "description": "List a paginated page of access requests with optional status filter. Default page size is 100; clients page via `limit` and `offset`, inspecting `has_more` (or comparing `offset + count` against `total`). Global admins see all rows. Resource admins see only requests over resources they administer \u2014 for those, the post-fetch filter may shrink the returned page below `limit`, but `total` and `has_more` reflect the pre-filter SQL paginator; clients should keep paging until `has_more` is false. Requires admin role.",
         "parameters": [
           {
             "name": "status",
@@ -1561,7 +1603,7 @@
                 "examples": {
                   "firstPage": {
                     "summary": "First page (defaults)",
-                    "description": "Abbreviated sample of the first page returned by a default admin listing — no `limit` / `offset` supplied. `total: 137` and `count: 100` would be realistic over a populated table; only one representative `requests[]` entry is shown here to keep the doc readable. `has_more: true` because `offset + count < total`.",
+                    "description": "Abbreviated sample of the first page returned by a default admin listing \u2014 no `limit` / `offset` supplied. `total: 137` and `count: 100` would be realistic over a populated table; only one representative `requests[]` entry is shown here to keep the doc readable. `has_more: true` because `offset + count < total`.",
                     "value": {
                       "requests": [
                         {
@@ -1610,7 +1652,7 @@
                   },
                   "lastPage": {
                     "summary": "Last page (has_more false)",
-                    "description": "Abbreviated sample of the final page of an admin traversal. `offset + count == total` (100 + 37 = 137), so `has_more` is false and the client stops. Only one representative `requests[]` entry is shown — a real response on this page would carry 37 items.",
+                    "description": "Abbreviated sample of the final page of an admin traversal. `offset + count == total` (100 + 37 = 137), so `has_more` is false and the client stops. Only one representative `requests[]` entry is shown \u2014 a real response on this page would carry 37 items.",
                     "value": {
                       "requests": [
                         {
@@ -1866,7 +1908,7 @@
         ],
         "summary": "Get admin notification counts",
         "operationId": "adminGetNotifications",
-        "description": "Get counts of pending items requiring admin attention. Requires admin role.",
+        "description": "Get counts of pending items requiring admin attention. Requires admin role or OpenFGA resource-admin access. Global admins receive unscoped counts across all resources; resource-admins receive counts scoped to the resources they administer.",
         "responses": {
           "200": {
             "description": "OK: Notification counts",
@@ -2025,7 +2067,7 @@
         ],
         "summary": "List permission tuples",
         "operationId": "adminListPermissions",
-        "description": "List OpenFGA permission tuples. Global admins see all; resource admins see only tuples on resources they administer. Supports filtering by user, object_type, object_id, and relation. **Resource admins must supply `object_type`** to scope the listing — calling without one returns 400.",
+        "description": "List OpenFGA permission tuples. Global admins see all; resource admins see only tuples on resources they administer. Supports filtering by user, object_type, object_id, and relation. **Resource admins must supply `object_type`** to scope the listing \u2014 calling without one returns 400.",
         "parameters": [
           {
             "name": "user",
@@ -2098,14 +2140,24 @@
             "description": "Paginated list of permission tuples.",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AdminListPermissionsResponse" },
+                "schema": {
+                  "$ref": "#/components/schemas/AdminListPermissionsResponse"
+                },
                 "examples": {
                   "firstPage": {
-                    "summary": "First page of results — more remain",
+                    "summary": "First page of results \u2014 more remain",
                     "value": {
                       "permissions": [
-                        { "user": "user:zitadel-123", "relation": "editor", "object": "national_calendar:IT" },
-                        { "user": "user:zitadel-456", "relation": "viewer", "object": "national_calendar:IT" }
+                        {
+                          "user": "user:zitadel-123",
+                          "relation": "editor",
+                          "object": "national_calendar:IT"
+                        },
+                        {
+                          "user": "user:zitadel-456",
+                          "relation": "viewer",
+                          "object": "national_calendar:IT"
+                        }
                       ],
                       "count": 2,
                       "has_more": true,
@@ -2113,10 +2165,14 @@
                     }
                   },
                   "lastPage": {
-                    "summary": "Final page — no more results",
+                    "summary": "Final page \u2014 no more results",
                     "value": {
                       "permissions": [
-                        { "user": "user:zitadel-789", "relation": "deleter", "object": "national_calendar:IT" }
+                        {
+                          "user": "user:zitadel-789",
+                          "relation": "deleter",
+                          "object": "national_calendar:IT"
+                        }
                       ],
                       "count": 1,
                       "has_more": false,
@@ -2263,7 +2319,9 @@
                     "cascaded_roles": {
                       "type": "array",
                       "description": "Zitadel role names that were cascade-revoked synchronously because the deleted tuple was the user's last in-scope tuple for the role. Empty when cascade_deferred is true, when no role lost its last tuple, or when Zitadel/OpenFGA is unconfigured.",
-                      "items": { "type": "string" }
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "tuples_deleted": {
                       "type": "array",
@@ -2271,11 +2329,21 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "user": { "type": "string" },
-                          "relation": { "type": "string" },
-                          "object": { "type": "string" }
+                          "user": {
+                            "type": "string"
+                          },
+                          "relation": {
+                            "type": "string"
+                          },
+                          "object": {
+                            "type": "string"
+                          }
                         },
-                        "required": ["user", "relation", "object"],
+                        "required": [
+                          "user",
+                          "relation",
+                          "object"
+                        ],
                         "additionalProperties": false
                       }
                     },
@@ -2285,18 +2353,30 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "outbox_id": { "type": "integer" },
-                          "status": { "type": "string" },
-                          "error": { "type": "string" }
+                          "outbox_id": {
+                            "type": "integer"
+                          },
+                          "status": {
+                            "type": "string"
+                          },
+                          "error": {
+                            "type": "string"
+                          }
                         },
-                        "required": ["outbox_id", "status", "error"],
+                        "required": [
+                          "outbox_id",
+                          "status",
+                          "error"
+                        ],
                         "additionalProperties": false
                       }
                     },
                     "outbox_ids": {
                       "type": "array",
                       "description": "Outbox row IDs created by this revoke. The handler always inserts exactly one row per call, so this is a single-element array.",
-                      "items": { "type": "integer" }
+                      "items": {
+                        "type": "integer"
+                      }
                     },
                     "outbox_pending": {
                       "type": "integer",
@@ -3398,7 +3478,7 @@
                         "gospel_acclamation": "Matteo 23, 9b.10b",
                         "gospel": "Matteo 23, 8-12"
                       },
-                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesiæ doctorum",
+                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesi\u00e6 doctorum",
                       "missal": "VATICAN_1970"
                     },
                     "StRayPenyafort": {
@@ -3486,7 +3566,7 @@
                         "gospel_acclamation": "Mt 23, 9b.10b",
                         "gospel": "Mt 23, 8-12"
                       },
-                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesiæ doctorum",
+                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesi\u00e6 doctorum",
                       "missal": "VATICAN_1970"
                     },
                     "StRayPenyafort": {
@@ -3593,7 +3673,7 @@
                         "gospel_acclamation": "Mt 23, 9b.10b",
                         "gospel": "Mt 23, 8-12"
                       },
-                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesiæ doctorum",
+                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesi\u00e6 doctorum",
                       "missal": "VATICAN_1970"
                     },
                     "StRayPenyafort": {
@@ -3698,7 +3778,7 @@
                         "gospel_acclamation": "Mt 23, 9b.10b",
                         "gospel": "Mt 23, 8-12"
                       },
-                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesiæ doctorum",
+                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesi\u00e6 doctorum",
                       "missal": "VATICAN_1970"
                     },
                     "StRayPenyafort": {
@@ -3797,7 +3877,7 @@
                         "gospel_acclamation": "Matteo 23, 9b.10b",
                         "gospel": "Matteo 23, 8-12"
                       },
-                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesiæ doctorum",
+                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesi\u00e6 doctorum",
                       "missal": "VATICAN_1970"
                     },
                     "StRayPenyafort": {
@@ -3894,7 +3974,7 @@
                         "gospel_acclamation": "Mt 23, 9b.10b",
                         "gospel": "Mt 23, 8-12"
                       },
-                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesiæ doctorum",
+                      "name": "Sancti Basilii Magni et Gregorii Nazianzeni, episcoporum et Ecclesi\u00e6 doctorum",
                       "missal": "VATICAN_1970"
                     },
                     "StRayPenyafort": {
@@ -7348,7 +7428,7 @@
       },
       "AccessRequest": {
         "type": "object",
-        "description": "An access request from the requester's perspective. Returned by GET /auth/access-requests (self-list) and used as the row shape inside AccessRequestListResponse. Admin-only review/sync fields (reviewed_by, zitadel_sync_status, zitadel_sync_error) are intentionally absent here — admin-facing endpoints return AccessRequestAdmin instead. `credentials` stays public so the requester sees what they themselves submitted.",
+        "description": "An access request from the requester's perspective. Returned by GET /auth/access-requests (self-list) and used as the row shape inside AccessRequestListResponse. Admin-only review/sync fields (reviewed_by, zitadel_sync_status, zitadel_sync_error) are intentionally absent here \u2014 admin-facing endpoints return AccessRequestAdmin instead. `credentials` stays public so the requester sees what they themselves submitted.",
         "properties": {
           "id": {
             "type": "string",
@@ -7434,7 +7514,7 @@
       },
       "AccessRequestAdmin": {
         "type": "object",
-        "description": "Admin-only view of an access request. Same shape as AccessRequest plus reviewer identity (`reviewed_by`) and Zitadel-sync diagnostics (`zitadel_sync_status`, `zitadel_sync_error`). The common fields are documented on AccessRequest. Duplicated inline (rather than composed via `allOf` over AccessRequest) because `allOf + additionalProperties: false` doesn't compose under Redocly's strict validator — each sub-schema's `additionalProperties` only sees its own properties and rejects the other side's fields.",
+        "description": "Admin-only view of an access request. Same shape as AccessRequest plus reviewer identity (`reviewed_by`) and Zitadel-sync diagnostics (`zitadel_sync_status`, `zitadel_sync_error`). The common fields are documented on AccessRequest. Duplicated inline (rather than composed via `allOf` over AccessRequest) because `allOf + additionalProperties: false` doesn't compose under Redocly's strict validator \u2014 each sub-schema's `additionalProperties` only sees its own properties and rejects the other side's fields.",
         "properties": {
           "id": {
             "type": "string",
@@ -7639,7 +7719,7 @@
       },
       "AccessRequestListResponse": {
         "type": "object",
-        "description": "Offset-paginated page of access requests returned by GET /auth/access-requests (the requester's own list). Each item is the public AccessRequest shape — admin-only review/sync fields are not present. See AdminAccessRequestListResponse for the /admin/access-requests envelope.",
+        "description": "Offset-paginated page of access requests returned by GET /auth/access-requests (the requester's own list). Each item is the public AccessRequest shape \u2014 admin-only review/sync fields are not present. See AdminAccessRequestListResponse for the /admin/access-requests envelope.",
         "properties": {
           "requests": {
             "type": "array",
@@ -7716,7 +7796,7 @@
           },
           "has_more": {
             "type": "boolean",
-            "description": "True iff more rows are available beyond this page. For global admins, equals `(offset + count) < total`. For non-global admins, reflects the SQL paginator state — `(offset + pre-filter SQL page size) < total` — rather than the post-filter `count`, so the client stops correctly on the final SQL page even when filterByAdminAccess trimmed it."
+            "description": "True iff more rows are available beyond this page. For global admins, equals `(offset + count) < total`. For non-global admins, reflects the SQL paginator state \u2014 `(offset + pre-filter SQL page size) < total` \u2014 rather than the post-filter `count`, so the client stops correctly on the final SQL page even when filterByAdminAccess trimmed it."
           }
         },
         "required": [
@@ -7875,11 +7955,21 @@
             "items": {
               "type": "object",
               "properties": {
-                "user": { "type": "string" },
-                "relation": { "type": "string" },
-                "object": { "type": "string" }
+                "user": {
+                  "type": "string"
+                },
+                "relation": {
+                  "type": "string"
+                },
+                "object": {
+                  "type": "string"
+                }
               },
-              "required": ["user", "relation", "object"],
+              "required": [
+                "user",
+                "relation",
+                "object"
+              ],
               "additionalProperties": false
             }
           },
@@ -7889,18 +7979,30 @@
             "items": {
               "type": "object",
               "properties": {
-                "outbox_id": { "type": "integer" },
-                "status": { "type": "string" },
-                "error": { "type": "string" }
+                "outbox_id": {
+                  "type": "integer"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "error": {
+                  "type": "string"
+                }
               },
-              "required": ["outbox_id", "status", "error"],
+              "required": [
+                "outbox_id",
+                "status",
+                "error"
+              ],
               "additionalProperties": false
             }
           },
           "outbox_ids": {
             "type": "array",
             "description": "Outbox row IDs created by this revoke (one per permission tuple). Empty on the no-permissions fast path.",
-            "items": { "type": "integer" }
+            "items": {
+              "type": "integer"
+            }
           },
           "outbox_pending": {
             "type": "integer",
@@ -8161,28 +8263,38 @@
       },
       "AdminListPermissionsResponse": {
         "type": "object",
-        "description": "Cursor-paginated page of OpenFGA permission tuples. Use `next_page_token` to fetch the next page; `null` means this was the last page. Note: when the handler applies a server-side admin-access filter, the returned `permissions` array may be shorter than `limit` — clients should keep paging until `has_more` is false.",
+        "description": "Cursor-paginated page of OpenFGA permission tuples. Use `next_page_token` to fetch the next page; `null` means this was the last page. Note: when the handler applies a server-side admin-access filter, the returned `permissions` array may be shorter than `limit` \u2014 clients should keep paging until `has_more` is false.",
         "properties": {
           "permissions": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/PermissionTuple" },
+            "items": {
+              "$ref": "#/components/schemas/PermissionTuple"
+            },
             "description": "Tuples in this page, up to the requested `limit` (may be fewer after server-side filtering)."
           },
           "count": {
             "type": "integer",
             "minimum": 0,
-            "description": "Number of tuples in this page (`permissions.length`). NOT a total count across all pages — OpenFGA does not expose an O(1) total."
+            "description": "Number of tuples in this page (`permissions.length`). NOT a total count across all pages \u2014 OpenFGA does not expose an O(1) total."
           },
           "has_more": {
             "type": "boolean",
             "description": "True iff the OpenFGA store has more tuples matching the filter beyond this page."
           },
           "next_page_token": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "description": "Opaque continuation token to pass back as `page_token` for the next page. `null` when `has_more` is false."
           }
         },
-        "required": ["permissions", "count", "has_more", "next_page_token"],
+        "required": [
+          "permissions",
+          "count",
+          "has_more",
+          "next_page_token"
+        ],
         "additionalProperties": false
       },
       "SuccessResponse": {
@@ -8759,7 +8871,7 @@
       },
       "UserNotificationsResponse": {
         "type": "object",
-        "description": "Response from GET /auth/notifications — the inbox with unread badge metadata.",
+        "description": "Response from GET /auth/notifications \u2014 the inbox with unread badge metadata.",
         "properties": {
           "items": {
             "type": "array",
@@ -8785,6 +8897,49 @@
           "total",
           "unread_count",
           "last_seen_at"
+        ],
+        "additionalProperties": false
+      },
+      "AdminScopesResponse": {
+        "type": "object",
+        "properties": {
+          "is_global_admin": {
+            "type": "boolean",
+            "description": "True when the caller holds the global `admin` Zitadel role."
+          },
+          "is_resource_admin": {
+            "type": "boolean",
+            "description": "True when the caller holds an OpenFGA `admin` relation on at least one resource."
+          },
+          "admin_scopes": {
+            "type": "array",
+            "description": "Resources the caller administers via OpenFGA. Empty when `is_resource_admin` is false.",
+            "items": {
+              "type": "object",
+              "properties": {
+                "object_type": {
+                  "type": "string",
+                  "example": "national_calendar",
+                  "description": "The OpenFGA object type."
+                },
+                "object_id": {
+                  "type": "string",
+                  "example": "IT",
+                  "description": "The OpenFGA object ID."
+                }
+              },
+              "required": [
+                "object_type",
+                "object_id"
+              ],
+              "additionalProperties": false
+            }
+          }
+        },
+        "required": [
+          "is_global_admin",
+          "is_resource_admin",
+          "admin_scopes"
         ],
         "additionalProperties": false
       }
@@ -9344,7 +9499,7 @@
           },
           "i18n": {
             "ja_JP": {
-              "StFrancisXavier": "聖フランシスコ・ザビエル司祭"
+              "StFrancisXavier": "\u8056\u30d5\u30e9\u30f3\u30b7\u30b9\u30b3\u30fb\u30b6\u30d3\u30a8\u30eb\u53f8\u796d"
             }
           }
         }
@@ -9642,7 +9797,7 @@
             "schema": {
               "type": "string"
             },
-            "example": "BEGIN:VCALENDAR\nPRODID:-//John Romano D'Orazio//Liturgical Calendar V1.0//EN\nVERSION:2.0\nCALSCALE:GREGORIAN\nMETHOD:PUBLISH\nX-MS-OLK-FORCEINSPECTOROPEN:FALSE\nX-WR-CALNAME:Roman Catholic Universal Liturgical Calendar LA\nX-WR-TIMEZONE:Europe/Vatican\nX-PUBLISHED-TTL:PT1D\nBEGIN:VEVENT\nCLASS:PUBLIC\nDTSTART;VALUE=DATE:20291231\nDTSTAMP:20240422T062620Z\nUID:c0e7126a841a70761e4057e58b5e2d52\nCREATED:\nDESCRIPTION:\\nSOLLEMNITAS\\nalbus\nLAST-MODIFIED:\nSUMMARY;LANGUAGE=la:SOLLEMNITAS SANCTÆ DEI GENITRICIS MARIÆ Missa in Vigi\n  lia\nTRANSP:TRANSPARENT\nX-MICROSOFT-CDO-ALLDAYEVENT:TRUE\nX-MICROSOFT-DISALLOW-COUNTER:TRUE\nX-ALT-DESC;FMTTYPE=text/html:<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.\n  2//EN\">\\n<HTML>\\n<BODY>\\n\\n<P DIR=LTR><BR><B>SOLLEMNITAS</B><BR><B><I><\n  SPAN LANG=la><FONT FACE=\"Calibri\" COLOR=\"#AAAAAA\">albus</FONT></SPAN></\n  I></B><BR>ANNUM B</P>\\n\\n</BODY>\\n</HTML>\nEND:VEVENT\nEND:VCALENDAR"
+            "example": "BEGIN:VCALENDAR\nPRODID:-//John Romano D'Orazio//Liturgical Calendar V1.0//EN\nVERSION:2.0\nCALSCALE:GREGORIAN\nMETHOD:PUBLISH\nX-MS-OLK-FORCEINSPECTOROPEN:FALSE\nX-WR-CALNAME:Roman Catholic Universal Liturgical Calendar LA\nX-WR-TIMEZONE:Europe/Vatican\nX-PUBLISHED-TTL:PT1D\nBEGIN:VEVENT\nCLASS:PUBLIC\nDTSTART;VALUE=DATE:20291231\nDTSTAMP:20240422T062620Z\nUID:c0e7126a841a70761e4057e58b5e2d52\nCREATED:\nDESCRIPTION:\\nSOLLEMNITAS\\nalbus\nLAST-MODIFIED:\nSUMMARY;LANGUAGE=la:SOLLEMNITAS SANCT\u00c6 DEI GENITRICIS MARI\u00c6 Missa in Vigi\n  lia\nTRANSP:TRANSPARENT\nX-MICROSOFT-CDO-ALLDAYEVENT:TRUE\nX-MICROSOFT-DISALLOW-COUNTER:TRUE\nX-ALT-DESC;FMTTYPE=text/html:<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.\n  2//EN\">\\n<HTML>\\n<BODY>\\n\\n<P DIR=LTR><BR><B>SOLLEMNITAS</B><BR><B><I><\n  SPAN LANG=la><FONT FACE=\"Calibri\" COLOR=\"#AAAAAA\">albus</FONT></SPAN></\n  I></B><BR>ANNUM B</P>\\n\\n</BODY>\\n</HTML>\nEND:VEVENT\nEND:VCALENDAR"
           },
           "application/xml": {
             "schema": {

--- a/phpunit_tests/Handlers/Admin/NotificationsHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/NotificationsHandlerTest.php
@@ -4,13 +4,19 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Handlers\Admin;
 
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use LiturgicalCalendar\Api\Handlers\Admin\NotificationsHandler;
 use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
 use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
 use LiturgicalCalendar\Api\Repositories\ApplicationRepository;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(NotificationsHandler::class)]
@@ -101,5 +107,83 @@ final class NotificationsHandlerTest extends AbstractHandlerTestCase
 
         $types = array_column($body['items'], 'type');
         self::assertSame(['application', 'access_request', 'access_request'], $types);
+    }
+
+    /**
+     * @param array<int, GuzzleResponse> $responses
+     */
+    private function handlerWithFga(array $responses): NotificationsHandler
+    {
+        $stack  = HandlerStack::create(new MockHandler($responses));
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+        return new NotificationsHandler($client);
+    }
+
+    public function testResourceAdminGetsScopedCount(): void
+    {
+        $accessRepo = new AccessRequestRepository(self::$pdo);
+        // Request the resource-admin administers (national_calendar:IT)
+        $accessRepo->create('user-it', 'it@x.test', 'ItUser', 'calendar_editor', [
+            ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+        ]);
+        usleep(2000);
+        // Request the resource-admin does NOT administer (national_calendar:US)
+        $accessRepo->create('user-us', 'us@x.test', 'UsUser', 'calendar_editor', [
+            ['object_type' => 'national_calendar', 'object_id' => 'US', 'relation' => 'editor'],
+        ]);
+
+        // resolveScopes: 4 list-objects calls (national_calendar -> IT, rest empty),
+        // then filterByAdminAccess: 1 check() per request (IT -> allowed, US -> denied).
+        $handler = $this->handlerWithFga([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"allowed":true}'),
+            new GuzzleResponse(200, [], '{"allowed":false}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/admin/notifications')
+            ->withAttribute('oidc_user', ['sub' => 'cei-admin', 'roles' => ['calendar_editor']]);
+
+        $response = $handler->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+        self::assertSame(1, $body['pending_access_requests']);
+        self::assertSame(0, $body['pending_applications']);
+        self::assertSame(1, $body['total']);
+        self::assertCount(1, $body['items']);
+        self::assertSame('access_request', $body['items'][0]['type']);
+        self::assertSame('admin-permissions.php', $body['items'][0]['url']);
+    }
+
+    public function testPlainEditorWithNoScopesIsForbidden(): void
+    {
+        // resolveScopes: 4 empty list-objects responses -> no scopes -> rejected.
+        $handler = $this->handlerWithFga([
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/admin/notifications')
+            ->withAttribute('oidc_user', ['sub' => 'plain-editor', 'roles' => ['calendar_editor']]);
+
+        $this->expectException(ForbiddenException::class);
+        $this->expectExceptionMessage('Admin role required');
+
+        $handler->handle($request);
     }
 }

--- a/phpunit_tests/Handlers/Auth/AdminScopesHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/AdminScopesHandlerTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers\Auth;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Handlers\Auth\AdminScopesHandler;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(AdminScopesHandler::class)]
+final class AdminScopesHandlerTest extends AbstractHandlerTestCase
+{
+    /**
+     * @param array<int, GuzzleResponse> $responses
+     */
+    private function handlerWith(array $responses): AdminScopesHandler
+    {
+        $stack  = HandlerStack::create(new MockHandler($responses));
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+        return new AdminScopesHandler($client);
+    }
+
+    public function testMissingOidcUserIsUnauthorized(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+        $this->handlerWith([])->handle($this->requestFor('GET', '/auth/admin-scopes'));
+    }
+
+    public function testResourceAdminGetsScopes(): void
+    {
+        // Four list-objects responses, in ADMIN_OBJECT_TYPES order.
+        $handler = $this->handlerWith([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/admin-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'cei-admin', 'roles' => ['calendar_editor']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertFalse($body['is_global_admin']);
+        self::assertTrue($body['is_resource_admin']);
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $body['admin_scopes']
+        );
+    }
+
+    public function testGlobalAdminIsFlaggedEvenWithNoFgaScopes(): void
+    {
+        $handler = $this->handlerWith([
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/admin-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'root', 'roles' => ['admin']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertTrue($body['is_global_admin']);
+        self::assertFalse($body['is_resource_admin']);
+        self::assertSame([], $body['admin_scopes']);
+    }
+
+    public function testPlainEditorGetsBothFalse(): void
+    {
+        $handler = $this->handlerWith([
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/admin-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'cei-editor', 'roles' => ['calendar_editor']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertFalse($body['is_global_admin']);
+        self::assertFalse($body['is_resource_admin']);
+        self::assertSame([], $body['admin_scopes']);
+    }
+
+    public function testFailsClosedWhenOpenFgaErrors(): void
+    {
+        $handler = $this->handlerWith([
+            new GuzzleResponse(500, [], 'boom'),
+        ]);
+
+        $request = $this->requestFor('GET', '/auth/admin-scopes')
+            ->withAttribute('oidc_user', ['sub' => 'cei-admin', 'roles' => ['admin']]);
+
+        $body = $this->decodeJsonBody($handler->handle($request));
+
+        self::assertTrue($body['is_global_admin']);
+        self::assertFalse($body['is_resource_admin']);
+        self::assertSame([], $body['admin_scopes']);
+    }
+}

--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ResourceAdminService::class)]
+final class ResourceAdminServiceTest extends TestCase
+{
+    /**
+     * @param array<int, GuzzleResponse> $responses Queued, replayed in order.
+     */
+    private function serviceWith(array $responses): ResourceAdminService
+    {
+        $stack  = HandlerStack::create(new MockHandler($responses));
+        $guzzle = new GuzzleClient(['handler' => $stack]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+        return new ResourceAdminService($client);
+    }
+
+    public function testResolveScopesUnionsAdminTuplesAcrossTypes(): void
+    {
+        // One list-objects response per ADMIN_OBJECT_TYPES entry, in order:
+        // national_calendar, diocesan_calendar, wider_region, general_roman_calendar
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $service->resolveScopes('cei-admin')
+        );
+    }
+
+    public function testResolveScopesFailsClosedOnOpenFgaError(): void
+    {
+        $service = $this->serviceWith([
+            new GuzzleResponse(500, [], 'boom'),
+        ]);
+
+        self::assertSame([], $service->resolveScopes('cei-admin'));
+    }
+
+    public function testFilterByAdminAccessKeepsOnlyFullyAdministeredRequests(): void
+    {
+        // check() calls, in request order:
+        // req A perm national_calendar:IT -> allowed
+        // req B perm national_calendar:US -> denied
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"allowed":true}'),
+            new GuzzleResponse(200, [], '{"allowed":false}'),
+        ]);
+
+        $requests = [
+            ['id' => 'A', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]],
+            ['id' => 'B', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'US', 'relation' => 'editor']]],
+            ['id' => 'C', 'permissions' => []],
+        ];
+
+        $filtered = $service->filterByAdminAccess($requests, 'cei-admin');
+
+        self::assertSame(['A'], array_column($filtered, 'id'));
+    }
+}

--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -137,12 +137,12 @@ final class ResourceAdminServiceTest extends TestCase
         self::assertSame(['A'], array_column($filtered, 'id'));
     }
 
-    public function testFilterByAdminAccessPropagatesRuntimeException(): void
+    public function testFilterByAdminAccessFailsClosedOnRuntimeException(): void
     {
-        // filterByAdminAccess does NOT catch RuntimeException (contrast with
-        // resolveScopes, which fails closed on error). A 500 response from
-        // OpenFGA causes OpenFgaApiException (which extends RuntimeException)
-        // to propagate out of the method uncaught.
+        // filterByAdminAccess fails closed (like resolveScopes): a 500 response
+        // from OpenFGA raises OpenFgaApiException (extends RuntimeException),
+        // which is caught per-request so the offending request is excluded
+        // rather than surfacing a 500 to the caller.
         $service = $this->serviceWith([
             new GuzzleResponse(500, [], 'boom'),
         ]);
@@ -151,7 +151,7 @@ final class ResourceAdminServiceTest extends TestCase
             ['id' => 'A', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]],
         ];
 
-        $this->expectException(\RuntimeException::class);
-        $service->filterByAdminAccess($requests, 'cei-admin');
+        $filtered = $service->filterByAdminAccess($requests, 'cei-admin');
+        $this->assertSame([], $filtered);
     }
 }

--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -83,4 +83,75 @@ final class ResourceAdminServiceTest extends TestCase
 
         self::assertSame(['A'], array_column($filtered, 'id'));
     }
+
+    public function testResolveScopesUnionsMultipleTypesWithResults(): void
+    {
+        // One list-objects response per ADMIN_OBJECT_TYPES entry, in order:
+        // national_calendar, diocesan_calendar, wider_region, general_roman_calendar.
+        // Two types return results; the union must include both in ADMIN_OBJECT_TYPES order.
+        // (The existing happy-path test covers a single type; this proves the cross-type union.)
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":["diocesan_calendar:ROMA"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ]);
+
+        self::assertSame(
+            [
+                ['object_type' => 'national_calendar', 'object_id' => 'IT'],
+                ['object_type' => 'diocesan_calendar', 'object_id' => 'ROMA'],
+            ],
+            $service->resolveScopes('multi-admin')
+        );
+    }
+
+    public function testFilterByAdminAccessCachesDuplicateResourceChecks(): void
+    {
+        // The same resource (national_calendar:IT) appears twice in the permissions
+        // array of a single request. Without per-call caching, filterByAdminAccess
+        // would call check() twice, consuming two queued responses. With caching it
+        // calls check() only once per unique "{type}:{id}" key.
+        //
+        // Proof mechanism: Guzzle MockHandler throws OutOfBoundsException when the
+        // response queue is exhausted. Queuing exactly ONE response and observing
+        // that the test completes without exception — and that the request is kept —
+        // demonstrates the second check was served from the in-memory cache rather
+        // than making a second network call.
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"allowed":true}'),
+        ]);
+
+        $requests = [
+            [
+                'id'          => 'A',
+                'permissions' => [
+                    ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+                    ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+                ],
+            ],
+        ];
+
+        $filtered = $service->filterByAdminAccess($requests, 'cei-admin');
+
+        self::assertSame(['A'], array_column($filtered, 'id'));
+    }
+
+    public function testFilterByAdminAccessPropagatesRuntimeException(): void
+    {
+        // filterByAdminAccess does NOT catch RuntimeException (contrast with
+        // resolveScopes, which fails closed on error). A 500 response from
+        // OpenFGA causes OpenFgaApiException (which extends RuntimeException)
+        // to propagate out of the method uncaught.
+        $service = $this->serviceWith([
+            new GuzzleResponse(500, [], 'boom'),
+        ]);
+
+        $requests = [
+            ['id' => 'A', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]],
+        ];
+
+        $this->expectException(\RuntimeException::class);
+        $service->filterByAdminAccess($requests, 'cei-admin');
+    }
 }

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -24,6 +24,7 @@ use LiturgicalCalendar\Api\Services\Outbox\OutboxNotifier;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxStatus;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
 use LiturgicalCalendar\Api\Services\RoleCascadeService;
 use LiturgicalCalendar\Api\Services\ZitadelService;
 use Psr\Http\Message\ResponseInterface;
@@ -1006,36 +1007,6 @@ final class AccessRequestAdminHandler extends AbstractHandler
             return [];
         }
 
-        $fgaUser = "user:{$adminId}";
-
-        // Cache admin checks to avoid redundant API calls
-        /** @var array<string, bool> $cache */
-        $cache = [];
-
-        return array_values(array_filter($requests, function (array $req) use ($fgaUser, &$cache): bool {
-            /** @var array<int, array{object_type: string, object_id: string, relation: string}> $permissions */
-            $permissions = is_array($req['permissions'] ?? null) ? $req['permissions'] : [];
-
-            if (empty($permissions)) {
-                return false;
-            }
-
-            // Admin must have access to ALL resources in the request
-            foreach ($permissions as $perm) {
-                $objectType = $perm['object_type'] ?? '';
-                $objectId   = $perm['object_id'] ?? '';
-                $key        = "{$objectType}:{$objectId}";
-
-                if (!isset($cache[$key])) {
-                    $cache[$key] = $this->getFgaClient()->check($fgaUser, 'admin', $key);
-                }
-
-                if (!$cache[$key]) {
-                    return false;
-                }
-            }
-
-            return true;
-        }));
+        return ( new ResourceAdminService($this->getFgaClient()) )->filterByAdminAccess($requests, $adminId);
     }
 }

--- a/src/Handlers/Admin/NotificationsHandler.php
+++ b/src/Handlers/Admin/NotificationsHandler.php
@@ -157,8 +157,10 @@ final class NotificationsHandler extends AbstractHandler
         $applicationRepo                       = $this->getApplicationRepository();
         $notifications['pending_applications'] = $applicationRepo->countPendingApplications();
 
+        // getPendingApplications() returns oldest-first (ORDER BY created_at ASC),
+        // so take the last 5 to include the most recent pending applications.
         $pendingApps = $applicationRepo->getPendingApplications();
-        foreach (array_slice($pendingApps, 0, 5) as $app) {
+        foreach (array_slice($pendingApps, -5) as $app) {
             $notifications['items'][] = [
                 'type'            => 'application',
                 'id'              => $app['id'] ?? '',

--- a/src/Handlers/Admin/NotificationsHandler.php
+++ b/src/Handlers/Admin/NotificationsHandler.php
@@ -14,6 +14,8 @@ use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
 use LiturgicalCalendar\Api\Repositories\ApplicationRepository;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -29,14 +31,29 @@ final class NotificationsHandler extends AbstractHandler
 {
     private ?AccessRequestRepository $accessRequestRepo = null;
     private ?ApplicationRepository $applicationRepo     = null;
+    private ?OpenFgaClient $fgaClient                   = null;
 
-    public function __construct()
+    public function __construct(?OpenFgaClient $fgaClient = null)
     {
         parent::__construct();
 
+        $this->fgaClient             = $fgaClient;
         $this->allowedRequestMethods = [RequestMethod::GET];
         $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
         $this->allowCredentials      = true;
+    }
+
+    private function isFgaClientAvailable(): bool
+    {
+        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
+    }
+
+    private function getFgaClient(): OpenFgaClient
+    {
+        if ($this->fgaClient === null) {
+            $this->fgaClient = OpenFgaClient::fromEnv();
+        }
+        return $this->fgaClient;
     }
 
     private function getAccessRequestRepository(): AccessRequestRepository
@@ -78,10 +95,8 @@ final class NotificationsHandler extends AbstractHandler
             throw new UnauthorizedException('Authentication required');
         }
 
-        // Verify admin role
-        if (!OidcAuthMiddleware::isAdmin($oidcUser)) {
-            throw new ForbiddenException('Admin role required');
-        }
+        $isGlobalAdmin = OidcAuthMiddleware::isAdmin($oidcUser);
+        $sub           = $oidcUser['sub'] ?? null;
 
         // Get notification counts
         $notifications = [
@@ -91,66 +106,131 @@ final class NotificationsHandler extends AbstractHandler
             'items'                   => [],
         ];
 
-        if (Connection::isConfigured()) {
-            // Get access request counts (unified role + permission requests)
-            $accessRequestRepo                        = $this->getAccessRequestRepository();
-            $notifications['pending_access_requests'] = $accessRequestRepo->countPending();
-
-            // Get recent pending access requests for the dropdown.
-            // getPending() returns oldest-first (ORDER BY created_at ASC),
-            // so take the last 5 and reverse to display newest-first.
-            $pendingRequests = $accessRequestRepo->getPending();
-            $recentPending   = array_reverse(array_slice($pendingRequests, -5));
-            foreach ($recentPending as $req) {
-                $displayName              = !empty($req['user_name'])
-                    ? $req['user_name']
-                    : ( !empty($req['user_email'])
-                        ? $req['user_email']
-                        : ( 'User ' . substr(is_string($req['zitadel_user_id'] ?? null) ? $req['zitadel_user_id'] : '', -6) ) );
-                $notifications['items'][] = [
-                    'type'       => 'access_request',
-                    'id'         => $req['id'] ?? '',
-                    'user_name'  => $displayName,
-                    'user_email' => $req['user_email'] ?? '',
-                    'role'       => $req['requested_role'] ?? '',
-                    'created_at' => $req['created_at'] ?? '',
-                    'url'        => 'admin-permissions.php',
-                ];
+        if ($isGlobalAdmin) {
+            if (Connection::isConfigured()) {
+                $notifications = $this->buildGlobalAdminNotifications($notifications);
+            }
+        } else {
+            // Resource-admin path: admit only callers who hold an OpenFGA admin
+            // tuple on at least one resource. Fail closed when FGA is unavailable.
+            if (!$this->isFgaClientAvailable() || !is_string($sub) || trim($sub) === '') {
+                throw new ForbiddenException('Admin role required');
             }
 
-            // Get pending applications count
-            $applicationRepo                       = $this->getApplicationRepository();
-            $notifications['pending_applications'] = $applicationRepo->countPendingApplications();
-
-            // Get recent pending applications for the dropdown
-            $pendingApps = $applicationRepo->getPendingApplications();
-            foreach (array_slice($pendingApps, 0, 5) as $app) {
-                $notifications['items'][] = [
-                    'type'            => 'application',
-                    'id'              => $app['id'] ?? '',
-                    'app_name'        => $app['name'] ?? 'Unknown',
-                    'zitadel_user_id' => $app['zitadel_user_id'] ?? '',
-                    'requested_scope' => $app['requested_scope'] ?? 'read',
-                    'created_at'      => $app['created_at'] ?? '',
-                    'url'             => 'admin-applications.php',
-                ];
+            $scopeService = new ResourceAdminService($this->getFgaClient());
+            if ($scopeService->resolveScopes($sub) === []) {
+                throw new ForbiddenException('Admin role required');
             }
 
-            // Sort items by created_at descending and limit to 5 most recent
-            usort($notifications['items'], function ($a, $b) {
-                $aDate = is_string($a['created_at']) ? $a['created_at'] : '';
-                $bDate = is_string($b['created_at']) ? $b['created_at'] : '';
-                return strcmp($bDate, $aDate);
-            });
-            $notifications['items'] = array_slice($notifications['items'], 0, 5);
-
-            $notifications['total'] = $notifications['pending_access_requests']
-                                    + $notifications['pending_applications'];
+            if (Connection::isConfigured()) {
+                $notifications = $this->buildResourceAdminNotifications($notifications, $scopeService, $sub);
+            }
         }
 
         // Add Cache-Control header to prevent caching
         $response = $response->withHeader('Cache-Control', 'no-store');
 
         return $this->encodeResponseBody($response, $notifications);
+    }
+
+    /**
+     * Build the unscoped (global-admin) notification payload.
+     *
+     * @param array{pending_access_requests: int, pending_applications: int, total: int, items: array<int, array<string, mixed>>} $notifications
+     * @return array{pending_access_requests: int, pending_applications: int, total: int, items: array<int, array<string, mixed>>}
+     */
+    private function buildGlobalAdminNotifications(array $notifications): array
+    {
+        $accessRequestRepo                        = $this->getAccessRequestRepository();
+        $notifications['pending_access_requests'] = $accessRequestRepo->countPending();
+
+        // getPending() returns oldest-first (ORDER BY created_at ASC),
+        // so take the last 5 and reverse to display newest-first.
+        $pendingRequests = $accessRequestRepo->getPending();
+        $recentPending   = array_reverse(array_slice($pendingRequests, -5));
+        foreach ($recentPending as $req) {
+            $notifications['items'][] = $this->accessRequestItem($req);
+        }
+
+        $applicationRepo                       = $this->getApplicationRepository();
+        $notifications['pending_applications'] = $applicationRepo->countPendingApplications();
+
+        $pendingApps = $applicationRepo->getPendingApplications();
+        foreach (array_slice($pendingApps, 0, 5) as $app) {
+            $notifications['items'][] = [
+                'type'            => 'application',
+                'id'              => $app['id'] ?? '',
+                'app_name'        => $app['name'] ?? 'Unknown',
+                'zitadel_user_id' => $app['zitadel_user_id'] ?? '',
+                'requested_scope' => $app['requested_scope'] ?? 'read',
+                'created_at'      => $app['created_at'] ?? '',
+                'url'             => 'admin-applications.php',
+            ];
+        }
+
+        usort($notifications['items'], function ($a, $b) {
+            $aDate = is_string($a['created_at']) ? $a['created_at'] : '';
+            $bDate = is_string($b['created_at']) ? $b['created_at'] : '';
+            return strcmp($bDate, $aDate);
+        });
+        $notifications['items'] = array_slice($notifications['items'], 0, 5);
+
+        $notifications['total'] = $notifications['pending_access_requests']
+                                + $notifications['pending_applications'];
+
+        return $notifications;
+    }
+
+    /**
+     * Build the scoped (resource-admin) notification payload: only the pending
+     * access-requests the caller administers; no applications.
+     *
+     * @param array{pending_access_requests: int, pending_applications: int, total: int, items: array<int, array<string, mixed>>} $notifications
+     * @return array{pending_access_requests: int, pending_applications: int, total: int, items: array<int, array<string, mixed>>}
+     */
+    private function buildResourceAdminNotifications(
+        array $notifications,
+        ResourceAdminService $scopeService,
+        string $sub
+    ): array {
+        $pendingRequests = $this->getAccessRequestRepository()->getPending();
+        $scoped          = $scopeService->filterByAdminAccess($pendingRequests, $sub);
+
+        $notifications['pending_access_requests'] = count($scoped);
+        $notifications['pending_applications']    = 0;
+        $notifications['total']                   = count($scoped);
+
+        // getPending() is oldest-first; filter preserves order. Newest 5, newest-first.
+        $recentScoped = array_reverse(array_slice($scoped, -5));
+        foreach ($recentScoped as $req) {
+            $notifications['items'][] = $this->accessRequestItem($req);
+        }
+
+        return $notifications;
+    }
+
+    /**
+     * Build a single access_request notification item.
+     *
+     * @param array<string, mixed> $req
+     * @return array<string, mixed>
+     */
+    private function accessRequestItem(array $req): array
+    {
+        $displayName = !empty($req['user_name'])
+            ? $req['user_name']
+            : ( !empty($req['user_email'])
+                ? $req['user_email']
+                : ( 'User ' . substr(is_string($req['zitadel_user_id'] ?? null) ? $req['zitadel_user_id'] : '', -6) ) );
+
+        return [
+            'type'       => 'access_request',
+            'id'         => $req['id'] ?? '',
+            'user_name'  => $displayName,
+            'user_email' => $req['user_email'] ?? '',
+            'role'       => $req['requested_role'] ?? '',
+            'created_at' => $req['created_at'] ?? '',
+            'url'        => 'admin-permissions.php',
+        ];
     }
 }

--- a/src/Handlers/Admin/NotificationsHandler.php
+++ b/src/Handlers/Admin/NotificationsHandler.php
@@ -25,7 +25,9 @@ use Psr\Http\Message\ServerRequestInterface;
  * Returns notification counts for admin users.
  * GET /admin/notifications - Get counts of pending items
  *
- * Requires admin role.
+ * Requires admin role or OpenFGA resource-admin access.
+ * Global admins receive unscoped counts across all resources;
+ * resource-admins receive counts scoped to their administered resources.
  */
 final class NotificationsHandler extends AbstractHandler
 {

--- a/src/Handlers/Auth/AdminScopesHandler.php
+++ b/src/Handlers/Auth/AdminScopesHandler.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Auth;
+
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Admin Scopes Handler
+ *
+ * GET /auth/admin-scopes — report the authenticated caller's admin status:
+ *   - is_global_admin: the Zitadel `admin` role is present in the token.
+ *   - admin_scopes: union of OpenFGA `admin` tuples across the admin-capable
+ *     object types, as [{object_type, object_id}].
+ *   - is_resource_admin: admin_scopes is non-empty.
+ *
+ * Fails closed: when OpenFGA is unavailable, admin_scopes is empty and
+ * is_resource_admin is false, but is_global_admin is still honored from the token.
+ */
+final class AdminScopesHandler extends AbstractHandler
+{
+    private ?OpenFgaClient $fgaClient = null;
+
+    public function __construct(?OpenFgaClient $fgaClient = null)
+    {
+        parent::__construct();
+
+        $this->fgaClient             = $fgaClient;
+        $this->allowedRequestMethods = [RequestMethod::GET];
+        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
+        $this->allowCredentials      = true;
+    }
+
+    private function isFgaClientAvailable(): bool
+    {
+        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
+    }
+
+    private function getFgaClient(): OpenFgaClient
+    {
+        if ($this->fgaClient === null) {
+            $this->fgaClient = OpenFgaClient::fromEnv();
+        }
+        return $this->fgaClient;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+        $method   = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime)
+            ->withHeader('Cache-Control', 'no-store');
+
+        /** @var array{sub?: string, roles?: array<string>}|null $oidcUser */
+        $oidcUser = $request->getAttribute('oidc_user');
+
+        if ($oidcUser === null) {
+            throw new UnauthorizedException('Authentication required');
+        }
+
+        $sub = $oidcUser['sub'] ?? null;
+        if (!is_string($sub) || trim($sub) === '') {
+            throw new UnauthorizedException('Invalid authentication token');
+        }
+
+        $isGlobalAdmin = OidcAuthMiddleware::isAdmin($oidcUser);
+
+        $scopes = [];
+        if ($this->isFgaClientAvailable()) {
+            $scopes = ( new ResourceAdminService($this->getFgaClient()) )->resolveScopes($sub);
+        }
+
+        return $this->encodeResponseBody($response, [
+            'is_global_admin'   => $isGlobalAdmin,
+            'is_resource_admin' => $scopes !== [],
+            'admin_scopes'      => $scopes,
+        ]);
+    }
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -29,6 +29,7 @@ use LiturgicalCalendar\Api\Handlers\Admin\AccessRequestAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\ApplicationAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\NotificationsHandler as AdminNotificationsHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\OutboxAdminHandler;
+use LiturgicalCalendar\Api\Handlers\Auth\AdminScopesHandler;
 use LiturgicalCalendar\Api\Handlers\Auth\NotificationsHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\PermissionAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\UsersHandler;
@@ -363,6 +364,10 @@ class Router
                         // POST /auth/notifications/seen   - Mark inbox seen
                         $notificationsHandler = new NotificationsHandler();
                         $this->handler        = $notificationsHandler;
+                    } elseif ($authRoute === 'admin-scopes') {
+                        // GET /auth/admin-scopes - Report caller's global/resource admin status + scopes
+                        $adminScopesHandler = new AdminScopesHandler();
+                        $this->handler      = $adminScopesHandler;
                     } else {
                         $this->response = new Response(StatusCode::NOT_FOUND->value, [], null, $this->request->getProtocolVersion(), StatusCode::NOT_FOUND->reason());
                         $this->emitResponse();
@@ -610,7 +615,7 @@ class Router
         // Apply OIDC authentication for auth routes (access-requests, email-verification, notifications), admin, and applications
         // These routes need the oidc_user attribute set before the handler checks authentication
         if (
-            ( $route === 'auth' && count($requestPathParts) >= 1 && in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications'], true) )
+            ( $route === 'auth' && count($requestPathParts) >= 1 && in_array($requestPathParts[0], ['access-requests', 'email-verification', 'notifications', 'admin-scopes'], true) )
             || $route === 'admin'
             || $route === 'applications'
         ) {

--- a/src/Services/ResourceAdminService.php
+++ b/src/Services/ResourceAdminService.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+/**
+ * Resolves and applies a user's OpenFGA `admin` scopes.
+ *
+ * Single home for the resource-admin scoping logic shared by
+ * AdminScopesHandler (GET /auth/admin-scopes), the widened
+ * NotificationsHandler (GET /admin/notifications), and
+ * AccessRequestAdminHandler (GET /admin/access-requests). Centralizing it
+ * keeps the badge count and the review list in agreement.
+ */
+final class ResourceAdminService
+{
+    /**
+     * Object types a user can hold the `admin` relation on. Mirrors the
+     * admin-capable types in the OpenFGA authorization model.
+     */
+    public const ADMIN_OBJECT_TYPES = [
+        'national_calendar',
+        'diocesan_calendar',
+        'wider_region',
+        'general_roman_calendar',
+    ];
+
+    public function __construct(private readonly OpenFgaClient $fgaClient)
+    {
+    }
+
+    /**
+     * Union of the objects the user holds `admin` on across ADMIN_OBJECT_TYPES.
+     *
+     * Fails closed: any OpenFGA transport error yields an empty scope set.
+     *
+     * @param string $sub Zitadel user ID (without "user:" prefix)
+     * @return list<array{object_type: string, object_id: string}>
+     */
+    public function resolveScopes(string $sub): array
+    {
+        $fgaUser = "user:{$sub}";
+        $scopes  = [];
+
+        try {
+            foreach (self::ADMIN_OBJECT_TYPES as $type) {
+                foreach ($this->fgaClient->listObjects($fgaUser, 'admin', $type) as $objectId) {
+                    $scopes[] = ['object_type' => $type, 'object_id' => $objectId];
+                }
+            }
+        } catch (\RuntimeException) {
+            // Fail closed — caller is treated as not-a-resource-admin.
+            return [];
+        }
+
+        return $scopes;
+    }
+
+    /**
+     * Filter requests to only those the resource admin administers in full.
+     *
+     * A request qualifies only if the admin holds the `admin` relation on
+     * EVERY resource in that request's permissions array. Requests with an
+     * empty permissions array are excluded.
+     *
+     * @param array<int, array<string, mixed>> $requests
+     * @param string $adminUserId Admin's Zitadel user ID (without "user:" prefix)
+     * @return array<int, array<string, mixed>> Filtered, re-indexed requests
+     */
+    public function filterByAdminAccess(array $requests, string $adminUserId): array
+    {
+        $fgaUser = "user:{$adminUserId}";
+
+        /** @var array<string, bool> $cache */
+        $cache = [];
+
+        return array_values(array_filter($requests, function (array $req) use ($fgaUser, &$cache): bool {
+            /** @var array<int, array{object_type: string, object_id: string, relation: string}> $permissions */
+            $permissions = is_array($req['permissions'] ?? null) ? $req['permissions'] : [];
+            return $this->administersAllResources($permissions, $fgaUser, $cache);
+        }));
+    }
+
+    /**
+     * True iff the admin holds `admin` on every resource in $permissions.
+     *
+     * An empty $permissions array returns false (matches the prior
+     * AccessRequestAdminHandler behavior of excluding empty-permission
+     * requests). The $cache de-duplicates OpenFGA `check` calls per resource.
+     *
+     * @param array<int, array{object_type: string, object_id: string, relation: string}> $permissions
+     * @param string $fgaUser Fully-qualified FGA user (e.g. "user:cei-admin")
+     * @param array<string, bool> $cache Shared per-call check cache (by reference)
+     */
+    public function administersAllResources(array $permissions, string $fgaUser, array &$cache): bool
+    {
+        if (empty($permissions)) {
+            return false;
+        }
+
+        foreach ($permissions as $perm) {
+            $objectType = $perm['object_type'] ?? '';
+            $objectId   = $perm['object_id'] ?? '';
+            $key        = "{$objectType}:{$objectId}";
+
+            if (!isset($cache[$key])) {
+                $cache[$key] = $this->fgaClient->check($fgaUser, 'admin', $key);
+            }
+
+            if (!$cache[$key]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Services/ResourceAdminService.php
+++ b/src/Services/ResourceAdminService.php
@@ -90,8 +90,11 @@ final class ResourceAdminService
      * requests). The $cache de-duplicates OpenFGA `check` calls per resource.
      *
      * @param array<int, array{object_type: string, object_id: string, relation: string}> $permissions
-     * @param string $fgaUser Fully-qualified FGA user (e.g. "user:cei-admin")
+     * @param string $fgaUser Fully-qualified FGA user string in `user:{sub}` form (already
+     *                        prefixed). Contrast with {@see filterByAdminAccess()}, which accepts
+     *                        a raw Zitadel sub and prepends the `user:` prefix internally.
      * @param array<string, bool> $cache Shared per-call check cache (by reference)
+     * @return bool True iff the caller holds `admin` on every listed resource
      */
     public function administersAllResources(array $permissions, string $fgaUser, array &$cache): bool
     {

--- a/src/Services/ResourceAdminService.php
+++ b/src/Services/ResourceAdminService.php
@@ -78,7 +78,13 @@ final class ResourceAdminService
         return array_values(array_filter($requests, function (array $req) use ($fgaUser, &$cache): bool {
             /** @var array<int, array{object_type: string, object_id: string, relation: string}> $permissions */
             $permissions = is_array($req['permissions'] ?? null) ? $req['permissions'] : [];
-            return $this->administersAllResources($permissions, $fgaUser, $cache);
+            try {
+                return $this->administersAllResources($permissions, $fgaUser, $cache);
+            } catch (\RuntimeException) {
+                // Fail closed — a transient OpenFGA failure excludes the request
+                // rather than surfacing a 500. Mirrors resolveScopes().
+                return false;
+            }
         }));
     }
 


### PR DESCRIPTION
## Summary

API half of the **scoped admin-review** feature: lets an OpenFGA *resource-admin* (holds an `admin` tuple on ≥1 resource, but **not** the global Zitadel `admin` role) review the access-requests scoped to the resources they administer. The frontend half is in **LiturgicalCalendarFrontend PR #345**.

The API remains the **sole authorization boundary** — these changes expose admin scope to the UI and widen the notifications endpoint; every privileged action stays authorized server-side against OpenFGA.

## Changes

- **`ResourceAdminService`** (new) — single home for the OpenFGA-backed scoping logic: `resolveScopes()` (union of `admin` objects across `national_calendar`, `diocesan_calendar`, `wider_region`, `general_roman_calendar`; fail-closed `[]` on any OpenFGA error), `filterByAdminAccess()` (keep requests the admin administers in full), and the `administersAllResources()` predicate with per-call `check()` caching.
- **`AccessRequestAdminHandler::filterByAdminAccess`** — refactored to delegate to the new service (behavior-preserving; existing suite is the regression oracle).
- **`GET /auth/admin-scopes`** (new, OIDC-protected) — reports `{ is_global_admin, is_resource_admin, admin_scopes: [{object_type, object_id}] }`. `is_global_admin` from the token; fail-closed when OpenFGA is unavailable.
- **`GET /admin/notifications`** (widened) — global-admin payload unchanged; resource-admins now get a **scoped** count + items (only the access-requests they administer, `pending_applications: 0`); plain editors still `403`.
- OpenAPI schema updated for both endpoints; docblocks clarified.

## Fail-closed / safety

When OpenFGA is unavailable, every layer treats the caller as not-a-resource-admin (`resolveScopes → []`, handler gates → 403), while `is_global_admin` is still honored from the token. The badge count and the review list use the **same predicate** (`filterByAdminAccess`) so they cannot disagree.

## Testing

- Full suite green: **1322 tests / 293,108 assertions** (6 pre-existing `@group slow`/env skips).
- New unit tests: `ResourceAdminServiceTest` (resolve/filter, multi-type union, check-cache dedup, RuntimeException propagation), `AdminScopesHandlerTest` (5 cases incl. fail-closed), `NotificationsHandlerTest` (+resource-admin scoped count, +plain-editor 403).
- PHPStan level 10 clean; phpcs clean; `lint:openapi` valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added a new authenticated endpoint to retrieve admin scope information, including whether the caller is a global admin or a resource admin and the corresponding administered resources.

* **Bug Fixes**
  * Improved Unicode rendering in liturgical calendar event example payloads.
  * Enhanced admin access request/notification behavior to respect resource-scoped permissions.

* **Documentation**
  * Refined OpenAPI response schemas, examples, and endpoint/field descriptions (including pagination semantics and revoke error details).

* **Tests**
  * Added coverage for admin scope resolution and fail-closed authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->