### PR TITLE
fix(api): make /calendars self-calls resilient (wildcard host + loopback rate-limit)

### DIFF
--- a/phpunit_tests/Http/ApiKeyRateLimitMiddlewareTest.php
+++ b/phpunit_tests/Http/ApiKeyRateLimitMiddlewareTest.php
@@ -216,6 +216,22 @@ final class ApiKeyRateLimitMiddlewareTest extends TestCase
         }
     }
 
+    public function testIpv4MappedIpv6LoopbackSelfCallsAreExemptFromRateLimit(): void
+    {
+        // Dual-stack IPv6 sockets can surface IPv4 loopback connections as the
+        // IPv4-mapped form ::ffff:127.0.0.1 — this must be exempt too.
+        $_ENV['APP_ENV'] = 'production';
+        putenv('APP_ENV=production');
+
+        $limit      = 2;
+        $middleware = new ApiKeyRateLimitMiddleware($limit, $this->storagePath, false);
+
+        for ($i = 0; $i < $limit + 5; $i++) {
+            $response = $middleware->process($this->makeLoopbackRequest('::ffff:127.0.0.1'), $this->okHandler);
+            $this->assertSame(200, $response->getStatusCode());
+        }
+    }
+
     public function testLoopbackExemptionDoesNotExemptOtherIps(): void
     {
         $_ENV['APP_ENV'] = 'production';

--- a/phpunit_tests/Http/ApiKeyRateLimitMiddlewareTest.php
+++ b/phpunit_tests/Http/ApiKeyRateLimitMiddlewareTest.php
@@ -172,6 +172,67 @@ final class ApiKeyRateLimitMiddlewareTest extends TestCase
         $this->assertSame((string) ( $limit - 1 ), $other->getHeaderLine('X-RateLimit-Remaining'));
     }
 
+    private function makeLoopbackRequest(string $remoteAddr): ServerRequestInterface
+    {
+        // A genuine API self-call (RegionalDataHandler / EventsParams fetching
+        // /calendars) carries no X-Forwarded-For and arrives from loopback.
+        return new ServerRequest(
+            'GET',
+            '/calendars',
+            [],
+            null,
+            '1.1',
+            ['REMOTE_ADDR' => $remoteAddr]
+        );
+    }
+
+    public function testLoopbackIpv4SelfCallsAreExemptFromRateLimit(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        putenv('APP_ENV=production');
+
+        $limit      = 2;
+        $middleware = new ApiKeyRateLimitMiddleware($limit, $this->storagePath, false);
+
+        // Far more than `$limit` loopback self-calls must all pass: the API
+        // must never throttle its own internal requests to itself.
+        for ($i = 0; $i < $limit + 5; $i++) {
+            $response = $middleware->process($this->makeLoopbackRequest('127.0.0.1'), $this->okHandler);
+            $this->assertSame(200, $response->getStatusCode());
+        }
+    }
+
+    public function testLoopbackIpv6SelfCallsAreExemptFromRateLimit(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        putenv('APP_ENV=production');
+
+        $limit      = 2;
+        $middleware = new ApiKeyRateLimitMiddleware($limit, $this->storagePath, false);
+
+        for ($i = 0; $i < $limit + 5; $i++) {
+            $response = $middleware->process($this->makeLoopbackRequest('::1'), $this->okHandler);
+            $this->assertSame(200, $response->getStatusCode());
+        }
+    }
+
+    public function testLoopbackExemptionDoesNotExemptOtherIps(): void
+    {
+        $_ENV['APP_ENV'] = 'production';
+        putenv('APP_ENV=production');
+
+        $limit      = 2;
+        $middleware = new ApiKeyRateLimitMiddleware($limit, $this->storagePath, false);
+
+        // A non-loopback REMOTE_ADDR must still be throttled normally, proving
+        // the exemption is scoped strictly to loopback self-calls.
+        $middleware->process($this->makeLoopbackRequest('203.0.113.7'), $this->okHandler);
+        $middleware->process($this->makeLoopbackRequest('203.0.113.7'), $this->okHandler);
+
+        $this->expectException(TooManyRequestsException::class);
+        $middleware->process($this->makeLoopbackRequest('203.0.113.7'), $this->okHandler);
+    }
+
     public function testTrustProxyHeadersOverridesProductionEnv(): void
     {
         $_ENV['APP_ENV'] = 'production';

--- a/phpunit_tests/RouterTest.php
+++ b/phpunit_tests/RouterTest.php
@@ -99,6 +99,37 @@ final class RouterTest extends TestCase
         self::assertFalse(Router::isLocalhost());
     }
 
+    public function testResolveServerHostFromServerName(): void
+    {
+        $_SERVER['SERVER_NAME'] = 'api.example.com';
+        self::assertSame('api.example.com', Router::resolveServerHost());
+    }
+
+    public function testResolveServerHostFallsBackToServerAddr(): void
+    {
+        $_SERVER['SERVER_ADDR'] = '203.0.113.42';
+        self::assertSame('203.0.113.42', Router::resolveServerHost());
+    }
+
+    public function testResolveServerHostDefaultsToLocalhost(): void
+    {
+        self::assertSame('localhost', Router::resolveServerHost());
+    }
+
+    public function testResolveServerHostNormalizesWildcardServerName(): void
+    {
+        // Under `php -S 0.0.0.0:8000` (e.g. in CI containers) SERVER_NAME is the
+        // wildcard bind address, which is not reliably routable for self-calls.
+        $_SERVER['SERVER_NAME'] = '0.0.0.0';
+        self::assertSame('127.0.0.1', Router::resolveServerHost());
+    }
+
+    public function testResolveServerHostNormalizesWildcardServerAddr(): void
+    {
+        $_SERVER['SERVER_ADDR'] = '0.0.0.0';
+        self::assertSame('127.0.0.1', Router::resolveServerHost());
+    }
+
     public function testGetApiPathsCliMode(): void
     {
         // In CLI mode (PHP_SAPI === 'cli', which is true under PHPUnit),

--- a/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
+++ b/src/Http/Middleware/ApiKeyRateLimitMiddleware.php
@@ -62,7 +62,21 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
             $limit      = is_int($rateLimit) ? $rateLimit : ( is_numeric($rateLimit) ? intval($rateLimit) : $this->defaultLimit );
         } else {
             // Unauthenticated: rate limit by IP address
-            $identifier = 'ip_' . $this->getClientIp($request);
+            $clientIp = $this->getClientIp($request);
+
+            // Exempt loopback self-calls. The API issues internal HTTP requests
+            // to its own endpoints (e.g. RegionalDataHandler and EventsParams
+            // fetching /calendars); these originate from 127.0.0.0/8 or ::1 and
+            // must not be charged against the public unauthenticated quota —
+            // otherwise the API throttles itself once UNAUTHENTICATED_RATE_LIMIT
+            // internal calls occur within the window. Deployments that terminate
+            // client traffic on the same host must set TRUST_PROXY_HEADERS=true
+            // so real clients resolve to their forwarded address, not loopback.
+            if (self::isLoopbackAddress($clientIp)) {
+                return $handler->handle($request);
+            }
+
+            $identifier = 'ip_' . $clientIp;
             $limit      = $this->defaultLimit;
         }
 
@@ -143,5 +157,29 @@ class ApiKeyRateLimitMiddleware implements MiddlewareInterface
         $serverParams = $request->getServerParams();
         $remoteAddr   = $serverParams['REMOTE_ADDR'] ?? '127.0.0.1';
         return is_string($remoteAddr) ? $remoteAddr : '127.0.0.1';
+    }
+
+    /**
+     * Determine whether an IP address is a loopback (self-call) address.
+     *
+     * Covers the IPv4 loopback range 127.0.0.0/8, the IPv6 loopback ::1, and
+     * the IPv4-mapped IPv6 form (::ffff:127.0.0.0/8).
+     *
+     * @param string $ip
+     * @return bool
+     */
+    private static function isLoopbackAddress(string $ip): bool
+    {
+        if ($ip === '::1') {
+            return true;
+        }
+
+        // IPv4-mapped IPv6 loopback, e.g. ::ffff:127.0.0.1
+        if (stripos($ip, '::ffff:') === 0) {
+            $ip = substr($ip, 7);
+        }
+
+        return filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false
+            && str_starts_with($ip, '127.');
     }
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -789,6 +789,32 @@ class Router
         return 'http';
     }
 
+    /**
+     * Resolve the host used to build the API's own base URL (self-referential requests).
+     *
+     * Prefers SERVER_NAME, falls back to SERVER_ADDR, then to 'localhost'. The wildcard
+     * bind address 0.0.0.0 (reported by SERVER_NAME/SERVER_ADDR under `php -S 0.0.0.0:8000`,
+     * as used in CI containers) is normalized to the loopback address: 0.0.0.0 is valid for
+     * binding but not reliably routable as a request target, so self-calls such as
+     * RegionalDataHandler validating against /calendars would otherwise fail.
+     */
+    public static function resolveServerHost(): string
+    {
+        $host = isset($_SERVER['SERVER_NAME']) && is_string($_SERVER['SERVER_NAME']) && '' !== $_SERVER['SERVER_NAME']
+            ? $_SERVER['SERVER_NAME']
+            : (
+                isset($_SERVER['SERVER_ADDR']) && is_string($_SERVER['SERVER_ADDR']) && '' !== $_SERVER['SERVER_ADDR']
+                ? $_SERVER['SERVER_ADDR']
+                : 'localhost'
+            );
+
+        if ('0.0.0.0' === $host) {
+            $host = '127.0.0.1';
+        }
+
+        return $host;
+    }
+
     public static function getApiPaths(): void
     {
         // The websocket server will be running in CLI mode,
@@ -835,13 +861,7 @@ class Router
         /**
          * Detect server name or server address if name is not available
          */
-        $api_full_path .= isset($_SERVER['SERVER_NAME']) && is_string($_SERVER['SERVER_NAME'])
-            ? $_SERVER['SERVER_NAME']
-            : (
-                isset($_SERVER['SERVER_ADDR']) && is_string($_SERVER['SERVER_ADDR'])
-                ? $_SERVER['SERVER_ADDR']
-                : 'localhost'
-            );
+        $api_full_path .= self::resolveServerHost();
 
 
         /**


### PR DESCRIPTION
## Summary

The API issues internal HTTP self-calls to its own `/calendars` endpoint —
`RegionalDataHandler`'s constructor and `EventsParams` both call
`Utilities::jsonUrlToObject(Route::CALENDARS->path())`. Two distinct bugs made
those self-calls fail inside a containerized deployment, which in turn made
`/data` write requests fail *before* reaching the authorization check
(returning a non-403 where a scoped denial was expected).

Both are fixed here, each with unit tests.

### 1. Normalize the wildcard host `0.0.0.0` (`51bce428`)

Under `php -S 0.0.0.0:8000` (the docker/CI run command), `$_SERVER['SERVER_NAME']`
is the wildcard bind address `0.0.0.0`. `Router::getApiPaths()` used it verbatim
to build `Router::$apiPath`, so self-calls hit `http://0.0.0.0:8000/calendars` —
valid for *binding* but not reliably routable as a request *target* inside a
container, so `Utilities::rawContentsFromUrl()` failed.

Host resolution is extracted into a testable `Router::resolveServerHost()`
(prefers `SERVER_NAME` → `SERVER_ADDR` → `localhost`) that normalizes the
wildcard `0.0.0.0` to the loopback `127.0.0.1`. This mirrors `isLocalhost()`,
which already classifies `0.0.0.0` as local.

### 2. Exempt loopback self-calls from the unauthenticated rate limit (`0cd6a197`)

`ApiKeyRateLimitMiddleware` charged the unauthenticated `/calendars` self-calls
(originating from `127.0.0.1`) against the per-IP `UNAUTHENTICATED_RATE_LIMIT`
bucket. Once that many internal calls occur within the window, the API begins
**throttling itself**: the self-call returns 429, the handler constructor throws,
and the request never reaches authorization. (Worse without APCu, e.g. the
`cli-server` SAPI, where `/calendars` isn't cached.) This is also a latent
production issue.

Loopback client IPs (`127.0.0.0/8`, `::1`, and the IPv4-mapped IPv6 form) are
now exempt from the unauthenticated rate limit. All other addresses are
throttled exactly as before. Deployments that terminate client traffic on the
same host must set `TRUST_PROXY_HEADERS=true` so real clients resolve to their
forwarded address rather than loopback (already required for correct per-client
limiting in that topology).

## Future work (not in this PR)

The cleanest long-term fix is to eliminate the HTTP self-call entirely:
`RegionalDataHandler`/`EventsParams` could build `MetadataCalendars` directly
from local source data (as `MetadataHandler::buildIndex()` does) instead of
looping back through the network. Tracked separately.

## Testing

- `Router::resolveServerHost()`: 5 new tests in `phpunit_tests/RouterTest.php`
- Loopback exemption: 3 new tests in `phpunit_tests/Http/ApiKeyRateLimitMiddlewareTest.php`
  (incl. a scoping test proving non-loopback IPs are still throttled)
- Full quick suite green (1321 tests), `composer lint` (phpcs) clean, `composer analyse` (PHPStan L10) clean
- **End-to-end:** verified against the frontend RBAC e2e suite (LiturgicalCalendarFrontend),
  temporarily pinned to this branch — **21/21 specs pass**, including the previously-failing
  scoped `/data` PATCH specs 10 & 11c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Localhost (loopback) requests are now exempt from API rate limiting, improving development and internal service workflows.
  * Enhanced server host resolution with improved handling of wildcard bind addresses.

* **Tests**
  * Added comprehensive test coverage for loopback rate-limit exemption across IPv4, IPv6, and IPv4-mapped IPv6 addresses.
  * Added test coverage for server host resolution with various configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->