### PR TITLE
refactor(api): eliminate the /calendars HTTP self-call (#659)

### DIFF
--- a/phpunit_tests/Handlers/EventsHandlerTest.php
+++ b/phpunit_tests/Handlers/EventsHandlerTest.php
@@ -7,23 +7,16 @@ namespace LiturgicalCalendar\Tests\Handlers;
 use LiturgicalCalendar\Api\Handlers\EventsHandler;
 use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
-use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(EventsHandler::class)]
 final class EventsHandlerTest extends AbstractHandlerTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-        // EventsHandler constructs an EventsParams, which fetches
-        // /calendars metadata via file_get_contents during its constructor.
-        // Point Router::$apiPath at the file:// fixture introduced in M1 so
-        // the fetch is deterministic and offline.
-        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
-        self::assertNotFalse($fixturePath, 'M1 calendars fixture must be present');
-        Router::$apiPath = 'file://' . $fixturePath;
-    }
+    // EventsHandler constructs an EventsParams, which now builds the calendars
+    // metadata index in-process from local source data (CalendarMetadataProvider)
+    // rather than fetching /calendars over HTTP. AbstractHandlerTestCase already
+    // pins Router::$apiFilePath to the project root, so the build resolves
+    // against the bundled sourcedata with no HTTP server or fixture needed.
 
     public function testOptionsPreflightSucceeds(): void
     {

--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -7,7 +7,6 @@ namespace LiturgicalCalendar\Tests\Handlers;
 use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
 use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
-use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
@@ -20,16 +19,11 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(RegionalDataHandler::class)]
 final class RegionalDataHandlerTest extends AbstractHandlerTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-        // The handler resolves national/diocesan keys against the /calendars
-        // metadata; route the fetch at the M1 fixture so the lookups succeed
-        // deterministically without an HTTP server.
-        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
-        self::assertNotFalse($fixturePath, 'M1 calendars fixture must be present');
-        Router::$apiPath = 'file://' . $fixturePath;
-    }
+    // The handler resolves national/diocesan keys against the calendars metadata
+    // index, which RegionalDataHandler now builds in-process from local source
+    // data (CalendarMetadataProvider). AbstractHandlerTestCase already pins
+    // Router::$apiFilePath to the project root, so those lookups resolve against
+    // the bundled sourcedata with no HTTP server or fixture needed.
 
     public function testOptionsPreflightSucceeds(): void
     {

--- a/phpunit_tests/Params/CalendarParamsTest.php
+++ b/phpunit_tests/Params/CalendarParamsTest.php
@@ -19,25 +19,25 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CalendarParams::class)]
 final class CalendarParamsTest extends TestCase
 {
-    private static string $savedApiPath = '';
+    private static string $savedApiPath     = '';
+    private static string $savedApiFilePath = '';
 
     public static function setUpBeforeClass(): void
     {
-        // Stand in a file:// URL pointing at the bundled metadata fixture so
-        // the constructor's HTTP fetch resolves locally and deterministically.
-        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
-        if ($fixturePath === false) {
-            throw new \RuntimeException(
-                'Missing fixture directory: ' . __DIR__ . '/../fixtures/api'
-            );
-        }
-        self::$savedApiPath = Router::$apiPath ?? '';
-        Router::$apiPath    = 'file://' . $fixturePath;
+        // CalendarParams builds the calendars metadata index in-process from
+        // local source data (no HTTP self-call), so pin Router::$apiPath/
+        // $apiFilePath to the real project root the way the production Router
+        // does, making JsonData::*->path() resolve to the bundled sourcedata.
+        self::$savedApiPath     = isset(Router::$apiPath) ? Router::$apiPath : '';
+        self::$savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        Router::$apiPath        = '';
+        Router::$apiFilePath    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
     }
 
     public static function tearDownAfterClass(): void
     {
-        Router::$apiPath = self::$savedApiPath;
+        Router::$apiPath     = self::$savedApiPath;
+        Router::$apiFilePath = self::$savedApiFilePath;
     }
 
     public function testConstructorAppliesDefaults(): void

--- a/phpunit_tests/Params/CalendarParamsTest.php
+++ b/phpunit_tests/Params/CalendarParamsTest.php
@@ -216,6 +216,29 @@ final class CalendarParamsTest extends TestCase
         $params->setParams(['locale' => 'xx_YY']);
     }
 
+    public function testEmptyLocaleStringIsRejected(): void
+    {
+        // Rejected deterministically by an explicit empty/whitespace guard,
+        // independent of the ambient ICU default (\Locale::getDefault()), which
+        // other requests/tests can mutate via \Locale::setDefault().
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('parameter `locale`');
+
+        $params->setParams(['locale' => '']);
+    }
+
+    public function testWhitespaceOnlyLocaleStringIsRejected(): void
+    {
+        $params = new CalendarParams();
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('parameter `locale`');
+
+        $params->setParams(['locale' => '   ']);
+    }
+
     public function testReturnTypeIsApplied(): void
     {
         $params = new CalendarParams();

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -44,6 +44,22 @@ final class EventsParamsTest extends TestCase
         self::assertNull($params->NationalCalendar);
         self::assertNull($params->DiocesanCalendar);
         self::assertNotEmpty($params->calendarsMetadata->national_calendars_keys);
+        // Locale defaults to Latin even when no locale param is supplied, per the
+        // documented contract (previously left uninitialized).
+        self::assertSame(LitLocale::LATIN, $params->Locale);
+        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $params->baseLocale);
+    }
+
+    public function testLocaleDefaultsToLatinWhenOnlyNonLocaleParamsGiven(): void
+    {
+        // Regression: a national_calendar (or any non-locale param) without a
+        // locale must still leave Locale/baseLocale initialized to the Latin
+        // default rather than uninitialized typed properties (an Error on access).
+        $params = new EventsParams(['national_calendar' => 'IT']);
+
+        self::assertSame('IT', $params->NationalCalendar);
+        self::assertSame(LitLocale::LATIN, $params->Locale);
+        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $params->baseLocale);
     }
 
     public function testValidLocaleSplitsLocaleAndBase(): void

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -69,14 +69,24 @@ final class EventsParamsTest extends TestCase
 
     public function testEmptyLocaleStringIsRejected(): void
     {
-        // Locale::canonicalize('') returns 'en_US_POSIX' on this build, which
-        // is unsupported — so empty strings end up in the new unsupported-locale
-        // arm rather than the upstream null-canonicalize guard. Either way, the
-        // user gets a ValidationException with the locale-rejection message.
+        // An empty locale is now rejected deterministically by an explicit
+        // empty/whitespace guard, independent of the ambient ICU default locale
+        // (\Locale::getDefault()), which other requests/tests can mutate via
+        // \Locale::setDefault(). Previously this relied on canonicalize('')
+        // happening to yield the unsupported 'en_US_POSIX', which made the test
+        // order-dependent.
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('param `locale`');
 
         new EventsParams(['locale' => '']);
+    }
+
+    public function testWhitespaceOnlyLocaleStringIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('param `locale`');
+
+        new EventsParams(['locale' => '   ']);
     }
 
     public function testNationalCalendarFromMetadataIsAccepted(): void

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -14,23 +14,25 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(EventsParams::class)]
 final class EventsParamsTest extends TestCase
 {
-    private static string $savedApiPath = '';
+    private static string $savedApiPath     = '';
+    private static string $savedApiFilePath = '';
 
     public static function setUpBeforeClass(): void
     {
-        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
-        if ($fixturePath === false) {
-            throw new \RuntimeException(
-                'Missing fixture directory: ' . __DIR__ . '/../fixtures/api'
-            );
-        }
-        self::$savedApiPath = Router::$apiPath ?? '';
-        Router::$apiPath    = 'file://' . $fixturePath;
+        // EventsParams builds the calendars metadata index in-process from local
+        // source data (no HTTP self-call), so pin Router::$apiPath/$apiFilePath
+        // to the real project root the way the production Router does, making
+        // JsonData::*->path() resolve to the bundled sourcedata.
+        self::$savedApiPath     = isset(Router::$apiPath) ? Router::$apiPath : '';
+        self::$savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        Router::$apiPath        = '';
+        Router::$apiFilePath    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
     }
 
     public static function tearDownAfterClass(): void
     {
-        Router::$apiPath = self::$savedApiPath;
+        Router::$apiPath     = self::$savedApiPath;
+        Router::$apiFilePath = self::$savedApiFilePath;
     }
 
     public function testConstructorAppliesDefaults(): void

--- a/phpunit_tests/Services/CalendarMetadataProviderTest.php
+++ b/phpunit_tests/Services/CalendarMetadataProviderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CalendarMetadataProvider::class)]
+final class CalendarMetadataProviderTest extends TestCase
+{
+    private static string $savedApiPath     = '';
+    private static string $savedApiFilePath = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        // Pin Router::$apiPath/$apiFilePath so JsonData::*->path() resolves to
+        // the real on-disk source data under the project root, mirroring
+        // production. isset() is false for typed-uninitialised properties.
+        self::$savedApiPath     = isset(Router::$apiPath) ? Router::$apiPath : '';
+        self::$savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        Router::$apiPath        = '';
+        Router::$apiFilePath    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath     = self::$savedApiPath;
+        Router::$apiFilePath = self::$savedApiFilePath;
+    }
+
+    public function testCreateBuildsPopulatedIndexFromLocalSourceData(): void
+    {
+        $metadata = CalendarMetadataProvider::create();
+
+        self::assertInstanceOf(MetadataCalendars::class, $metadata);
+        // The General Roman Calendar as used in the Vatican is always injected.
+        self::assertContains('VA', $metadata->national_calendars_keys);
+        self::assertNotEmpty($metadata->national_calendars);
+        self::assertNotEmpty($metadata->locales);
+
+        // Item lists and their parallel key lists must stay in lock-step.
+        self::assertCount(count($metadata->national_calendars), $metadata->national_calendars_keys);
+        self::assertCount(count($metadata->diocesan_calendars), $metadata->diocesan_calendars_keys);
+        self::assertCount(count($metadata->wider_regions), $metadata->wider_regions_keys);
+    }
+
+    /**
+     * Single-source-of-truth guarantee.
+     *
+     * Consumers (RegionalDataHandler, EventsParams, CalendarParams) used to
+     * obtain this index over the network: GET /calendars → json_decode →
+     * MetadataCalendars::fromObject(). They now use the in-process built object
+     * directly. This proves the two are equivalent: serializing the built
+     * object exactly as the /calendars endpoint does, re-parsing it through the
+     * same fromObject() path consumers used, and re-serializing yields byte-for-
+     * byte identical JSON — i.e. the round-trip is idempotent, so "use the built
+     * object directly" is indistinguishable from "fetch it over the network".
+     */
+    public function testBuiltObjectIsIdenticalToNetworkRoundTrip(): void
+    {
+        $built = CalendarMetadataProvider::create();
+
+        // Exactly how MetadataHandler serializes the /calendars response body.
+        $encoded = json_encode(['litcal_metadata' => $built], JSON_THROW_ON_ERROR);
+
+        // Exactly how the former self-call consumers reconstructed it.
+        $decoded   = json_decode($encoded, false, 512, JSON_THROW_ON_ERROR);
+        $reparsed  = MetadataCalendars::fromObject($decoded->litcal_metadata);
+        $reEncoded = json_encode(['litcal_metadata' => $reparsed], JSON_THROW_ON_ERROR);
+
+        self::assertSame($encoded, $reEncoded);
+    }
+
+    public function testRepeatedBuildsAreDeterministic(): void
+    {
+        $first  = json_encode(['litcal_metadata' => CalendarMetadataProvider::create()], JSON_THROW_ON_ERROR);
+        $second = json_encode(['litcal_metadata' => CalendarMetadataProvider::create()], JSON_THROW_ON_ERROR);
+
+        self::assertSame($first, $second);
+    }
+}

--- a/src/Handlers/MetadataHandler.php
+++ b/src/Handlers/MetadataHandler.php
@@ -2,260 +2,24 @@
 
 namespace LiturgicalCalendar\Api\Handlers;
 
-use LiturgicalCalendar\Api\Enum\Ascension;
-use LiturgicalCalendar\Api\Enum\Epiphany;
-use LiturgicalCalendar\Api\Enum\JsonData;
-use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
 use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
 use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
 use LiturgicalCalendar\Api\Http\Enum\StatusCode;
 use LiturgicalCalendar\Api\Http\Exception\UnsupportedMediaTypeException;
 use LiturgicalCalendar\Api\Http\Exception\YamlException;
+use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
 use Symfony\Component\Yaml\Yaml;
 use Symfony\Component\Yaml\Exception\DumpException;
-use LiturgicalCalendar\Api\Models\CatholicDiocesesLatinRite\CatholicDiocesesMap;
-use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
-use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
-use LiturgicalCalendar\Api\Models\Metadata\MetadataNationalCalendarItem;
-use LiturgicalCalendar\Api\Models\Metadata\MetadataWiderRegionItem;
-use LiturgicalCalendar\Api\Router;
-use LiturgicalCalendar\Api\Utilities;
 use Nyholm\Psr7\Stream;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-/**
- * @phpstan-import-type CatholicDiocesesLatinRite from \LiturgicalCalendar\Api\Handlers\CalendarHandler
- * @phpstan-import-type NationalCalendarDataObject from \LiturgicalCalendar\Api\Models\RegionalData\NationalData\NationalData
- * @phpstan-import-type DiocesanCalendarDataObject from \LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanData
- */
 final class MetadataHandler extends AbstractHandler
 {
-    private static MetadataCalendars $metadataCalendars;
-
-    private static CatholicDiocesesMap $worldDiocesesLatinRite;
-
-    private const array FULLY_TRANSLATED_LOCALES = ['en', 'fr', 'it', 'nl', 'la'];
-
     public function __construct()
     {
         parent::__construct();
-    }
-
-    /**
-     * Scans the JsonData::NATIONAL_CALENDARS_FOLDER directory and builds an index of all National calendars,
-     * their metadata and their supported locales.
-     *
-     * Each National calendar is identified by a folder name and a JSON file of the same name within that folder.
-     * The JSON file must contain a "metadata" section with a "region" attribute.
-     * The folder name is used as the National calendar identifier.
-     * The JSON file is used to retrieve the supported locales for the National calendar.
-     * The supported locales are stored in the MetadataHandler::$baseNationalCalendars array.
-     *
-     * @return void
-     */
-    private static function buildNationalCalendarData(): void
-    {
-        // We add the General Roman Calendar as used in the Vatican to the list of "national" calendars
-        $metadataNationalCalendarItem = MetadataNationalCalendarItem::fromArray([
-            'calendar_id' => 'VA',
-            'locales'     => [ 'la_VA' ],
-            'missals'     => [
-                'EDITIO_TYPICA_1970',
-                'EDITIO_TYPICA_1971',
-                'EDITIO_TYPICA_1975',
-                'EDITIO_TYPICA_2002',
-                'EDITIO_TYPICA_2008'
-            ],
-            'settings'    => [
-                'epiphany'               => Epiphany::JAN6->value,
-                'ascension'              => Ascension::THURSDAY->value,
-                'corpus_christi'         => Ascension::THURSDAY->value,
-                'eternal_high_priest'    => false,
-                'holydays_of_obligation' => [
-                    'Christmas'            => true,
-                    'Epiphany'             => true,
-                    'Ascension'            => true,
-                    'CorpusChristi'        => true,
-                    'MaryMotherOfGod'      => true,
-                    'ImmaculateConception' => true,
-                    'Assumption'           => true,
-                    'StJoseph'             => true,
-                    'StsPeterPaulAp'       => true,
-                    'AllSaints'            => true
-                ]
-            ]
-        ]);
-        self::$metadataCalendars->pushNationalCalendarMetadata($metadataNationalCalendarItem);
-
-        $folderGlob = glob(JsonData::NATIONAL_CALENDARS_FOLDER->path() . '/*', GLOB_ONLYDIR);
-        if (false === $folderGlob) {
-            throw new \RuntimeException('MetadataHandler::buildNationalCalendarData: glob failed');
-        }
-
-        /** @var string[] $countryISOs */
-        $countryISOs = array_map('basename', $folderGlob);
-        foreach ($countryISOs as $countryISO) {
-            $nationalCalendarDataFile = JsonData::NATIONAL_CALENDARS_FOLDER->path() . "/$countryISO/$countryISO.json";
-            /** @var NationalCalendarDataObject $nationalCalendarData */
-            $nationalCalendarData                        = Utilities::jsonFileToObject($nationalCalendarDataFile);
-            $nationalCalendarData->metadata->settings    = $nationalCalendarData->settings;
-            $nationalCalendarData->metadata->calendar_id = $nationalCalendarData->metadata->nation;
-            unset($nationalCalendarData->metadata->nation);
-            $nationalCalendarData->metadata->dioceses = [];
-            $metadataNationalCalendarItem             = MetadataNationalCalendarItem::fromObject($nationalCalendarData->metadata);
-            self::$metadataCalendars->pushNationalCalendarMetadata($metadataNationalCalendarItem);
-        }
-    }
-
-    /**
-     * Takes a diocese ID and returns the corresponding diocese name.
-     * If the diocese ID is not found, returns null.
-     *
-     * @param string $id The diocese ID.
-     * @return string|null The diocese name or null if not found.
-     */
-    private static function dioceseIdToName(string $nation, string $id): ?string
-    {
-        if (false === isset(MetadataHandler::$worldDiocesesLatinRite)) {
-            $worldDiocesesFile = JsonData::FOLDER->path() . '/world_dioceses.json';
-            $worldDiocesesData = Utilities::jsonFileToObject($worldDiocesesFile);
-
-            MetadataHandler::$worldDiocesesLatinRite = CatholicDiocesesMap::fromObject($worldDiocesesData);
-        }
-        return MetadataHandler::$worldDiocesesLatinRite->dioceseNameFromId($nation, $id);
-    }
-
-    /**
-     * Builds an index of all diocesan calendars.
-     *
-     * @return void
-     */
-    private static function buildDiocesanCalendarData(): void
-    {
-        $countryFolders = glob(JsonData::DIOCESAN_CALENDARS_FOLDER->path() . '/*', GLOB_ONLYDIR);
-        if (false === $countryFolders) {
-            throw new \RuntimeException('MetadataHandler::buildDiocesanCalendarData: diocesan calendars folder glob failed');
-        }
-
-        foreach ($countryFolders as $countryFolder) {
-            $nation         = basename($countryFolder);
-            $dioceseFolders = glob($countryFolder . '/*', GLOB_ONLYDIR);
-            if (false === $dioceseFolders) {
-                throw new \RuntimeException('MetadataHandler::buildDiocesanCalendarData: countryFolder glob failed');
-            }
-
-            /** @var string[] $dioceseIDs */
-            $dioceseIDs = array_map('basename', $dioceseFolders);
-            foreach ($dioceseIDs as $calendar_id) {
-                $dioceseName = MetadataHandler::dioceseIdToName($nation, $calendar_id);
-                if (null === $dioceseName) {
-                    throw new \RuntimeException("MetadataHandler::buildDiocesanCalendarData: diocese name not found for nation = `{$nation}` and calendar_id = `{$calendar_id}`");
-                }
-                $diocesanCalendarFile = JsonData::DIOCESAN_CALENDARS_FOLDER->path() . "/$nation/$calendar_id/$dioceseName.json";
-                $diocesanCalendarData = Utilities::jsonFileToObject($diocesanCalendarFile);
-                /** @var DiocesanCalendarDataObject $diocesanCalendarData */
-                $diocesanCalendarData->metadata->diocese = $dioceseName;
-                if (property_exists($diocesanCalendarData, 'settings')) {
-                    $diocesanCalendarData->metadata->settings = $diocesanCalendarData->settings;
-                }
-                $diocesanCalendarData->metadata->calendar_id = $diocesanCalendarData->metadata->diocese_id;
-                unset($diocesanCalendarData->metadata->diocese_id);
-                $metadataDiocesanCalendarItem = MetadataDiocesanCalendarItem::fromObject($diocesanCalendarData->metadata);
-                self::$metadataCalendars->pushDiocesanCalendarMetadata($metadataDiocesanCalendarItem);
-            }
-        }
-    }
-
-
-    /**
-     * Scans the {@see \LiturgicalCalendar\Api\Enum\JsonData::WIDER_REGIONS_FOLDER} directory and build an index of all Wider regions,
-     * their supported locales and their data files.
-     *
-     * Each Wider region is identified by a folder name and a JSON file of the same name within that folder.
-     * Wider region identifiers are added to the MetadataHandler::$widerRegionsNames array.
-     * Supported locales are retrieved by scanning the `i18n` subfolder for each Wider region,
-     * based on the JSON files present.
-     *
-     * @return void
-     */
-    private static function buildWiderRegionData(): void
-    {
-        $folderGlob = glob(JsonData::WIDER_REGIONS_FOLDER->path() . '/*', GLOB_ONLYDIR);
-        if (false === $folderGlob) {
-            throw new \RuntimeException('MetadataHandler::buildWiderRegionData: wider regions folder glob failed');
-        }
-
-        /** @var string[] $widerRegionIDs */
-        $widerRegionIDs = array_map('basename', $folderGlob);
-        foreach ($widerRegionIDs as $widerRegionId) {
-            $WiderRegionFile = strtr(
-                JsonData::WIDER_REGION_FILE->path(),
-                ['{wider_region}' => $widerRegionId]
-            );
-
-            if (file_exists($WiderRegionFile)) {
-                $widerRegionI18nFolder = strtr(
-                    JsonData::WIDER_REGION_I18N_FOLDER->path(),
-                    [ '{wider_region}' => $widerRegionId ]
-                );
-
-                $folderGlob = glob($widerRegionI18nFolder . '/*.json');
-                if (false === $folderGlob) {
-                    throw new \RuntimeException('MetadataHandler::buildWiderRegionData: wider region i18n folder glob failed');
-                }
-
-                $locales = array_map(
-                    fn (string $filename) => pathinfo($filename, PATHINFO_FILENAME),
-                    $folderGlob
-                );
-
-                $metadataWiderRegionItem = MetadataWiderRegionItem::fromArray([
-                    'name'     => $widerRegionId,
-                    'locales'  => $locales,
-                    'api_path' => Router::$apiPath . Route::DATA_WIDERREGION->value . '/' . $widerRegionId . '?locale={locale}'
-                ]);
-                self::$metadataCalendars->pushWiderRegionMetadata($metadataWiderRegionItem);
-            }
-        }
-    }
-
-    /**
-     * Populates the MetadataHandler::$locales array with the list of supported locales.
-     *
-     * It does this by scanning the i18n/ folder and retrieving the folder names
-     * of all its subfolders. The result is an array of strings, where each string
-     * is a locale code. The locale code is in the format of a single string
-     * containing the language code (optionally followed by an underscore and the
-     * region code; for now none of the locales have regional identifiers).
-     */
-    private static function buildLocales(): void
-    {
-        // Since we can't actually request the General Roman Calendar for locales that are not fully translated,
-        // we remove those locales from the list of supported locales
-        $folderGlob = glob(Router::$apiFilePath . 'i18n/*', GLOB_ONLYDIR);
-        if (false === $folderGlob) {
-            throw new \RuntimeException('MetadataHandler::buildLocales: i18n folder glob failed');
-        }
-
-        self::$metadataCalendars->locales = array_values(array_intersect(
-            array_merge(['en'], array_map('basename', $folderGlob)),
-            MetadataHandler::FULLY_TRANSLATED_LOCALES
-        ));
-    }
-
-    /**
-     * Builds an index of all National and Diocesan calendars,
-     * and of locales supported for the General Roman Calendar
-     */
-    private static function buildIndex(): void
-    {
-        self::$metadataCalendars = new MetadataCalendars();
-        MetadataHandler::buildNationalCalendarData();
-        MetadataHandler::buildDiocesanCalendarData();
-        MetadataHandler::buildWiderRegionData();
-        MetadataHandler::buildLocales();
     }
 
     /**
@@ -290,9 +54,9 @@ final class MetadataHandler extends AbstractHandler
 
         $response = $response->withHeader('Content-Type', $mime);
 
-        MetadataHandler::buildIndex();
+        $metadataCalendars = CalendarMetadataProvider::create();
 
-        $responseBody = json_encode(['litcal_metadata' => self::$metadataCalendars], JSON_THROW_ON_ERROR);
+        $responseBody = json_encode(['litcal_metadata' => $metadataCalendars], JSON_THROW_ON_ERROR);
         $responseHash = md5($responseBody);
         $etag         = '"' . $responseHash . '"';
         $response     = $response->withHeader('ETag', $etag);

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -6,7 +6,7 @@ use Swaggest\JsonSchema\Schema;
 use Swaggest\JsonSchema\InvalidValue;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitLocale;
-use LiturgicalCalendar\Api\Enum\Route;
+use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
 use LiturgicalCalendar\Api\Handlers\Auth\ClientIpTrait;
 use LiturgicalCalendar\Api\JsonFormatter;
 use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
@@ -45,7 +45,6 @@ use Nyholm\Psr7\Stream;
  * The source data for these calendars can be created (PUT), or updated (PATCH),
  * or retrieved (GET), or deleted (DELETE).
  *
- * @phpstan-import-type MetadataCalendarsObject from \LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars
  * @phpstan-import-type LitCalItemObject from \LiturgicalCalendar\Api\Models\LitCalItem
  * @phpstan-import-type DiocesanLitCalItemObject from \LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanLitCalItem
  * @phpstan-import-type NationalCalendarDataObject from \LiturgicalCalendar\Api\Models\RegionalData\NationalData\NationalData
@@ -69,9 +68,9 @@ final class RegionalDataHandler extends AbstractHandler
         parent::__construct($requestPathParams);
         // Allow credentials for cross-origin cookie requests (required for authenticated PUT/PATCH/DELETE)
         $this->allowCredentials = true;
-        /** @var \stdClass&object{litcal_metadata:MetadataCalendarsObject} $metadataObj */
-        $metadataObj             = Utilities::jsonUrlToObject(Route::CALENDARS->path());
-        $this->CalendarsMetadata = MetadataCalendars::fromObject($metadataObj->litcal_metadata);
+        // Build the calendars metadata index in-process from local source data
+        // (single source of truth) instead of looping back through GET /calendars.
+        $this->CalendarsMetadata = CalendarMetadataProvider::create();
         // Initialize the list of available locales
         LitLocale::init();
         // Initialize audit logger for write operations

--- a/src/Params/CalendarParams.php
+++ b/src/Params/CalendarParams.php
@@ -344,6 +344,14 @@ class CalendarParams implements ParamsInterface
 
     private static function normalizeLocale(string $input): string
     {
+        // Reject empty/whitespace-only locales explicitly. Otherwise
+        // \Locale::canonicalize('') resolves to the ambient ICU default
+        // (\Locale::getDefault()), which a prior request in the same worker may
+        // have mutated via \Locale::setDefault() — making an empty locale param
+        // non-deterministically "valid".
+        if (trim($input) === '') {
+            throw new ValidationException('Invalid empty value for parameter `locale`');
+        }
         $locale = \Locale::canonicalize($input);
         if (null === $locale || '' === $locale) {
             throw new ValidationException('Invalid locale string: ' . $input . '. “If they were scattered abroad into foreign tongues, it was because their intention was profane. But now, by the distribution of tongues, the impiety is dissolved and the unity of the Spirit is restored.”

--- a/src/Params/CalendarParams.php
+++ b/src/Params/CalendarParams.php
@@ -131,7 +131,17 @@ class CalendarParams implements ParamsInterface
 
         // Build the calendars metadata index in-process from local source data
         // (single source of truth) instead of looping back through GET /calendars.
-        $this->calendars = CalendarMetadataProvider::create();
+        // Map a build failure (e.g. unreadable source data) to the documented
+        // 503 contract rather than letting it surface as a generic 500.
+        try {
+            $this->calendars = CalendarMetadataProvider::create();
+        } catch (ServiceUnavailableException $e) {
+            // Already the documented 503 (e.g. a missing source file) — preserve
+            // its specific message rather than re-wrapping it generically.
+            throw $e;
+        } catch (\RuntimeException $e) {
+            throw new ServiceUnavailableException('Unable to load calendars metadata', $e);
+        }
     }
 
     /**

--- a/src/Params/CalendarParams.php
+++ b/src/Params/CalendarParams.php
@@ -8,11 +8,11 @@ use LiturgicalCalendar\Api\Enum\Ascension;
 use LiturgicalCalendar\Api\Enum\CorpusChristi;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitLocale;
-use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
 use LiturgicalCalendar\Api\Utilities;
 
 /**
@@ -129,14 +129,9 @@ class CalendarParams implements ParamsInterface
         $this->Year               = (int) date('Y');
         $this->Locale             = LitLocale::LATIN;
 
-        $calendarsRoute = Route::CALENDARS->path();
-        $metadata       = Utilities::jsonUrlToObject($calendarsRoute);
-
-        if (property_exists($metadata, 'litcal_metadata') && $metadata->litcal_metadata instanceof \stdClass) {
-            $this->calendars = MetadataCalendars::fromObject($metadata->litcal_metadata);
-        } else {
-            throw new ServiceUnavailableException('Unable to load calendars metadata');
-        }
+        // Build the calendars metadata index in-process from local source data
+        // (single source of truth) instead of looping back through GET /calendars.
+        $this->calendars = CalendarMetadataProvider::create();
     }
 
     /**

--- a/src/Params/EventsParams.php
+++ b/src/Params/EventsParams.php
@@ -109,6 +109,14 @@ class EventsParams implements ParamsInterface
             if (in_array($key, self::ALLOWED_PARAMS)) {
                 switch ($key) {
                     case 'locale':
+                        // Reject empty/whitespace-only locales explicitly. Otherwise
+                        // \Locale::canonicalize('') resolves to the ambient ICU default
+                        // (\Locale::getDefault()), which a prior request in the same
+                        // worker may have mutated via \Locale::setDefault() — making an
+                        // empty locale param non-deterministically "valid".
+                        if (trim($value) === '') {
+                            throw new ValidationException('Invalid empty value for param `locale`');
+                        }
                         $locale = \Locale::canonicalize($value);
                         if (null === $locale) {
                             throw new ValidationException('Invalid locale string: ' . $value);

--- a/src/Params/EventsParams.php
+++ b/src/Params/EventsParams.php
@@ -69,8 +69,12 @@ class EventsParams implements ParamsInterface
         $this->calendarsMetadata = CalendarMetadataProvider::create();
 
         // We need at least a default value for the current year and for the locale
-        //   (which we already took from the request headers)
-        $this->Year = (int) date('Y');
+        //   (which we already took from the request headers). The Latin defaults
+        //   match the documented contract and guard against Locale/baseLocale
+        //   being left uninitialized when setParams() receives no locale.
+        $this->Year       = (int) date('Y');
+        $this->Locale     = LitLocale::LATIN;
+        $this->baseLocale = LitLocale::LATIN_PRIMARY_LANGUAGE;
         $this->setParams($params);
     }
 

--- a/src/Params/EventsParams.php
+++ b/src/Params/EventsParams.php
@@ -3,10 +3,9 @@
 namespace LiturgicalCalendar\Api\Params;
 
 use LiturgicalCalendar\Api\Enum\LitLocale;
-use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
-use LiturgicalCalendar\Api\Utilities;
+use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
 
 /**
  * This class encapsulates the parameters that can be passed to the Events endpoint.
@@ -20,8 +19,6 @@ use LiturgicalCalendar\Api\Utilities;
  *
  * The class also provides a way to retrieve the last error message set by the class,
  * as well as to check if the parameters are valid.
- *
- * @phpstan-import-type MetadataCalendarsObject from \LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars
  */
 class EventsParams implements ParamsInterface
 {
@@ -67,9 +64,9 @@ class EventsParams implements ParamsInterface
      */
     public function __construct($params = [])
     {
-        /** @var \stdClass&object{litcal_metadata:MetadataCalendarsObject} $calendarsMetadataObj */
-        $calendarsMetadataObj    = Utilities::jsonUrlToObject(Route::CALENDARS->path());
-        $this->calendarsMetadata = MetadataCalendars::fromObject($calendarsMetadataObj->litcal_metadata);
+        // Build the calendars metadata index in-process from local source data
+        // (single source of truth) instead of looping back through GET /calendars.
+        $this->calendarsMetadata = CalendarMetadataProvider::create();
 
         // We need at least a default value for the current year and for the locale
         //   (which we already took from the request headers)

--- a/src/Services/CalendarMetadataProvider.php
+++ b/src/Services/CalendarMetadataProvider.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Enum\Ascension;
+use LiturgicalCalendar\Api\Enum\Epiphany;
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Route;
+use LiturgicalCalendar\Api\Models\CatholicDiocesesLatinRite\CatholicDiocesesMap;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataNationalCalendarItem;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataWiderRegionItem;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Utilities;
+
+/**
+ * Builds the calendars metadata index ({@see MetadataCalendars}) directly from
+ * local source data, in-process — without looping back through the network to
+ * the API's own `/calendars` endpoint.
+ *
+ * This is the single source of truth for that index. {@see MetadataHandler}
+ * (serving GET /calendars), {@see \LiturgicalCalendar\Api\Handlers\RegionalDataHandler},
+ * {@see \LiturgicalCalendar\Api\Params\EventsParams}, and
+ * {@see \LiturgicalCalendar\Api\Params\CalendarParams} all consume the object
+ * produced here. The object returned by {@see self::create()} is, by design,
+ * identical to what those consumers previously obtained via
+ * `MetadataCalendars::fromObject(jsonDecode(GET /calendars))`: the build path
+ * populates every field (`*_keys`, `diocesan_groups`, and the per-nation
+ * `dioceses` lists) that `jsonSerialize()` emits and `fromObject()` reads back,
+ * so the JSON round-trip is idempotent (guarded by CalendarMetadataProviderTest).
+ *
+ * Building reads the same on-disk source data on every call (no cross-request
+ * memoization): the `/data` write endpoints can mutate calendar definition
+ * files at runtime, so caching the index across requests would risk serving
+ * stale metadata.
+ *
+ * @phpstan-import-type NationalCalendarDataObject from \LiturgicalCalendar\Api\Models\RegionalData\NationalData\NationalData
+ * @phpstan-import-type DiocesanCalendarDataObject from \LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanData
+ */
+final class CalendarMetadataProvider
+{
+    /**
+     * Lazily-loaded world dioceses map (reference data, not written by the
+     * /data endpoints), memoized for the lifetime of the process so repeated
+     * diocese-name lookups within and across builds don't re-read the file.
+     */
+    private static ?CatholicDiocesesMap $worldDiocesesLatinRite = null;
+
+    private const array FULLY_TRANSLATED_LOCALES = ['en', 'fr', 'it', 'nl', 'la'];
+
+    /**
+     * Builds and returns the complete calendars metadata index from local
+     * source data.
+     */
+    public static function create(): MetadataCalendars
+    {
+        $metadata = new MetadataCalendars();
+        self::buildNationalCalendarData($metadata);
+        self::buildDiocesanCalendarData($metadata);
+        self::buildWiderRegionData($metadata);
+        self::buildLocales($metadata);
+        return $metadata;
+    }
+
+    /**
+     * Scans the JsonData::NATIONAL_CALENDARS_FOLDER directory and builds an index of all National calendars,
+     * their metadata and their supported locales.
+     *
+     * Each National calendar is identified by a folder name and a JSON file of the same name within that folder.
+     * The JSON file must contain a "metadata" section with a "region" attribute.
+     * The folder name is used as the National calendar identifier.
+     *
+     * @return void
+     */
+    private static function buildNationalCalendarData(MetadataCalendars $metadata): void
+    {
+        // We add the General Roman Calendar as used in the Vatican to the list of "national" calendars
+        $metadataNationalCalendarItem = MetadataNationalCalendarItem::fromArray([
+            'calendar_id' => 'VA',
+            'locales'     => [ 'la_VA' ],
+            'missals'     => [
+                'EDITIO_TYPICA_1970',
+                'EDITIO_TYPICA_1971',
+                'EDITIO_TYPICA_1975',
+                'EDITIO_TYPICA_2002',
+                'EDITIO_TYPICA_2008'
+            ],
+            'settings'    => [
+                'epiphany'               => Epiphany::JAN6->value,
+                'ascension'              => Ascension::THURSDAY->value,
+                'corpus_christi'         => Ascension::THURSDAY->value,
+                'eternal_high_priest'    => false,
+                'holydays_of_obligation' => [
+                    'Christmas'            => true,
+                    'Epiphany'             => true,
+                    'Ascension'            => true,
+                    'CorpusChristi'        => true,
+                    'MaryMotherOfGod'      => true,
+                    'ImmaculateConception' => true,
+                    'Assumption'           => true,
+                    'StJoseph'             => true,
+                    'StsPeterPaulAp'       => true,
+                    'AllSaints'            => true
+                ]
+            ]
+        ]);
+        $metadata->pushNationalCalendarMetadata($metadataNationalCalendarItem);
+
+        $folderGlob = glob(JsonData::NATIONAL_CALENDARS_FOLDER->path() . '/*', GLOB_ONLYDIR);
+        if (false === $folderGlob) {
+            throw new \RuntimeException('CalendarMetadataProvider::buildNationalCalendarData: glob failed');
+        }
+
+        /** @var string[] $countryISOs */
+        $countryISOs = array_map('basename', $folderGlob);
+        foreach ($countryISOs as $countryISO) {
+            $nationalCalendarDataFile = JsonData::NATIONAL_CALENDARS_FOLDER->path() . "/$countryISO/$countryISO.json";
+            /** @var NationalCalendarDataObject $nationalCalendarData */
+            $nationalCalendarData                        = Utilities::jsonFileToObject($nationalCalendarDataFile);
+            $nationalCalendarData->metadata->settings    = $nationalCalendarData->settings;
+            $nationalCalendarData->metadata->calendar_id = $nationalCalendarData->metadata->nation;
+            unset($nationalCalendarData->metadata->nation);
+            $nationalCalendarData->metadata->dioceses = [];
+            $metadataNationalCalendarItem             = MetadataNationalCalendarItem::fromObject($nationalCalendarData->metadata);
+            $metadata->pushNationalCalendarMetadata($metadataNationalCalendarItem);
+        }
+    }
+
+    /**
+     * Takes a diocese ID and returns the corresponding diocese name.
+     * If the diocese ID is not found, returns null.
+     *
+     * @param string $id The diocese ID.
+     * @return string|null The diocese name or null if not found.
+     */
+    private static function dioceseIdToName(string $nation, string $id): ?string
+    {
+        if (null === self::$worldDiocesesLatinRite) {
+            $worldDiocesesFile = JsonData::FOLDER->path() . '/world_dioceses.json';
+            $worldDiocesesData = Utilities::jsonFileToObject($worldDiocesesFile);
+
+            self::$worldDiocesesLatinRite = CatholicDiocesesMap::fromObject($worldDiocesesData);
+        }
+        return self::$worldDiocesesLatinRite->dioceseNameFromId($nation, $id);
+    }
+
+    /**
+     * Builds an index of all diocesan calendars.
+     *
+     * @return void
+     */
+    private static function buildDiocesanCalendarData(MetadataCalendars $metadata): void
+    {
+        $countryFolders = glob(JsonData::DIOCESAN_CALENDARS_FOLDER->path() . '/*', GLOB_ONLYDIR);
+        if (false === $countryFolders) {
+            throw new \RuntimeException('CalendarMetadataProvider::buildDiocesanCalendarData: diocesan calendars folder glob failed');
+        }
+
+        foreach ($countryFolders as $countryFolder) {
+            $nation         = basename($countryFolder);
+            $dioceseFolders = glob($countryFolder . '/*', GLOB_ONLYDIR);
+            if (false === $dioceseFolders) {
+                throw new \RuntimeException('CalendarMetadataProvider::buildDiocesanCalendarData: countryFolder glob failed');
+            }
+
+            /** @var string[] $dioceseIDs */
+            $dioceseIDs = array_map('basename', $dioceseFolders);
+            foreach ($dioceseIDs as $calendar_id) {
+                $dioceseName = self::dioceseIdToName($nation, $calendar_id);
+                if (null === $dioceseName) {
+                    throw new \RuntimeException("CalendarMetadataProvider::buildDiocesanCalendarData: diocese name not found for nation = `{$nation}` and calendar_id = `{$calendar_id}`");
+                }
+                $diocesanCalendarFile = JsonData::DIOCESAN_CALENDARS_FOLDER->path() . "/$nation/$calendar_id/$dioceseName.json";
+                $diocesanCalendarData = Utilities::jsonFileToObject($diocesanCalendarFile);
+                /** @var DiocesanCalendarDataObject $diocesanCalendarData */
+                $diocesanCalendarData->metadata->diocese = $dioceseName;
+                if (property_exists($diocesanCalendarData, 'settings')) {
+                    $diocesanCalendarData->metadata->settings = $diocesanCalendarData->settings;
+                }
+                $diocesanCalendarData->metadata->calendar_id = $diocesanCalendarData->metadata->diocese_id;
+                unset($diocesanCalendarData->metadata->diocese_id);
+                $metadataDiocesanCalendarItem = MetadataDiocesanCalendarItem::fromObject($diocesanCalendarData->metadata);
+                $metadata->pushDiocesanCalendarMetadata($metadataDiocesanCalendarItem);
+            }
+        }
+    }
+
+
+    /**
+     * Scans the {@see \LiturgicalCalendar\Api\Enum\JsonData::WIDER_REGIONS_FOLDER} directory and build an index of all Wider regions,
+     * their supported locales and their data files.
+     *
+     * Each Wider region is identified by a folder name and a JSON file of the same name within that folder.
+     * Supported locales are retrieved by scanning the `i18n` subfolder for each Wider region,
+     * based on the JSON files present.
+     *
+     * @return void
+     */
+    private static function buildWiderRegionData(MetadataCalendars $metadata): void
+    {
+        $folderGlob = glob(JsonData::WIDER_REGIONS_FOLDER->path() . '/*', GLOB_ONLYDIR);
+        if (false === $folderGlob) {
+            throw new \RuntimeException('CalendarMetadataProvider::buildWiderRegionData: wider regions folder glob failed');
+        }
+
+        /** @var string[] $widerRegionIDs */
+        $widerRegionIDs = array_map('basename', $folderGlob);
+        foreach ($widerRegionIDs as $widerRegionId) {
+            $WiderRegionFile = strtr(
+                JsonData::WIDER_REGION_FILE->path(),
+                ['{wider_region}' => $widerRegionId]
+            );
+
+            if (file_exists($WiderRegionFile)) {
+                $widerRegionI18nFolder = strtr(
+                    JsonData::WIDER_REGION_I18N_FOLDER->path(),
+                    [ '{wider_region}' => $widerRegionId ]
+                );
+
+                $folderGlob = glob($widerRegionI18nFolder . '/*.json');
+                if (false === $folderGlob) {
+                    throw new \RuntimeException('CalendarMetadataProvider::buildWiderRegionData: wider region i18n folder glob failed');
+                }
+
+                $locales = array_map(
+                    fn (string $filename) => pathinfo($filename, PATHINFO_FILENAME),
+                    $folderGlob
+                );
+
+                $metadataWiderRegionItem = MetadataWiderRegionItem::fromArray([
+                    'name'     => $widerRegionId,
+                    'locales'  => $locales,
+                    'api_path' => Router::$apiPath . Route::DATA_WIDERREGION->value . '/' . $widerRegionId . '?locale={locale}'
+                ]);
+                $metadata->pushWiderRegionMetadata($metadataWiderRegionItem);
+            }
+        }
+    }
+
+    /**
+     * Populates the MetadataCalendars::$locales array with the list of supported locales.
+     *
+     * It does this by scanning the i18n/ folder and retrieving the folder names
+     * of all its subfolders. The result is an array of strings, where each string
+     * is a locale code. The locale code is in the format of a single string
+     * containing the language code (optionally followed by an underscore and the
+     * region code; for now none of the locales have regional identifiers).
+     */
+    private static function buildLocales(MetadataCalendars $metadata): void
+    {
+        // Since we can't actually request the General Roman Calendar for locales that are not fully translated,
+        // we remove those locales from the list of supported locales
+        $folderGlob = glob(Router::$apiFilePath . 'i18n/*', GLOB_ONLYDIR);
+        if (false === $folderGlob) {
+            throw new \RuntimeException('CalendarMetadataProvider::buildLocales: i18n folder glob failed');
+        }
+
+        $metadata->locales = array_values(array_intersect(
+            array_merge(['en'], array_map('basename', $folderGlob)),
+            self::FULLY_TRANSLATED_LOCALES
+        ));
+    }
+}

--- a/src/Services/CalendarMetadataProvider.php
+++ b/src/Services/CalendarMetadataProvider.php
@@ -265,9 +265,12 @@ final class CalendarMetadataProvider
         // we remove those locales from the list of supported locales
         $folderGlob = self::globOrThrow(Router::$apiFilePath . 'i18n/*', GLOB_ONLYDIR, 'CalendarMetadataProvider::buildLocales');
 
-        $metadata->locales = array_values(array_intersect(
+        // array_unique guards against a duplicate 'en' if an i18n/en/ folder is
+        // ever added (en is prepended explicitly as the untranslated source
+        // language, and array_intersect preserves duplicates from its first arg).
+        $metadata->locales = array_values(array_unique(array_intersect(
             array_merge(['en'], array_map('basename', $folderGlob)),
             self::FULLY_TRANSLATED_LOCALES
-        ));
+        )));
     }
 }

--- a/src/Services/CalendarMetadataProvider.php
+++ b/src/Services/CalendarMetadataProvider.php
@@ -66,6 +66,26 @@ final class CalendarMetadataProvider
     }
 
     /**
+     * glob() that throws instead of returning the system-error sentinel `false`.
+     *
+     * glob() returns an empty array (not false) when a readable directory simply
+     * has no matches, so the false branch only fires on a genuine filesystem
+     * error against a directory we expect to exist — an unreachable defensive
+     * guard in normal operation, hence excluded from coverage.
+     *
+     * @return string[]
+     * @codeCoverageIgnore
+     */
+    private static function globOrThrow(string $pattern, int $flags, string $context): array
+    {
+        $result = glob($pattern, $flags);
+        if (false === $result) {
+            throw new \RuntimeException($context . ': glob failed');
+        }
+        return $result;
+    }
+
+    /**
      * Scans the JsonData::NATIONAL_CALENDARS_FOLDER directory and builds an index of all National calendars,
      * their metadata and their supported locales.
      *
@@ -109,10 +129,7 @@ final class CalendarMetadataProvider
         ]);
         $metadata->pushNationalCalendarMetadata($metadataNationalCalendarItem);
 
-        $folderGlob = glob(JsonData::NATIONAL_CALENDARS_FOLDER->path() . '/*', GLOB_ONLYDIR);
-        if (false === $folderGlob) {
-            throw new \RuntimeException('CalendarMetadataProvider::buildNationalCalendarData: glob failed');
-        }
+        $folderGlob = self::globOrThrow(JsonData::NATIONAL_CALENDARS_FOLDER->path() . '/*', GLOB_ONLYDIR, 'CalendarMetadataProvider::buildNationalCalendarData');
 
         /** @var string[] $countryISOs */
         $countryISOs = array_map('basename', $folderGlob);
@@ -154,25 +171,24 @@ final class CalendarMetadataProvider
      */
     private static function buildDiocesanCalendarData(MetadataCalendars $metadata): void
     {
-        $countryFolders = glob(JsonData::DIOCESAN_CALENDARS_FOLDER->path() . '/*', GLOB_ONLYDIR);
-        if (false === $countryFolders) {
-            throw new \RuntimeException('CalendarMetadataProvider::buildDiocesanCalendarData: diocesan calendars folder glob failed');
-        }
+        $countryFolders = self::globOrThrow(JsonData::DIOCESAN_CALENDARS_FOLDER->path() . '/*', GLOB_ONLYDIR, 'CalendarMetadataProvider::buildDiocesanCalendarData');
 
         foreach ($countryFolders as $countryFolder) {
             $nation         = basename($countryFolder);
-            $dioceseFolders = glob($countryFolder . '/*', GLOB_ONLYDIR);
-            if (false === $dioceseFolders) {
-                throw new \RuntimeException('CalendarMetadataProvider::buildDiocesanCalendarData: countryFolder glob failed');
-            }
+            $dioceseFolders = self::globOrThrow($countryFolder . '/*', GLOB_ONLYDIR, 'CalendarMetadataProvider::buildDiocesanCalendarData');
 
             /** @var string[] $dioceseIDs */
             $dioceseIDs = array_map('basename', $dioceseFolders);
             foreach ($dioceseIDs as $calendar_id) {
                 $dioceseName = self::dioceseIdToName($nation, $calendar_id);
+                // @codeCoverageIgnoreStart
+                // Defensive: every bundled diocese folder maps to a name in
+                // world_dioceses.json, so this guard only fires on inconsistent
+                // source data and is unreachable in unit tests.
                 if (null === $dioceseName) {
                     throw new \RuntimeException("CalendarMetadataProvider::buildDiocesanCalendarData: diocese name not found for nation = `{$nation}` and calendar_id = `{$calendar_id}`");
                 }
+                // @codeCoverageIgnoreEnd
                 $diocesanCalendarFile = JsonData::DIOCESAN_CALENDARS_FOLDER->path() . "/$nation/$calendar_id/$dioceseName.json";
                 $diocesanCalendarData = Utilities::jsonFileToObject($diocesanCalendarFile);
                 /** @var DiocesanCalendarDataObject $diocesanCalendarData */
@@ -201,10 +217,7 @@ final class CalendarMetadataProvider
      */
     private static function buildWiderRegionData(MetadataCalendars $metadata): void
     {
-        $folderGlob = glob(JsonData::WIDER_REGIONS_FOLDER->path() . '/*', GLOB_ONLYDIR);
-        if (false === $folderGlob) {
-            throw new \RuntimeException('CalendarMetadataProvider::buildWiderRegionData: wider regions folder glob failed');
-        }
+        $folderGlob = self::globOrThrow(JsonData::WIDER_REGIONS_FOLDER->path() . '/*', GLOB_ONLYDIR, 'CalendarMetadataProvider::buildWiderRegionData');
 
         /** @var string[] $widerRegionIDs */
         $widerRegionIDs = array_map('basename', $folderGlob);
@@ -220,10 +233,7 @@ final class CalendarMetadataProvider
                     [ '{wider_region}' => $widerRegionId ]
                 );
 
-                $folderGlob = glob($widerRegionI18nFolder . '/*.json');
-                if (false === $folderGlob) {
-                    throw new \RuntimeException('CalendarMetadataProvider::buildWiderRegionData: wider region i18n folder glob failed');
-                }
+                $folderGlob = self::globOrThrow($widerRegionI18nFolder . '/*.json', 0, 'CalendarMetadataProvider::buildWiderRegionData');
 
                 $locales = array_map(
                     fn (string $filename) => pathinfo($filename, PATHINFO_FILENAME),
@@ -253,10 +263,7 @@ final class CalendarMetadataProvider
     {
         // Since we can't actually request the General Roman Calendar for locales that are not fully translated,
         // we remove those locales from the list of supported locales
-        $folderGlob = glob(Router::$apiFilePath . 'i18n/*', GLOB_ONLYDIR);
-        if (false === $folderGlob) {
-            throw new \RuntimeException('CalendarMetadataProvider::buildLocales: i18n folder glob failed');
-        }
+        $folderGlob = self::globOrThrow(Router::$apiFilePath . 'i18n/*', GLOB_ONLYDIR, 'CalendarMetadataProvider::buildLocales');
 
         $metadata->locales = array_values(array_intersect(
             array_merge(['en'], array_map('basename', $folderGlob)),


### PR DESCRIPTION
Closes #659.

## Summary

`RegionalDataHandler`, `EventsParams`, and `CalendarParams` built their calendars metadata by issuing an HTTP request to the API's own `/calendars` endpoint and re-parsing the response via `MetadataCalendars::fromObject()`. That self-call is fragile (it produced the two failures fixed in #658 — wildcard host and self-throttling), adds latency, consumes a worker, and runs *before* the middleware pipeline so its failures bypass `ErrorHandlingMiddleware`.

This builds the metadata index **in-process from local source data** instead, via a new single-source-of-truth service.

## Changes

- **New `src/Services/CalendarMetadataProvider.php`** — `create(): MetadataCalendars` builds the index from local source data. The `build*` logic moved here out of `MetadataHandler`.
- **`MetadataHandler`** (serving `GET /calendars`) now delegates to the provider.
- **Three former self-call sites** now build in-process (no HTTP, no `fromObject`):
  - `RegionalDataHandler::__construct`
  - `EventsParams::__construct`
  - `CalendarParams::__construct` *(the issue listed the first two; this is the same anti-pattern in a third spot, fixed for completeness)*
- `Health.php`'s `/calendars` call is **intentionally retained** — it deliberately exercises the live endpoint as a health check.
- The wildcard-host normalization and loopback rate-limit exemption from #658 remain valid for any other self-calls but are no longer required by these paths.

## Single source of truth — provable equivalence

Consumers now use the built object directly instead of round-tripping it through JSON. `CalendarMetadataProviderTest::testBuiltObjectIsIdenticalToNetworkRoundTrip` guarantees that's safe: it serializes the built object exactly as the `/calendars` endpoint does, re-parses it through the same `fromObject()` path consumers used, re-serializes, and asserts **byte-for-byte identical JSON**. The round-trip is idempotent, so "use the built object directly" is indistinguishable from "fetch it over the network".

## Bonus fix — latent locale flakiness

While verifying, I found a pre-existing order-dependent flake (`EventsParamsTest::testEmptyLocaleStringIsRejected`) rooted in a real product bug: an empty `locale` param was run through `\Locale::canonicalize('')`, which resolves to the ambient ICU default (`\Locale::getDefault()`) — and that default can be mutated within a worker by a prior request (`CalendarHandler` calls `\Locale::setDefault()`). So an empty locale was accepted or rejected depending on prior request state. The second commit adds an explicit empty/whitespace guard in both `EventsParams` and `CalendarParams`, making rejection deterministic, plus coverage.

## Acceptance criteria (#659)

- [x] `RegionalDataHandler` and `EventsParams` (and `CalendarParams`) no longer issue an HTTP request to `/calendars`
- [x] Equivalent metadata produced (existing `/data`, `/events`, `/calendars` tests stay green; idempotency proof added)
- [x] Wildcard-host normalization and loopback rate-limit exemption remain valid for other self-calls but are no longer required by these paths

## Validation

- PHPStan level 10 (full): no errors
- phpcs: clean
- `composer test:quick` (full suite): **1328 tests, 152k assertions, 0 failures** (3 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar and regional metadata are now generated directly from bundled data, improving reliability and reducing dependence on live metadata lookups.

* **Bug Fixes**
  * Locale fields now correctly reject empty or whitespace-only values.
  * Metadata responses are now more consistent and deterministic across repeated requests and test environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->