### PR TITLE
fix(api): reject non-string EventsParams locale/nation/diocese as 400 (#664)

### DIFF
--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -236,6 +236,31 @@ final class EventsParamsTest extends TestCase
         new EventsParams(['diocesan_calendar' => ['romamo_it']]); // @phpstan-ignore-line
     }
 
+    public function testObjectLocaleIsRejectedAsValidationError(): void
+    {
+        // Object payloads must be rejected as 400s too, the same way arrays are.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('locale');
+
+        new EventsParams(['locale' => (object) ['en']]); // @phpstan-ignore-line
+    }
+
+    public function testObjectNationalCalendarIsRejectedAsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('national_calendar');
+
+        new EventsParams(['national_calendar' => (object) ['IT']]); // @phpstan-ignore-line
+    }
+
+    public function testObjectDiocesanCalendarIsRejectedAsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('diocesan_calendar');
+
+        new EventsParams(['diocesan_calendar' => (object) ['romamo_it']]); // @phpstan-ignore-line
+    }
+
     public function testEternalHighPriestAcceptsBooleanish(): void
     {
         $params = new EventsParams(['eternal_high_priest' => 'true']); // @phpstan-ignore-line

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -165,9 +165,9 @@ final class EventsParamsTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('eternal_high_priest');
 
-        new EventsParams([
+        new EventsParams([ // @phpstan-ignore argument.type
             'national_calendar'   => 'VA',
-            'eternal_high_priest' => 'maybe', // @phpstan-ignore-line
+            'eternal_high_priest' => 'maybe',
         ]);
     }
 
@@ -217,7 +217,7 @@ final class EventsParamsTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('locale');
 
-        new EventsParams(['locale' => ['en']]); // @phpstan-ignore-line
+        new EventsParams(['locale' => ['en']]); // @phpstan-ignore argument.type
     }
 
     public function testNonStringNationalCalendarIsRejectedAsValidationError(): void
@@ -225,7 +225,7 @@ final class EventsParamsTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('national_calendar');
 
-        new EventsParams(['national_calendar' => ['IT']]); // @phpstan-ignore-line
+        new EventsParams(['national_calendar' => ['IT']]); // @phpstan-ignore argument.type
     }
 
     public function testNonStringDiocesanCalendarIsRejectedAsValidationError(): void
@@ -233,7 +233,7 @@ final class EventsParamsTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('diocesan_calendar');
 
-        new EventsParams(['diocesan_calendar' => ['romamo_it']]); // @phpstan-ignore-line
+        new EventsParams(['diocesan_calendar' => ['romamo_it']]); // @phpstan-ignore argument.type
     }
 
     public function testObjectLocaleIsRejectedAsValidationError(): void
@@ -242,7 +242,7 @@ final class EventsParamsTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('locale');
 
-        new EventsParams(['locale' => (object) ['en']]); // @phpstan-ignore-line
+        new EventsParams(['locale' => (object) ['en']]); // @phpstan-ignore argument.type
     }
 
     public function testObjectNationalCalendarIsRejectedAsValidationError(): void
@@ -250,7 +250,7 @@ final class EventsParamsTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('national_calendar');
 
-        new EventsParams(['national_calendar' => (object) ['IT']]); // @phpstan-ignore-line
+        new EventsParams(['national_calendar' => (object) ['IT']]); // @phpstan-ignore argument.type
     }
 
     public function testObjectDiocesanCalendarIsRejectedAsValidationError(): void
@@ -258,12 +258,12 @@ final class EventsParamsTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('diocesan_calendar');
 
-        new EventsParams(['diocesan_calendar' => (object) ['romamo_it']]); // @phpstan-ignore-line
+        new EventsParams(['diocesan_calendar' => (object) ['romamo_it']]); // @phpstan-ignore argument.type
     }
 
     public function testEternalHighPriestAcceptsBooleanish(): void
     {
-        $params = new EventsParams(['eternal_high_priest' => 'true']); // @phpstan-ignore-line
+        $params = new EventsParams(['eternal_high_priest' => 'true']); // @phpstan-ignore argument.type
 
         self::assertTrue($params->EternalHighPriest);
     }
@@ -273,12 +273,12 @@ final class EventsParamsTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('eternal_high_priest');
 
-        new EventsParams(['eternal_high_priest' => 'maybe']); // @phpstan-ignore-line
+        new EventsParams(['eternal_high_priest' => 'maybe']); // @phpstan-ignore argument.type
     }
 
     public function testUnknownKeysAreSilentlyIgnored(): void
     {
-        $params = new EventsParams(['locale' => 'en_US', 'noise' => 'whatever']); // @phpstan-ignore-line
+        $params = new EventsParams(['locale' => 'en_US', 'noise' => 'whatever']);
 
         self::assertSame('en_US', $params->Locale);
     }

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -210,6 +210,32 @@ final class EventsParamsTest extends TestCase
         new EventsParams(['diocesan_calendar' => 'nowhere']);
     }
 
+    public function testNonStringLocaleIsRejectedAsValidationError(): void
+    {
+        // A non-string locale (e.g. ?locale[]=en in a POST body) must surface as
+        // a 400 ValidationException, not a 500 TypeError from string operations.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('locale');
+
+        new EventsParams(['locale' => ['en']]); // @phpstan-ignore-line
+    }
+
+    public function testNonStringNationalCalendarIsRejectedAsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('national_calendar');
+
+        new EventsParams(['national_calendar' => ['IT']]); // @phpstan-ignore-line
+    }
+
+    public function testNonStringDiocesanCalendarIsRejectedAsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('diocesan_calendar');
+
+        new EventsParams(['diocesan_calendar' => ['romamo_it']]); // @phpstan-ignore-line
+    }
+
     public function testEternalHighPriestAcceptsBooleanish(): void
     {
         $params = new EventsParams(['eternal_high_priest' => 'true']); // @phpstan-ignore-line

--- a/src/Params/EventsParams.php
+++ b/src/Params/EventsParams.php
@@ -111,6 +111,13 @@ class EventsParams implements ParamsInterface
 
         foreach ($params as $key => $value) {
             if (in_array($key, self::ALLOWED_PARAMS)) {
+                // The string-typed params must be validated as strings up front so
+                // a non-string payload (e.g. ?locale[]=en in a POST body) is a 400
+                // ValidationException rather than a 500 TypeError from trim() /
+                // \Locale::canonicalize() / isValid*() / strtoupper().
+                if (in_array($key, ['locale', 'national_calendar', 'diocesan_calendar'], true)) {
+                    $value = $this->validateStringValue($key, $value);
+                }
                 switch ($key) {
                     case 'locale':
                         // Reject empty/whitespace-only locales explicitly. Otherwise
@@ -179,6 +186,30 @@ class EventsParams implements ParamsInterface
             // call that switches to VA fully resets the request shape.
             $this->NationalCalendar = null;
         }
+    }
+
+    /**
+     * Assert that a string-typed request parameter value really is a string.
+     *
+     * Rejects non-string input (e.g. an array from `?locale[]=en` in a POST body)
+     * with a ValidationException (400) so it never reaches string-only operations
+     * — trim(), \Locale::canonicalize(), isValid*(), strtoupper() — as a
+     * TypeError (500). Empty/whitespace handling and metadata validation remain
+     * the responsibility of each param's own branch (which produce clearer,
+     * param-specific messages), so this guard deliberately does not reject or
+     * mutate the string contents.
+     *
+     * @param string $key   The parameter name (for the error message).
+     * @param mixed  $value The raw request value.
+     * @return string The validated string value.
+     */
+    private function validateStringValue(string $key, mixed $value): string
+    {
+        if (!is_string($value)) {
+            throw new ValidationException("Expected value of type String for parameter `{$key}`, instead found type " . gettype($value));
+        }
+
+        return $value;
     }
 
     private function isValidNationalCalendar(string $calendar): bool


### PR DESCRIPTION
Closes #664.

## Summary

`EventsParams::setParams()` fed the raw request value straight into string-only operations for `locale`, `national_calendar`, and `diocesan_calendar` (`trim()`, `\Locale::canonicalize()`, `isValidNationalCalendar()`/`isValidDiocesanCalendar()`, `strtoupper()`). A non-string payload — most realistically an array from a POST JSON body like `{"national_calendar": ["IT"]}` — raised a **`TypeError` → 500** instead of the intended **`ValidationException` → 400**. (Numeric values coerced silently since the file isn't under `strict_types`, so only non-coercible **array/object** values produced the 500.)

This is a pre-existing gap deferred from #663; `CalendarParams` already guarded against it, `EventsParams` did not.

## Fix

- Add a `validateStringValue(string $key, mixed $value): string` guard and route the three string params through it **before** any string operation.
- The guard is intentionally **minimal — an `is_string()` check only**. Empty/whitespace handling and metadata validation stay with each param's own branch (which emit clearer, param-specific messages, e.g. `Invalid empty value for param \`locale\``). I deliberately did **not** copy `CalendarParams`' `filter_var(FILTER_SANITIZE_SPECIAL_CHARS)` step because:
  - It carries a `'0'`/`''` falsy-string pitfall (`if (!$filteredValue)`) that would have mis-reported an empty locale as a sanitization failure and shadowed the dedicated empty-value guard.
  - Reflected-value XSS isn't a concern here — these messages are emitted as `application/problem+json`, not HTML.

## Tests

Added coverage for non-string (array / object) input on each of the three params, asserting a `ValidationException` with the param name. Existing empty/whitespace-locale tests stay green (their clearer messages are preserved).

## Validation

- PHPStan level 10: clean · phpcs: clean
- `composer test:quick`: **1332 tests, 0 failures** (3 pre-existing env skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for event-related settings so invalid non-text values are rejected cleanly with a clear error message.
  * Prevented unexpected type errors when entering locale or calendar values in unsupported formats.

* **Tests**
  * Added coverage for invalid locale, national calendar, and diocesan calendar inputs to verify the new validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->