### PR TITLE
fix(outbox): make reconcile-outbox deployable + staging-env aware

### DIFF
--- a/.github/deploy/rsync-exclude.txt
+++ b/.github/deploy/rsync-exclude.txt
@@ -52,11 +52,17 @@ server.pid
 server.vscode.pid
 
 # --- CLI tooling that cannot run in the SSH chroot anyway ---
-# bin/ currently contains only doctrine-migrations, which is invoked
-# in-process via the /_ops/migrate endpoint. doctrine-migrations.php
-# (Doctrine config at the repo root) IS shipped — it's read by
-# MigrateHandler via PhpFile.
-bin/
+# bin/doctrine-migrations is invoked in-process via the /_ops/migrate
+# endpoint, never as a server-side CLI, so it stays off the wire.
+# doctrine-migrations.php (Doctrine config at the repo root) IS shipped —
+# it's read by MigrateHandler via PhpFile.
+#
+# bin/reconcile-outbox, by contrast, MUST ship: the OpenFGA outbox
+# consumer (systemd) and backstop (cron) invoke it as a server-side CLI.
+# Excluding the whole bin/ dir previously kept it off the server, which is
+# why the outbox drain infra could not be installed. Exclude only the one
+# entry that should not ship.
+bin/doctrine-migrations
 
 # --- Composer install-time only (never read at runtime) ---
 # composer.json IS shipped — Router::findProjectRoot() uses it as a

--- a/bin/reconcile-outbox
+++ b/bin/reconcile-outbox
@@ -24,11 +24,17 @@ use LiturgicalCalendar\Api\Services\Outbox\RedisStreamConsumer;
 $root = dirname(__DIR__);
 require $root . '/vendor/autoload.php';
 
-if (file_exists($root . '/.env.local')) {
-    Dotenv::createImmutable($root, '.env.local')->safeLoad();
-} elseif (file_exists($root . '/.env')) {
-    Dotenv::createImmutable($root)->safeLoad();
-}
+// Load the same env-file chain as public/index.php so this CLI picks up the
+// environment-specific file (.env.staging, .env.production, …) and not just
+// .env.local. Dotenv populates $_ENV itself, which matters here because PHP
+// CLI may run with variables_order=GPCS (no 'E'): a systemd EnvironmentFile or
+// exported shell vars would NOT reach $_ENV, so the entrypoint must read its
+// configuration from the files directly.
+Dotenv::createImmutable(
+    $root,
+    ['.env', '.env.local', '.env.development', '.env.test', '.env.staging', '.env.production'],
+    false
+)->safeLoad();
 
 $mode = $argv[1] ?? '';
 if ($mode !== 'consumer' && $mode !== 'backstop') {


### PR DESCRIPTION
## Why

The OpenFGA outbox consumer/backstop entrypoint (`bin/reconcile-outbox`) could not be installed on the staging/production server, so the outbox drain infrastructure described in `docs/ops/openfga-outbox-runbook.md` was never running. On staging this left **two `write_tuple` grants stuck `retrying` for ~2 weeks** (a real user's `editor@national_calendar:USA` + `admin@wider_region:Americas` never reached OpenFGA). Those rows have now been drained manually; this PR fixes the two root causes so the infra can be installed durably.

## What

1. **`.github/deploy/rsync-exclude.txt`** — the whole `bin/` dir was excluded from the rsync deploy, so `bin/reconcile-outbox` never shipped to the server. Narrowed the exclusion to `bin/doctrine-migrations` (the only entry that should stay off the wire).
2. **`bin/reconcile-outbox`** — it loaded only `.env.local`/`.env`, missing `.env.staging`/`.env.production`. Now loads the same env-file chain as `public/index.php`. Dotenv populates `$_ENV` directly, which is required because the server's PHP CLI runs with `variables_order=GPCS` (no `E`) — a systemd `EnvironmentFile=` or exported shell vars would **not** reach `$_ENV`.

## Testing

- `php -l bin/reconcile-outbox` — clean.
- Verified on staging: running the backstop with the corrected env chain drained the 2 stuck rows to `succeeded`, and OpenFGA now returns `true` for both grants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment loading for the outbox reconciliation command so it works more reliably across different deployment setups.
  * Adjusted deployment packaging rules so more command-line tools can be included, while keeping migration tooling excluded from delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->