### PR TITLE
chore(fga): drop test_definition type (test-scope Step 6)

### DIFF
--- a/scripts/openfga-model.json
+++ b/scripts/openfga-model.json
@@ -139,36 +139,6 @@
       }
     },
     {
-      "type": "test_definition",
-      "relations": {
-        "admin": { "this": {} },
-        "editor": {
-          "union": {
-            "child": [
-              { "this": {} },
-              { "computedUserset": { "relation": "admin" } }
-            ]
-          }
-        },
-        "viewer": {
-          "union": {
-            "child": [
-              { "this": {} },
-              { "computedUserset": { "relation": "editor" } },
-              { "computedUserset": { "relation": "admin" } }
-            ]
-          }
-        }
-      },
-      "metadata": {
-        "relations": {
-          "admin":  { "directly_related_user_types": [{ "type": "user" }] },
-          "editor": { "directly_related_user_types": [{ "type": "user" }] },
-          "viewer": { "directly_related_user_types": [{ "type": "user" }] }
-        }
-      }
-    },
-    {
       "type": "national_calendar_test",
       "relations": {
         "admin": { "this": {} },

--- a/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
+++ b/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
@@ -29,7 +29,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  *   /data/nation/{id}       → national_calendar:{id}
  *   /data/diocese/{id}      → diocesan_calendar:{id}
  *   /data/widerregion/{id}  → wider_region:{id}
- *   /tests/{id}             → test_definition:{id}
+ *   /tests/{id}             → {national,diocesan,general_roman}_calendar_test:{scopeId} (via TestScopeResolver)
  *   /temporale, /decrees    → general_roman_calendar:{fixedId}
  *   /missals/{editio_typica}→ general_roman_calendar:{missalId}
  *   /missals/{national}     → national_calendar:{nation}


### PR DESCRIPTION
## Why

Executes the deferred **Step 6** of `docs/ops/test-scope-migration-runbook.md`. The flat `test_definition` OpenFGA type was replaced by the calendar-scoped test types (`national_calendar_test`, `diocesan_calendar_test`, `general_roman_calendar_test`) in #666 and intentionally retained during the migration window. All environments are now migrated and clean — **0 `test_definition` tuples** in both the production/staging store and the local dev store — so the type can be dropped.

## What

- **`scripts/openfga-model.json`** — remove the `test_definition` type definition. (The model already has no `deleter` from #668.)
- **`OpenFgaAuthorizationMiddleware`** — fix the stale `/tests/{id} → test_definition:{id}` docstring; live `/tests` authz resolves to the scoped types via `TestScopeResolver` (`forTestScopes`, Router.php), never `test_definition`.

## Safety

- No live authz path uses `test_definition` (`OBJECT_TYPE_MAP` has no entry; `/tests` uses the scoped resolver).
- No PHP constant references it (`JsonDataConstants` has none).
- Migration tooling (`TestTupleMigration`, `scripts/migrate-test-tuples.php`) is **retained** as the documented migration/rollback path.
- `OpenFgaModelTest` still passes (asserts `deleter`-absence + union/TTU structure, not `test_definition`).

## Testing

- `composer parallel-lint`, `composer analyse` (phpstan L10), and the FGA test set (`OpenFgaModelTest`, `TestTupleMigrationTest`, `OpenFgaAuthorizationMiddlewareTest`) — **32 tests pass**.
- Applied to the **local dev store** (`01KVZQ2F`) → model `01KW48R03…`; container recreated and verified (live check `True`).

## Rollout note

Production/staging still carries the unused, **0-tuple** `test_definition` type until this model is applied there — safe to leave or apply as a quick follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated route permission guidance for test-related pages so the documented access checks match the current authorization behavior.

* **Chores**
  * Cleaned up an unused test-related permission definition from the authorization model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->