### PR TITLE
Throttle WS server outbound requests to stay under nginx per-IP rate limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,10 @@ WS_PORT=8082
 # Maximum concurrent HTTP requests for WebSocket server (default: 10 in production, 4 in development)
 # Reduce this on memory-constrained servers to prevent overwhelming the API
 WS_MAX_CONCURRENCY=10
+# Maximum outbound API requests dispatched per rolling 1-second window (default: 3).
+# Keeps the WebSocket test server under the public API's per-IP rate limit (nginx limit_req)
+# without needing server-side IP exemptions. Set to match your API's unauthenticated rate.
+WS_MAX_REQUEST_RATE=3
 # Optional first-party API key the WebSocket test server sends (X-Api-Key header) on its internal
 # API requests, so they authenticate and bypass the unauthenticated per-IP rate limit.
 # Mint one with: php scripts/mint-official-key.php --name=test-runner --owner=<zitadel_user_id>

--- a/src/Health.php
+++ b/src/Health.php
@@ -96,6 +96,16 @@ class Health implements MessageComponentInterface
     private array $queue  = [];
     private bool $ticking = false;
 
+    /**
+     * Maximum number of outbound API requests to dispatch per rolling 1-second window.
+     * Keeps the WS server under the public API's per-IP rate limit (nginx limit_req) without
+     * relying on server-side IP exemptions. Override via WS_MAX_REQUEST_RATE env var.
+     */
+    private int $maxRequestRate;
+    /** @var list<float> microtime(true) timestamps of dispatches within the trailing 1-second window */
+    private array $dispatchTimes       = [];
+    private bool $rateLimitTimerActive = false;
+
     private static bool $cacheInitialized = false;
     private static bool $cacheEnabled     = false;
     private static string $cacheBackend   = 'none';
@@ -141,6 +151,11 @@ class Health implements MessageComponentInterface
         $this->staggerInterval = isset($_ENV['WS_STAGGER_INTERVAL']) && is_numeric($_ENV['WS_STAGGER_INTERVAL'])
             ? max(0.01, (float) $_ENV['WS_STAGGER_INTERVAL'])
             : 0.05;
+
+        // Cap outbound requests to stay under the public API's per-IP rate limit (nginx limit_req).
+        $this->maxRequestRate = isset($_ENV['WS_MAX_REQUEST_RATE']) && is_numeric($_ENV['WS_MAX_REQUEST_RATE'])
+            ? max(1, (int) $_ENV['WS_MAX_REQUEST_RATE'])
+            : 3;
     }
 
     /**
@@ -1689,6 +1704,33 @@ class Health implements MessageComponentInterface
     {
         echo 'Processing queue, inFlight: ' . $this->inFlight . ', maxConcurrency: ' . $this->maxConcurrency . ', queue size: ' . count($this->queue) . "\n";
         while ($this->inFlight < $this->maxConcurrency && !empty($this->queue)) {
+            // Enforce the outbound request-rate cap: no more than $maxRequestRate dispatches within
+            // any trailing 1-second window. This keeps the WS server under the public API's per-IP
+            // rate limit (nginx limit_req) without needing server-side IP exemptions.
+            $now                 = microtime(true);
+            $this->dispatchTimes = array_values(array_filter(
+                $this->dispatchTimes,
+                static fn (float $t): bool => ( $now - $t ) < 1.0
+            ));
+            if (count($this->dispatchTimes) >= $this->maxRequestRate) {
+                // Window is full: resume dispatching once the oldest dispatch ages out of the window.
+                if (false === $this->rateLimitTimerActive) {
+                    $this->rateLimitTimerActive = true;
+                    $oldest                     = $this->dispatchTimes[0] ?? $now;
+                    $wait                       = 1.0 - ( $now - $oldest );
+                    if ($wait < 0.0) {
+                        $wait = 0.0;
+                    }
+                    Loop::addTimer($wait, function (): void {
+                        $this->rateLimitTimerActive = false;
+                        $this->multiHandler->tick();
+                        $this->processQueue();
+                    });
+                }
+                echo 'Rate limit reached (' . $this->maxRequestRate . '/s), deferring ' . count($this->queue) . " queued request(s)\n";
+                return;
+            }
+
             [
                 'url'     => $url,
                 'options' => $options,
@@ -1697,6 +1739,7 @@ class Health implements MessageComponentInterface
             ] = array_shift($this->queue);
 
             ++$this->inFlight;
+            $this->dispatchTimes[] = microtime(true);
 
             if (isset($_ENV['APP_ENV']) && $_ENV['APP_ENV'] === 'development') {
                 $date         = date('Y-m-d H:i:s.u');


### PR DESCRIPTION
## Problem

The Health WebSocket test server funnels every API fetch through `cachedGet` → `processQueue`, which was **concurrency**-limited (`maxConcurrency`) but not **rate**-limited. As responses completed, it could burst well past the API vhost's nginx `limit_req` (`rate=3r/s burst=15`), producing HTTP 429s during full test runs (e.g. ~59/82 keyed requests 429'd at 10-concurrent).

Two things that do **not** solve this on their own:

- `WS_API_KEY` bypasses the **app-level** `UNAUTHENTICATED_RATE_LIMIT`, but nginx's per-IP `limit_req` doesn't read API keys, so it still fires.
- A Plesk `geo`/`map` IP exemption for the box's own hairpin IP proved intractable (the exemption never took effect and Plesk's location-level directives swallowed diagnostics).

## Fix

Cap the WS server's **own** outbound rate below the nginx limit, so no server-side IP exemption is needed. Added a sliding-window rate limiter in `Health::processQueue`:

- No more than `$maxRequestRate` dispatches within any trailing 1-second window (tracked in `$dispatchTimes`).
- When the window is full, dispatching pauses and resumes via a guarded `Loop::addTimer` (`$rateLimitTimerActive` prevents double-scheduling and CPU busy-spin); in-flight completions resume within a sub-second bound.
- Configurable via new env var `WS_MAX_REQUEST_RATE` (default **3**), documented in `.env.example`.
- Instance-level = effectively global, since Ratchet shares one `Health` instance across all connections/runs — matching what nginx's per-IP limit sees.

Complements (does not replace) `WS_API_KEY`.

## Verification

- `php -l` — no syntax errors
- **phpcs** (PSR-12) — clean
- **PHPStan level 10** — no errors
- **PHPUnit** — `HealthHelpersTest` + `WebSocket` suite: 35 tests, 189 assertions, all pass

## Deploy notes

Set `WS_MAX_REQUEST_RATE` in the live `.env.staging` (or leave default 3) and restart `litcal-websocket.service`. If any 429s survive, drop it to `2` rather than touching nginx. Adding the box IP to the fail2ban `litcal-429` `ignoreip` remains a worthwhile backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable request-rate limit for the WebSocket test server to better stay within API limits.
  * Introduced a new environment setting to control the maximum number of outbound requests per second.

* **Bug Fixes**
  * Improved queue handling so requests are automatically paced instead of being sent in bursts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->