### PR TITLE
Allow '*/*' wildcard in LitCal request_headers.Accept schema

### DIFF
--- a/jsondata/schemas/LitCal.json
+++ b/jsondata/schemas/LitCal.json
@@ -43,8 +43,8 @@
                     "properties": {
                         "Accept": {
                             "type": "string",
-                            "description": "If present, must contain at least one of the following",
-                            "pattern": "(?:text/html|application/xml|application/json|text/calendar|application/yaml)"
+                            "description": "If present, must contain at least one of the acceptable media types, or the '*/*' wildcard (sent by clients such as curl or browsers that do not specify an explicit Accept)",
+                            "pattern": "(?:text/html|application/xml|application/json|text/calendar|application/yaml|\\*/\\*)"
                         },
                         "Accept-Language": {
                             "$ref": "./CommonDef.json#/definitions/AcceptLanguage"


### PR DESCRIPTION
## Problem

`metadata.request_headers.Accept` in a calendar response echoes the **raw incoming `Accept` header verbatim** (`CalendarHandler::handle` → `prepareResponseBody`, line ~4548), and that value is serialized into the **cached** calendar body. Clients that don't send an explicit `Accept` — `curl`, browsers hitting the URL directly — send `Accept: */*`. So a cached response can carry `request_headers.Accept: "*/*"`.

The endpoint's own `LitCal.json` schema constrained that field to a pattern listing only the five negotiable media types, so `*/*` failed validation:

```
"*/*" does not match to (?:text/html|application/xml|application/json|text/calendar|application/yaml)
  ... -> properties:metadata -> properties:request_headers -> properties:Accept
```

This surfaced in the UnitTestInterface WS test runner only after the outbound-rate fix (#682) stopped the requests from 429ing — the requests now succeed and reach schema validation, reading back cache entries that earlier diagnostic `curl` bursts had populated with `*/*`.

## Fix

`*/*` is a valid `Accept` value meaning "any acceptable type", so add it to the allowed alternation. Truly unsupported types (e.g. `application/pdf`) still fail. No code change — the schema is read from disk by the validator.

```
(?:text/html|application/xml|application/json|text/calendar|application/yaml|\*/\*)
```

Verified the JSON parses and the pattern matches `*/*`, `application/json`, `application/json, text/plain, */*`, while still rejecting `application/pdf`.

## Note / possible follow-up

Baking a **request-specific** echo field (`request_headers`) into a **shared** cache means a cached calendar reflects whichever client first populated it. This fix makes that harmless for `Accept`, but if you'd prefer the field to always reflect the *current* request, a follow-up could inject `request_headers` after cache retrieval rather than caching it. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)