### PR TITLE
Accept 127.0.0.1 loopback host in api_path schema patterns

### DIFF
--- a/jsondata/schemas/LitCalDecreesSource.json
+++ b/jsondata/schemas/LitCalDecreesSource.json
@@ -33,7 +33,7 @@
                 },
                 "api_path": {
                     "type": "string",
-                    "pattern": "^https?:\\\/\\\/(?:litcal\\.johnromanodorazio\\.com\\\/api\\\/(?:dev|v[4-9]|v[1-9]\\d+)|localhost(?:\\:\\d{4}))\\\/decrees\\\/[A-Z][A-Za-z]+_(Upgrade|Create|NameChange|Doctor)$"
+                    "pattern": "^https?:\\\/\\\/(?:litcal\\.johnromanodorazio\\.com\\\/api\\\/(?:dev|v[4-9]|v[1-9]\\d+)|(?:localhost|127\\.0\\.0\\.1)(?:\\:\\d{4}))\\\/decrees\\\/[A-Z][A-Za-z]+_(Upgrade|Create|NameChange|Doctor)$"
                 }
             },
             "required": [

--- a/jsondata/schemas/LitCalMetadata.json
+++ b/jsondata/schemas/LitCalMetadata.json
@@ -175,7 +175,7 @@
                 "api_path": {
                     "type": "string",
                     "description": "Template URL for the wider region endpoint; {locale} must be substituted and path segments URL-encoded by clients.",
-                    "pattern": "^https?:\\\/\\\/(?:litcal\\.johnromanodorazio\\.com\\\/api\\\/(?:dev|v[3-9]|v[1-9]\\d+)|localhost(?:\\:\\d{4}))\\\/data\\\/widerregion\\\/(?:Africa|Alsace|Americas|Anatolia|Antarctica|Asia|Australasia|Central Africa|Central America|Europe|Indies|Middle East|North Africa|Oceania|Scandinavia|South America|West Indies)\\?locale=\\{locale\\}$"
+                    "pattern": "^https?:\\\/\\\/(?:litcal\\.johnromanodorazio\\.com\\\/api\\\/(?:dev|v[3-9]|v[1-9]\\d+)|(?:localhost|127\\.0\\.0\\.1)(?:\\:\\d{4}))\\\/data\\\/widerregion\\\/(?:Africa|Alsace|Americas|Anatolia|Antarctica|Asia|Australasia|Central Africa|Central America|Europe|Indies|Middle East|North Africa|Oceania|Scandinavia|South America|West Indies)\\?locale=\\{locale\\}$"
                 }
             },
             "required": ["name", "locales", "api_path"]

--- a/jsondata/schemas/LitCalMissalsPath.json
+++ b/jsondata/schemas/LitCalMissalsPath.json
@@ -69,7 +69,7 @@
                 "api_path": {
                     "type": "string",
                     "format": "uri",
-                    "pattern": "^https?:\\\/\\\/(?:litcal\\.johnromanodorazio\\.com\\\/api\\\/(?:dev|v[3-9]|v[1-9]\\d+)|localhost(?:\\:\\d{4}))\\\/missals\\\/(EDITIO_TYPICA|IT|US|NL|CA)_(19[7-9]|[2-9][0-9][0-9])[0-9]$"
+                    "pattern": "^https?:\\\/\\\/(?:litcal\\.johnromanodorazio\\.com\\\/api\\\/(?:dev|v[3-9]|v[1-9]\\d+)|(?:localhost|127\\.0\\.0\\.1)(?:\\:\\d{4}))\\\/missals\\\/(EDITIO_TYPICA|IT|US|NL|CA)_(19[7-9]|[2-9][0-9][0-9])[0-9]$"
                 }
             },
             "required": [

--- a/jsondata/schemas/LitCalSchemasPath.json
+++ b/jsondata/schemas/LitCalSchemasPath.json
@@ -8,7 +8,7 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "pattern": "^https?:\\\/\\\/(?:litcal\\.johnromanodorazio\\.com\\\/api\\\/(?:dev|v[3-9]|v[1-9]\\d+)|localhost(?:\\:\\d{4}))\\\/schemas\\\/[a-zA-Z]+\\.json"
+                "pattern": "^https?:\\\/\\\/(?:litcal\\.johnromanodorazio\\.com\\\/api\\\/(?:dev|v[3-9]|v[1-9]\\d+)|(?:localhost|127\\.0\\.0\\.1)(?:\\:\\d{4}))\\\/schemas\\\/[a-zA-Z]+\\.json"
             }
         }
     }


### PR DESCRIPTION
## Problem

The `LitCalMetadata` and `MemorialsFromDecrees` source-data checks fail schema validation against a **dev/docker** API stack. Root cause is a host-format mismatch, not bad data:

- The API runs under `php -S 0.0.0.0:8000`. `Router::resolveServerHost()` normalizes the non-routable `0.0.0.0` wildcard bind to the **IPv4 loopback `127.0.0.1`** — deliberately, since `localhost` can resolve to IPv6 `::1` where `php -S` isn't listening.
- So `api_path` values come out as e.g. `http://127.0.0.1:8000/data/widerregion/Americas?locale={locale}` and `http://127.0.0.1:8000/decrees/StMaryMagdalene_Upgrade`.
- But the `api_path` regex in these schemas only allowed the production domain or **`localhost:<port>`** — not `127.0.0.1` — so validation fails:

```
"http://127.0.0.1:8000/data/widerregion/Americas?locale={locale}" does not match
  ^https?://(?:litcal.johnromanodorazio.com/api/(?:dev|v[3-9]|…)|localhost(?::\d{4}))/data/widerregion/…
```

Production is unaffected (its `SERVER_NAME` is the real domain, which matches).

## Fix

The producer (`127.0.0.1`) is correct — it must be a routable IPv4 loopback — so the schema is the side to widen. Change the host alternation from `localhost(?::\d{4})` to `(?:localhost|127\.0\.0\.1)(?::\d{4})` in the four schemas whose `api_path` carries this pattern:

- `LitCalMetadata.json` (wider regions)
- `LitCalDecreesSource.json` (decrees)
- `LitCalMissalsPath.json` (missals)
- `LitCalSchemasPath.json` (schemas)

## Verification

Reproduced the exact `swaggest/json-schema` validation the WS server runs, against live docker-stack responses:

- `/calendars` vs `LitCalMetadata.json` → **VALID** (was: wider_regions `api_path` mismatch)
- `/decrees` vs `LitCalDecreesPath.json` (which `$ref`s the widened `LitCalDecreesSource.json`) → **VALID**

🤖 Generated with [Claude Code](https://claude.com/claude-code)