### PR TITLE
fix: enable credentialed CORS on /tests (browser writes from the admin frontend)

### DIFF
--- a/src/Handlers/TestsHandler.php
+++ b/src/Handlers/TestsHandler.php
@@ -47,6 +47,13 @@ final class TestsHandler extends AbstractHandler
     public function __construct(array $requestPathParams = [])
     {
         parent::__construct($requestPathParams);
+        // The frontend admin-tests page performs cookie-authenticated writes
+        // (PUT / PATCH / DELETE) against /tests from the browser. On split-origin
+        // deployments (e.g. the docker e2e stack: frontend :3000 → API :8000) a
+        // wildcard Access-Control-Allow-Origin makes the browser reject any
+        // credentialed request, so echo the validated origin and allow credentials
+        // — same as the /auth and /admin handlers.
+        $this->allowCredentials = true;
     }
 
     /**


### PR DESCRIPTION
## Summary

`TestsHandler` never opted into credentialed CORS, so `/tests` responses carried the wildcard `Access-Control-Allow-Origin: *`. Browsers reject wildcard ACAO for requests made with `credentials: 'include'`, and preflighted writes never even reach the API.

This went unnoticed because production serves the frontend and API same-origin (`/api/dev`), and the old UnitTestInterface editor fetched `/tests` **server-side**. The new frontend admin-tests page (Liturgical-Calendar/LiturgicalCalendarFrontend#379) performs cookie-authenticated `PUT/PATCH/DELETE /tests` **from the browser**, and the split-origin docker e2e stack (frontend `:3000` → API `:8000`) exposed the gap: the API logged `GET /tests → 200` while the browser recorded a network error, and the `PUT` preflight was never sent.

One-line fix: set `$this->allowCredentials = true;` in `TestsHandler::__construct()` — the exact mode every `/auth/*` and `/admin/*` handler already uses (validated-origin echo + `Access-Control-Allow-Credentials: true` via the existing `AbstractHandler` machinery). `EventsHandler` is intentionally untouched: the events catalog is public, and the frontend fetches it without credentials.

## Test plan

- [x] `composer analyse` (PHPStan level 10) — clean
- [x] `composer lint` — clean (CaptainHook pre-commit)
- [ ] Frontend PR #379's e2e run (`rbac` project, spec 13) goes green against a `litcal-api` image built from `development` after this merges — that suite is the real end-to-end verification

## Sequencing

Frontend PR #379's CI builds `litcal-api` from `development`, so its failing e2e spec can only pass after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)