### PR TITLE
fix(ics): escape description newlines once and restore liturgical rank

### DIFF
--- a/phpunit_tests/Handlers/CalendarHandlerTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerTest.php
@@ -144,4 +144,72 @@ final class CalendarHandlerTest extends AbstractHandlerTestCase
             'Fallback published_at must be an RFC3339 UTC timestamp for the ICS CREATED field'
         );
     }
+
+    /**
+     * Request the 2025 calendar as ICS (Latin locale for deterministic grade
+     * strings) and return the response body with RFC 5545 line folding undone,
+     * so assertions can match logical content lines directly.
+     */
+    private function fetchUnfoldedIcs(): string
+    {
+        // The handler serves cached responses from engineCache/ when one
+        // exists for the same API version + source-data hash; a cache file
+        // produced by earlier (possibly buggy) code would mask regressions,
+        // so force a fresh ICS computation.
+        foreach (glob(dirname(__DIR__, 2) . '/engineCache/v*/*.ics') ?: [] as $staleIcs) {
+            unlink($staleIcs);
+        }
+
+        $response = $this->makeHandler(['2025'])->handle(
+            $this->requestFor('GET', '/calendar/2025', [
+                'Accept'          => 'text/calendar',
+                'Accept-Language' => 'la',
+            ])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        self::assertStringStartsWith('BEGIN:VCALENDAR', $body);
+
+        // produceIcal folds long lines with a CRLF + HT continuation sequence.
+        return str_replace("\r\n\t", '', $body);
+    }
+
+    /**
+     * Regression: DESCRIPTION values were built with pre-escaped literal '\n'
+     * sequences, which escapeIcal() then double-escaped to '\\n'. RFC 5545
+     * clients (e.g. Google Calendar) unescape '\\' to a literal backslash and
+     * therefore rendered a literal "\n" instead of a line break.
+     */
+    public function testIcsTextValuesAreNotDoubleEscaped(): void
+    {
+        $unfolded = $this->fetchUnfoldedIcs();
+
+        self::assertStringNotContainsString(
+            '\\\\n',
+            $unfolded,
+            'ICS body must not contain double-escaped newline sequences (backslash-backslash-n)'
+        );
+    }
+
+    /**
+     * Regression: the plain-text DESCRIPTION only included the liturgical
+     * rank when grade_display was explicitly set, which it is not for most
+     * events; unlike the HTML X-ALT-DESC it never fell back to the localized
+     * grade, so the rank never appeared in calendar clients.
+     */
+    public function testIcsDescriptionIncludesLiturgicalGrade(): void
+    {
+        $unfolded = $this->fetchUnfoldedIcs();
+
+        // With a Latin locale LitGrade::MEMORIAL->i18n('la', false) is the
+        // hardcoded string 'Memoria obligatoria' (no gettext involved); the
+        // 2025 General Roman Calendar contains many obligatory memorials, so
+        // at least one DESCRIPTION must carry it on an escaped newline.
+        self::assertStringContainsString(
+            '\nMemoria obligatoria',
+            $unfolded,
+            'ICS DESCRIPTION must include the localized liturgical rank for memorials'
+        );
+    }
 }

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4918,15 +4918,14 @@ final class CalendarHandler extends AbstractHandler
             $displayGrade     = '';
             $displayGradeHTML = '';
 
-            if ($liturgicalEvent->grade_display !== null) {
-                $displayGrade = $liturgicalEvent->grade_display;
-            }
-
             if ($liturgicalEvent->event_key === 'DedicationLateran' || $liturgicalEvent->event_key === 'DedicationLateran_vigil') {
+                $displayGrade     = LitGrade::FEAST->i18n($this->CalendarParams->Locale, false);
                 $displayGradeHTML = LitGrade::FEAST->i18n($this->CalendarParams->Locale, true);
             } elseif ($liturgicalEvent->grade_display === null) {
+                $displayGrade     = $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, false);
                 $displayGradeHTML = $liturgicalEvent->grade->i18n($this->CalendarParams->Locale, true);
             } else {
+                $displayGrade = $liturgicalEvent->grade_display;
                 if ($liturgicalEvent->grade_display === '') {
                     $displayGradeHTML = '';
                 } elseif ($liturgicalEvent->grade->value >= LitGrade::FEAST->value) {
@@ -4936,17 +4935,18 @@ final class CalendarHandler extends AbstractHandler
                 }
             }
 
-            $description  = $liturgicalEvent->getCommonLcl();
-            $description .=  '\n' . $displayGrade;
-            $description .= ( count($liturgicalEvent->color) > 0 )
-                ? '\n' . Utilities::parseColorToString($liturgicalEvent->color, $this->CalendarParams->Locale, false)
-                : '';
-            $description .= (
-                    isset($liturgicalEvent->liturgical_year) // no need to check for null value, isset will fail for a null value
-                    && $liturgicalEvent->liturgical_year !== ''
-                )
-                ? '\n' . $liturgicalEvent->liturgical_year
-                : '';
+            // Build the description with real newlines between the non-empty parts:
+            // escapeIcal() takes care of converting them to the '\n' sequences
+            // required by RFC 5545.
+            $descriptionParts = array_filter([
+                $liturgicalEvent->getCommonLcl(),
+                $displayGrade,
+                count($liturgicalEvent->color) > 0
+                    ? Utilities::parseColorToString($liturgicalEvent->color, $this->CalendarParams->Locale, false)
+                    : '',
+                $liturgicalEvent->liturgical_year ?? '',
+            ], static fn (string $part): bool => $part !== '');
+            $description      = implode("\n", $descriptionParts);
 
             $htmlDescription  = '<P DIR=LTR>' . $liturgicalEvent->getCommonLcl();
             $htmlDescription .=  '<BR>' . $displayGradeHTML;


### PR DESCRIPTION
## Summary

Fixes two long-standing regressions in the ICS (`text/calendar`) output:

- **Literal `\n` shown in Google Calendar** — the `DESCRIPTION` property was assembled with pre-escaped literal `'\n'` sequences, a holdover from before `escapeIcal()` existed. Since 958085e1 introduced `escapeIcal()`, its backslash doubling turned them into `\\n`, which RFC 5545 clients unescape to a literal backslash + `n` instead of a line break. The description is now built with real newlines and escaped exactly once by `escapeIcal()`.
- **Liturgical rank (memorial, feast, …) never displayed** — unlike the HTML `X-ALT-DESC` branch, the plain-text `$displayGrade` had no fallback to the localized grade when `grade_display` was `null` (the common case). The fallback existed in the original 2021 implementation and was lost in a refactor. The plain-text branch now mirrors the HTML logic, including the `DedicationLateran` special case.

Also joins only non-empty description parts, so events without commons no longer start with a blank line.

Before / after for a memorial (Latin locale):

```text
DESCRIPTION:De Commune Beatæ Mariæ Virginis\\n\\nalbus
DESCRIPTION:De Commune Beatæ Mariæ Virginis\nmemoria ad libitum\nalbus
```

## Tests

Two regression tests in `CalendarHandlerTest` request the 2025 calendar as `text/calendar` and assert (on the unfolded body) that no double-escaped sequences are present and that the localized rank appears in `DESCRIPTION`. They delete cached `engineCache/*.ics` files first, since a cache file produced by earlier buggy code would otherwise mask regressions.

- `composer test:quick`: 1472 tests pass (3 environment-dependent skips)
- `composer analyse` (PHPStan level 10): clean
- `composer lint`: clean

## Deployment note

⚠️ The response cache under `engineCache/` is keyed by API version + source-data hash only, so deploying this fix does **not** invalidate previously cached `.ics` responses. Clear `engineCache/v*/​*.ics` on the server after deploying (or bump the API version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar export text so descriptions appear correctly formatted in ICS files, avoiding double-escaped line breaks.
  * Ensured memorial entries include the localized liturgical grade in the calendar description.
  * Updated feast-day labeling in calendar exports so the correct grade is shown consistently, including special cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->