### PR TITLE
ci(deploy): exclude dev-only files from rsync deploys

### DIFF
--- a/.github/deploy/rsync-exclude.txt
+++ b/.github/deploy/rsync-exclude.txt
@@ -7,6 +7,13 @@
 # Anything that should live only on the server (env files, runtime
 # logs, server-managed state) MUST be listed here so it isn't wiped
 # on deploy.
+#
+# GOTCHA (consequence of #2): adding a pattern here does NOT clean up
+# copies already on the server from earlier deploys — the new pattern
+# protects them from --delete, fossilizing them. When adding an entry
+# for something previously deployed, also remove it once manually on
+# the server. Never use --delete-excluded for that: it would wipe the
+# server-managed state below (.env.production, logs/, cache/, ...).
 
 # --- VCS / CI / agent metadata ---
 .git/
@@ -28,6 +35,8 @@
 phpunit_tests/
 coverage/
 docs/
+literature/
+stubs/
 
 # --- Build / dev configuration with no runtime role ---
 phpcs.xml
@@ -39,6 +48,8 @@ phpunit.xml.dist
 captainhook.json
 redocly.yaml
 .markdownlint.yml
+.markdownlint-wiki.yml
+.php-version
 docker-compose.yml
 docker-compose.yaml
 Dockerfile
@@ -50,6 +61,33 @@ stop-server.sh
 restart-server.sh
 server.pid
 server.vscode.pid
+# The WebSocket test server does not run from this directory on the VPS.
+ws-start-server.sh
+ws-stop-server.sh
+ws-server.pid
+parseOpenAPI.js
+
+# --- Provisioning sources (installed elsewhere, not read at runtime) ---
+# deploy/ holds systemd/cron unit SOURCES; the installed units live under
+# /etc/systemd and reference /opt/liturgical-calendar, not this vhost.
+# infrastructure/ is Zitadel provisioning material. migrations/ at the
+# repo root is an empty placeholder (.gitkeep) — Doctrine reads
+# src/Migrations per doctrine-migrations.php.
+deploy/
+infrastructure/
+/migrations/
+
+# --- Dev-only entries inside scripts/ ---
+# scripts/ itself MUST ship: the operational scripts (mint-official-key,
+# migrate-*-tuples, reconcile-resource-tuples, seed-wider-region-membership,
+# and the openfga-model*.json they apply) bootstrap from the deployed app
+# root's vendor/ + .env and are run ON the server per the RBAC runbook,
+# since production OpenFGA/Postgres are only reachable there. Exclude only
+# the local coverage tooling and the Docker-bootstrap SQL.
+scripts/coverage-summary.php
+scripts/coverage-with-server.sh
+scripts/merge-pcov-coverage.php
+scripts/init-db.sql
 
 # --- CLI tooling that cannot run in the SSH chroot anyway ---
 # bin/doctrine-migrations is invoked in-process via the /_ops/migrate
@@ -73,6 +111,11 @@ composer.lock
 # --- Project meta files ---
 CLAUDE.md
 README.md
+CHANGELOG.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+DATA_RETENTION.md
+LICENSE
 
 # --- TRACKED EXAMPLE FILE (transferred + overwritten every deploy) ---
 # The "+" prefix is an rsync include-override: this rule must precede the


### PR DESCRIPTION
## Summary

The live server's deploy directory had accumulated a lot of files the API doesn't need at runtime. Two distinct causes:

1. **Tracked dev-only files were never excluded**, so every deploy shipped them: project meta files (`CHANGELOG.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, `DATA_RETENTION.md`, `LICENSE`), `literature/` (historical missal PDFs — the heaviest offender), `stubs/`, `parseOpenAPI.js`, the WS dev-server scripts, provisioning sources (`deploy/`, `infrastructure/`, the empty root `migrations/` placeholder), and the local coverage/bootstrap helpers inside `scripts/`.
2. **Already-excluded files were fossilized on the server**: exclude patterns also protect matching destination paths from `--delete`, so `docs/`, `phpunit_tests/`, `CLAUDE.md`, `README.md`, and `composer.lock` deployed before their exclude entries existed can never be removed by rsync. This gotcha is now documented in the exclude file header.

`scripts/` intentionally keeps shipping (minus coverage tooling and `init-db.sql`): the operational scripts (`mint-official-key.php`, `migrate-*-tuples.php`, `reconcile-resource-tuples.php`, `seed-wider-region-membership.php`, `openfga-model*.json`) bootstrap from the deployed app root's `vendor/` + `.env` and are run on the server per the RBAC runbook.

Verified with a local `rsync -an --delete --exclude-from` dry run; the shipped tree reduces to:

```text
.env.example  bin  composer.json  doctrine-migrations.php  i18n  jsondata  public  scripts(ops only)  src  vendor
```

## One-time server cleanup required

Adding excludes does **not** remove already-deployed copies (cause 2 above). After this merges and deploys, run once per environment (`api/dev`, and the production `api/vN` after the next release):

```bash
cd /var/www/vhosts/johnromanodorazio.com/httpdocs/LiturgicalCalendar/api/dev
rm -rf CHANGELOG.md CLAUDE.md CODE_OF_CONDUCT.md CONTRIBUTING.md DATA_RETENTION.md LICENSE README.md \
  composer.lock docs phpunit_tests literature parseOpenAPI.js stubs infrastructure deploy migrations \
  ws-start-server.sh ws-stop-server.sh \
  scripts/coverage-summary.php scripts/coverage-with-server.sh scripts/merge-pcov-coverage.php scripts/init-db.sql
```

Do NOT use `rsync --delete-excluded` for this — it would also wipe `.env.production`, `logs/`, `cache/`, and `public/engineCache/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)