### PR TITLE
fix(ics): don't 503 when the GitHub-release cache dir can't be written

### DIFF
--- a/phpunit_tests/Handlers/CalendarHandlerTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerTest.php
@@ -146,6 +146,58 @@ final class CalendarHandlerTest extends AbstractHandlerTestCase
     }
 
     /**
+     * Caching the GitHub release JSON is a non-essential optimization. When the
+     * engine cache directory exists and is writable, cacheDirectoryIsAvailable()
+     * reports true so the caller may persist the release info.
+     */
+    public function testCacheDirectoryIsAvailableReturnsTrueWhenWritable(): void
+    {
+        $handler  = $this->makeHandler();
+        $cacheDir = sys_get_temp_dir() . '/litcal-cache-writable-' . bin2hex(random_bytes(4));
+        self::assertTrue(mkdir($cacheDir, 0755));
+
+        try {
+            ( new \ReflectionProperty(CalendarHandler::class, 'CachePath') )
+                ->setValue($handler, $cacheDir . '/');
+            $available = ( new \ReflectionMethod(CalendarHandler::class, 'cacheDirectoryIsAvailable') )
+                ->invoke($handler);
+            self::assertTrue($available, 'A writable cache directory must report as available');
+        } finally {
+            rmdir($cacheDir);
+        }
+    }
+
+    /**
+     * Regression: on localhost the response cache is skipped entirely, yet
+     * getGithubReleaseInfo() still tried to create the cache directory to
+     * persist GHRelease.json and threw a 503 (ServiceUnavailableException) when
+     * it could not — taking down ICS output even though the release info is
+     * non-essential. cacheDirectoryIsAvailable() must report false instead of
+     * throwing, so the caller can proceed without caching.
+     */
+    public function testCacheDirectoryIsAvailableReturnsFalseWhenParentNotWritable(): void
+    {
+        if (function_exists('posix_getuid') && posix_getuid() === 0) {
+            self::markTestSkipped('Running as root bypasses directory permissions, so a read-only parent cannot be simulated.');
+        }
+
+        $handler  = $this->makeHandler();
+        $roParent = sys_get_temp_dir() . '/litcal-cache-readonly-' . bin2hex(random_bytes(4));
+        self::assertTrue(mkdir($roParent, 0500)); // read + execute only: cannot create children
+
+        try {
+            ( new \ReflectionProperty(CalendarHandler::class, 'CachePath') )
+                ->setValue($handler, $roParent . '/v5_7-deadbeef/');
+            $available = ( new \ReflectionMethod(CalendarHandler::class, 'cacheDirectoryIsAvailable') )
+                ->invoke($handler);
+            self::assertFalse($available, 'An uncreatable cache directory must report as unavailable, not throw');
+        } finally {
+            chmod($roParent, 0700);
+            rmdir($roParent);
+        }
+    }
+
+    /**
      * Request the 2025 calendar as ICS (Latin locale for deterministic grade
      * strings) and return the response body with RFC 5545 line folding undone,
      * so assertions can match logical content lines directly.

--- a/phpunit_tests/Handlers/CalendarHandlerTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerTest.php
@@ -147,23 +147,32 @@ final class CalendarHandlerTest extends AbstractHandlerTestCase
 
     /**
      * Caching the GitHub release JSON is a non-essential optimization. When the
-     * engine cache directory exists and is writable, cacheDirectoryIsAvailable()
-     * reports true so the caller may persist the release info.
+     * versioned cache directory does not yet exist but sits under a writable
+     * parent, cacheDirectoryIsAvailable() must create it (exercising
+     * ensureCachePathExists()'s create-succeeds branch, which is the real
+     * first-request scenario) and report true.
      */
     public function testCacheDirectoryIsAvailableReturnsTrueWhenWritable(): void
     {
-        $handler  = $this->makeHandler();
-        $cacheDir = sys_get_temp_dir() . '/litcal-cache-writable-' . bin2hex(random_bytes(4));
-        self::assertTrue(mkdir($cacheDir, 0755));
+        $handler = $this->makeHandler();
+        $parent  = sys_get_temp_dir() . '/litcal-cache-writable-' . bin2hex(random_bytes(4));
+        self::assertTrue(mkdir($parent, 0755));
+        // A not-yet-existing versioned subdir under the writable parent, mirroring
+        // the vN-<hash> dir that is absent on the first request for a given version.
+        $cacheDir = $parent . '/v5_7-cafef00d';
 
         try {
             ( new \ReflectionProperty(CalendarHandler::class, 'CachePath') )
                 ->setValue($handler, $cacheDir . '/');
             $available = ( new \ReflectionMethod(CalendarHandler::class, 'cacheDirectoryIsAvailable') )
                 ->invoke($handler);
-            self::assertTrue($available, 'A writable cache directory must report as available');
+            self::assertTrue($available, 'A creatable cache directory must report as available');
+            self::assertDirectoryExists($cacheDir, 'The versioned cache directory must have been created');
         } finally {
-            rmdir($cacheDir);
+            if (is_dir($cacheDir)) {
+                rmdir($cacheDir);
+            }
+            rmdir($parent);
         }
     }
 

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -628,6 +628,31 @@ final class CalendarHandler extends AbstractHandler
     }
 
     /**
+     * Non-throwing counterpart to {@see self::ensureCachePathExists()}, for callers
+     * whose caching is a best-effort optimization rather than a hard requirement
+     * (currently {@see self::getGithubReleaseInfo()}).
+     *
+     * Returns true when the cache directory exists (or was created) and is writable,
+     * false when it cannot be prepared. A false result must never abort the response:
+     * the caller keeps its in-memory data and simply skips persisting it.
+     *
+     * @return bool Whether the cache directory is available for writing
+     */
+    private function cacheDirectoryIsAvailable(): bool
+    {
+        try {
+            $this->ensureCachePathExists();
+            return true;
+        } catch (ServiceUnavailableException $e) {
+            $logger = LoggerFactory::create('calendar', null, 30, false, true, false);
+            $logger->warning('Cache directory unavailable; proceeding without caching', [
+                'reason' => $e->getMessage(),
+            ]);
+            return false;
+        }
+    }
+
+    /**
      * Short content fingerprint of the data that determines calendar output:
      * the source JSON (jsondata/sourcedata) and the compiled gettext catalogs
      * (i18n .mo files, which supply the translated event names baked into the
@@ -4424,9 +4449,12 @@ final class CalendarHandler extends AbstractHandler
             $returnObj->status = 'success';
             $returnObj->obj    = Utilities::jsonFileToObject($ghReleaseCacheFile);
         } else {
-            // We always create a cache of the Github Release, even for localhost development,
-            // to avoid sending too many requests
-            $this->ensureCachePathExists();
+            // We try to cache the GitHub Release, even for localhost development,
+            // to avoid sending too many requests. Caching is a non-essential
+            // optimization, though: if the cache directory cannot be created
+            // (e.g. a read-only deployment) we must still fetch and return the
+            // release info rather than 503 the whole ICS response.
+            $cacheAvailable = $this->cacheDirectoryIsAvailable();
 
             $GithubReleasesAPI = 'https://api.github.com/repos/Liturgical-Calendar/LiturgicalCalendarAPI/releases/latest';
 
@@ -4458,9 +4486,12 @@ final class CalendarHandler extends AbstractHandler
                     if (false === $GitHubReleaseEncoded) {
                         throw new \Exception('Could not re-encode JSON object');
                     }
-                    $bytes = file_put_contents($ghReleaseCacheFile, $GitHubReleaseEncoded, LOCK_EX);
+                    // Only attempt the write when the cache directory is available;
+                    // we still have the data in memory regardless, so ICS output
+                    // succeeds even when caching is impossible.
+                    $bytes = $cacheAvailable ? @file_put_contents($ghReleaseCacheFile, $GitHubReleaseEncoded, LOCK_EX) : false;
                     if (false === $bytes) {
-                        // Cache write failed, but we have the data in memory - log and continue
+                        // Cache unavailable or write failed - log and continue
                         // This allows ICS responses to succeed even when caching fails
                         $logger = LoggerFactory::create('calendar', null, 30, false, true, false);
                         $logger->warning('Could not write GitHub release cache file', [

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4488,11 +4488,11 @@ final class CalendarHandler extends AbstractHandler
                     }
                     // Only attempt the write when the cache directory is available;
                     // we still have the data in memory regardless, so ICS output
-                    // succeeds even when caching is impossible.
-                    $bytes = $cacheAvailable ? @file_put_contents($ghReleaseCacheFile, $GitHubReleaseEncoded, LOCK_EX) : false;
-                    if (false === $bytes) {
-                        // Cache unavailable or write failed - log and continue
-                        // This allows ICS responses to succeed even when caching fails
+                    // succeeds even when caching is impossible. The unavailable
+                    // case is already logged by cacheDirectoryIsAvailable(), so we
+                    // only warn here when an available directory unexpectedly
+                    // rejects the write (e.g. a race or disk error).
+                    if ($cacheAvailable && false === @file_put_contents($ghReleaseCacheFile, $GitHubReleaseEncoded, LOCK_EX)) {
                         $logger = LoggerFactory::create('calendar', null, 30, false, true, false);
                         $logger->warning('Could not write GitHub release cache file', [
                             'cache_file' => $ghReleaseCacheFile


### PR DESCRIPTION
## Summary

ICS calendar output returned **503 Service Unavailable** whenever the engine cache directory could not be created, even though the GitHub release info it wanted to cache is non-essential metadata.

`getGithubReleaseInfo()` called `ensureCachePathExists()` **unconditionally** to persist `GHRelease.json` — including on localhost, where response caching is otherwise skipped. `ensureCachePathExists()` throws `ServiceUnavailableException` (503) when the directory can't be created, so a read-only cache location (e.g. the local full-stack dev container, which mounts `public/` read-only) took down the entire ICS response.

This is the parallel gap to #649: that PR made the GitHub *fetch* failure non-fatal (`resolveIcalReleaseObject()` falls back to UTC-now); this PR closes the same gap for the cache-*write* path.

## Change

- New non-throwing `cacheDirectoryIsAvailable()` helper — wraps the existing `ensureCachePathExists()` in a try/catch, logs a warning, returns `bool`.
- `getGithubReleaseInfo()` gates the `GHRelease.json` write on it. When the cache dir is unavailable, the release info is still fetched and returned from memory; only the caching is skipped. `file_put_contents` is now `@`-suppressed and guarded (consistent with `prepareResponseBody`).
- `prepareResponseBody()`'s response-cache path is **unchanged**: it still fails closed for non-localhost, where a non-writable cache is a genuine deployment fault worth surfacing.

## Tests

Two deterministic unit tests on the new helper (written first, red before the fix):

- writable dir → `true`
- uncreatable dir (read-only parent) → `false`, never throws — skipped when running as root, since root bypasses directory permissions

`composer analyse` (PHPStan level 10) and `composer lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub release metadata handling when the cache directory can’t be written.
  * The app now continues to load the latest release information even if caching isn’t available, instead of failing the request.
  * Added coverage for writable and non-writable cache directory scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->