### PR TITLE
fix: transfer Sts. Peter and Paul when impeded by the Sacred Heart (#564)

### DIFF
--- a/phpunit_tests/Handlers/CalendarHandlerTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
  * CalendarHandler is the heart of the API — it computes the full liturgical
@@ -307,6 +308,70 @@ final class CalendarHandlerTest extends AbstractHandlerTestCase
 
         self::assertSame('2023-01-23', $dates['PrayerUnborn'] ?? null, 'Day of Prayer must move to Jan 23 when Jan 22 is a Sunday');
         self::assertSame('2023-01-23', $dates['StVincentDeacon'] ?? null, 'St Vincent must be recreated on Jan 23 alongside the Day of Prayer');
+    }
+
+    /**
+     * Recurrence years for the Sacred Heart / Saints Peter and Paul collision:
+     * years in which Easter falls on 22 April, so the movable Solemnity of the
+     * Sacred Heart falls on 29 June (Friday after the Second Sunday after
+     * Pentecost) and impedes the fixed Solemnity of Saints Peter and Paul.
+     *
+     * @return array<string, array{int}>
+     */
+    public static function sacredHeartImpedesPeterAndPaulYears(): array
+    {
+        return [
+            '1973' => [1973],
+            '1984' => [1984],
+            '2057' => [2057],
+            '2068' => [2068],
+        ];
+    }
+
+    /**
+     * Regression for issue #564: when the movable Solemnity of the Sacred Heart
+     * (of the Lord) occurs on 29 June it impedes the fixed Solemnity of Saints
+     * Peter and Paul (of the Saints); both are ranked I.3 in the Table of
+     * Liturgical Days, but the Lord's Solemnity is observed and the Apostles'
+     * Solemnity, per Universal Norms n. 60, is transferred to the nearest free
+     * day — postponed to 30 June — rather than being silently dropped. When it
+     * lands on 30 June it supersedes the optional memorial of the First Martyrs
+     * of the Church of Rome that normally sits there.
+     */
+    #[DataProvider('sacredHeartImpedesPeterAndPaulYears')]
+    public function testPeterAndPaulTransferredWhenImpededBySacredHeart(int $year): void
+    {
+        $this->purgeEngineCache('json');
+
+        $response = $this->makeHandler([(string) $year])->handle(
+            $this->requestFor('GET', '/calendar/' . $year, ['Accept-Language' => 'la'])
+        );
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeJsonBody($response);
+
+        $byKey = static fn (string $key): array => array_values(array_filter(
+            $body['litcal'],
+            static fn (array $event): bool => $event['event_key'] === $key
+        ));
+
+        $sacredHeart = $byKey('SacredHeart');
+        self::assertCount(1, $sacredHeart, "The Sacred Heart must be present in $year");
+        self::assertStringStartsWith("$year-06-29", $sacredHeart[0]['date'], "The Sacred Heart falls on 29 June $year");
+
+        $peterPaul = $byKey('StsPeterPaulAp');
+        self::assertCount(1, $peterPaul, "Saints Peter and Paul must not be dropped when impeded by the Sacred Heart in $year");
+        self::assertStringStartsWith(
+            "$year-06-30",
+            $peterPaul[0]['date'],
+            "Saints Peter and Paul must be transferred to 30 June $year (Universal Norms n. 60)"
+        );
+
+        self::assertCount(
+            0,
+            $byKey('FirstMartyrsRome'),
+            "The First Martyrs of Rome memorial must be superseded by the transferred Solemnity on 30 June $year"
+        );
     }
 
     /**

--- a/phpunit_tests/Handlers/CalendarHandlerTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerTest.php
@@ -335,8 +335,10 @@ final class CalendarHandlerTest extends AbstractHandlerTestCase
      * Liturgical Days, but the Lord's Solemnity is observed and the Apostles'
      * Solemnity, per Universal Norms n. 60, is transferred to the nearest free
      * day — postponed to 30 June — rather than being silently dropped. When it
-     * lands on 30 June it supersedes the optional memorial of the First Martyrs
-     * of the Church of Rome that normally sits there.
+     * lands on 30 June it supersedes the memorials that sit there: the optional
+     * memorial of the First Martyrs of the Church of Rome and — since the
+     * Immaculate Heart of Mary (Easter+64) always falls on 30 June in these
+     * Easter-on-22-April years — the memorial of the Immaculate Heart too.
      */
     #[DataProvider('sacredHeartImpedesPeterAndPaulYears')]
     public function testPeterAndPaulTransferredWhenImpededBySacredHeart(int $year): void
@@ -371,6 +373,12 @@ final class CalendarHandlerTest extends AbstractHandlerTestCase
             0,
             $byKey('FirstMartyrsRome'),
             "The First Martyrs of Rome memorial must be superseded by the transferred Solemnity on 30 June $year"
+        );
+
+        self::assertCount(
+            0,
+            $byKey('ImmaculateHeart'),
+            "The Immaculate Heart of Mary (30 June in these years) must be superseded by the transferred Solemnity on 30 June $year"
         );
     }
 

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -1500,6 +1500,66 @@ final class CalendarHandler extends AbstractHandler
                             '<a href="https://www.cultodivino.va/content/dam/cultodivino/rivista-notitiae/1990/notitiae-26-(1990)/Notitiae-284-285-1990.pdf" target="_blank">' . _('Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments') . '</a>'
                         );
                     }
+                } elseif (
+                    $propriumDeSanctisEvent->event_key === 'StsPeterPaulAp'
+                    && $this->Cal->solemnityKeyFromDate($currentLitEventDate) === 'SacredHeart'
+                ) {
+                    /**
+                     * In years when Easter falls on 22 April (e.g. 1973, 1984, 2057, 2068, 2114),
+                     *   the movable Solemnity of the Most Sacred Heart of Jesus (the Friday after the
+                     *   Second Sunday after Pentecost) falls on 29 June, impeding the fixed Solemnity
+                     *   of Saints Peter and Paul, Apostles.
+                     *
+                     * Both are ranked I.3 in the Table of Liturgical Days
+                     *   ( << Sollemnitates Domini, beatae Mariae Virginis, Sanctorum in calendario generali
+                     *     inscriptae; commemoratio omnium fidelium defunctorum >> ),
+                     *   but within that rank the Solemnities of the Lord precede those of the Saints, so the
+                     *   Sacred Heart is observed and Saints Peter and Paul, being impeded, is transferred to
+                     *   the nearest free day per the Universal Norms on the Liturgical Year and the Calendar, n. 60:
+                     *   << Attamen sollemnitas, quae impeditur a die liturgico, qui praecedentia gaudeat,
+                     *      ad proximiorem diem transferatur qui sit liber a diebus sub nn. 1-8
+                     *      in tabula praecedentiae recensitis, servatis de quibus n. 5. >>
+                     *
+                     * 29 June is flanked by two equidistant free days: 28 June (memorial of St Irenaeus) and
+                     *   30 June (optional memorial of the First Martyrs of the Church of Rome, plus, in years
+                     *   such as 1973, the memorial of the Immaculate Heart of Mary). All of these are memorials
+                     *   (ranks 10-12, i.e. below nn. 1-8) and so are freely superseded. Since n. 60 does not itself
+                     *   resolve the direction, and no Dicastery dubium addresses this specific pairing (cf. the
+                     *   analogous Nativity of John the Baptist case handled below, which was *anticipated* per the
+                     *   2020 Responsa ad dubia), the impeded Solemnity is *postponed* to the following day, 30 June:
+                     *   postponement is the ordinary preference over anticipation, and the First Martyrs of the
+                     *   Church of Rome on 30 June are the liturgical companions of the Apostles.
+                     *
+                     * See https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/564
+                     */
+                    $coincidingSolemnity = $this->Cal->solemnityFromDate($currentLitEventDate);
+                    if (null === $coincidingSolemnity) {
+                        throw new ServiceUnavailableException('No coinciding Solemnity found for ' . $currentLitEventDate->format('Y-m-d'));
+                    }
+
+                    $StsPeterPaulNewDate = clone( $currentLitEventDate );
+                    $StsPeterPaulNewDate->add(new \DateInterval('P1D'));
+                    if (false === $this->Cal->inSolemnities($StsPeterPaulNewDate)) {
+                        $tempLiturgicalEvent->date = $StsPeterPaulNewDate;
+                        $this->Messages[]          = sprintf(
+                            /**translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral, 5: actual date for the transferral, 6: Reference to the norm that governs the transferral */
+                            _('The Solemnity \'%1$s\' falls on %2$s in the year %3$d, the celebration has been transferred to %4$s (%5$s) as per the %6$s.'),
+                            $tempLiturgicalEvent->name,
+                            $coincidingSolemnity->name,
+                            $this->CalendarParams->Year,
+                            _('the following day'),
+                            $this->localeDateFormatter->formatLocalizedDate($tempLiturgicalEvent->date),
+                            _('General Norms for the Liturgical Year and the Calendar') . ', n. 60'
+                        );
+                    } else {
+                        $this->Messages[] = '<span style="padding:3px 6px; font-weight: bold; background-color: #FFC;color:Red;border-radius:6px;">IMPORTANT</span> ' . sprintf(
+                            /**translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year */
+                            _('The Solemnity \'%1$s\' coincides with the Solemnity \'%2$s\' in the year %3$d. We should ask the Dicastery for Divine Worship and the Discipline of the Sacraments what to do about this!'),
+                            $propriumDeSanctisEvent->name,
+                            $coincidingSolemnity->name,
+                            $this->CalendarParams->Year
+                        );
+                    }
                 } else {
                     //In all other cases, let's make a note of what's happening and ask the Congegation for Divine Worship
                     $coincidingSolemnity = $this->Cal->solemnityFromDate($currentLitEventDate);


### PR DESCRIPTION
## Summary

Fixes #564. In years when Easter falls on **22 April** (1973, 1984, 2057, 2068, 2114, …), the movable Solemnity of the **Most Sacred Heart of Jesus** falls on **29 June** and impedes the fixed Solemnity of **Saints Peter and Paul, Apostles**. The Sacred Heart is correctly observed, but Peter & Paul was being **silently dropped** from the calendar instead of transferred.

Reported by Olivier Chavarin (@scriptura), who also cross-filed the parallel case against romcal.

## Authoritative grounding

Both celebrations are ranked **I.3** in the Table of Liturgical Days (*Normae universales de anno liturgico et de calendario*, 1969 / 2002):

> *Sollemnitates Domini, beatae Mariae Virginis, Sanctorum in calendario generali inscriptae; commemoratio omnium fidelium defunctorum.*

Within that rank the Solemnities of the Lord precede those of the Saints, so the Sacred Heart is observed and Peter & Paul is impeded. Per **Universal Norms n. 60**, an impeded Solemnity is **transferred to the nearest free day**, not omitted:

> *Attamen sollemnitas, quae impeditur a die liturgico, qui praecedentia gaudeat, ad proximiorem diem transferatur qui sit liber a diebus sub nn. 1-8 in tabula praecedentiae recensitis, servatis de quibus n. 5.*

## Behaviour

`calculateFixedSolemnities()` now handles the coincidence explicitly: Peter & Paul is **postponed to 30 June**, superseding the memorials normally there (First Martyrs of the Church of Rome; and, in years such as 1973, the Immaculate Heart of Mary).

⚠️ **Direction is a deliberate choice.** 29 June is flanked by two equidistant free days — 28 June (St Irenaeus) and 30 June — and n. 60's *"nearest day"* does not itself resolve the tie, nor does any CDW *dubium* address this specific pairing (unlike the analogous Nativity of John the Baptist case, *anticipated* to 23 June per the 2020 *Responsa ad dubia*, already handled in this method). **30 June (postponement)** was chosen because postponement is the ordinary preference over anticipation and the First Martyrs of Rome are the liturgical companions of the Apostles. The full reasoning and the n. 60 wording are documented inline in the code.

## Tests

Adds a data-provider regression test over the recurrence years **1973, 1984, 2057, 2068** asserting:

- the Sacred Heart on 29 June,
- Saints Peter and Paul transferred to 30 June (present exactly once, not dropped),
- the First Martyrs of Rome memorial superseded on 30 June.

## Verification

- New regression test: 4/4 years pass.
- Full `CalendarHandlerTest`: 19/19 pass (no regression — the handler is gated on `solemnityKeyFromDate === 'SacredHeart'`, so non-collision years are untouched).
- `composer analyse` (PHPStan level 10): no errors.
- `phpcs`: clean.

## Out of scope

The transferred Solemnity has no Vigil Mass in the output (28 June carries the Sacred Heart vigil instead). This PR only addresses the solemnity being dropped; vigil-on-transfer behaviour is left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the calendar so Saints Peter and Paul are transferred to 30 June when their date is impeded by the Sacred Heart on 29 June.
  * Added clearer handling for the rare case where the transfer cannot occur because the next day is also occupied.
  * Ensured related calendar entries no longer appear when they are superseded by the transferred solemnity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->