### PR TITLE
fix: reflect each caller's request headers on cache hits (#684)

### DIFF
--- a/phpunit_tests/Handlers/CalendarRequestHeadersCacheTest.php
+++ b/phpunit_tests/Handlers/CalendarRequestHeadersCacheTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Issue #684: metadata.request_headers is request-specific data, but the calendar
+ * cache is shared (keyed by calendar params, not headers). On a cache hit the handler
+ * re-injects the current caller's headers into the serialized body so it never echoes
+ * whichever client first populated the entry. These tests cover the per-format textual
+ * splice helpers directly, plus one end-to-end check on the shared JSON cache entry.
+ */
+#[CoversClass(CalendarHandler::class)]
+final class CalendarRequestHeadersCacheTest extends AbstractHandlerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $fixturePath = realpath(__DIR__ . '/../fixtures/api');
+        self::assertNotFalse($fixturePath, 'M1 calendars fixture must be present');
+        Router::$apiPath = 'file://' . $fixturePath;
+    }
+
+    /**
+     * Invoke a private splice helper with a given set of request headers. The helpers
+     * use only $this->requestHeaders, so the constructor (and its metadata fetch) is skipped.
+     *
+     * @param array<string,string> $headers
+     */
+    private function splice(string $method, array $headers, string $body): string
+    {
+        $handler = ( new \ReflectionClass(CalendarHandler::class) )->newInstanceWithoutConstructor();
+        ( new \ReflectionProperty(CalendarHandler::class, 'requestHeaders') )->setValue($handler, $headers);
+        return (string) ( new \ReflectionMethod(CalendarHandler::class, $method) )->invoke($handler, $body);
+    }
+
+    public function testJsonSpliceReplacesOnlyRequestHeaders(): void
+    {
+        $body = '{"metadata":{"request_headers":{"Accept":"*\/*","Accept-Language":"en"},"version":"5.0"}}';
+        $out  = $this->splice('spliceRequestHeadersJson', ['Accept' => 'application/json', 'Accept-Language' => 'it'], $body);
+
+        $decoded = json_decode($out, true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['Accept' => 'application/json', 'Accept-Language' => 'it'], $decoded['metadata']['request_headers']);
+        self::assertSame('5.0', $decoded['metadata']['version'], 'Everything except request_headers must be untouched');
+    }
+
+    public function testJsonSpliceHandlesEmptyCachedHeaders(): void
+    {
+        // A caller that sent none of the useful headers serializes request_headers as [].
+        $body = '{"metadata":{"request_headers":[],"version":"5.0"}}';
+        $out  = $this->splice('spliceRequestHeadersJson', ['Accept' => 'application/json'], $body);
+
+        $decoded = json_decode($out, true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['Accept' => 'application/json'], $decoded['metadata']['request_headers']);
+    }
+
+    public function testXmlSpliceReplacesRequestHeaders(): void
+    {
+        $body = "<LiturgicalCalendar><Metadata>\n    <RequestHeaders>\n      <Accept>*/*</Accept>\n"
+            . "    </RequestHeaders>\n    <Version>5.0</Version></Metadata></LiturgicalCalendar>";
+        $out  = $this->splice('spliceRequestHeadersXml', ['Accept' => 'application/xml', 'Accept-Language' => 'it'], $body);
+
+        self::assertStringContainsString('<Accept>application/xml</Accept>', $out);
+        self::assertStringContainsString('<Accept-Language>it</Accept-Language>', $out);
+        self::assertStringNotContainsString('*/*', $out, 'The first caller\'s Accept must be gone');
+        self::assertStringContainsString('<Version>5.0</Version>', $out, 'Everything else must be untouched');
+        self::assertNotFalse(simplexml_load_string($out), 'Result must remain well-formed XML');
+    }
+
+    public function testYamlSpliceReplacesRequestHeaders(): void
+    {
+        $body = "metadata:\n  request_headers:\n    Accept: '*/*'\n    Accept-Language: en\n  version: '5.0'\n";
+        $out  = $this->splice('spliceRequestHeadersYaml', ['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $body);
+
+        $parsed = Yaml::parse($out);
+        self::assertSame(['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $parsed['metadata']['request_headers']);
+        self::assertSame('5.0', $parsed['metadata']['version'], 'Everything except request_headers must be untouched');
+    }
+
+    private function purgeEngineCache(string $extension): void
+    {
+        foreach (glob(dirname(__DIR__, 2) . '/engineCache/v*/[0-9a-f]*.' . $extension) ?: [] as $staleCache) {
+            unlink($staleCache);
+        }
+    }
+
+    /**
+     * End-to-end: two requests with identical calendar params (hence the SAME shared cache
+     * key) but a different request-specific header must each see their OWN header echoed —
+     * even though the second is served from the shared server cache the first populated.
+     *
+     * X-Requested-With is used (rather than Accept) because it is captured into
+     * request_headers without participating in return-type negotiation, so both requests
+     * deterministically resolve to JSON and hit the same cache entry. The per-format Accept
+     * replacement itself is covered by the splice unit tests above.
+     */
+    public function testSharedCacheReflectsEachCallersOwnHeader(): void
+    {
+        $this->purgeEngineCache('json');
+
+        $make = function (): CalendarHandler {
+            $handler = new CalendarHandler(['2025']);
+            $handler->setAllowedReturnTypes([ReturnTypeParam::JSON, ReturnTypeParam::YAML, ReturnTypeParam::XML, ReturnTypeParam::ICS]);
+            return $handler;
+        };
+
+        $r1 = $make()->handle($this->requestFor('GET', '/calendar/2025', ['Accept-Language' => 'la', 'X-Requested-With' => 'FirstClient']));
+        self::assertSame(200, $r1->getStatusCode());
+        self::assertSame('FirstClient', $this->decodeJsonBody($r1)['metadata']['request_headers']['X-Requested-With']);
+
+        $r2 = $make()->handle($this->requestFor('GET', '/calendar/2025', ['Accept-Language' => 'la', 'X-Requested-With' => 'SecondClient']));
+        self::assertSame(200, $r2->getStatusCode());
+        self::assertSame('ServerCache', $r2->getHeaderLine('X-LitCal-Generated'), 'Second request must be served from the shared server cache');
+        self::assertSame(
+            'SecondClient',
+            $this->decodeJsonBody($r2)['metadata']['request_headers']['X-Requested-With'],
+            'The cached response must reflect the second caller\'s own header, not the first caller\'s'
+        );
+    }
+}

--- a/phpunit_tests/Handlers/CalendarRequestHeadersCacheTest.php
+++ b/phpunit_tests/Handlers/CalendarRequestHeadersCacheTest.php
@@ -8,14 +8,13 @@ use LiturgicalCalendar\Api\Handlers\CalendarHandler;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
-use Symfony\Component\Yaml\Yaml;
 
 /**
- * Issue #684: metadata.request_headers is request-specific data, but the calendar
- * cache is shared (keyed by calendar params, not headers). On a cache hit the handler
- * re-injects the current caller's headers into the serialized body so it never echoes
- * whichever client first populated the entry. These tests cover the per-format textual
- * splice helpers directly, plus one end-to-end check on the shared JSON cache entry.
+ * Issue #684: metadata.request_headers is request-specific data, but the calendar cache is
+ * shared (keyed by calendar params, not headers). On a cache hit the handler re-injects the
+ * current caller's headers into the serialized body so it never echoes whichever client
+ * first populated the entry. This is the handle()-driven end-to-end check on that behaviour;
+ * the per-format splice helpers are covered as pure logic in CalendarRequestHeadersSpliceTest.
  */
 #[CoversClass(CalendarHandler::class)]
 final class CalendarRequestHeadersCacheTest extends AbstractHandlerTestCase
@@ -26,84 +25,6 @@ final class CalendarRequestHeadersCacheTest extends AbstractHandlerTestCase
         $fixturePath = realpath(__DIR__ . '/../fixtures/api');
         self::assertNotFalse($fixturePath, 'M1 calendars fixture must be present');
         Router::$apiPath = 'file://' . $fixturePath;
-    }
-
-    /**
-     * Invoke a private splice helper with a given set of request headers. The helpers
-     * use only $this->requestHeaders, so the constructor (and its metadata fetch) is skipped.
-     *
-     * @param array<string,string> $headers
-     */
-    private function splice(string $method, array $headers, string $body): string
-    {
-        $handler = ( new \ReflectionClass(CalendarHandler::class) )->newInstanceWithoutConstructor();
-        ( new \ReflectionProperty(CalendarHandler::class, 'requestHeaders') )->setValue($handler, $headers);
-        return (string) ( new \ReflectionMethod(CalendarHandler::class, $method) )->invoke($handler, $body);
-    }
-
-    public function testJsonSpliceReplacesOnlyRequestHeaders(): void
-    {
-        $body = '{"metadata":{"request_headers":{"Accept":"*\/*","Accept-Language":"en"},"version":"5.0"}}';
-        $out  = $this->splice('spliceRequestHeadersJson', ['Accept' => 'application/json', 'Accept-Language' => 'it'], $body);
-
-        $decoded = json_decode($out, true, 512, JSON_THROW_ON_ERROR);
-        self::assertSame(['Accept' => 'application/json', 'Accept-Language' => 'it'], $decoded['metadata']['request_headers']);
-        self::assertSame('5.0', $decoded['metadata']['version'], 'Everything except request_headers must be untouched');
-    }
-
-    public function testJsonSpliceHandlesEmptyCachedHeaders(): void
-    {
-        // A caller that sent none of the useful headers serializes request_headers as [].
-        $body = '{"metadata":{"request_headers":[],"version":"5.0"}}';
-        $out  = $this->splice('spliceRequestHeadersJson', ['Accept' => 'application/json'], $body);
-
-        $decoded = json_decode($out, true, 512, JSON_THROW_ON_ERROR);
-        self::assertSame(['Accept' => 'application/json'], $decoded['metadata']['request_headers']);
-    }
-
-    public function testYamlSpliceHandlesEmptyCachedHeaders(): void
-    {
-        // A header-less caller serializes request_headers as Symfony's inline empty map.
-        $body = "metadata:\n  request_headers: {  }\n  version: '5.0'\n";
-        $out  = $this->splice('spliceRequestHeadersYaml', ['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $body);
-
-        $parsed = Yaml::parse($out);
-        self::assertSame(['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $parsed['metadata']['request_headers']);
-        self::assertSame('5.0', $parsed['metadata']['version'], 'Everything except request_headers must be untouched');
-    }
-
-    public function testXmlSpliceHandlesEmptyCachedHeaders(): void
-    {
-        // A header-less caller serializes request_headers as a self-closing element.
-        $body = "<LiturgicalCalendar><Metadata>\n    <RequestHeaders/>\n    <Version>5.0</Version></Metadata></LiturgicalCalendar>";
-        $out  = $this->splice('spliceRequestHeadersXml', ['Accept' => 'application/xml'], $body);
-
-        self::assertStringContainsString('<Accept>application/xml</Accept>', $out);
-        self::assertStringContainsString('<Version>5.0</Version>', $out, 'Everything else must be untouched');
-        self::assertNotFalse(simplexml_load_string($out), 'Result must remain well-formed XML');
-    }
-
-    public function testXmlSpliceReplacesRequestHeaders(): void
-    {
-        $body = "<LiturgicalCalendar><Metadata>\n    <RequestHeaders>\n      <Accept>*/*</Accept>\n"
-            . "    </RequestHeaders>\n    <Version>5.0</Version></Metadata></LiturgicalCalendar>";
-        $out  = $this->splice('spliceRequestHeadersXml', ['Accept' => 'application/xml', 'Accept-Language' => 'it'], $body);
-
-        self::assertStringContainsString('<Accept>application/xml</Accept>', $out);
-        self::assertStringContainsString('<Accept-Language>it</Accept-Language>', $out);
-        self::assertStringNotContainsString('*/*', $out, 'The first caller\'s Accept must be gone');
-        self::assertStringContainsString('<Version>5.0</Version>', $out, 'Everything else must be untouched');
-        self::assertNotFalse(simplexml_load_string($out), 'Result must remain well-formed XML');
-    }
-
-    public function testYamlSpliceReplacesRequestHeaders(): void
-    {
-        $body = "metadata:\n  request_headers:\n    Accept: '*/*'\n    Accept-Language: en\n  version: '5.0'\n";
-        $out  = $this->splice('spliceRequestHeadersYaml', ['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $body);
-
-        $parsed = Yaml::parse($out);
-        self::assertSame(['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $parsed['metadata']['request_headers']);
-        self::assertSame('5.0', $parsed['metadata']['version'], 'Everything except request_headers must be untouched');
     }
 
     private function purgeEngineCache(string $extension): void
@@ -121,7 +42,7 @@ final class CalendarRequestHeadersCacheTest extends AbstractHandlerTestCase
      * X-Requested-With is used (rather than Accept) because it is captured into
      * request_headers without participating in return-type negotiation, so both requests
      * deterministically resolve to JSON and hit the same cache entry. The per-format Accept
-     * replacement itself is covered by the splice unit tests above.
+     * replacement itself is covered by the splice unit tests.
      */
     public function testSharedCacheReflectsEachCallersOwnHeader(): void
     {

--- a/phpunit_tests/Handlers/CalendarRequestHeadersCacheTest.php
+++ b/phpunit_tests/Handlers/CalendarRequestHeadersCacheTest.php
@@ -61,6 +61,28 @@ final class CalendarRequestHeadersCacheTest extends AbstractHandlerTestCase
         self::assertSame(['Accept' => 'application/json'], $decoded['metadata']['request_headers']);
     }
 
+    public function testYamlSpliceHandlesEmptyCachedHeaders(): void
+    {
+        // A header-less caller serializes request_headers as Symfony's inline empty map.
+        $body = "metadata:\n  request_headers: {  }\n  version: '5.0'\n";
+        $out  = $this->splice('spliceRequestHeadersYaml', ['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $body);
+
+        $parsed = Yaml::parse($out);
+        self::assertSame(['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $parsed['metadata']['request_headers']);
+        self::assertSame('5.0', $parsed['metadata']['version'], 'Everything except request_headers must be untouched');
+    }
+
+    public function testXmlSpliceHandlesEmptyCachedHeaders(): void
+    {
+        // A header-less caller serializes request_headers as a self-closing element.
+        $body = "<LiturgicalCalendar><Metadata>\n    <RequestHeaders/>\n    <Version>5.0</Version></Metadata></LiturgicalCalendar>";
+        $out  = $this->splice('spliceRequestHeadersXml', ['Accept' => 'application/xml'], $body);
+
+        self::assertStringContainsString('<Accept>application/xml</Accept>', $out);
+        self::assertStringContainsString('<Version>5.0</Version>', $out, 'Everything else must be untouched');
+        self::assertNotFalse(simplexml_load_string($out), 'Result must remain well-formed XML');
+    }
+
     public function testXmlSpliceReplacesRequestHeaders(): void
     {
         $body = "<LiturgicalCalendar><Metadata>\n    <RequestHeaders>\n      <Accept>*/*</Accept>\n"

--- a/phpunit_tests/Handlers/CalendarRequestHeadersSpliceTest.php
+++ b/phpunit_tests/Handlers/CalendarRequestHeadersSpliceTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Handlers;
 
 use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Params\CalendarParams;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Yaml;
@@ -30,6 +32,41 @@ final class CalendarRequestHeadersSpliceTest extends TestCase
         $handler = ( new \ReflectionClass(CalendarHandler::class) )->newInstanceWithoutConstructor();
         ( new \ReflectionProperty(CalendarHandler::class, 'requestHeaders') )->setValue($handler, $headers);
         return (string) ( new \ReflectionMethod(CalendarHandler::class, $method) )->invoke($handler, $body);
+    }
+
+    /**
+     * Invoke injectRequestHeaders() (the dispatcher) with a given return type, so the
+     * per-format routing arms are covered end-to-end from the switch.
+     *
+     * @param array<string,string> $headers
+     */
+    private function inject(ReturnTypeParam $returnType, array $headers, string $body): string
+    {
+        $handler = ( new \ReflectionClass(CalendarHandler::class) )->newInstanceWithoutConstructor();
+        ( new \ReflectionProperty(CalendarHandler::class, 'requestHeaders') )->setValue($handler, $headers);
+        $params             = ( new \ReflectionClass(CalendarParams::class) )->newInstanceWithoutConstructor();
+        $params->ReturnType = $returnType;
+        ( new \ReflectionProperty(CalendarHandler::class, 'CalendarParams') )->setValue($handler, $params);
+        return (string) ( new \ReflectionMethod(CalendarHandler::class, 'injectRequestHeaders') )->invoke($handler, $body);
+    }
+
+    /**
+     * injectRequestHeaders() dispatches to the correct per-format splice, and returns ICS
+     * (which carries no request_headers) unchanged.
+     */
+    public function testInjectRoutesByReturnType(): void
+    {
+        $json = $this->inject(ReturnTypeParam::JSON, ['Accept' => 'application/json'], '{"metadata":{"request_headers":[],"version":"5.0"}}');
+        self::assertSame(['Accept' => 'application/json'], json_decode($json, true, 512, JSON_THROW_ON_ERROR)['metadata']['request_headers']);
+
+        $yaml = $this->inject(ReturnTypeParam::YAML, ['Accept' => 'application/yaml'], "metadata:\n  request_headers: {  }\n  version: '5.0'\n");
+        self::assertSame(['Accept' => 'application/yaml'], Yaml::parse($yaml)['metadata']['request_headers']);
+
+        $xml = $this->inject(ReturnTypeParam::XML, ['Accept' => 'application/xml'], "<Metadata>\n    <RequestHeaders/>\n    <Version>5.0</Version></Metadata>");
+        self::assertStringContainsString('<Accept>application/xml</Accept>', $xml);
+
+        $icsBody = "BEGIN:VCALENDAR\r\nPRODID:x\r\nEND:VCALENDAR\r\n";
+        self::assertSame($icsBody, $this->inject(ReturnTypeParam::ICS, ['Accept' => 'text/calendar'], $icsBody), 'ICS carries no request_headers and must be returned unchanged');
     }
 
     public function testJsonSpliceReplacesOnlyRequestHeaders(): void

--- a/phpunit_tests/Handlers/CalendarRequestHeadersSpliceTest.php
+++ b/phpunit_tests/Handlers/CalendarRequestHeadersSpliceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Pure-logic coverage for CalendarHandler's per-format request_headers splice helpers
+ * (issue #684). Each helper operates only on $this->requestHeaders and a serialized body,
+ * so it is exercised via reflection with the constructor skipped — no Router/JWT/DB setup
+ * is needed, hence a plain PHPUnit\Framework\TestCase rather than AbstractHandlerTestCase.
+ * The handle()-driven end-to-end cache behaviour lives in CalendarRequestHeadersCacheTest.
+ */
+#[CoversClass(CalendarHandler::class)]
+final class CalendarRequestHeadersSpliceTest extends TestCase
+{
+    /**
+     * Invoke a private splice helper with a given set of request headers. The helpers
+     * use only $this->requestHeaders, so the constructor (and its metadata fetch) is skipped.
+     *
+     * @param array<string,string> $headers
+     */
+    private function splice(string $method, array $headers, string $body): string
+    {
+        $handler = ( new \ReflectionClass(CalendarHandler::class) )->newInstanceWithoutConstructor();
+        ( new \ReflectionProperty(CalendarHandler::class, 'requestHeaders') )->setValue($handler, $headers);
+        return (string) ( new \ReflectionMethod(CalendarHandler::class, $method) )->invoke($handler, $body);
+    }
+
+    public function testJsonSpliceReplacesOnlyRequestHeaders(): void
+    {
+        $body = '{"metadata":{"request_headers":{"Accept":"*\/*","Accept-Language":"en"},"version":"5.0"}}';
+        $out  = $this->splice('spliceRequestHeadersJson', ['Accept' => 'application/json', 'Accept-Language' => 'it'], $body);
+
+        $decoded = json_decode($out, true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['Accept' => 'application/json', 'Accept-Language' => 'it'], $decoded['metadata']['request_headers']);
+        self::assertSame('5.0', $decoded['metadata']['version'], 'Everything except request_headers must be untouched');
+    }
+
+    public function testJsonSpliceHandlesEmptyCachedHeaders(): void
+    {
+        // A caller that sent none of the useful headers serializes request_headers as [].
+        $body = '{"metadata":{"request_headers":[],"version":"5.0"}}';
+        $out  = $this->splice('spliceRequestHeadersJson', ['Accept' => 'application/json'], $body);
+
+        $decoded = json_decode($out, true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame(['Accept' => 'application/json'], $decoded['metadata']['request_headers']);
+    }
+
+    public function testYamlSpliceReplacesRequestHeaders(): void
+    {
+        $body = "metadata:\n  request_headers:\n    Accept: '*/*'\n    Accept-Language: en\n  version: '5.0'\n";
+        $out  = $this->splice('spliceRequestHeadersYaml', ['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $body);
+
+        $parsed = Yaml::parse($out);
+        self::assertSame(['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $parsed['metadata']['request_headers']);
+        self::assertSame('5.0', $parsed['metadata']['version'], 'Everything except request_headers must be untouched');
+    }
+
+    public function testYamlSpliceHandlesEmptyCachedHeaders(): void
+    {
+        // A header-less caller serializes request_headers as Symfony's inline empty map.
+        $body = "metadata:\n  request_headers: {  }\n  version: '5.0'\n";
+        $out  = $this->splice('spliceRequestHeadersYaml', ['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $body);
+
+        $parsed = Yaml::parse($out);
+        self::assertSame(['Accept' => 'application/yaml', 'Accept-Language' => 'it'], $parsed['metadata']['request_headers']);
+        self::assertSame('5.0', $parsed['metadata']['version'], 'Everything except request_headers must be untouched');
+    }
+
+    public function testXmlSpliceReplacesRequestHeaders(): void
+    {
+        $body = "<LiturgicalCalendar><Metadata>\n    <RequestHeaders>\n      <Accept>*/*</Accept>\n"
+            . "    </RequestHeaders>\n    <Version>5.0</Version></Metadata></LiturgicalCalendar>";
+        $out  = $this->splice('spliceRequestHeadersXml', ['Accept' => 'application/xml', 'Accept-Language' => 'it'], $body);
+
+        self::assertStringContainsString('<Accept>application/xml</Accept>', $out);
+        self::assertStringContainsString('<Accept-Language>it</Accept-Language>', $out);
+        self::assertStringNotContainsString('*/*', $out, 'The first caller\'s Accept must be gone');
+        self::assertStringContainsString('<Version>5.0</Version>', $out, 'Everything else must be untouched');
+        self::assertNotFalse(simplexml_load_string($out), 'Result must remain well-formed XML');
+    }
+
+    public function testXmlSpliceHandlesEmptyCachedHeaders(): void
+    {
+        // A header-less caller serializes request_headers as a self-closing element.
+        $body = "<LiturgicalCalendar><Metadata>\n    <RequestHeaders/>\n    <Version>5.0</Version></Metadata></LiturgicalCalendar>";
+        $out  = $this->splice('spliceRequestHeadersXml', ['Accept' => 'application/xml'], $body);
+
+        self::assertStringContainsString('<Accept>application/xml</Accept>', $out);
+        self::assertStringContainsString('<Version>5.0</Version>', $out, 'Everything else must be untouched');
+        self::assertNotFalse(simplexml_load_string($out), 'Result must remain well-formed XML');
+    }
+}

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4657,15 +4657,16 @@ final class CalendarHandler extends AbstractHandler
     /**
      * Splices request_headers into a YAML body. Only the tiny request_headers map is
      * (re)dumped — cheap and byte-identical to Symfony's own scalar quoting — then indented
-     * two spaces to sit under `metadata` and spliced over the existing block (matched from
-     * its `request_headers:` key through its 4-space-indented children).
+     * two spaces to sit under `metadata` and spliced over the existing entry. The pattern
+     * matches both a non-empty block (`request_headers:` + 4-space-indented children) and the
+     * inline empty form Symfony emits for a header-less caller (`request_headers: {  }`).
      */
     private function spliceRequestHeadersYaml(string $responseBody): string
     {
         $dumped = Yaml::dump(['request_headers' => $this->requestHeaders], 10, 2);
         $block  = ( preg_replace('/^/m', '  ', rtrim($dumped, "\n")) ?? $dumped ) . "\n";
         return preg_replace_callback(
-            '/^  request_headers:\n(?:    .*(?:\n|$))*/m',
+            '/^  request_headers:.*\n(?:    .*(?:\n|$))*/m',
             static fn (): string => $block,
             $responseBody,
             1
@@ -4674,8 +4675,9 @@ final class CalendarHandler extends AbstractHandler
 
     /**
      * Splices request_headers into an XML body. The <RequestHeaders> element is contiguous
-     * and cannot nest, so a non-greedy match bounds it exactly. The useful header names
-     * contain no underscores, so they map to element names unchanged (mirroring
+     * and cannot nest, so a non-greedy match bounds it exactly; the pattern also matches the
+     * self-closing <RequestHeaders/> that a header-less caller produces. The useful header
+     * names contain no underscores, so they map to element names unchanged (mirroring
      * Utilities::convertArray2XML), and values are XML-escaped the same way.
      */
     private function spliceRequestHeadersXml(string $responseBody): string
@@ -4687,7 +4689,7 @@ final class CalendarHandler extends AbstractHandler
         }
         $replacement = '<RequestHeaders>' . $children . "\n    </RequestHeaders>";
         return preg_replace_callback(
-            '#<RequestHeaders>.*?</RequestHeaders>#s',
+            '#<RequestHeaders(?:\s*/>|>.*?</RequestHeaders>)#s',
             static fn (): string => $replacement,
             $responseBody,
             1

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4610,6 +4610,91 @@ final class CalendarHandler extends AbstractHandler
 
 
     /**
+     * Re-injects the current request's headers into an already-serialized (and cached)
+     * response body so that `metadata.request_headers` always reflects the actual caller.
+     *
+     * The calendar cache is keyed by request parameters (calendar + year + return type),
+     * NOT by request headers, so a single shared cache entry is served to many clients.
+     * Without this step the headers of whichever client first populated a given entry would
+     * be echoed to every later client for that key (issue #684).
+     *
+     * A full decode + re-encode would be prohibitively expensive on every cache hit
+     * (measured ~235 ms to round-trip a year of YAML, ~2.5 ms for JSON), so instead we do a
+     * targeted textual splice of just the request_headers section (~0.04 ms). ICS output
+     * carries no request_headers and is returned unchanged.
+     */
+    private function injectRequestHeaders(string $responseBody): string
+    {
+        switch ($this->CalendarParams->ReturnType) {
+            case ReturnTypeParam::YAML:
+                return $this->spliceRequestHeadersYaml($responseBody);
+            case ReturnTypeParam::XML:
+                return $this->spliceRequestHeadersXml($responseBody);
+            case ReturnTypeParam::ICS:
+                return $responseBody;
+            case ReturnTypeParam::JSON:
+            default:
+                return $this->spliceRequestHeadersJson($responseBody);
+        }
+    }
+
+    /**
+     * Splices request_headers into a JSON body. Header values never contain a '}', so the
+     * request_headers object is matched unambiguously with `\{[^{}]*\}` (or `[]` when empty).
+     * The replacement is emitted via a callback so its backslashes/`$` are not reinterpreted.
+     */
+    private function spliceRequestHeadersJson(string $responseBody): string
+    {
+        $encoded = json_encode($this->requestHeaders, JSON_THROW_ON_ERROR);
+        return preg_replace_callback(
+            '/"request_headers":(?:\{[^{}]*\}|\[\])/',
+            static fn (): string => '"request_headers":' . $encoded,
+            $responseBody,
+            1
+        ) ?? $responseBody;
+    }
+
+    /**
+     * Splices request_headers into a YAML body. Only the tiny request_headers map is
+     * (re)dumped — cheap and byte-identical to Symfony's own scalar quoting — then indented
+     * two spaces to sit under `metadata` and spliced over the existing block (matched from
+     * its `request_headers:` key through its 4-space-indented children).
+     */
+    private function spliceRequestHeadersYaml(string $responseBody): string
+    {
+        $dumped = Yaml::dump(['request_headers' => $this->requestHeaders], 10, 2);
+        $block  = ( preg_replace('/^/m', '  ', rtrim($dumped, "\n")) ?? $dumped ) . "\n";
+        return preg_replace_callback(
+            '/^  request_headers:\n(?:    .*(?:\n|$))*/m',
+            static fn (): string => $block,
+            $responseBody,
+            1
+        ) ?? $responseBody;
+    }
+
+    /**
+     * Splices request_headers into an XML body. The <RequestHeaders> element is contiguous
+     * and cannot nest, so a non-greedy match bounds it exactly. The useful header names
+     * contain no underscores, so they map to element names unchanged (mirroring
+     * Utilities::convertArray2XML), and values are XML-escaped the same way.
+     */
+    private function spliceRequestHeadersXml(string $responseBody): string
+    {
+        $children = '';
+        foreach ($this->requestHeaders as $name => $value) {
+            $tag       = (string) $name;
+            $children .= "\n      <$tag>" . htmlspecialchars((string) $value) . "</$tag>";
+        }
+        $replacement = '<RequestHeaders>' . $children . "\n    </RequestHeaders>";
+        return preg_replace_callback(
+            '#<RequestHeaders>.*?</RequestHeaders>#s',
+            static fn (): string => $replacement,
+            $responseBody,
+            1
+        ) ?? $responseBody;
+    }
+
+    /**
      * This function generates the response for the requested Liturgical Calendar.
      *
      * Depending on the value of $this->CalendarParams->ReturnType, it will either return a JSON object,
@@ -5216,7 +5301,10 @@ final class CalendarHandler extends AbstractHandler
             //  and stored the results in a cache file
             //  then we're done, just output this and die;
             //  or even better, make the client use it's own cache copy!
-            $responseBody  = Utilities::rawContentsFromFile($this->CacheFile);
+            // The cache entry is shared across clients (keyed by calendar params, not by
+            //   request headers), so re-inject THIS request's headers into
+            //   metadata.request_headers before serving; see injectRequestHeaders() and #684.
+            $responseBody  = $this->injectRequestHeaders(Utilities::rawContentsFromFile($this->CacheFile));
             $responseHash  = md5($responseBody);
             $etag          = '"' . $responseHash . '"';
             $this->endTime = hrtime(true);
@@ -5225,7 +5313,8 @@ final class CalendarHandler extends AbstractHandler
                 ->withHeader('X-LitCal-Starttime', $this->startTime . '')
                 ->withHeader('X-LitCal-Endtime', $this->endTime . '')
                 ->withHeader('X-LitCal-Executiontime', $executionTime . '')
-                ->withHeader('Etag', $etag);
+                ->withHeader('Etag', $etag)
+                ->withHeader('Vary', 'Accept, Accept-Language');
 
             if (
                 $request->getHeaderLine('If-None-Match') !== ''


### PR DESCRIPTION
## Summary

Fixes #684. `metadata.request_headers` is request-specific, but the calendar cache is **shared** — keyed by request parameters (calendar + year + return type), **not** by request headers. So whichever client first populated a given entry had its `Accept` / `Accept-Language` / `Origin` / `X-Requested-With` baked into the body returned to **every** later client for that key, until the entry was invalidated. (The motivating symptom: a `curl` with `Accept: */*` populated the cache, and later clients received `request_headers.Accept: "*/*"` regardless of their own header.)

## Fix

On the **cache-hit path**, re-inject the current request's headers into the already-serialized body so `request_headers` always reflects the actual caller.

The write/miss path is deliberately **left untouched** — it already serializes the live headers, so first-time responses were always correct; only shared-cache reads were stale. This keeps the change entirely off the hot serializer.

### Why a textual splice, not decode + re-encode

The hit path exists to serve bytes cheaply. A full decode + re-encode on every hit is a real tax — measured on a full-year 2025 General Roman Calendar:

| Format | Body | decode + re-encode | targeted splice |
|--------|------|--------------------|-----------------|
| JSON   | 481 KB | 2.45 ms | **0.041 ms** |
| YAML   | 532 KB | **234.9 ms** | ~splice |
| XML    | 837 KB | 8.1 ms | ~splice |

(For reference the hit path already spends ~0.58 ms computing the body's `md5`.) So injection is done as a **targeted splice of just the `request_headers` section** (~0.04 ms):

- **JSON** — regex over `"request_headers":{…}` (header values never contain `}`).
- **YAML** — re-dumps only the tiny map (exact Symfony quoting) and splices the block.
- **XML** — replaces the contiguous, non-nesting `<RequestHeaders>…</RequestHeaders>` element.
- **ICS** — no-op (carries no `request_headers`).

The cache-hit response now also sends `Vary: Accept, Accept-Language`, since the served body varies by caller.

## Tests

- Unit coverage for the JSON/YAML/XML splices (incl. the empty-`request_headers` edge case).
- End-to-end: two requests with identical calendar params (same cache key) but a different `X-Requested-With` each see their **own** header — the second served from the shared server cache (`X-LitCal-Generated: ServerCache`).

## Acceptance (from the issue)

- ✅ Two requests differing only in a request-specific header (same calendar params) each see their own header, whether served fresh or from cache.
- ✅ No change to cache key or hit rate.

## Note

Injection is on the cache-hit path only; the cache **file** still stores whichever caller first populated it, but those headers are always overwritten on read, so no client ever sees them. Truly neutralizing the on-disk file would require touching the write path for a purely cosmetic on-disk benefit, so it was left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cached calendar responses now correctly reflect the current caller’s request headers in `metadata.request_headers`, instead of reusing headers from the first request that populated the cache.
  * Works for JSON, XML, and YAML responses; ICS responses are unchanged.
  * Improved cache behavior by adding a `Vary: Accept, Accept-Language` header and ensuring the validation token updates based on the injected header content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->