### PR TITLE
ci: merge the automated .pot PR directly instead of via --auto

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,17 +139,31 @@ jobs:
       # The .pot PR is created with the default GITHUB_TOKEN, which by design
       # does not trigger further workflows — so a separate pull_request-based
       # auto-merge job (like the Dependabot one) would never fire. Instead we
-      # merge here, in the same push-triggered run that opened the PR. Branch
-      # protection on the base requires neither reviews nor status checks, so
-      # GITHUB_TOKEN can merge immediately; --auto is belt-and-suspenders for
-      # the brief window after creation, and --delete-branch removes the
+      # merge here, in the same push-triggered run that opened the PR.
+      #
+      # Branch protection on the base requires neither reviews nor status checks,
+      # so the PR is immediately mergeable ("clean"). We must NOT use
+      # `gh pr merge --auto` here: enabling auto-merge on an already-clean PR
+      # fails with "Pull request is in clean status (enablePullRequestAutoMerge)",
+      # which left every .pot PR stranded (see issue #684 follow-up). Merge
+      # directly instead, retrying to cover the brief window after creation while
+      # GitHub is still computing mergeability. --delete-branch removes the
       # automated/update-pot head branch (explicit, not relying on the repo's
-      # delete_branch_on_merge setting). The github.ref guard pins auto-merge to
+      # delete_branch_on_merge setting). The github.ref guard pins the merge to
       # development, so widening the push filter above can never cause an
-      # accidental auto-merge into another branch (e.g. stable).
+      # accidental merge into another branch (e.g. stable).
       - name: Auto-merge the POT update PR
         if: ${{ steps.cpr.outputs.pull-request-number && github.ref == 'refs/heads/development' }}
-        run: gh pr merge "$PR_NUMBER" --merge --auto --delete-branch
+        run: |
+          for attempt in 1 2 3 4 5 6; do
+            if gh pr merge "$PR_NUMBER" --merge --delete-branch; then
+              exit 0
+            fi
+            echo "Merge attempt $attempt failed (PR not yet mergeable?); retrying in 5s…"
+            sleep 5
+          done
+          echo "::error::Failed to merge POT update PR #$PR_NUMBER after 6 attempts"
+          exit 1
         env:
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The automated `.pot` update PRs (e.g. #700) get stuck open instead of auto-merging.

`main.yml`'s `gettext_update` job opens the `automated/update-pot` PR and merges it in the same push-triggered run with:

```bash
gh pr merge "$PR_NUMBER" --merge --auto --delete-branch
```

Because `development` has **no required status checks**, a freshly-created PR is immediately mergeable ("clean"), and enabling auto-merge on a clean PR fails:

```
GraphQL: Pull request is in clean status (enablePullRequestAutoMerge)
```

So every time the `.pot` actually changes, the step errors (exit 1), the workflow run is marked **failed**, and the PR is left open awaiting a manual merge. The `action_required` checks that appear on the PR are a red herring — with no required checks they never block a merge; the merge just never happens.

(Runs where the `.pot` didn't change are unaffected: no PR is created, so the step is skipped.)

## Fix

Drop `--auto` and merge the PR **directly** (it is mergeable immediately), retrying a few times to cover the brief window after creation while GitHub computes mergeability:

```bash
for attempt in 1 2 3 4 5 6; do
  gh pr merge "$PR_NUMBER" --merge --delete-branch && exit 0
  sleep 5
done
exit 1
```

The `github.ref == 'refs/heads/development'` guard and `--delete-branch` are unchanged.

## Notes

- No behavioural change to the `.pot` content or when the PR is created — only how it is merged.
- If required status checks are ever added to `development`, this should switch back to `--auto` (which is the correct tool once a PR is *not* immediately mergeable).
- The stranded PR #700 was merged manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
