### PR TITLE
refactor: merge variableCorrespondence test type into exactCorrespondence

### DIFF
--- a/jsondata/schemas/LitCalTest.json
+++ b/jsondata/schemas/LitCalTest.json
@@ -53,10 +53,7 @@
                 },
                 "test_type": {
                     "type": "string",
-                    "enum": [
-                        "exactCorrespondence",
-                        "variableCorrespondence"
-                    ]
+                    "const": "exactCorrespondence"
                 },
                 "applies_to": {
                     "$ref": "#/definitions/AppliesToOrExcludes"

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -6880,6 +6880,7 @@
           },
           "assertions": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "anyOf": [
                 {
@@ -6939,6 +6940,7 @@
           },
           "assertions": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "anyOf": [
                 {
@@ -6999,6 +7001,7 @@
           },
           "assertions": {
             "type": "array",
+            "minItems": 1,
             "items": {
               "anyOf": [
                 {

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -5274,7 +5274,7 @@
                     "name": "StJaneFrancesDeChantalTest",
                     "event_key": "StJaneFrancesDeChantal",
                     "description": "Saint Jane Frances de Chantal was moved from December 12 to August 12 in the 2002 Latin Edition of the Roman Missal, to allow bishops conferences to insert Our Lady of Guadalupe as an optional memorial on December 12. DOES ST JANE FRANCES DE CHANTAL FALL ON THE RIGHT DAY BOTH BEFORE AND AFTER 2002, OR IT CORRECTLY OVERRIDEN BY GREATER FESTIVITIES?",
-                    "test_type": "variableCorrespondence",
+                    "test_type": "exactCorrespondence",
                     "assertions": [
                       {
                         "year": 2001,
@@ -5334,7 +5334,7 @@
               "schema": {
                 "oneOf": [
                   {
-                    "$ref": "#/components/schemas/ExactOrVariableCorrespondenceUnitTest"
+                    "$ref": "#/components/schemas/ExactCorrespondenceUnitTest"
                   },
                   {
                     "$ref": "#/components/schemas/ExactCorrespondenceSinceUnitTest"
@@ -5420,7 +5420,7 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/ExactOrVariableCorrespondenceUnitTest"
+                      "$ref": "#/components/schemas/ExactCorrespondenceUnitTest"
                     },
                     {
                       "$ref": "#/components/schemas/ExactCorrespondenceSinceUnitTest"
@@ -5498,7 +5498,7 @@
               "schema": {
                 "oneOf": [
                   {
-                    "$ref": "#/components/schemas/ExactOrVariableCorrespondenceUnitTest"
+                    "$ref": "#/components/schemas/ExactCorrespondenceUnitTest"
                   },
                   {
                     "$ref": "#/components/schemas/ExactCorrespondenceSinceUnitTest"
@@ -6842,7 +6842,7 @@
         "items": {
           "anyOf": [
             {
-              "$ref": "#/components/schemas/ExactOrVariableCorrespondenceUnitTest"
+              "$ref": "#/components/schemas/ExactCorrespondenceUnitTest"
             },
             {
               "$ref": "#/components/schemas/ExactCorrespondenceSinceUnitTest"
@@ -6853,8 +6853,8 @@
           ]
         }
       },
-      "ExactOrVariableCorrespondenceUnitTest": {
-        "title": "Exact or Variable Existence",
+      "ExactCorrespondenceUnitTest": {
+        "title": "Exact Correspondence",
         "description": "test that the liturgical event exists on an expected date in a given year or does not exist in a given year",
         "type": "object",
         "additionalProperties": false,
@@ -6875,11 +6875,8 @@
           },
           "test_type": {
             "type": "string",
-            "description": "* `exactCorrespondence`: the liturgical event should exist on an expected date for each of the years defined in the `years` array\n* `variableCorrespondence`: the liturgical event should not exist for certain years, and should exist on an expected date for other years",
-            "enum": [
-              "exactCorrespondence",
-              "variableCorrespondence"
-            ]
+            "description": "each assertion independently defines the expectation for its year: the liturgical event should either exist on the expected date, or not exist at all, for each of the years defined in the `assertions` array",
+            "const": "exactCorrespondence"
           },
           "assertions": {
             "type": "array",

--- a/jsondata/tests/StJaneFrancesDeChantalTest.json
+++ b/jsondata/tests/StJaneFrancesDeChantalTest.json
@@ -2,7 +2,7 @@
     "name": "StJaneFrancesDeChantalTest",
     "event_key": "StJaneFrancesDeChantal",
     "description": "Saint Jane Frances de Chantal was moved from December 12 to August 12 in the 2002 Latin Edition of the Roman Missal, to allow bishops conferences to insert Our Lady of Guadalupe as an optional memorial on December 12. DOES ST JANE FRANCES DE CHANTAL FALL ON THE RIGHT DAY BOTH BEFORE AND AFTER 2002, OR IT CORRECTLY OVERRIDEN BY GREATER FESTIVITIES?",
-    "test_type": "variableCorrespondence",
+    "test_type": "exactCorrespondence",
     "assertions": [
         {
             "year": 2001,

--- a/phpunit_tests/Enum/SimpleEnumsTest.php
+++ b/phpunit_tests/Enum/SimpleEnumsTest.php
@@ -89,7 +89,7 @@ final class SimpleEnumsTest extends TestCase
     {
         self::assertSame('exactCorrespondence', LitEventTestType::EXACT_CORRESPONDENCE->value);
         self::assertSame('exactCorrespondenceSince', LitEventTestType::EXACT_CORRESPONDENCE_SINCE->value);
-        self::assertSame('variableCorrespondence', LitEventTestType::VARIABLE_CORRESPONDENCE->value);
+        self::assertSame('exactCorrespondenceUntil', LitEventTestType::EXACT_CORRESPONDENCE_UNTIL->value);
     }
 
     public function testLitEventTestAssertionCases(): void

--- a/src/Enum/LitEventTestType.php
+++ b/src/Enum/LitEventTestType.php
@@ -6,5 +6,5 @@ enum LitEventTestType: string
 {
     case EXACT_CORRESPONDENCE       = 'exactCorrespondence';
     case EXACT_CORRESPONDENCE_SINCE = 'exactCorrespondenceSince';
-    case VARIABLE_CORRESPONDENCE    = 'variableCorrespondence';
+    case EXACT_CORRESPONDENCE_UNTIL = 'exactCorrespondenceUntil';
 }


### PR DESCRIPTION
Closes #704

## Summary

Merges the `variableCorrespondence` liturgical test type into `exactCorrespondence`. The distinction had collapsed in every layer (see the full evaluation in #704): the schema already gave them a single shared branch, `LitTestRunner` never reads `test_type` (it branches per-assertion on `assert`), and 4 of the 7 `exactCorrespondence` test files already contained `eventNotExists` assertions.

Three types remain, whose distinction is carried by data rather than intent:

- `exactCorrespondence` — each assertion independently asserts existence-on-date or non-existence for its year
- `exactCorrespondenceSince` — `year_since` pivot (decree-based introduction)
- `exactCorrespondenceUntil` — `year_until` pivot (mirror)

## Changes

- `jsondata/schemas/LitCalTest.json`: `test_type` becomes `const "exactCorrespondence"`, matching the Since/Until branches
- `jsondata/tests/StJaneFrancesDeChantalTest.json`: retyped to `exactCorrespondence` (one-word change; the runner and all UIs treat the values identically, so nothing changes behaviorally)
- `src/Enum/LitEventTestType.php`: drop `VARIABLE_CORRESPONDENCE`, add the missing `EXACT_CORRESPONDENCE_UNTIL` (schema and UIs already had it)
- `jsondata/schemas/openapi.json`: rename `ExactOrVariableCorrespondenceUnitTest` → `ExactCorrespondenceUnitTest` (internal `$ref`s only), enum → const, updated description and example
- `phpunit_tests/Enum/SimpleEnumsTest.php`: updated accordingly

The wiki page ([Liturgical event tests](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/wiki/Liturgical-event-tests)) has been updated in parallel.

## Verification

- `composer test:quick`: 1491 tests green
- All 10 `jsondata/tests/*.json` files validated against the updated `LitCalTest.json` schema via `Swaggest\JsonSchema`
- `composer analyse` (PHPStan level 10), `composer lint`, `composer lint:openapi`: clean

## Companion PRs

- Liturgical-Calendar/UnitTestInterface#36 (legacy admin UI)
- Liturgical-Calendar/LiturgicalCalendarFrontend#393 (admin-tests page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `exactCorrespondenceUntil` test type.

* **Updates**
  * Test configurations and API schemas now use exact correspondence testing.
  * Updated API request and response definitions to reflect the revised test type options.

* **Bug Fixes**
  * Corrected the sample test configuration and validation rules to prevent unsupported variable correspondence values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->