### PR TITLE
feat: align resource creation paths to PUT /{collection}/{id}

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ Some characteristics of this API:
   as new decrees are issued by the Dicastery for Divine Worship and the Discipline of the Sacraments or new editions of the Roman Missal are published,
   the script will need to be updated to account for any new criteria)
 
+* **HTTP method semantics follow [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110)**:
+  `PUT` is create-or-replace at the resource's own URI (idempotent, returning `409 Conflict` when attempting to create a resource that already exists),
+  and `PATCH`/`DELETE` likewise address resources by path (e.g. `PUT /data/nation/IT`, `PATCH /tests/MaryMotherChurchTest`).
+  One deliberate exception: on read endpoints this API uses `POST` as a body-parameterized synonym of `GET` (not as collection-create),
+  pending possible adoption of the [`QUERY` method](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/) when it becomes standard.
+
 # Example applications
 
 There are a few proof of concept example applications for usage of the API at [LitCal Usage](https://litcal.johnromanodorazio.com/usage.php),

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ Some characteristics of this API:
   and not as it would be today (obviously future years will reflect the calendar as it is generated in the current year;
   as new decrees are issued by the Dicastery for Divine Worship and the Discipline of the Sacraments or new editions of the Roman Missal are published,
   the script will need to be updated to account for any new criteria)
-
 * **HTTP method semantics follow [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110)**:
   `PUT` is create-or-replace at the resource's own URI (idempotent, returning `409 Conflict` when attempting to create a resource that already exists),
   and `PATCH`/`DELETE` likewise address resources by path (e.g. `PUT /data/nation/IT`, `PATCH /tests/MaryMotherChurchTest`).

--- a/docs/superpowers/plans/2026-07-14-put-creation-paths.md
+++ b/docs/superpowers/plans/2026-07-14-put-creation-paths.md
@@ -1,0 +1,1063 @@
+# RFC 9110-Aligned Creation Paths Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans
+> to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move resource creation to `PUT /{collection}/{id}` (path id authoritative, body id must match, 409 on conflict) for `/tests` and
+`/data`, move the `/missals` route shape, document it in OpenAPI and README, per issue #706.
+
+**Architecture:** Hard cutover modeled on the existing `DecreesHandler` pattern (`PUT /decrees/{decree_id}`). Router arity changes let the
+existing path-based FGA middleware cover creates; a new payload-based scope fallback in `TestScopeResolver` handles the tests create flow
+where the file does not exist yet.
+
+**Tech Stack:** PHP 8.4, PSR-7/15, PHPUnit, OpenFGA (mocked in unit tests), OpenAPI 3.1 (`jsondata/schemas/openapi.json`).
+
+**Spec:** `docs/superpowers/specs/2026-07-14-put-creation-paths-design.md`
+
+## Global Constraints
+
+- Work in the worktree `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI/.claude/worktrees/feat-put-creation-paths`,
+  branch `feat/put-creation-paths`. Never commit in the main checkout.
+- PHPStan level 10 (`composer analyse`), PSR-12 (`composer lint`), markdownlint (`composer lint:md`), OpenAPI lint (`composer lint:openapi`).
+- Never use `--no-verify`. CaptainHook pre-commit runs linting.
+- All `phpunit` commands run from the worktree root: `vendor/bin/phpunit phpunit_tests/<path> --testdox`.
+- `Routes/*` tests hit the server configured in `.env`/`.env.local`; port 8000 runs a STALE docker image. See Task 8 for how to run them
+  against worktree code on port 8001. Handler/unit tests need no server.
+- Status-code conventions: 201 create, 409 create-conflict (`ConflictException` from `LiturgicalCalendar\Api\Http\Exception`), 422
+  path/body id mismatch (`UnprocessableContentException` for tests/data, matching each handler's existing PATCH behavior), 400
+  `ValidationException` for path-shape errors.
+- Legacy-shape responses after the cutover: `PUT /tests` and `PUT /missals` → 405 (those handlers validate the request method first);
+  `PUT /data/{category}` → **400** with the 'Expected two path params' message, because `RegionalDataHandler` validates the path before
+  the method — do not reorder that handler's validation to force a 405 (it would change documented GET/POST arity errors).
+
+---
+
+### Task 1: TestScopeResolver — `isSafeName()` + `resolveFromPayload()`
+
+**Files:**
+
+- Modify: `src/Services/TestScopeResolver.php`
+- Test: `phpunit_tests/Services/TestScopeResolverTest.php`
+
+**Interfaces:**
+
+- Produces: `TestScopeResolver::isSafeName(string $testName): bool` (public static);
+  `TestScopeResolver::resolveFromPayload(mixed $decoded): ?array` returning `array{0: string, 1: string}|null`.
+  Task 2's middleware closure and Task 4's handler consume both.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `phpunit_tests/Services/TestScopeResolverTest.php` (inside the class; `$this->fixturesDir` already exists):
+
+```php
+    public function testResolveFromPayloadNational(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['national_calendar_test', 'NL'],
+            $r->resolveFromPayload(['applies_to' => ['national_calendar' => 'NL']])
+        );
+    }
+
+    public function testResolveFromPayloadDiocesan(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['diocesan_calendar_test', 'romamo_it'],
+            $r->resolveFromPayload(['applies_to' => ['diocesan_calendar' => 'romamo_it']])
+        );
+    }
+
+    public function testResolveFromPayloadDefaultsToGeneralRoman(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['general_roman_calendar_test', 'general_roman_calendar'],
+            $r->resolveFromPayload(['name' => 'SomeTest'])
+        );
+    }
+
+    public function testResolveFromPayloadReturnsNullForNonArray(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertNull($r->resolveFromPayload(null));
+        $this->assertNull($r->resolveFromPayload('not-json'));
+    }
+
+    public function testIsSafeName(): void
+    {
+        $this->assertTrue(TestScopeResolver::isSafeName('Foo_Test-1'));
+        $this->assertFalse(TestScopeResolver::isSafeName('..'));
+        $this->assertFalse(TestScopeResolver::isSafeName('a/b'));
+        $this->assertFalse(TestScopeResolver::isSafeName(''));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/TestScopeResolverTest.php --testdox`
+Expected: FAIL — `Call to undefined method ... resolveFromPayload()` / `isSafeName()`.
+
+- [ ] **Step 3: Implement**
+
+In `src/Services/TestScopeResolver.php`, add both methods and refactor `resolve()` to use `isSafeName()` in place of its inline
+`preg_match` (keep the existing comment about path traversal on `isSafeName()`):
+
+```php
+    /**
+     * True when the given name is safe to use as a bare file-stem.
+     *
+     * Only letters, digits, hyphens, and underscores are allowed. This rejects
+     * '..', '/', '\', null bytes, spaces, and every other special character.
+     */
+    public static function isSafeName(string $testName): bool
+    {
+        return (bool) preg_match('/\A[A-Za-z0-9_-]+\z/', $testName);
+    }
+
+    /**
+     * Resolve the FGA scope pair for a test that does not yet exist on disk,
+     * using the decoded request payload's `applies_to` key (create flow).
+     *
+     * Mirrors the mapping applied by resolve() to the stored file, so the scope
+     * that authorizes the create is the same scope the created file will have.
+     *
+     * @param mixed $decoded The json_decode'd (assoc mode) request body
+     * @return array{0: string, 1: string}|null
+     */
+    public function resolveFromPayload(mixed $decoded): ?array
+    {
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        $appliesTo = $decoded['applies_to'] ?? null;
+
+        if (is_array($appliesTo) && isset($appliesTo['diocesan_calendar']) && is_string($appliesTo['diocesan_calendar'])) {
+            return ['diocesan_calendar_test', $appliesTo['diocesan_calendar']];
+        }
+
+        if (is_array($appliesTo) && isset($appliesTo['national_calendar']) && is_string($appliesTo['national_calendar'])) {
+            return ['national_calendar_test', $appliesTo['national_calendar']];
+        }
+
+        return ['general_roman_calendar_test', 'general_roman_calendar'];
+    }
+```
+
+In `resolve()`, replace:
+
+```php
+        if (!preg_match('/\A[A-Za-z0-9_-]+\z/', $testName)) {
+            return null;
+        }
+```
+
+with:
+
+```php
+        if (!self::isSafeName($testName)) {
+            return null;
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/TestScopeResolverTest.php --testdox`
+Expected: PASS (all, including the pre-existing resolve() tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Services/TestScopeResolver.php phpunit_tests/Services/TestScopeResolverTest.php
+git commit -m "feat(auth): payload-based test scope resolution for create flows"
+```
+
+---
+
+### Task 2: forTestScopes — payload fallback on PUT create
+
+**Files:**
+
+- Modify: `src/Http/Middleware/OpenFgaAuthorizationMiddleware.php` (`forTestScopes()`, lines ~230-262)
+- Test: `phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php`
+
+**Interfaces:**
+
+- Consumes: `TestScopeResolver::isSafeName()`, `TestScopeResolver::resolveFromPayload()` from Task 1.
+- Produces: unchanged middleware factory signature `forTestScopes(OpenFgaClient $client, TestScopeResolver $resolver): self`;
+  new behavior: on PUT with a missing test file, the FGA object is derived from the request body's `applies_to`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php` (model: `testForTestScopesFactoryPutMapsToEditor` at line ~434;
+`$this->tempPaths`, `$this->nextHandler` and imports already exist in the file):
+
+```php
+    public function testForTestScopesPutCreateResolvesScopeFromPayload(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->once())
+            ->method('check')
+            ->with('user:user-123', 'editor', 'national_calendar_test:NL')
+            ->willReturn(true);
+
+        // Empty temp dir: the test file does NOT exist (create flow).
+        $tempDir = sys_get_temp_dir() . '/fga_test_' . uniqid();
+        mkdir($tempDir);
+        $this->tempPaths[] = $tempDir;
+        $scopeResolver     = new TestScopeResolver($tempDir);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forTestScopes($client, $scopeResolver);
+
+        $body    = (string) json_encode(['applies_to' => ['national_calendar' => 'NL']]);
+        $request = ( new ServerRequest('PUT', '/tests/BrandNewTest', [], $body) )
+            ->withAttribute('oidc_user', ['sub' => 'user-123', 'roles' => ['test_editor']])
+            ->withAttribute('test_id', 'BrandNewTest');
+
+        $response = $middleware->process($request, $this->nextHandler);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testForTestScopesPutCreateUnparseableBodyIsForbidden(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->never())->method('check');
+
+        $tempDir = sys_get_temp_dir() . '/fga_test_' . uniqid();
+        mkdir($tempDir);
+        $this->tempPaths[] = $tempDir;
+        $scopeResolver     = new TestScopeResolver($tempDir);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forTestScopes($client, $scopeResolver);
+
+        $request = ( new ServerRequest('PUT', '/tests/BrandNewTest', [], 'not-json') )
+            ->withAttribute('oidc_user', ['sub' => 'user-123', 'roles' => ['test_editor']])
+            ->withAttribute('test_id', 'BrandNewTest');
+
+        $this->expectException(ForbiddenException::class);
+        $middleware->process($request, $this->nextHandler);
+    }
+
+    public function testForTestScopesPatchMissingFileStillFailsClosed(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->never())->method('check');
+
+        $tempDir = sys_get_temp_dir() . '/fga_test_' . uniqid();
+        mkdir($tempDir);
+        $this->tempPaths[] = $tempDir;
+        $scopeResolver     = new TestScopeResolver($tempDir);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forTestScopes($client, $scopeResolver);
+
+        // PATCH must NOT fall back to the payload: the resource must already exist.
+        $body    = (string) json_encode(['applies_to' => ['national_calendar' => 'NL']]);
+        $request = ( new ServerRequest('PATCH', '/tests/BrandNewTest', [], $body) )
+            ->withAttribute('oidc_user', ['sub' => 'user-123', 'roles' => ['test_editor']])
+            ->withAttribute('test_id', 'BrandNewTest');
+
+        $this->expectException(ForbiddenException::class);
+        $middleware->process($request, $this->nextHandler);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php --testdox`
+Expected: the first new test FAILS with `ForbiddenException: Cannot resolve authorization scope for this request` (no fallback yet);
+the other two already pass (they pin current fail-closed behavior).
+
+- [ ] **Step 3: Implement**
+
+In `forTestScopes()` replace the `$objectResolver` closure with:
+
+```php
+        $objectResolver = static function (ServerRequestInterface $request) use ($resolver): ?array {
+            $testId = $request->getAttribute('test_id');
+            if (!is_string($testId) || trim($testId) === '') {
+                return null;
+            }
+            $resolved = $resolver->resolve($testId);
+            if (
+                $resolved === null
+                && strtoupper($request->getMethod()) === 'PUT'
+                && TestScopeResolver::isSafeName($testId)
+            ) {
+                // Create flow: the test file does not exist yet, so derive the scope
+                // from the payload's `applies_to` — the same value the handler will
+                // persist, so the scope that authorizes the create is the scope the
+                // created resource will carry.
+                $body = (string) $request->getBody();
+                if ($request->getBody()->isSeekable()) {
+                    $request->getBody()->rewind();
+                }
+                $resolved = $resolver->resolveFromPayload(json_decode($body, true));
+            }
+            return $resolved;
+        };
+```
+
+Update the `forTestScopes()` docblock: the sentence "If the attribute is absent or the resolver returns null the request is denied
+(fail-closed)." becomes "If the attribute is absent or the scope cannot be resolved the request is denied (fail-closed). For PUT
+(create), when no file exists yet, the scope is resolved from the request payload's `applies_to`."
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php --testdox`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Http/Middleware/OpenFgaAuthorizationMiddleware.php phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
+git commit -m "feat(auth): resolve tests create scope from payload applies_to on PUT"
+```
+
+---
+
+### Task 3: Router — creation moves to per-item paths
+
+**Files:**
+
+- Modify: `src/Router.php` (route cases: `missals` ~201-234, `data` ~459-495, `tests` ~496-523; `configureAuthorizationPipeline()`
+  `missals` branch ~731-744)
+- Test: `phpunit_tests/Http/RouterPipelineTest.php` (`testMissalsWithoutIdRequiresAdminAndSkipsFga` ~344-372)
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces: route arities — `PUT` accepted at `/tests/{name}`, `/data/{category}/{key}`, `/missals/{missal_id}` (1/2/1 segments) and no
+  longer at `/tests`, `/data/{category}`, `/missals`. Tasks 4-5 handlers rely on these arities; the existing count>=1 (tests) and
+  count>=2 (data) FGA branches in `configureAuthorizationPipeline()` now cover PUT unchanged.
+
+- [ ] **Step 1: Update the failing pipeline test first**
+
+In `phpunit_tests/Http/RouterPipelineTest.php`, replace the whole method `testMissalsWithoutIdRequiresAdminAndSkipsFga` with:
+
+```php
+    public function testMissalsWithoutIdUsesCalendarEditorAndSkipsFga(): void
+    {
+        $router   = $this->routerWithoutConstructor();
+        $pipeline = $this->emptyPipeline();
+
+        // Collection-level writes are no longer routed (PUT moved to /missals/{missal_id});
+        // an id-less write is still role-gated but only ever reaches the handler's 405.
+        $this->callConfigurePipeline($router, $pipeline, 'missals', []);
+
+        $queue = $this->getQueue($pipeline);
+
+        $authMw = null;
+        foreach ($queue as $mw) {
+            if ($mw instanceof AuthorizationMiddleware) {
+                $authMw = $mw;
+                break;
+            }
+        }
+        self::assertNotNull($authMw, 'Expected an AuthorizationMiddleware for an id-less missals write');
+        self::assertSame('calendar_editor', $this->getPrivateProp($authMw, 'requiredRole'));
+
+        foreach ($queue as $mw) {
+            self::assertNotInstanceOf(
+                OpenFgaAuthorizationMiddleware::class,
+                $mw,
+                'No fine-grained FGA middleware should be added when the missal id is absent'
+            );
+        }
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Http/RouterPipelineTest.php --testdox`
+Expected: FAIL — `requiredRole` is `admin`, not `calendar_editor`.
+
+- [ ] **Step 3: Implement the Router changes**
+
+3a. `tests` case (~line 496): move PUT from the 0-segment list to the 1-segment list:
+
+```php
+            case 'tests':
+                $testsHandler = new TestsHandler($requestPathParts);
+                if (count($requestPathParts) === 0) {
+                    $testsHandler->setAllowedRequestMethods([
+                        RequestMethod::GET,
+                        RequestMethod::POST
+                    ]);
+                } elseif (count($requestPathParts) === 1) {
+                    $testsHandler->setAllowedRequestMethods([
+                        RequestMethod::GET,
+                        RequestMethod::POST,
+                        RequestMethod::PUT,
+                        RequestMethod::PATCH,
+                        RequestMethod::DELETE
+                    ]);
+                } else {
+                    $testsHandler->setAllowedRequestMethods([]);
+                }
+```
+
+3b. `data` case (~line 463): PUT moves from the 1-segment arm to the 2-segment arm; the 1-segment arms collapse into `default`:
+
+```php
+                $allowedMethods      = match (true) {
+                    $pathCount === 2 && $firstInCategory => [
+                        RequestMethod::GET,
+                        RequestMethod::POST,
+                        RequestMethod::PUT,
+                        RequestMethod::PATCH,
+                        RequestMethod::DELETE
+                    ],
+                    $pathCount === 3 && $firstInCategory => [
+                        RequestMethod::GET,
+                        RequestMethod::POST
+                    ],
+                    default => []
+                };
+```
+
+3c. `missals` case (~line 203): move PUT from the 0-segment list to the 1-segment list (write paths remain 405 stubs in the handler):
+
+```php
+                if (count($requestPathParts) === 0) {
+                    $missalsHandler->setAllowedRequestMethods([
+                        RequestMethod::GET,
+                        RequestMethod::POST
+                    ]);
+                } elseif (count($requestPathParts) === 1) {
+                    $missalsHandler->setAllowedRequestMethods([
+                        RequestMethod::GET,
+                        RequestMethod::POST,
+                        RequestMethod::PUT,
+                        RequestMethod::PATCH,
+                        RequestMethod::DELETE
+                    ]);
+                } else {
+                    $missalsHandler->setAllowedRequestMethods([]);
+                }
+```
+
+3d. `configureAuthorizationPipeline()` `missals` branch: replace the whole `elseif ($route === 'missals') { ... }` block with:
+
+```php
+        } elseif ($route === 'missals') {
+            // Writes are authorized per-missal: calendar_editor role plus fine-grained FGA
+            // (Editio Typica -> general_roman_calendar, national missal -> national_calendar).
+            // Collection-level writes are no longer routed (PUT moved to /missals/{missal_id}),
+            // so an id-less write only ever reaches the handler's 405 Method Not Allowed.
+            $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
+            if ($oidcAvailable && $fgaClient !== null && count($requestPathParts) >= 1) {
+                $pipeline->pipe(OpenFgaAuthorizationMiddleware::forMissals($fgaClient, $requestPathParts[0]));
+            }
+        }
+```
+
+The `data` and `tests` authorization branches are intentionally untouched: their existing count>=2 / count>=1 conditions now cover PUT
+because the id is in the path.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit phpunit_tests/Http/RouterPipelineTest.php --testdox`
+Expected: PASS (all, including `testTestsRouteWithoutPathPartSkipsFga`, which pins the unchanged count-0 config).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Router.php phpunit_tests/Http/RouterPipelineTest.php
+git commit -m "feat(router): route resource creation at PUT /{collection}/{id} (#706)"
+```
+
+---
+
+### Task 4: TestsHandler — path-based create, 409 on conflict
+
+**Files:**
+
+- Modify: `src/Handlers/TestsHandler.php` (`handlePutRequest()` ~243-283; class `use` imports)
+- Test: `phpunit_tests/Handlers/TestsHandlerTest.php`
+
+**Interfaces:**
+
+- Consumes: `TestScopeResolver::isSafeName()` (Task 1); `ConflictException` from
+  `LiturgicalCalendar\Api\Http\Exception\ConflictException` (same import as `DecreesHandler`).
+- Produces: `PUT /tests/{test_name}` — 201 create; 400 `ValidationException` on wrong arity or unsafe name; 422
+  `UnprocessableContentException` on body/path name mismatch; 409 `ConflictException` when the test exists.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `phpunit_tests/Handlers/TestsHandlerTest.php` add the import `use LiturgicalCalendar\Api\Http\Exception\ConflictException;`
+(alongside the existing exception imports) and `use LiturgicalCalendar\Api\Enum\JsonData;` if not already present. Update the existing
+`testPutWithMalformedPayloadIsValidationError` to the new shape (URI and constructor arg):
+
+```php
+        $req = $this->requestFor('PUT', '/tests/SomeTest', [], '[1, 2, 3]')
+            ->withHeader('Content-Type', 'application/json');
+        ( new TestsHandler(['SomeTest']) )->handle($req);
+```
+
+Then append the new tests:
+
+```php
+    public function testPutCreatesTestAtPathName(): void
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = json_decode(
+            (string) file_get_contents(JsonData::TESTS_FOLDER->path() . '/MaryMotherChurchTest.json'),
+            true
+        );
+        $payload['name'] = 'ZzzPutCreatedTest';
+
+        $this->testFixturePath = JsonData::TESTS_FOLDER->path() . '/ZzzPutCreatedTest.json';
+
+        $response = ( new TestsHandler(['ZzzPutCreatedTest']) )->handle(
+            $this->requestFor('PUT', '/tests/ZzzPutCreatedTest', [], $payload)
+        );
+
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertFileExists($this->testFixturePath);
+    }
+
+    public function testPutWithNoPathParamsIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new TestsHandler() )->handle(
+            $this->requestFor('PUT', '/tests', [], ['name' => 'SomeTest'])
+        );
+    }
+
+    public function testPutExistingTestConflicts(): void
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = json_decode(
+            (string) file_get_contents(JsonData::TESTS_FOLDER->path() . '/MaryMotherChurchTest.json'),
+            true
+        );
+
+        $this->expectException(ConflictException::class);
+        ( new TestsHandler(['MaryMotherChurchTest']) )->handle(
+            $this->requestFor('PUT', '/tests/MaryMotherChurchTest', [], $payload)
+        );
+    }
+
+    public function testPutBodyNameMismatchIsRejected(): void
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = json_decode(
+            (string) file_get_contents(JsonData::TESTS_FOLDER->path() . '/MaryMotherChurchTest.json'),
+            true
+        );
+        // Body says MaryMotherChurchTest, path says ZzzOtherTest.
+
+        $this->expectException(UnprocessableContentException::class);
+        ( new TestsHandler(['ZzzOtherTest']) )->handle(
+            $this->requestFor('PUT', '/tests/ZzzOtherTest', [], $payload)
+        );
+    }
+
+    public function testPutUnsafePathNameIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new TestsHandler(['..']) )->handle(
+            $this->requestFor('PUT', '/tests/..', [], ['name' => '..'])
+        );
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/TestsHandlerTest.php --testdox`
+Expected: the new tests FAIL — current handler throws `ValidationException` ("Expected no path params") for path-based PUT.
+`testPutWithNoPathParamsIsValidationError` may pass already only if payload parsing rejects first; expect failures for the others.
+
+- [ ] **Step 3: Implement**
+
+In `src/Handlers/TestsHandler.php` add imports:
+
+```php
+use LiturgicalCalendar\Api\Http\Exception\ConflictException;
+use LiturgicalCalendar\Api\Services\TestScopeResolver;
+```
+
+Replace `handlePutRequest()` (including its docblock) with:
+
+```php
+    /**
+     * Handles PUT requests for creating a specific test at /tests/{test_name}.
+     *
+     * The test name in the request path is authoritative; the payload's `name`
+     * must match it. The payload is validated against the LitCalTest JSON schema
+     * (422 on failure). If a test with the same name already exists a 409 Conflict
+     * is returned. On success the test is written to disk and a 201 Created
+     * response is returned.
+     */
+    private function handlePutRequest(ResponseInterface $response): ResponseInterface
+    {
+        if (count($this->requestPathParams) !== 1) {
+            $description = 'Expected one and only one path param for PUT requests, received ' . count($this->requestPathParams) . '.';
+            throw new ValidationException($description);
+        }
+
+        $testName = $this->requestPathParams[0];
+        if (false === TestScopeResolver::isSafeName($testName)) {
+            $description = 'The Unit Test name in the request path may only contain letters, digits, hyphens and underscores.';
+            throw new ValidationException($description);
+        }
+
+        $this->validatePayloadAgainstTestSchema('create');
+        self::sanitizeObjectValues($this->payload);
+
+        if (false === property_exists($this->payload, 'name') || false === is_string($this->payload->name)) {
+            $description = 'The Unit Test you are attempting to create must have a valid name.';
+            throw new UnprocessableContentException($description);
+        }
+
+        if ($this->payload->name !== $testName) {
+            $description = 'You are attempting to create the Unit Test at /tests/' . $testName . ' with a Unit Test that has the name '
+                . $this->payload->name . ' in the request body. This is not allowed.';
+            throw new UnprocessableContentException($description);
+        }
+
+        $testFilePath = JsonData::TESTS_FOLDER->path() . '/' . $testName . '.json';
+        if (file_exists($testFilePath)) {
+            $description = 'A Unit Test with the name ' . $testName . ' already exists. Did you perhaps mean to use a PATCH request?';
+            throw new ConflictException($description);
+        }
+
+        $jsonEncodedTest = JsonFormatter::encode($this->payload, false);
+        $bytesWritten    = file_put_contents($testFilePath, $jsonEncodedTest);
+        if (false === $bytesWritten) {
+            $description = 'The server did not succeed in writing to disk the Unit Test. Please try again later or contact the service administrator for support.';
+            throw new ServiceUnavailableException($description);
+        }
+
+        $responseBody = (object) ['response' => 'Unit Test ' . $testName . ' created successfully.'];
+        return $this->encodeResponseBody($response, $responseBody, StatusCode::CREATED);
+    }
+```
+
+Also fix the copy-pasted docblock on `handlePatchRequest()` (it currently says "Handles PUT requests ... expects no path parameters"):
+first line becomes "Handles PATCH requests for updating a specific test at /tests/{test_name}."
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/TestsHandlerTest.php --testdox`
+Expected: PASS (all).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Handlers/TestsHandler.php phpunit_tests/Handlers/TestsHandlerTest.php
+git commit -m "feat(tests): create tests at PUT /tests/{test_name} with 409 on conflict (#706)"
+```
+
+---
+
+### Task 5: RegionalDataHandler — PUT key from path
+
+**Files:**
+
+- Modify: `src/Handlers/RegionalDataHandler.php` (`validateRequestPath()` ~1307-1347; `handle()` ~1548-1721)
+- Test: `phpunit_tests/Handlers/RegionalDataHandlerTest.php`
+- Test: `phpunit_tests/Routes/ReadWrite/RegionalDataTest.php`
+
+**Interfaces:**
+
+- Consumes: Router arity from Task 3 (`PUT /data/{category}/{key}`).
+- Produces: PUT requires exactly 2 path params; `$params['key']` comes from `requestPathParams[1]` for ALL of GET/POST/PUT/PATCH/DELETE;
+  payload-derived key must equal the path key for both PUT and PATCH (422 otherwise). Conflict/creation status codes unchanged
+  (409 `ResourceConflictException` / 201).
+
+- [ ] **Step 1: Write/update the failing handler tests**
+
+In `phpunit_tests/Handlers/RegionalDataHandlerTest.php`:
+
+Update `testPutWithoutPayloadIsValidationError` (~line 174) to the 2-param shape:
+
+```php
+    public function testPutWithoutPayloadIsValidationError(): void
+    {
+        // PUT requires exactly 2 path params (category + key). Passing the
+        // request without a body trips the empty-payload check in
+        // parseBodyPayload → ValidationException.
+        $this->expectException(ValidationException::class);
+        ( new RegionalDataHandler(['nation', 'ZZ']) )
+            ->handle($this->requestFor('PUT', '/data/nation/ZZ', ['Content-Type' => 'application/json'], ''));
+    }
+```
+
+Update `testCreateNationalCalendarRejectsNonIsoNationCode` (~line 184): change only the last statement to the 2-param shape:
+
+```php
+        ( new RegionalDataHandler(['nation', 'ZZ']) )->handle($this->requestFor('PUT', '/data/nation/ZZ', [], $payload));
+```
+
+Append two new tests (reuse the `$payload` array literal from `testCreateNationalCalendarRejectsNonIsoNationCode` verbatim where
+indicated):
+
+```php
+    public function testPutWithSinglePathParamIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new RegionalDataHandler(['nation']) )
+            ->handle($this->requestFor('PUT', '/data/nation', ['Content-Type' => 'application/json'], ''));
+    }
+
+    public function testPutPathBodyKeyMismatchIsUnprocessable(): void
+    {
+        // Same payload shape as testCreateNationalCalendarRejectsNonIsoNationCode
+        // (metadata.nation = 'ZZ'), but PUT to /data/nation/XK: path/body key mismatch
+        // must be rejected before any create-condition checks (including the ISO gate).
+        $payload = [
+            'litcal'   => [
+                [
+                    'liturgical_event' => ['event_key' => 'StGeorgeMartyr', 'grade' => 4],
+                    'metadata'         => ['action' => 'makePatron', 'since_year' => 1868, 'url' => 'https://www.vatican.va/'],
+                ],
+            ],
+            'settings' => [
+                'epiphany'               => 'JAN6',
+                'ascension'              => 'SUNDAY',
+                'corpus_christi'         => 'SUNDAY',
+                'eternal_high_priest'    => false,
+                'holydays_of_obligation' => [
+                    'Christmas'            => true,
+                    'Epiphany'             => false,
+                    'Ascension'            => false,
+                    'CorpusChristi'        => false,
+                    'MaryMotherOfGod'      => true,
+                    'ImmaculateConception' => true,
+                    'Assumption'           => true,
+                    'StJoseph'             => false,
+                    'StsPeterPaulAp'       => false,
+                    'AllSaints'            => false,
+                ],
+            ],
+            'metadata' => [
+                'nation'  => 'ZZ',
+                'missals' => ['IT_1983'],
+                'locales' => ['en'],
+            ],
+            'i18n'     => [
+                'en' => ['StGeorgeMartyr' => 'Saint George, Martyr'],
+            ],
+        ];
+
+        $this->expectException(UnprocessableContentException::class);
+        $this->expectExceptionMessage('The key in the request path does not match the key in the payload');
+        ( new RegionalDataHandler(['nation', 'XK']) )->handle($this->requestFor('PUT', '/data/nation/XK', [], $payload));
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/RegionalDataHandlerTest.php --testdox`
+Expected: the updated/new PUT tests FAIL (current code: 'Expected one path param for PUT requests, received 2').
+
+- [ ] **Step 3: Implement**
+
+3a. `validateRequestPath()`: merge PUT into the PATCH/DELETE branch. Replace the `case RequestMethod::PUT: ... break;` and
+`case RequestMethod::PATCH: ... case RequestMethod::DELETE: ... break;` blocks with:
+
+```php
+            case RequestMethod::PUT:
+                // no break (intentional fallthrough)
+            case RequestMethod::PATCH:
+                // no break (intentional fallthrough)
+            case RequestMethod::DELETE:
+                if (count($this->requestPathParams) !== 2) {
+                    $description = 'Expected two path params for PUT, PATCH and DELETE requests, received ' . count($this->requestPathParams);
+                    throw new ValidationException($description);
+                }
+                break;
+```
+
+3b. In `handle()`, the key now always comes from the path. Replace:
+
+```php
+        if (in_array($method, [RequestMethod::GET, RequestMethod::POST, RequestMethod::PATCH, RequestMethod::DELETE], true)) {
+            $params['key'] = $this->requestPathParams[1];
+        }
+```
+
+with:
+
+```php
+        if (in_array($method, [RequestMethod::GET, RequestMethod::POST, RequestMethod::PUT, RequestMethod::PATCH, RequestMethod::DELETE], true)) {
+            $params['key'] = $this->requestPathParams[1];
+        }
+```
+
+3c. Still in `handle()`, replace the PUT/PATCH key handling:
+
+```php
+            if ($method === RequestMethod::PUT) {
+                $params['key'] = $key;
+            } else {
+                if ($params['key'] !== $key) {
+                    throw new UnprocessableContentException('The key in the request path does not match the key in the payload');
+                }
+            }
+```
+
+with:
+
+```php
+            if ($params['key'] !== $key) {
+                throw new UnprocessableContentException('The key in the request path does not match the key in the payload');
+            }
+```
+
+3d. Update the comment above `$this->validateRequestPath($request);` that reads "We expect the key to be set in the request path for
+GET, POST, PATCH and DELETE requests" to "We expect the key to be set in the request path for all request methods".
+
+- [ ] **Step 4: Run handler tests to verify they pass**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/RegionalDataHandlerTest.php --testdox`
+Expected: PASS (all).
+
+- [ ] **Step 5: Update the route-level tests (verified in Task 8 / CI)**
+
+In `phpunit_tests/Routes/ReadWrite/RegionalDataTest.php`:
+
+- `testPutOrPatchWithoutContentTypeHeaderReturnsError` (~176): `self::$http->put('/data/nation', [])` → `self::$http->put('/data/nation/IT', [])`.
+- `testPutDataExistingCalendarReturnsError` (~212): `'/data/nation'` → `'/data/nation/CA'` (matches `self::$existingBody`, which is
+  Canada's calendar — check the `$existingBody` fixture at the top of the file and use its `metadata.nation` value).
+- `testAuthenticatedPutDataExistingCalendarReturns409` (~245): `'/data/nation'` → `'/data/nation/CA'` (same fixture-key note).
+- `testAuthenticatedPutPatchWithoutContentTypeReturns415` (~294): `'/data/nation'` → `'/data/nation/CA'`.
+- `testAuthenticatedWriteOperationsWithoutPathParametersReturnValidationErrors` (~321): comment "(expects one path param)" →
+  "(expects two path params)".
+- `validatePutNoPathParametersErrorResponse` (~390): assert the new message
+  `'Expected two path params for PUT, PATCH and DELETE requests, received 0'`.
+- `validatePatchDeleteNoPathParametersErrorResponse`: update its asserted message to the same new merged wording.
+- Add to `testGetOrPostOrPatchOrDeleteWithoutKeyParameterInPathReturnsError` (~97) two entries exercising the retired create shape,
+  `[ 'uri' => '/data/nation/', 'method' => 'PUT' ]` and `[ 'uri' => '/data/diocese/', 'method' => 'PUT' ]`, and confirm the expected
+  status code logic in that test treats PUT like PATCH/DELETE (401 unauthenticated).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Handlers/RegionalDataHandler.php phpunit_tests/Handlers/RegionalDataHandlerTest.php phpunit_tests/Routes/ReadWrite/RegionalDataTest.php
+git commit -m "feat(data): create calendars at PUT /data/{category}/{key} (#706)"
+```
+
+---
+
+### Task 6: OpenAPI schema
+
+**Files:**
+
+- Modify: `jsondata/schemas/openapi.json`
+
+**Interfaces:**
+
+- Consumes: final route shapes from Tasks 3-5.
+- Produces: documented `put` operations under `/data/nation/{key}` (~4019), `/data/diocese/{key}` (~4220), `/data/widerregion/{key}`
+  (~4419), `/tests/{test_name}` (~5328); path items `/data/nation` (~3794), `/data/widerregion` (~3869), `/data/diocese` (~3944) removed;
+  `put` removed from `/tests` (~5249).
+
+- [ ] **Step 1: Move the three `/data/{category}` put operations**
+
+For each of `/data/nation`, `/data/widerregion`, `/data/diocese`: cut the entire `"put": { ... }` operation object and paste it as a new
+`"put"` member of the corresponding `/{...}/{key}` path item (after `"get"`). Then DELETE the now-empty `/data/nation`,
+`/data/widerregion`, `/data/diocese` path items entirely. In each moved operation:
+
+- Add a `parameters` array as the first member after `operationId`, copying the `key` parameter object verbatim from the sibling `get`
+  operation in the same path item (name/schema/description identical).
+- Update the `summary` (e.g. "Create a national calendar data resource" stays) and `description`: append the sentence
+  "The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it."
+- Keep `operationId` values (`nationalCalendarDataPUT`, `widerregionDataPUT`, `diocesanDataPUT`) and all response entries (409 and 422
+  are already documented for the data PUTs; no response changes needed).
+
+- [ ] **Step 2: Move the `/tests` put operation**
+
+Cut the `"put": { ... }` from the `/tests` path item (~5249-5326) and add it to `/tests/{test_name}` (~5328, after `"get"`):
+
+- Add a `parameters` array copying the `test_name` parameter from the sibling `get` (~5338-5347).
+- Rename `operationId` from `testsIndexPUT` to `createTestByNamePUT` (consistent with `retrieveTestByNameGET`).
+- Change `summary` to "Create a new unit test at its own URI in the API `tests` folder".
+- Fix the `201` response description (it currently claims overwrites return 201): "201 Created. The unit test did not previously exist
+  and was created at the request URI."
+- Add a `409` response: `"409": { "$ref": "#/components/responses/Conflict409" }` (alphabetical position between 403 and 415).
+
+- [ ] **Step 3: Lint and validate**
+
+Run: `composer lint:openapi`
+Expected: no errors (warnings pre-existing are acceptable if already present on development).
+Also run: `vendor/bin/phpunit phpunit_tests/Schemas/ --testdox` — schema-corpus tests must still pass (use
+`vendor/bin/phpunit --group slow phpunit_tests/Schemas/SchemaValidationTest.php` if the default run skips it).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add jsondata/schemas/openapi.json
+git commit -m "docs(openapi): document creation at PUT /{collection}/{id} (#706)"
+```
+
+---
+
+### Task 7: README RFC 9110 note
+
+**Files:**
+
+- Modify: `README.md` (the "Some characteristics of this API" bullet list, ~line 69)
+
+- [ ] **Step 1: Add the bullet**
+
+Append as a third top-level bullet after the "**The data is historically accurate**" bullet:
+
+```markdown
+* **HTTP method semantics follow [RFC 9110](https://www.rfc-editor.org/rfc/rfc9110)**:
+  `PUT` is create-or-replace at the resource's own URI (idempotent, returning `409 Conflict` when attempting to create a resource that already exists),
+  and `PATCH`/`DELETE` likewise address resources by path (e.g. `PUT /data/nation/IT`, `PATCH /tests/MaryMotherChurchTest`).
+  One deliberate exception: on read endpoints this API uses `POST` as a body-parameterized synonym of `GET` (not as collection-create),
+  pending possible adoption of the [`QUERY` method](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/) when it becomes standard.
+```
+
+- [ ] **Step 2: Lint**
+
+Run: `composer lint:md`
+Expected: clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): note RFC 9110 method semantics (#706)"
+```
+
+---
+
+### Task 8: Full verification gate + PR
+
+**Files:** none new (verification + PR only).
+
+- [ ] **Step 1: Static analysis + style**
+
+Run: `composer analyse && composer lint && composer parallel-lint`
+Expected: no errors. Fix anything reported before proceeding.
+
+- [ ] **Step 2: Unit + handler suite (no server)**
+
+Run: `composer test:quick`
+Expected: `Routes/*` tests hit port 8000 (STALE docker image) — the RegionalData ReadWrite tests updated in Task 5 will FAIL against it.
+That is expected; verify them in Step 3 instead. Everything else must pass.
+
+- [ ] **Step 3: Route tests against worktree code on port 8001**
+
+```bash
+sed -i 's/^API_PORT=.*/API_PORT=8001/' .env.local
+PHP_CLI_SERVER_WORKERS=6 php -S localhost:8001 -t public &> /dev/null &
+SERVER_PID=$!
+vendor/bin/phpunit phpunit_tests/Routes/ReadWrite/RegionalDataTest.php --testdox
+kill $SERVER_PID
+git checkout -- .env.local 2>/dev/null || sed -i 's/^API_PORT=.*/API_PORT=8000/' .env.local
+```
+
+Expected: PASS (auth-dependent tests skip if the local DB/Zitadel stack is down — that's acceptable; CI covers them).
+Note: `.env.local` is gitignored, so `git checkout` won't restore it — use the `sed` fallback to revert the port.
+
+- [ ] **Step 4: Push and open the PR**
+
+```bash
+git push -u origin feat/put-creation-paths
+gh pr create --repo Liturgical-Calendar/LiturgicalCalendarAPI --base development \
+  --title "feat: align resource creation paths to PUT /{collection}/{id}" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- `PUT /tests/{test_name}`, `PUT /data/{category}/{key}`, and (route shape only) `PUT /missals/{missal_id}` replace the
+  id-in-body collection-level PUT creates, per RFC 9110 create-or-replace semantics.
+- Path id is authoritative; body id must match (422). Creating over an existing resource returns 409 Conflict
+  (tests endpoint changed from 422 to 409).
+- OpenFGA fine-grained authorization now covers creates (the id is in the path); tests creates resolve their FGA scope
+  from the payload's `applies_to`, the same value the created file will carry.
+- OpenAPI schema updated; README documents the RFC 9110 method semantics.
+
+Design: docs/superpowers/specs/2026-07-14-put-creation-paths-design.md
+
+Coordinated frontend PR (merge after this): Liturgical-Calendar/LiturgicalCalendarFrontend (admin-tests.js, extending.js).
+
+Closes #706
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR opens against `development`.
+
+---
+
+### Task 9: Frontend PR (LiturgicalCalendarFrontend repo)
+
+**Files** (in `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend`, own branch `feat/put-creation-paths`
+off `development` — use a worktree there too):
+
+- Modify: `assets/js/admin-tests.js` (~line 781)
+- Modify: `assets/js/extending.js` (`API.path` proxy branches ~504-513, ~526-530, ~569-572, ~587-593)
+- Verify only: `assets/js/missals-editor.js` (~730-744)
+
+**Interfaces:**
+
+- Consumes: the new API shapes from Tasks 3-5. Merge this PR only AFTER the API PR is merged (frontend e2e builds `litcal-api`
+  from `development`).
+
+- [ ] **Step 1: admin-tests.js**
+
+Line ~781, in the save flow (`state.editing` is null on create; the payload carries the new name):
+
+```javascript
+// before
+await fetchJson('PUT', '/tests', payload);
+// after
+await fetchJson('PUT', `/tests/${encodeURIComponent(payload.name)}`, payload);
+```
+
+Confirm in place that the create branch's payload variable is named `payload` and its name property is `payload.name`;
+the 409 handling branch (`err.status === 409`) already exists at ~787.
+
+- [ ] **Step 2: extending.js**
+
+The `API.path` proxy deliberately omits the key from PUT URLs in four `case` branches. In each, make PUT build the same
+`${RegionalDataUrl}/${category}/${key}` URL the other verbs use. Representative shape (apply the same edit to all four branches —
+`path`, `category`, `key`, `method`):
+
+```javascript
+// before
+if (API.method === 'PUT') {
+    return `${RegionalDataUrl}/${API.category}`;
+}
+return `${RegionalDataUrl}/${API.category}/${API.key}`;
+// after
+return `${RegionalDataUrl}/${API.category}/${API.key}`;
+```
+
+Read each branch before editing — the four sites are near lines 504-513, 526-530, 569-572, 587-593 and differ slightly in variable
+naming; the invariant is: PUT no longer gets a key-less URL. Verify `API.key` is always populated before a PUT is issued
+(it is what the PATCH/DELETE flows already rely on).
+
+- [ ] **Step 3: missals-editor.js — verify only**
+
+Confirm the PUT at ~line 734 already targets a per-file endpoint (`apiUrl = BaseUrl + '/' + encodePathSegments(endpoint)`) and keeps
+its 405-stub handling. No change expected.
+
+- [ ] **Step 4: Verify end-to-end**
+
+With the API worktree server running on 8001 (Task 8 Step 3 setup) and the frontend configured against it
+(`.env.development`: `API_PORT=8001`), exercise: create a test in admin-tests UI, create/patch a calendar in extending.php.
+Then restore `.env.development`.
+
+- [ ] **Step 5: Commit and PR**
+
+```bash
+git add assets/js/admin-tests.js assets/js/extending.js
+git commit -m "feat: use PUT /{collection}/{id} creation paths (API #706)"
+git push -u origin feat/put-creation-paths
+gh pr create --repo Liturgical-Calendar/LiturgicalCalendarFrontend --base development \
+  --title "feat: use PUT /{collection}/{id} creation paths" \
+  --body "Companion to Liturgical-Calendar/LiturgicalCalendarAPI PUT-creation-paths PR (issue API#706). Merge after the API PR.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+```
+
+Expected: PR opens; its e2e runs against the freshly-merged API `development` code.

--- a/docs/superpowers/specs/2026-07-14-put-creation-paths-design.md
+++ b/docs/superpowers/specs/2026-07-14-put-creation-paths-design.md
@@ -33,9 +33,13 @@ request attribute from the path), leaving creates gated by role only.
 | Endpoint     | New create shape                              | Old shape fate                |
 |--------------|-----------------------------------------------|-------------------------------|
 | `/tests`     | `PUT /tests/{test_name}`                      | `PUT /tests` → 405            |
-| `/data`      | `PUT /data/{category}/{key}`                  | `PUT /data/{category}` → 405  |
+| `/data`      | `PUT /data/{category}/{key}`                  | `PUT /data/{category}` → 400* |
 | `/missals`   | `PUT /missals/{missal_id}` (405 stub for now) | `PUT /missals` → 405          |
 | `/temporale` | unchanged (singleton bulk payload)            | —                             |
+
+\* `RegionalDataHandler` validates the request path before the request method, so the legacy `/data` create shape yields a
+400 `ValidationException` ("Expected two path params…") rather than a 405. Reordering the handler's validation to force a
+405 would change its documented GET/POST arity errors, so the 400 is accepted as the legacy-shape response for `/data`.
 
 ## API changes
 
@@ -89,7 +93,7 @@ pending possible adoption of the `QUERY` method when it becomes standard.
 - Update `phpunit_tests/Handlers/TestsHandlerTest.php`, `RegionalDataHandlerTest.php`, and
   `phpunit_tests/Routes/ReadWrite/RegionalDataTest.php` to the new shapes, using
   `DecreesHandlerWriteTest.php` as the pattern.
-- Explicit assertions: old collection-level PUT yields 405; path/body id mismatch yields 422;
+- Explicit assertions: old collection-level PUT yields 405 (tests/missals) or 400 (data — see Target shapes note); path/body id mismatch yields 422;
   duplicate create yields 409; FGA-on-create behavior (grant present → allowed, absent → 403,
   admin bypass); missals route shape (PUT `/missals/{id}` → 405 stub, PUT `/missals` → 405
   method-not-allowed).

--- a/docs/superpowers/specs/2026-07-14-put-creation-paths-design.md
+++ b/docs/superpowers/specs/2026-07-14-put-creation-paths-design.md
@@ -1,0 +1,117 @@
+# Design: RFC 9110-aligned resource creation paths (issue #706)
+
+Date: 2026-07-14
+Status: Approved
+Issue: [#706](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/706)
+
+## Problem
+
+Write-enabled endpoints are inconsistent about where the resource identifier lives on creation.
+PATCH and DELETE address resources by path everywhere, but PUT creations carry the id in the
+request body (`PUT /tests` with body `name`, `PUT /data/{category}` with the key in body
+metadata). Per RFC 9110, `PUT` targets the resource's own URI (create-or-replace at a known
+location, idempotent). The id-in-body shape is also the reason `OpenFgaAuthorizationMiddleware`
+is skipped entirely on those creates (the Router cannot populate the `test_id`/`calendar_id`
+request attribute from the path), leaving creates gated by role only.
+
+`DecreesHandler` (PR #708) already implements the target pattern and serves as the template:
+`PUT /decrees/{decree_id}`, path id authoritative, body id must match path, 409 on conflict,
+201 on create.
+
+## Decisions
+
+| Decision            | Choice                                                                     |
+|---------------------|----------------------------------------------------------------------------|
+| Rollout             | Hard cutover; no deprecated aliases. Old collection-level PUT returns 405. |
+| Missals scope       | Route shape only: PUT accepted at `/missals/{missal_id}`, still 405 stub.  |
+| Tests conflict code | Align to 409 Conflict (was 422).                                           |
+| README              | Brief RFC 9110 note in the API description (see below).                    |
+| PR structure        | One API PR + one Frontend PR, merged API-first the same day.               |
+
+## Target shapes
+
+| Endpoint     | New create shape                              | Old shape fate                |
+|--------------|-----------------------------------------------|-------------------------------|
+| `/tests`     | `PUT /tests/{test_name}`                      | `PUT /tests` → 405            |
+| `/data`      | `PUT /data/{category}/{key}`                  | `PUT /data/{category}` → 405  |
+| `/missals`   | `PUT /missals/{missal_id}` (405 stub for now) | `PUT /missals` → 405          |
+| `/temporale` | unchanged (singleton bulk payload)            | —                             |
+
+## API changes
+
+### Router (`src/Router.php`)
+
+- **tests**: 0 segments → `GET/POST`; 1 segment → `GET/POST/PUT/PATCH/DELETE`. The existing
+  count>=1 branch that sets the `test_id` request attribute and applies
+  `OpenFgaAuthorizationMiddleware::forTestScopes` now covers create.
+- **data**: 1 segment → no write methods (405); 2 segments → `GET/POST/PUT/PATCH/DELETE`.
+  The count>=2 branch that sets `calendar_id` from `pathParts[1]` and applies
+  `forCalendarData` now covers create.
+- **missals**: PUT moves from 0 segments to 1 segment; the collection-level `forAdmin`
+  fail-closed fallback becomes dead code and is removed.
+
+**Flagged behavior change — FGA on create:** the FGA check now runs against an object that may
+not exist yet (e.g. `editor` on `national_calendar:XYZ` before the file exists). OpenFGA tuples
+are independent of resource files, so grants provisioned via the access-request flow still
+work, and the `admin` role bypasses; but a plain `calendar_editor` with no object tuple will
+now receive 403 on create where the previous role-only check passed. This is the intended
+tightening of #706, must be covered by explicit tests, and must be confirmed against the RBAC
+model's intent (dev store currently on the ADDITIVE model).
+
+### Handlers
+
+- **TestsHandler::handlePutRequest**: require exactly 1 path param; path `test_name` is
+  authoritative; body `name` must match path (mirroring the existing PATCH check and
+  `DecreesHandler::requireValidatedPayload`); "already exists" becomes 409 `ConflictException`
+  (was 422) with a "use PATCH" hint; still 201 on create.
+- **RegionalDataHandler**: `validateRequestPath` requires exactly 2 path params for PUT; the
+  payload-derived key (`metadata.diocese_id` / `nation` / `wider_region`) must match the path
+  key — same 422 mismatch error PATCH already uses; conflict stays 409, create stays 201.
+- **MissalsHandler**: untouched (stubs remain; only the route arity changes).
+
+### OpenAPI (`jsondata/schemas/openapi.json`)
+
+Move the `put` operations from `/data/nation|diocese|widerregion` and `/tests` to the
+corresponding `/{...}/{key}` and `/tests/{test_name}` path items; document 409 responses;
+remove the collection-level PUTs. Missals writes stay undocumented (still stubs).
+`composer lint:openapi` must pass.
+
+### README
+
+Brief note in the API description: HTTP method semantics follow RFC 9110 — `PUT` is
+create-or-replace at the resource's own URI (idempotent, 409 when creating over an existing
+resource); `PATCH`/`DELETE` address resources by path. Note that this API deliberately uses
+`POST` on read endpoints as a body-parameterized synonym of `GET` (not as collection-create),
+pending possible adoption of the `QUERY` method when it becomes standard.
+
+## Tests
+
+- Update `phpunit_tests/Handlers/TestsHandlerTest.php`, `RegionalDataHandlerTest.php`, and
+  `phpunit_tests/Routes/ReadWrite/RegionalDataTest.php` to the new shapes, using
+  `DecreesHandlerWriteTest.php` as the pattern.
+- Explicit assertions: old collection-level PUT yields 405; path/body id mismatch yields 422;
+  duplicate create yields 409; FGA-on-create behavior (grant present → allowed, absent → 403,
+  admin bypass); missals route shape (PUT `/missals/{id}` → 405 stub, PUT `/missals` → 405
+  method-not-allowed).
+- Full gate: `composer test`, `composer analyse`, `composer lint`, `composer lint:openapi`.
+
+## Frontend PR (LiturgicalCalendarFrontend)
+
+- `assets/js/admin-tests.js` (~line 781): create becomes
+  `PUT /tests/${encodeURIComponent(name)}`; its `err.status === 409` branch already exists.
+- `assets/js/extending.js`: the `API.path` proxy currently strips the key from PUT URLs in
+  four case branches — update so PUT builds `${RegionalDataUrl}/${category}/${key}` like the
+  other verbs.
+- `assets/js/missals-editor.js`: verify only — it already PUTs to a per-file endpoint and
+  handles the 405 stub.
+- Frontend e2e builds `litcal-api` from `development`, so merging the API PR first lets the
+  frontend PR's e2e validate the new shapes.
+
+## Process
+
+- API work in a git worktree (`.claude/worktrees/feat-put-creation-paths`, branch
+  `feat/put-creation-paths` off `development`); the main checkout is shared with concurrent
+  agents and must not be committed in.
+- API PR targets `development` and closes #706 (`Closes #706`).
+- README RFC 9110 note lands in the same API PR (it documents the state after the change).
+- Frontend changes in their own branch/PR in the Frontend repo, merged after the API PR.

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -5400,17 +5400,14 @@
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "status": {
-                      "type": "string",
-                      "const": "OK"
-                    },
                     "response": {
                       "type": "string",
-                      "const": "Resource Created"
+                      "examples": [
+                        "Unit Test MaryMotherChurchTest created successfully."
+                      ]
                     }
                   },
                   "required": [
-                    "status",
                     "response"
                   ]
                 }

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -3791,7 +3791,45 @@
         }
       }
     },
-    "/data/nation": {
+    "/data/nation/{key}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve a national calendar data resource",
+        "operationId": "nationalDataGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/Nation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: National calendar data resource retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./NationalCalendar.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      },
       "put": {
         "tags": [
           "Calendar Source Data"
@@ -3805,8 +3843,18 @@
           }
         ],
         "summary": "Create a national calendar data resource",
-        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`.",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.",
         "operationId": "nationalCalendarDataPUT",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/Nation"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -3862,196 +3910,6 @@
           },
           "422": {
             "$ref": "#/components/responses/UnprocessableEntity422"
-          }
-        }
-      }
-    },
-    "/data/widerregion": {
-      "put": {
-        "tags": [
-          "Calendar Source Data"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "CookieAuth": []
-          }
-        ],
-        "summary": "Create a wider region data resource",
-        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`.",
-        "operationId": "widerregionDataPUT",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "./WiderRegionCalendar.json"
-              },
-              "examples": {
-                "EuropeWiderRegion": {
-                  "$ref": "#/components/examples/WiderRegionCalendarRequestBody"
-                },
-                "AsiaWiderRegion": {
-                  "$ref": "#/components/examples/WiderRegionCalendarAsiaRequestBody"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "201 Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "success": {
-                      "type": "string",
-                      "examples": [
-                        "Wider region calendar created or updated for region {REGION}"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "success"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest400"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized401"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden403"
-          },
-          "409": {
-            "$ref": "#/components/responses/Conflict409"
-          },
-          "422": {
-            "$ref": "#/components/responses/UnprocessableEntity422"
-          }
-        }
-      }
-    },
-    "/data/diocese": {
-      "put": {
-        "tags": [
-          "Calendar Source Data"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "CookieAuth": []
-          }
-        ],
-        "summary": "Create a diocesan calendar data resource",
-        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`.",
-        "operationId": "diocesanDataPUT",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "./DiocesanCalendar.json"
-              },
-              "examples": {
-                "BostonDiocesan": {
-                  "$ref": "#/components/examples/DiocesanCalendarRequestBody"
-                },
-                "RomeDiocesan": {
-                  "$ref": "#/components/examples/DiocesanCalendarRomeRequestBody"
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "201 Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "success": {
-                      "type": "string",
-                      "examples": [
-                        "Diocesan calendar created or updated for diocese {DIOCESE}"
-                      ]
-                    }
-                  },
-                  "required": [
-                    "success"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest400"
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized401"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden403"
-          },
-          "409": {
-            "$ref": "#/components/responses/Conflict409"
-          },
-          "422": {
-            "$ref": "#/components/responses/UnprocessableEntity422"
-          }
-        }
-      }
-    },
-    "/data/nation/{key}": {
-      "get": {
-        "tags": [
-          "Calendar Source Data"
-        ],
-        "security": [
-          {}
-        ],
-        "summary": "Retrieve a national calendar data resource",
-        "operationId": "nationalDataGET",
-        "parameters": [
-          {
-            "name": "key",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "$ref": "./CommonDef.json#/definitions/Nation"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK: National calendar data resource retrieved successfully",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "./NationalCalendar.json"
-                }
-              }
-            }
-          },
-          "400": {
-            "$ref": "#/components/responses/BadRequest400"
-          },
-          "404": {
-            "$ref": "#/components/responses/NotFound404"
           }
         }
       },
@@ -4256,6 +4114,89 @@
           }
         }
       },
+      "put": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a diocesan calendar data resource",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.",
+        "operationId": "diocesanDataPUT",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./DiocesanCalendar.json"
+              },
+              "examples": {
+                "BostonDiocesan": {
+                  "$ref": "#/components/examples/DiocesanCalendarRequestBody"
+                },
+                "RomeDiocesan": {
+                  "$ref": "#/components/examples/DiocesanCalendarRomeRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "examples": [
+                        "Diocesan calendar created or updated for diocese {DIOCESE}"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict409"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
       "post": {
         "tags": [
           "Calendar Source Data"
@@ -4452,6 +4393,89 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a wider region data resource",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.",
+        "operationId": "widerregionDataPUT",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./WiderRegionCalendar.json"
+              },
+              "examples": {
+                "EuropeWiderRegion": {
+                  "$ref": "#/components/examples/WiderRegionCalendarRequestBody"
+                },
+                "AsiaWiderRegion": {
+                  "$ref": "#/components/examples/WiderRegionCalendarAsiaRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "examples": [
+                        "Wider region calendar created or updated for region {REGION}"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict409"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -5245,84 +5269,6 @@
             "$ref": "#/components/responses/NotFound404"
           }
         }
-      },
-      "put": {
-        "tags": [
-          "Unit Tests"
-        ],
-        "security": [
-          {
-            "BearerAuth": []
-          },
-          {
-            "CookieAuth": []
-          }
-        ],
-        "summary": "Create a new unit test in the API `tests` folder",
-        "description": "Create (`PUT`) requires the `editor` relation.",
-        "operationId": "testsIndexPUT",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "oneOf": [
-                  {
-                    "$ref": "#/components/schemas/ExactCorrespondenceUnitTest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/ExactCorrespondenceSinceUnitTest"
-                  },
-                  {
-                    "$ref": "#/components/schemas/ExactCorrespondenceUntilUnitTest"
-                  }
-                ]
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": false,
-                  "properties": {
-                    "status": {
-                      "type": "string",
-                      "const": "OK"
-                    },
-                    "response": {
-                      "type": "string",
-                      "const": "Resource Created"
-                    }
-                  },
-                  "required": [
-                    "status",
-                    "response"
-                  ]
-                }
-              }
-            }
-          },
-          "401": {
-            "$ref": "#/components/responses/Unauthorized401"
-          },
-          "403": {
-            "$ref": "#/components/responses/Forbidden403"
-          },
-          "415": {
-            "$ref": "#/components/responses/UnsupportedMediaType415"
-          },
-          "422": {
-            "$ref": "#/components/responses/UnprocessableEntity422"
-          },
-          "503": {
-            "$ref": "#/components/responses/ServiceUnavailable503"
-          }
-        }
       }
     },
     "/tests/{test_name}": {
@@ -5396,6 +5342,98 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Unit Tests"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a new unit test at its own URI in the API `tests` folder",
+        "description": "Create (`PUT`) requires the `editor` relation.",
+        "operationId": "createTestByNamePUT",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "test_name",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^(?:[a-z]+_[a-z]+_)?[A-Z][a-zA-Z0-9]+(?:_\\d+)?(?:_vigil)?Test$"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/ExactCorrespondenceUnitTest"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ExactCorrespondenceSinceUnitTest"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ExactCorrespondenceUntilUnitTest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created. The unit test did not previously exist and was created at the request URI.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "const": "OK"
+                    },
+                    "response": {
+                      "type": "string",
+                      "const": "Resource Created"
+                    }
+                  },
+                  "required": [
+                    "status",
+                    "response"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict409"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
           }
         }
       },

--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -174,12 +174,12 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
 
     public function testPutWithoutPayloadIsValidationError(): void
     {
-        // PUT requires exactly 1 path param (the category). Passing the
+        // PUT requires exactly 2 path params (category + key). Passing the
         // request without a body trips the empty-payload check in
         // parseBodyPayload → ValidationException.
         $this->expectException(ValidationException::class);
-        ( new RegionalDataHandler(['nation']) )
-            ->handle($this->requestFor('PUT', '/data/nation', ['Content-Type' => 'application/json'], ''));
+        ( new RegionalDataHandler(['nation', 'ZZ']) )
+            ->handle($this->requestFor('PUT', '/data/nation/ZZ', ['Content-Type' => 'application/json'], ''));
     }
 
     /**
@@ -229,7 +229,64 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
         ];
 
         $this->expectException(UnprocessableContentException::class);
-        ( new RegionalDataHandler(['nation']) )->handle($this->requestFor('PUT', '/data/nation', [], $payload));
+        ( new RegionalDataHandler(['nation', 'ZZ']) )->handle($this->requestFor('PUT', '/data/nation/ZZ', [], $payload));
+    }
+
+    public function testPutWithSinglePathParamIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new RegionalDataHandler(['nation']) )
+            ->handle($this->requestFor('PUT', '/data/nation', ['Content-Type' => 'application/json'], ''));
+    }
+
+    public function testPutPathBodyKeyMismatchIsUnprocessable(): void
+    {
+        // Unlike testCreateNationalCalendarRejectsNonIsoNationCode's 'ZZ' payload (which
+        // is missing `wider_region` and uses a non-ISO nation code, both of which trip
+        // schema validation before the key is ever extracted), this payload must be
+        // schema-valid so that the mismatch check — not an unrelated schema error — is
+        // what fires. PUT to /data/nation/XK with metadata.nation = 'IT': path/body key
+        // mismatch must be rejected before any create-condition checks (including the
+        // "already exists" / ISO-region gate in checkNationalCalendarConditions).
+        $payload = [
+            'litcal'   => [
+                [
+                    'liturgical_event' => ['event_key' => 'StGeorgeMartyr', 'grade' => 4],
+                    'metadata'         => ['action' => 'makePatron', 'since_year' => 1868, 'url' => 'https://www.vatican.va/'],
+                ],
+            ],
+            'settings' => [
+                'epiphany'               => 'JAN6',
+                'ascension'              => 'SUNDAY',
+                'corpus_christi'         => 'SUNDAY',
+                'eternal_high_priest'    => false,
+                'holydays_of_obligation' => [
+                    'Christmas'            => true,
+                    'Epiphany'             => false,
+                    'Ascension'            => false,
+                    'CorpusChristi'        => false,
+                    'MaryMotherOfGod'      => true,
+                    'ImmaculateConception' => true,
+                    'Assumption'           => true,
+                    'StJoseph'             => false,
+                    'StsPeterPaulAp'       => false,
+                    'AllSaints'            => false,
+                ],
+            ],
+            'metadata' => [
+                'nation'       => 'IT',
+                'wider_region' => 'Europe',
+                'missals'      => ['IT_1983'],
+                'locales'      => ['it_IT'],
+            ],
+            'i18n'     => [
+                'it_IT' => ['StGeorgeMartyr' => 'San Giorgio, Martire'],
+            ],
+        ];
+
+        $this->expectException(UnprocessableContentException::class);
+        $this->expectExceptionMessage('The key in the request path does not match the key in the payload');
+        ( new RegionalDataHandler(['nation', 'XK']) )->handle($this->requestFor('PUT', '/data/nation/XK', [], $payload));
     }
 
     public function testDeletePurgeFailureDoesNotFailDeletion(): void
@@ -343,9 +400,9 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
         }
 
         // --- Build handler with injected mock OutboxRepository ----------------
-        // PUT requests expect exactly ONE path param (the category); the nation
-        // key is derived from the payload body, not the URL.
-        $handler = new RegionalDataHandler(['nation']);
+        // PUT requests expect exactly TWO path params (category + key); the key
+        // in the path must match the nation key in the payload body.
+        $handler = new RegionalDataHandler(['nation', 'MT']);
 
         $repo = $this->createMock(OutboxBatchInsertInterface::class);
         $repo->expects($this->atLeastOnce())
@@ -425,7 +482,7 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
 
         try {
             // --- Act: issue PUT (bypasses JWT middleware — in-process) -------
-            $response = $handler->handle($this->requestFor('PUT', '/data/nation', [], $payload));
+            $response = $handler->handle($this->requestFor('PUT', '/data/nation/MT', [], $payload));
             self::assertContains($response->getStatusCode(), [200, 201]);
             // insertBatch assertion is enforced by the mock expectation above
         } finally {

--- a/phpunit_tests/Handlers/TestsHandlerTest.php
+++ b/phpunit_tests/Handlers/TestsHandlerTest.php
@@ -6,7 +6,9 @@ namespace LiturgicalCalendar\Tests\Handlers;
 
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Handlers\TestsHandler;
+use LiturgicalCalendar\Api\Http\Exception\ConflictException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -77,9 +79,73 @@ final class TestsHandlerTest extends AbstractHandlerTestCase
         // surfaces this as a ValidationException at the AbstractHandler layer before
         // TestsHandler's own object check fires.
         $this->expectException(ValidationException::class);
-        $req = $this->requestFor('PUT', '/tests', [], '[1, 2, 3]')
+        $req = $this->requestFor('PUT', '/tests/SomeTest', [], '[1, 2, 3]')
             ->withHeader('Content-Type', 'application/json');
-        ( new TestsHandler() )->handle($req);
+        ( new TestsHandler(['SomeTest']) )->handle($req);
+    }
+
+    public function testPutCreatesTestAtPathName(): void
+    {
+        /** @var array<string,mixed> $payload */
+        $payload         = json_decode(
+            (string) file_get_contents(JsonData::TESTS_FOLDER->path() . '/MaryMotherChurchTest.json'),
+            true
+        );
+        $payload['name'] = 'ZzzPutCreatedTest';
+
+        $this->testFixturePath = JsonData::TESTS_FOLDER->path() . '/ZzzPutCreatedTest.json';
+
+        $response = ( new TestsHandler(['ZzzPutCreatedTest']) )->handle(
+            $this->requestFor('PUT', '/tests/ZzzPutCreatedTest', [], $payload)
+        );
+
+        $this->assertSame(201, $response->getStatusCode());
+        $this->assertFileExists($this->testFixturePath);
+    }
+
+    public function testPutWithNoPathParamsIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new TestsHandler() )->handle(
+            $this->requestFor('PUT', '/tests', [], ['name' => 'SomeTest'])
+        );
+    }
+
+    public function testPutExistingTestConflicts(): void
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = json_decode(
+            (string) file_get_contents(JsonData::TESTS_FOLDER->path() . '/MaryMotherChurchTest.json'),
+            true
+        );
+
+        $this->expectException(ConflictException::class);
+        ( new TestsHandler(['MaryMotherChurchTest']) )->handle(
+            $this->requestFor('PUT', '/tests/MaryMotherChurchTest', [], $payload)
+        );
+    }
+
+    public function testPutBodyNameMismatchIsRejected(): void
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = json_decode(
+            (string) file_get_contents(JsonData::TESTS_FOLDER->path() . '/MaryMotherChurchTest.json'),
+            true
+        );
+        // Body says MaryMotherChurchTest, path says ZzzOtherTest.
+
+        $this->expectException(UnprocessableContentException::class);
+        ( new TestsHandler(['ZzzOtherTest']) )->handle(
+            $this->requestFor('PUT', '/tests/ZzzOtherTest', [], $payload)
+        );
+    }
+
+    public function testPutUnsafePathNameIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new TestsHandler(['..']) )->handle(
+            $this->requestFor('PUT', '/tests/..', [], ['name' => '..'])
+        );
     }
 
     public function testDeleteRejectsWrongPathParamCount(): void

--- a/phpunit_tests/Handlers/TestsHandlerTest.php
+++ b/phpunit_tests/Handlers/TestsHandlerTest.php
@@ -148,6 +148,71 @@ final class TestsHandlerTest extends AbstractHandlerTestCase
         );
     }
 
+    public function testPatchUpdatesExistingTest(): void
+    {
+        /** @var array<string,mixed> $payload */
+        $payload         = json_decode(
+            (string) file_get_contents(JsonData::TESTS_FOLDER->path() . '/MaryMotherChurchTest.json'),
+            true
+        );
+        $payload['name'] = 'ZzzPatchTargetTest';
+
+        // Seed the fixture on disk, then PATCH it with an updated description.
+        $this->testFixturePath = JsonData::TESTS_FOLDER->path() . '/ZzzPatchTargetTest.json';
+        file_put_contents($this->testFixturePath, json_encode($payload, JSON_THROW_ON_ERROR));
+
+        $payload['description'] = 'Updated description via PATCH';
+
+        $response = ( new TestsHandler(['ZzzPatchTargetTest']) )->handle(
+            $this->requestFor('PATCH', '/tests/ZzzPatchTargetTest', [], $payload)
+        );
+
+        $this->assertSame(200, $response->getStatusCode());
+        /** @var array<string,mixed> $written */
+        $written = json_decode((string) file_get_contents($this->testFixturePath), true);
+        $this->assertSame('Updated description via PATCH', $written['description']);
+    }
+
+    public function testPatchWithNoPathParamsIsValidationError(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new TestsHandler() )->handle(
+            $this->requestFor('PATCH', '/tests', [], ['name' => 'SomeTest'])
+        );
+    }
+
+    public function testPatchNonexistentTestIsUnprocessable(): void
+    {
+        /** @var array<string,mixed> $payload */
+        $payload         = json_decode(
+            (string) file_get_contents(JsonData::TESTS_FOLDER->path() . '/MaryMotherChurchTest.json'),
+            true
+        );
+        $payload['name'] = 'ZzzNoSuchTest';
+
+        $this->expectException(UnprocessableContentException::class);
+        $this->expectExceptionMessage('does not exist');
+        ( new TestsHandler(['ZzzNoSuchTest']) )->handle(
+            $this->requestFor('PATCH', '/tests/ZzzNoSuchTest', [], $payload)
+        );
+    }
+
+    public function testPatchBodyNameMismatchIsRejected(): void
+    {
+        /** @var array<string,mixed> $payload */
+        $payload = json_decode(
+            (string) file_get_contents(JsonData::TESTS_FOLDER->path() . '/MaryMotherChurchTest.json'),
+            true
+        );
+        // Body names an existing test, but the path addresses a different one.
+
+        $this->expectException(UnprocessableContentException::class);
+        $this->expectExceptionMessage('This is not allowed');
+        ( new TestsHandler(['ZzzOtherTest']) )->handle(
+            $this->requestFor('PATCH', '/tests/ZzzOtherTest', [], $payload)
+        );
+    }
+
     public function testDeleteRejectsWrongPathParamCount(): void
     {
         $this->expectException(ValidationException::class);

--- a/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
+++ b/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
@@ -528,13 +528,16 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
 
         $middleware = OpenFgaAuthorizationMiddleware::forTestScopes($client, $scopeResolver);
 
-        $body    = (string) json_encode(['applies_to' => ['national_calendar' => 'NL']]);
+        $payload = ['applies_to' => ['national_calendar' => 'NL']];
+        $body    = (string) json_encode($payload);
         $request = ( new ServerRequest('PUT', '/tests/BrandNewTest', [], $body) )
+            ->withParsedBody($payload)
             ->withAttribute('oidc_user', ['sub' => 'user-123', 'roles' => ['test_editor']])
             ->withAttribute('test_id', 'BrandNewTest');
 
-        // The middleware reads and rewinds the request body to resolve the FGA scope.
-        // Pin that the downstream handler can still read the same body afterwards.
+        // The middleware resolves the FGA scope from getParsedBody() (populated by
+        // JsonBodyParserMiddleware in production) and must not consume the stream.
+        // Pin that the downstream handler can still read the raw body afterwards.
         $downstreamHandler = new class ($body) implements RequestHandlerInterface {
             public function __construct(private string $expectedBody)
             {
@@ -543,8 +546,8 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 // Use getContents() (like AbstractHandler::parseBodyPayload), NOT (string) casting:
-                // StreamTrait::__toString() rewinds unconditionally, which would mask a missing
-                // rewind() in the middleware and make this assertion tautological.
+                // StreamTrait::__toString() rewinds unconditionally, which would mask any
+                // stream consumption in the middleware and make this assertion tautological.
                 $received = $request->getBody()->getContents();
                 if ($received === '') {
                     throw new \RuntimeException('Downstream handler received an empty body.');
@@ -576,6 +579,8 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
 
         $middleware = OpenFgaAuthorizationMiddleware::forTestScopes($client, $scopeResolver);
 
+        // No withParsedBody(): an unparseable body means JsonBodyParserMiddleware
+        // leaves getParsedBody() null, so the scope fallback fails closed.
         $request = ( new ServerRequest('PUT', '/tests/BrandNewTest', [], 'not-json') )
             ->withAttribute('oidc_user', ['sub' => 'user-123', 'roles' => ['test_editor']])
             ->withAttribute('test_id', 'BrandNewTest');

--- a/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
+++ b/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
@@ -511,4 +511,71 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
         $response = $middleware->process($request, $this->nextHandler);
         $this->assertEquals(200, $response->getStatusCode());
     }
+
+    public function testForTestScopesPutCreateResolvesScopeFromPayload(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->once())
+            ->method('check')
+            ->with('user:user-123', 'editor', 'national_calendar_test:NL')
+            ->willReturn(true);
+
+        // Empty temp dir: the test file does NOT exist (create flow).
+        $tempDir = sys_get_temp_dir() . '/fga_test_' . uniqid();
+        mkdir($tempDir);
+        $this->tempPaths[] = $tempDir;
+        $scopeResolver     = new TestScopeResolver($tempDir);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forTestScopes($client, $scopeResolver);
+
+        $body    = (string) json_encode(['applies_to' => ['national_calendar' => 'NL']]);
+        $request = ( new ServerRequest('PUT', '/tests/BrandNewTest', [], $body) )
+            ->withAttribute('oidc_user', ['sub' => 'user-123', 'roles' => ['test_editor']])
+            ->withAttribute('test_id', 'BrandNewTest');
+
+        $response = $middleware->process($request, $this->nextHandler);
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testForTestScopesPutCreateUnparseableBodyIsForbidden(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->never())->method('check');
+
+        $tempDir = sys_get_temp_dir() . '/fga_test_' . uniqid();
+        mkdir($tempDir);
+        $this->tempPaths[] = $tempDir;
+        $scopeResolver     = new TestScopeResolver($tempDir);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forTestScopes($client, $scopeResolver);
+
+        $request = ( new ServerRequest('PUT', '/tests/BrandNewTest', [], 'not-json') )
+            ->withAttribute('oidc_user', ['sub' => 'user-123', 'roles' => ['test_editor']])
+            ->withAttribute('test_id', 'BrandNewTest');
+
+        $this->expectException(ForbiddenException::class);
+        $middleware->process($request, $this->nextHandler);
+    }
+
+    public function testForTestScopesPatchMissingFileStillFailsClosed(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->never())->method('check');
+
+        $tempDir = sys_get_temp_dir() . '/fga_test_' . uniqid();
+        mkdir($tempDir);
+        $this->tempPaths[] = $tempDir;
+        $scopeResolver     = new TestScopeResolver($tempDir);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forTestScopes($client, $scopeResolver);
+
+        // PATCH must NOT fall back to the payload: the resource must already exist.
+        $body    = (string) json_encode(['applies_to' => ['national_calendar' => 'NL']]);
+        $request = ( new ServerRequest('PATCH', '/tests/BrandNewTest', [], $body) )
+            ->withAttribute('oidc_user', ['sub' => 'user-123', 'roles' => ['test_editor']])
+            ->withAttribute('test_id', 'BrandNewTest');
+
+        $this->expectException(ForbiddenException::class);
+        $middleware->process($request, $this->nextHandler);
+    }
 }

--- a/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
+++ b/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
@@ -533,7 +533,34 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
             ->withAttribute('oidc_user', ['sub' => 'user-123', 'roles' => ['test_editor']])
             ->withAttribute('test_id', 'BrandNewTest');
 
-        $response = $middleware->process($request, $this->nextHandler);
+        // The middleware reads and rewinds the request body to resolve the FGA scope.
+        // Pin that the downstream handler can still read the same body afterwards.
+        $downstreamHandler = new class ($body) implements RequestHandlerInterface {
+            public function __construct(private string $expectedBody)
+            {
+            }
+
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                // Use getContents() (like AbstractHandler::parseBodyPayload), NOT (string) casting:
+                // StreamTrait::__toString() rewinds unconditionally, which would mask a missing
+                // rewind() in the middleware and make this assertion tautological.
+                $received = $request->getBody()->getContents();
+                if ($received === '') {
+                    throw new \RuntimeException('Downstream handler received an empty body.');
+                }
+
+                $decoded         = json_decode($received, true);
+                $expectedDecoded = json_decode($this->expectedBody, true);
+                if ($decoded !== $expectedDecoded) {
+                    throw new \RuntimeException('Downstream handler received a different body than expected.');
+                }
+
+                return new Response(200);
+            }
+        };
+
+        $response = $middleware->process($request, $downstreamHandler);
         $this->assertEquals(200, $response->getStatusCode());
     }
 

--- a/phpunit_tests/Http/RouterPipelineTest.php
+++ b/phpunit_tests/Http/RouterPipelineTest.php
@@ -342,13 +342,13 @@ final class RouterPipelineTest extends TestCase
         }
     }
 
-    public function testMissalsWithoutIdRequiresAdminAndSkipsFga(): void
+    public function testMissalsWithoutIdUsesCalendarEditorAndSkipsFga(): void
     {
         $router   = $this->routerWithoutConstructor();
         $pipeline = $this->emptyPipeline();
 
-        // A collection-level write (no missal id) cannot be resource-authorized, so it must
-        // fail closed to admin rather than fall back to calendar_editor + no FGA check.
+        // Collection-level writes are no longer routed (PUT moved to /missals/{missal_id});
+        // an id-less write is still role-gated but only ever reaches the handler's 405.
         $this->callConfigurePipeline($router, $pipeline, 'missals', []);
 
         $queue = $this->getQueue($pipeline);
@@ -361,7 +361,7 @@ final class RouterPipelineTest extends TestCase
             }
         }
         self::assertNotNull($authMw, 'Expected an AuthorizationMiddleware for an id-less missals write');
-        self::assertSame('admin', $this->getPrivateProp($authMw, 'requiredRole'));
+        self::assertSame('calendar_editor', $this->getPrivateProp($authMw, 'requiredRole'));
 
         foreach ($queue as $mw) {
             self::assertNotInstanceOf(

--- a/phpunit_tests/Routes/ReadWrite/RegionalDataTest.php
+++ b/phpunit_tests/Routes/ReadWrite/RegionalDataTest.php
@@ -329,7 +329,7 @@ JSON;
             'body'    => self::$existingBody
         ]);
         $this->assertSame(400, $putResponse->getStatusCode(), 'Expected HTTP 400 Bad Request for PUT without path params');
-        $this->validatePutNoPathParametersErrorResponse($putResponse);
+        $this->validateWriteNoPathParametersErrorResponse($putResponse);
 
         // PATCH without path params should return 400 (expects two path params)
         $patchResponse = self::$http->patch('/data', [
@@ -340,14 +340,14 @@ JSON;
             'body'    => self::$existingBody
         ]);
         $this->assertSame(400, $patchResponse->getStatusCode(), 'Expected HTTP 400 Bad Request for PATCH without path params');
-        $this->validatePatchDeleteNoPathParametersErrorResponse($patchResponse);
+        $this->validateWriteNoPathParametersErrorResponse($patchResponse);
 
         // DELETE without path params should return 400 (expects two path params)
         $deleteResponse = self::$http->delete('/data', [
             'headers' => self::authHeaders($token)
         ]);
         $this->assertSame(400, $deleteResponse->getStatusCode(), 'Expected HTTP 400 Bad Request for DELETE without path params');
-        $this->validatePatchDeleteNoPathParametersErrorResponse($deleteResponse);
+        $this->validateWriteNoPathParametersErrorResponse($deleteResponse);
     }
 
     public function deleteCalendarDataNationStillHeldByDiocesanCalendarsReturnsError(\Psr\Http\Message\ResponseInterface $response): void
@@ -390,13 +390,7 @@ JSON;
         $this->assertSame('Expected at least two and at most three path params for GET and POST requests, received 1', $description);
     }
 
-    private function validatePutNoPathParametersErrorResponse(\Psr\Http\Message\ResponseInterface $response, string $content_type = 'application/problem+json'): void
-    {
-        $description = $this->validateRequestNoPathParametersErrorResponse($response, $content_type);
-        $this->assertSame('Expected two path params for PUT, PATCH and DELETE requests, received 0', $description);
-    }
-
-    private function validatePatchDeleteNoPathParametersErrorResponse(\Psr\Http\Message\ResponseInterface $response, string $content_type = 'application/problem+json'): void
+    private function validateWriteNoPathParametersErrorResponse(\Psr\Http\Message\ResponseInterface $response, string $content_type = 'application/problem+json'): void
     {
         $description = $this->validateRequestNoPathParametersErrorResponse($response, $content_type);
         $this->assertSame('Expected two path params for PUT, PATCH and DELETE requests, received 0', $description);

--- a/phpunit_tests/Routes/ReadWrite/RegionalDataTest.php
+++ b/phpunit_tests/Routes/ReadWrite/RegionalDataTest.php
@@ -97,10 +97,12 @@ JSON;
         $requests = [
             [ 'uri' => '/data/nation/', 'method' => 'GET' ],
             [ 'uri' => '/data/nation/', 'method' => 'POST' ],
+            [ 'uri' => '/data/nation/', 'method' => 'PUT' ],
             [ 'uri' => '/data/nation/', 'method' => 'PATCH' ],
             [ 'uri' => '/data/nation/', 'method' => 'DELETE' ],
             [ 'uri' => '/data/diocese/', 'method' => 'GET' ],
             [ 'uri' => '/data/diocese/', 'method' => 'POST' ],
+            [ 'uri' => '/data/diocese/', 'method' => 'PUT' ],
             [ 'uri' => '/data/diocese/', 'method' => 'PATCH' ],
             [ 'uri' => '/data/diocese/', 'method' => 'DELETE' ],
         ];
@@ -118,9 +120,9 @@ JSON;
                         ->then(
                             function (ResponseInterface $response) use ($idx, $request, &$responses) {
                                 $responses[$idx] = $response;
-                                // PATCH and DELETE require authentication and return 401
+                                // PUT, PATCH and DELETE require authentication and return 401
                                 // GET and POST don't require authentication and return 400 for invalid parameters
-                                $expectedCode = in_array($request['method'], ['PATCH', 'DELETE'], true) ? 401 : 400;
+                                $expectedCode = in_array($request['method'], ['PUT', 'PATCH', 'DELETE'], true) ? 401 : 400;
                                 if ($response->getStatusCode() !== $expectedCode) {
                                     throw new \RuntimeException(
                                         "Expected HTTP $expectedCode for {$request['method']} {$request['uri']}, got {$response->getStatusCode()}"
@@ -152,16 +154,16 @@ JSON;
 
         foreach ($responses as $idx => $response) {
             $request = $requests[$idx];
-            // PATCH and DELETE require authentication and return 401
+            // PUT, PATCH and DELETE require authentication and return 401
             // GET and POST don't require authentication and return 400 for invalid parameters
-            $expectedCode = in_array($request['method'], ['PATCH', 'DELETE'], true) ? 401 : 400;
+            $expectedCode = in_array($request['method'], ['PUT', 'PATCH', 'DELETE'], true) ? 401 : 400;
             $this->assertSame(
                 $expectedCode,
                 $response->getStatusCode(),
                 "Expected HTTP $expectedCode for {$request['method']} {$request['uri']}, got {$response->getStatusCode()}"
             );
             // For GET and POST, validate the error detail message
-            // For PATCH and DELETE, we get 401 before the handler logic
+            // For PUT, PATCH and DELETE, we get 401 before the handler logic
             if (in_array($request['method'], ['GET', 'POST'], true)) {
                 $this->validateGetPostNationalOrDiocesanCalendarDataNoIdentifierErrorResponse($response);
             }
@@ -173,7 +175,7 @@ JSON;
         // Note: These requests return 401 Unauthorized because JWT authentication is required
         // for PUT/PATCH operations. Without authentication, the request doesn't reach the
         // Content-Type validation. To test Content-Type validation, authentication must be provided.
-        $putResponse = self::$http->put('/data/nation', []);
+        $putResponse = self::$http->put('/data/nation/IT', []);
         $this->assertSame(401, $putResponse->getStatusCode(), 'Expected HTTP 401 Unauthorized (authentication required for PUT)');
         $patchResponse = self::$http->patch('/data/nation/IT', []);
         $this->assertSame(401, $patchResponse->getStatusCode(), 'Expected HTTP 401 Unauthorized (authentication required for PATCH)');
@@ -209,7 +211,7 @@ JSON;
         // Note: This request returns 401 Unauthorized because JWT authentication is required
         // for PUT operations. Without authentication, the request doesn't reach the handler
         // logic that would check for existing calendars (409 Conflict).
-        $response = self::$http->put('/data/nation', [
+        $response = self::$http->put('/data/nation/CA', [
             'headers' => [ 'Content-Type' => 'application/json' ],
             'body'    => self::$existingBody
         ]);
@@ -242,7 +244,7 @@ JSON;
         $token = self::getJwtToken();
         $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
 
-        $response = self::$http->put('/data/nation', [
+        $response = self::$http->put('/data/nation/CA', [
             'headers' => array_merge(
                 self::authHeaders($token),
                 [ 'Content-Type' => 'application/json' ]
@@ -291,7 +293,7 @@ JSON;
         $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
 
         // PUT without Content-Type
-        $putResponse = self::$http->put('/data/nation', [
+        $putResponse = self::$http->put('/data/nation/CA', [
             'headers' => self::authHeaders($token),
             'body'    => self::$existingBody
         ]);
@@ -318,7 +320,7 @@ JSON;
         $token = self::getJwtToken();
         $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
 
-        // PUT without path params should return 400 (expects one path param)
+        // PUT without path params should return 400 (expects two path params)
         $putResponse = self::$http->put('/data', [
             'headers' => array_merge(
                 self::authHeaders($token),
@@ -391,12 +393,12 @@ JSON;
     private function validatePutNoPathParametersErrorResponse(\Psr\Http\Message\ResponseInterface $response, string $content_type = 'application/problem+json'): void
     {
         $description = $this->validateRequestNoPathParametersErrorResponse($response, $content_type);
-        $this->assertSame('Expected one path param for PUT requests, received 0', $description);
+        $this->assertSame('Expected two path params for PUT, PATCH and DELETE requests, received 0', $description);
     }
 
     private function validatePatchDeleteNoPathParametersErrorResponse(\Psr\Http\Message\ResponseInterface $response, string $content_type = 'application/problem+json'): void
     {
         $description = $this->validateRequestNoPathParametersErrorResponse($response, $content_type);
-        $this->assertSame('Expected two path params for PATCH and DELETE requests, received 0', $description);
+        $this->assertSame('Expected two path params for PUT, PATCH and DELETE requests, received 0', $description);
     }
 }

--- a/phpunit_tests/Services/TestScopeResolverTest.php
+++ b/phpunit_tests/Services/TestScopeResolverTest.php
@@ -82,4 +82,46 @@ final class TestScopeResolverTest extends TestCase
         // Non-existent file: no traversal, just a missing file → null
         $this->assertNull($r->resolve('Valid-Test_Name-123'));
     }
+
+    public function testResolveFromPayloadNational(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['national_calendar_test', 'NL'],
+            $r->resolveFromPayload(['applies_to' => ['national_calendar' => 'NL']])
+        );
+    }
+
+    public function testResolveFromPayloadDiocesan(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['diocesan_calendar_test', 'romamo_it'],
+            $r->resolveFromPayload(['applies_to' => ['diocesan_calendar' => 'romamo_it']])
+        );
+    }
+
+    public function testResolveFromPayloadDefaultsToGeneralRoman(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['general_roman_calendar_test', 'general_roman_calendar'],
+            $r->resolveFromPayload(['name' => 'SomeTest'])
+        );
+    }
+
+    public function testResolveFromPayloadReturnsNullForNonArray(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertNull($r->resolveFromPayload(null));
+        $this->assertNull($r->resolveFromPayload('not-json'));
+    }
+
+    public function testIsSafeName(): void
+    {
+        $this->assertTrue(TestScopeResolver::isSafeName('Foo_Test-1'));
+        $this->assertFalse(TestScopeResolver::isSafeName('..'));
+        $this->assertFalse(TestScopeResolver::isSafeName('a/b'));
+        $this->assertFalse(TestScopeResolver::isSafeName(''));
+    }
 }

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -1324,16 +1324,12 @@ final class RegionalDataHandler extends AbstractHandler
                 }
                 break;
             case RequestMethod::PUT:
-                if (count($this->requestPathParams) !== 1) {
-                    $description = 'Expected one path param for PUT requests, received ' . count($this->requestPathParams);
-                    throw new ValidationException($description);
-                }
-                break;
+                // no break (intentional fallthrough)
             case RequestMethod::PATCH:
                 // no break (intentional fallthrough)
             case RequestMethod::DELETE:
                 if (count($this->requestPathParams) !== 2) {
-                    $description = 'Expected two path params for PATCH and DELETE requests, received ' . count($this->requestPathParams);
+                    $description = 'Expected two path params for PUT, PATCH and DELETE requests, received ' . count($this->requestPathParams);
                     throw new ValidationException($description);
                 }
                 break;
@@ -1602,11 +1598,11 @@ final class RegionalDataHandler extends AbstractHandler
         $params = [];
 
         // We always expect the category to be set in the request path
-        // We expect the key to be set in the request path for GET, POST, PATCH and DELETE requests
+        // We expect the key to be set in the request path for all request methods
         $this->validateRequestPath($request);
 
         $params['category'] = PathCategory::from($this->requestPathParams[0]);
-        if (in_array($method, [RequestMethod::GET, RequestMethod::POST, RequestMethod::PATCH, RequestMethod::DELETE], true)) {
+        if (in_array($method, [RequestMethod::GET, RequestMethod::POST, RequestMethod::PUT, RequestMethod::PATCH, RequestMethod::DELETE], true)) {
             $params['key'] = $this->requestPathParams[1];
         }
 
@@ -1685,12 +1681,8 @@ final class RegionalDataHandler extends AbstractHandler
             if (false === isset($key)) {
                 throw new ValidationException('Invalid payload, could not extract diocese_id, nation or wider_region accordingly');
             }
-            if ($method === RequestMethod::PUT) {
-                $params['key'] = $key;
-            } else {
-                if ($params['key'] !== $key) {
-                    throw new UnprocessableContentException('The key in the request path does not match the key in the payload');
-                }
+            if ($params['key'] !== $key) {
+                throw new UnprocessableContentException('The key in the request path does not match the key in the payload');
             }
             /** @var array{category:PathCategory,key:string,i18n?:string,locale:string,payload:DiocesanData|NationalData|WiderRegionData,rawPayload:\stdClass} $params */
         }

--- a/src/Handlers/TestsHandler.php
+++ b/src/Handlers/TestsHandler.php
@@ -12,6 +12,7 @@ use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use LiturgicalCalendar\Api\JsonFormatter;
 use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
 use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Exception\ConflictException;
 use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
@@ -242,19 +243,24 @@ final class TestsHandler extends AbstractHandler
     }
 
     /**
-     * Handles PUT requests for creating or updating a specific test.
+     * Handles PUT requests for creating a specific test at /tests/{test_name}.
      *
-     * This method expects no path parameters. The request body is expected to contain a JSON object
-     * which is validated against the LitCalTest JSON schema. If the validation fails, it returns a 422
-     * Unprocessable Content error response. If the validation succeeds, it attempts to write the JSON
-     * object to disk as a file in the tests directory. If the write fails, it returns a 503 Service Unavailable
-     * error response. If the write succeeds, it returns a 201 Created response with a JSON object indicating
-     * the resource has been created or updated.
+     * The test name in the request path is authoritative; the payload's `name`
+     * must match it. The payload is validated against the LitCalTest JSON schema
+     * (422 on failure). If a test with the same name already exists a 409 Conflict
+     * is returned. On success the test is written to disk and a 201 Created
+     * response is returned.
      */
     private function handlePutRequest(ResponseInterface $response): ResponseInterface
     {
-        if (count($this->requestPathParams)) {
-            $description = 'Expected no path params for PUT requests, received ' . count($this->requestPathParams) . '. Please use the base /tests endpoint for PUT requests.';
+        if (count($this->requestPathParams) !== 1) {
+            $description = 'Expected one and only one path param for PUT requests, received ' . count($this->requestPathParams) . '.';
+            throw new ValidationException($description);
+        }
+
+        $testName = $this->requestPathParams[0];
+        if (false === TestScopeResolver::isSafeName($testName)) {
+            $description = 'The Unit Test name in the request path may only contain letters, digits, hyphens and underscores.';
             throw new ValidationException($description);
         }
 
@@ -266,10 +272,16 @@ final class TestsHandler extends AbstractHandler
             throw new UnprocessableContentException($description);
         }
 
-        $testFilePath = JsonData::TESTS_FOLDER->path() . '/' . $this->payload->name . '.json';
-        if (file_exists($testFilePath)) {
-            $description = 'A Unit Test with the name ' . $this->payload->name . ' already exists. Did you perhaps mean to use a PATCH request?';
+        if ($this->payload->name !== $testName) {
+            $description = 'You are attempting to create the Unit Test at /tests/' . $testName . ' with a Unit Test that has the name '
+                . $this->payload->name . ' in the request body. This is not allowed.';
             throw new UnprocessableContentException($description);
+        }
+
+        $testFilePath = JsonData::TESTS_FOLDER->path() . '/' . $testName . '.json';
+        if (file_exists($testFilePath)) {
+            $description = 'A Unit Test with the name ' . $testName . ' already exists. Did you perhaps mean to use a PATCH request?';
+            throw new ConflictException($description);
         }
 
         $jsonEncodedTest = JsonFormatter::encode($this->payload, false);
@@ -279,12 +291,12 @@ final class TestsHandler extends AbstractHandler
             throw new ServiceUnavailableException($description);
         }
 
-        $responseBody = (object) ['response' => 'Unit Test ' . $this->payload->name . ' created successfully.'];
+        $responseBody = (object) ['response' => 'Unit Test ' . $testName . ' created successfully.'];
         return $this->encodeResponseBody($response, $responseBody, StatusCode::CREATED);
     }
 
     /**
-     * Handles PUT requests for creating or updating a specific test.
+     * Handles PATCH requests for updating a specific test at /tests/{test_name}.
      *
      * This method expects no path parameters. The request body is expected to contain a JSON object
      * which is validated against the LitCalTest JSON schema. If the validation fails, it returns a 422

--- a/src/Handlers/TestsHandler.php
+++ b/src/Handlers/TestsHandler.php
@@ -284,15 +284,25 @@ final class TestsHandler extends AbstractHandler
             throw new ConflictException($description);
         }
 
+        $this->writeTestToDisk($testFilePath);
+
+        $responseBody = (object) ['response' => 'Unit Test ' . $testName . ' created successfully.'];
+        return $this->encodeResponseBody($response, $responseBody, StatusCode::CREATED);
+    }
+
+    /**
+     * Writes the current payload to disk as a Unit Test JSON file.
+     *
+     * @throws ServiceUnavailableException When the write to disk fails
+     */
+    private function writeTestToDisk(string $testFilePath): void
+    {
         $jsonEncodedTest = JsonFormatter::encode($this->payload, false);
         $bytesWritten    = file_put_contents($testFilePath, $jsonEncodedTest);
         if (false === $bytesWritten) {
             $description = 'The server did not succeed in writing to disk the Unit Test. Please try again later or contact the service administrator for support.';
             throw new ServiceUnavailableException($description);
         }
-
-        $responseBody = (object) ['response' => 'Unit Test ' . $testName . ' created successfully.'];
-        return $this->encodeResponseBody($response, $responseBody, StatusCode::CREATED);
     }
 
     /**
@@ -322,25 +332,22 @@ final class TestsHandler extends AbstractHandler
             throw new UnprocessableContentException($description);
         }
 
-        $testFilePath = JsonData::TESTS_FOLDER->path() . '/' . $this->payload->name . '.json';
+        $testName = $this->payload->name;
+
+        $testFilePath = JsonData::TESTS_FOLDER->path() . '/' . $testName . '.json';
         if (false === file_exists($testFilePath)) {
-            $description = 'A Unit Test with the name ' . $this->payload->name . ' does not exist. Did you perhaps mean to use a PUT request?';
+            $description = 'A Unit Test with the name ' . $testName . ' does not exist. Did you perhaps mean to use a PUT request?';
             throw new UnprocessableContentException($description);
         }
 
-        if ($this->payload->name !== $this->requestPathParams[0]) {
-            $description = 'You are attempting to update the Unit Test at /tests/' . $this->requestPathParams[0] . ' with a Unit Test that has the name ' . $this->payload->name . ' in the request body. This is not allowed.';
+        if ($testName !== $this->requestPathParams[0]) {
+            $description = 'You are attempting to update the Unit Test at /tests/' . $this->requestPathParams[0] . ' with a Unit Test that has the name ' . $testName . ' in the request body. This is not allowed.';
             throw new UnprocessableContentException($description);
         }
 
-        $jsonEncodedTest = JsonFormatter::encode($this->payload, false);
-        $bytesWritten    = file_put_contents($testFilePath, $jsonEncodedTest);
-        if (false === $bytesWritten) {
-            $description = 'The server did not succeed in writing to disk the Unit Test. Please try again later or contact the service administrator for support.';
-            throw new ServiceUnavailableException($description);
-        }
+        $this->writeTestToDisk($testFilePath);
 
-        $responseBody = (object) ['response' => 'Unit Test ' . $this->payload->name . ' updated successfully.'];
+        $responseBody = (object) ['response' => 'Unit Test ' . $testName . ' updated successfully.'];
         return $this->encodeResponseBody($response, $responseBody);
     }
 

--- a/src/Handlers/TestsHandler.php
+++ b/src/Handlers/TestsHandler.php
@@ -298,12 +298,14 @@ final class TestsHandler extends AbstractHandler
     /**
      * Handles PATCH requests for updating a specific test at /tests/{test_name}.
      *
-     * This method expects no path parameters. The request body is expected to contain a JSON object
-     * which is validated against the LitCalTest JSON schema. If the validation fails, it returns a 422
-     * Unprocessable Content error response. If the validation succeeds, it attempts to write the JSON
-     * object to disk as a file in the tests directory. If the write fails, it returns a 503 Service Unavailable
-     * error response. If the write succeeds, it returns a 201 Created response with a JSON object indicating
-     * the resource has been created or updated.
+     * This method expects exactly one path parameter: the name of the test to update. The request body
+     * is expected to contain a JSON object which is validated against the LitCalTest JSON schema; if the
+     * validation fails, it returns a 422 Unprocessable Content error response. It also returns a 422 error
+     * if a Unit Test with the given name does not already exist, or if the `name` in the request body does
+     * not match the `test_name` path parameter. If validation succeeds, it attempts to write the JSON object
+     * to disk as a file in the tests directory; if the write fails, it returns a 503 Service Unavailable
+     * error response. If the write succeeds, it returns a 200 response with a JSON object indicating the
+     * resource has been updated.
      */
     private function handlePatchRequest(ResponseInterface $response): ResponseInterface
     {

--- a/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
+++ b/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
@@ -233,8 +233,9 @@ final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
      *
      * The `test_id` request attribute is passed to `$resolver->resolve()` to
      * derive the FGA [objectType, objectId] pair at request time. If the
-     * attribute is absent or the resolver returns null the request is denied
-     * (fail-closed).
+     * attribute is absent or the scope cannot be resolved the request is denied
+     * (fail-closed). For PUT (create), when no file exists yet, the scope is
+     * resolved from the request payload's `applies_to`.
      *
      * @param OpenFgaClient     $client   The OpenFGA client
      * @param TestScopeResolver $resolver Scope resolver for the test
@@ -247,7 +248,23 @@ final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
             if (!is_string($testId) || trim($testId) === '') {
                 return null;
             }
-            return $resolver->resolve($testId);
+            $resolved = $resolver->resolve($testId);
+            if (
+                $resolved === null
+                && strtoupper($request->getMethod()) === 'PUT'
+                && TestScopeResolver::isSafeName($testId)
+            ) {
+                // Create flow: the test file does not exist yet, so derive the scope
+                // from the payload's `applies_to` — the same value the handler will
+                // persist, so the scope that authorizes the create is the scope the
+                // created resource will carry.
+                $body = (string) $request->getBody();
+                if ($request->getBody()->isSeekable()) {
+                    $request->getBody()->rewind();
+                }
+                $resolved = $resolver->resolveFromPayload(json_decode($body, true));
+            }
+            return $resolved;
         };
 
         // objectType and resourceIdAttribute are unused when objectResolver is set:

--- a/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
+++ b/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
@@ -257,12 +257,11 @@ final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
                 // Create flow: the test file does not exist yet, so derive the scope
                 // from the payload's `applies_to` — the same value the handler will
                 // persist, so the scope that authorizes the create is the scope the
-                // created resource will carry.
-                $body = (string) $request->getBody();
-                if ($request->getBody()->isSeekable()) {
-                    $request->getBody()->rewind();
-                }
-                $resolved = $resolver->resolveFromPayload(json_decode($body, true));
+                // created resource will carry. The payload comes from getParsedBody()
+                // (populated by JsonBodyParserMiddleware earlier in the pipeline)
+                // rather than the raw stream, so the body is never consumed here;
+                // a missing/unparseable body yields null and fails closed.
+                $resolved = $resolver->resolveFromPayload($request->getParsedBody());
             }
             return $resolved;
         };

--- a/src/Router.php
+++ b/src/Router.php
@@ -203,13 +203,13 @@ class Router
                 if (count($requestPathParts) === 0) {
                     $missalsHandler->setAllowedRequestMethods([
                         RequestMethod::GET,
-                        RequestMethod::POST,
-                        RequestMethod::PUT
+                        RequestMethod::POST
                     ]);
                 } elseif (count($requestPathParts) === 1) {
                     $missalsHandler->setAllowedRequestMethods([
                         RequestMethod::GET,
                         RequestMethod::POST,
+                        RequestMethod::PUT,
                         RequestMethod::PATCH,
                         RequestMethod::DELETE
                     ]);
@@ -461,12 +461,10 @@ class Router
                 $pathCount           = count($requestPathParts);
                 $firstInCategory     = $pathCount > 0 && in_array($requestPathParts[0], PathCategory::values(), true);
                 $allowedMethods      = match (true) {
-                    $pathCount === 0 => [],
-                    $pathCount === 1 && !$firstInCategory => [],
-                    $pathCount === 1 && $firstInCategory => [RequestMethod::PUT],
                     $pathCount === 2 && $firstInCategory => [
                         RequestMethod::GET,
                         RequestMethod::POST,
+                        RequestMethod::PUT,
                         RequestMethod::PATCH,
                         RequestMethod::DELETE
                     ],
@@ -498,13 +496,13 @@ class Router
                 if (count($requestPathParts) === 0) {
                     $testsHandler->setAllowedRequestMethods([
                         RequestMethod::GET,
-                        RequestMethod::POST,
-                        RequestMethod::PUT
+                        RequestMethod::POST
                     ]);
                 } elseif (count($requestPathParts) === 1) {
                     $testsHandler->setAllowedRequestMethods([
                         RequestMethod::GET,
                         RequestMethod::POST,
+                        RequestMethod::PUT,
                         RequestMethod::PATCH,
                         RequestMethod::DELETE
                     ]);
@@ -728,18 +726,13 @@ class Router
                 ));
             }
         } elseif ($route === 'missals') {
-            // The missal id identifies the resource being authorized. With an id, gate by
-            // calendar_editor + fine-grained FGA (Editio Typica -> general_roman_calendar,
-            // national missal -> national_calendar). Without an id (a collection-level write,
-            // e.g. creating a new missal) no resource-level check is possible, so fail closed
-            // to admin rather than falling back to role-only authorization.
-            if (count($requestPathParts) >= 1) {
-                $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
-                if ($oidcAvailable && $fgaClient !== null) {
-                    $pipeline->pipe(OpenFgaAuthorizationMiddleware::forMissals($fgaClient, $requestPathParts[0]));
-                }
-            } else {
-                $pipeline->pipe(AuthorizationMiddleware::forAdmin());
+            // Writes are authorized per-missal: calendar_editor role plus fine-grained FGA
+            // (Editio Typica -> general_roman_calendar, national missal -> national_calendar).
+            // Collection-level writes are no longer routed (PUT moved to /missals/{missal_id}),
+            // so an id-less write only ever reaches the handler's 405 Method Not Allowed.
+            $pipeline->pipe(AuthorizationMiddleware::forCalendarEditor());
+            if ($oidcAvailable && $fgaClient !== null && count($requestPathParts) >= 1) {
+                $pipeline->pipe(OpenFgaAuthorizationMiddleware::forMissals($fgaClient, $requestPathParts[0]));
             }
         }
     }

--- a/src/Services/TestScopeResolver.php
+++ b/src/Services/TestScopeResolver.php
@@ -29,6 +29,46 @@ final class TestScopeResolver
     }
 
     /**
+     * True when the given name is safe to use as a bare file-stem.
+     *
+     * Only letters, digits, hyphens, and underscores are allowed. This rejects
+     * '..', '/', '\', null bytes, spaces, and every other special character.
+     */
+    public static function isSafeName(string $testName): bool
+    {
+        return (bool) preg_match('/\A[A-Za-z0-9_-]+\z/', $testName);
+    }
+
+    /**
+     * Resolve the FGA scope pair for a test that does not yet exist on disk,
+     * using the decoded request payload's `applies_to` key (create flow).
+     *
+     * Mirrors the mapping applied by resolve() to the stored file, so the scope
+     * that authorizes the create is the same scope the created file will have.
+     *
+     * @param mixed $decoded The json_decode'd (assoc mode) request body
+     * @return array{0: string, 1: string}|null
+     */
+    public function resolveFromPayload(mixed $decoded): ?array
+    {
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        $appliesTo = $decoded['applies_to'] ?? null;
+
+        if (is_array($appliesTo) && isset($appliesTo['diocesan_calendar']) && is_string($appliesTo['diocesan_calendar'])) {
+            return ['diocesan_calendar_test', $appliesTo['diocesan_calendar']];
+        }
+
+        if (is_array($appliesTo) && isset($appliesTo['national_calendar']) && is_string($appliesTo['national_calendar'])) {
+            return ['national_calendar_test', $appliesTo['national_calendar']];
+        }
+
+        return ['general_roman_calendar_test', 'general_roman_calendar'];
+    }
+
+    /**
      * @return array{0: string, 1: string}|null
      */
     public function resolve(string $testName): ?array
@@ -37,7 +77,7 @@ final class TestScopeResolver
         // Only allow characters that are safe for use as a bare file-stem: letters,
         // digits, hyphens, and underscores. This rejects '..', '/', '\', null bytes,
         // spaces, and every other special character before touching the filesystem.
-        if (!preg_match('/\A[A-Za-z0-9_-]+\z/', $testName)) {
+        if (!self::isSafeName($testName)) {
             return null;
         }
 


### PR DESCRIPTION
## Summary

- `PUT /tests/{test_name}`, `PUT /data/{category}/{key}`, and (route shape only) `PUT /missals/{missal_id}` replace the id-in-body collection-level PUT creates, per RFC 9110 create-or-replace semantics.
- Path id is authoritative; body id must match (422). Creating over an existing resource returns 409 Conflict (the tests endpoint changed from 422 to 409).
- OpenFGA fine-grained authorization now covers creates (the id is in the path). Tests creates resolve their FGA scope from the payload's `applies_to` — the same value the created file will carry — so the scope that authorizes the create is the scope the resource ends up with. PATCH deliberately does not get this fallback (fail-closed).
- Legacy shapes after the cutover: `PUT /tests` and `PUT /missals` → 405 (401 unauthenticated); `PUT /data/{category}` → 400 with an explanatory message (RegionalDataHandler validates the path before the method — see the spec note).
- OpenAPI schema updated (put operations moved to per-item path items, tests PUT gains a 409 and a corrected 201 schema); README documents the RFC 9110 method semantics, including the deliberate POST-as-GET-synonym exception.

Design: `docs/superpowers/specs/2026-07-14-put-creation-paths-design.md`
Plan: `docs/superpowers/plans/2026-07-14-put-creation-paths.md`

## Verification

- PHPStan level 10, phpcs, parallel-lint, lint:openapi, lint:md: all clean
- Full suite: 1582/1585 (the 3 failures are `Routes/ReadWrite/RegionalDataTest` against the stale docker image on :8000; the same tests pass 13/13 against a live server running this branch)
- Mutation-checked test pins the middleware→handler body-readability seam (removing the middleware's `rewind()` makes it fail)

## Known deferred follow-ups (deliberate)

- `/data` success messages still say "created or updated" — stale wording now that PUT can't update; cosmetic
- YAML-body creates on `/tests` fail closed (403) when FGA is active: the FGA scope fallback only parses JSON. Fail-closed by design; worth documenting if YAML write clients ever materialize
- Spec-promised route-level 405 assertions for the missals shapes not added (pipeline-composition test covers the auth side)
- `TestScopeResolver::resolveFromPayload` intentionally mirrors `resolve()`'s branching; a shared helper could be extracted later

Coordinated frontend PR (merge after this): Liturgical-Calendar/LiturgicalCalendarFrontend (admin-tests.js, extending.js).

Closes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added national calendar source retrieval at `GET /data/nation/{key}`.
  * Enabled per-test creation at `PUT /tests/{test_name}`.

* **API Changes**
  * PUT/PATCH/DELETE now require identifier-specific paths; URL identifiers must match request-body identifiers.
  * Duplicate test creation now returns `409 Conflict`.
  * Updated missals write authorization and routing behavior for id-less requests.

* **Bug Fixes**
  * Improved validation for missing/incorrect path parameters and unsafe test names.

* **Documentation**
  * Updated HTTP method semantics (including RFC 9110-aligned PUT behavior) and endpoint contract details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->