### PR TITLE
chore: follow-ups deferred from #713 (PUT creation paths)

### DIFF
--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -3885,7 +3885,7 @@
                     "success": {
                       "type": "string",
                       "examples": [
-                        "National calendar created or updated for nation {NATION}"
+                        "National calendar created for nation {NATION}"
                       ]
                     }
                   },
@@ -4006,7 +4006,7 @@
                   "properties": {
                     "success": {
                       "type": "string",
-                      "example": "National calendar created or updated for nation {NATION}"
+                      "example": "National calendar updated for nation {NATION}"
                     }
                   },
                   "required": [
@@ -4169,7 +4169,7 @@
                     "success": {
                       "type": "string",
                       "examples": [
-                        "Diocesan calendar created or updated for diocese {DIOCESE}"
+                        "Diocesan calendar created for diocese {DIOCESE}"
                       ]
                     }
                   },
@@ -4289,7 +4289,7 @@
                   "properties": {
                     "success": {
                       "type": "string",
-                      "example": "Diocesan calendar created or updated for diocese {DIOCESE}"
+                      "example": "Diocesan calendar updated for diocese {DIOCESE}"
                     }
                   },
                   "required": [
@@ -4451,7 +4451,7 @@
                     "success": {
                       "type": "string",
                       "examples": [
-                        "Wider region calendar created or updated for region {REGION}"
+                        "Wider region calendar created for region {REGION}"
                       ]
                     }
                   },
@@ -4571,7 +4571,7 @@
                   "properties": {
                     "success": {
                       "type": "string",
-                      "example": "Wider region calendar created or updated for region {REGION}"
+                      "example": "Wider region calendar updated for region {REGION}"
                     }
                   },
                   "required": [
@@ -5358,7 +5358,7 @@
           }
         ],
         "summary": "Create a new unit test at its own URI in the API `tests` folder",
-        "description": "Create (`PUT`) requires the `editor` relation.",
+        "description": "Create (`PUT`) requires the `editor` relation. When fine-grained authorization (OpenFGA) is enabled, the request body must be JSON: the authorization scope is resolved from the parsed JSON payload's `applies_to`, so YAML or form-encoded bodies fail closed with a 403.",
         "operationId": "createTestByNamePUT",
         "parameters": [
           {

--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -370,22 +370,11 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
     }
 
     /**
-     * When a national calendar whose payload declares a wider_region is created
-     * via PUT, the handler must enqueue a WRITE_TUPLE outbox row that links
-     * `national_calendar:<N>` to `wider_region:<R>` via the `member_nation`
-     * relation.
-     *
-     * Malta (MT) is used as the fixture nation because:
-     * - It is a valid European nation code recognised by PHP's ICU locales.
-     * - It has no existing national calendar in the bundled source data, so
-     *   the PUT does not trigger a ResourceConflictException.
-     *
-     * The new MT files written by the handler are deleted unconditionally in
-     * tearDown via {@see cleanupMtFixture()} to keep the working tree clean.
+     * Registers the MT fixture paths for {@see cleanupMtFixture()} and skips
+     * the calling test if an MT national calendar unexpectedly already exists.
      */
-    public function testCreateNationalCalendarEnqueuesMemberNationTuple(): void
+    private function armMtFixture(): void
     {
-        // --- Arrange: record paths so tearDown can delete the new files -------
         $base              = Router::$apiFilePath . 'jsondata/sourcedata/calendars/nations/MT';
         $this->mtNationDir = $base;
         $this->mtJsonPath  = $base . '/MT.json';
@@ -395,36 +384,20 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
         // Defensive guard: if MT already exists (it shouldn't), skip.
         if (file_exists($this->mtJsonPath)) {
             $this->markTestSkipped(
-                'MT national-calendar file already exists; skipping enqueue test to avoid overwriting it.'
+                'MT national-calendar file already exists; skipping to avoid overwriting it.'
             );
         }
+    }
 
-        // --- Build handler with injected mock OutboxRepository ----------------
-        // PUT requests expect exactly TWO path params (category + key); the key
-        // in the path must match the nation key in the payload body.
-        $handler = new RegionalDataHandler(['nation', 'MT']);
-
-        $repo = $this->createMock(OutboxBatchInsertInterface::class);
-        $repo->expects($this->atLeastOnce())
-            ->method('insertBatch')
-            ->with($this->callback(function (array $rows): bool {
-                foreach ($rows as $r) {
-                    if (
-                        $r['fga_user'] === 'national_calendar:MT'
-                        && $r['fga_relation'] === 'member_nation'
-                        && $r['fga_object'] === 'wider_region:Europe'
-                    ) {
-                        return true;
-                    }
-                }
-                return false;
-            }))
-            ->willReturn([99]);
-        $handler->setOutboxRepository($repo);
-
-        // Build a valid PUT payload for Malta (MT) with wider_region=Europe.
-        // The i18n section is required by the PUT handler.
-        $payload = [
+    /**
+     * A schema-valid national-calendar PUT/PATCH payload for Malta (MT) with
+     * wider_region=Europe. The i18n section is required by the PUT/PATCH handlers.
+     *
+     * @return array<string,mixed>
+     */
+    private static function mtNationalCalendarPayload(): array
+    {
+        return [
             'litcal'   => [
                 [
                     'liturgical_event' => ['event_key' => 'StGeorgeMartyr', 'grade' => 4],
@@ -463,6 +436,79 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
                 'en_MT' => ['StGeorgeMartyr' => 'Saint George, Martyr, Patron of Malta'],
             ],
         ];
+    }
+
+    /**
+     * A successful PATCH on an existing national calendar must report the
+     * update with the nation's English name alongside the ISO code — the same
+     * format createNationalCalendar uses.
+     *
+     * Creates MT via PUT first (no OpenFGA env forced, so no outbox/DB needed),
+     * then updates it via PATCH. MT files are cleaned up in tearDown.
+     */
+    public function testUpdateNationalCalendarSucceeds(): void
+    {
+        $this->armMtFixture();
+
+        $payload = self::mtNationalCalendarPayload();
+
+        $createResponse = ( new RegionalDataHandler(['nation', 'MT']) )
+            ->handle($this->requestFor('PUT', '/data/nation/MT', [], $payload));
+        self::assertSame(201, $createResponse->getStatusCode());
+
+        // PATCH must send a locale the MT calendar supports (defaults to Latin otherwise).
+        $updateResponse = ( new RegionalDataHandler(['nation', 'MT']) )
+            ->handle($this->requestFor('PATCH', '/data/nation/MT', ['Accept-Language' => 'en-MT'], $payload));
+
+        self::assertSame(201, $updateResponse->getStatusCode());
+        $body = $this->decodeJsonBody($updateResponse);
+        self::assertSame('Calendar data updated for Nation "Malta" ("MT")', $body['success']);
+    }
+
+    /**
+     * When a national calendar whose payload declares a wider_region is created
+     * via PUT, the handler must enqueue a WRITE_TUPLE outbox row that links
+     * `national_calendar:<N>` to `wider_region:<R>` via the `member_nation`
+     * relation.
+     *
+     * Malta (MT) is used as the fixture nation because:
+     * - It is a valid European nation code recognised by PHP's ICU locales.
+     * - It has no existing national calendar in the bundled source data, so
+     *   the PUT does not trigger a ResourceConflictException.
+     *
+     * The new MT files written by the handler are deleted unconditionally in
+     * tearDown via {@see cleanupMtFixture()} to keep the working tree clean.
+     */
+    public function testCreateNationalCalendarEnqueuesMemberNationTuple(): void
+    {
+        // --- Arrange: record paths so tearDown can delete the new files -------
+        $this->armMtFixture();
+
+        // --- Build handler with injected mock OutboxRepository ----------------
+        // PUT requests expect exactly TWO path params (category + key); the key
+        // in the path must match the nation key in the payload body.
+        $handler = new RegionalDataHandler(['nation', 'MT']);
+
+        $repo = $this->createMock(OutboxBatchInsertInterface::class);
+        $repo->expects($this->atLeastOnce())
+            ->method('insertBatch')
+            ->with($this->callback(function (array $rows): bool {
+                foreach ($rows as $r) {
+                    if (
+                        $r['fga_user'] === 'national_calendar:MT'
+                        && $r['fga_relation'] === 'member_nation'
+                        && $r['fga_object'] === 'wider_region:Europe'
+                    ) {
+                        return true;
+                    }
+                }
+                return false;
+            }))
+            ->willReturn([99]);
+        $handler->setOutboxRepository($repo);
+
+        // Build a valid PUT payload for Malta (MT) with wider_region=Europe.
+        $payload = self::mtNationalCalendarPayload();
 
         // Force OpenFGA "configured" so the create-sync transaction + processSync
         // branches execute (CI does not configure OpenFGA, so they would otherwise

--- a/phpunit_tests/Routes/ReadWrite/MissalsTest.php
+++ b/phpunit_tests/Routes/ReadWrite/MissalsTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace LiturgicalCalendar\Tests\Routes\ReadWrite;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Route-shape assertions for the /missals write paths.
+ *
+ * The missals write handlers are still "Not yet implemented" stubs, but the
+ * route shape is already aligned with the PUT /{collection}/{id} convention
+ * (see issue #706): PUT is routed at /missals/{missal_id}, and the retired
+ * collection-level PUT /missals is no longer an allowed method. These tests
+ * pin that shape so a Router change cannot silently resurrect the old form.
+ */
+#[Group('ReadWrite')]
+class MissalsTest extends ApiTestCase
+{
+    public function testPutWithoutAuthenticationIsUnauthorized(): void
+    {
+        // Authentication middleware runs before method validation for write requests.
+        $response = self::$http->put('/missals/EDITIO_TYPICA_1970', [
+            'headers' => ['Content-Type' => 'application/json'],
+            'body'    => '{}'
+        ]);
+        $this->assertSame(401, $response->getStatusCode(), 'Expected HTTP 401 Unauthorized (authentication required for PUT)');
+    }
+
+    public function testAuthenticatedPutAtCollectionLevelIsMethodNotAllowed(): void
+    {
+        if (!self::isDatabaseConfigured()) {
+            $this->markTestSkipped('Database not configured — authorization middleware requires database connection');
+        }
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        // The retired create shape: PUT /missals (id in body) must no longer be routed.
+        $response = self::$http->put('/missals', [
+            'headers' => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'    => '{}'
+        ]);
+        $this->assertSame(405, $response->getStatusCode(), 'Expected HTTP 405 Method Not Allowed for collection-level PUT /missals, instead got ' . $response->getStatusCode() . ': ' . $response->getBody());
+    }
+
+    public function testAuthenticatedPutAtItemLevelReachesUnimplementedStub(): void
+    {
+        if (!self::isDatabaseConfigured()) {
+            $this->markTestSkipped('Database not configured — authorization middleware requires database connection');
+        }
+        $token = self::getJwtToken();
+        $this->assertNotNull($token, 'Failed to obtain JWT token for authenticated test');
+
+        // PUT /missals/{missal_id} is routed, but the write handler is still a
+        // 405 "Not yet implemented" stub; the future implementation debuts here.
+        $response = self::$http->put('/missals/EDITIO_TYPICA_1970', [
+            'headers' => array_merge(
+                self::authHeaders($token),
+                ['Content-Type' => 'application/json']
+            ),
+            'body'    => '{}'
+        ]);
+        $this->assertSame(405, $response->getStatusCode(), 'Expected HTTP 405 Not yet implemented for PUT /missals/{missal_id}, instead got ' . $response->getStatusCode() . ': ' . $response->getBody());
+        $this->assertStringContainsString('Not yet implemented', (string) $response->getBody(), 'Expected the item-level PUT to reach the unimplemented-stub handler');
+    }
+}

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -395,7 +395,7 @@ final class RegionalDataHandler extends AbstractHandler
         ]);
 
         $responseObj          = new \stdClass();
-        $responseObj->success = "Calendar data created or updated for Diocese \"{$diocese_name}\" (Nation: \"{$nation}\")";
+        $responseObj->success = "Calendar data created for Diocese \"{$diocese_name}\" (Nation: \"{$nation}\")";
         $responseObj->data    = $rawPayload;
         return $this->encodeResponseBody($response, $responseObj, StatusCode::CREATED);
     }
@@ -527,7 +527,7 @@ final class RegionalDataHandler extends AbstractHandler
         ]);
 
         $responseObj          = new \stdClass();
-        $responseObj->success = "Calendar data created or updated for Nation \"{$nationEnglish}\" (\"{$nation}\")";
+        $responseObj->success = "Calendar data created for Nation \"{$nationEnglish}\" (\"{$nation}\")";
         $responseObj->data    = $rawPayload;
         return $this->encodeResponseBody($response, $responseObj, StatusCode::CREATED);
     }
@@ -618,11 +618,11 @@ final class RegionalDataHandler extends AbstractHandler
     }
 
     /**
-     * Handle PUT requests to create or update a regional calendar data resource.
+     * Handle PUT requests to create a regional calendar data resource.
      *
      * This is a private method and should only be called from {@see \LiturgicalCalendar\Api\Handlers\RegionalDataHandler::handleRequestMethod()}.
      *
-     * The resource is created or updated in the `jsondata/sourcedata/calendars/` directory.
+     * The resource is created in the `jsondata/sourcedata/calendars/` directory; if it already exists, a 409 Conflict is returned.
      *
      * If the payload is invalid, the response will be a JSON error response with a 422 Unprocessable Content status code.
      *
@@ -734,7 +734,7 @@ final class RegionalDataHandler extends AbstractHandler
         ]);
 
         $responseObj          = new \stdClass();
-        $responseObj->success = "Calendar data created or updated for Nation \"{$this->params->key}\"";
+        $responseObj->success = "Calendar data updated for Nation \"{$this->params->key}\"";
         $responseObj->data    = $rawPayload;
         return $this->encodeResponseBody($response, $responseObj, StatusCode::CREATED);
     }
@@ -823,7 +823,7 @@ final class RegionalDataHandler extends AbstractHandler
         ]);
 
         $responseObj          = new \stdClass();
-        $responseObj->success = "Calendar data created or updated for Wider Region \"{$this->params->key}\"";
+        $responseObj->success = "Calendar data updated for Wider Region \"{$this->params->key}\"";
         $responseObj->data    = $rawPayload;
         return $this->encodeResponseBody($response, $responseObj, StatusCode::CREATED);
     }
@@ -916,7 +916,7 @@ final class RegionalDataHandler extends AbstractHandler
         ]);
 
         $responseObj          = new \stdClass();
-        $responseObj->success = "Calendar data created or updated for Diocese \"{$dioceseEntry->diocese}\" (Nation: \"{$dioceseEntry->nation}\")";
+        $responseObj->success = "Calendar data updated for Diocese \"{$dioceseEntry->diocese}\" (Nation: \"{$dioceseEntry->nation}\")";
         $responseObj->data    = $rawPayload;
         return $this->encodeResponseBody($response, $responseObj, StatusCode::CREATED);
     }

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -734,7 +734,7 @@ final class RegionalDataHandler extends AbstractHandler
         ]);
 
         $responseObj          = new \stdClass();
-        $responseObj->success = "Calendar data updated for Nation \"{$this->params->key}\"";
+        $responseObj->success = "Calendar data updated for Nation \"{$nationEnglish}\" (\"{$this->params->key}\")";
         $responseObj->data    = $rawPayload;
         return $this->encodeResponseBody($response, $responseObj, StatusCode::CREATED);
     }

--- a/src/Services/TestScopeResolver.php
+++ b/src/Services/TestScopeResolver.php
@@ -40,11 +40,32 @@ final class TestScopeResolver
     }
 
     /**
+     * Map an `applies_to` value to the FGA (object type, object id) scope pair.
+     *
+     * This is the single source of truth for the applies_to → scope mapping,
+     * shared by both the stored-file path (resolve()) and the create-payload
+     * path (resolveFromPayload()): the scope that authorizes a create must be
+     * the same scope the stored file resolves to afterwards.
+     *
+     * @param mixed $appliesTo The decoded `applies_to` value (assoc array or absent)
+     * @return array{0: string, 1: string}
+     */
+    private static function mapAppliesTo(mixed $appliesTo): array
+    {
+        if (is_array($appliesTo) && isset($appliesTo['diocesan_calendar']) && is_string($appliesTo['diocesan_calendar'])) {
+            return ['diocesan_calendar_test', $appliesTo['diocesan_calendar']];
+        }
+
+        if (is_array($appliesTo) && isset($appliesTo['national_calendar']) && is_string($appliesTo['national_calendar'])) {
+            return ['national_calendar_test', $appliesTo['national_calendar']];
+        }
+
+        return ['general_roman_calendar_test', 'general_roman_calendar'];
+    }
+
+    /**
      * Resolve the FGA scope pair for a test that does not yet exist on disk,
      * using the decoded request payload's `applies_to` key (create flow).
-     *
-     * Mirrors the mapping applied by resolve() to the stored file, so the scope
-     * that authorizes the create is the same scope the created file will have.
      *
      * @param mixed $decoded The json_decode'd (assoc mode) request body
      * @return array{0: string, 1: string}|null
@@ -55,17 +76,7 @@ final class TestScopeResolver
             return null;
         }
 
-        $appliesTo = $decoded['applies_to'] ?? null;
-
-        if (is_array($appliesTo) && isset($appliesTo['diocesan_calendar']) && is_string($appliesTo['diocesan_calendar'])) {
-            return ['diocesan_calendar_test', $appliesTo['diocesan_calendar']];
-        }
-
-        if (is_array($appliesTo) && isset($appliesTo['national_calendar']) && is_string($appliesTo['national_calendar'])) {
-            return ['national_calendar_test', $appliesTo['national_calendar']];
-        }
-
-        return ['general_roman_calendar_test', 'general_roman_calendar'];
+        return self::mapAppliesTo($decoded['applies_to'] ?? null);
     }
 
     /**
@@ -93,16 +104,6 @@ final class TestScopeResolver
             return null;
         }
 
-        $appliesTo = $data['applies_to'] ?? null;
-
-        if (is_array($appliesTo) && isset($appliesTo['diocesan_calendar']) && is_string($appliesTo['diocesan_calendar'])) {
-            return ['diocesan_calendar_test', $appliesTo['diocesan_calendar']];
-        }
-
-        if (is_array($appliesTo) && isset($appliesTo['national_calendar']) && is_string($appliesTo['national_calendar'])) {
-            return ['national_calendar_test', $appliesTo['national_calendar']];
-        }
-
-        return ['general_roman_calendar_test', 'general_roman_calendar'];
+        return self::mapAppliesTo($data['applies_to'] ?? null);
     }
 }


### PR DESCRIPTION
## Summary

Addresses the deferred follow-ups listed in #713:

- **Stale wording**: `/data` success messages (and the matching OpenAPI examples) said "created or updated" — PUT can no longer update (409 on existing resource), so creates now say "created" and PATCH updates say "updated". Also fixed the `createCalendar()` docblock.
- **Shared scope mapping**: extracted `TestScopeResolver::mapAppliesTo()` so the applies_to → FGA-scope mapping used to authorize a create is structurally identical to the one applied to the stored file afterwards (previously mirrored by convention across `resolve()`/`resolveFromPayload()`).
- **Missals route-shape assertions** (spec-promised in the #706 design doc): new `Routes/ReadWrite/MissalsTest` pins that the retired collection-level `PUT /missals` is 405 and `PUT /missals/{missal_id}` reaches the "Not yet implemented" stub.
- **FGA JSON-only note**: `createTestByNamePUT`'s OpenAPI description now documents that under OpenFGA the request body must be JSON (scope is resolved from the parsed JSON payload; other formats fail closed) — documented rather than implemented per YAGNI.

## Verification

- PHPStan level 10, phpcs, lint:openapi: clean
- TestScopeResolver + FGA middleware + RegionalDataHandler + Schemas suites: 114/114
- Route tests against a live server running this branch: new MissalsTest 3/3, RegionalDataTest 13/13 (confirms no test asserted the old wording)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified calendar API success messages to explicitly differentiate “created for …” versus “updated for …” across national, diocesan, and wider-region calendars.
  - Strengthened OpenAPI notes for `PUT /tests/{test_name}` when fine-grained authorization is enabled, including the required editor permission and that only JSON request bodies are accepted.

- **Bug Fixes**
  - Improved consistency in resolving test scopes based on `applies_to` across create and stored-file flows.

- **Tests**
  - Added coverage for missal write-route authentication/method handling.
  - Extended regional data handler tests, including a national calendar update scenario with language-specific assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->