### PR TITLE
Ambrosian Rite integration — Plan 2: Rite routing & validation (501 interim)

### DIFF
--- a/docs/superpowers/plans/2026-07-20-ambrosian-02-rite-routing.md
+++ b/docs/superpowers/plans/2026-07-20-ambrosian-02-rite-routing.md
@@ -23,8 +23,12 @@ lint:openapi`), phpcs (PSR-12 + custom ruleset), PHPStan level 10, CaptainHook g
   on branch `feature/ambrosian-rite-routing` (based on `development`, which already contains Plan 1). **Verify with
   `git rev-parse --show-toplevel` before each task's first command** — it MUST print that worktree path, never
   `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI` (the shared main checkout is off-limits).
-- **`vendor/` is a symlink in the worktree** (already created + git-excluded). `vendor/bin/phpunit`,
-  `vendor/bin/phpcs`, `composer analyse` work. Never `git add` the `vendor` symlink; always stage explicit paths.
+- **`vendor/` is a real, worktree-local install** (git-excluded via the worktree's `.git/info/exclude`).
+  `vendor/bin/phpunit`, `vendor/bin/phpcs`, `composer analyse` operate on the worktree's own `src/`. Do NOT
+  replace it with a symlink to the main checkout's `vendor/` — a symlinked vendor makes Composer's autoload
+  `$baseDir` resolve (through the symlink) to the MAIN checkout's `src/`, so `vendor/bin/phpunit` silently tests
+  the wrong code (worktree-only classes come back "not found"). If `vendor/` is missing or a symlink, fix it with
+  `rm -f vendor && composer install --no-interaction` from the worktree. Never `git add` vendor; stage explicit paths.
 - **`.env.local` must exist** for in-process handler tests to run rather than skip: if `vendor/bin/phpunit
   phpunit_tests/Handlers/...` reports the target as skipped, run `cp .env.example .env.local` (gitignored) once, then
   re-run. A "Skipped" target is NOT a pass — report real tallies.

--- a/docs/superpowers/plans/2026-07-20-ambrosian-02-rite-routing.md
+++ b/docs/superpowers/plans/2026-07-20-ambrosian-02-rite-routing.md
@@ -1,0 +1,704 @@
+# Ambrosian Rite — Plan 2: Rite routing & validation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional leading `ambrosian` path segment to the `/calendar` route (absence = Roman, every existing
+URL unchanged), validate rite↔calendar compatibility and the 1976 year floor (→ 400), and return a clean **501 Not
+Implemented** for valid Ambrosian requests until the engine and data land in Plans 3–5.
+
+**Architecture:** Plan 1 merged the `Rite → RiteProfile → TemporaleEngine` seam. This plan wires the *request side*:
+`Router` strips the `ambrosian` segment and records the `Rite`; `CalendarHandler` threads it into `CalendarParams`;
+`CalendarParams` validates the combination; and the handler short-circuits Ambrosian with `ImplementationException`
+(501) before doing any Roman pipeline work. The Ambrosian whitelist lives as a constant on a new
+`AmbrosianRiteProfile` (data-driven in Plan 5). Roman output stays byte-identical.
+
+**Tech Stack:** PHP 8.4, PHPUnit 12, PSR-7/15 (`nyholm/psr7`), `swaggest/json-schema`, Redocly CLI (`composer
+lint:openapi`), phpcs (PSR-12 + custom ruleset), PHPStan level 10, CaptainHook git hooks.
+
+## Global Constraints
+
+- **Working directory:** the git worktree
+  `/tmp/claude-1000/-home-johnrdorazio-development-LiturgicalCalendar-LiturgicalCalendarAPI/6218483e-ad13-46d0-a0c6-2b582615e843/scratchpad/wt-ambrosian-p2`
+  on branch `feature/ambrosian-rite-routing` (based on `development`, which already contains Plan 1). **Verify with
+  `git rev-parse --show-toplevel` before each task's first command** — it MUST print that worktree path, never
+  `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI` (the shared main checkout is off-limits).
+- **`vendor/` is a symlink in the worktree** (already created + git-excluded). `vendor/bin/phpunit`,
+  `vendor/bin/phpcs`, `composer analyse` work. Never `git add` the `vendor` symlink; always stage explicit paths.
+- **`.env.local` must exist** for in-process handler tests to run rather than skip: if `vendor/bin/phpunit
+  phpunit_tests/Handlers/...` reports the target as skipped, run `cp .env.example .env.local` (gitignored) once, then
+  re-run. A "Skipped" target is NOT a pass — report real tallies.
+- **Backward compatibility is absolute.** Every existing `/calendar` URL (no `ambrosian` segment) must behave
+  byte-identically. The golden-master gate `phpunit_tests/Handlers/CalendarGoldenMasterTest.php` (9 cases) must stay
+  **9/9** after any task touching the Router/handler/params. It runs in-process and constructs the handler directly,
+  so it does not exercise the Router — Router changes need their own tests (Task 3).
+- **Never bypass git hooks.** No `--no-verify`. Commits are GPG-signed; on `gpg: signing failed: Timeout`, STOP and
+  report BLOCKED (ask the user to unlock GPG; never disable signing).
+- **PHP standards:** short array `[]`, 4-space indent, single quotes unless interpolating. New code passes
+  `vendor/bin/phpcs <file>` and `composer analyse` (PHPStan level 10, scans `src`). Production classes →
+  `LiturgicalCalendar\Api\...` (`src/`); tests → `LiturgicalCalendar\Tests\...` (`phpunit_tests/`, per
+  `autoload-dev`).
+- **Commit trailer:** end every commit body with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Error semantics (fixed contract for this plan):**
+  - Ambrosian + a `nation` calendar → **400** (Ambrosian has no national layer).
+  - Ambrosian + a diocese not in the whitelist → **400**.
+  - Ambrosian + year `< 1976` → **400**.
+  - Ambrosian + otherwise-valid request → **501** (planned, not yet implemented).
+  - No `ambrosian` segment → Roman, unchanged.
+- **Whitelist (provisional):** the four Ambrosian diocese IDs are `milano_it`, `bergam_it`, `novara_it`, `lugano_ch`.
+  These are the intended IDs for the diocese calendar files created in **Plan 5**; the whitelist constant here MUST
+  match those files when they are created. Until then, no Ambrosian diocese file exists, so a whitelisted-diocese
+  request still 400s as "unknown diocese" from the existing diocesan-existence validation — the *positive* whitelist
+  path (→ 501) is only reachable/testable once Plan 5 lands. Plan 2's testable Ambrosian-success case is the bare
+  comune (`/calendar/ambrosian`, `/calendar/ambrosian/{year}`) → 501.
+
+---
+
+### Task 1: `AmbrosianRiteProfile` + factory wiring
+
+Add the Ambrosian rite profile that owns the diocese whitelist, and make the factory return it instead of throwing.
+
+**Files:**
+
+- Create: `src/Models/Calendar/Rite/AmbrosianRiteProfile.php`
+- Modify: `src/Models/Calendar/Rite/RiteProfileFactory.php`
+- Test: `phpunit_tests/Models/Calendar/Rite/AmbrosianRiteProfileTest.php`, and extend `phpunit_tests/Models/Calendar/Rite/RiteProfileFactoryTest.php`
+
+**Interfaces:**
+
+- Consumes: `RiteProfile` interface, `Rite` enum, `TemporaleEngine` interface (all from Plan 1).
+- Produces:
+  - `final class AmbrosianRiteProfile implements RiteProfile` with `public const SUPPORTED_DIOCESES = ['milano_it',
+    'bergam_it', 'novara_it', 'lugano_ch']` (a `list<string>`), `rite(): Rite` → `Rite::AMBROSIAN`, and
+    `temporaleEngine(): TemporaleEngine` throwing `\LogicException` (unreachable — the handler 501-guards before
+    calling it; the real engine replaces this in Plan 3).
+  - `RiteProfileFactory::forRite(Rite::AMBROSIAN)` now returns `new AmbrosianRiteProfile()` (no longer throws `\InvalidArgumentException`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `phpunit_tests/Models/Calendar/Rite/AmbrosianRiteProfileTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar\Rite;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Models\Calendar\Rite\AmbrosianRiteProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AmbrosianRiteProfile::class)]
+final class AmbrosianRiteProfileTest extends TestCase
+{
+    public function testRiteIsAmbrosian(): void
+    {
+        self::assertSame(Rite::AMBROSIAN, (new AmbrosianRiteProfile())->rite());
+    }
+
+    public function testWhitelistIsTheFourDioceses(): void
+    {
+        self::assertSame(
+            ['milano_it', 'bergam_it', 'novara_it', 'lugano_ch'],
+            AmbrosianRiteProfile::SUPPORTED_DIOCESES
+        );
+    }
+
+    public function testTemporaleEngineIsNotYetImplemented(): void
+    {
+        $this->expectException(\LogicException::class);
+        (new AmbrosianRiteProfile())->temporaleEngine();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Rite/AmbrosianRiteProfileTest.php -v`
+Expected: FAIL — `Class "…AmbrosianRiteProfile" not found`.
+
+- [ ] **Step 3: Implement the profile**
+
+Create `src/Models/Calendar/Rite/AmbrosianRiteProfile.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\Calendar\Rite;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleEngine;
+
+/**
+ * Ambrosian rite profile. Plan 2 wires only the diocese whitelist and rite
+ * identity; the temporale engine, precedence resolver, missal resolver, and
+ * vocabularies arrive in later plans.
+ */
+final class AmbrosianRiteProfile implements RiteProfile
+{
+    /**
+     * Diocesan calendars that support the Ambrosian rite. Provisional constant
+     * until Plan 5 creates these diocese files with `supported_rites` metadata,
+     * at which point the whitelist becomes data-driven. These IDs MUST match the
+     * diocese calendar files created in Plan 5.
+     *
+     * @var list<string>
+     */
+    public const SUPPORTED_DIOCESES = ['milano_it', 'bergam_it', 'novara_it', 'lugano_ch'];
+
+    public function rite(): Rite
+    {
+        return Rite::AMBROSIAN;
+    }
+
+    public function temporaleEngine(): TemporaleEngine
+    {
+        // Unreachable in normal flow: CalendarHandler returns 501 for the
+        // Ambrosian rite before any temporale computation. Replaced by the
+        // real AmbrosianTemporale in Plan 3.
+        throw new \LogicException('The Ambrosian temporale engine is not yet implemented (Plan 3).');
+    }
+}
+```
+
+- [ ] **Step 4: Update the factory**
+
+In `src/Models/Calendar/Rite/RiteProfileFactory.php`, replace the throwing arm:
+
+```php
+return match ($rite) {
+    Rite::ROMAN     => new RomanRiteProfile(),
+    Rite::AMBROSIAN => new AmbrosianRiteProfile(),
+};
+```
+
+- [ ] **Step 5: Update the factory test**
+
+In `phpunit_tests/Models/Calendar/Rite/RiteProfileFactoryTest.php`, the existing `testAmbrosianNotYetWired` asserts
+`\InvalidArgumentException`. Replace it with an assertion that the factory now returns an `AmbrosianRiteProfile`:
+
+```php
+public function testAmbrosianProfileIsReturned(): void
+{
+    $profile = RiteProfileFactory::forRite(Rite::AMBROSIAN);
+    self::assertInstanceOf(AmbrosianRiteProfile::class, $profile);
+    self::assertSame(Rite::AMBROSIAN, $profile->rite());
+}
+```
+
+Add `use LiturgicalCalendar\Api\Models\Calendar\Rite\AmbrosianRiteProfile;` to that test's imports. (Read the file
+first to match its exact structure and remove the now-obsolete `InvalidArgumentException` test.)
+
+- [ ] **Step 6: Run to verify pass + lint + analyse**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Rite/ -v && vendor/bin/phpcs src/Models/Calendar/Rite/ phpunit_tests/Models/Calendar/Rite/ && composer analyse`
+Expected: all tests PASS; phpcs clean; PHPStan level 10 clean.
+
+- [ ] **Step 7: Confirm the golden master is unaffected (Roman path untouched)**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/CalendarGoldenMasterTest.php`
+Expected: 9/9 (this task only adds an Ambrosian profile the Roman path never uses).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Models/Calendar/Rite/ phpunit_tests/Models/Calendar/Rite/
+git commit -m "feat(rite): AmbrosianRiteProfile with diocese whitelist; factory returns it
+
+Adds the Ambrosian rite profile (rite identity + provisional SUPPORTED_DIOCESES
+whitelist constant; temporale engine throws until Plan 3). RiteProfileFactory
+now returns it instead of throwing. Roman path and golden master unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Rite property + compatibility validation in `CalendarParams`
+
+Add the `Rite` to `CalendarParams` and the cross-field validation (national-layer / whitelist / year-floor →
+`ValidationException` → 400). No wiring into the live request path yet (that is Task 3) — this task is additive and
+unit-tested in isolation.
+
+**Files:**
+
+- Modify: `src/Params/CalendarParams.php`
+- Test: `phpunit_tests/Params/CalendarParamsRiteValidationTest.php`
+
+**Interfaces:**
+
+- Consumes: `Rite` enum, `AmbrosianRiteProfile::SUPPORTED_DIOCESES` (Task 1), existing `ValidationException`.
+- Produces (on `CalendarParams`):
+  - `public Rite $Rite = Rite::ROMAN;` (new public property).
+  - `public const AMBROSIAN_YEAR_LOWER_LIMIT = 1976;`
+  - `public function setRite(Rite $rite): void` (assigns `$this->Rite`).
+  - `public function validateRiteCompatibility(): void` — no-op for Roman; for Ambrosian throws `ValidationException`
+    when `NationalCalendar !== null`, when `DiocesanCalendar` is set but not in
+    `AmbrosianRiteProfile::SUPPORTED_DIOCESES`, or when `Year < AMBROSIAN_YEAR_LOWER_LIMIT`.
+
+- [ ] **Step 1: Write the failing test**
+
+`validateRiteCompatibility()` reads only the public `$Rite`, `$NationalCalendar`, `$DiocesanCalendar`, `$Year`
+properties (never `$this->calendars`), so the test builds a `CalendarParams` without its metadata-loading constructor
+(via reflection) and sets those properties directly — a pure, no-I/O unit test. Create
+`phpunit_tests/Params/CalendarParamsRiteValidationTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Params;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use PHPUnit\Framework\TestCase;
+
+final class CalendarParamsRiteValidationTest extends TestCase
+{
+    /** Build a CalendarParams with the given fields set, bypassing the metadata-loading constructor. */
+    private function params(Rite $rite, ?string $national, ?string $diocesan, int $year): CalendarParams
+    {
+        $p = (new \ReflectionClass(CalendarParams::class))->newInstanceWithoutConstructor();
+        $p->Rite             = $rite;
+        $p->NationalCalendar = $national;
+        $p->DiocesanCalendar = $diocesan;
+        $p->Year             = $year;
+        return $p;
+    }
+
+    public function testRomanAcceptsEverything(): void
+    {
+        $this->params(Rite::ROMAN, 'US', null, 1970)->validateRiteCompatibility();
+        $this->params(Rite::ROMAN, null, 'romamo_it', 1970)->validateRiteCompatibility();
+        $this->addToAssertionCount(1); // no exception thrown
+    }
+
+    public function testAmbrosianComuneBaseIsValid(): void
+    {
+        $this->params(Rite::AMBROSIAN, null, null, 2025)->validateRiteCompatibility();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAmbrosianWhitelistedDioceseIsValid(): void
+    {
+        $this->params(Rite::AMBROSIAN, null, 'milano_it', 2025)->validateRiteCompatibility();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAmbrosianRejectsNationalCalendar(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->params(Rite::AMBROSIAN, 'US', null, 2025)->validateRiteCompatibility();
+    }
+
+    public function testAmbrosianRejectsNonWhitelistedDiocese(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->params(Rite::AMBROSIAN, null, 'romamo_it', 2025)->validateRiteCompatibility();
+    }
+
+    public function testAmbrosianRejectsYearBelow1976(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->params(Rite::AMBROSIAN, null, null, 1975)->validateRiteCompatibility();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Params/CalendarParamsRiteValidationTest.php -v`
+Expected: FAIL — `$Rite`/`setRite`/`validateRiteCompatibility` do not exist (Error or failure).
+
+- [ ] **Step 3: Add the property, constant, setter, and validator**
+
+In `src/Params/CalendarParams.php`:
+
+1. Add the import near the other `use` statements: `use LiturgicalCalendar\Api\Enum\Rite;` and `use LiturgicalCalendar\Api\Models\Calendar\Rite\AmbrosianRiteProfile;`
+2. Add the property alongside the other public typed properties (near `$NationalCalendar`/`$DiocesanCalendar`, ~line 45): `public Rite $Rite = Rite::ROMAN;`
+3. Add the constant near `YEAR_LOWER_LIMIT` (~line 107): `public const AMBROSIAN_YEAR_LOWER_LIMIT = 1976;`
+4. Add the setter and validator as public methods (e.g. after `initParamsFromRequestPath()`):
+
+```php
+public function setRite(Rite $rite): void
+{
+    $this->Rite = $rite;
+}
+
+/**
+ * Cross-field validation of the rite against the requested calendar and year.
+ * Roman accepts every calendar shape and the full year range. The Ambrosian
+ * rite has no national layer, is restricted to its whitelisted dioceses (plus
+ * the comune ambrosiano when no diocese is given), and starts at 1976 (the
+ * first reformed Ambrosian Missal). Throws ValidationException (HTTP 400) on
+ * mismatch. Must be called after the rite, calendar, and year are all set.
+ */
+public function validateRiteCompatibility(): void
+{
+    if ($this->Rite === Rite::ROMAN) {
+        return;
+    }
+
+    if ($this->NationalCalendar !== null) {
+        throw new ValidationException(
+            'The Ambrosian rite has no national calendars; request the comune ambrosiano (`/calendar/ambrosian`) or one of its dioceses.'
+        );
+    }
+
+    if ($this->DiocesanCalendar !== null && !in_array($this->DiocesanCalendar, AmbrosianRiteProfile::SUPPORTED_DIOCESES, true)) {
+        throw new ValidationException(sprintf(
+            'Diocesan calendar `%s` does not support the Ambrosian rite. Ambrosian dioceses are: %s',
+            $this->DiocesanCalendar,
+            implode(', ', AmbrosianRiteProfile::SUPPORTED_DIOCESES)
+        ));
+    }
+
+    if ($this->Year < self::AMBROSIAN_YEAR_LOWER_LIMIT) {
+        throw new ValidationException(sprintf(
+            'The Ambrosian rite is only available from %d onward (the first reformed Ambrosian Missal); requested year %d.',
+            self::AMBROSIAN_YEAR_LOWER_LIMIT,
+            $this->Year
+        ));
+    }
+}
+```
+
+Verify the exact `ValidationException` FQCN by reading the existing `use` block in `CalendarParams.php` (Task-map
+shows validators already throw `ValidationException`, so it is already imported — reuse it).
+
+- [ ] **Step 4: Run to verify pass + lint + analyse**
+
+Run: `vendor/bin/phpunit phpunit_tests/Params/CalendarParamsRiteValidationTest.php -v && vendor/bin/phpcs
+src/Params/CalendarParams.php phpunit_tests/Params/CalendarParamsRiteValidationTest.php && composer analyse`
+Expected: 6 tests PASS; phpcs clean; PHPStan level 10 clean.
+
+- [ ] **Step 5: Confirm golden master unaffected**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/CalendarGoldenMasterTest.php`
+Expected: 9/9 (the new property defaults to `Rite::ROMAN` and `validateRiteCompatibility` is not yet called from the handler).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Params/CalendarParams.php phpunit_tests/Params/CalendarParamsRiteValidationTest.php
+git commit -m "feat(params): Rite property + validateRiteCompatibility (400 rules)
+
+Adds CalendarParams::\$Rite, setRite(), AMBROSIAN_YEAR_LOWER_LIMIT=1976, and
+validateRiteCompatibility() enforcing: Ambrosian has no national layer, only
+whitelisted dioceses, and year >= 1976. Additive; not yet wired into the
+request path. Golden master unchanged.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Wire the rite live — Router segment + handler threading + 501 short-circuit
+
+Tie it together so `/calendar/ambrosian/...` is parsed, validated, and returns 400/501 as specified, while every Roman URL is unchanged.
+
+**Files:**
+
+- Modify: `src/Router.php` (the `calendar` case in `route()`)
+- Modify: `src/Handlers/CalendarHandler.php` (constructor + `handle()` wiring + the `RiteProfileFactory::forRite(...)` call site)
+- Test: `phpunit_tests/Handlers/CalendarRiteRoutingTest.php` (in-process handler tests); extend `phpunit_tests/Routes/Readonly/CalendarTest.php` if present (live-server, optional)
+- Gate: `phpunit_tests/Handlers/CalendarGoldenMasterTest.php`
+
+**Interfaces:**
+
+- Consumes: `Rite` (Plan 1), `CalendarParams::setRite`/`validateRiteCompatibility` (Task 2), `ImplementationException`
+  (existing, `src/Http/Exception/ImplementationException.php`, → 501).
+- Produces:
+  - `CalendarHandler::__construct(array $requestPathParams = [], Rite $rite = Rite::ROMAN)` storing `private Rite $rite`.
+  - Router passes the parsed rite: `new CalendarHandler($requestPathParts, $rite)`.
+
+- [ ] **Step 1: Confirm the golden-master baseline is green**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/CalendarGoldenMasterTest.php`
+Expected: 9/9. (Do not proceed on red.)
+
+- [ ] **Step 2: Write the failing routing tests**
+
+These exercise the handler as the Router constructs it — `new CalendarHandler($strippedPathParts, $rite)`. Create `phpunit_tests/Handlers/CalendarRiteRoutingTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+
+final class CalendarRiteRoutingTest extends AbstractHandlerTestCase
+{
+    private function handle(array $pathParts, Rite $rite, string $uri): int
+    {
+        $handler = new CalendarHandler($pathParts, $rite);
+        $handler->setAllowedReturnTypes(['json', 'yaml', 'xml', 'ics']);
+        return $handler->handle($this->requestFor('GET', $uri, ['Accept' => 'application/json']))->getStatusCode();
+    }
+
+    public function testRomanDefaultStillWorks(): void
+    {
+        self::assertSame(200, $this->handle(['2025'], Rite::ROMAN, '/calendar/2025'));
+    }
+
+    public function testAmbrosianComuneBaseReturns501(): void
+    {
+        self::assertSame(StatusCode::NOT_IMPLEMENTED->value, $this->handle([], Rite::AMBROSIAN, '/calendar/ambrosian'));
+    }
+
+    public function testAmbrosianComuneWithYearReturns501(): void
+    {
+        self::assertSame(StatusCode::NOT_IMPLEMENTED->value, $this->handle(['2008'], Rite::AMBROSIAN, '/calendar/ambrosian/2008'));
+    }
+
+    public function testAmbrosianRejectsNationalCalendarWith400(): void
+    {
+        self::assertSame(StatusCode::BAD_REQUEST->value, $this->handle(['nation', 'US'], Rite::AMBROSIAN, '/calendar/ambrosian/nation/US'));
+    }
+
+    public function testAmbrosianRejectsNonWhitelistedDioceseWith400(): void
+    {
+        self::assertSame(StatusCode::BAD_REQUEST->value, $this->handle(['diocese', 'romamo_it'], Rite::AMBROSIAN, '/calendar/ambrosian/diocese/romamo_it'));
+    }
+
+    public function testAmbrosianRejectsYearBelow1976With400(): void
+    {
+        self::assertSame(StatusCode::BAD_REQUEST->value, $this->handle(['1975'], Rite::AMBROSIAN, '/calendar/ambrosian/1975'));
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/CalendarRiteRoutingTest.php -v`
+Expected: FAIL — `CalendarHandler::__construct` does not accept a `Rite` argument (ArgumentCountError / TypeError), or the Ambrosian cases return 500 instead of 501/400.
+
+- [ ] **Step 4: Add the rite to the handler constructor**
+
+In `src/Handlers/CalendarHandler.php`:
+
+1. Ensure imports: `use LiturgicalCalendar\Api\Enum\Rite;` (already present per Plan 1) and add `use LiturgicalCalendar\Api\Http\Exception\ImplementationException;`
+2. Add a property near the other instance properties: `private Rite $rite = Rite::ROMAN;`
+3. Change the constructor to accept and store it:
+
+```php
+public function __construct(array $requestPathParams = [], Rite $rite = Rite::ROMAN)
+{
+    parent::__construct($requestPathParams);
+    $this->rite      = $rite;
+    $this->startTime = hrtime(true);
+}
+```
+
+- [ ] **Step 5: Thread the rite through `handle()` and add the 501 short-circuit**
+
+In `handle()`, locate the block where `CalendarParams` is built and `initParamsFromRequestPath()` is called (Task-map:
+around lines 4996–5011). Insert `setRite` right after the params object is constructed, and the compatibility check +
+501 short-circuit right after `initParamsFromRequestPath()` and `validateRequestMethod()`, **before**
+`loadDiocesanCalendarData()` (so no Roman-national/diocesan data loading or cache work happens for an Ambrosian
+request):
+
+```php
+$this->CalendarParams = new CalendarParams();
+$this->CalendarParams->setAllowedReturnTypes($this->allowedReturnTypes);
+$this->CalendarParams->setRite($this->rite);            // NEW
+$this->CalendarParams->setParams($params);
+// ... existing lines up to and including:
+$this->CalendarParams->initParamsFromRequestPath($this->requestPathParams);
+$this->CalendarParams->validateRiteCompatibility();     // NEW (throws 400 on mismatch)
+$this->validateRequestMethod($request);
+if ($this->CalendarParams->Rite === Rite::AMBROSIAN) {  // NEW (501 until Plans 3-5)
+    throw new ImplementationException(
+        'The Ambrosian rite is planned but not yet available; only the Roman rite is currently implemented.'
+    );
+}
+$this->loadDiocesanCalendarData();
+// ... rest unchanged
+```
+
+Read the current `handle()` around those lines first and preserve the exact existing statements/order; you are only inserting the three NEW lines at the indicated points.
+
+- [ ] **Step 6: Route the temporale-engine selection through the parsed rite**
+
+In `calculateUniversalCalendar()` (Task-map: ~line 3882), change the hardcoded default to the request's rite. (This is
+only reached for Roman now — Ambrosian 501s earlier — but it makes the seam honest for Plan 3.)
+
+```php
+// before:
+$riteProfile = RiteProfileFactory::forRite(Rite::default());
+// after:
+$riteProfile = RiteProfileFactory::forRite($this->CalendarParams->Rite);
+```
+
+- [ ] **Step 7: Parse the `ambrosian` segment in the Router**
+
+In `src/Router.php`:
+
+1. Add `use LiturgicalCalendar\Api\Enum\Rite;` to the imports.
+2. Immediately after `$route = array_shift($requestPathParts);` (Task-map: ~line 120), strip an optional leading `ambrosian` segment for the calendar route and record the rite:
+
+   ```php
+   $rite = Rite::default();
+   if (($route === 'calendar' || $route === '') && ($requestPathParts[0] ?? null) === 'ambrosian') {
+       $rite = Rite::AMBROSIAN;
+       array_shift($requestPathParts);
+   }
+   ```
+
+3. In the `case 'calendar':` block, pass the rite to the handler — change `new CalendarHandler($requestPathParts)` to
+   `new CalendarHandler($requestPathParts, $rite)`. The existing 0/1/2/3-part shape `if/elseif` chain now runs on the
+   already-stripped `$requestPathParts`, reproducing today's shapes for the remainder (e.g.
+   `/calendar/ambrosian/diocese/milano_it` → `['diocese','milano_it']` → the existing 2-part `PathCategory` branch).
+
+- [ ] **Step 8: Run the routing tests + golden master**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/CalendarRiteRoutingTest.php phpunit_tests/Handlers/CalendarGoldenMasterTest.php -v`
+Expected: routing tests 6/6 PASS (Roman 200; Ambrosian comune → 501; nation/non-whitelist/year<1976 → 400); golden master 9/9 (Roman byte-identical).
+If an Ambrosian case returns 500 instead of 501, the short-circuit is placed after
+`RiteProfileFactory::forRite(Rite::AMBROSIAN)` is reachable — move the 501 guard earlier (Step 5), before any code
+that could call the factory or load Roman data.
+
+- [ ] **Step 9: phpcs + PHPStan on all touched files**
+
+Run: `vendor/bin/phpcs src/Router.php src/Handlers/CalendarHandler.php phpunit_tests/Handlers/CalendarRiteRoutingTest.php && composer analyse`
+Expected: phpcs clean; PHPStan level 10 clean. Fix violations without changing behaviour; re-run Step 8 after any change.
+
+- [ ] **Step 10: Handler-group regression**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/ -v`
+Expected: no NEW failures versus the base (compare tallies; the generator group is config-excluded so it will not run).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/Router.php src/Handlers/CalendarHandler.php phpunit_tests/Handlers/CalendarRiteRoutingTest.php
+git commit -m "feat(rite): parse /calendar/ambrosian, validate, return 501 (not yet impl)
+
+Router strips an optional leading 'ambrosian' segment and threads the Rite
+into CalendarHandler; the handler validates rite<->calendar/year (400 on
+mismatch) and returns 501 for valid Ambrosian requests until the engine
+lands (Plans 3-5). Every existing /calendar URL is unchanged; golden master
+9/9. Temporale-engine selection now goes through the parsed rite.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: OpenAPI — Ambrosian path items, 501 response, rite-conditional params
+
+Document the new URL shapes and the 501, and record (from spec §3) that `epiphany`/`ascension`/`corpus_christi` are
+inert under the Ambrosian rite. This is documentation; it must stay consistent with the Router logic from Task 3.
+
+**Files:**
+
+- Modify: `jsondata/schemas/openapi.json`
+- (No test file — validated by `composer lint:openapi`.)
+
+**Interfaces:**
+
+- Consumes: existing `#/components/responses/*` and `#/components/parameters/*` refs; `ImplementationException`'s problem+json shape.
+- Produces: new path items `/calendar/ambrosian`, `/calendar/ambrosian/{year}`,
+  `/calendar/ambrosian/diocese/{calendar_id}`, `/calendar/ambrosian/diocese/{calendar_id}/{year}`; a reusable
+  `#/components/responses/NotImplemented501`.
+
+- [ ] **Step 1: Add the reusable 501 response component**
+
+Read the existing `#/components/responses/BadRequest400` block in `jsondata/schemas/openapi.json` to copy its exact
+shape (it references `application/problem+json`). Add a sibling `NotImplemented501` response next to it, describing
+the RFC 9457 problem+json body returned by `ImplementationException` (status 501, title "Not Implemented"). Keep the
+2-space indentation and hand-formatting — make surgical text edits; do NOT round-trip the whole file through a JSON
+serializer.
+
+- [ ] **Step 2: Add the four Ambrosian path items**
+
+Read one existing calendar path item in full as a template: `/calendar` (Task-map: lines ~105–232) for the no-arg
+shape, `/calendar/{year}` for the year shape, and `/calendar/diocese/{calendar_id}` /
+`/calendar/diocese/{calendar_id}/{year}` for the diocese shapes. Add four new literal path keys mirroring those, but:
+
+- **No `nation` variant** (Ambrosian has no national layer).
+- Each `get`/`post` keeps the shared parameter refs, but add a description note on the operation (and/or on the
+  `EpiphanyParam`/`AscensionParam`/`CorpusChristiParam` usage) stating these parameters are **ignored under the
+  Ambrosian rite** (spec §3): Epiphany is fixed to Jan 6, Ascension to the 40th day (Thursday), Corpus Christi to its
+  rite-fixed placement.
+- Replace the success/response set so each includes `"501": { "$ref": "#/components/responses/NotImplemented501" }`
+  and `"400": { "$ref": "#/components/responses/BadRequest400" }`. Since the Ambrosian calendar is not yet computed,
+  mark the operation `summary`/`description` as "planned; currently returns 501 Not Implemented".
+- Add a top-of-operation note that `/calendar/ambrosian/diocese/{calendar_id}` accepts only the Ambrosian dioceses (Milano, Bergamo, Novara, Lugano).
+
+- [ ] **Step 3: Lint the OpenAPI schema**
+
+Run: `composer lint:openapi`
+Expected: passes (Redocly). Fix any structural errors (missing refs, duplicate keys, indentation) until clean.
+
+- [ ] **Step 4: Sanity-check the JSON is well-formed and refs resolve**
+
+Run: `php -r '$d=json_decode(file_get_contents("jsondata/schemas/openapi.json"), false, 512, JSON_THROW_ON_ERROR);
+echo "paths: ", implode(\", \", array_values(array_filter(array_keys((array)$d->paths),
+fn($k)=>str_contains($k,\"ambrosian\")))), \"\n\";'`
+Expected: prints the four new `/calendar/ambrosian…` path keys.
+
+- [ ] **Step 5: Run any OpenAPI-reconciliation tests (if present)**
+
+Run: `vendor/bin/phpunit --filter OpenApi phpunit_tests 2>&1 | tail -5` (there is an OpenAPI response-schema
+reconciliation test suite from issue #709; confirm it still passes with the new paths, or that it does not assert an
+exhaustive path list that the additions would break).
+Expected: PASS, or clearly not applicable. If a reconciliation test enumerates calendar paths and now fails because
+the Ambrosian paths lack a live 200 contract, report it — the 501-only paths are intentional and the test may need a
+documented exclusion (surface to the controller, do not weaken the test silently).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add jsondata/schemas/openapi.json
+git commit -m "docs(openapi): document /calendar/ambrosian paths (501) + rite-conditional params
+
+Adds the four Ambrosian path items (no national layer), a reusable
+NotImplemented501 response, and notes that epiphany/ascension/corpus_christi
+are inert under the Ambrosian rite (spec 3). Paths are marked planned /
+currently 501 until the engine lands.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage (this plan = spec §3 request-side: routing, validation, discovery-of-inert-params; interim 501):**
+
+- §3 optional `ambrosian` path segment, Roman default, existing URLs unchanged → Task 3 (Router) + golden master. ✓
+- §3 whitelist (four dioceses), data-driven-later → Task 1 (`AmbrosianRiteProfile::SUPPORTED_DIOCESES`), consumed by Task 2 validation. Provisional-constant approach documented. ✓
+- §3 no national layer / non-whitelisted diocese → 400 → Task 2 + Task 3 tests. ✓
+- §6/scope decision: year floor 1976 → explicit 400 → Task 2 (`AMBROSIAN_YEAR_LOWER_LIMIT`) + Task 3 test. ✓
+- §3 rite-conditional parameters (epiphany/ascension/corpus_christi inert) documented in OpenAPI → Task 4. ✓
+- Interim behaviour = 501 (user decision) → Task 3 short-circuit via existing `ImplementationException`. ✓
+- **Deferred (stated):** `supported_rites` metadata on `/calendars` and the data-driven whitelist → Plan 5 (needs the
+  diocese files). `AmbrosianTemporale` + flipping 501→computation → Plan 3+. The positive whitelist→501 path is only
+  reachable once Plan 5 creates the diocese files (noted in Global Constraints).
+
+**Placeholder scan:** No "TBD"/"add validation"/"similar to". The one deliberate throw
+(`AmbrosianRiteProfile::temporaleEngine()` → `\LogicException`) is asserted by a test (Task 1) and documented as
+Plan-3 replacement. Line numbers are marked "Task-map: ~N" and each editing step says to read the current code first
+and preserve exact statements — mechanical insertion, not guesswork.
+
+**Type consistency:** `Rite` used identically across Router, `CalendarHandler::__construct(array, Rite)`,
+`CalendarParams::$Rite`/`setRite(Rite)`. `AmbrosianRiteProfile::SUPPORTED_DIOCESES` (a `list<string>` const)
+referenced with the same FQCN in Task 2's validator and Task 2's test. `validateRiteCompatibility(): void` defined in
+Task 2, called in Task 3 Step 5. `ImplementationException` (501) and `ValidationException` (400) match
+`StatusCode::NOT_IMPLEMENTED`/`BAD_REQUEST` used in Task 3's assertions.
+
+**Scope check:** Four tasks, each an independently testable deliverable; Tasks 1–2 are additive/unit-tested (no
+live-path change), Task 3 is the single integration point (so there is no exposed broken intermediate), Task 4 is
+docs. Focused enough for one plan.

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -11,7 +11,7 @@
     }
   ],
   "info": {
-    "description": "An API which allows to retrieve data about the **Roman Calendar** for any given year, between 1970 and 9999. The data strives for historical accuracy (memorials and feast days are only generated from the year in which they were effectively introduced). The data is based on original sources (Roman Missals, Decrees of the Dicastery for Divine Worship and the Discipline of the Sacraments, Mysterii Paschalis, etc.), not on data copied or retrieved from online sources which may not be accurate. The API offers multiple locales and multiple calendars, from the **General Roman Calendar** to national or diocesan calendars.",
+    "description": "An API which allows to retrieve data about the **Roman Calendar** for any given year, between 1970 and 9999. The data strives for historical accuracy (memorials and feast days are only generated from the year in which they were effectively introduced). The data is based on original sources (Roman Missals, Decrees of the Dicastery for Divine Worship and the Discipline of the Sacraments, Mysterii Paschalis, etc.), not on data copied or retrieved from online sources which may not be accurate. The API offers multiple locales and multiple calendars, from the **General Roman Calendar** to national or diocesan calendars. The Roman rite is the default and may also be requested explicitly with a `/calendar/roman` prefix (equivalent to no prefix); a `/calendar/ambrosian` prefix selects the Ambrosian rite (currently returns `501 Not Implemented` — see the `/calendar/ambrosian` paths).",
     "version": "5.7",
     "title": "Liturgical Calendar",
     "contact": {

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -1055,7 +1055,7 @@
         ],
         "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for each day of the given year (currently returns 501 Not Implemented)",
         "operationId": "retrieveAmbrosianCalendarForYearGET",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1109,7 +1109,7 @@
         ],
         "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for each day of the given year (currently returns 501 Not Implemented)",
         "operationId": "retrieveAmbrosianCalendarForYearPOST",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi request body parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi request body parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1189,7 +1189,7 @@
         ],
         "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of the current year (currently returns 501 Not Implemented)",
         "operationId": "retrieveAmbrosianDiocesanCalendarGET",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of the current year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of the current year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1308,7 +1308,7 @@
         ],
         "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of a given year (currently returns 501 Not Implemented)",
         "operationId": "retrieveAmbrosianDiocesanCalendarForYearGET",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1353,7 +1353,7 @@
         ],
         "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of a given year (currently returns 501 Not Implemented)",
         "operationId": "retrieveAmbrosianDiocesanCalendarForYearPOST",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -925,6 +925,512 @@
         }
       }
     },
+    "/calendar/ambrosian": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "[Planned] Retrieve liturgical events for the Ambrosian calendar for each day of the current year (currently returns 501 Not Implemented)",
+        "operationId": "retrieveAmbrosianCalendarGET",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the current year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          },
+          {
+            "$ref": "#/components/parameters/EpiphanyParam"
+          },
+          {
+            "$ref": "#/components/parameters/AscensionParam"
+          },
+          {
+            "$ref": "#/components/parameters/CorpusChristiParam"
+          },
+          {
+            "$ref": "#/components/parameters/EternalHighPriestParam"
+          }
+        ],
+        "responses": {
+          "501": {
+            "$ref": "#/components/responses/NotImplemented501"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "[Planned] Retrieve liturgical events for the Ambrosian calendar for each day of the current year (currently returns 501 Not Implemented)",
+        "operationId": "retrieveAmbrosianCalendarPOST",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the current year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi request body parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveCalendarRequestBody"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveCalendarRequestBody"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "501": {
+            "$ref": "#/components/responses/NotImplemented501"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        }
+      }
+    },
+    "/calendar/ambrosian/{year}": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for each day of the given year (currently returns 501 Not Implemented)",
+        "operationId": "retrieveAmbrosianCalendarForYearGET",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/YearPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          },
+          {
+            "$ref": "#/components/parameters/EpiphanyParam"
+          },
+          {
+            "$ref": "#/components/parameters/AscensionParam"
+          },
+          {
+            "$ref": "#/components/parameters/CorpusChristiParam"
+          },
+          {
+            "$ref": "#/components/parameters/EternalHighPriestParam"
+          }
+        ],
+        "responses": {
+          "501": {
+            "$ref": "#/components/responses/NotImplemented501"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for each day of the given year (currently returns 501 Not Implemented)",
+        "operationId": "retrieveAmbrosianCalendarForYearPOST",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi request body parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1970,
+              "maximum": 9999
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveCalendarRequestBody"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveCalendarRequestBody"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "501": {
+            "$ref": "#/components/responses/NotImplemented501"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        }
+      }
+    },
+    "/calendar/ambrosian/diocese/{calendar_id}": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of the current year (currently returns 501 Not Implemented)",
+        "operationId": "retrieveAmbrosianDiocesanCalendarGET",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of the current year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/DiocesanCalendarIdPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          }
+        ],
+        "responses": {
+          "501": {
+            "$ref": "#/components/responses/NotImplemented501"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of the current year (currently returns 501 Not Implemented)",
+        "operationId": "retrieveAmbrosianDiocesanCalendarPOST",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of the current year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "501": {
+            "$ref": "#/components/responses/NotImplemented501"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        }
+      }
+    },
+    "/calendar/ambrosian/diocese/{calendar_id}/{year}": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of a given year (currently returns 501 Not Implemented)",
+        "operationId": "retrieveAmbrosianDiocesanCalendarForYearGET",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/DiocesanCalendarIdPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          }
+        ],
+        "responses": {
+          "501": {
+            "$ref": "#/components/responses/NotImplemented501"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of a given year (currently returns 501 Not Implemented)",
+        "operationId": "retrieveAmbrosianDiocesanCalendarForYearPOST",
+        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1970,
+              "maximum": 9999
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "501": {
+            "$ref": "#/components/responses/NotImplemented501"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        }
+      }
+    },
     "/auth/login": {
       "post": {
         "tags": [
@@ -9497,6 +10003,22 @@
               "status": 429,
               "detail": "Too many login attempts. Please try again later.",
               "retryAfter": 847
+            }
+          }
+        }
+      },
+      "NotImplemented501": {
+        "description": "501 Not Implemented. The request was valid and routable, but the requested calendar computation has not yet been implemented on the server.",
+        "content": {
+          "application/problem+json": {
+            "schema": {
+              "$ref": "./Problem.json"
+            },
+            "example": {
+              "type": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501",
+              "title": "Not Implemented",
+              "status": 501,
+              "detail": "This calendar computation has not yet been implemented"
             }
           }
         }

--- a/phpunit_tests/Handlers/CalendarRiteRoutingTest.php
+++ b/phpunit_tests/Handlers/CalendarRiteRoutingTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use LiturgicalCalendar\Api\Http\Exception\ApiException;
+
+final class CalendarRiteRoutingTest extends AbstractHandlerTestCase
+{
+    /**
+     * In-process handler tests call handle() directly, bypassing the PSR-15
+     * ErrorHandlingMiddleware that normally converts an ApiException into an
+     * HTTP problem+json response (see Router::route()). So here we catch the
+     * ApiException ourselves and read its status, mirroring what the
+     * middleware does in production.
+     *
+     * @param string[] $pathParts
+     */
+    private function handle(array $pathParts, Rite $rite, string $uri): int
+    {
+        $handler = new CalendarHandler($pathParts, $rite);
+        $handler->setAllowedReturnTypes([
+            ReturnTypeParam::JSON,
+            ReturnTypeParam::YAML,
+            ReturnTypeParam::XML,
+            ReturnTypeParam::ICS,
+        ]);
+        try {
+            return $handler->handle($this->requestFor('GET', $uri, ['Accept' => 'application/json']))->getStatusCode();
+        } catch (ApiException $e) {
+            return $e->getStatus();
+        }
+    }
+
+    public function testRomanDefaultStillWorks(): void
+    {
+        self::assertSame(200, $this->handle(['2025'], Rite::ROMAN, '/calendar/2025'));
+    }
+
+    public function testAmbrosianComuneBaseReturns501(): void
+    {
+        self::assertSame(StatusCode::NOT_IMPLEMENTED->value, $this->handle([], Rite::AMBROSIAN, '/calendar/ambrosian'));
+    }
+
+    public function testAmbrosianComuneWithYearReturns501(): void
+    {
+        self::assertSame(StatusCode::NOT_IMPLEMENTED->value, $this->handle(['2008'], Rite::AMBROSIAN, '/calendar/ambrosian/2008'));
+    }
+
+    public function testAmbrosianRejectsNationalCalendarWith400(): void
+    {
+        self::assertSame(StatusCode::BAD_REQUEST->value, $this->handle(['nation', 'US'], Rite::AMBROSIAN, '/calendar/ambrosian/nation/US'));
+    }
+
+    public function testAmbrosianRejectsNonWhitelistedDioceseWith400(): void
+    {
+        self::assertSame(StatusCode::BAD_REQUEST->value, $this->handle(['diocese', 'romamo_it'], Rite::AMBROSIAN, '/calendar/ambrosian/diocese/romamo_it'));
+    }
+
+    public function testAmbrosianRejectsYearBelow1976With400(): void
+    {
+        self::assertSame(StatusCode::BAD_REQUEST->value, $this->handle(['1975'], Rite::AMBROSIAN, '/calendar/ambrosian/1975'));
+    }
+}

--- a/phpunit_tests/Models/Calendar/Rite/AmbrosianRiteProfileTest.php
+++ b/phpunit_tests/Models/Calendar/Rite/AmbrosianRiteProfileTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar\Rite;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Models\Calendar\Rite\AmbrosianRiteProfile;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(AmbrosianRiteProfile::class)]
+final class AmbrosianRiteProfileTest extends TestCase
+{
+    public function testRiteIsAmbrosian(): void
+    {
+        self::assertSame(Rite::AMBROSIAN, ( new AmbrosianRiteProfile() )->rite());
+    }
+
+    public function testWhitelistIsTheFourDioceses(): void
+    {
+        self::assertSame(
+            ['milano_it', 'bergam_it', 'novara_it', 'lugano_ch'],
+            AmbrosianRiteProfile::SUPPORTED_DIOCESES
+        );
+    }
+
+    public function testTemporaleEngineIsNotYetImplemented(): void
+    {
+        $this->expectException(\LogicException::class);
+        ( new AmbrosianRiteProfile() )->temporaleEngine();
+    }
+}

--- a/phpunit_tests/Models/Calendar/Rite/RiteProfileFactoryTest.php
+++ b/phpunit_tests/Models/Calendar/Rite/RiteProfileFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Models\Calendar\Rite;
 
 use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Models\Calendar\Rite\AmbrosianRiteProfile;
 use LiturgicalCalendar\Api\Models\Calendar\Rite\RiteProfileFactory;
 use LiturgicalCalendar\Api\Models\Calendar\Rite\RomanRiteProfile;
 use LiturgicalCalendar\Api\Models\Calendar\Temporale\RomanTemporale;
@@ -20,9 +21,10 @@ final class RiteProfileFactoryTest extends TestCase
         self::assertInstanceOf(RomanTemporale::class, $profile->temporaleEngine());
     }
 
-    public function testAmbrosianNotYetWired(): void
+    public function testAmbrosianProfileIsReturned(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
-        RiteProfileFactory::forRite(Rite::AMBROSIAN);
+        $profile = RiteProfileFactory::forRite(Rite::AMBROSIAN);
+        self::assertInstanceOf(AmbrosianRiteProfile::class, $profile);
+        self::assertSame(Rite::AMBROSIAN, $profile->rite());
     }
 }

--- a/phpunit_tests/Params/CalendarParamsRiteValidationTest.php
+++ b/phpunit_tests/Params/CalendarParamsRiteValidationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Params;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use PHPUnit\Framework\TestCase;
+
+final class CalendarParamsRiteValidationTest extends TestCase
+{
+    /** Build a CalendarParams with the given fields set, bypassing the metadata-loading constructor. */
+    private function params(Rite $rite, ?string $national, ?string $diocesan, int $year): CalendarParams
+    {
+        $p                   = ( new \ReflectionClass(CalendarParams::class) )->newInstanceWithoutConstructor();
+        $p->Rite             = $rite;
+        $p->NationalCalendar = $national;
+        $p->DiocesanCalendar = $diocesan;
+        $p->Year             = $year;
+        return $p;
+    }
+
+    public function testRomanAcceptsEverything(): void
+    {
+        $this->params(Rite::ROMAN, 'US', null, 1970)->validateRiteCompatibility();
+        $this->params(Rite::ROMAN, null, 'romamo_it', 1970)->validateRiteCompatibility();
+        $this->addToAssertionCount(1); // no exception thrown
+    }
+
+    public function testAmbrosianComuneBaseIsValid(): void
+    {
+        $this->params(Rite::AMBROSIAN, null, null, 2025)->validateRiteCompatibility();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAmbrosianWhitelistedDioceseIsValid(): void
+    {
+        $this->params(Rite::AMBROSIAN, null, 'milano_it', 2025)->validateRiteCompatibility();
+        $this->addToAssertionCount(1);
+    }
+
+    public function testAmbrosianRejectsNationalCalendar(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->params(Rite::AMBROSIAN, 'US', null, 2025)->validateRiteCompatibility();
+    }
+
+    public function testAmbrosianRejectsNonWhitelistedDiocese(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->params(Rite::AMBROSIAN, null, 'romamo_it', 2025)->validateRiteCompatibility();
+    }
+
+    public function testAmbrosianRejectsYearBelow1976(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->params(Rite::AMBROSIAN, null, null, 1975)->validateRiteCompatibility();
+    }
+}

--- a/phpunit_tests/RouterRiteSegmentTest.php
+++ b/phpunit_tests/RouterRiteSegmentTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The Router recognises an optional leading rite segment on the calendar route.
+ * `/calendar` and `/calendar/roman` are equivalent (both Roman); `/calendar/ambrosian`
+ * selects the Ambrosian rite. Any other leading segment (a year, `nation`, `diocese`)
+ * is left untouched for the existing shape parsing.
+ */
+#[CoversMethod(Router::class, 'extractRiteSegment')]
+final class RouterRiteSegmentTest extends TestCase
+{
+    public function testAmbrosianSegmentSelectsAmbrosianAndIsStripped(): void
+    {
+        $parts = ['ambrosian', 'diocese', 'milano_it'];
+        self::assertSame(Rite::AMBROSIAN, Router::extractRiteSegment('calendar', $parts));
+        self::assertSame(['diocese', 'milano_it'], $parts);
+    }
+
+    public function testRomanSegmentSelectsRomanAndIsStripped(): void
+    {
+        $parts = ['roman', '2025'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('calendar', $parts));
+        self::assertSame(['2025'], $parts);
+    }
+
+    public function testBareRomanSegmentIsStripped(): void
+    {
+        $parts = ['roman'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('calendar', $parts));
+        self::assertSame([], $parts);
+    }
+
+    public function testNoRiteSegmentDefaultsToRomanAndLeavesPartsIntact(): void
+    {
+        $parts = ['2025'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('calendar', $parts));
+        self::assertSame(['2025'], $parts);
+    }
+
+    public function testBareCalendarDefaultsToRoman(): void
+    {
+        $parts = [];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('calendar', $parts));
+        self::assertSame([], $parts);
+    }
+
+    public function testNationSegmentIsNotARite(): void
+    {
+        $parts = ['nation', 'US'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('calendar', $parts));
+        self::assertSame(['nation', 'US'], $parts);
+    }
+
+    public function testRiteSegmentOnlyAppliesToTheCalendarRoute(): void
+    {
+        // A non-calendar route must never treat a leading 'ambrosian'/'roman' as a rite.
+        $parts = ['ambrosian'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('metadata', $parts));
+        self::assertSame(['ambrosian'], $parts);
+    }
+}

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -26,6 +26,7 @@ use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Enum\StatusCode;
 use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\ImplementationException;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Http\Exception\YamlException;
@@ -108,6 +109,7 @@ final class CalendarHandler extends AbstractHandler
     private array $allowedReturnTypes = [];
     private static CatholicDiocesesMap $worldDiocesesLatinRite; // can only be set once, after which it will be read-only
     private CalendarParams $CalendarParams;
+    private Rite $rite = Rite::ROMAN;
     private \NumberFormatter $formatter;
     private \NumberFormatter $formatterFem;
     private \IntlDateFormatter $dayOfTheWeek;
@@ -311,9 +313,10 @@ final class CalendarHandler extends AbstractHandler
     /**
      * @param string[] $requestPathParams
      */
-    public function __construct(array $requestPathParams = [])
+    public function __construct(array $requestPathParams = [], Rite $rite = Rite::ROMAN)
     {
         parent::__construct($requestPathParams);
+        $this->rite      = $rite;
         $this->startTime = hrtime(true);
     }
 
@@ -3877,9 +3880,10 @@ final class CalendarHandler extends AbstractHandler
         // The contiguous Roman temporale block (Easter Triduum through the mobile
         // Solemnities of the Lord) is delegated to the rite's temporale engine,
         // obtained via the RiteProfile seam, which mutates the shared calendar
-        // and message sink through the context. Until a later plan parses the
-        // rite from the request path, this always resolves to Rite::default().
-        $riteProfile      = RiteProfileFactory::forRite(Rite::default());
+        // and message sink through the context. This is only ever reached for
+        // Rite::ROMAN today: an Ambrosian request short-circuits with a 501
+        // earlier in handle() (Plans 3-5 will implement the Ambrosian engine).
+        $riteProfile      = RiteProfileFactory::forRite($this->CalendarParams->Rite);
         $temporaleContext = new TemporaleContext(
             $this->Cal,
             $this->CalendarParams,
@@ -4995,6 +4999,7 @@ final class CalendarHandler extends AbstractHandler
 
         $this->CalendarParams = new CalendarParams();
         $this->CalendarParams->setAllowedReturnTypes($this->allowedReturnTypes);
+        $this->CalendarParams->setRite($this->rite);
         $this->CalendarParams->setParams($params);
         if ($this->CalendarParams->ReturnType !== null) {
             $responseContentType = $this->CalendarParams->ReturnType->toResponseContentType();
@@ -5007,8 +5012,15 @@ final class CalendarHandler extends AbstractHandler
         // If a national calendar or diocesan calendar is requested, these will override
         //   most of the other parameters (taken care of by the updateSettingsBasedOn[National|Diocesan]Calendar methods)
         $this->CalendarParams->initParamsFromRequestPath($this->requestPathParams);
+        $this->CalendarParams->validateRiteCompatibility();
 
         $this->validateRequestMethod($request);
+
+        if ($this->CalendarParams->Rite === Rite::AMBROSIAN) {
+            throw new ImplementationException(
+                'The Ambrosian rite is planned but not yet available; only the Roman rite is currently implemented.'
+            );
+        }
 
         $this->loadDiocesanCalendarData();
         $this->loadNationalCalendarData();

--- a/src/Models/Calendar/Rite/AmbrosianRiteProfile.php
+++ b/src/Models/Calendar/Rite/AmbrosianRiteProfile.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\Calendar\Rite;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleEngine;
+
+/**
+ * Ambrosian rite profile. Plan 2 wires only the diocese whitelist and rite
+ * identity; the temporale engine, precedence resolver, missal resolver, and
+ * vocabularies arrive in later plans.
+ */
+final class AmbrosianRiteProfile implements RiteProfile
+{
+    /**
+     * Diocesan calendars that support the Ambrosian rite. Provisional constant
+     * until Plan 5 creates these diocese files with `supported_rites` metadata,
+     * at which point the whitelist becomes data-driven. These IDs MUST match the
+     * diocese calendar files created in Plan 5.
+     *
+     * @var list<string>
+     */
+    public const SUPPORTED_DIOCESES = ['milano_it', 'bergam_it', 'novara_it', 'lugano_ch'];
+
+    public function rite(): Rite
+    {
+        return Rite::AMBROSIAN;
+    }
+
+    public function temporaleEngine(): TemporaleEngine
+    {
+        // Unreachable in normal flow: CalendarHandler returns 501 for the
+        // Ambrosian rite before any temporale computation. Replaced by the
+        // real AmbrosianTemporale in Plan 3.
+        throw new \LogicException('The Ambrosian temporale engine is not yet implemented (Plan 3).');
+    }
+}

--- a/src/Models/Calendar/Rite/RiteProfileFactory.php
+++ b/src/Models/Calendar/Rite/RiteProfileFactory.php
@@ -12,7 +12,7 @@ final class RiteProfileFactory
     {
         return match ($rite) {
             Rite::ROMAN     => new RomanRiteProfile(),
-            Rite::AMBROSIAN => throw new \InvalidArgumentException('Ambrosian rite not yet wired'),
+            Rite::AMBROSIAN => new AmbrosianRiteProfile(),
         };
     }
 }

--- a/src/Params/CalendarParams.php
+++ b/src/Params/CalendarParams.php
@@ -8,9 +8,11 @@ use LiturgicalCalendar\Api\Enum\Ascension;
 use LiturgicalCalendar\Api\Enum\CorpusChristi;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Models\Calendar\Rite\AmbrosianRiteProfile;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
 use LiturgicalCalendar\Api\Utilities;
@@ -44,6 +46,7 @@ class CalendarParams implements ParamsInterface
     public ?ReturnTypeParam $ReturnType   = null;
     public ?string $NationalCalendar      = null;
     public ?string $DiocesanCalendar      = null;
+    public Rite $Rite                     = Rite::ROMAN;
     private ?MetadataCalendars $calendars = null;
 
     public Epiphany $Epiphany           = Epiphany::JAN6;
@@ -109,6 +112,9 @@ class CalendarParams implements ParamsInterface
     //  public const YEAR_LOWER_LIMIT          = 1583;
     // For now we'll just deal with the Liturgical Calendar from the Editio Typica 1970
     public const YEAR_LOWER_LIMIT = 1970;
+
+    // The Ambrosian rite is only available from 1976 onward (the first reformed Ambrosian Missal).
+    public const AMBROSIAN_YEAR_LOWER_LIMIT = 1976;
 
     //The upper limit is determined by the limit of PHP in dealing with DateTime objects
     public const YEAR_UPPER_LIMIT = 9999;
@@ -630,6 +636,55 @@ class CalendarParams implements ParamsInterface
             if (count($params)) {
                 $this->setParams($params);
             }
+        }
+    }
+
+    /**
+     * Sets the liturgical rite for which the calendar should be calculated.
+     *
+     * @param Rite $rite the liturgical rite (ROMAN or AMBROSIAN)
+     */
+    public function setRite(Rite $rite): void
+    {
+        $this->Rite = $rite;
+    }
+
+    /**
+     * Cross-field validation of the rite against the requested calendar and year.
+     * Roman accepts every calendar shape and the full year range. The Ambrosian
+     * rite has no national layer, is restricted to its whitelisted dioceses (plus
+     * the comune ambrosiano when no diocese is given), and starts at 1976 (the
+     * first reformed Ambrosian Missal). Throws ValidationException (HTTP 400) on
+     * mismatch. Must be called after the rite, calendar, and year are all set.
+     *
+     * @throws ValidationException
+     */
+    public function validateRiteCompatibility(): void
+    {
+        if ($this->Rite === Rite::ROMAN) {
+            return;
+        }
+
+        if ($this->NationalCalendar !== null) {
+            throw new ValidationException(
+                'The Ambrosian rite has no national calendars; request the comune ambrosiano (`/calendar/ambrosian`) or one of its dioceses.'
+            );
+        }
+
+        if ($this->DiocesanCalendar !== null && !in_array($this->DiocesanCalendar, AmbrosianRiteProfile::SUPPORTED_DIOCESES, true)) {
+            throw new ValidationException(sprintf(
+                'Diocesan calendar `%s` does not support the Ambrosian rite. Ambrosian dioceses are: %s',
+                $this->DiocesanCalendar,
+                implode(', ', AmbrosianRiteProfile::SUPPORTED_DIOCESES)
+            ));
+        }
+
+        if ($this->Year < self::AMBROSIAN_YEAR_LOWER_LIMIT) {
+            throw new ValidationException(sprintf(
+                'The Ambrosian rite is only available from %d onward (the first reformed Ambrosian Missal); requested year %d.',
+                self::AMBROSIAN_YEAR_LOWER_LIMIT,
+                $this->Year
+            ));
         }
     }
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -104,6 +104,34 @@ class Router
     }
 
     /**
+     * Determines the liturgical rite from an optional leading rite segment on the
+     * calendar route, stripping that segment from the request-path parts when present.
+     *
+     * Only the calendar route (`calendar`, or the empty root route) carries a rite
+     * segment. A leading segment whose value is a valid {@see Rite} case (`roman`,
+     * `ambrosian`) selects that rite and is removed from `$requestPathParts` so the
+     * remaining 0/1/2/3-part shape parsing runs identically to an un-prefixed request;
+     * `/calendar` and `/calendar/roman` are therefore equivalent, symmetric with
+     * `/calendar/ambrosian`. Absence of a rite segment defaults to Roman. No nation or
+     * diocese identifier collides with a rite value, so this is unambiguous.
+     *
+     * @param string       $route            the first path segment (the endpoint), already shifted off
+     * @param list<string> $requestPathParts the remaining path segments; the rite segment is removed in place when present
+     */
+    public static function extractRiteSegment(string $route, array &$requestPathParts): Rite
+    {
+        if ($route === 'calendar' || $route === '') {
+            $maybeRite = Rite::tryFrom((string) ( $requestPathParts[0] ?? '' ));
+            if ($maybeRite !== null) {
+                array_shift($requestPathParts);
+                return $maybeRite;
+            }
+        }
+
+        return Rite::default();
+    }
+
+    /**
      * Route the incoming HTTP request to the appropriate API endpoint, execute the configured middleware pipeline, and emit the HTTP response.
      *
      * The method selects and configures a per-endpoint request handler based on the request path, applies middlewares (including error handling, logging, and conditional JWT authentication for protected data modification routes), runs the pipeline, appends the X-Request-Id header to the final response, and terminates execution by emitting the response.
@@ -120,15 +148,10 @@ class Router
         $requestPathParts = explode('/', $pathParams);
         $route            = array_shift($requestPathParts);
 
-        // An optional leading 'ambrosian' segment on the calendar route selects the
-        // Ambrosian rite; strip it so the existing 0/1/2/3-part shape parsing below
-        // runs unchanged on the remainder (e.g. /calendar/ambrosian/diocese/milano_it
-        // -> ['diocese', 'milano_it'], same shape as a Roman diocesan request).
-        $rite = Rite::default();
-        if (( $route === 'calendar' || $route === '' ) && ( $requestPathParts[0] ?? null ) === 'ambrosian') {
-            $rite = Rite::AMBROSIAN;
-            array_shift($requestPathParts);
-        }
+        // An optional leading rite segment on the calendar route selects the rite;
+        // it is stripped so the existing 0/1/2/3-part shape parsing below runs
+        // unchanged on the remainder (see extractRiteSegment()).
+        $rite = self::extractRiteSegment($route, $requestPathParts);
 
         // Parse allowed origins from environment (comma-separated list, or '*' for all)
         // This is used for both handler-level CORS and error response CORS

--- a/src/Router.php
+++ b/src/Router.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
 use LiturgicalCalendar\Api\Http\Enum\RequestContentType;
 use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
 use LiturgicalCalendar\Api\Enum\PathCategory;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Handlers\CalendarHandler;
 use LiturgicalCalendar\Api\Handlers\EasterHandler;
 use LiturgicalCalendar\Api\Handlers\EventsHandler;
@@ -119,6 +120,16 @@ class Router
         $requestPathParts = explode('/', $pathParams);
         $route            = array_shift($requestPathParts);
 
+        // An optional leading 'ambrosian' segment on the calendar route selects the
+        // Ambrosian rite; strip it so the existing 0/1/2/3-part shape parsing below
+        // runs unchanged on the remainder (e.g. /calendar/ambrosian/diocese/milano_it
+        // -> ['diocese', 'milano_it'], same shape as a Roman diocesan request).
+        $rite = Rite::default();
+        if (( $route === 'calendar' || $route === '' ) && ( $requestPathParts[0] ?? null ) === 'ambrosian') {
+            $rite = Rite::AMBROSIAN;
+            array_shift($requestPathParts);
+        }
+
         // Parse allowed origins from environment (comma-separated list, or '*' for all)
         // This is used for both handler-level CORS and error response CORS
         $allowedOriginsEnv = isset($_ENV['CORS_ALLOWED_ORIGINS']) && is_string($_ENV['CORS_ALLOWED_ORIGINS'])
@@ -135,7 +146,7 @@ class Router
             case '':
                 // no break (intentional fallthrough)
             case 'calendar':
-                $calendarHandler = new CalendarHandler($requestPathParts);
+                $calendarHandler = new CalendarHandler($requestPathParts, $rite);
                 if (count($requestPathParts) === 0) {
                     $calendarHandler->setAllowedRequestMethods([
                         RequestMethod::GET,


### PR DESCRIPTION
## Ambrosian Rite integration — Plan 2 of 6: Rite routing & validation

Second installment. Adds the **request-side plumbing** for the Ambrosian rite: an optional rite path segment, rite↔calendar validation, and a **501 Not Implemented** placeholder for valid Ambrosian requests. **The Ambrosian calendar is not computed here** — that arrives in Plans 3–5. Every existing `/calendar` URL is byte-identical (golden master 9/9).

### What this PR does

- **`Rite` routing** — `Router` strips an optional leading `{rite}` segment on the calendar route, currently supporting two rites: **`roman`** and **`ambrosian`** (recognized via `Rite::tryFrom()`, extracted into a testable `Router::extractRiteSegment()`). Absence of a segment defaults to Roman, so `/calendar` and `/calendar/roman` are equivalent — symmetric with `/calendar/ambrosian`. The remaining path shape (`/{year}`, `/nation/{id}`, `/diocese/{id}`…) parses unchanged. No nation/diocese id collides with a rite value.
- **Validation → 400** (`CalendarParams::validateRiteCompatibility()`): Ambrosian has no national layer; only whitelisted dioceses; year ≥ 1976 (first reformed Ambrosian Missal). Reuses the existing `ValidationException`.
- **501 interim** — the handler returns `ImplementationException` (501) for otherwise-valid Ambrosian requests, fired *before* any Roman-national/diocesan data loading or cache work, so a `nation`-shaped Ambrosian request never touches Roman code.
- **`AmbrosianRiteProfile`** — owns the provisional diocese whitelist (`milano_it`, `bergam_it`, `novara_it`, `lugano_ch`); `RiteProfileFactory` returns it. Temporale-engine selection now flows through the parsed rite (`forRite($params->Rite)`), the single swap point for Plan 3.
- **OpenAPI** — four `/calendar/ambrosian…` path items (no national variant), a reusable `NotImplemented501` response, a note on the optional rite prefix, and notes that `epiphany`/`ascension`/`corpus_christi` are inert under the Ambrosian rite (spec §3).

### Behavior contract

| Request | Result |
|---|---|
| `/calendar/...` (no rite segment) | Roman, unchanged |
| `/calendar/roman` , `/calendar/roman/{year}` , `/calendar/roman/nation/{id}` , `/calendar/roman/diocese/{id}` | Roman — identical to the un-prefixed forms |
| `/calendar/ambrosian` , `/calendar/ambrosian/{year≥1976}` | **501** (planned) |
| `/calendar/ambrosian/nation/...` | **400** (no national layer) |
| `/calendar/ambrosian/diocese/{non-whitelisted}` | **400** |
| `/calendar/ambrosian/{year<1976}` | **400** |

### Testing

- Golden master **9/9** at every step (Roman byte-identical); rite-routing **6/6**; params validation **6/6**; `Router::extractRiteSegment()` unit test **7/7** (server-independent, so it runs in CI unlike the live-server route tests); handler-group **380/380** (0 new failures).
- **PHPStan level 10** clean; **phpcs** clean; **`composer lint:openapi`** exit 0 (8 non-fatal `operation-2xx-response` warnings — intentional, these operations have no 2xx until the engine lands).

### Known transitional behavior (by design)

The four whitelisted dioceses don't have calendar *files* until **Plan 5**, so `GET /calendar/ambrosian/diocese/milano_it` currently returns **400 "unknown diocese"** (from the existing diocesan-existence check, which runs before the rite whitelist), not the OpenAPI-documented 501. Once Plan 5 creates the files, existence passes → whitelist passes → 501. Plan 2's demonstrable Ambrosian-success case is the bare comune (`/calendar/ambrosian` → 501).

### Deferred (Minor, tracked for later plans)

- Soften the OpenAPI diocese-GET wording about the inert params (they're accepted at runtime but not declared in the operation's `parameters`, mirroring the Roman template).
- When Plan 3 lands, replace `AmbrosianRiteProfile::temporaleEngine()`'s `\LogicException` placeholder with the real engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
