### PR TITLE
Complete the Ambrosian temporale (after-* Sundays, all-season ferial fill, seasons + is_aliturgical)

### DIFF
--- a/docs/superpowers/plans/2026-07-22-ambrosian-06-temporale-completion.md
+++ b/docs/superpowers/plans/2026-07-22-ambrosian-06-temporale-completion.md
@@ -1,0 +1,1357 @@
+# Ambrosian Temporale Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `AmbrosianTemporale` so `buildTemporale()` produces a *complete* Ambrosian temporal year — every day from Advent I to the Saturday before the next Advent I is
+covered by a liturgical event — by adding the after-Epiphany and after-Pentecost Sunday numbering (3 sub-blocks), all-season ferial weekday fill (including Lenten aliturgical
+Fridays), and `liturgical_season` stamping on every engine-created event.
+
+**Architecture:** The engine synthesizes the numbered Sundays and every ferial weekday **in code** (exactly how `RomanTemporale`/`CalendarHandler` synthesize Roman Ordinary-Time
+weekdays), stamping `liturgical_season` via `LitSeason::forEventKey()`. The existing anchor block (Advent/Christmas/Lent/Easter Sundays + solemnities) remains data-driven and
+unchanged. A single `is_aliturgical` boolean is added to the event models + source schema, mirroring the existing `is_dominical` wiring, and is set on Lenten Friday ferie.
+
+**Tech Stack:** PHP 8.4, PHPUnit 11, PHPStan level 10, PHP_CodeSniffer (PSR-12 + custom ruleset). No new runtime dependencies.
+
+## Global Constraints
+
+- **Endpoint stays 501.** Nothing in this plan wires `AmbrosianTemporale` into `CalendarHandler`; `/calendar/ambrosian` continues to return `ImplementationException` (501). The
+  engine is exercised **only** through the existing unit-test harness (`AmbrosianTemporaleHarnessTrait::runEngine()`), by invoking `buildTemporale()` directly. Do **not** touch
+  `CalendarHandler`.
+- **Roman output byte-identical.** `phpunit_tests/Handlers/CalendarGoldenMasterTest.php` (9 tests / 36 assertions) is the gate and must stay green. Every change is strictly
+  additive. `is_aliturgical` serializes **only when non-null** (mirror `is_dominical`), so no Roman event's JSON changes.
+- **Seasons are stamped by the engine, not by the collection.** `LiturgicalEventCollection::setSeasonsAndHolyDaysOfObligation()` is Roman-only (it requires an `AshWednesday` event
+  and knows only the 6 Roman seasons) and must **not** be called for Ambrosian. The engine stamps `liturgical_season` on every event it creates via
+  `LitSeason::forEventKey($eventKey)`.
+- **Synthesized keys must classify under `forEventKey`.** Every synthesized event key MUST begin with one of these stems so `LitSeason::forEventKey()` returns the correct season:
+  `AdventWeekday`, `Christmas` (→`ChristmasWeekday`), `LentWeekday`, `EasterWeekday`, `AfterEpiphany` (Sundays `AfterEpiphany2..N`, ferie `AfterEpiphanyWeekday…`), `AfterPentecost`
+  (Sundays/ferie `AfterPentecost…`, `AfterPentecostMartyrdom…`, `AfterPentecostDedication…` — all begin with `AfterPentecost`).
+- **LitGrade ladder is unchanged** (`HIGHER_SOLEMNITY`=7 … `WEEKDAY`=0). Grades/colours for synthesized events:
+- After-***Sundays**: `LitGrade::FEAST_LORD`, `LitColor::GREEN`, `is_dominical = true`. (The precedence resolver's rank-3 clause excludes AFTER_* seasons, so these FEAST_LORD
+    dominical Sundays correctly land at Tabella rank 4 — see `AmbrosianLiturgicalDayRank`.)
+- **Ferial weekdays**: `LitGrade::WEEKDAY`, `is_dominical` left null. Colours per season: Advent → `LitColor::MORELLO`, Christmas → `LitColor::WHITE`, Lent → `LitColor::MORELLO`,
+    Easter → `LitColor::WHITE`, after-Epiphany/after-Pentecost → `LitColor::GREEN`.
+- **Edition scope: 2024 (post-2008) only.** The pre-2008 (1976) single-block post-Pentecost structure and the year-2008 branch are Plan 9 (1976 backfill). This plan implements the
+  post-2008 rules for all years the harness exercises (2024–2026).
+- **Names are norm-derived and synthesized in code; exact ordo names/numbering are validated in Plan 9.** Do not hand-author a speculative Sunday data file. Build display names
+  from a per-season template + localized weekday + ordinal, for the two Ambrosian locales present (`it`, `la`).
+- **All work happens in the worktree** `…/scratchpad/wt-ambrosian-p6` (branch `feature/ambrosian-temporale-fill`). Verify `git rev-parse --show-toplevel` ends in `wt-ambrosian-p6`
+  before editing. Signed commits (unlock GPG if a commit times out).
+- **Quality gates per task:** `composer test:quick` (or the named test), `composer analyse` (PHPStan L10, scans `src` only), `composer lint` (phpcs). PHPStan-ignore uses the modern
+  `@phpstan-ignore <identifier>` form.
+
+---
+
+## File Structure
+
+- `src/Models/Calendar/LiturgicalEvent.php` — add `public ?bool $is_aliturgical = null;` + serialization + hydration (mirror `is_dominical`).
+- `src/Models/PropriumDeTemporeEvent.php` — add readonly `?bool $is_aliturgical` (ctor/`fromArray`/`fromObject`), mirror `is_dominical`.
+- `jsondata/schemas/PropriumDeTempore.json` — add optional `is_aliturgical` boolean property.
+- `src/Enum/LitSeason.php` — add 4 anchor-key patterns so the existing Ambrosian anchor keys classify correctly.
+- `src/Models/Calendar/Temporale/AmbrosianTemporale.php` — the core work: a `stampSeason()` hook on every created event; `calculateAfterEpiphanySundays()`;
+  `calculateAfterPentecostSundays()` (3 sub-blocks); a generic `fillFerialWeekdays()` helper + `buildFerialName()`; six per-season fill methods; all wired into `buildTemporale()`.
+- `phpunit_tests/Enum/LitSeasonAmbrosianTest.php` — extend for the 4 new anchor-key patterns.
+- `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php` — extend with Sundays, sub-blocks, weekday fill, seasons, aliturgical Fridays.
+- `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleHarnessTrait.php` — add a `runEngineEvents()` helper returning full `LiturgicalEvent` objects (not just dates) so tests
+  can assert season/grade/is_aliturgical.
+- `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleCompletenessTest.php` — **new**; full-year gap-free coverage acceptance test (`@group slow`).
+- `phpunit_tests/Models/Calendar/LiturgicalEventIsAliturgicalTest.php` — **new**; model round-trip for `is_aliturgical`.
+
+**Naming conventions (fixed for this plan):**
+
+| Block                     | Sunday keys                   | Ferial keys                                      | Season          | Colour  |
+| ------------------------- | ----------------------------- | ------------------------------------------------ | --------------- | ------- |
+| Advent (existing anchors) | `Advent1..6`                  | `AdventWeekday{DDD}` (see Task 6)                | ADVENT          | morello |
+| Christmas                 | anchors only                  | `ChristmasWeekday{DDD}`                          | CHRISTMAS       | white   |
+| After-Epiphany            | `AfterEpiphany2..N`           | `AfterEpiphanyWeekday{N}{EnglishDay}`            | AFTER_EPIPHANY  | green   |
+| Lent (existing anchors)   | `Lent1..5`                    | `LentWeekday{N}{EnglishDay}`                     | LENT            | morello |
+| Easter (existing anchors) | `Easter2..7`                  | `EasterWeekday{N}{EnglishDay}`                   | EASTER          | white   |
+| After-Pentecost (a)       | `AfterPentecost{N}`           | `AfterPentecostWeekday{N}{EnglishDay}`           | AFTER_PENTECOST | green   |
+| After-Pentecost (b)       | `AfterPentecostMartyrdom{N}`  | `AfterPentecostMartyrdomWeekday{N}{EnglishDay}`  | AFTER_PENTECOST | green   |
+| After-Pentecost (c)       | `AfterPentecostDedication{N}` | `AfterPentecostDedicationWeekday{N}{EnglishDay}` | AFTER_PENTECOST | green   |
+
+`{DDD}` = zero-padded day-of-month; `{N}` = week number within the block/season; `{EnglishDay}` = English weekday name (`Monday`…`Saturday`) — matching the Roman
+`OrdWeekday{N}{EnglishDay}` key convention so keys are locale-independent.
+
+---
+
+### Task 1: Add the `is_aliturgical` flag to the event models and source schema
+
+**Files:**
+
+- Modify: `src/Models/Calendar/LiturgicalEvent.php` (property near line 51; serialization near line 312; hydration near line 566)
+- Modify: `src/Models/PropriumDeTemporeEvent.php`
+- Modify: `jsondata/schemas/PropriumDeTempore.json` (property block near line 25)
+- Test: `phpunit_tests/Models/Calendar/LiturgicalEventIsAliturgicalTest.php` (create)
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces: `LiturgicalEvent::$is_aliturgical` (`public ?bool`, serialized only when non-null); `PropriumDeTemporeEvent::$is_aliturgical` (`public readonly ?bool`). Task 7 sets
+  `$event->is_aliturgical = true` on Lenten Friday ferie.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `phpunit_tests/Models/Calendar/LiturgicalEventIsAliturgicalTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar;
+
+use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\LitColor;
+use LiturgicalCalendar\Api\Enum\LitEventType;
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use PHPUnit\Framework\TestCase;
+
+final class LiturgicalEventIsAliturgicalTest extends TestCase
+{
+    public function testIsAliturgicalDefaultsNullAndIsOmittedFromSerialization(): void
+    {
+        $event = new LiturgicalEvent('Test', DateTime::fromFormat('14-3-2025'), LitColor::MORELLO, LitEventType::MOBILE, LitGrade::WEEKDAY);
+        self::assertNull($event->is_aliturgical);
+        self::assertArrayNotHasKey('is_aliturgical', $event->jsonSerialize());
+    }
+
+    public function testIsAliturgicalSerializesWhenSet(): void
+    {
+        $event                 = new LiturgicalEvent('Test', DateTime::fromFormat('14-3-2025'), LitColor::MORELLO, LitEventType::MOBILE, LitGrade::WEEKDAY);
+        $event->is_aliturgical = true;
+        self::assertTrue($event->jsonSerialize()['is_aliturgical']);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/LiturgicalEventIsAliturgicalTest.php`
+Expected: FAIL — "Undefined property ... $is_aliturgical" (or the serialization assertion fails).
+
+- [ ] **Step 3: Add the property to `LiturgicalEvent`**
+
+In `src/Models/Calendar/LiturgicalEvent.php`, directly after the `public ?bool $is_dominical = null;` line (≈ line 51):
+
+```php
+    public ?bool $is_aliturgical         = null;
+```
+
+- [ ] **Step 4: Serialize it (only when non-null)**
+
+In the same file, directly after the `is_dominical` serialization block (≈ lines 312–314):
+
+```php
+        if ($this->is_aliturgical !== null) {
+            $returnArr['is_aliturgical'] = $this->is_aliturgical;
+        }
+```
+
+Also add `is_aliturgical?: ?bool,` to the serialization return-shape docblock next to the existing `is_dominical?: ?bool,` entry (≈ line 250), so PHPStan L10 sees the key.
+
+- [ ] **Step 5: Hydrate it from source objects**
+
+In `fromObject()`, directly after the `is_dominical` carry-over block (≈ lines 561–567):
+
+```php
+        // Carry over `is_aliturgical` from source data (e.g. PropriumDeTemporeEvent) when present and non-null.
+        if (property_exists($obj, 'is_aliturgical') && null !== $obj->is_aliturgical) {
+            if (false === is_bool($obj->is_aliturgical)) {
+                throw new \Exception('Invalid object provided to create LiturgicalEvent: is_aliturgical is not a boolean or null');
+            }
+            $litEvent->is_aliturgical = $obj->is_aliturgical;
+        }
+```
+
+- [ ] **Step 6: Add `is_aliturgical` to `PropriumDeTemporeEvent`**
+
+In `src/Models/PropriumDeTemporeEvent.php`, mirror every `is_dominical` site:
+
+- Property (after the `$is_dominical` property declaration):
+
+```php
+    /**
+     * Whether the event is aliturgical (no Mass celebrated), if applicable to the source data.
+     * Absent/null for source data that does not classify aliturgical days (e.g. the Roman proprium).
+     */
+    public readonly ?bool $is_aliturgical;
+```
+
+- Constructor: add `?bool $is_aliturgical = null` as the final parameter and `$this->is_aliturgical = $is_aliturgical;` in the body.
+- `fromArrayInternal()`: add `$data['is_aliturgical'] ?? null` as the final `new static(...)` argument, and add `is_aliturgical?:bool|null` to its `@param` array shape.
+- `fromObjectInternal()`: mirror the `is_dominical` guard:
+
+```php
+        $is_aliturgical = null;
+        if (property_exists($data, 'is_aliturgical') && is_bool($data->is_aliturgical)) {
+            $is_aliturgical = $data->is_aliturgical;
+        }
+```
+
+  and pass `$is_aliturgical` as the final `new static(...)` argument; add `is_aliturgical?:bool|null` to the `@param` shape.
+
+- [ ] **Step 7: Add the schema property**
+
+In `jsondata/schemas/PropriumDeTempore.json`, inside the same `properties` object as `is_dominical` (≈ line 25), add:
+
+```json
+                "is_aliturgical": {
+                    "type": "boolean",
+                    "description": "Whether the event is aliturgical (no Mass is celebrated). Used by the Ambrosian proprium for the aliturgical Fridays of Lent."
+                },
+```
+
+(`is_aliturgical` stays optional — do not add it to any `required` array. `additionalProperties` is `false`, so this new key must be declared to be accepted.)
+
+- [ ] **Step 8: Run tests + static analysis**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/LiturgicalEventIsAliturgicalTest.php` → PASS.
+Run: `composer analyse` → no new errors.
+Run: `composer lint` → clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Models/Calendar/LiturgicalEvent.php src/Models/PropriumDeTemporeEvent.php jsondata/schemas/PropriumDeTempore.json phpunit_tests/Models/Calendar/LiturgicalEventIsAliturgicalTest.php
+git commit -m "feat(ambrosian): add is_aliturgical flag to event models and PropriumDeTempore schema"
+```
+
+---
+
+### Task 2: Classify the Ambrosian anchor keys under `LitSeason::forEventKey()` and stamp seasons in the engine
+
+**Files:**
+
+- Modify: `src/Enum/LitSeason.php` (`CHRISTMAS_PATTERNS`, `LENT_PATTERNS`, `AFTER_PENTECOST_PATTERNS`)
+- Modify: `src/Models/Calendar/Temporale/AmbrosianTemporale.php` (add `stampSeason()`, call it in `createPropriumDeTemporeLiturgicalEventByKey()`)
+- Test: `phpunit_tests/Enum/LitSeasonAmbrosianTest.php`, `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php`
+
+**Interfaces:**
+
+- Consumes: `LitSeason::forEventKey(string): LitSeason` (existing).
+- Produces: `AmbrosianTemporale::stampSeason(LiturgicalEvent $event): void` (private) — sets `$event->liturgical_season = LitSeason::forEventKey($event->event_key)`. Every event
+  the engine creates (now and in Tasks 3–9) is stamped through the single creation path.
+
+**Background — the 4 anchor keys that currently misclassify:** `forEventKey()` sends any unmatched key to `ORDINARY_TIME`. Of the 38 existing Ambrosian anchor keys, four have no
+pattern and wrongly resolve to `ORDINARY_TIME`: `Circoncisione` (Jan 1 octave day → CHRISTMAS), `AshesMonday` (→ LENT), `SabatoTradSymb` (Saturday before Palm Sunday → LENT),
+`ChristKing` (last Sunday after the Dedication → AFTER_PENTECOST). All others already classify correctly (`Advent\d`, `Christmas`, `Epiphany`, `BaptismLord`, `Lent\d`, `PalmSun`,
+`HolyThurs`/`GoodFri`/`EasterVigil`, `Easter\d*`, `*OctaveEaster`, `Ascension`, `Pentecost`, `DedicationDuomo`).
+
+- [ ] **Step 1: Write the failing test (patterns)**
+
+Add to `phpunit_tests/Enum/LitSeasonAmbrosianTest.php`:
+
+```php
+    public function testAmbrosianAnchorKeysClassifyCorrectly(): void
+    {
+        self::assertSame(LitSeason::CHRISTMAS, LitSeason::forEventKey('Circoncisione'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('AshesMonday'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('SabatoTradSymb'));
+        self::assertSame(LitSeason::AFTER_PENTECOST, LitSeason::forEventKey('ChristKing'));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Enum/LitSeasonAmbrosianTest.php --filter testAmbrosianAnchorKeysClassifyCorrectly`
+Expected: FAIL — each returns `ORDINARY_TIME`.
+
+- [ ] **Step 3: Add the patterns**
+
+In `src/Enum/LitSeason.php`:
+
+- To `CHRISTMAS_PATTERNS` add `'/^Circoncisione$/',`
+- To `LENT_PATTERNS` add `'/^AshesMonday$/',` and `'/^SabatoTradSymb$/',`
+- To `AFTER_PENTECOST_PATTERNS` add `'/^ChristKing$/',`
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Enum/LitSeasonAmbrosianTest.php` → PASS.
+
+- [ ] **Step 5: Write the failing test (engine stamping)**
+
+Add to `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php` a test that uses a new `runEngineEvents()` harness helper (added in Step 6) to assert seasons on the
+anchor block:
+
+```php
+    public function testAnchorBlockSeasonsStamped2025(): void
+    {
+        $events = $this->runEngineEvents(2025);
+        self::assertSame(LitSeason::ADVENT, $events['Advent1']->liturgical_season);
+        self::assertSame(LitSeason::CHRISTMAS, $events['Christmas']->liturgical_season);
+        self::assertSame(LitSeason::CHRISTMAS, $events['Circoncisione']->liturgical_season);
+        self::assertSame(LitSeason::CHRISTMAS, $events['Epiphany']->liturgical_season);
+        self::assertSame(LitSeason::CHRISTMAS, $events['BaptismLord']->liturgical_season);
+        self::assertSame(LitSeason::LENT, $events['Lent1']->liturgical_season);
+        self::assertSame(LitSeason::LENT, $events['AshesMonday']->liturgical_season);
+        self::assertSame(LitSeason::LENT, $events['SabatoTradSymb']->liturgical_season);
+        self::assertSame(LitSeason::EASTER_TRIDUUM, $events['HolyThurs']->liturgical_season);
+        self::assertSame(LitSeason::EASTER, $events['Easter']->liturgical_season);
+        self::assertSame(LitSeason::EASTER, $events['Pentecost']->liturgical_season);
+        self::assertSame(LitSeason::AFTER_PENTECOST, $events['DedicationDuomo']->liturgical_season);
+        self::assertSame(LitSeason::AFTER_PENTECOST, $events['ChristKing']->liturgical_season);
+    }
+```
+
+Add `use LiturgicalCalendar\Api\Enum\LitSeason;` to the test's imports.
+
+- [ ] **Step 6: Add `runEngineEvents()` to the harness trait**
+
+In `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleHarnessTrait.php`, add alongside `runEngine()`:
+
+```php
+    /** @return array<string,\LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent> map of event_key => event after buildTemporale */
+    private function runEngineEvents(int $year): array
+    {
+        $messages = [];
+        $ctx      = $this->buildContext($year, $messages);
+        ( new AmbrosianTemporale() )->buildTemporale($ctx);
+
+        $events = [];
+        foreach ($ctx->cal->getLiturgicalEvents()->getKeys() as $key) {
+            $event = $ctx->cal->getLiturgicalEvent($key);
+            self::assertNotNull($event, "Expected a LiturgicalEvent for key $key");
+            $events[$key] = $event;
+        }
+        return $events;
+    }
+```
+
+- [ ] **Step 7: Add `stampSeason()` and call it on every created event**
+
+In `src/Models/Calendar/Temporale/AmbrosianTemporale.php`, add the helper and call it from `createPropriumDeTemporeLiturgicalEventByKey()` (before `return $event;`):
+
+```php
+    /**
+     * Stamp the Ambrosian liturgical season onto an event from its key. Called on
+     * every event the engine creates, because the Roman
+     * `LiturgicalEventCollection::setSeasonsAndHolyDaysOfObligation()` cannot run
+     * for the Ambrosian rite (it requires an AshWednesday event and knows only the
+     * six Roman seasons).
+     */
+    private function stampSeason(LiturgicalEvent $event): void
+    {
+        $event->liturgical_season = \LiturgicalCalendar\Api\Enum\LitSeason::forEventKey($event->event_key);
+    }
+```
+
+In `createPropriumDeTemporeLiturgicalEventByKey()`, change the tail to:
+
+```php
+        $event = LiturgicalEvent::fromObject($ctx->propriumDeTempore[$key]);
+        $ctx->cal->addLiturgicalEvent($key, $event);
+        $this->stampSeason($event);
+        return $event;
+```
+
+Add `use LiturgicalCalendar\Api\Enum\LitSeason;` to the file's imports and reference it unqualified in `stampSeason()`.
+
+- [ ] **Step 8: Run tests + static analysis + lint**
+
+Run: `vendor/bin/phpunit phpunit_tests/Enum/LitSeasonAmbrosianTest.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php` → PASS.
+Run: `composer analyse` → clean. `composer lint` → clean.
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/CalendarGoldenMasterTest.php` → still green (Roman unaffected: the new patterns only match Ambrosian-only keys;
+`Circoncisione`/`AshesMonday`/`SabatoTradSymb` do not exist in the Roman proprium, and `ChristKing` in the Roman path is dated but its season is set by the Roman date-range method,
+not `forEventKey`).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Enum/LitSeason.php src/Models/Calendar/Temporale/AmbrosianTemporale.php phpunit_tests/Enum/LitSeasonAmbrosianTest.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleHarnessTrait.php
+git commit -m "feat(ambrosian): classify anchor keys by season and stamp liturgical_season in the temporale engine"
+```
+
+---
+
+### Task 3: After-Epiphany Sundays
+
+**Files:**
+
+- Modify: `src/Models/Calendar/Temporale/AmbrosianTemporale.php`
+- Test: `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php`
+
+**Interfaces:**
+
+- Consumes: `TemporaleContext` (`$ctx->params->Year`, `$ctx->cal`), `Utilities::calcGregEaster()`, `AmbrosianTemporale::synthesizeSunday()` (added here, reused by Task 4).
+- Produces: `AmbrosianTemporale::calculateAfterEpiphanySundays(TemporaleContext $ctx): void`; `synthesizeSunday(TemporaleContext $ctx, string $key, DateTime $date, string $name):
+  LiturgicalEvent` (private; FEAST_LORD, GREEN, MOBILE, `is_dominical=true`, season-stamped). Numbered Sundays `AfterEpiphany2..N`.
+
+**Norm (n.40):** "Il tempo dopo l'Epifania comincia il lunedì che segue la domenica … del battesimo del Signore, e si protrae fino … del sabato che precede la domenica all'inizio
+della quaresima." So the after-Epiphany Sundays are those **strictly after** `BaptismLord` (the Sunday after Jan 6) and **strictly before** `Lent1` (`Easter − 42d`). Numbering
+starts at **2** (Baptism is the 1st Sunday of the block, keyed `BaptismLord`), mirroring Roman `OrdSunday2..`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `AmbrosianTemporaleTest.php` (Baptism 2025 = 2025-01-12; Lent1 2025 = 2025-03-09; so Sundays Jan 19, 26, Feb 2, 9, 16, 23, Mar 2 → `AfterEpiphany2..8`):
+
+```php
+    public function testAfterEpiphanySundays2025(): void
+    {
+        $d = $this->runEngine(2025);
+        self::assertSame('2025-01-19', $d['AfterEpiphany2']);
+        self::assertSame('2025-01-26', $d['AfterEpiphany3']);
+        self::assertSame('2025-02-02', $d['AfterEpiphany4']);
+        self::assertSame('2025-02-09', $d['AfterEpiphany5']);
+        self::assertSame('2025-02-16', $d['AfterEpiphany6']);
+        self::assertSame('2025-02-23', $d['AfterEpiphany7']);
+        self::assertSame('2025-03-02', $d['AfterEpiphany8']);
+        self::assertArrayNotHasKey('AfterEpiphany9', $d); // Mar 9 is Lent1
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php --filter testAfterEpiphanySundays2025`
+Expected: FAIL — `AfterEpiphany2` key absent.
+
+- [ ] **Step 3: Add `synthesizeSunday()` and `calculateAfterEpiphanySundays()`**
+
+Add to `AmbrosianTemporale.php`:
+
+```php
+    /**
+     * Create a synthesized numbered Sunday (not drawn from the Proprium de Tempore
+     * data file): a dominical FEAST_LORD in green, season-stamped from its key.
+     * Used for the after-Epiphany and after-Pentecost Sunday blocks whose exact
+     * names/numbering are validated against a published ordo in a later plan.
+     */
+    private function synthesizeSunday(TemporaleContext $ctx, string $key, DateTime $date, string $name): LiturgicalEvent
+    {
+        $event               = new LiturgicalEvent($name, $date, LitColor::GREEN, LitEventType::MOBILE, LitGrade::FEAST_LORD);
+        $event->is_dominical = true;
+        $ctx->cal->addLiturgicalEvent($key, $event);
+        $this->stampSeason($event);
+        return $event;
+    }
+
+    /**
+     * After-Epiphany Sundays (n. 40): every Sunday strictly after BaptismLord
+     * (the Sunday after Jan 6) and strictly before Lent I (Easter − 42d).
+     * Numbered from 2 — BaptismLord is the block's 1st Sunday.
+     */
+    private function calculateAfterEpiphanySundays(TemporaleContext $ctx): void
+    {
+        $year    = $ctx->params->Year;
+        $baptism = DateTime::fromFormat('6-1-' . $year)->modify('next Sunday');
+        $lent1   = Utilities::calcGregEaster($year)->sub(new \DateInterval('P' . ( 6 * 7 ) . 'D'));
+
+        $ordinal = 2;
+        $sunday  = ( clone $baptism )->modify('next Sunday');
+        while ($sunday < $lent1) {
+            $key = 'AfterEpiphany' . $ordinal;
+            $this->synthesizeSunday($ctx, $key, clone $sunday, $this->afterEpiphanySundayName($ordinal, $ctx));
+            $ordinal++;
+            $sunday = ( clone $sunday )->modify('next Sunday');
+        }
+    }
+```
+
+Add the required `use` imports at the top of the file if not present: `LitColor`, `LitEventType`, `LitGrade` (`LiturgicalCalendar\Api\Enum\LitColor`, `…\LitEventType`,
+`…\LitGrade`).
+
+- [ ] **Step 4: Add the Sunday name builder**
+
+Add a name builder (locale-aware; `it` and `la` are the only Ambrosian locales). Latin uses `LatinUtils::LATIN_ORDINAL`:
+
+```php
+    /**
+     * Localized display name for an after-Epiphany Sunday, e.g. (it) "II domenica
+     * dopo l'Epifania", (la) "Dominica II post Epiphaniam". Exact ordo wording is
+     * validated in a later plan.
+     */
+    private function afterEpiphanySundayName(int $ordinal, TemporaleContext $ctx): string
+    {
+        if (LitLocale::LATIN_PRIMARY_LANGUAGE === LitLocale::$PRIMARY_LANGUAGE) {
+            return sprintf('Dominica %s post Epiphaniam', LatinUtils::LATIN_ORDINAL[$ordinal]);
+        }
+        $ordinalStr = Utilities::getOrdinal($ordinal, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
+        return sprintf("%s domenica dopo l'Epifania", $ordinalStr);
+    }
+
+    /**
+     * Feminine \NumberFormatter for ordinal rendering, cached per engine call.
+     */
+    private ?\NumberFormatter $ordinalFormatterCache = null;
+
+    private function ordinalFormatter(TemporaleContext $ctx): \NumberFormatter
+    {
+        if (null === $this->ordinalFormatterCache) {
+            $this->ordinalFormatterCache = new \NumberFormatter($ctx->localeDateFormatter->getLocale(), \NumberFormatter::SPELLOUT);
+            $this->ordinalFormatterCache->setTextAttribute(\NumberFormatter::DEFAULT_RULESET, '%spellout-ordinal-feminine');
+        }
+        return $this->ordinalFormatterCache;
+    }
+```
+
+Add `use LiturgicalCalendar\Api\Enum\LitLocale;` and `use LiturgicalCalendar\Api\LatinUtils;` to the imports.
+
+> **Note for the implementer:** the display text is intentionally provisional (Plan 9 pins ordo wording). If the `%spellout-ordinal-feminine` ruleset is unavailable for a locale,
+> fall back to `LatinUtils::LATIN_ORDINAL[$ordinal]` — but for `it` it is available. Keep the name-builder logic identical in shape to the Roman weekday-name construction in
+> `CalendarHandler::calculateWeekdaysOrdinaryTime()`.
+
+- [ ] **Step 5: Wire into `buildTemporale()`**
+
+In `buildTemporale()`, add `$this->calculateAfterEpiphanySundays($ctx);` **after** `calculateChristmasEpiphany` and `calculateLent` have run (both provide the boundary anchors it
+reads) — place it after `calculateEasterCycle($ctx);` for simplicity, or immediately after `calculateLent($ctx);`. Ordering does not matter for dates (boundaries are recomputed),
+but keep it before the weekday fill added in later tasks.
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php --filter testAfterEpiphanySundays2025` → PASS.
+Run: `composer analyse`, `composer lint` → clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Models/Calendar/Temporale/AmbrosianTemporale.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+git commit -m "feat(ambrosian): synthesize after-Epiphany Sundays in the temporale engine"
+```
+
+---
+
+### Task 4: After-Pentecost Sundays (3 sub-blocks)
+
+**Files:**
+
+- Modify: `src/Models/Calendar/Temporale/AmbrosianTemporale.php`
+- Test: `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php`, `AmbrosianTemporaleOrdoValidationTest.php`
+
+**Interfaces:**
+
+- Consumes: `synthesizeSunday()` (Task 3), `Utilities::calcGregEaster()`, existing `adventOne()`, existing `DedicationDuomo`/`ChristKing` anchors.
+- Produces: `AmbrosianTemporale::calculateAfterPentecostSundays(TemporaleContext $ctx): void`; `martyrdomAnchor(int $year): DateTime` (private).
+
+**Norm (n.42):** The time after Pentecost runs from the Monday after Pentecost to the Saturday before Advent I, in **three sub-blocks**:
+
+- **(a) dopo Pentecoste** — Sundays from the 1st Sunday after Pentecost up to the Saturday before the **1st Sunday after the Martyrdom of St John the Baptist (Aug 29; postponed to
+  Sep 1 if Aug 29 is a Sunday)**.
+- **(b) dopo il Martirio** — Sundays from that 1st Sunday after the Martyrdom up to the Saturday before the **3rd Sunday of October** (the Dedication of the Duomo, already an
+  anchor).
+- **(c) dopo la Dedicazione** — Sundays from the Dedication Sunday up to the Saturday before Advent I. The last is **Christ the King** (already an anchor); do not re-emit it.
+
+Numbering **restarts at 1 in each sub-block**. `DedicationDuomo` and `ChristKing` are dominical anchors already placed by `calculateAfterPentecostAnchors()` — the sub-block Sunday
+loops must **skip Sundays already occupied** (`$ctx->cal->inCalendar($sunday)`), which naturally excludes the Dedication Sunday from block (c)'s numbering and Christ the King as
+the terminal Sunday.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `AmbrosianTemporaleTest.php`. Anchors for 2025: Pentecost = 2025-06-08; Aug 29 2025 = Friday → Martyrdom Aug 29; 1st Sunday after Martyrdom = 2025-08-31; Dedication (3rd Sun
+Oct) = 2025-10-19; Advent I = 2025-11-16 → Christ the King = 2025-11-09.
+
+```php
+    public function testAfterPentecostSubBlocks2025(): void
+    {
+        $d = $this->runEngine(2025);
+
+        // (a) dopo Pentecoste: 1st Sunday after Pentecost (Jun 15) .. Sat before Aug 31
+        self::assertSame('2025-06-15', $d['AfterPentecost1']);
+        self::assertSame('2025-08-24', $d['AfterPentecost11']); // last before the Martyrdom Sunday
+        self::assertArrayNotHasKey('AfterPentecost12', $d);
+
+        // (b) dopo il Martirio: Aug 31 .. Sat before Oct 19 (Dedication)
+        self::assertSame('2025-08-31', $d['AfterPentecostMartyrdom1']);
+        self::assertSame('2025-10-12', $d['AfterPentecostMartyrdom7']);
+        self::assertArrayNotHasKey('AfterPentecostMartyrdom8', $d);
+
+        // (c) dopo la Dedicazione: 1st Sunday after Dedication (Oct 26) .. Sat before Advent I;
+        // Christ the King (Nov 9) is the terminal anchor, not re-emitted as a numbered Sunday.
+        self::assertSame('2025-10-26', $d['AfterPentecostDedication1']);
+        self::assertSame('2025-11-02', $d['AfterPentecostDedication2']);
+        self::assertArrayNotHasKey('AfterPentecostDedication3', $d); // Nov 9 = ChristKing
+        self::assertSame('2025-11-09', $d['ChristKing']);
+    }
+```
+
+> **Implementer note:** verify the exact week counts for 2025 by running the engine once and reading back the keys; the assertions above are computed from the anchors (Pentecost
+> 2025-06-08, Dedication 2025-10-19, ChristKing 2025-11-09) but confirm `AfterPentecost11`/`AfterPentecostMartyrdom7` are the true last-in-block before adjusting. If a boundary
+> count differs by one, fix the assertion to the engine's computed value **only after** confirming the date arithmetic against the norm (the loop condition, not the expected count,
+> is authoritative).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php --filter testAfterPentecostSubBlocks2025`
+Expected: FAIL — keys absent.
+
+- [ ] **Step 3: Implement the Martyrdom anchor + the three-block loop**
+
+```php
+    /**
+     * Martyrdom of St John the Baptist (n. 42a): Aug 29, postponed to Sep 1 when
+     * Aug 29 falls on a Sunday.
+     */
+    private function martyrdomAnchor(int $year): DateTime
+    {
+        $aug29 = DateTime::fromFormat('29-8-' . $year);
+        return self::dateIsSunday($aug29) ? DateTime::fromFormat('1-9-' . $year) : $aug29;
+    }
+
+    /**
+     * After-Pentecost Sundays (n. 42), in three sub-blocks with per-block numbering:
+     *   (a) dopo Pentecoste     — 1st Sunday after Pentecost … Sat before the 1st Sunday after the Martyrdom
+     *   (b) dopo il Martirio    — that Sunday … Sat before the Dedication (3rd Sunday of October)
+     *   (c) dopo la Dedicazione — 1st Sunday after the Dedication … Sat before Advent I (ends at Christ the King)
+     * DedicationDuomo and ChristKing are anchors already placed; Sundays already in
+     * the calendar are skipped, so those two are not re-emitted as numbered Sundays.
+     */
+    private function calculateAfterPentecostSundays(TemporaleContext $ctx): void
+    {
+        $year          = $ctx->params->Year;
+        $pentecost     = Utilities::calcGregEaster($year)->add(new \DateInterval('P49D'));
+        $martyrdomSun  = ( clone $this->martyrdomAnchor($year) )->modify('next Sunday'); // 1st Sunday after the Martyrdom
+        $dedication    = $ctx->cal->getLiturgicalEvent('DedicationDuomo')?->date
+            ?? throw new ServiceUnavailableException('DedicationDuomo anchor must be placed before after-Pentecost Sundays');
+        $advent1       = $this->adventOne($year);
+
+        // (a) dopo Pentecoste
+        $this->numberSundayBlock($ctx, 'AfterPentecost', ( clone $pentecost )->modify('next Sunday'), $martyrdomSun, 'afterPentecostSundayName');
+        // (b) dopo il Martirio
+        $this->numberSundayBlock($ctx, 'AfterPentecostMartyrdom', clone $martyrdomSun, $dedication, 'afterMartyrdomSundayName');
+        // (c) dopo la Dedicazione
+        $this->numberSundayBlock($ctx, 'AfterPentecostDedication', ( clone $dedication )->modify('next Sunday'), $advent1, 'afterDedicationSundayName');
+    }
+
+    /**
+     * Emit consecutive numbered Sundays [$firstSunday, $endExclusive) under $keyStem,
+     * numbering from 1, skipping Sundays already occupied by an anchor. $nameMethod
+     * is the name of the per-block localized name builder (see below).
+     */
+    private function numberSundayBlock(TemporaleContext $ctx, string $keyStem, DateTime $firstSunday, DateTime $endExclusive, string $nameMethod): void
+    {
+        $ordinal = 1;
+        $sunday  = clone $firstSunday;
+        while ($sunday < $endExclusive) {
+            if (false === $ctx->cal->inCalendar($sunday)) {
+                $this->synthesizeSunday($ctx, $keyStem . $ordinal, clone $sunday, $this->{$nameMethod}($ordinal, $ctx));
+            }
+            $ordinal++;
+            $sunday = ( clone $sunday )->modify('next Sunday');
+        }
+    }
+```
+
+Add name builders mirroring `afterEpiphanySundayName()` (it/la), for the three phrases — "dopo Pentecoste" / "dopo il Martirio" / "dopo la Dedicazione" (Latin: "post Pentecosten" /
+"post Martyrium" / "post Dedicationem"):
+
+```php
+    private function afterPentecostSundayName(int $ordinal, TemporaleContext $ctx): string
+    {
+        return $this->afterPentecostFamilyName($ordinal, $ctx, 'dopo Pentecoste', 'post Pentecosten');
+    }
+
+    private function afterMartyrdomSundayName(int $ordinal, TemporaleContext $ctx): string
+    {
+        return $this->afterPentecostFamilyName($ordinal, $ctx, 'dopo il Martirio', 'post Martyrium');
+    }
+
+    private function afterDedicationSundayName(int $ordinal, TemporaleContext $ctx): string
+    {
+        return $this->afterPentecostFamilyName($ordinal, $ctx, 'dopo la Dedicazione', 'post Dedicationem');
+    }
+
+    private function afterPentecostFamilyName(int $ordinal, TemporaleContext $ctx, string $phraseIt, string $phraseLa): string
+    {
+        if (LitLocale::LATIN_PRIMARY_LANGUAGE === LitLocale::$PRIMARY_LANGUAGE) {
+            return sprintf('Dominica %s %s', LatinUtils::LATIN_ORDINAL[$ordinal], $phraseLa);
+        }
+        $ordinalStr = Utilities::getOrdinal($ordinal, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
+        return sprintf('%s domenica %s', $ordinalStr, $phraseIt);
+    }
+```
+
+`ServiceUnavailableException` is already imported by the file (used by `createPropriumDeTemporeLiturgicalEventByKey`).
+
+- [ ] **Step 4: Wire into `buildTemporale()`**
+
+Add `$this->calculateAfterPentecostSundays($ctx);` **after** `calculateAfterPentecostAnchors($ctx);` (it reads the `DedicationDuomo` anchor).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php --filter testAfterPentecostSubBlocks2025`
+Expected: PASS (adjust the two "last-in-block" ordinals to the engine's computed values per the Step-1 note, if needed).
+
+- [ ] **Step 6: Extend the ordo-validation pin**
+
+Add a spot-check to `AmbrosianTemporaleOrdoValidationTest.php` asserting the **first** Sunday of each sub-block for 2024/2025/2026 (first-Sundays are anchor-derived and stable).
+Keep `@group slow`.
+
+- [ ] **Step 7: Run + analyse + lint + golden master**
+
+Run: `composer test:quick`, `composer analyse`, `composer lint` → clean. Golden master green.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Models/Calendar/Temporale/AmbrosianTemporale.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleOrdoValidationTest.php
+git commit -m "feat(ambrosian): synthesize after-Pentecost Sundays in three sub-blocks"
+```
+
+---
+
+### Task 5: Generic ferial-weekday fill helper + weekday name builder
+
+**Files:**
+
+- Modify: `src/Models/Calendar/Temporale/AmbrosianTemporale.php`
+- Test: `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php`
+
+**Interfaces:**
+
+- Consumes: `$ctx->cal->inCalendar()`, `$ctx->localeDateFormatter->getDayOfTheWeekFormatter()`, `LatinUtils::LATIN_DAYOFTHEWEEK`, `Utilities::getOrdinal()`.
+- Produces:
+- `fillFerialWeekdays(TemporaleContext $ctx, DateTime $from, DateTime $to, LitColor $color, callable $keyBuilder, callable $nameBuilder, bool $lentenAliturgicalFridays = false):
+    void` — iterates day-by-day over `[$from, $to)`, skipping Sundays and any date already `inCalendar()`, creating a `WEEKDAY` event per free ferial day; season-stamped; on Lenten
+    Fridays sets `is_aliturgical = true` when `$lentenAliturgicalFridays`. `$keyBuilder(DateTime): string` and `$nameBuilder(DateTime): string` are supplied by each per-season
+    caller.
+- `weekdayName(DateTime $date, string $seasonPhraseIt, string $seasonPhraseLa, ?int $weekNumber, TemporaleContext $ctx): string` — e.g. (it) "Lunedì della II settimana dopo
+    Pentecoste", (la) "Feria II hebdomadæ II post Pentecosten".
+  - `englishWeekday(DateTime $date): string` — `Monday`…`Saturday` for locale-independent keys.
+
+- [ ] **Step 1: Write the failing test**
+
+Test the helper directly through a tiny public-ish seam. Since the engine has no public fill entry yet, assert it via a season fill you can add trivially: instead, unit-test
+`fillFerialWeekdays` by adding the after-Epiphany fill (Task 9 uses it too) is premature — so test the helper's **observable contract** through a temporary spy is overkill.
+Instead, write the test against the **after-Epiphany** weekday fill wired in this task as the helper's first caller (a natural, self-contained range):
+
+```php
+    public function testAfterEpiphanyWeekdaysFillGaps2025(): void
+    {
+        $d = $this->runEngine(2025);
+        // After-Epiphany block: Mon after Baptism (2025-01-13) .. Sat before Lent1 (2025-03-08).
+        // Mondays are weekdays; assert a representative weekday exists and Sundays are NOT overwritten.
+        self::assertArrayHasKey('AfterEpiphanyWeekday2Monday', $d);   // week 2 Monday = 2025-01-13
+        self::assertSame('2025-01-13', $d['AfterEpiphanyWeekday2Monday']);
+        self::assertArrayHasKey('AfterEpiphanyWeekday3Saturday', $d); // 2025-01-25
+        self::assertSame('2025-01-25', $d['AfterEpiphanyWeekday3Saturday']);
+        // The Sunday 2025-01-19 remains AfterEpiphany2 (a weekday fill must never take a Sunday)
+        self::assertSame('2025-01-19', $d['AfterEpiphany2']);
+    }
+```
+
+> **Implementer note:** the week-number scheme for after-Epiphany weekdays follows the Roman convention (week of the *following* Sunday; Baptism-week = week 1, so the first Monday
+> after Baptism is in week 2). Confirm the exact `{N}` from the engine and adjust the key in the assertion if the numbering base differs — but the base MUST match the Sunday
+> numbering (a Monday in the week leading to `AfterEpiphany{k}` is `AfterEpiphanyWeekday{k}Monday`).
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php --filter testAfterEpiphanyWeekdaysFillGaps2025`
+Expected: FAIL — key absent.
+
+- [ ] **Step 3: Implement the helper + name/key builders**
+
+```php
+    /**
+     * Fill ferial weekdays over [$from, $to), skipping Sundays and any date already
+     * occupied (Sundays, anchors). Each free ferial day becomes a WEEKDAY event,
+     * season-stamped from its key. $keyBuilder(DateTime $date): string produces the
+     * event key; $nameBuilder(DateTime $date): string the display name. On Lenten
+     * Fridays, when $lentenAliturgicalFridays is true, is_aliturgical is set.
+     *
+     * @param callable(DateTime):string $keyBuilder
+     * @param callable(DateTime):string $nameBuilder
+     */
+    private function fillFerialWeekdays(TemporaleContext $ctx, DateTime $from, DateTime $to, LitColor $color, callable $keyBuilder, callable $nameBuilder, bool $lentenAliturgicalFridays = false): void
+    {
+        $day = clone $from;
+        while ($day < $to) {
+            $isSunday = (int) $day->format('N') === 7;
+            if (false === $isSunday && false === $ctx->cal->inCalendar($day)) {
+                $key   = $keyBuilder($day);
+                $name  = $nameBuilder($day);
+                $event = new LiturgicalEvent($name, clone $day, $color, LitEventType::MOBILE, LitGrade::WEEKDAY);
+                if ($lentenAliturgicalFridays && (int) $day->format('N') === 5) {
+                    $event->is_aliturgical = true;
+                }
+                $ctx->cal->addLiturgicalEvent($key, $event);
+                $this->stampSeason($event);
+            }
+            $day = ( clone $day )->add(new \DateInterval('P1D'));
+        }
+    }
+
+    /** English weekday name (Monday…Saturday) for locale-independent keys. */
+    private function englishWeekday(DateTime $date): string
+    {
+        return ['1' => 'Monday', '2' => 'Tuesday', '3' => 'Wednesday', '4' => 'Thursday', '5' => 'Friday', '6' => 'Saturday'][$date->format('N')];
+    }
+
+    /**
+     * Localized ferial name, e.g. (it) "Lunedì della II settimana dopo Pentecoste",
+     * (la) "Feria II hebdomadæ II post Pentecosten". When $weekNumber is null the
+     * week clause is omitted (e.g. de Exceptáto ferie named by date in Task 6).
+     */
+    private function weekdayName(DateTime $date, string $seasonPhraseIt, string $seasonPhraseLa, ?int $weekNumber, TemporaleContext $ctx): string
+    {
+        $n = (int) $date->format('N');
+        if (LitLocale::LATIN_PRIMARY_LANGUAGE === LitLocale::$PRIMARY_LANGUAGE) {
+            $feria = LatinUtils::LATIN_DAYOFTHEWEEK[$date->format('w')]; // e.g. "Feria II"
+            if (null === $weekNumber) {
+                return sprintf('%s %s', $feria, $seasonPhraseLa);
+            }
+            return sprintf('%s hebdomadæ %s %s', $feria, LatinUtils::LATIN_ORDINAL[$weekNumber], $seasonPhraseLa);
+        }
+        $weekday = $ctx->localeDateFormatter->getDayOfTheWeekFormatter()->format($date->format('U'));
+        $weekday = Utilities::ucfirst(is_string($weekday) ? $weekday : '');
+        if (null === $weekNumber) {
+            return sprintf('%s %s', $weekday, $seasonPhraseIt);
+        }
+        $ordinalStr = Utilities::getOrdinal($weekNumber, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
+        return sprintf('%s della %s settimana %s', $weekday, $ordinalStr, $seasonPhraseIt);
+    }
+```
+
+Confirm `Utilities::ucfirst()` exists (used by the Roman weekday code — see `CalendarHandler::calculateWeekdaysOrdinaryTime`); if the signature differs, match the Roman call site
+exactly.
+
+- [ ] **Step 4: Wire the after-Epiphany weekday fill (first caller)**
+
+Add `calculateAfterEpiphanyWeekdays()` and call it from `buildTemporale()` after `calculateAfterEpiphanySundays()`:
+
+```php
+    /** After-Epiphany ferie: Monday after Baptism … Saturday before Lent I. */
+    private function calculateAfterEpiphanyWeekdays(TemporaleContext $ctx): void
+    {
+        $year    = $ctx->params->Year;
+        $baptism = DateTime::fromFormat('6-1-' . $year)->modify('next Sunday');
+        $lent1   = Utilities::calcGregEaster($year)->sub(new \DateInterval('P' . ( 6 * 7 ) . 'D'));
+        $from    = ( clone $baptism )->add(new \DateInterval('P1D')); // Monday after Baptism
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            $lent1,
+            LitColor::GREEN,
+            fn (DateTime $d): string => 'AfterEpiphanyWeekday' . $this->afterEpiphanyWeekNumber($d, $baptism) . $this->englishWeekday($d),
+            fn (DateTime $d): string => $this->weekdayName($d, "dopo l'Epifania", 'post Epiphaniam', $this->afterEpiphanyWeekNumber($d, $baptism), $ctx)
+        );
+    }
+
+    /**
+     * Week number of a ferial day in the after-Epiphany block: the ordinal of the
+     * Sunday that closes its week, matching the Sunday numbering (BaptismLord = week 1,
+     * so the first Monday after Baptism is week 2).
+     */
+    private function afterEpiphanyWeekNumber(DateTime $date, DateTime $baptism): int
+    {
+        $daysSinceBaptism = (int) $baptism->diff($date)->format('%a');
+        return (int) floor(( $daysSinceBaptism - 1 ) / 7) + 2;
+    }
+```
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php --filter testAfterEpiphanyWeekdaysFillGaps2025`
+Expected: PASS (adjust `{N}` in the test assertion to the engine's computed week number if the base differs; the loop is authoritative).
+
+- [ ] **Step 6: Analyse + lint + golden master**
+
+Run: `composer analyse`, `composer lint` → clean. Golden master green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Models/Calendar/Temporale/AmbrosianTemporale.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+git commit -m "feat(ambrosian): add ferial weekday-fill helper and after-Epiphany ferie"
+```
+
+---
+
+### Task 6: Advent (de Exceptáto) and Christmas ferial fill
+
+**Files:**
+
+- Modify: `src/Models/Calendar/Temporale/AmbrosianTemporale.php`
+- Test: `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php`
+
+**Interfaces:**
+
+- Consumes: `fillFerialWeekdays()`, `adventOne()`.
+- Produces: `calculateAdventWeekdays()`, `calculateChristmasWeekdays()`.
+
+**Norms:** Advent ferie run from the Monday after Advent I to the Saturday before Christmas; the ferie *de Exceptáto* are **Dec 17–23** (Dec 18–23 when Dec 17 is a Sunday) (n. 39).
+Christmas ferie run from Dec 26 to the Saturday before Baptism, with `Circoncisione` (Jan 1) and `Epiphany` (Jan 6) already placed as anchors and skipped by `inCalendar()`.
+
+- Advent keys: `AdventWeekday{DDD}` (`{DDD}` = zero-padded day-of-month) — matches the Roman `AdventWeekdayDec{N}` family closely enough to classify under `/^AdventWeekday/`.
+  Colour morello. Names: the de Exceptáto days (Dec 17/18–23) get a distinct phrase; the rest use the week-of-Advent phrase.
+- Christmas keys: `ChristmasWeekday{DDD}`. Colour white.
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+    public function testAdventDeExceptatoFerie2025(): void
+    {
+        $d = $this->runEngine(2025);
+        // 2025: Dec 17 is Wednesday, so de Exceptáto = Dec 17..23 (Sundays excluded).
+        self::assertArrayHasKey('AdventWeekday017', $d);
+        self::assertSame('2025-12-17', $d['AdventWeekday017']);
+        self::assertArrayHasKey('AdventWeekday023', $d);
+        self::assertSame('2025-12-23', $d['AdventWeekday023']);
+    }
+
+    public function testChristmasFerieSkipAnchors2025(): void
+    {
+        $d = $this->runEngine(2025);
+        self::assertArrayHasKey('ChristmasWeekday029', $d); // Dec 29 2025 (Mon)
+        self::assertSame('2025-12-29', $d['ChristmasWeekday029']);
+        // Jan 1 (Circoncisione) and Jan 6 (Epiphany) stay anchors, never overwritten:
+        self::assertArrayNotHasKey('ChristmasWeekday001', $d);
+        self::assertArrayNotHasKey('ChristmasWeekday006', $d);
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php --filter 'testAdventDeExceptatoFerie2025|testChristmasFerieSkipAnchors2025'`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement the two fills**
+
+```php
+    /** Advent ferie: Monday after Advent I … Saturday before Christmas; Dec 17(18)–23 are de Exceptáto (n. 39). */
+    private function calculateAdventWeekdays(TemporaleContext $ctx): void
+    {
+        $year    = $ctx->params->Year;
+        $from    = ( clone $this->adventOne($year) )->add(new \DateInterval('P1D'));
+        $to      = DateTime::fromFormat('25-12-' . $year); // Christmas (exclusive)
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            $to,
+            LitColor::MORELLO,
+            fn (DateTime $d): string => 'AdventWeekday' . $d->format('d'),
+            fn (DateTime $d): string => $this->adventWeekdayName($d, $ctx)
+        );
+    }
+
+    private function adventWeekdayName(DateTime $date, TemporaleContext $ctx): string
+    {
+        $md = (int) $date->format('nd'); // e.g. 1217 for Dec 17
+        if ($md >= 1217 && $md <= 1223) {
+            return $this->weekdayName($date, 'de Exceptáto', 'de Exceptato', null, $ctx);
+        }
+        return $this->weekdayName($date, "d'Avvento", 'Adventus', null, $ctx);
+    }
+
+    /** Christmas ferie: Dec 26 … Saturday before Baptism (Circoncisione/Epiphany anchors skipped). */
+    private function calculateChristmasWeekdays(TemporaleContext $ctx): void
+    {
+        $year    = $ctx->params->Year;
+        $baptism = DateTime::fromFormat('6-1-' . $year)->modify('next Sunday');
+        $from    = DateTime::fromFormat('26-12-' . $year);
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            clone $baptism, // up to (not incl.) Baptism Sunday
+            LitColor::WHITE,
+            fn (DateTime $d): string => 'ChristmasWeekday' . $d->format('d'),
+            fn (DateTime $d): string => $this->weekdayName($d, 'del tempo di Natale', 'Nativitatis', null, $ctx)
+        );
+    }
+```
+
+> **Implementer note on the Dec/Jan key collision:** `ChristmasWeekday{DDD}` uses day-of-month only, so Dec 27 → `ChristmasWeekday027` and Jan 3 → `ChristmasWeekday003`; no
+> collision within one civil year because the Christmas fill spans Dec 26–31 (`0DD` = 26–31) then Jan 2–5 (`00D`). If a future year needs both a Dec and Jan day with the same
+> day-number they still differ (`0DD` vs `00D` never overlap). The `fillFerialWeekdays` loop crosses the Dec→Jan boundary automatically because the same civil `$year` is used for
+> both anchors here (the harness builds a single civil year; the handler-level year semantics are Plan 7's concern).
+
+- [ ] **Step 4: Wire into `buildTemporale()`**
+
+Add `$this->calculateAdventWeekdays($ctx);` and `$this->calculateChristmasWeekdays($ctx);` after the Sunday tasks.
+
+- [ ] **Step 5–7: Run, analyse, lint, golden master, commit**
+
+Run the two filters → PASS (adjust dates to the engine's computed values only after confirming arithmetic). `composer analyse`, `composer lint`, golden master → clean.
+
+```bash
+git add src/Models/Calendar/Temporale/AmbrosianTemporale.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+git commit -m "feat(ambrosian): fill Advent (de Exceptato) and Christmas ferie"
+```
+
+---
+
+### Task 7: Lenten ferial fill with aliturgical Fridays
+
+**Files:**
+
+- Modify: `src/Models/Calendar/Temporale/AmbrosianTemporale.php`
+- Test: `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php`
+
+**Interfaces:**
+
+- Consumes: `fillFerialWeekdays(..., lentenAliturgicalFridays: true)`.
+- Produces: `calculateLentWeekdays()`.
+
+**Norm (nn. 24–27):** Lent has no Ash Wednesday; it begins on a Sunday (`Lent1`), ashes are imposed the following Monday (`AshesMonday`, an anchor). Lenten Fridays are
+**aliturgical** (no Mass). The block runs from `Lent1` (Sunday, excluded) to the Saturday before `PalmSun`; `SabatoTradSymb` (Saturday before Palm Sunday) is an anchor, skipped.
+Colour morello. Keys `LentWeekday{N}{EnglishDay}` (matches `/^LentWeekday\d/`).
+
+- [ ] **Step 1: Write the failing test**
+
+2025: Lent1 = 2025-03-09; PalmSun = 2025-04-13. Lenten Fridays: Mar 14, 21, 28, Apr 4, 11. Each must carry `is_aliturgical = true`.
+
+```php
+    public function testLentenFridaysAreAliturgical2025(): void
+    {
+        $events = $this->runEngineEvents(2025);
+        $fridays = array_filter(
+            $events,
+            fn ($e) => $e->liturgical_season === LitSeason::LENT
+                && (int) $e->date->format('N') === 5
+                && $e->grade === LitGrade::WEEKDAY
+        );
+        self::assertNotEmpty($fridays);
+        foreach ($fridays as $key => $e) {
+            self::assertTrue($e->is_aliturgical, "$key should be aliturgical");
+        }
+        // A Lenten non-Friday ferial is not aliturgical:
+        $someThursday = $events['LentWeekday1Thursday'] ?? null;
+        self::assertNotNull($someThursday);
+        self::assertNull($someThursday->is_aliturgical);
+    }
+```
+
+Add `use LiturgicalCalendar\Api\Enum\LitGrade;` to the test imports.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: FAIL — no Lenten ferie yet.
+
+- [ ] **Step 3: Implement**
+
+```php
+    /** Lenten ferie: Lent I (excl.) … Saturday before Palm Sunday; Fridays are aliturgical (nn. 24–27). */
+    private function calculateLentWeekdays(TemporaleContext $ctx): void
+    {
+        $year    = $ctx->params->Year;
+        $lent1   = Utilities::calcGregEaster($year)->sub(new \DateInterval('P' . ( 6 * 7 ) . 'D'));
+        $palmSun = Utilities::calcGregEaster($year)->sub(new \DateInterval('P7D'));
+        $from    = ( clone $lent1 )->add(new \DateInterval('P1D'));
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            clone $palmSun, // up to (not incl.) Palm Sunday; SabatoTradSymb anchor is skipped by inCalendar()
+            LitColor::MORELLO,
+            fn (DateTime $d): string => 'LentWeekday' . $this->lentWeekNumber($d, $lent1) . $this->englishWeekday($d),
+            fn (DateTime $d): string => $this->weekdayName($d, 'di Quaresima', 'Quadragesimæ', $this->lentWeekNumber($d, $lent1), $ctx),
+            true
+        );
+    }
+
+    /** Lenten week number: Lent I is week 1; the following Monday begins week 1's ferie. */
+    private function lentWeekNumber(DateTime $date, DateTime $lent1): int
+    {
+        $daysSince = (int) $lent1->diff($date)->format('%a');
+        return (int) floor(( $daysSince - 1 ) / 7) + 1;
+    }
+```
+
+> **Aliturgical suspension note (n. 4, deferred):** the norm suspends the no-Mass rule when Annunciation/St Joseph land on an aliturgical Friday. That interaction is
+> precedence-layer + ordo-validation (Plan 9); here the temporale unconditionally flags Lenten Fridays `is_aliturgical = true`, and precedence later clears it when a solemnity
+> supersedes. Do not implement the suspension in this task.
+
+- [ ] **Step 4: Wire into `buildTemporale()`** — add `$this->calculateLentWeekdays($ctx);`.
+
+- [ ] **Step 5–6: Run, analyse, lint, golden master** → clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Models/Calendar/Temporale/AmbrosianTemporale.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+git commit -m "feat(ambrosian): fill Lenten ferie and flag aliturgical Fridays"
+```
+
+---
+
+### Task 8: Easter ferial fill
+
+**Files:**
+
+- Modify: `src/Models/Calendar/Temporale/AmbrosianTemporale.php`
+- Test: `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php`
+
+**Interfaces:**
+
+- Consumes: `fillFerialWeekdays()`.
+- Produces: `calculateEasterWeekdays()`.
+
+**Norm:** The Easter octave weekdays (`Mon..SatOctaveEaster`) are already anchors. The remaining Easter ferie run from the Monday after `Easter2` (i.e. after the octave) to the
+Saturday before `Pentecost`; `Ascension` (Thursday, Easter + 39d) is an anchor and skipped. Colour white. Keys `EasterWeekday{N}{EnglishDay}` (matches `/^EasterWeekday\d/`).
+
+- [ ] **Step 1: Write the failing test**
+
+2025: Easter = 2025-04-20; octave ends Sat 2025-04-26; Easter2 = 2025-04-27; Pentecost = 2025-06-08. First post-octave ferial Monday = 2025-04-28.
+
+```php
+    public function testEasterFerieAfterOctave2025(): void
+    {
+        $d = $this->runEngine(2025);
+        self::assertArrayHasKey('EasterWeekday2Monday', $d);
+        self::assertSame('2025-04-28', $d['EasterWeekday2Monday']);
+        // Ascension (Thu 2025-05-29) stays its own anchor:
+        self::assertSame('2025-05-29', $d['Ascension']);
+        // Octave weekdays remain their own anchors, not re-emitted:
+        self::assertArrayHasKey('MonOctaveEaster', $d);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails** → FAIL.
+
+- [ ] **Step 3: Implement**
+
+```php
+    /** Easter ferie after the octave: Monday after Easter II … Saturday before Pentecost (Ascension anchor skipped). */
+    private function calculateEasterWeekdays(TemporaleContext $ctx): void
+    {
+        $year      = $ctx->params->Year;
+        $easter    = Utilities::calcGregEaster($year);
+        $easter2   = ( clone $easter )->add(new \DateInterval('P7D'));   // Easter II
+        $pentecost = ( clone $easter )->add(new \DateInterval('P49D'));
+        $from      = ( clone $easter2 )->add(new \DateInterval('P1D'));  // Monday after Easter II
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            clone $pentecost, // up to (not incl.) Pentecost Sunday
+            LitColor::WHITE,
+            fn (DateTime $d): string => 'EasterWeekday' . $this->easterWeekNumber($d, $easter) . $this->englishWeekday($d),
+            fn (DateTime $d): string => $this->weekdayName($d, 'di Pasqua', 'Paschæ', $this->easterWeekNumber($d, $easter), $ctx)
+        );
+    }
+
+    /** Easter week number: octave = week 1; Easter II opens week 2. */
+    private function easterWeekNumber(DateTime $date, DateTime $easter): int
+    {
+        $daysSince = (int) $easter->diff($date)->format('%a');
+        return (int) floor($daysSince / 7) + 1;
+    }
+```
+
+- [ ] **Step 4: Wire into `buildTemporale()`** — add `$this->calculateEasterWeekdays($ctx);`.
+
+- [ ] **Step 5–6: Run, analyse, lint, golden master** → clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Models/Calendar/Temporale/AmbrosianTemporale.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+git commit -m "feat(ambrosian): fill post-octave Easter ferie"
+```
+
+---
+
+### Task 9: After-Pentecost ferial fill (3 sub-blocks)
+
+**Files:**
+
+- Modify: `src/Models/Calendar/Temporale/AmbrosianTemporale.php`
+- Test: `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php`
+
+**Interfaces:**
+
+- Consumes: `fillFerialWeekdays()`, `martyrdomAnchor()`, `adventOne()`, `DedicationDuomo` anchor.
+- Produces: `calculateAfterPentecostWeekdays()`.
+
+**Norm (n. 42):** ferie across the three sub-blocks, from the Monday after Pentecost to the Saturday before Advent I. Colour green. Per-block key stems and week numbering restart
+with each block, matching the Sunday numbering of Task 4:
+
+- (a) `AfterPentecostWeekday{N}{EnglishDay}`, phrase "dopo Pentecoste" — Monday after Pentecost … Sat before the 1st Sunday after the Martyrdom.
+- (b) `AfterPentecostMartyrdomWeekday{N}{EnglishDay}`, phrase "dopo il Martirio" — that Sunday's Monday … Sat before the Dedication.
+- (c) `AfterPentecostDedicationWeekday{N}{EnglishDay}`, phrase "dopo la Dedicazione" — Monday after the Dedication … Sat before Advent I (`DedicationDuomo` and `ChristKing` anchors
+  are skipped by `inCalendar()`).
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+    public function testAfterPentecostWeekdaysFill2025(): void
+    {
+        $d = $this->runEngine(2025);
+        // (a) first ferial Monday after Pentecost (2025-06-08) = 2025-06-09, week 1
+        self::assertArrayHasKey('AfterPentecostWeekday1Monday', $d);
+        self::assertSame('2025-06-09', $d['AfterPentecostWeekday1Monday']);
+        // (b) Monday after the 1st Sunday after the Martyrdom (Sun 2025-08-31) = 2025-09-01
+        self::assertArrayHasKey('AfterPentecostMartyrdomWeekday1Monday', $d);
+        self::assertSame('2025-09-01', $d['AfterPentecostMartyrdomWeekday1Monday']);
+        // (c) Monday after the Dedication (Sun 2025-10-19) = 2025-10-20
+        self::assertArrayHasKey('AfterPentecostDedicationWeekday1Monday', $d);
+        self::assertSame('2025-10-20', $d['AfterPentecostDedicationWeekday1Monday']);
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails** → FAIL.
+
+- [ ] **Step 3: Implement (reuse a block helper)**
+
+```php
+    /** After-Pentecost ferie across the three sub-blocks (n. 42). */
+    private function calculateAfterPentecostWeekdays(TemporaleContext $ctx): void
+    {
+        $year         = $ctx->params->Year;
+        $pentecost    = Utilities::calcGregEaster($year)->add(new \DateInterval('P49D'));
+        $martyrdomSun = ( clone $this->martyrdomAnchor($year) )->modify('next Sunday');
+        $dedication   = $ctx->cal->getLiturgicalEvent('DedicationDuomo')?->date
+            ?? throw new ServiceUnavailableException('DedicationDuomo anchor must be placed before after-Pentecost ferie');
+        $advent1      = $this->adventOne($year);
+
+        // (a) dopo Pentecoste — anchored on Pentecost
+        $this->fillFerialBlock($ctx, ( clone $pentecost )->add(new \DateInterval('P1D')), $martyrdomSun, $pentecost, 'AfterPentecostWeekday', 'dopo Pentecoste', 'post Pentecosten', $ctx);
+        // (b) dopo il Martirio — anchored on the 1st Sunday after the Martyrdom
+        $this->fillFerialBlock($ctx, ( clone $martyrdomSun )->add(new \DateInterval('P1D')), $dedication, $martyrdomSun, 'AfterPentecostMartyrdomWeekday', 'dopo il Martirio', 'post Martyrium', $ctx);
+        // (c) dopo la Dedicazione — anchored on the Dedication Sunday
+        $this->fillFerialBlock($ctx, ( clone $dedication )->add(new \DateInterval('P1D')), $advent1, $dedication, 'AfterPentecostDedicationWeekday', 'dopo la Dedicazione', 'post Dedicationem', $ctx);
+    }
+
+    /**
+     * Fill one after-Pentecost sub-block [$from, $to) with green ferie whose week
+     * number is measured from $blockAnchorSunday (block week 1 = the anchor's week).
+     */
+    private function fillFerialBlock(TemporaleContext $ctx, DateTime $from, DateTime $to, DateTime $blockAnchorSunday, string $keyStem, string $phraseIt, string $phraseLa, TemporaleContext $ctxRef): void
+    {
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            $to,
+            LitColor::GREEN,
+            fn (DateTime $d): string => $keyStem . $this->blockWeekNumber($d, $blockAnchorSunday) . $this->englishWeekday($d),
+            fn (DateTime $d): string => $this->weekdayName($d, $phraseIt, $phraseLa, $this->blockWeekNumber($d, $blockAnchorSunday), $ctxRef)
+        );
+    }
+
+    /** Week number within an after-Pentecost sub-block: week 1 opens the Monday after $anchorSunday. */
+    private function blockWeekNumber(DateTime $date, DateTime $anchorSunday): int
+    {
+        $daysSince = (int) $anchorSunday->diff($date)->format('%a');
+        return (int) floor(( $daysSince - 1 ) / 7) + 1;
+    }
+```
+
+> **Note:** `$ctxRef` duplicates `$ctx` only to satisfy the `weekdayName()` signature within closures without capturing `$this` twice; the implementer may instead pass `$ctx`
+> directly and drop the extra parameter — keep whichever passes PHPStan L10 cleanly.
+
+- [ ] **Step 4: Wire into `buildTemporale()`** — add `$this->calculateAfterPentecostWeekdays($ctx);` after the after-Pentecost Sundays.
+
+- [ ] **Step 5–6: Run, analyse, lint, golden master** → clean.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Models/Calendar/Temporale/AmbrosianTemporale.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+git commit -m "feat(ambrosian): fill after-Pentecost ferie across the three sub-blocks"
+```
+
+---
+
+### Task 10: Full-year completeness acceptance test + ordo-validation extension
+
+**Files:**
+
+- Create: `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleCompletenessTest.php`
+- Modify: `phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleOrdoValidationTest.php`
+
+**Interfaces:**
+
+- Consumes: `AmbrosianTemporaleHarnessTrait::runEngineEvents()`.
+- Produces: a gap-free coverage guarantee for the temporal year.
+
+**Goal:** prove that after `buildTemporale()`, **every day** from `Advent1` to the day before the *next* Advent I is covered by exactly one temporale event (an anchor, a numbered
+Sunday, or a ferial weekday), and that every event carries a non-null `liturgical_season`. This is the load-bearing invariant that makes Plan 7's un-501 wiring able to render a
+complete calendar.
+
+- [ ] **Step 1: Write the completeness test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar\Temporale;
+
+use LiturgicalCalendar\Api\DateTime;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @group slow
+ * Full-year gap-free coverage of the Ambrosian temporal cycle.
+ */
+final class AmbrosianTemporaleCompletenessTest extends TestCase
+{
+    use AmbrosianTemporaleHarnessTrait;
+
+    /**
+     * Every day from Advent I (year Y) to the day before Advent I (year Y+1) is
+     * covered by exactly one temporale event, and every event has a season.
+     *
+     * @dataProvider civilYears
+     */
+    public function testTemporalYearIsGapFree(int $year): void
+    {
+        $events = $this->runEngineEvents($year);
+
+        // Index events by Y-m-d; assert no two temporale events share a date.
+        $byDate = [];
+        foreach ($events as $key => $e) {
+            self::assertNotNull($e->liturgical_season, "Event $key has no liturgical_season");
+            $ymd = $e->date->format('Y-m-d');
+            self::assertArrayNotHasKey($ymd, $byDate, "Two temporale events on $ymd: $key and {$byDate[$ymd]}");
+            $byDate[$ymd] = $key;
+        }
+
+        // Walk Advent I (Y) .. day before Advent I (Y+1); every day must be covered.
+        $adventThisYear = DateTime::fromFormat('11-11-' . $year)->modify('next Sunday');
+        $adventNextYear = DateTime::fromFormat('11-11-' . ( $year + 1 ))->modify('next Sunday');
+        $cursor         = clone $adventThisYear;
+        while ($cursor < $adventNextYear) {
+            $ymd = $cursor->format('Y-m-d');
+            self::assertArrayHasKey($ymd, $byDate, "Uncovered temporal day: $ymd");
+            $cursor = $cursor->add(new \DateInterval('P1D'));
+        }
+    }
+
+    /** @return array<string,array{int}> */
+    public static function civilYears(): array
+    {
+        return ['2024' => [2024], '2025' => [2025], '2026' => [2026]];
+    }
+}
+```
+
+> **Implementer note:** `runEngineEvents()` builds a single civil year. The anchor block that belongs to the *previous* liturgical year's tail (Jan 1 – Baptism) and the *next*
+> liturgical year's head (Advent I of Y is in year Y; the walk ends before Advent I of Y+1, which this civil-year build does not produce). If the single-civil-year harness cannot
+> cover the Advent-I(Y) → Dec-31 → … boundary cleanly, scope the walk to **Advent I (Y) .. Dec 31 (Y)** plus **Jan 1 (Y) .. Saturday before Advent I (Y)** as the harness actually
+> produces them, i.e. assert gap-freeness over the two contiguous stretches the civil-year build yields. The essential invariant is *no uncovered day inside a produced stretch* and
+> *no duplicate dates* — adapt the walk bounds to the harness's civil-year semantics rather than forcing a cross-year build (cross-year assembly is Plan 7's handler concern).
+
+- [ ] **Step 2: Run it**
+
+Run: `vendor/bin/phpunit phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleCompletenessTest.php`
+Expected: PASS. If it reports an uncovered day, that is a real gap — fix the responsible season fill's boundaries (off-by-one at a season seam) before proceeding. If it reports a
+duplicate date, two fills overlap at a seam — tighten the `[from, to)` bounds.
+
+- [ ] **Step 3: Extend the ordo-validation test**
+
+In `AmbrosianTemporaleOrdoValidationTest.php`, add the first-Sunday-of-each-sub-block pins for 2024/2025/2026 (from Task 4) if not already present, and add a single assertion that
+the count of `AfterEpiphany*` + `AfterPentecost*` numbered Sundays for 2025 is > 0 (guards against a silently empty block). Keep `@group slow`.
+
+- [ ] **Step 4: Run the full suite + analyse + lint + golden master**
+
+Run: `composer test` (full, includes `@group slow`) → green.
+Run: `composer analyse` → clean. `composer lint` → clean.
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/CalendarGoldenMasterTest.php` → 9/36 green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleCompletenessTest.php phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleOrdoValidationTest.php
+git commit -m "test(ambrosian): assert gap-free temporal-year coverage and extend ordo validation"
+```
+
+---
+
+## Post-Plan Notes
+
+- **Deferred to Plan 9 (ordo-validation + 1976 backfill):** exact ordo wording/numbering of the synthesized Sunday and ferial names; the pre-2008 single-block post-Pentecost
+  structure + the year-2008 engine branch; the n. 4 aliturgical-Friday suspension when Annunciation/St Joseph supersede; Holy-Family-on-the-last-January-Sunday interaction (a
+  sanctorale feast that supersedes the coincident after-Epiphany Sunday — a precedence concern, validated once wired).
+- **Deferred to Plan 7 (un-501 wiring):** adding `AFTER_EPIPHANY`/`AFTER_PENTECOST` (and, if surfaced, `is_dominical`/`is_aliturgical`) to the **response** schema
+  `jsondata/schemas/LitCal.json` — its `liturgical_season` enum currently lists only the 6 Roman values in two places, so an Ambrosian calendar response would fail validation. Not
+  needed while the endpoint is 501; wire it alongside the handler branch.
+- **Whole-branch final review:** dispatch on the most capable model. Focus lenses: (1) season-seam off-by-ones (every `[from, to)` boundary vs its neighbor); (2) that no
+  synthesized key can collide with an anchor key or another synthesized key within a year; (3) golden-master byte-identity; (4) PHPStan L10 on the closures/`callable` signatures.

--- a/docs/superpowers/plans/2026-07-22-ambrosian-06-temporale-completion.md
+++ b/docs/superpowers/plans/2026-07-22-ambrosian-06-temporale-completion.md
@@ -61,8 +61,8 @@ unchanged. A single `is_aliturgical` boolean is added to the event models + sour
 
 | Block                     | Sunday keys                   | Ferial keys                                      | Season          | Colour  |
 | ------------------------- | ----------------------------- | ------------------------------------------------ | --------------- | ------- |
-| Advent (existing anchors) | `Advent1..6`                  | `AdventWeekday{DDD}` (see Task 6)                | ADVENT          | morello |
-| Christmas                 | anchors only                  | `ChristmasWeekday{DDD}`                          | CHRISTMAS       | white   |
+| Advent (existing anchors) | `Advent1..6`                  | `AdventWeekday{MMDD}` (see Task 6)               | ADVENT          | morello |
+| Christmas                 | anchors only                  | `ChristmasWeekday{MMDD}`                         | CHRISTMAS       | white   |
 | After-Epiphany            | `AfterEpiphany2..N`           | `AfterEpiphanyWeekday{N}{EnglishDay}`            | AFTER_EPIPHANY  | green   |
 | Lent (existing anchors)   | `Lent1..5`                    | `LentWeekday{N}{EnglishDay}`                     | LENT            | morello |
 | Easter (existing anchors) | `Easter2..7`                  | `EasterWeekday{N}{EnglishDay}`                   | EASTER          | white   |
@@ -70,7 +70,7 @@ unchanged. A single `is_aliturgical` boolean is added to the event models + sour
 | After-Pentecost (b)       | `AfterPentecostMartyrdom{N}`  | `AfterPentecostMartyrdomWeekday{N}{EnglishDay}`  | AFTER_PENTECOST | green   |
 | After-Pentecost (c)       | `AfterPentecostDedication{N}` | `AfterPentecostDedicationWeekday{N}{EnglishDay}` | AFTER_PENTECOST | green   |
 
-`{DDD}` = zero-padded day-of-month; `{N}` = week number within the block/season; `{EnglishDay}` = English weekday name (`Monday`…`Saturday`) — matching the Roman
+`{MMDD}` = zero-padded month+day; `{N}` = week number within the block/season; `{EnglishDay}` = English weekday name (`Monday`…`Saturday`) — matching the Roman
 `OrdWeekday{N}{EnglishDay}` key convention so keys are locale-independent.
 
 ---
@@ -871,9 +871,10 @@ git commit -m "feat(ambrosian): add ferial weekday-fill helper and after-Epiphan
 **Norms:** Advent ferie run from the Monday after Advent I to the Saturday before Christmas; the ferie *de Exceptáto* are **Dec 17–23** (Dec 18–23 when Dec 17 is a Sunday) (n. 39).
 Christmas ferie run from Dec 26 to the Saturday before Baptism, with `Circoncisione` (Jan 1) and `Epiphany` (Jan 6) already placed as anchors and skipped by `inCalendar()`.
 
-- Advent keys: `AdventWeekday{DDD}` (`{DDD}` = zero-padded day-of-month) — matches the Roman `AdventWeekdayDec{N}` family closely enough to classify under `/^AdventWeekday/`.
+- Advent keys: `AdventWeekday{MMDD}` (`{MMDD}` = zero-padded month+day, e.g. `AdventWeekday1217`) — Advent spans November **and** December, so bare day-of-month would
+  collide (Nov 17 vs Dec 17); month+day avoids it. Keys start with `AdventWeekday` → classify under `/^AdventWeekday/`.
   Colour morello. Names: the de Exceptáto days (Dec 17/18–23) get a distinct phrase; the rest use the week-of-Advent phrase.
-- Christmas keys: `ChristmasWeekday{DDD}`. Colour white.
+- Christmas keys: `ChristmasWeekday{MMDD}`. Colour white.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -882,20 +883,20 @@ Christmas ferie run from Dec 26 to the Saturday before Baptism, with `Circoncisi
     {
         $d = $this->runEngine(2025);
         // 2025: Dec 17 is Wednesday, so de Exceptáto = Dec 17..23 (Sundays excluded).
-        self::assertArrayHasKey('AdventWeekday017', $d);
-        self::assertSame('2025-12-17', $d['AdventWeekday017']);
-        self::assertArrayHasKey('AdventWeekday023', $d);
-        self::assertSame('2025-12-23', $d['AdventWeekday023']);
+        self::assertArrayHasKey('AdventWeekday1217', $d);
+        self::assertSame('2025-12-17', $d['AdventWeekday1217']);
+        self::assertArrayHasKey('AdventWeekday1223', $d);
+        self::assertSame('2025-12-23', $d['AdventWeekday1223']);
     }
 
     public function testChristmasFerieSkipAnchors2025(): void
     {
         $d = $this->runEngine(2025);
-        self::assertArrayHasKey('ChristmasWeekday029', $d); // Dec 29 2025 (Mon)
-        self::assertSame('2025-12-29', $d['ChristmasWeekday029']);
+        self::assertArrayHasKey('ChristmasWeekday1229', $d); // Dec 29 2025 (Mon)
+        self::assertSame('2025-12-29', $d['ChristmasWeekday1229']);
         // Jan 1 (Circoncisione) and Jan 6 (Epiphany) stay anchors, never overwritten:
-        self::assertArrayNotHasKey('ChristmasWeekday001', $d);
-        self::assertArrayNotHasKey('ChristmasWeekday006', $d);
+        self::assertArrayNotHasKey('ChristmasWeekday0101', $d);
+        self::assertArrayNotHasKey('ChristmasWeekday0106', $d);
     }
 ```
 
@@ -918,7 +919,7 @@ Expected: FAIL.
             $from,
             $to,
             LitColor::MORELLO,
-            fn (DateTime $d): string => 'AdventWeekday' . $d->format('d'),
+            fn (DateTime $d): string => 'AdventWeekday' . $d->format('md'),
             fn (DateTime $d): string => $this->adventWeekdayName($d, $ctx)
         );
     }
@@ -943,16 +944,16 @@ Expected: FAIL.
             $from,
             clone $baptism, // up to (not incl.) Baptism Sunday
             LitColor::WHITE,
-            fn (DateTime $d): string => 'ChristmasWeekday' . $d->format('d'),
+            fn (DateTime $d): string => 'ChristmasWeekday' . $d->format('md'),
             fn (DateTime $d): string => $this->weekdayName($d, 'del tempo di Natale', 'Nativitatis', null, $ctx)
         );
     }
 ```
 
-> **Implementer note on the Dec/Jan key collision:** `ChristmasWeekday{DDD}` uses day-of-month only, so Dec 27 → `ChristmasWeekday027` and Jan 3 → `ChristmasWeekday003`; no
-> collision within one civil year because the Christmas fill spans Dec 26–31 (`0DD` = 26–31) then Jan 2–5 (`00D`). If a future year needs both a Dec and Jan day with the same
-> day-number they still differ (`0DD` vs `00D` never overlap). The `fillFerialWeekdays` loop crosses the Dec→Jan boundary automatically because the same civil `$year` is used for
-> both anchors here (the harness builds a single civil year; the handler-level year semantics are Plan 7's concern).
+> **Implementer note on the Nov/Dec key collision:** the weekday key uses **month+day** (`$d->format('md')`, e.g. `AdventWeekday1117` vs `AdventWeekday1217`), NOT bare
+> day-of-month — Advent spans November **and** December, so day-of-month alone would collide (Nov 17 and Dec 17 both → `AdventWeekday17`) and silently drop the earlier ferie.
+> The Christmas fill likewise uses `ChristmasWeekday{md}` (Dec 26–31 → `1226`…`1231`). The de Exceptáto range check keeps `format('nd')`, which equals `md` for two-digit months
+> (11/12). The Christmas fill here is bounded to Dec 31; the January Christmas ferie (Jan 2 → Baptism) are added in Task 10, and handler-level liturgical-year merging is Plan 7's concern.
 
 - [ ] **Step 4: Wire into `buildTemporale()`**
 

--- a/jsondata/schemas/PropriumDeTempore.json
+++ b/jsondata/schemas/PropriumDeTempore.json
@@ -25,6 +25,10 @@
                 "is_dominical": {
                     "type": "boolean",
                     "description": "Whether the event is \"of the Lord\" (dominical). Optional; used by the Ambrosian proprium to distinguish Sundays and solemnities/feasts of the Lord from weekday ferie."
+                },
+                "is_aliturgical": {
+                    "type": "boolean",
+                    "description": "Whether the event is aliturgical (no Mass is celebrated). Used by the Ambrosian proprium for the aliturgical Fridays of Lent."
                 }
             },
             "required": [

--- a/phpunit_tests/Enum/LitSeasonAmbrosianTest.php
+++ b/phpunit_tests/Enum/LitSeasonAmbrosianTest.php
@@ -66,6 +66,6 @@ final class LitSeasonAmbrosianTest extends TestCase
         self::assertSame(LitSeason::CHRISTMAS, LitSeason::forEventKey('Circoncisione'));
         self::assertSame(LitSeason::LENT, LitSeason::forEventKey('AshesMonday'));
         self::assertSame(LitSeason::LENT, LitSeason::forEventKey('SabatoTradSymb'));
-        self::assertSame(LitSeason::AFTER_PENTECOST, LitSeason::forEventKey('ChristKing'));
+        self::assertSame(LitSeason::ORDINARY_TIME, LitSeason::forEventKey('ChristKing')); // shared Roman key — must NOT become Ambrosian-only AFTER_PENTECOST (regression guard for TemporaleHandler)
     }
 }

--- a/phpunit_tests/Enum/LitSeasonAmbrosianTest.php
+++ b/phpunit_tests/Enum/LitSeasonAmbrosianTest.php
@@ -60,4 +60,12 @@ final class LitSeasonAmbrosianTest extends TestCase
         self::assertSame('Tempus post Epiphaniam', LitSeason::AFTER_EPIPHANY->i18n(LitLocale::LATIN));
         self::assertSame('Tempus post Pentecosten', LitSeason::AFTER_PENTECOST->i18n(LitLocale::LATIN));
     }
+
+    public function testAmbrosianAnchorKeysClassifyCorrectly(): void
+    {
+        self::assertSame(LitSeason::CHRISTMAS, LitSeason::forEventKey('Circoncisione'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('AshesMonday'));
+        self::assertSame(LitSeason::LENT, LitSeason::forEventKey('SabatoTradSymb'));
+        self::assertSame(LitSeason::AFTER_PENTECOST, LitSeason::forEventKey('ChristKing'));
+    }
 }

--- a/phpunit_tests/Models/Calendar/LiturgicalEventIsAliturgicalTest.php
+++ b/phpunit_tests/Models/Calendar/LiturgicalEventIsAliturgicalTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar;
+
+use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\LitCommon;
+use LiturgicalCalendar\Api\Models\Calendar\LitCommons;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use LiturgicalCalendar\Api\Models\Lectionary\ReadingsCommons;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LiturgicalEvent::class)]
+final class LiturgicalEventIsAliturgicalTest extends TestCase
+{
+    private function makeEvent(): LiturgicalEvent
+    {
+        $event            = new LiturgicalEvent(
+            'Test Event',
+            new DateTime('2026-07-20T00:00:00+00:00')
+        );
+        $event->event_key = 'TestEvent';
+        $event->setReadings(new ReadingsCommons(LitCommons::create([LitCommon::NONE])));
+
+        return $event;
+    }
+
+    public function testIsAliturgicalDefaultsNullAndIsOmittedFromSerialization(): void
+    {
+        $event = $this->makeEvent();
+
+        self::assertNull($event->is_aliturgical);
+        self::assertArrayNotHasKey('is_aliturgical', $event->jsonSerialize());
+    }
+
+    public function testIsAliturgicalSerializesWhenSet(): void
+    {
+        $event                 = $this->makeEvent();
+        $event->is_aliturgical = true;
+
+        self::assertTrue($event->jsonSerialize()['is_aliturgical']);
+    }
+}

--- a/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
+++ b/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
@@ -37,10 +37,18 @@ final class AmbrosianRealYearAssemblyTest extends TestCase
      * Three event keys (`Christmas`, `Circoncisione`, `Epiphany`) are listed in
      * both the temporale anchor block and the comune sanctorale source; adding
      * the sanctorale row for one of these keys overwrites the already-added
-     * temporale entry rather than creating a duplicate, so the final distinct
-     * key count is 65 + 254 - 3 = 316, not the plain sum of 319.
+     * temporale entry rather than creating a duplicate, so the anchor/Sunday
+     * distinct key count is 65 + 254 - 3 = 316, not the plain sum of 319.
+     *
+     * Plan 6 / Task 5 adds the after-Epiphany ferial-weekday fill
+     * (`fillFerialWeekdays()`, wired via `calculateAfterEpiphanyWeekdays()`),
+     * which for civil year 2025 emits 48 `AfterEpiphanyWeekday{N}{EnglishDay}`
+     * keys (Mon after Baptism 2025-01-13 .. Sat before Lent1 2025-03-08, 6
+     * ferial days/week x 8 weeks = 48; none of these dates collide with an
+     * existing temporale or sanctorale key, so all 48 are additive). New total:
+     * 316 + 48 = 364.
      */
-    private const int EXPECTED_TOTAL_2025 = 316;
+    private const int EXPECTED_TOTAL_2025 = 364;
 
     public function testAssembleAmbrosianYear2025IncludesTemporaleAnchor(): void
     {

--- a/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
+++ b/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
@@ -77,8 +77,20 @@ final class AmbrosianRealYearAssemblyTest extends TestCase
      * including the 5 Lenten Fridays (Mar 14, 21, 28, Apr 4, 11). None of these 28
      * dates collide with an existing temporale or sanctorale key, so all 28 are
      * additive. New total: 402 + 28 = 430.
+     *
+     * Plan 6 / Task 8 adds the post-octave Easter ferial-weekday fill
+     * (`calculateEasterWeekdays()`, via `fillFerialWeekdays()`). The Easter
+     * octave weekdays (`Mon..SatOctaveEaster`) are already anchors placed by
+     * `calculateEasterCycle()`, so this fill runs from the Monday after Easter II
+     * (2025-04-28, exclusive of the octave/Easter II) through the Saturday before
+     * Pentecost (2025-06-07; Pentecost itself, 2025-06-08, is exclusive). Keys are
+     * `EasterWeekday{N}{EnglishDay}`. For civil year 2025 this spans weeks 2-7 (6
+     * full Mon-Sat weeks = 36 slots) minus 1 anchor date (Ascension, 2025-05-29,
+     * a Thursday) already in the calendar = 35 ferial days. None of these 35
+     * dates collide with an existing temporale or sanctorale key, so all 35 are
+     * additive. New total: 430 + 35 = 465.
      */
-    private const int EXPECTED_TOTAL_2025 = 430;
+    private const int EXPECTED_TOTAL_2025 = 465;
 
     public function testAssembleAmbrosianYear2025IncludesTemporaleAnchor(): void
     {

--- a/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
+++ b/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
@@ -109,8 +109,27 @@ final class AmbrosianRealYearAssemblyTest extends TestCase
      * sanctorale key (each block's Sundays are already-placed anchors, skipped
      * by the fill's own Sunday check), so all 138 are additive. New total:
      * 465 + 138 = 603.
+     *
+     * Plan 6 / Task 10 closes the three remaining coverage gaps found by
+     * walking the engine's 2025/2026 output (the n.32 "domenica nell'ottava
+     * del Natale" Dec 27/28 Sunday is spec-deferred and NOT modeled here):
+     *   - `calculateLentWeekdays()`'s upper bound is extended from Palm Sunday
+     *     to Holy Thursday (exclusive), adding the Holy Week Mon/Tue/Wed ferie
+     *     (2025: Apr 14/15/16 = `LentWeekday6Monday/Tuesday/Wednesday`) = 3
+     *     additive keys (Palm Sunday is a Sunday, skipped; `SabatoTradSymb` is
+     *     an anchor, skipped).
+     *   - `calculateChristmasSundayAfterOctave()` (n. 33) adds the "eventuale"
+     *     Sunday in [Jan 2, Jan 5] -- for 2025, Jan 5 -- as
+     *     `ChristmasSundayAfterOctave` = 1 additive key.
+     *   - `calculateChristmasJanuaryWeekdays()` fills Jan 2 .. Baptism of the
+     *     Lord (exclusive). For 2025 that range is Jan 2-11, minus the Jan 5
+     *     Sunday (now the n.33 anchor above) and the Jan 6 Epiphany anchor =
+     *     8 additive keys (`ChristmasWeekday0102`, `0103`, `0104`, `0107`,
+     *     `0108`, `0109`, `0110`, `0111`).
+     * None of these 3+1+8 = 12 dates collide with an existing temporale or
+     * sanctorale key. New total: 603 + 12 = 615.
      */
-    private const int EXPECTED_TOTAL_2025 = 603;
+    private const int EXPECTED_TOTAL_2025 = 615;
 
     public function testAssembleAmbrosianYear2025IncludesTemporaleAnchor(): void
     {

--- a/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
+++ b/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
@@ -89,8 +89,28 @@ final class AmbrosianRealYearAssemblyTest extends TestCase
      * a Thursday) already in the calendar = 35 ferial days. None of these 35
      * dates collide with an existing temporale or sanctorale key, so all 35 are
      * additive. New total: 430 + 35 = 465.
+     *
+     * Plan 6 / Task 9 adds the after-Pentecost ferial-weekday fill
+     * (`calculateAfterPentecostWeekdays()`, via `fillFerialWeekdays()`), the
+     * largest of the seven fills (Jun-mid-Nov), across the same three n.42
+     * sub-blocks as the after-Pentecost Sundays. Keys are
+     * `AfterPentecost{,Martyrdom,Dedication}Weekday{N}{EnglishDay}`. For civil
+     * year 2025:
+     *   - (a) dopo Pentecoste: Mon after Pentecost (2025-06-09) .. Sat before the
+     *     1st Sunday after the Martyrdom (2025-08-31 is exclusive) = 83 days,
+     *     minus 11 Sundays = 72 ferial days.
+     *   - (b) dopo il Martirio: Mon after that Sunday (2025-09-01) .. Sat before
+     *     the Dedication (2025-10-19 is exclusive) = 48 days, minus 6 Sundays
+     *     = 42 ferial days.
+     *   - (c) dopo la Dedicazione: Mon after the Dedication (2025-10-20) .. Sat
+     *     before Advent I (2025-11-16 is exclusive) = 27 days, minus 3 Sundays
+     *     = 24 ferial days.
+     * None of these 72+42+24 = 138 dates collide with an existing temporale or
+     * sanctorale key (each block's Sundays are already-placed anchors, skipped
+     * by the fill's own Sunday check), so all 138 are additive. New total:
+     * 465 + 138 = 603.
      */
-    private const int EXPECTED_TOTAL_2025 = 465;
+    private const int EXPECTED_TOTAL_2025 = 603;
 
     public function testAssembleAmbrosianYear2025IncludesTemporaleAnchor(): void
     {

--- a/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
+++ b/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
@@ -47,8 +47,25 @@ final class AmbrosianRealYearAssemblyTest extends TestCase
      * ferial days/week x 8 weeks = 48; none of these dates collide with an
      * existing temporale or sanctorale key, so all 48 are additive). New total:
      * 316 + 48 = 364.
+     *
+     * Plan 6 / Task 6 adds the Advent (incl. de Exceptáto, n. 39) and Christmas
+     * ferial-weekday fills (`calculateAdventWeekdays()` / `calculateChristmasWeekdays()`,
+     * both via `fillFerialWeekdays()`). Their keys are `AdventWeekday{md}` /
+     * `ChristmasWeekday{md}` (month+day, not bare day-of-month -- the Advent
+     * block spans Nov and Dec, where day-of-month alone collides, e.g. both
+     * Nov 17 and Dec 17 fall inside the block; see `calculateAdventWeekdays()`'s
+     * doc comment). For civil year 2025:
+     *   - Advent: Mon after Advent I (2025-11-17) .. Sat before Christmas
+     *     (2025-12-24), skipping Sundays (Advent2..6 anchors) = 33 ferial days.
+     *   - Christmas: Dec 26 .. Dec 31 of the same civil year (bounded there,
+     *     not through Baptism -- Baptism/Circoncisione/Epiphany are always
+     *     dated in *January of this same $year*, i.e. structurally before
+     *     Dec 26 of that year, not after it; see `calculateChristmasWeekdays()`'s
+     *     doc comment), skipping the Dec 28 Sunday = 5 ferial days.
+     * None of these 38 dates collide with an existing temporale or sanctorale
+     * key, so all 38 are additive. New total: 364 + 38 = 402.
      */
-    private const int EXPECTED_TOTAL_2025 = 364;
+    private const int EXPECTED_TOTAL_2025 = 402;
 
     public function testAssembleAmbrosianYear2025IncludesTemporaleAnchor(): void
     {

--- a/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
+++ b/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
@@ -64,8 +64,21 @@ final class AmbrosianRealYearAssemblyTest extends TestCase
      *     doc comment), skipping the Dec 28 Sunday = 5 ferial days.
      * None of these 38 dates collide with an existing temporale or sanctorale
      * key, so all 38 are additive. New total: 364 + 38 = 402.
+     *
+     * Plan 6 / Task 7 adds the Lenten ferial-weekday fill (`calculateLentWeekdays()`,
+     * via `fillFerialWeekdays(..., lentenAliturgicalFridays: true)`), which flags
+     * every Lenten Friday `is_aliturgical = true` (nn. 24-27). Keys are
+     * `LentWeekday{N}{EnglishDay}`, run from the day after Lent I (2025-03-10,
+     * exclusive of Lent I itself, but AshesMonday already occupies that date as an
+     * anchor) through the Saturday before Palm Sunday (2025-04-12, where
+     * SabatoTradSymb already occupies that date as an anchor). For civil year 2025
+     * this produces 5 full weeks of Mon-Sat ferie (30 slots) minus the 2 anchor
+     * dates (AshesMonday, SabatoTradSymb) already in the calendar = 28 ferial days,
+     * including the 5 Lenten Fridays (Mar 14, 21, 28, Apr 4, 11). None of these 28
+     * dates collide with an existing temporale or sanctorale key, so all 28 are
+     * additive. New total: 402 + 28 = 430.
      */
-    private const int EXPECTED_TOTAL_2025 = 402;
+    private const int EXPECTED_TOTAL_2025 = 430;
 
     public function testAssembleAmbrosianYear2025IncludesTemporaleAnchor(): void
     {

--- a/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
+++ b/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearAssemblyTest.php
@@ -28,15 +28,19 @@ final class AmbrosianRealYearAssemblyTest extends TestCase
 
     /**
      * The comune ambrosiano (2024 edition, `propriumdesanctis.json`) has 254
-     * rows. The temporale engine produces 38 anchor keys for civil year 2025
-     * (verified via `AmbrosianTemporaleTest`/`AmbrosianTemporaleOrdoValidationTest`).
+     * rows. The temporale engine produces 65 anchor/synthesized keys for civil
+     * year 2025 (verified via `AmbrosianTemporaleTest`/`AmbrosianTemporaleOrdoValidationTest`):
+     * 38 major-block anchors (Advent through Christ the King) + 7 after-Epiphany
+     * Sundays (`AfterEpiphany2`..`AfterEpiphany8`) + 20 after-Pentecost Sundays
+     * across the three n.42 sub-blocks (`AfterPentecost1`..`11`,
+     * `AfterPentecostMartyrdom1`..`7`, `AfterPentecostDedication1`..`2`).
      * Three event keys (`Christmas`, `Circoncisione`, `Epiphany`) are listed in
      * both the temporale anchor block and the comune sanctorale source; adding
      * the sanctorale row for one of these keys overwrites the already-added
      * temporale entry rather than creating a duplicate, so the final distinct
-     * key count is 38 + 254 - 3 = 289, not the plain sum of 292.
+     * key count is 65 + 254 - 3 = 316, not the plain sum of 319.
      */
-    private const int EXPECTED_TOTAL_2025 = 289;
+    private const int EXPECTED_TOTAL_2025 = 316;
 
     public function testAssembleAmbrosianYear2025IncludesTemporaleAnchor(): void
     {

--- a/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearPrecedenceTest.php
+++ b/phpunit_tests/Models/Calendar/Sanctorale/AmbrosianRealYearPrecedenceTest.php
@@ -163,29 +163,41 @@ final class AmbrosianRealYearPrecedenceTest extends TestCase
     }
 
     /**
-     * A concrete real coincidence (task brief Step 1(ii)), documented in the
-     * Task 8 report: in the 2025 assembled year, `Advent4` (the temporale
-     * anchor for Advent IV, a dominical Higher Solemnity) and `StAmbrose`
-     * (the comune sanctorale Solemnity for the patron of Milan) both fall on
-     * 2025-12-07. `Advent4` outranks `StAmbrose` (rank 3 vs rank 5), so
-     * `StAmbrose` is impeded and transferred via the generic n.56 walk.
+     * A concrete real coincidence (task brief Step 1(ii)): in the 2025
+     * assembled year, `Advent4` (the temporale anchor for Advent IV, a
+     * dominical Higher Solemnity and privileged Advent Sunday) and
+     * `StAmbrose` (the comune sanctorale Solemnity for the patron of Milan)
+     * both fall on 2025-12-07.
      *
-     * The walk cannot land on 2025-12-08: the comune sanctorale also places
-     * `ImmaculateConception` (a Solemnity, rank 5 -- NOT free of ranks 1-10)
-     * there, so the walk skips it. It lands on 2025-12-09 instead, where the
-     * comune sanctorale independently places `StJuanDiego` (an optional
-     * memorial, rank 12 -- free of ranks 1-10, so the walk does not skip
-     * it). This creates a FRESH coincidence at the destination that only the
-     * Task 8 iterative pass resolves: `StJuanDiego` is suppressed by the
-     * now-co-located, higher-ranking `StAmbrose` in the second pass.
+     * Once Plan 6 Task 2 made `AmbrosianTemporale` populate
+     * `liturgical_season` on every event, the resolver's season-gated
+     * branches stopped being inert and now correctly recognize 2025-12-07 as
+     * a privileged Advent Sunday. That triggers the saint-Solemnity-on-a-
+     * privileged-Sunday rule (spec §5 / nn.4, 56) instead of the generic
+     * n.56 forward walk: `StAmbrose` is displaced to the following Monday,
+     * 2025-12-08 -- but that Monday is itself occupied by
+     * `ImmaculateConception` (also a Solemnity), so `StAmbrose` is
+     * ANTICIPATED to the preceding Saturday, 2025-12-06, instead.
      *
-     * This single real-year coincidence exercises: the generic n.56 walk
-     * skipping an occupied-by-a-solemnity day, landing on an
-     * occupied-by-a-memorial day, and the iterative pass cleaning up the
-     * resulting collision -- i.e. it is the real-data analogue of the
-     * constructed cascade in `AmbrosianPrecedenceResolverTest::testGenericTransferOntoOccupiedDayIsReResolvedByIterativePass()`.
+     * (Before `liturgical_season` was populated, the resolver could not see
+     * that Dec 7 was a privileged Sunday and fell through to the generic
+     * n.56 forward walk, which incorrectly landed `StAmbrose` on 2025-12-09
+     * -- suppressing `StJuanDiego` there. That was a bug; this test now
+     * documents and locks in the corrected anticipation-to-Saturday
+     * behavior.)
+     *
+     * The Dec-6 landing is confirmed correct by the authoritative Milan
+     * diocesan ordo:
+     * https://www.chiesadimilano.it/almanacco/letture-rito-ambrosiano/anno-a-2025-2026-ra/ordinazione-di-santambrogio-8-2851534.html
+     *
+     * The generic n.56 iterative-pass mechanism (a transfer landing on an
+     * already-occupied day, re-resolved by a second pass) is still covered
+     * on constructed fixture data by
+     * `AmbrosianPrecedenceResolverTest::testGenericTransferOntoOccupiedDayIsReResolvedByIterativePass()`;
+     * this real-year scenario no longer exercises that generic path, since
+     * the season-aware anticipation rule now applies instead.
      */
-    public function testStAmbroseCascadeThroughOccupiedImmaculateConceptionOntoStJuanDiego(): void
+    public function testStAmbroseOnAdventSundayAnticipatedToSaturdayPastOccupiedImmaculateConception(): void
     {
         $cal = $this->assembleAmbrosianYear(2025);
 
@@ -219,26 +231,36 @@ final class AmbrosianRealYearPrecedenceTest extends TestCase
 
         // ImmaculateConception is untouched: it was never contested (it wins
         // its own uncontested date and blocks -- but is not itself impeded by
-        // -- the n.56 walk).
+        // -- StAmbrose's displacement).
         $immaculateAfter = $cal->getLiturgicalEvent('ImmaculateConception');
         self::assertNotNull($immaculateAfter);
         self::assertSame('2025-12-08', $immaculateAfter->date->format('Y-m-d'));
         self::assertFalse($cal->isSuppressed('ImmaculateConception'));
 
-        // StAmbrose survives, transferred past the occupied Dec 8 onto Dec 9.
+        // StAmbrose survives: displaced from privileged Sunday Dec 7 to
+        // Monday Dec 8, which is occupied by ImmaculateConception, so it is
+        // anticipated to the preceding Saturday, Dec 6.
         self::assertFalse($cal->isSuppressed('StAmbrose'));
         $stAmbroseAfter = $cal->getLiturgicalEvent('StAmbrose');
         self::assertNotNull($stAmbroseAfter);
-        self::assertSame('2025-12-09', $stAmbroseAfter->date->format('Y-m-d'));
+        self::assertSame('2025-12-06', $stAmbroseAfter->date->format('Y-m-d'));
 
-        // StJuanDiego -- the fresh coincidence StAmbrose's transfer created at
-        // its destination -- is suppressed, but only by the SECOND pass.
-        self::assertTrue($cal->isSuppressed('StJuanDiego'));
-        self::assertNull($cal->getLiturgicalEvent('StJuanDiego'));
+        // StJuanDiego is untouched: with StAmbrose now anticipated to Dec 6
+        // instead of transferred to Dec 9, there is no fresh coincidence at
+        // StJuanDiego's date -- it remains active on its original 2025-12-09.
+        self::assertFalse($cal->isSuppressed('StJuanDiego'));
+        $stJuanDiegoAfter = $cal->getLiturgicalEvent('StJuanDiego');
+        self::assertNotNull($stJuanDiegoAfter);
+        self::assertSame('2025-12-09', $stJuanDiegoAfter->date->format('Y-m-d'));
 
-        // Dec 9 ends up holding exactly one active event: StAmbrose.
+        // Dec 6 ends up holding exactly one active event: StAmbrose.
+        $dec6Occupants = $cal->getCalEventsFromDate(\LiturgicalCalendar\Api\DateTime::fromFormat('6-12-2025'));
+        self::assertCount(1, $dec6Occupants);
+        self::assertArrayHasKey('StAmbrose', $dec6Occupants);
+
+        // Dec 9 ends up holding exactly one active event: StJuanDiego.
         $dec9Occupants = $cal->getCalEventsFromDate(\LiturgicalCalendar\Api\DateTime::fromFormat('9-12-2025'));
         self::assertCount(1, $dec9Occupants);
-        self::assertArrayHasKey('StAmbrose', $dec9Occupants);
+        self::assertArrayHasKey('StJuanDiego', $dec9Occupants);
     }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleCompletenessTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleCompletenessTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar\Temporale;
+
+use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\AmbrosianTemporale;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Full-year completeness acceptance gate for the Ambrosian temporale engine
+ * (Plan 6, Task 11).
+ *
+ * Proves that for a full civil year, the engine produces exactly one
+ * temporale event per day, gap-free, with a single documented exception:
+ * the Sunday within the Christmas octave (n.32 "domenica nell'ottava del
+ * Natale"). Its vigil-shift placement is explicitly deferred by spec §4 to
+ * ordo-validation; in the assembled calendar that day is instead covered by
+ * the sanctorale (St Stephen/John/Holy Innocents, Dec 26/27/28), so its
+ * absence from the temporale-only view is expected, not a regression.
+ *
+ * Marked @group slow per project convention for full-engine acceptance runs;
+ * excluded from `composer test:quick`.
+ */
+#[CoversClass(AmbrosianTemporale::class)]
+#[Group('slow')]
+final class AmbrosianTemporaleCompletenessTest extends TestCase
+{
+    use AmbrosianTemporaleHarnessTrait;
+
+    /** @return array<int,array{0:int}> */
+    public static function civilYears(): array
+    {
+        return [
+            [2024],
+            [2025],
+            [2026],
+        ];
+    }
+
+    #[DataProvider('civilYears')]
+    public function testTemporalYearIsGapFree(int $year): void
+    {
+        $events = $this->runEngineEvents($year);
+
+        // 1. Every event must carry a resolved liturgical season.
+        foreach ($events as $key => $event) {
+            self::assertNotNull($event->liturgical_season, "Event '$key' ($year) is missing a liturgical_season");
+        }
+
+        // 2. Zero duplicate dates: index events by Y-m-d and detect collisions.
+        /** @var array<string,string> $byDate map of 'Y-m-d' => event_key */
+        $byDate = [];
+        foreach ($events as $key => $event) {
+            $date = $event->date->format('Y-m-d');
+            if (array_key_exists($date, $byDate)) {
+                self::fail("Duplicate temporale event on $date ($year): '{$byDate[$date]}' and '$key'");
+            }
+            $byDate[$date] = $key;
+        }
+
+        // 3. Compute the single allowlisted exception: the Sunday within the
+        // Christmas octave window [Dec 26, Dec 31] of $year, if one exists.
+        // n.32 "domenica nell'ottava del Natale" has its vigil-shift placement
+        // deferred by spec §4 to ordo-validation, and in the assembled
+        // calendar the sanctorale (Stephen/John/Innocents) covers that day,
+        // so it is expected to be absent from the temporale-only view.
+        $dec26 = DateTime::fromFormat('26-12-' . $year);
+        $dec31 = DateTime::fromFormat('31-12-' . $year);
+        if ((int) $dec26->format('N') === 7) {
+            $octaveSunday = $dec26;
+        } else {
+            $octaveSunday = ( clone $dec26 )->modify('next Sunday');
+        }
+        $allow = $octaveSunday <= $dec31 ? [$octaveSunday->format('Y-m-d')] : [];
+
+        // 4. Walk Jan 1 -> Dec 31 of $year; every day must be covered by the
+        // temporale except the allowlisted octave Sunday computed above.
+        $cursor    = DateTime::fromFormat('1-1-' . $year);
+        $yearEnd   = DateTime::fromFormat('31-12-' . $year);
+        $uncovered = [];
+        while ($cursor <= $yearEnd) {
+            $iso = $cursor->format('Y-m-d');
+            if (!array_key_exists($iso, $byDate) && !in_array($iso, $allow, true)) {
+                $weekday     = $cursor->format('l');
+                $uncovered[] = "$iso ($weekday)";
+            }
+            $cursor->modify('+1 day');
+        }
+
+        self::assertSame(
+            [],
+            $uncovered,
+            "Uncovered day(s) found in $year temporale coverage (excluding allowlisted octave Sunday): "
+                . implode(', ', $uncovered)
+        );
+
+        // 5. Guard the allowlist itself: the octave Sunday, when it exists,
+        // must genuinely be uncovered by the temporale. If a future engine
+        // change starts covering it, this assertion should fail so the
+        // allowlist is updated deliberately rather than silently masking
+        // renewed (or regressed) coverage.
+        if ($allow !== []) {
+            self::assertArrayNotHasKey(
+                $allow[0],
+                $byDate,
+                'octave Sunday expected to be temporale-uncovered (n.32 deferred, spec §4)'
+            );
+        }
+    }
+}

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleHarnessTrait.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleHarnessTrait.php
@@ -107,4 +107,20 @@ trait AmbrosianTemporaleHarnessTrait
         }
         return $dates;
     }
+
+    /** @return array<string,\LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent> map of event_key => event after buildTemporale */
+    private function runEngineEvents(int $year): array
+    {
+        $messages = [];
+        $ctx      = $this->buildContext($year, $messages);
+        ( new AmbrosianTemporale() )->buildTemporale($ctx);
+
+        $events = [];
+        foreach ($ctx->cal->getLiturgicalEvents()->getKeys() as $key) {
+            $event = $ctx->cal->getLiturgicalEvent($key);
+            self::assertNotNull($event, "Expected a LiturgicalEvent for key $key");
+            $events[$key] = $event;
+        }
+        return $events;
+    }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleHarnessTrait.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleHarnessTrait.php
@@ -95,17 +95,10 @@ trait AmbrosianTemporaleHarnessTrait
     /** @return array<string,string> map of event_key => 'Y-m-d' after buildTemporale */
     private function runEngine(int $year): array
     {
-        $messages = [];
-        $ctx      = $this->buildContext($year, $messages);
-        ( new AmbrosianTemporale() )->buildTemporale($ctx);
-
-        $dates = [];
-        foreach ($ctx->cal->getLiturgicalEvents()->getKeys() as $key) {
-            $event = $ctx->cal->getLiturgicalEvent($key);
-            self::assertNotNull($event, "Expected a LiturgicalEvent for key $key");
-            $dates[$key] = $event->date->format('Y-m-d');
-        }
-        return $dates;
+        return array_map(
+            static fn (\LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent $event): string => $event->date->format('Y-m-d'),
+            $this->runEngineEvents($year)
+        );
     }
 
     /** @return array<string,\LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent> map of event_key => event after buildTemporale */

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleOrdoValidationTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleOrdoValidationTest.php
@@ -122,4 +122,31 @@ final class AmbrosianTemporaleOrdoValidationTest extends TestCase
             }
         }
     }
+
+    /**
+     * Guards against a silently empty after-Epiphany or after-Pentecost block:
+     * asserts the engine emits at least one numbered Sunday of each family for
+     * 2025 (the block sizes themselves vary year to year with the date of
+     * Easter/Pentecost/Dedication and are covered by the engine-level
+     * sub-block tests in AmbrosianTemporaleTest, so only a non-zero count is
+     * asserted here).
+     */
+    public function testAfterEpiphanyAndAfterPentecostBlocksAreNonEmpty2025(): void
+    {
+        $d = $this->runEngine(2025);
+
+        $afterEpiphanyCount  = 0;
+        $afterPentecostCount = 0;
+        foreach (array_keys($d) as $key) {
+            if (preg_match('/^AfterEpiphany\d+$/', $key)) {
+                $afterEpiphanyCount++;
+            }
+            if (preg_match('/^AfterPentecost(Martyrdom|Dedication)?\d+$/', $key)) {
+                $afterPentecostCount++;
+            }
+        }
+
+        self::assertGreaterThan(0, $afterEpiphanyCount, 'Expected at least one AfterEpiphanyN Sunday for 2025');
+        self::assertGreaterThan(0, $afterPentecostCount, 'Expected at least one AfterPentecost(Martyrdom|Dedication)N Sunday for 2025');
+    }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleOrdoValidationTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleOrdoValidationTest.php
@@ -68,9 +68,54 @@ final class AmbrosianTemporaleOrdoValidationTest extends TestCase
         ],
     ];
 
+    /**
+     * First Sunday of each after-Pentecost sub-block (n. 42a-c) for the three
+     * composing civil years. These are anchor-derived (1st Sunday after
+     * Pentecost / after the Martyrdom / after the Dedication) and therefore
+     * stable regression pins, unlike the last-in-block ordinal counts (which
+     * vary year to year with the Pentecost/Dedication/Advent-I gap and are
+     * covered by the engine-level sub-block tests in AmbrosianTemporaleTest).
+     *
+     * REGRESSION PIN for all three years: chiesadimilano.it's daily-liturgy
+     * widget does not expose a "Nth Sunday after Pentecost/Martyrdom/Dedication"
+     * ordo listing, so these are computed from the engine's own rules
+     * (Pentecost = Easter+49d, Martyrdom = Aug 29 postponed to Sep 1 on a
+     * Sunday, Dedication = 3rd Sunday of October) rather than spot-checked
+     * against a printed/published ordo.
+     *
+     * @var array<int, array<string,string>>
+     */
+    private const EXPECTED_SUB_BLOCK_FIRST_SUNDAYS = [
+        2024 => [
+            'AfterPentecost1'           => '2024-05-26',
+            'AfterPentecostMartyrdom1'  => '2024-09-01',
+            'AfterPentecostDedication1' => '2024-10-27',
+        ],
+        2025 => [
+            'AfterPentecost1'           => '2025-06-15',
+            'AfterPentecostMartyrdom1'  => '2025-08-31',
+            'AfterPentecostDedication1' => '2025-10-26',
+        ],
+        2026 => [
+            'AfterPentecost1'           => '2026-05-31',
+            'AfterPentecostMartyrdom1'  => '2026-08-30',
+            'AfterPentecostDedication1' => '2026-10-25',
+        ],
+    ];
+
     public function testAnchorsAcrossValidatedYears(): void
     {
         foreach (self::EXPECTED as $year => $expected) {
+            $d = $this->runEngine($year);
+            foreach ($expected as $key => $date) {
+                $this->assertSame($date, $d[$key], "$key ($year)");
+            }
+        }
+    }
+
+    public function testAfterPentecostSubBlockFirstSundaysAcrossValidatedYears(): void
+    {
+        foreach (self::EXPECTED_SUB_BLOCK_FIRST_SUNDAYS as $year => $expected) {
             $d = $this->runEngine($year);
             foreach ($expected as $key => $date) {
                 $this->assertSame($date, $d[$key], "$key ($year)");

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -271,4 +271,18 @@ final class AmbrosianTemporaleTest extends TestCase
         // Octave weekdays remain their own anchors, not re-emitted:
         self::assertArrayHasKey('MonOctaveEaster', $d);
     }
+
+    public function testAfterPentecostWeekdaysFill2025(): void
+    {
+        $d = $this->runEngine(2025);
+        // (a) first ferial Monday after Pentecost (2025-06-08) = 2025-06-09, week 1
+        self::assertArrayHasKey('AfterPentecostWeekday1Monday', $d);
+        self::assertSame('2025-06-09', $d['AfterPentecostWeekday1Monday']);
+        // (b) Monday after the 1st Sunday after the Martyrdom (Sun 2025-08-31) = 2025-09-01
+        self::assertArrayHasKey('AfterPentecostMartyrdomWeekday1Monday', $d);
+        self::assertSame('2025-09-01', $d['AfterPentecostMartyrdomWeekday1Monday']);
+        // (c) Monday after the Dedication (Sun 2025-10-19) = 2025-10-20
+        self::assertArrayHasKey('AfterPentecostDedicationWeekday1Monday', $d);
+        self::assertSame('2025-10-20', $d['AfterPentecostDedicationWeekday1Monday']);
+    }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Models\Calendar\Temporale;
 
+use LiturgicalCalendar\Api\Enum\LitColor;
 use LiturgicalCalendar\Api\Enum\LitGrade;
 use LiturgicalCalendar\Api\Enum\LitSeason;
 use LiturgicalCalendar\Api\Models\Calendar\Temporale\AmbrosianTemporale;
@@ -284,5 +285,58 @@ final class AmbrosianTemporaleTest extends TestCase
         // (c) Monday after the Dedication (Sun 2025-10-19) = 2025-10-20
         self::assertArrayHasKey('AfterPentecostDedicationWeekday1Monday', $d);
         self::assertSame('2025-10-20', $d['AfterPentecostDedicationWeekday1Monday']);
+    }
+
+    public function testHolyWeekFerieCovered2025(): void
+    {
+        $events = $this->runEngineEvents(2025);
+        // 2025: Palm Sunday = Apr 13, Holy Thursday = Apr 17. Mon/Tue/Wed of Holy
+        // Week (Apr 14/15/16) were previously uncovered because
+        // calculateLentWeekdays() stopped at Palm Sunday; the fix extends the
+        // upper bound to Holy Thursday (exclusive).
+        self::assertArrayHasKey('LentWeekday6Monday', $events);
+        self::assertSame('2025-04-14', $events['LentWeekday6Monday']->date->format('Y-m-d'));
+        self::assertNull($events['LentWeekday6Monday']->is_aliturgical);
+
+        self::assertArrayHasKey('LentWeekday6Tuesday', $events);
+        self::assertSame('2025-04-15', $events['LentWeekday6Tuesday']->date->format('Y-m-d'));
+        self::assertNull($events['LentWeekday6Tuesday']->is_aliturgical);
+
+        self::assertArrayHasKey('LentWeekday6Wednesday', $events);
+        self::assertSame('2025-04-16', $events['LentWeekday6Wednesday']->date->format('Y-m-d'));
+        self::assertNull($events['LentWeekday6Wednesday']->is_aliturgical);
+    }
+
+    public function testJanuaryChristmasFerie2025(): void
+    {
+        $d = $this->runEngine(2025);
+        self::assertArrayHasKey('ChristmasWeekday0102', $d);
+        self::assertSame('2025-01-02', $d['ChristmasWeekday0102']);
+        self::assertArrayHasKey('ChristmasWeekday0111', $d);
+        self::assertSame('2025-01-11', $d['ChristmasWeekday0111']);
+        // Epiphany (Jan 6) and Circoncisione (Jan 1) must not be overwritten.
+        self::assertSame('2025-01-06', $d['Epiphany']);
+        self::assertSame('2025-01-01', $d['Circoncisione']);
+    }
+
+    public function testSundayAfterChristmasOctave2025And2026(): void
+    {
+        $events2025 = $this->runEngineEvents(2025);
+        self::assertArrayHasKey('ChristmasSundayAfterOctave', $events2025);
+        $event2025 = $events2025['ChristmasSundayAfterOctave'];
+        self::assertSame('2025-01-05', $event2025->date->format('Y-m-d'));
+        self::assertSame(LitSeason::CHRISTMAS, $event2025->liturgical_season);
+        self::assertTrue($event2025->is_dominical);
+        self::assertSame(LitGrade::FEAST_LORD, $event2025->grade);
+        self::assertContains(LitColor::WHITE, $event2025->color);
+
+        $d2026 = $this->runEngine(2026);
+        self::assertSame('2026-01-04', $d2026['ChristmasSundayAfterOctave']);
+
+        // 2023: Jan 1, 2023 is a Sunday, so [Jan 2, Jan 5] contains no Sunday --
+        // the n.33 Sunday does not exist that year ("eventuale").
+        self::assertSame('7', ( new \DateTime('2023-01-01') )->format('N'), 'Expected Jan 1, 2023 to be a Sunday');
+        $d2023 = $this->runEngine(2023);
+        self::assertArrayNotHasKey('ChristmasSundayAfterOctave', $d2023);
     }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Models\Calendar\Temporale;
 
+use LiturgicalCalendar\Api\Enum\LitSeason;
 use LiturgicalCalendar\Api\Models\Calendar\Temporale\AmbrosianTemporale;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -115,5 +116,23 @@ final class AmbrosianTemporaleTest extends TestCase
             $this->assertSame(7, (int) $ck->format('N'), "Christ the King must be a Sunday ($year)");
             $this->assertSame($a1->modify('-7 days')->format('Y-m-d'), $d['ChristKing']);
         }
+    }
+
+    public function testAnchorBlockSeasonsStamped2025(): void
+    {
+        $events = $this->runEngineEvents(2025);
+        self::assertSame(LitSeason::ADVENT, $events['Advent1']->liturgical_season);
+        self::assertSame(LitSeason::CHRISTMAS, $events['Christmas']->liturgical_season);
+        self::assertSame(LitSeason::CHRISTMAS, $events['Circoncisione']->liturgical_season);
+        self::assertSame(LitSeason::CHRISTMAS, $events['Epiphany']->liturgical_season);
+        self::assertSame(LitSeason::CHRISTMAS, $events['BaptismLord']->liturgical_season);
+        self::assertSame(LitSeason::LENT, $events['Lent1']->liturgical_season);
+        self::assertSame(LitSeason::LENT, $events['AshesMonday']->liturgical_season);
+        self::assertSame(LitSeason::LENT, $events['SabatoTradSymb']->liturgical_season);
+        self::assertSame(LitSeason::EASTER_TRIDUUM, $events['HolyThurs']->liturgical_season);
+        self::assertSame(LitSeason::EASTER, $events['Easter']->liturgical_season);
+        self::assertSame(LitSeason::EASTER, $events['Pentecost']->liturgical_season);
+        self::assertSame(LitSeason::AFTER_PENTECOST, $events['DedicationDuomo']->liturgical_season);
+        self::assertSame(LitSeason::AFTER_PENTECOST, $events['ChristKing']->liturgical_season);
     }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Models\Calendar\Temporale;
 
+use LiturgicalCalendar\Api\Enum\LitGrade;
 use LiturgicalCalendar\Api\Enum\LitSeason;
 use LiturgicalCalendar\Api\Models\Calendar\Temporale\AmbrosianTemporale;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -239,5 +240,24 @@ final class AmbrosianTemporaleTest extends TestCase
         // January at all -- see calculateChristmasWeekdays()'s doc comment.
         self::assertArrayNotHasKey('ChristmasWeekday0101', $d);
         self::assertArrayNotHasKey('ChristmasWeekday0106', $d);
+    }
+
+    public function testLentenFridaysAreAliturgical2025(): void
+    {
+        $events  = $this->runEngineEvents(2025);
+        $fridays = array_filter(
+            $events,
+            fn ($e) => $e->liturgical_season === LitSeason::LENT
+                && (int) $e->date->format('N') === 5
+                && $e->grade === LitGrade::WEEKDAY
+        );
+        self::assertNotEmpty($fridays);
+        foreach ($fridays as $key => $e) {
+            self::assertTrue($e->is_aliturgical, "$key should be aliturgical");
+        }
+        // A Lenten non-Friday ferial is not aliturgical:
+        $someThursday = $events['LentWeekday1Thursday'] ?? null;
+        self::assertNotNull($someThursday);
+        self::assertNull($someThursday->is_aliturgical);
     }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -178,4 +178,24 @@ final class AmbrosianTemporaleTest extends TestCase
         self::assertSame(LitSeason::AFTER_PENTECOST, $events['AfterPentecostMartyrdom1']->liturgical_season);
         self::assertSame(LitSeason::AFTER_PENTECOST, $events['AfterPentecostDedication1']->liturgical_season);
     }
+
+    /**
+     * `martyrdomAnchor()` (n. 42a) postpones the Martyrdom of St John the
+     * Baptist from Aug 29 to Sep 1 whenever Aug 29 falls on a Sunday, so the
+     * "dopo il Martirio" block never overlaps a privileged Sunday. 2027 is
+     * the nearest civil year in which Aug 29 is a Sunday (verified via
+     * `date -d '2027-08-29' +%u` => 7), so the block's first Sunday
+     * (`AfterPentecostMartyrdom1`) must be measured from the postponed Sep 1
+     * anchor, not from Aug 29 itself: Sep 1, 2027 is a Wednesday, and the
+     * first Sunday on/after it is Sep 5, 2027.
+     */
+    public function testMartyrdomPostponedWhenAug29IsSunday(): void
+    {
+        $d = $this->runEngine(2027);
+
+        // Sanity: Aug 29, 2027 really is a Sunday -- the edge this test targets.
+        self::assertSame('7', ( new \DateTime('2027-08-29') )->format('N'), 'Expected Aug 29, 2027 to be a Sunday');
+
+        self::assertSame('2027-09-05', $d['AfterPentecostMartyrdom1']);
+    }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -260,4 +260,15 @@ final class AmbrosianTemporaleTest extends TestCase
         self::assertNotNull($someThursday);
         self::assertNull($someThursday->is_aliturgical);
     }
+
+    public function testEasterFerieAfterOctave2025(): void
+    {
+        $d = $this->runEngine(2025);
+        self::assertArrayHasKey('EasterWeekday2Monday', $d);
+        self::assertSame('2025-04-28', $d['EasterWeekday2Monday']);
+        // Ascension (Thu 2025-05-29) stays its own anchor:
+        self::assertSame('2025-05-29', $d['Ascension']);
+        // Octave weekdays remain their own anchors, not re-emitted:
+        self::assertArrayHasKey('MonOctaveEaster', $d);
+    }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -198,4 +198,17 @@ final class AmbrosianTemporaleTest extends TestCase
 
         self::assertSame('2027-09-05', $d['AfterPentecostMartyrdom1']);
     }
+
+    public function testAfterEpiphanyWeekdaysFillGaps2025(): void
+    {
+        $d = $this->runEngine(2025);
+        // After-Epiphany block: Mon after Baptism (2025-01-13) .. Sat before Lent1 (2025-03-08).
+        // Mondays are weekdays; assert a representative weekday exists and Sundays are NOT overwritten.
+        self::assertArrayHasKey('AfterEpiphanyWeekday2Monday', $d);   // week 2 Monday = 2025-01-13
+        self::assertSame('2025-01-13', $d['AfterEpiphanyWeekday2Monday']);
+        self::assertArrayHasKey('AfterEpiphanyWeekday3Saturday', $d); // 2025-01-25
+        self::assertSame('2025-01-25', $d['AfterEpiphanyWeekday3Saturday']);
+        // The Sunday 2025-01-19 remains AfterEpiphany2 (a weekday fill must never take a Sunday)
+        self::assertSame('2025-01-19', $d['AfterEpiphany2']);
+    }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -118,6 +118,19 @@ final class AmbrosianTemporaleTest extends TestCase
         }
     }
 
+    public function testAfterEpiphanySundays2025(): void
+    {
+        $d = $this->runEngine(2025);
+        self::assertSame('2025-01-19', $d['AfterEpiphany2']);
+        self::assertSame('2025-01-26', $d['AfterEpiphany3']);
+        self::assertSame('2025-02-02', $d['AfterEpiphany4']);
+        self::assertSame('2025-02-09', $d['AfterEpiphany5']);
+        self::assertSame('2025-02-16', $d['AfterEpiphany6']);
+        self::assertSame('2025-02-23', $d['AfterEpiphany7']);
+        self::assertSame('2025-03-02', $d['AfterEpiphany8']);
+        self::assertArrayNotHasKey('AfterEpiphany9', $d); // Mar 9 is Lent1
+    }
+
     public function testAnchorBlockSeasonsStamped2025(): void
     {
         $events = $this->runEngineEvents(2025);

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -148,4 +148,34 @@ final class AmbrosianTemporaleTest extends TestCase
         self::assertSame(LitSeason::AFTER_PENTECOST, $events['DedicationDuomo']->liturgical_season);
         self::assertSame(LitSeason::AFTER_PENTECOST, $events['ChristKing']->liturgical_season);
     }
+
+    public function testAfterPentecostSubBlocks2025(): void
+    {
+        $d = $this->runEngine(2025);
+
+        // (a) dopo Pentecoste: 1st Sunday after Pentecost (Jun 15) .. Sat before Aug 31
+        self::assertSame('2025-06-15', $d['AfterPentecost1']);
+        self::assertSame('2025-08-24', $d['AfterPentecost11']); // last before the Martyrdom Sunday
+        self::assertArrayNotHasKey('AfterPentecost12', $d);
+
+        // (b) dopo il Martirio: Aug 31 .. Sat before Oct 19 (Dedication)
+        self::assertSame('2025-08-31', $d['AfterPentecostMartyrdom1']);
+        self::assertSame('2025-10-12', $d['AfterPentecostMartyrdom7']);
+        self::assertArrayNotHasKey('AfterPentecostMartyrdom8', $d);
+
+        // (c) dopo la Dedicazione: 1st Sunday after Dedication (Oct 26) .. Sat before Advent I;
+        // Christ the King (Nov 9) is the terminal anchor, not re-emitted as a numbered Sunday.
+        self::assertSame('2025-10-26', $d['AfterPentecostDedication1']);
+        self::assertSame('2025-11-02', $d['AfterPentecostDedication2']);
+        self::assertArrayNotHasKey('AfterPentecostDedication3', $d); // Nov 9 = ChristKing
+        self::assertSame('2025-11-09', $d['ChristKing']);
+    }
+
+    public function testAfterPentecostSundaysStamped2025(): void
+    {
+        $events = $this->runEngineEvents(2025);
+        self::assertSame(LitSeason::AFTER_PENTECOST, $events['AfterPentecost1']->liturgical_season);
+        self::assertSame(LitSeason::AFTER_PENTECOST, $events['AfterPentecostMartyrdom1']->liturgical_season);
+        self::assertSame(LitSeason::AFTER_PENTECOST, $events['AfterPentecostDedication1']->liturgical_season);
+    }
 }

--- a/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/AmbrosianTemporaleTest.php
@@ -211,4 +211,33 @@ final class AmbrosianTemporaleTest extends TestCase
         // The Sunday 2025-01-19 remains AfterEpiphany2 (a weekday fill must never take a Sunday)
         self::assertSame('2025-01-19', $d['AfterEpiphany2']);
     }
+
+    public function testAdventDeExceptatoFerie2025(): void
+    {
+        $d = $this->runEngine(2025);
+        // 2025: Dec 17 is Wednesday, so de Exceptáto = Dec 17..23 (Sundays excluded).
+        // Keys are month+day ('md'), not bare day-of-month: the Advent block spans
+        // Nov and Dec, and day-of-month alone collides (e.g. both Nov 17 and Dec 17
+        // fall inside the block) -- see calculateAdventWeekdays()'s doc comment.
+        self::assertArrayHasKey('AdventWeekday1217', $d);
+        self::assertSame('2025-12-17', $d['AdventWeekday1217']);
+        self::assertArrayHasKey('AdventWeekday1223', $d);
+        self::assertSame('2025-12-23', $d['AdventWeekday1223']);
+        // Sanity: the Nov 17/Dec 17 collision case does NOT silently drop the
+        // November occurrence (both are distinct 'md' keys).
+        self::assertArrayHasKey('AdventWeekday1117', $d);
+        self::assertSame('2025-11-17', $d['AdventWeekday1117']);
+    }
+
+    public function testChristmasFerieSkipAnchors2025(): void
+    {
+        $d = $this->runEngine(2025);
+        self::assertArrayHasKey('ChristmasWeekday1229', $d); // Dec 29 2025 (Mon)
+        self::assertSame('2025-12-29', $d['ChristmasWeekday1229']);
+        // Jan 1 (Circoncisione) and Jan 6 (Epiphany) stay anchors, never overwritten:
+        // the fill is bounded to Dec 31 of the same civil year and never reaches
+        // January at all -- see calculateChristmasWeekdays()'s doc comment.
+        self::assertArrayNotHasKey('ChristmasWeekday0101', $d);
+        self::assertArrayNotHasKey('ChristmasWeekday0106', $d);
+    }
 }

--- a/src/Enum/LitSeason.php
+++ b/src/Enum/LitSeason.php
@@ -44,6 +44,7 @@ enum LitSeason: string
         '/^BaptismLord$/',
         '/^MaryMotherOfGod$/',
         '/^DayAfterEpiphany/',
+        '/^Circoncisione$/',
     ];
 
     /**
@@ -57,6 +58,8 @@ enum LitSeason: string
         '/^PalmSun$/',
         '/^(Mon|Tue|Wed)HolyWeek$/',
         '/^HolyThursChrism$/',
+        '/^AshesMonday$/',
+        '/^SabatoTradSymb$/',
     ];
 
     /**
@@ -94,6 +97,7 @@ enum LitSeason: string
     private const array AFTER_PENTECOST_PATTERNS = [
         '/^DedicationDuomo$/',
         '/^AfterPentecost/',
+        '/^ChristKing$/',
     ];
 
     /**

--- a/src/Enum/LitSeason.php
+++ b/src/Enum/LitSeason.php
@@ -97,7 +97,6 @@ enum LitSeason: string
     private const array AFTER_PENTECOST_PATTERNS = [
         '/^DedicationDuomo$/',
         '/^AfterPentecost/',
-        '/^ChristKing$/',
     ];
 
     /**

--- a/src/Models/Calendar/LiturgicalEvent.php
+++ b/src/Models/Calendar/LiturgicalEvent.php
@@ -49,6 +49,7 @@ final class LiturgicalEvent implements \JsonSerializable
     public ?bool $is_vigil_mass          = null;
     public ?bool $has_vigil_mass         = null;
     public ?bool $is_dominical           = null;
+    public ?bool $is_aliturgical         = null;
     public ?bool $is_proper              = null;
     public ?bool $has_vesper_i           = null;
     public ?bool $has_vesper_ii          = null;
@@ -212,6 +213,7 @@ final class LiturgicalEvent implements \JsonSerializable
      * - liturgical_year: the liturgical year of the liturgical event, if applicable
      * - is_vigil_mass: a boolean indicating whether the liturgical event is a vigil mass, if applicable
      * - is_dominical: a boolean indicating whether the liturgical event is "of the Lord" (dominical), if applicable
+     * - is_aliturgical: a boolean indicating whether the liturgical event is aliturgical (no Mass celebrated), if applicable
      * - is_proper: a boolean indicating whether the liturgical event is proper to a particular calendar
      *   (as opposed to "comune", i.e. taken from the General Calendar), if applicable
      * - is_vigil_for: the liturgical event that the current liturgical event is a vigil for, if applicable
@@ -248,6 +250,7 @@ final class LiturgicalEvent implements \JsonSerializable
      *      liturgical_year?: ?string,
      *      is_vigil_mass?: ?bool,
      *      is_dominical?: ?bool,
+     *      is_aliturgical?: ?bool,
      *      is_proper?: ?bool,
      *      is_vigil_for?: ?string,
      *      has_vigil_mass?: ?bool,
@@ -311,6 +314,10 @@ final class LiturgicalEvent implements \JsonSerializable
 
         if ($this->is_dominical !== null) {
             $returnArr['is_dominical'] = $this->is_dominical;
+        }
+
+        if ($this->is_aliturgical !== null) {
+            $returnArr['is_aliturgical'] = $this->is_aliturgical;
         }
 
         if ($this->is_proper !== null) {
@@ -398,6 +405,8 @@ final class LiturgicalEvent implements \JsonSerializable
      *   If not provided, defaults to LitEventType::FIXED.
      * - grade_display: The grade display of the liturgical event, as a string. If not provided, defaults to null.
      * - is_dominical: whether the liturgical event is "of the Lord" (dominical), as a boolean, if the source object
+     *   declares the property (e.g. PropriumDeTemporeEvent). If not provided (property absent) or null, defaults to null.
+     * - is_aliturgical: whether the liturgical event is aliturgical (no Mass celebrated), as a boolean, if the source object
      *   declares the property (e.g. PropriumDeTemporeEvent). If not provided (property absent) or null, defaults to null.
      *
      * @param \stdClass|LitCalItemCreateNewFixed|LitCalItemCreateNewMobile|DiocesanLitCalItemCreateNewFixed|DiocesanLitCalItemCreateNewMobile|DecreeItemCreateNewFixed|DecreeItemCreateNewMobile|PropriumDeTemporeEvent|PropriumDeSanctisEvent $obj
@@ -565,6 +574,14 @@ final class LiturgicalEvent implements \JsonSerializable
                 throw new \Exception('Invalid object provided to create LiturgicalEvent: is_dominical is not a boolean or null');
             }
             $litEvent->is_dominical = $obj->is_dominical;
+        }
+
+        // Carry over `is_aliturgical` from source data (e.g. PropriumDeTemporeEvent) when present and non-null.
+        if (property_exists($obj, 'is_aliturgical') && null !== $obj->is_aliturgical) {
+            if (false === is_bool($obj->is_aliturgical)) {
+                throw new \Exception('Invalid object provided to create LiturgicalEvent: is_aliturgical is not a boolean or null');
+            }
+            $litEvent->is_aliturgical = $obj->is_aliturgical;
         }
 
         return $litEvent;

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -77,7 +77,9 @@ final class AmbrosianTemporale implements TemporaleEngine
     /**
      * True if the given date falls on a Sunday. Used by
      * `calculateAfterPentecostAnchors()` to guard the 3rd-Sunday-of-October
-     * computation for the Dedication of the Duomo di Milano.
+     * computation for the Dedication of the Duomo di Milano, and by
+     * `martyrdomAnchor()` to guard the Aug 29 -> Sep 1 postponement of the
+     * Martyrdom of St John the Baptist when Aug 29 falls on a Sunday.
      */
     private static function dateIsSunday(DateTime $dt): bool
     {

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -38,6 +38,7 @@ final class AmbrosianTemporale implements TemporaleEngine
         $this->calculateAfterEpiphanySundays($ctx);
         $this->calculateAfterEpiphanyWeekdays($ctx);
         $this->calculateAfterPentecostSundays($ctx);
+        $this->calculateAfterPentecostWeekdays($ctx);
         $this->calculateAdventWeekdays($ctx);
         $this->calculateChristmasWeekdays($ctx);
         $this->calculateLentWeekdays($ctx);
@@ -567,6 +568,56 @@ final class AmbrosianTemporale implements TemporaleEngine
         }
         $ordinalStr = Utilities::getOrdinal($ordinal, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
         return sprintf('%s domenica %s', $ordinalStr, $phraseIt);
+    }
+
+    /**
+     * After-Pentecost ferie (n. 42), across the same three sub-blocks as
+     * `calculateAfterPentecostSundays()`, green (`LitColor::GREEN`), from the
+     * Monday after Pentecost to the Saturday before Advent I:
+     *   (a) dopo Pentecoste     — Monday after Pentecost … Sat before the 1st Sunday after the Martyrdom
+     *   (b) dopo il Martirio    — that Sunday's Monday … Sat before the Dedication
+     *   (c) dopo la Dedicazione — Monday after the Dedication … Sat before Advent I
+     * `DedicationDuomo`, `ChristKing`, and the after-Pentecost Sundays are all
+     * anchors already placed and are skipped by `inCalendar()`.
+     */
+    private function calculateAfterPentecostWeekdays(TemporaleContext $ctx): void
+    {
+        $year         = $ctx->params->Year;
+        $pentecost    = Utilities::calcGregEaster($year)->add(new \DateInterval('P49D'));
+        $martyrdomSun = ( clone $this->martyrdomAnchor($year) )->modify('next Sunday');
+        $dedication   = $ctx->cal->getLiturgicalEvent('DedicationDuomo')->date
+            ?? throw new ServiceUnavailableException('DedicationDuomo anchor must be placed before after-Pentecost ferie');
+        $advent1      = $this->adventOne($year);
+
+        // (a) dopo Pentecoste — anchored on Pentecost
+        $this->fillFerialBlock($ctx, ( clone $pentecost )->add(new \DateInterval('P1D')), $martyrdomSun, $pentecost, 'AfterPentecostWeekday', 'dopo Pentecoste', 'post Pentecosten');
+        // (b) dopo il Martirio — anchored on the 1st Sunday after the Martyrdom
+        $this->fillFerialBlock($ctx, ( clone $martyrdomSun )->add(new \DateInterval('P1D')), $dedication, $martyrdomSun, 'AfterPentecostMartyrdomWeekday', 'dopo il Martirio', 'post Martyrium');
+        // (c) dopo la Dedicazione — anchored on the Dedication Sunday
+        $this->fillFerialBlock($ctx, ( clone $dedication )->add(new \DateInterval('P1D')), $advent1, $dedication, 'AfterPentecostDedicationWeekday', 'dopo la Dedicazione', 'post Dedicationem');
+    }
+
+    /**
+     * Fill one after-Pentecost sub-block [$from, $to) with green ferie whose week
+     * number is measured from $blockAnchorSunday (block week 1 = the anchor's week).
+     */
+    private function fillFerialBlock(TemporaleContext $ctx, DateTime $from, DateTime $to, DateTime $blockAnchorSunday, string $keyStem, string $phraseIt, string $phraseLa): void
+    {
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            $to,
+            LitColor::GREEN,
+            fn (DateTime $d): string => $keyStem . $this->blockWeekNumber($d, $blockAnchorSunday) . $this->englishWeekday($d),
+            fn (DateTime $d): string => $this->weekdayName($d, $phraseIt, $phraseLa, $this->blockWeekNumber($d, $blockAnchorSunday), $ctx)
+        );
+    }
+
+    /** Week number within an after-Pentecost sub-block: week 1 opens the Monday after $anchorSunday. */
+    private function blockWeekNumber(DateTime $date, DateTime $anchorSunday): int
+    {
+        $daysSince = (int) $anchorSunday->diff($date)->format('%a');
+        return (int) floor(( $daysSince - 1 ) / 7) + 1;
     }
 
     /** Lenten ferie: Lent I (excl.) … Saturday before Palm Sunday; Fridays are aliturgical (nn. 24–27). */

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -248,6 +248,28 @@ final class AmbrosianTemporale implements TemporaleEngine
     }
 
     /**
+     * Shared boundary anchors for the three after-Pentecost sub-blocks (n. 42),
+     * consumed by both the Sunday numbering and the ferial fill so their block
+     * boundaries stay aligned: Pentecost (Easter + 49d), the 1st Sunday after the
+     * Martyrdom (Aug 29, postponed to Sep 1 when Aug 29 is a Sunday), the Dedication
+     * of the Duomo (must already be placed), and Advent I. Each call returns fresh
+     * DateTime objects.
+     *
+     * @return array{pentecost: DateTime, martyrdomSun: DateTime, dedication: DateTime, advent1: DateTime}
+     */
+    private function afterPentecostSubBlockBoundaries(TemporaleContext $ctx): array
+    {
+        $year = $ctx->params->Year;
+        return [
+            'pentecost'    => Utilities::calcGregEaster($year)->add(new \DateInterval('P49D')),
+            'martyrdomSun' => ( clone $this->martyrdomAnchor($year) )->modify('next Sunday'),
+            'dedication'   => $ctx->cal->getLiturgicalEvent('DedicationDuomo')->date
+                ?? throw new ServiceUnavailableException('DedicationDuomo anchor must be placed before the after-Pentecost sub-blocks'),
+            'advent1'      => $this->adventOne($year),
+        ];
+    }
+
+    /**
      * After-Pentecost Sundays (n. 42), in three sub-blocks with per-block numbering:
      *   (a) dopo Pentecoste     — 1st Sunday after Pentecost … Sat before the 1st Sunday after the Martyrdom
      *   (b) dopo il Martirio    — that Sunday … Sat before the Dedication (3rd Sunday of October)
@@ -257,12 +279,8 @@ final class AmbrosianTemporale implements TemporaleEngine
      */
     private function calculateAfterPentecostSundays(TemporaleContext $ctx): void
     {
-        $year         = $ctx->params->Year;
-        $pentecost    = Utilities::calcGregEaster($year)->add(new \DateInterval('P49D'));
-        $martyrdomSun = ( clone $this->martyrdomAnchor($year) )->modify('next Sunday'); // 1st Sunday after the Martyrdom
-        $dedication   = $ctx->cal->getLiturgicalEvent('DedicationDuomo')->date
-            ?? throw new ServiceUnavailableException('DedicationDuomo anchor must be placed before after-Pentecost Sundays');
-        $advent1      = $this->adventOne($year);
+        ['pentecost' => $pentecost, 'martyrdomSun' => $martyrdomSun, 'dedication' => $dedication, 'advent1' => $advent1]
+            = $this->afterPentecostSubBlockBoundaries($ctx);
 
         // (a) dopo Pentecoste
         $this->numberSundayBlock(
@@ -643,12 +661,8 @@ final class AmbrosianTemporale implements TemporaleEngine
      */
     private function calculateAfterPentecostWeekdays(TemporaleContext $ctx): void
     {
-        $year         = $ctx->params->Year;
-        $pentecost    = Utilities::calcGregEaster($year)->add(new \DateInterval('P49D'));
-        $martyrdomSun = ( clone $this->martyrdomAnchor($year) )->modify('next Sunday');
-        $dedication   = $ctx->cal->getLiturgicalEvent('DedicationDuomo')->date
-            ?? throw new ServiceUnavailableException('DedicationDuomo anchor must be placed before after-Pentecost ferie');
-        $advent1      = $this->adventOne($year);
+        ['pentecost' => $pentecost, 'martyrdomSun' => $martyrdomSun, 'dedication' => $dedication, 'advent1' => $advent1]
+            = $this->afterPentecostSubBlockBoundaries($ctx);
 
         // (a) dopo Pentecoste — anchored on Pentecost
         $this->fillFerialBlock($ctx, ( clone $pentecost )->add(new \DateInterval('P1D')), $martyrdomSun, $pentecost, 'AfterPentecostWeekday', 'dopo Pentecoste', 'post Pentecosten');

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -41,6 +41,7 @@ final class AmbrosianTemporale implements TemporaleEngine
         $this->calculateAdventWeekdays($ctx);
         $this->calculateChristmasWeekdays($ctx);
         $this->calculateLentWeekdays($ctx);
+        $this->calculateEasterWeekdays($ctx);
     }
 
     /**
@@ -591,6 +592,37 @@ final class AmbrosianTemporale implements TemporaleEngine
     {
         $daysSince = (int) $lent1->diff($date)->format('%a');
         return (int) floor(( $daysSince - 1 ) / 7) + 1;
+    }
+
+    /**
+     * Easter ferie after the octave (n. 21): the Easter octave weekdays
+     * (`Mon..SatOctaveEaster`) are already anchors placed by `calculateEasterCycle()`,
+     * so this fill starts strictly after Easter II — Monday after Easter II …
+     * Saturday before Pentecost. Ascension (Thursday, Easter + 39d) is an anchor
+     * and is skipped by `inCalendar()`.
+     */
+    private function calculateEasterWeekdays(TemporaleContext $ctx): void
+    {
+        $year      = $ctx->params->Year;
+        $easter    = Utilities::calcGregEaster($year);
+        $easter2   = ( clone $easter )->add(new \DateInterval('P7D'));   // Easter II
+        $pentecost = ( clone $easter )->add(new \DateInterval('P49D'));
+        $from      = ( clone $easter2 )->add(new \DateInterval('P1D'));  // Monday after Easter II
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            clone $pentecost, // up to (not incl.) Pentecost Sunday
+            LitColor::WHITE,
+            fn (DateTime $d): string => 'EasterWeekday' . $this->easterWeekNumber($d, $easter) . $this->englishWeekday($d),
+            fn (DateTime $d): string => $this->weekdayName($d, 'di Pasqua', 'Paschæ', $this->easterWeekNumber($d, $easter), $ctx)
+        );
+    }
+
+    /** Easter week number: the octave is week 1; Easter II opens week 2. */
+    private function easterWeekNumber(DateTime $date, DateTime $easter): int
+    {
+        $daysSince = (int) $easter->diff($date)->format('%a');
+        return (int) floor($daysSince / 7) + 1;
     }
 
     /**

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -36,6 +36,7 @@ final class AmbrosianTemporale implements TemporaleEngine
         $this->calculateEasterCycle($ctx);
         $this->calculateAfterPentecostAnchors($ctx);
         $this->calculateAfterEpiphanySundays($ctx);
+        $this->calculateAfterPentecostSundays($ctx);
     }
 
     /**
@@ -227,6 +228,79 @@ final class AmbrosianTemporale implements TemporaleEngine
     }
 
     /**
+     * Martyrdom of St John the Baptist (n. 42a): Aug 29, postponed to Sep 1 when
+     * Aug 29 falls on a Sunday.
+     */
+    private function martyrdomAnchor(int $year): DateTime
+    {
+        $aug29 = DateTime::fromFormat('29-8-' . $year);
+        return self::dateIsSunday($aug29) ? DateTime::fromFormat('1-9-' . $year) : $aug29;
+    }
+
+    /**
+     * After-Pentecost Sundays (n. 42), in three sub-blocks with per-block numbering:
+     *   (a) dopo Pentecoste     — 1st Sunday after Pentecost … Sat before the 1st Sunday after the Martyrdom
+     *   (b) dopo il Martirio    — that Sunday … Sat before the Dedication (3rd Sunday of October)
+     *   (c) dopo la Dedicazione — 1st Sunday after the Dedication … Sat before Advent I (ends at Christ the King)
+     * DedicationDuomo and ChristKing are anchors already placed; Sundays already in
+     * the calendar are skipped, so those two are not re-emitted as numbered Sundays.
+     */
+    private function calculateAfterPentecostSundays(TemporaleContext $ctx): void
+    {
+        $year         = $ctx->params->Year;
+        $pentecost    = Utilities::calcGregEaster($year)->add(new \DateInterval('P49D'));
+        $martyrdomSun = ( clone $this->martyrdomAnchor($year) )->modify('next Sunday'); // 1st Sunday after the Martyrdom
+        $dedication   = $ctx->cal->getLiturgicalEvent('DedicationDuomo')->date
+            ?? throw new ServiceUnavailableException('DedicationDuomo anchor must be placed before after-Pentecost Sundays');
+        $advent1      = $this->adventOne($year);
+
+        // (a) dopo Pentecoste
+        $this->numberSundayBlock(
+            $ctx,
+            'AfterPentecost',
+            ( clone $pentecost )->modify('next Sunday'),
+            $martyrdomSun,
+            fn (int $ordinal): string => $this->afterPentecostSundayName($ordinal, $ctx)
+        );
+        // (b) dopo il Martirio
+        $this->numberSundayBlock(
+            $ctx,
+            'AfterPentecostMartyrdom',
+            clone $martyrdomSun,
+            $dedication,
+            fn (int $ordinal): string => $this->afterMartyrdomSundayName($ordinal, $ctx)
+        );
+        // (c) dopo la Dedicazione
+        $this->numberSundayBlock(
+            $ctx,
+            'AfterPentecostDedication',
+            ( clone $dedication )->modify('next Sunday'),
+            $advent1,
+            fn (int $ordinal): string => $this->afterDedicationSundayName($ordinal, $ctx)
+        );
+    }
+
+    /**
+     * Emit consecutive numbered Sundays [$firstSunday, $endExclusive) under $keyStem,
+     * numbering from 1, skipping Sundays already occupied by an anchor. $nameBuilder
+     * is the per-block localized name builder (see below), invoked with the ordinal.
+     *
+     * @param \Closure(int): string $nameBuilder
+     */
+    private function numberSundayBlock(TemporaleContext $ctx, string $keyStem, DateTime $firstSunday, DateTime $endExclusive, \Closure $nameBuilder): void
+    {
+        $ordinal = 1;
+        $sunday  = clone $firstSunday;
+        while ($sunday < $endExclusive) {
+            if (false === $ctx->cal->inCalendar($sunday)) {
+                $this->synthesizeSunday($ctx, $keyStem . $ordinal, clone $sunday, $nameBuilder($ordinal));
+            }
+            $ordinal++;
+            $sunday = ( clone $sunday )->modify('next Sunday');
+        }
+    }
+
+    /**
      * Create a synthesized numbered Sunday (not drawn from the Proprium de Tempore
      * data file): a dominical FEAST_LORD in green, season-stamped from its key.
      * Used for the after-Epiphany and after-Pentecost Sunday blocks whose exact
@@ -274,6 +348,47 @@ final class AmbrosianTemporale implements TemporaleEngine
         }
         $ordinalStr = Utilities::getOrdinal($ordinal, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
         return sprintf("%s domenica dopo l'Epifania", $ordinalStr);
+    }
+
+    /**
+     * Localized display name for an after-Pentecost Sunday in sub-block (a)
+     * "dopo Pentecoste", e.g. (it) "II domenica dopo Pentecoste", (la) "Dominica
+     * II post Pentecosten".
+     */
+    private function afterPentecostSundayName(int $ordinal, TemporaleContext $ctx): string
+    {
+        return $this->afterPentecostFamilyName($ordinal, $ctx, 'dopo Pentecoste', 'post Pentecosten');
+    }
+
+    /**
+     * Localized display name for an after-Pentecost Sunday in sub-block (b)
+     * "dopo il Martirio" (of St John the Baptist).
+     */
+    private function afterMartyrdomSundayName(int $ordinal, TemporaleContext $ctx): string
+    {
+        return $this->afterPentecostFamilyName($ordinal, $ctx, 'dopo il Martirio', 'post Martyrium');
+    }
+
+    /**
+     * Localized display name for an after-Pentecost Sunday in sub-block (c)
+     * "dopo la Dedicazione" (of the Duomo di Milano).
+     */
+    private function afterDedicationSundayName(int $ordinal, TemporaleContext $ctx): string
+    {
+        return $this->afterPentecostFamilyName($ordinal, $ctx, 'dopo la Dedicazione', 'post Dedicationem');
+    }
+
+    /**
+     * Shared name-building logic for the three after-Pentecost sub-block name
+     * builders above.
+     */
+    private function afterPentecostFamilyName(int $ordinal, TemporaleContext $ctx, string $phraseIt, string $phraseLa): string
+    {
+        if (LitLocale::LATIN_PRIMARY_LANGUAGE === LitLocale::$PRIMARY_LANGUAGE) {
+            return sprintf('Dominica %s %s', LatinUtils::LATIN_ORDINAL[$ordinal], $phraseLa);
+        }
+        $ordinalStr = Utilities::getOrdinal($ordinal, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
+        return sprintf('%s domenica %s', $ordinalStr, $phraseIt);
     }
 
     /**

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -41,6 +41,8 @@ final class AmbrosianTemporale implements TemporaleEngine
         $this->calculateAfterPentecostWeekdays($ctx);
         $this->calculateAdventWeekdays($ctx);
         $this->calculateChristmasWeekdays($ctx);
+        $this->calculateChristmasSundayAfterOctave($ctx);
+        $this->calculateChristmasJanuaryWeekdays($ctx);
         $this->calculateLentWeekdays($ctx);
         $this->calculateEasterWeekdays($ctx);
     }
@@ -530,6 +532,65 @@ final class AmbrosianTemporale implements TemporaleEngine
     }
 
     /**
+     * The n.33 "Domenica dopo l'ottava di Natale" (ambrosian.txt L4749-4750):
+     * "L'eventuale domenica tra il 2 e il 5 gennaio è la domenica dopo l'ottava
+     * di Natale." Computes the Sunday, if any, in the inclusive window
+     * [Jan 2, Jan 5] of the civil year — it exists only when Jan 1 falls on
+     * Wed/Thu/Fri/Sat; when Jan 1 is Sun/Mon/Tue there is no such Sunday and no
+     * event is created ("eventuale" = possible, not guaranteed). Unlike the
+     * other synthesized numbered Sundays this one is WHITE, not GREEN, so it is
+     * built directly (like `synthesizeSunday()`) rather than through it. Must
+     * run before `calculateChristmasJanuaryWeekdays()` so that helper's
+     * `inCalendar()` guard skips this date when it exists.
+     */
+    private function calculateChristmasSundayAfterOctave(TemporaleContext $ctx): void
+    {
+        $year = $ctx->params->Year;
+        $jan2 = DateTime::fromFormat('2-1-' . $year);
+        $jan5 = DateTime::fromFormat('5-1-' . $year);
+        $sun  = self::dateIsSunday($jan2) ? $jan2 : ( clone $jan2 )->modify('next Sunday');
+        if ($sun > $jan5) {
+            // No Sunday falls within [Jan 2, Jan 5] this year -- "eventuale" not realized.
+            return;
+        }
+
+        $name = LitLocale::LATIN_PRIMARY_LANGUAGE === LitLocale::$PRIMARY_LANGUAGE
+            ? 'Dominica post octavam Nativitatis'
+            : 'Domenica dopo l\'ottava di Natale';
+
+        $event               = new LiturgicalEvent($name, clone $sun, LitColor::WHITE, LitEventType::MOBILE, LitGrade::FEAST_LORD);
+        $event->is_dominical = true;
+        $ctx->cal->addLiturgicalEvent('ChristmasSundayAfterOctave', $event);
+        $this->stampSeason($event);
+    }
+
+    /**
+     * January Christmas ferie: Jan 2 … Baptism of the Lord (Sunday after Jan 6),
+     * exclusive. `Circoncisione` (Jan 1, before this range), `Epiphany` (Jan 6),
+     * `BaptismLord`, and the n.33 `ChristmasSundayAfterOctave` Sunday (when it
+     * exists) are all anchors already placed and are skipped by
+     * `fillFerialWeekdays()`'s Sunday/`inCalendar()` guards. Must run after
+     * `calculateChristmasSundayAfterOctave()` for that skip to take effect.
+     */
+    private function calculateChristmasJanuaryWeekdays(TemporaleContext $ctx): void
+    {
+        $year    = $ctx->params->Year;
+        $from    = DateTime::fromFormat('2-1-' . $year);
+        $baptism = DateTime::fromFormat('6-1-' . $year)->modify('next Sunday');
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            $baptism,
+            LitColor::WHITE,
+            // Bounded to January, so day-of-month alone would not collide here,
+            // but 'md' matches calculateChristmasWeekdays()'s (Dec) key shape for
+            // consistency, and the two never collide since the months differ.
+            fn (DateTime $d): string => 'ChristmasWeekday' . $d->format('md'),
+            fn (DateTime $d): string => $this->weekdayName($d, 'del tempo di Natale', 'Nativitatis', null, $ctx)
+        );
+    }
+
+    /**
      * Localized display name for an after-Pentecost Sunday in sub-block (a)
      * "dopo Pentecoste", e.g. (it) "II domenica dopo Pentecoste", (la) "Dominica
      * II post Pentecosten".
@@ -620,17 +681,26 @@ final class AmbrosianTemporale implements TemporaleEngine
         return (int) floor(( $daysSince - 1 ) / 7) + 1;
     }
 
-    /** Lenten ferie: Lent I (excl.) … Saturday before Palm Sunday; Fridays are aliturgical (nn. 24–27). */
+    /**
+     * Lenten ferie: Lent I (excl.) … Wednesday of Holy Week (excl.); Fridays are
+     * aliturgical (nn. 24–27). The upper bound reaches past Palm Sunday through
+     * the Holy Week Monday/Tuesday/Wednesday ("settimana autentica"), which are
+     * still Lent-season ferie: Palm Sunday itself is a Sunday (skipped by
+     * `fillFerialWeekdays()`'s Sunday guard) and `SabatoTradSymb` is an anchor
+     * already placed (skipped by `inCalendar()`). Holy Week Mon–Wed contains no
+     * Friday, so `lentenAliturgicalFridays` never fires for them; Holy Thursday
+     * itself opens the Triduum and is excluded as the upper bound.
+     */
     private function calculateLentWeekdays(TemporaleContext $ctx): void
     {
-        $year    = $ctx->params->Year;
-        $lent1   = Utilities::calcGregEaster($year)->sub(new \DateInterval('P' . ( 6 * 7 ) . 'D'));
-        $palmSun = Utilities::calcGregEaster($year)->sub(new \DateInterval('P7D'));
-        $from    = ( clone $lent1 )->add(new \DateInterval('P1D'));
+        $year      = $ctx->params->Year;
+        $lent1     = Utilities::calcGregEaster($year)->sub(new \DateInterval('P' . ( 6 * 7 ) . 'D'));
+        $holyThurs = Utilities::calcGregEaster($year)->sub(new \DateInterval('P3D'));
+        $from      = ( clone $lent1 )->add(new \DateInterval('P1D'));
         $this->fillFerialWeekdays(
             $ctx,
             $from,
-            clone $palmSun, // up to (not incl.) Palm Sunday; SabatoTradSymb anchor is skipped by inCalendar()
+            clone $holyThurs, // up to (not incl.) Holy Thursday; PalmSun (Sunday) and SabatoTradSymb anchor are skipped
             LitColor::MORELLO,
             fn (DateTime $d): string => 'LentWeekday' . $this->lentWeekNumber($d, $lent1) . $this->englishWeekday($d),
             fn (DateTime $d): string => $this->weekdayName($d, 'di Quaresima', 'Quadragesimæ', $this->lentWeekNumber($d, $lent1), $ctx),

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -36,6 +36,7 @@ final class AmbrosianTemporale implements TemporaleEngine
         $this->calculateEasterCycle($ctx);
         $this->calculateAfterPentecostAnchors($ctx);
         $this->calculateAfterEpiphanySundays($ctx);
+        $this->calculateAfterEpiphanyWeekdays($ctx);
         $this->calculateAfterPentecostSundays($ctx);
     }
 
@@ -350,6 +351,104 @@ final class AmbrosianTemporale implements TemporaleEngine
         }
         $ordinalStr = Utilities::getOrdinal($ordinal, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
         return sprintf("%s domenica dopo l'Epifania", $ordinalStr);
+    }
+
+    /**
+     * Fill ferial weekdays over [$from, $to), skipping Sundays and any date already
+     * occupied (Sundays, anchors). Each free ferial day becomes a WEEKDAY event,
+     * season-stamped from its key. $keyBuilder(DateTime $date): string produces the
+     * event key; $nameBuilder(DateTime $date): string the display name. On Lenten
+     * Fridays, when $lentenAliturgicalFridays is true, is_aliturgical is set.
+     *
+     * @param callable(DateTime):string $keyBuilder
+     * @param callable(DateTime):string $nameBuilder
+     */
+    private function fillFerialWeekdays(TemporaleContext $ctx, DateTime $from, DateTime $to, LitColor $color, callable $keyBuilder, callable $nameBuilder, bool $lentenAliturgicalFridays = false): void
+    {
+        $day = clone $from;
+        while ($day < $to) {
+            $isSunday = (int) $day->format('N') === 7;
+            if (false === $isSunday && false === $ctx->cal->inCalendar($day)) {
+                $key   = $keyBuilder($day);
+                $name  = $nameBuilder($day);
+                $event = new LiturgicalEvent($name, clone $day, $color, LitEventType::MOBILE, LitGrade::WEEKDAY);
+                if ($lentenAliturgicalFridays && (int) $day->format('N') === 5) {
+                    $event->is_aliturgical = true;
+                }
+                $ctx->cal->addLiturgicalEvent($key, $event);
+                $this->stampSeason($event);
+            }
+            $day = ( clone $day )->add(new \DateInterval('P1D'));
+        }
+    }
+
+    /** English weekday name (Monday…Saturday) for locale-independent keys. */
+    private function englishWeekday(DateTime $date): string
+    {
+        return match ((int) $date->format('N')) {
+            1       => 'Monday',
+            2       => 'Tuesday',
+            3       => 'Wednesday',
+            4       => 'Thursday',
+            5       => 'Friday',
+            6       => 'Saturday',
+            default => 'Sunday',
+        };
+    }
+
+    /**
+     * Localized ferial name, e.g. (it) "Lunedì della II settimana dopo Pentecoste",
+     * (la) "Feria II hebdomadæ II post Pentecosten". When $weekNumber is null the
+     * week clause is omitted (e.g. de Exceptáto ferie named by date in Task 6).
+     */
+    private function weekdayName(DateTime $date, string $seasonPhraseIt, string $seasonPhraseLa, ?int $weekNumber, TemporaleContext $ctx): string
+    {
+        if (LitLocale::LATIN_PRIMARY_LANGUAGE === LitLocale::$PRIMARY_LANGUAGE) {
+            $feria = LatinUtils::LATIN_DAYOFTHEWEEK[$date->format('w')]; // e.g. "Feria II"
+            if (null === $weekNumber) {
+                return sprintf('%s %s', $feria, $seasonPhraseLa);
+            }
+            return sprintf('%s hebdomadæ %s %s', $feria, LatinUtils::LATIN_ORDINAL[$weekNumber], $seasonPhraseLa);
+        }
+        $weekday = $ctx->localeDateFormatter->getDayOfTheWeekFormatter()->format($date->format('U'));
+        $weekday = Utilities::ucfirst($weekday);
+        if (null === $weekNumber) {
+            return sprintf('%s %s', $weekday, $seasonPhraseIt);
+        }
+        $ordinalStr = Utilities::getOrdinal($weekNumber, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
+        return sprintf('%s della %s settimana %s', $weekday, $ordinalStr, $seasonPhraseIt);
+    }
+
+    /**
+     * After-Epiphany ferie: Monday after Baptism … Saturday before Lent I. First
+     * caller of `fillFerialWeekdays()`; keys as `AfterEpiphanyWeekday{N}{EnglishDay}`
+     * where N matches the after-Epiphany Sunday numbering (BaptismLord = week 1).
+     */
+    private function calculateAfterEpiphanyWeekdays(TemporaleContext $ctx): void
+    {
+        $year    = $ctx->params->Year;
+        $baptism = DateTime::fromFormat('6-1-' . $year)->modify('next Sunday');
+        $lent1   = Utilities::calcGregEaster($year)->sub(new \DateInterval('P' . ( 6 * 7 ) . 'D'));
+        $from    = ( clone $baptism )->add(new \DateInterval('P1D')); // Monday after Baptism
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            $lent1,
+            LitColor::GREEN,
+            fn (DateTime $d): string => 'AfterEpiphanyWeekday' . $this->afterEpiphanyWeekNumber($d, $baptism) . $this->englishWeekday($d),
+            fn (DateTime $d): string => $this->weekdayName($d, "dopo l'Epifania", 'post Epiphaniam', $this->afterEpiphanyWeekNumber($d, $baptism), $ctx)
+        );
+    }
+
+    /**
+     * Week number of a ferial day in the after-Epiphany block: the ordinal of the
+     * Sunday that closes its week, matching the Sunday numbering (BaptismLord = week 1,
+     * so the first Monday after Baptism is week 2).
+     */
+    private function afterEpiphanyWeekNumber(DateTime $date, DateTime $baptism): int
+    {
+        $daysSinceBaptism = (int) $baptism->diff($date)->format('%a');
+        return (int) floor(( $daysSinceBaptism - 1 ) / 7) + 2;
     }
 
     /**

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -38,6 +38,8 @@ final class AmbrosianTemporale implements TemporaleEngine
         $this->calculateAfterEpiphanySundays($ctx);
         $this->calculateAfterEpiphanyWeekdays($ctx);
         $this->calculateAfterPentecostSundays($ctx);
+        $this->calculateAdventWeekdays($ctx);
+        $this->calculateChristmasWeekdays($ctx);
     }
 
     /**
@@ -449,6 +451,79 @@ final class AmbrosianTemporale implements TemporaleEngine
     {
         $daysSinceBaptism = (int) $baptism->diff($date)->format('%a');
         return (int) floor(( $daysSinceBaptism - 1 ) / 7) + 2;
+    }
+
+    /** Advent ferie: Monday after Advent I … Saturday before Christmas; Dec 17(18)–23 are de Exceptáto (n. 39). */
+    private function calculateAdventWeekdays(TemporaleContext $ctx): void
+    {
+        $year = $ctx->params->Year;
+        $from = ( clone $this->adventOne($year) )->add(new \DateInterval('P1D'));
+        $to   = DateTime::fromFormat('25-12-' . $year); // Christmas (exclusive)
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            $to,
+            LitColor::MORELLO,
+            // Advent runs Nov->Dec, so day-of-month alone collides (e.g. both Nov 17
+            // and Dec 17 fall inside the block); key on month+day ('md') instead so
+            // every ferial day gets a distinct key. Season classification only needs
+            // the 'AdventWeekday' prefix (LitSeason::ADVENT_PATTERNS), so the exact
+            // suffix shape is free.
+            fn (DateTime $d): string => 'AdventWeekday' . $d->format('md'),
+            fn (DateTime $d): string => $this->adventWeekdayName($d, $ctx)
+        );
+    }
+
+    /**
+     * Ferial name for an Advent weekday: the de Exceptáto phrase for Dec 17–23
+     * (n. 39), otherwise the generic Advent phrase. Named by phrase, not week
+     * number, so $weekNumber is null in both branches.
+     */
+    private function adventWeekdayName(DateTime $date, TemporaleContext $ctx): string
+    {
+        $md = (int) $date->format('nd'); // e.g. 1217 for Dec 17
+        if ($md >= 1217 && $md <= 1223) {
+            return $this->weekdayName($date, 'de Exceptáto', 'de Exceptato', null, $ctx);
+        }
+        return $this->weekdayName($date, "d'Avvento", 'Adventus', null, $ctx);
+    }
+
+    /**
+     * Christmas ferie: Dec 26 … Dec 31 of the same civil year.
+     *
+     * The norm's upper bound is "the Saturday before Baptism", but within a
+     * single-civil-year engine call Baptism/Circoncisione/Epiphany are always
+     * dated in *January of this same $year* (see `calculateChristmasEpiphany()`),
+     * i.e. structurally *before* Dec 26 of that same $year, not after it —
+     * RomanTemporale's `Epiphany`/`Christmas` follow the identical same-$year
+     * convention, and `CalendarHandler::calculateWeekdaysChristmasOctave()`
+     * mirrors this exact boundary by stopping its own Christmas-octave weekday
+     * fill at `31-12-$year` rather than reaching into January. So the true
+     * Dec 26->Baptism span only exists once a caller merges this engine's
+     * output for $year with the *next* call's output for $year+1 (whose
+     * Circoncisione/Epiphany/BaptismLord anchors land on the correct forward
+     * dates) — real cross-year continuity is out of scope here and deferred,
+     * like the rest of the handler-level year semantics, to Plan 7. Bounding
+     * at Dec 31 keeps this call's output correct and self-contained: it never
+     * touches (or spuriously duplicates) the Jan 1 / Jan 6 anchors already
+     * placed by `calculateChristmasEpiphany()` for this same $year.
+     */
+    private function calculateChristmasWeekdays(TemporaleContext $ctx): void
+    {
+        $year = $ctx->params->Year;
+        $from = DateTime::fromFormat('26-12-' . $year);
+        $to   = DateTime::fromFormat('1-1-' . ( $year + 1 )); // Dec 31 $year inclusive, exclusive bound
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            $to,
+            LitColor::WHITE,
+            // Bounded to a single month (Dec), so day-of-month alone would not
+            // collide here, but 'md' matches the Advent fill's key shape for
+            // consistency and stays collision-safe if the bound ever changes.
+            fn (DateTime $d): string => 'ChristmasWeekday' . $d->format('md'),
+            fn (DateTime $d): string => $this->weekdayName($d, 'del tempo di Natale', 'Nativitatis', null, $ctx)
+        );
     }
 
     /**

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -40,6 +40,7 @@ final class AmbrosianTemporale implements TemporaleEngine
         $this->calculateAfterPentecostSundays($ctx);
         $this->calculateAdventWeekdays($ctx);
         $this->calculateChristmasWeekdays($ctx);
+        $this->calculateLentWeekdays($ctx);
     }
 
     /**
@@ -565,6 +566,31 @@ final class AmbrosianTemporale implements TemporaleEngine
         }
         $ordinalStr = Utilities::getOrdinal($ordinal, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
         return sprintf('%s domenica %s', $ordinalStr, $phraseIt);
+    }
+
+    /** Lenten ferie: Lent I (excl.) … Saturday before Palm Sunday; Fridays are aliturgical (nn. 24–27). */
+    private function calculateLentWeekdays(TemporaleContext $ctx): void
+    {
+        $year    = $ctx->params->Year;
+        $lent1   = Utilities::calcGregEaster($year)->sub(new \DateInterval('P' . ( 6 * 7 ) . 'D'));
+        $palmSun = Utilities::calcGregEaster($year)->sub(new \DateInterval('P7D'));
+        $from    = ( clone $lent1 )->add(new \DateInterval('P1D'));
+        $this->fillFerialWeekdays(
+            $ctx,
+            $from,
+            clone $palmSun, // up to (not incl.) Palm Sunday; SabatoTradSymb anchor is skipped by inCalendar()
+            LitColor::MORELLO,
+            fn (DateTime $d): string => 'LentWeekday' . $this->lentWeekNumber($d, $lent1) . $this->englishWeekday($d),
+            fn (DateTime $d): string => $this->weekdayName($d, 'di Quaresima', 'Quadragesimæ', $this->lentWeekNumber($d, $lent1), $ctx),
+            true
+        );
+    }
+
+    /** Lenten week number: Lent I is week 1; the following Monday begins week 1's ferie. */
+    private function lentWeekNumber(DateTime $date, DateTime $lent1): int
+    {
+        $daysSince = (int) $lent1->diff($date)->format('%a');
+        return (int) floor(( $daysSince - 1 ) / 7) + 1;
     }
 
     /**

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Api\Models\Calendar\Temporale;
 
 use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\LitSeason;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
 use LiturgicalCalendar\Api\Utilities;
@@ -43,7 +44,20 @@ final class AmbrosianTemporale implements TemporaleEngine
         }
         $event = LiturgicalEvent::fromObject($ctx->propriumDeTempore[$key]);
         $ctx->cal->addLiturgicalEvent($key, $event);
+        $this->stampSeason($event);
         return $event;
+    }
+
+    /**
+     * Stamp the Ambrosian liturgical season onto an event from its key. Called on
+     * every event the engine creates, because the Roman
+     * `LiturgicalEventCollection::setSeasonsAndHolyDaysOfObligation()` cannot run
+     * for the Ambrosian rite (it requires an AshWednesday event and knows only the
+     * six Roman seasons).
+     */
+    private function stampSeason(LiturgicalEvent $event): void
+    {
+        $event->liturgical_season = LitSeason::forEventKey($event->event_key);
     }
 
     /**

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -57,7 +57,14 @@ final class AmbrosianTemporale implements TemporaleEngine
      */
     private function stampSeason(LiturgicalEvent $event): void
     {
-        $event->liturgical_season = LitSeason::forEventKey($event->event_key);
+        // `ChristKing` is a shared temporale key: in the Ambrosian rite it is the
+        // last Sunday after the Dedication (AFTER_PENTECOST), but in the Roman rite
+        // it is the last Sunday of Ordinary Time. `LitSeason::forEventKey()` is
+        // rite-agnostic and is also consumed by the Roman /temporale endpoint, so we
+        // must NOT globally reclassify `ChristKing` there — override it locally here.
+        $event->liturgical_season = 'ChristKing' === $event->event_key
+            ? LitSeason::AFTER_PENTECOST
+            : LitSeason::forEventKey($event->event_key);
     }
 
     /**

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Api\Models\Calendar\Temporale;
 
 use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\LitColor;
+use LiturgicalCalendar\Api\Enum\LitEventType;
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Enum\LitLocale;
 use LiturgicalCalendar\Api\Enum\LitSeason;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\LatinUtils;
 use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
 use LiturgicalCalendar\Api\Utilities;
 
@@ -30,6 +35,7 @@ final class AmbrosianTemporale implements TemporaleEngine
         $this->calculateLent($ctx);
         $this->calculateEasterCycle($ctx);
         $this->calculateAfterPentecostAnchors($ctx);
+        $this->calculateAfterEpiphanySundays($ctx);
     }
 
     /**
@@ -218,5 +224,69 @@ final class AmbrosianTemporale implements TemporaleEngine
         $christKing = ( clone $advent1 )->sub(new \DateInterval('P7D'));
         $ctx->propriumDeTempore['ChristKing']->setDate($christKing);
         $this->createPropriumDeTemporeLiturgicalEventByKey('ChristKing', $ctx);
+    }
+
+    /**
+     * Create a synthesized numbered Sunday (not drawn from the Proprium de Tempore
+     * data file): a dominical FEAST_LORD in green, season-stamped from its key.
+     * Used for the after-Epiphany and after-Pentecost Sunday blocks whose exact
+     * names/numbering are validated against a published ordo in a later plan.
+     */
+    private function synthesizeSunday(TemporaleContext $ctx, string $key, DateTime $date, string $name): LiturgicalEvent
+    {
+        $event               = new LiturgicalEvent($name, $date, LitColor::GREEN, LitEventType::MOBILE, LitGrade::FEAST_LORD);
+        $event->is_dominical = true;
+        $ctx->cal->addLiturgicalEvent($key, $event);
+        $this->stampSeason($event);
+        return $event;
+    }
+
+    /**
+     * After-Epiphany Sundays (n. 40): every Sunday strictly after BaptismLord
+     * (the Sunday after Jan 6) and strictly before Lent I (Easter − 42d).
+     * Numbered from 2 — BaptismLord is the block's 1st Sunday.
+     */
+    private function calculateAfterEpiphanySundays(TemporaleContext $ctx): void
+    {
+        $year    = $ctx->params->Year;
+        $baptism = DateTime::fromFormat('6-1-' . $year)->modify('next Sunday');
+        $lent1   = Utilities::calcGregEaster($year)->sub(new \DateInterval('P' . ( 6 * 7 ) . 'D'));
+
+        $ordinal = 2;
+        $sunday  = ( clone $baptism )->modify('next Sunday');
+        while ($sunday < $lent1) {
+            $key = 'AfterEpiphany' . $ordinal;
+            $this->synthesizeSunday($ctx, $key, clone $sunday, $this->afterEpiphanySundayName($ordinal, $ctx));
+            $ordinal++;
+            $sunday = ( clone $sunday )->modify('next Sunday');
+        }
+    }
+
+    /**
+     * Localized display name for an after-Epiphany Sunday, e.g. (it) "II domenica
+     * dopo l'Epifania", (la) "Dominica II post Epiphaniam". Exact ordo wording is
+     * validated in a later plan.
+     */
+    private function afterEpiphanySundayName(int $ordinal, TemporaleContext $ctx): string
+    {
+        if (LitLocale::LATIN_PRIMARY_LANGUAGE === LitLocale::$PRIMARY_LANGUAGE) {
+            return sprintf('Dominica %s post Epiphaniam', LatinUtils::LATIN_ORDINAL[$ordinal]);
+        }
+        $ordinalStr = Utilities::getOrdinal($ordinal, $ctx->localeDateFormatter->getLocale(), $this->ordinalFormatter($ctx), LatinUtils::LATIN_ORDINAL);
+        return sprintf("%s domenica dopo l'Epifania", $ordinalStr);
+    }
+
+    /**
+     * Feminine \NumberFormatter for ordinal rendering, cached per engine call.
+     */
+    private ?\NumberFormatter $ordinalFormatterCache = null;
+
+    private function ordinalFormatter(TemporaleContext $ctx): \NumberFormatter
+    {
+        if (null === $this->ordinalFormatterCache) {
+            $this->ordinalFormatterCache = new \NumberFormatter($ctx->localeDateFormatter->getLocale(), \NumberFormatter::SPELLOUT);
+            $this->ordinalFormatterCache->setTextAttribute(\NumberFormatter::DEFAULT_RULESET, '%spellout-ordinal-feminine');
+        }
+        return $this->ordinalFormatterCache;
     }
 }

--- a/src/Models/PropriumDeTemporeEvent.php
+++ b/src/Models/PropriumDeTemporeEvent.php
@@ -28,6 +28,11 @@ final class PropriumDeTemporeEvent extends AbstractJsonSrcData
      * Absent/null for source data that does not classify dominical events (e.g. the Roman proprium).
      */
     public readonly ?bool $is_dominical;
+    /**
+     * Whether the event is aliturgical (no Mass celebrated), if applicable to the source data.
+     * Absent/null for source data that does not classify aliturgical days (e.g. the Roman proprium).
+     */
+    public readonly ?bool $is_aliturgical;
 
     /**
      * Constructor for the PropriumDeTemporeEvent class.
@@ -37,25 +42,28 @@ final class PropriumDeTemporeEvent extends AbstractJsonSrcData
      * @param LitEventType $type The type of the event.
      * @param LitColor[] $color The color of the event.
      * @param bool|null $is_dominical Whether the event is "of the Lord" (dominical), if applicable.
+     * @param bool|null $is_aliturgical Whether the event is aliturgical (no Mass celebrated), if applicable.
      */
     public function __construct(
         string $event_key,
         LitGrade $grade,
         LitEventType $type,
         array $color,
-        ?bool $is_dominical = null
+        ?bool $is_dominical = null,
+        ?bool $is_aliturgical = null
     ) {
-        $this->event_key    = $event_key;
-        $this->grade        = $grade;
-        $this->type         = $type;
-        $this->color        = $color;
-        $this->is_dominical = $is_dominical;
+        $this->event_key      = $event_key;
+        $this->grade          = $grade;
+        $this->type           = $type;
+        $this->color          = $color;
+        $this->is_dominical   = $is_dominical;
+        $this->is_aliturgical = $is_aliturgical;
     }
 
     /**
      * Creates an instance of PropriumDeTemporeEvent from an associative array.
      *
-     * @param array{event_key:string,grade:int,type:int,color:string[],is_dominical?:bool|null} $data
+     * @param array{event_key:string,grade:int,type:int,color:string[],is_dominical?:bool|null,is_aliturgical?:bool|null} $data
      * @return static
      */
     protected static function fromArrayInternal(array $data): static
@@ -67,7 +75,8 @@ final class PropriumDeTemporeEvent extends AbstractJsonSrcData
             LitGrade::from($data['grade']),
             LitEventType::from($data['type']),
             array_map(fn (string $color): LitColor => LitColor::from($color), $data['color']),
-            $data['is_dominical'] ?? null
+            $data['is_dominical'] ?? null,
+            $data['is_aliturgical'] ?? null
         );
     }
 
@@ -80,7 +89,7 @@ final class PropriumDeTemporeEvent extends AbstractJsonSrcData
      * - grade (int): The liturgical grade of the event.
      * - color (array): The liturgical colors for the event.
      *
-     * @param \stdClass&object{event_key:string,grade:int,type:int,color:string[],is_dominical?:bool|null} $data The stdClass object or array containing event data.
+     * @param \stdClass&object{event_key:string,grade:int,type:int,color:string[],is_dominical?:bool|null,is_aliturgical?:bool|null} $data The stdClass object or array containing event data.
      * @return static The newly created instance(s).
      */
     protected static function fromObjectInternal(\stdClass $data): static
@@ -92,12 +101,18 @@ final class PropriumDeTemporeEvent extends AbstractJsonSrcData
             $is_dominical = $data->is_dominical;
         }
 
+        $is_aliturgical = null;
+        if (property_exists($data, 'is_aliturgical') && is_bool($data->is_aliturgical)) {
+            $is_aliturgical = $data->is_aliturgical;
+        }
+
         return new static(
             $data->event_key,
             LitGrade::from($data->grade),
             LitEventType::from($data->type),
             array_map(fn (string $color): LitColor => LitColor::from($color), $data->color),
-            $is_dominical
+            $is_dominical,
+            $is_aliturgical
         );
     }
 


### PR DESCRIPTION
## Ambrosian temporale completion (Plan 6)

Extends `AmbrosianTemporale` so `buildTemporale()` produces a **gap-free Ambrosian temporal year**. The engine now synthesizes the numbered Sundays and every ferial weekday (mirroring how the Roman engine/handler build Ordinary-Time weekdays), stamps `liturgical_season` on every event, and flags the aliturgical Lenten Fridays.

The `/calendar/ambrosian` endpoint **stays 501** — the engine is exercised only through unit/integration tests (invoking `buildTemporale()` directly). **Roman output is byte-identical** (`CalendarGoldenMasterTest` 9/9 green).

### What's added

- **After-Epiphany Sundays** (`AfterEpiphany2..N`) and **after-Pentecost Sundays** in the three n.42 sub-blocks (*dopo Pentecoste* / *dopo il Martirio*, anchored on the Aug 29 Martyrdom → Sep 1 when it's a Sunday / *dopo la Dedicazione*, anchored on the 3rd Sunday of October).
- **All-season ferial weekday fill**: Advent (incl. *de Exceptáto*, Dec 17–23) + January Christmas ferie, Lent (incl. **aliturgical Fridays** → `is_aliturgical`) + Holy Week Mon–Wed, Easter (post-octave), after-Epiphany, and after-Pentecost (all three sub-blocks).
- The **n.33 "Domenica dopo l'ottava di Natale"** (the Sunday, when it exists, in Jan 2–5).
- `liturgical_season` stamped on **every** engine event via `LitSeason::forEventKey()` (the Roman date-range season method can't run for the Ambrosian rite). Four Ambrosian anchor keys now classify correctly (`Circoncisione`→CHRISTMAS, `AshesMonday`/`SabatoTradSymb`→LENT, `ChristKing`→AFTER_PENTECOST — the last handled engine-locally so the shared Roman `/temporale` path is unaffected).
- `is_aliturgical` plumbed into `LiturgicalEvent`, `PropriumDeTemporeEvent`, and the `PropriumDeTempore` source schema (mirrors `is_dominical`; serializes only when non-null).

### Verification

- `CalendarGoldenMasterTest` 9/9 (Roman byte-identical).
- Ambrosian temporale + sanctorale suites: 54 tests / 17,349 assertions, plus 9 `@group slow` / 5,305 assertions — all green.
- New `AmbrosianTemporaleCompletenessTest` (`@group slow`) proves gap-free civil-year coverage for 2024/2025/2026 with zero duplicate dates and a season on every event, allowlisting exactly the one spec-deferred n.32 Christmas-octave Sunday (covered by the sanctorale in the assembled calendar).
- The season stamping now makes the precedence resolver's season-gated branches fire on real data: **St Ambrose** (patron of Milan, Solennità dS) on Advent IV Sunday now correctly **anticipates to Sat 6 Dec 2025** (saint-sol → Mon → Immaculate Conception occupied → Saturday), matching the [chiesadimilano.it ordo](https://www.chiesadimilano.it/almanacco/letture-rito-ambrosiano/anno-a-2025-2026-ra/ordinazione-di-santambrogio-8-2851534.html) — previously it fell through to the generic n.56 walk to Dec 9. Closes a deferred precedence item.
- PHPStan level 10 clean; phpcs clean.

### Deferred to later plans

- **Plan 7 (un-501 wiring):** wire the engine into `CalendarHandler`; add `AFTER_EPIPHANY`/`AFTER_PENTECOST` (and `is_dominical`/`is_aliturgical`) to the response schema `LitCal.json`; a rite-aware `forEventKey` for an Ambrosian `/temporale`.
- **Plan 9 (ordo-validation + 1976 backfill):** exact ordo names/numbering (incl. Holy Week "Settimana Santa" naming and the *dopo il Martirio* week-numbering convention); the n.32 "domenica nell'ottava" vigil-shift placement; the pre-2008 (1976 edition) single-block post-Pentecost structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the Ambrosian calendar’s year-round generation, adding more numbered Sundays and weekday celebrations across key seasons.
  * Added liturgical-season metadata to all generated events.
  * Introduced an optional “aliturgical” indicator for non-Mass days (e.g., Lenten Fridays).
* **Bug Fixes**
  * Improved season classification and event date/preference handling to avoid overlaps and duplicates.
* **Tests**
  * Added and strengthened coverage for full-year completeness, season stamping, aliturgical serialization, and precedence/acceptance scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->