### PR TITLE
Wire the Ambrosian rite into the handler: /calendar/ambrosian goes live (comune)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,13 @@ Some characteristics of this API:
   and `PATCH`/`DELETE` likewise address resources by path (e.g. `PUT /data/nation/IT`, `PATCH /tests/MaryMotherChurchTest`).
   One deliberate exception: on read endpoints this API uses `POST` as a body-parameterized synonym of `GET` (not as collection-create),
   pending possible adoption of the [`QUERY` method](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/) when it becomes standard.
+* **Ambrosian rite support (comune ambrosiano) is live**: `GET/POST /calendar/ambrosian` and `/calendar/ambrosian/{year}` calculate the calendar for the
+  Ambrosian rite as celebrated in common (no diocesan overlay yet — the Ambrosian dioceses of Milano, Bergamo, Novara, and Lugano are planned for a future
+  release), `/events/ambrosian` returns its event catalog, and the `/calendars` discovery endpoint announces it under `ambrosian_calendars`. A few notes on
+  the current state of this data:
+  * **Readings are a placeholder**: the Ambrosian rite does not yet have its own lectionary wired up, so `readings` is always empty for Ambrosian events.
+  * **Year cycles, first-vespers vigils, and psalter-week numbering are provisional**, pending validation against the official Ambrosian ordo.
+  * The Ambrosian rite is only available from **1976 onward** (the first reformed Ambrosian Missal); earlier years return `400 Bad Request`.
 
 # Example applications
 

--- a/docs/superpowers/plans/2026-07-22-ambrosian-07-un501-wiring.md
+++ b/docs/superpowers/plans/2026-07-22-ambrosian-07-un501-wiring.md
@@ -1,0 +1,428 @@
+# Ambrosian Un-501 Wiring Implementation Plan (Plan 7)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `/calendar/ambrosian/{year}` return a real, complete comune-ambrosiano calendar (replacing the current HTTP 501), with full-parity post-processing (year cycles,
+first-vespers vigils, psalter week, holy-days-of-obligation, seasons — readings as an empty placeholder), and make `/calendars` and `/events` rite-aware.
+
+**Architecture:** The handler is monolithic and ~98% Roman-hardcoded, and the Ambrosian assembly model ("add every event, then resolve to a fixpoint via
+`AmbrosianPrecedenceResolver`") is incompatible with the Roman "check-before-add" pipeline. So we add a **separate Ambrosian generation path** — a new
+`calculateAmbrosianCalendar()` orchestrator + an Ambrosian branch in `CalendarHandler::handle()` that replaces the 501 — rather than threading rite-`if`s through the Roman
+`calculate*` methods. All Roman code paths stay byte-identical.
+
+**Tech Stack:** PHP 8.4, PHPUnit 12, PHPStan level 10, PHP_CodeSniffer. The Ambrosian temporale engine, sanctorale loader, missal resolver, and precedence resolver already exist
+(Plans 3–6, merged); this plan wires them into the handler and adds the post-processing + discovery.
+
+## Global Constraints
+
+- **Roman output byte-identical.** `phpunit_tests/Handlers/CalendarGoldenMasterTest.php` (9 tests / 36 assertions) is the gate. The Ambrosian path is **separate** — do NOT modify
+  any Roman `calculate*` method, `setSeasonsAndHolyDaysOfObligation()`, `setYearCyclesAndVigils()`, `calculateVigilMass()`, or the Roman branch of `handle()`. New Ambrosian methods
+  live alongside; shared helpers are only *added to*, never behaviourally changed for Roman.
+- **The 501 stays until the final wiring task.** Build and unit/integration-test the whole Ambrosian generation path with the 501 still in place (mirroring Plan 6's discipline —
+  never ship a half-built calendar). The **last** task flips the 501 to route to `calculateAmbrosianCalendar()` and adds the end-to-end gate. Every task before it keeps
+  `/calendar/ambrosian` returning 501.
+- **Ambrosian response must validate against `jsondata/schemas/LitCal.json`.** A new schema-validation test is the second gate. The schema needs `AFTER_EPIPHANY`/`AFTER_PENTECOST`
+  added to the two `liturgical_season` enums and `is_dominical`/`is_aliturgical` declared in the two event definitions (both have `additionalProperties: false`).
+- **Readings = empty placeholder.** No Ambrosian lectionary exists; `readings` is `required` in both event defs. Every Ambrosian event gets a structurally-valid **empty** readings
+  object (see Task 2). No change to the `readings` schema. A real Ambrosian lectionary is a separate future plan.
+- **Season stamping:** the Ambrosian temporale self-stamps `liturgical_season` on temporale events; **sanctorale events do not** — the Ambrosian generation path must stamp season
+  on sanctorale events before running the precedence resolver, or its season-gated transfer rules stay inert.
+- **LitGrade ladder & existing enums unchanged.** All additions are additive. PHPStan L10 + phpcs clean; modern `@phpstan-ignore <identifier>` only where unavoidable.
+- **Work in the worktree** `…/scratchpad/wt-ambrosian-p7` (branch `feature/ambrosian-un501`, off merged `84bcceab`). Verify `git rev-parse --show-toplevel` ends in
+  `wt-ambrosian-p7` before editing. Signed commits (unlock GPG if a commit times out; never `--no-verify`).
+
+## Key file:line references (from the integration study; verify before editing — the handler is being modified)
+
+- **501 gate:** `CalendarHandler.php:5019-5023` (`if Rite::AMBROSIAN throw ImplementationException`). Sits after `validateRiteCompatibility()` (5015), before
+  `loadDiocesanCalendarData()` (5025) and the Roman generation `else` (5065-5144).
+- **Roman generation:** `handle()` `CalendarHandler.php:4921`; generation body 5065-5144; per-run 5070-5093 (main year) + 5104-5137 (prev year for `YearType::LITURGICAL`).
+- **Core pipeline:** `calculateUniversalCalendar()` 3866-3981; the one rite-abstracted seam 3886-3894
+  (`RiteProfileFactory::forRite(...)->temporaleEngine()->buildTemporale($temporaleContext)`); `loadPropriumDeTemporeData()` at 3868 (Roman-hardcoded, runs before the rite dispatch
+  — the wiring bug Task 3 fixes).
+- **Post-processors:** `LiturgicalEventCollection::setSeasonsAndHolyDaysOfObligation()` 1054-1099; `setYearCyclesAndVigils()` 1111-1329; `calculatePsalterWeek()` 1824-1871;
+  `createVigilMassFor()` 1378-1408; `liturgicalEventCanHaveVigil()` 1341-1365; `calculateVigilMass()` 1516-1600; `addLiturgicalEvent()` 236-298 (psalter/season-map auto-assign
+  258-296).
+- **Ambrosian strategies (exist, unwired):** `AmbrosianSanctoraleLoader::load(string $missal, string $locale): PropriumDeSanctisMap`
+  (`src/Models/Calendar/Sanctorale/AmbrosianSanctoraleLoader.php:29`); `AmbrosianMissalResolver::resolve(int $year): array` → `['EDITIO_2024']`;
+  `AmbrosianPrecedenceResolver::resolve(PrecedenceContext $ctx): void` (`.../Precedence/AmbrosianPrecedenceResolver.php:106`); `PrecedenceContext(cal, params, localeDateFormatter,
+  &messages)` (`.../Precedence/PrecedenceContext.php`); `AmbrosianTemporale::stampSeason()` (self-stamps season, `AmbrosianTemporale.php:73-83`); `RiteProfileFactory::forRite()`;
+  `AmbrosianRiteProfile` (all 4 seams impl; `SUPPORTED_DIOCESES` @31).
+- **HDoO source:** `CalendarParams::$HolyDaysOfObligation` default (Roman 10-key) `CalendarParams.php:80-91`.
+- **Discovery:** `/calendars` → `src/Services/CalendarMetadataProvider.php` (`create()` 58-66; `MetadataCalendars` shape `src/Models/Metadata/MetadataCalendars.php:74-98`);
+  `/events` → `EventsHandler` (`processTemporaleEvents()` 344, `processSanctoraleEvents()` 304; Roman-hardcoded; Router builds it WITHOUT a rite `Router.php:324`; `EventsParams`
+  has no `Rite`).
+- **Response schema:** `LitCal.json` `liturgical_season` enums at 570-581 + 760-771; `additionalProperties:false` at 436 (`LiturgicalEventVigil`) + 636 (`LiturgicalEvent`);
+  `readings` `$ref ./CommonDef.json#/definitions/Readings`.
+- **Data:** `jsondata/sourcedata/missals/ambrosian/{propriumdetempore/propriumdetempore.json, propriumdesanctis_2024/propriumdesanctis.json}` + i18n;
+  `JsonData::AMBROSIAN_TEMPORALE_FILE`/`_I18N_FILE`/`AMBROSIAN_SANCTORALE_FILE`/`_I18N_FILE` (`src/Enum/JsonData.php:131/144/156/169`).
+
+---
+
+## File Structure
+
+- `jsondata/schemas/LitCal.json` — additive schema changes (Task 1).
+- `src/Models/Calendar/LiturgicalEvent.php` or a small factory — empty-readings placeholder (Task 2).
+- `src/Handlers/CalendarHandler.php` — rite-aware tempore load (Task 3); the new `calculateAmbrosianCalendar()` orchestrator + Ambrosian post-processing methods (Tasks 4–9); the
+  501→branch flip (Task 10).
+- `src/Models/Calendar/LiturgicalEventCollection.php` — a new Ambrosian season+HDoO pass and Ambrosian year-cycle/vigil methods **added alongside** the Roman ones (Tasks 6–8);
+  optionally a small guard in `addLiturgicalEvent` for the Ambrosian psalter pre-stamp (Task 8).
+- `src/Enum/AmbrosianHolyDaysOfObligation.php` (or a const) — the Ambrosian HDoO default set (Task 6).
+- `src/Services/CalendarMetadataProvider.php` + `src/Models/Metadata/*` — `/calendars` comune announcement (Task 11).
+- `src/Handlers/EventsHandler.php`, `src/Params/EventsParams.php`, `src/Router.php` — `/events` rite dimension (Task 12).
+- `phpunit_tests/` — per-task unit/handler tests + a schema-validation test + a final Routes integration test.
+
+**Architecture note (the orchestrator).** `calculateAmbrosianCalendar()` mirrors the shape of the Roman `calculateUniversalCalendar()` + the `handle()` post-processing block, but
+as a self-contained Ambrosian pipeline:
+
+```text
+calculateAmbrosianCalendar():
+  1. loadAmbrosianPropriumDeTempore()                    (Task 3)
+  2. RiteProfileFactory::forRite(AMBROSIAN)->temporaleEngine()->buildTemporale(TemporaleContext)   (existing engine; self-stamps season)
+  3. loadAmbrosianSanctorale() -> add rows to $this->Cal, de-dup vs temporale keys, empty-readings   (Task 4)
+  4. stampAmbrosianSeasonOnSanctorale()                  (Task 6, season half)
+  5. new AmbrosianPrecedenceResolver()->resolve(PrecedenceContext(...))   (Task 5)
+  6. setAmbrosianHolyDaysOfObligation()                  (Task 6, HDoO half)
+  7. setAmbrosianYearCyclesAndVigils()                   (Task 7)
+  8. calculatePsalterWeek()   (reuse Roman as-is; Task 8 guards the pre-stamp)
+  9. sortLiturgicalEvents()   (reuse)
+```
+
+The `handle()` Ambrosian branch (Task 10) calls this in place of the Roman block, honouring `YearType::LITURGICAL` (two runs + splice) exactly as the Roman branch does at
+5065-5144.
+
+---
+
+### Task 1: Response-schema support for Ambrosian events
+
+**Files:**
+
+- Modify: `jsondata/schemas/LitCal.json` (enums at 570-581 & 760-771; property blocks in `LiturgicalEventVigil` def opening ~434 and `LiturgicalEvent` def opening ~634)
+- Test: `phpunit_tests/Schemas/` (add an Ambrosian-event schema fixture test)
+
+**Interfaces:**
+
+- Produces: a `LitCal.json` that accepts `liturgical_season ∈ {…, AFTER_EPIPHANY, AFTER_PENTECOST}` and optional `is_dominical`/`is_aliturgical` booleans, in BOTH event
+  definitions.
+
+- [ ] **Step 1: Add the two season enum values** in BOTH `liturgical_season` enum arrays (the `LiturgicalEventVigil` block ~570-581 and the `LiturgicalEvent` block ~760-771).
+  Append `"AFTER_EPIPHANY"` and `"AFTER_PENTECOST"` to each `enum` array, and extend each `description` string's "one of:" list. Keep the two blocks byte-identical to each other
+  (they already are).
+
+- [ ] **Step 2: Declare `is_dominical` and `is_aliturgical`** in BOTH event definitions' `properties` (since both have `additionalProperties:false`), as optional booleans (do NOT
+  add to `required`):
+
+```json
+                "is_dominical": {
+                    "type": "boolean",
+                    "description": "True if the event is 'of the Lord' (dominical). Present only for rites that classify dominical events (Ambrosian)."
+                },
+                "is_aliturgical": {
+                    "type": "boolean",
+                    "description": "True if the event is aliturgical (no Mass celebrated), e.g. the aliturgical Fridays of Ambrosian Lent."
+                },
+```
+
+- [ ] **Step 3: Write a schema-validation test.** In `phpunit_tests/Schemas/`, add a test that loads `LitCal.json` (resolving `$ref`s the same way the existing schema tests do —
+  follow the sibling `SchemaValidationTest` pattern) and validates a hand-built minimal Ambrosian event object carrying `liturgical_season: "AFTER_PENTECOST"`, `is_dominical:
+  true`, `is_aliturgical: true`, and an empty readings object (Task 2 shape) — asserting it PASSES; and a second object with `liturgical_season: "NONSENSE"` asserting it FAILS.
+  This pins both the new enum values and the new properties.
+
+- [ ] **Step 4: Validate.** `composer lint:openapi` (if it covers LitCal.json) or the JSON is well-formed; run the new test → green; run the existing `phpunit_tests/Schemas/` suite
+  → still green (Roman events unaffected — the additions are optional/additive). Commit.
+
+```bash
+git add jsondata/schemas/LitCal.json phpunit_tests/Schemas/
+git commit -m "feat(ambrosian): allow AFTER_* seasons + is_dominical/is_aliturgical in LitCal response schema"
+```
+
+---
+
+### Task 2: Empty-readings placeholder for Ambrosian events
+
+**Files:**
+
+- Inspect: `src/Models/Calendar/Readings/` (the `ReadingsAbstract` hierarchy) + `jsondata/schemas/CommonDef.json#/definitions/Readings`
+- Create/Modify: a small factory or static helper that yields a schema-valid empty readings object; wire it where Ambrosian events are finalized.
+- Test: unit test asserting the placeholder serializes to a `Readings`-schema-valid shape.
+
+**Interfaces:**
+
+- Produces: `AmbrosianReadings::empty(): ReadingsAbstract` (or equivalent) — a readings object whose `jsonSerialize()` satisfies `CommonDef.json#/definitions/Readings`.
+
+- [ ] **Step 1: Determine the minimal valid `Readings` shape.** Read `CommonDef.json#/definitions/Readings` and the `ReadingsAbstract`/`ReadingsCommons` classes to find which
+  fields are `required` and their minimal valid values (likely `first_reading`, `responsorial_psalm`, `gospel`, etc. as strings — empty strings `""` are the placeholder). Write the
+  failing test first: build the placeholder, `json_encode` it, and validate against the `Readings` schema definition — expect PASS.
+
+- [ ] **Step 2: Implement the placeholder** as the least-effort schema-valid object (reuse the existing readings class whose required fields you can set to empty strings; do NOT
+  invent a new schema shape). Ensure `LiturgicalEvent::jsonSerialize()` (line 267 guards `isset($this->readings)`; 304 emits `->readings->jsonSerialize()`) emits it when set.
+
+- [ ] **Step 3:** In the Ambrosian generation path this will be applied to every event (Task 4 for sanctorale, and after the temporale engine runs for temporale events) via
+  `setReadings(AmbrosianReadings::empty())`. For THIS task, just build + unit-test the placeholder in isolation. Validate + commit.
+
+> **Note:** if the `Readings` schema's required fields cannot all be satisfied by empty strings (e.g. an enum or pattern), use the smallest legal values and document them. The goal
+> is schema-validity, not liturgical content.
+
+---
+
+### Task 3: Rite-aware Proprium de Tempore loading
+
+**Files:**
+
+- Modify: `src/Handlers/CalendarHandler.php` (`loadPropriumDeTemporeData()`, called at 3868)
+- Test: `phpunit_tests/Handlers/` (assert an Ambrosian-configured handler loads the Ambrosian tempore keys)
+
+**Background:** `loadPropriumDeTemporeData()` is Roman-hardcoded and runs at 3868 *before* the rite dispatch at 3886, so `$this->PropriumDeTempore` would hold the Roman proprium
+even for an Ambrosian request. The Ambrosian temporale reads `$ctx->propriumDeTempore`, so it must be the Ambrosian file.
+
+- [ ] **Step 1:** Write a failing handler test: configure `CalendarParams` with `Rite::AMBROSIAN`, invoke the tempore-load step, assert `$this->PropriumDeTempore` contains an
+  Ambrosian-only key (e.g. `Circoncisione` or `DedicationDuomo`) and NOT a Roman-only one (e.g. `AshWednesday`).
+
+- [ ] **Step 2:** Make `loadPropriumDeTemporeData()` rite-aware: when `$this->CalendarParams->Rite === Rite::AMBROSIAN`, load `JsonData::AMBROSIAN_TEMPORALE_FILE` +
+  `AMBROSIAN_TEMPORALE_I18N_FILE` into `$this->PropriumDeTempore` (mirroring the existing Roman load but with the Ambrosian paths; the harness in
+  `AmbrosianTemporaleHarnessTrait::buildContext` shows the exact `PropriumDeTemporeMap::fromObject` + `setNames` calls). Keep the Roman branch untouched (default).
+
+- [ ] **Step 3:** Golden master 9/9 (Roman branch unchanged); new test green; analyse + lint clean. Commit.
+
+---
+
+### Task 4: Ambrosian sanctorale assembly + temporale/sanctorale de-dup + empty readings
+
+**Files:**
+
+- Modify: `src/Handlers/CalendarHandler.php` (new private `loadAmbrosianSanctorale()` / `addAmbrosianSanctoraleToCalendar()`)
+- Test: `phpunit_tests/Handlers/`
+
+**Background:** `AmbrosianSanctoraleLoader::load($edition, $locale)` returns a `PropriumDeSanctisMap` (254 comune rows). These must be added to `$this->Cal`. The Ambrosian assembly
+model is "add everything, then resolve", so — unlike Roman's check-before-add — add ALL sanctorale rows, then let Task 5's resolver sort coincidences. BUT: **key collisions** (same
+`event_key` in both temporale and sanctorale, e.g. `Christmas`/`Circoncisione`/`Epiphany`) silently overwrite via `addLiturgicalEvent` (keyed by `event_key`). Every Ambrosian event
+also needs the empty-readings placeholder (Task 2).
+
+- [ ] **Step 1: Audit the overlap.** Read the 254 `propriumdesanctis_2024` event_keys and the temporale keys; determine which keys appear in BOTH. Write a test asserting the actual
+  overlap set (likely `Christmas`/`Circoncisione`/`Epiphany` are ONLY in tempore, per the Roman curation convention — verify). Document the finding.
+
+- [ ] **Step 2: Implement `addAmbrosianSanctoraleToCalendar()`**: `$edition = (new AmbrosianMissalResolver())->resolve($year)[...]`; `$map = (new
+  AmbrosianSanctoraleLoader())->load($edition, $locale)`; for each event, build a `LiturgicalEvent` (via `LiturgicalEvent::fromObject` on the `PropriumDeSanctisEvent`, carrying
+  grade/color/is_dominical), set the empty readings placeholder, and `$this->Cal->addLiturgicalEvent($key, $event)`. If any key already exists from the temporale (collision), SKIP
+  it with a `$this->Messages[]` note (the temporale definition wins) OR fail loudly if the collision is unexpected — decide per the Step-1 audit.
+
+- [ ] **Step 3:** Unit-test: after temporale + this step for 2025, assert (a) a known comune saint (e.g. `StAmbrose`) is present with its date/grade, (b) no duplicate event_key,
+  (c) every event has a (placeholder) readings object. Golden master untouched (Roman path not involved). Commit.
+
+---
+
+### Task 5: Wire the Ambrosian precedence resolver
+
+**Files:**
+
+- Modify: `src/Handlers/CalendarHandler.php` (call the resolver in the orchestrator)
+- Test: `phpunit_tests/Handlers/` — the end-to-end precedence effect on the assembled year.
+
+**Interfaces:**
+
+- Consumes: `PrecedenceContext(LiturgicalEventCollection $cal, CalendarParams $params, LocaleDateFormatter $localeDateFormatter, array &$messages)`;
+  `AmbrosianPrecedenceResolver::resolve($ctx)`.
+
+- [ ] **Step 1:** Write a failing test that assembles the 2025 Ambrosian year (temporale + sanctorale, Tasks 3–4) and asserts that BEFORE `resolve()`, `StAmbrose` and `Advent4`
+  both sit on 2025-12-07; then after building a `PrecedenceContext` and calling `resolve()`, `StAmbrose` has anticipated to **2025-12-06** (the norm-correct behaviour validated in
+  Plan 6, confirmed against the chiesadimilano.it ordo — see [[ambrosian-ordo-validation-source]]). This is the end-to-end proof that season-stamping (Task 6 must run first — see
+  ordering) + the resolver fire on real handler-assembled data.
+
+- [ ] **Step 2:** In the orchestrator, construct the `PrecedenceContext` from `$this->Cal`, `$this->CalendarParams`, `$this->localeDateFormatter`, and `$this->Messages` (by-ref),
+  and call `(new AmbrosianPrecedenceResolver())->resolve($ctx)`. **Ordering:** this MUST run AFTER Task 6's sanctorale season-stamping (the resolver's season-gated branches read
+  `liturgical_season`). Wire the orchestrator step order per the Architecture note.
+
+- [ ] **Step 3:** Test green; golden master untouched; analyse + lint. Commit.
+
+---
+
+### Task 6: Ambrosian season-on-sanctorale + Holy-Days-of-Obligation pass
+
+**Files:**
+
+- Create: `src/Enum/AmbrosianHolyDaysOfObligation.php` (or a const list) — the Ambrosian HDoO default set.
+- Modify: `src/Models/Calendar/LiturgicalEventCollection.php` — a new `setAmbrosianSeasonsAndHolyDaysOfObligation()` (or two methods) ADDED alongside the Roman one (do NOT change
+  the Roman method).
+- Test: `phpunit_tests/Models/Calendar/` + `phpunit_tests/Handlers/`.
+
+**Background (from the study):** the Roman `setSeasonsAndHolyDaysOfObligation()` needs `AshWednesday` + the 6 Roman seasons and can't run for Ambrosian. Its **season half is
+redundant for temporale** (self-stamped) but **sanctorale events have no season**. Its **HDoO half** (`array_keys(array_filter($params->HolyDaysOfObligation))` +
+`in_array($event_key, …)`) is rite-agnostic and reusable, but needs an Ambrosian HDoO key set.
+
+- [ ] **Step 1: Season on sanctorale.** Write a failing test: a comune saint (e.g. one falling in Lent) has `liturgical_season === null` after assembly. Implement
+  `stampAmbrosianSeasonOnSanctorale()` on the collection: for every event whose `liturgical_season` is null, assign the season of that DATE — computed from the Ambrosian temporale
+  anchors already in the collection (Advent1, Christmas/Circoncisione, Epiphany/BaptismLord, Lent1, HolyThurs, Easter, Pentecost, and the after-* boundaries), OR by copying the
+  season of the temporale event already occupying that date if one exists (`getCalEventsFromDate`). Use the Ambrosian season set (`LitSeason::AFTER_EPIPHANY`/`AFTER_PENTECOST`
+  etc.), NOT the Roman date-range logic. Assert the Lenten saint now has `LitSeason::LENT`. **This step must run before Task 5's `resolve()`.**
+
+- [ ] **Step 2: Ambrosian HDoO set.** Define the Ambrosian holy-days-of-obligation default (event_key ⇒ true). Base it on the Italian/Swiss conference set over Ambrosian keys —
+  e.g. `Christmas, Epiphany, Ascension, Pentecost, Circoncisione (Jan 1), Assumption, AllSaints, ImmaculateConception, StAmbrose (Milan patron), DedicationDuomo`, plus every
+  Sunday. **Flag the exact set for ordo-validation (Plan 9)** — this is provisional; the mechanism must be correct even if the membership is refined later. Do NOT reuse the Roman
+  `CalendarParams::$HolyDaysOfObligation` default (Roman keys like `StJoseph`/`StsPeterPaulAp`/`CorpusChristi` and Roman `MaryMotherOfGod` don't match Ambrosian keys).
+
+- [ ] **Step 3: HDoO stamping.** Implement the HDoO half (mirror the Roman loop at 1095-1097): for each event whose `event_key` is in the Ambrosian HDoO set, set
+  `holy_day_of_obligation = true`; additionally mark every Sunday (`(int)$date->format('N') === 7`) as a holy day of obligation (Ambrosian, like Roman, obliges all Sundays). Write
+  a test asserting `Christmas` and a Sunday are HDoO and an ordinary ferial weekday is not.
+
+- [ ] **Step 4:** Golden master untouched (Roman method not modified); new tests green; analyse + lint. Commit.
+
+---
+
+### Task 7: Ambrosian year cycles + first-vespers vigils
+
+**Files:**
+
+- Modify: `src/Models/Calendar/LiturgicalEventCollection.php` — new `setAmbrosianYearCyclesAndVigils()` alongside the Roman one; new `calculateAmbrosianVigilMass()` +
+  `ambrosianEventCanHaveVigil()` alongside the Roman vigil methods.
+- Test: `phpunit_tests/Models/Calendar/`.
+
+**Background:** the A/B/C Sunday cycle (off `Advent1` date + `$Year%3`) and I/II weekday cycle (`($Year-1)%2`) arithmetic are rite-agnostic (Roman `setYearCyclesAndVigils`
+1142-1156, consts `SUNDAY_CYCLE`/`WEEKDAY_CYCLE`) — REUSE the arithmetic. But `inOrdinaryTime()` (1016-1032) needs `AshWednesday` → replace the I/II guard with an Ambrosian
+"ordinary" test (season ∈ {AFTER_EPIPHANY, AFTER_PENTECOST}). The ~150 lines of Roman **lectionary readings** retrieval are OMITTED (empty-readings placeholder already set in Task
+4). The vigil mechanism (`_vigil` key, `is_vigil_mass`/`is_vigil_for`/`has_vesper_i`/`has_vesper_ii`, `createVigilMassFor` 1378-1408) is reusable; the eligibility
+(`liturgicalEventCanHaveVigil` anchors `PalmSun`/`Easter`/`Easter2`/`AllSouls`/`AshWednesday`, the `SOLEMNITIES_LORD_BVM` list, the `Year===2022` decree) is Roman → adapt.
+
+- [ ] **Step 1: Year-cycle test + impl.** Failing test: a 2025 Ambrosian Sunday has `liturgical_year` set to the correct A/B/C string; an after-Pentecost ferial weekday has the
+  correct I/II string. Implement `setAmbrosianYearCyclesAndVigils()` reusing the A/B/C math (keyed off `Advent1`) and the I/II math, with the I/II guard = `liturgical_season ∈
+  {AFTER_EPIPHANY, AFTER_PENTECOST}` (the Ambrosian "ordinary" analogue) instead of `inOrdinaryTime()`. **Do NOT retrieve readings** (they're placeholders). Suppress the cycle
+  string for the fixed-date events where Roman does (adapt the 1208 list to Ambrosian: `Christmas`, `Circoncisione`, `Epiphany`).
+
+- [ ] **Step 2: Vigil test + impl.** Failing test: a 2025 Ambrosian Solemnity (e.g. `DedicationDuomo` or `Assumption`) gets a `{key}_vigil` event on the prior day with
+  `is_vigil_mass=true`/`is_vigil_for={key}`, and the parent gets `has_vesper_i/ii=true`. Implement `ambrosianEventCanHaveVigil()` + `calculateAmbrosianVigilMass()` reusing
+  `createVigilMassFor`'s field-stamping, but with: Ambrosian eligibility (dominical Sundays + grade ≥ SOLEMNITY, minus the Triduum window using the Ambrosian anchors
+  `PalmSun`/`Easter`/`Easter2` which DO exist in the Ambrosian temporale); NO `AshWednesday`/`AllSouls` Roman exclusions; NO `SOLEMNITIES_LORD_BVM`/`Year===2022` Roman special
+  cases (use `is_dominical` for the of-the-Lord distinction). Keep it day-granularity (a `_vigil` Mass event + the vesper flags), matching the Roman model the response schema
+  expects. **Flag the exact Ambrosian vigil-eligibility rules for ordo-validation (Plan 9).**
+
+- [ ] **Step 3:** Golden master untouched; tests green; analyse + lint. Commit (may be two commits: cycles, then vigils).
+
+---
+
+### Task 8: Psalter week for the Ambrosian collection
+
+**Files:**
+
+- Modify: `src/Models/Calendar/LiturgicalEventCollection.php` (`addLiturgicalEvent` psalter pre-stamp guard, and/or reuse `calculatePsalterWeek()`)
+- Test: `phpunit_tests/Models/Calendar/`.
+
+**Background:** `calculatePsalterWeek()` (1824-1871) is a rite-agnostic gap-filler and works as-is. BUT `addLiturgicalEvent`'s regex `/(Advent|Lent|Easter)([1-7])/` (258)
+auto-stamps Ambrosian `Advent1..6`/`Lent1..5` with ROMAN psalter numbering (`psalterWeek(6)=2`, etc.) — potentially wrong for the Ambrosian psalter (Ambrosian Advent has 6 weeks).
+The after-* Sundays get `null` → 0 from `calculatePsalterWeek`.
+
+- [ ] **Step 1:** Decide the Ambrosian psalter-week policy. Simplest correct-enough policy for this plan: let `calculatePsalterWeek()` run as-is (fills gaps with 0), and either (a)
+  accept the Roman-regex pre-stamp on Advent/Lent Sundays as a provisional value flagged for Plan 9 ordo-validation, or (b) if the Ambrosian psalter genuinely differs, add a rite
+  guard so the `/(Advent|Lent|Easter)([1-7])/` pre-stamp is skipped for Ambrosian (leaving those to `calculatePsalterWeek`). Prefer (a) unless ordo evidence says otherwise — keep
+  the change minimal.
+
+- [ ] **Step 2:** Test that after the full Ambrosian pipeline every event has a non-null `psalter_week` (0 is valid). Wire `calculatePsalterWeek()` into the orchestrator. Golden
+  master untouched (the guard, if added, is behind a rite check). Commit.
+
+> **Note:** `calculatePsalterWeek()` is shared and used by Roman — if you touch it or `addLiturgicalEvent`, gate every change behind `Rite::AMBROSIAN` so Roman psalter numbering is
+> byte-identical. Verify with the golden master.
+
+---
+
+### Task 9: The `calculateAmbrosianCalendar()` orchestrator (still behind the 501)
+
+**Files:**
+
+- Modify: `src/Handlers/CalendarHandler.php` — assemble Tasks 3–8 into one private method.
+- Test: `phpunit_tests/Handlers/` — a full-pipeline handler test that invokes the orchestrator directly (NOT through the 501-gated `handle()` yet).
+
+- [ ] **Step 1:** Implement `calculateAmbrosianCalendar()` calling, in order: rite-aware tempore load (T3) →
+  `RiteProfileFactory::forRite(AMBROSIAN)->temporaleEngine()->buildTemporale(...)` → `addAmbrosianSanctoraleToCalendar()` (T4) → `stampAmbrosianSeasonOnSanctorale()` (T6 season) →
+  `resolve()` (T5) → `setAmbrosianHolyDaysOfObligation()` (T6 HDoO) → `setAmbrosianYearCyclesAndVigils()` (T7) → `calculatePsalterWeek()` (T8) → `sortLiturgicalEvents()`.
+
+- [ ] **Step 2:** Handler test: directly call `calculateAmbrosianCalendar()` for 2025 (via a test seam or reflection, as the existing handler tests do) and assert a complete,
+  resolved, seasoned, HDoO-marked, cycle-stamped calendar — including the end-to-end `StAmbrose → 2025-12-06` anticipation and every day covered (reuse the Plan-6 completeness idea
+  at the handler level). The 501 is STILL in place; this test bypasses it. Golden master untouched. Commit.
+
+---
+
+### Task 10: Flip the 501 → route to the Ambrosian orchestrator (endpoint goes live)
+
+**Files:**
+
+- Modify: `src/Handlers/CalendarHandler.php` (`handle()`, the 501 block at 5019-5023 and the generation branch).
+- Test: `phpunit_tests/Routes/` — a live integration test hitting `/calendar/ambrosian/{year}` (skipped when `localhost:8000` is down, per `ApiTestCase`), plus the
+  schema-validation gate on the real response.
+
+- [ ] **Step 1:** Replace the 501 block: when `Rite::AMBROSIAN`, route the generation to `calculateAmbrosianCalendar()` instead of throwing — honouring `YearType::LITURGICAL` (two
+  runs + splice) exactly as the Roman branch does (5065-5144). Keep the Roman branch byte-identical. The comune case = no national/diocesan layer (both null), so skip
+  `applyNationalCalendar`/`applyDiocesanCalendar` for Ambrosian (dioceses are Plan 8).
+
+- [ ] **Step 2: Schema gate.** Add a test that generates the Ambrosian 2025 calendar response and validates the FULL response against `LitCal.json` (with the Task-1 additions) —
+  this is the acceptance gate that the response is well-formed (AFTER_* seasons, is_dominical/is_aliturgical, empty readings all satisfy the schema).
+
+- [ ] **Step 3: Integration test** (`Routes/`, `ApiTestCase`): `GET /calendar/ambrosian/2025` returns 200 (not 501) with a `litcal` array; spot-check `DedicationDuomo`,
+  `ChristKing`, `StAmbrose` (2025-12-06), and that `settings.rite`/metadata reflect Ambrosian. Mark `@group slow` if it does a full-year generation.
+
+- [ ] **Step 4:** Golden master 9/9 (Roman untouched); full suite green; analyse + lint. Commit. **The endpoint is now live.**
+
+---
+
+### Task 11: `/calendars` discovery announces the comune ambrosiano
+
+**Files:**
+
+- Modify: `src/Services/CalendarMetadataProvider.php`, `src/Models/Metadata/MetadataCalendars.php` (+ a new item type if needed)
+- Test: `phpunit_tests/Handlers/` or `Services/`.
+
+**Background:** the comune `/calendar/ambrosian` has NO representation in the metadata today (it's neither nation, diocese, nor wider region), and there's no `rite` dimension.
+
+- [ ] **Step 1:** Decide the surface. Minimal: add a top-level `ambrosian` (or `rites`) entry to `MetadataCalendars` announcing the comune calendar path (`/calendar/ambrosian`),
+  its supported locales (`it`, `la` — the Ambrosian i18n locales), and its rite. Write a failing test asserting `/calendars` output includes the Ambrosian comune with its locales.
+
+- [ ] **Step 2:** Implement the new builder in `CalendarMetadataProvider::create()` (add e.g. `self::buildAmbrosianCalendarData($metadata)`), and extend `MetadataCalendars` with
+  the field + its serialization. Keep the existing national/diocesan/wider-region output byte-identical. Update the metadata schema (`jsondata/schemas/`) if `/calendars` has one.
+
+- [ ] **Step 3:** Test green; existing `/calendars` (Roman) output unchanged; analyse + lint. Commit.
+
+---
+
+### Task 12: `/events` rite-aware (Ambrosian event catalog)
+
+**Files:**
+
+- Modify: `src/Router.php` (extract the rite segment for the `events` route), `src/Params/EventsParams.php` (add a `Rite` field), `src/Handlers/EventsHandler.php`
+  (`processTemporaleEvents()` 344, `processSanctoraleEvents()` 304 — rite-branch to the Ambrosian files)
+- Test: `phpunit_tests/Handlers/EventsHandlerTest.php` or `Routes/`.
+
+**Background:** `/events` has NO rite awareness — the Router builds `EventsHandler` without a rite (`Router.php:324`), `EventsParams` has no `Rite`, and the temporale/sanctorale
+processors are Roman-hardcoded.
+
+- [ ] **Step 1:** Add rite extraction for the `events` route in `Router::route()` (mirror the `calendar` route's `extractRiteSegment` usage — support `/events/ambrosian`), thread
+  the `Rite` into `new EventsHandler(...)` and into `EventsParams`. Write a failing test: `/events/ambrosian` yields a catalog containing an Ambrosian-only key (e.g.
+  `DedicationDuomo`, `Circoncisione`) and NOT a Roman-only one.
+
+- [ ] **Step 2:** Rite-branch `processTemporaleEvents()` (read `JsonData::AMBROSIAN_TEMPORALE_FILE`/`_I18N_FILE` when Ambrosian) and `processSanctoraleEvents()` (read
+  `AMBROSIAN_SANCTORALE_FILE`/`_I18N_FILE` via `AmbrosianMissalResolver`, instead of `RomanMissal::getLatinMissalIds()`). Skip the Roman national/decrees processors for Ambrosian
+  (comune only).
+
+- [ ] **Step 3:** Test green; Roman `/events` byte-identical; analyse + lint. Commit.
+
+---
+
+### Task 13: Whole-branch acceptance + docs
+
+- [ ] **Step 1:** Full suite: `composer test` (incl. `@group slow`), `composer analyse`, `composer lint`, `composer lint:openapi`, golden master 9/9. All green.
+- [ ] **Step 2:** Manual spot-check (if `localhost:8000` available): `GET /calendar/ambrosian/2025` and `/2026`, eyeball against the chiesadimilano.it ordo for a few dates (Advent
+  I, Dedication, Christ the King, St Ambrose Dec 6). Record findings in this plan's "Ordo-validation findings" section.
+- [ ] **Step 3:** Update `README`/handler docs to note `/calendar/ambrosian`, `/events/ambrosian`, and `/calendars` Ambrosian discovery are live (comune only; dioceses = Plan 8).
+  Commit.
+
+---
+
+## Post-Plan Notes
+
+- **Deferred to Plan 8 (diocesan overlays):** the 4 Ambrosian dioceses (milano_it, bergam_it, novara_it, lugano_ch), the `lugano_ch` no-Swiss-national-tier fix
+  (`loadDiocesanCalendarData` forces `NationalCalendar=CH` at `:444` → `loadNationalCalendarData` 503s on missing `CH/CH.json`), `DiocesanCalendar` schema `+supported_rites/rite`,
+  own-church-dedication modelling.
+- **Deferred to Plan 9 (ordo-validation + 1976 backfill):** the Ambrosian HDoO membership set (Task 6), the vigil-eligibility rules (Task 7), the Ambrosian psalter-week numbering
+  (Task 8), exact ordo names/numbering, the pre-2008/1976 edition branch.
+- **Deferred to a dedicated future plan (Ambrosian lectionary):** real readings (this plan ships the empty-readings placeholder). When authored, `setAmbrosianYearCyclesAndVigils`
+  gains the readings-retrieval half and the placeholder is replaced.
+- **Whole-branch final review:** dispatch on the most capable model. Focus lenses: (1) Roman byte-identity — every shared method (`addLiturgicalEvent`, `calculatePsalterWeek`,
+  `LitSeason::forEventKey`) change gated behind a rite check; (2) the Ambrosian orchestrator step ORDER (season-on-sanctorale before `resolve()`; seasons/HDoO before cycles/vigils;
+  psalter last); (3) the `YearType::LITURGICAL` two-run splice for Ambrosian; (4) response-schema validity of the live output; (5) no un-guarded null-deref on the new anchor
+  lookups.

--- a/jsondata/schemas/LitCal.json
+++ b/jsondata/schemas/LitCal.json
@@ -570,14 +570,16 @@
                 "liturgical_season": {
                     "type": "string",
                     "title": "Liturgical Season",
-                    "description": "an enumeration value of the liturgical season in which the event falls, one of: ADVENT, CHRISTMAS, LENT, EASTER_TRIDUUM, EASTER, ORDINARY_TIME",
+                    "description": "an enumeration value of the liturgical season in which the event falls, one of: ADVENT, CHRISTMAS, LENT, EASTER_TRIDUUM, EASTER, ORDINARY_TIME, AFTER_EPIPHANY, AFTER_PENTECOST",
                     "enum": [
                         "ADVENT",
                         "CHRISTMAS",
                         "LENT",
                         "EASTER_TRIDUUM",
                         "EASTER",
-                        "ORDINARY_TIME"
+                        "ORDINARY_TIME",
+                        "AFTER_EPIPHANY",
+                        "AFTER_PENTECOST"
                     ]
                 },
                 "liturgical_season_lcl": {
@@ -599,6 +601,14 @@
                     "const": true,
                     "title": "Is Holy Day of Obligation",
                     "description": "the property will only exist and will be true if the celebration is a Holy Day of Obligation, according to the calendar requested; otherwise the property will be absent"
+                },
+                "is_dominical": {
+                    "type": "boolean",
+                    "description": "True if the event is 'of the Lord' (dominical). Present only for rites that classify dominical events (Ambrosian)."
+                },
+                "is_aliturgical": {
+                    "type": "boolean",
+                    "description": "True if the event is aliturgical (no Mass celebrated), e.g. the aliturgical Fridays of Ambrosian Lent."
                 }
             },
             "required": [
@@ -760,14 +770,16 @@
                 "liturgical_season": {
                     "type": "string",
                     "title": "Liturgical Season",
-                    "description": "an enumeration value of the liturgical season in which the event falls, one of: ADVENT, CHRISTMAS, LENT, EASTER_TRIDUUM, EASTER, ORDINARY_TIME",
+                    "description": "an enumeration value of the liturgical season in which the event falls, one of: ADVENT, CHRISTMAS, LENT, EASTER_TRIDUUM, EASTER, ORDINARY_TIME, AFTER_EPIPHANY, AFTER_PENTECOST",
                     "enum": [
                         "ADVENT",
                         "CHRISTMAS",
                         "LENT",
                         "EASTER_TRIDUUM",
                         "EASTER",
-                        "ORDINARY_TIME"
+                        "ORDINARY_TIME",
+                        "AFTER_EPIPHANY",
+                        "AFTER_PENTECOST"
                     ]
                 },
                 "liturgical_season_lcl": {
@@ -804,6 +816,14 @@
                     "const": true,
                     "title": "Is Holy Day of Obligation",
                     "description": "the property will only exist and will be true if the celebration is a Holy Day of Obligation, according to the calendar requested; otherwise the property will be absent"
+                },
+                "is_dominical": {
+                    "type": "boolean",
+                    "description": "True if the event is 'of the Lord' (dominical). Present only for rites that classify dominical events (Ambrosian)."
+                },
+                "is_aliturgical": {
+                    "type": "boolean",
+                    "description": "True if the event is aliturgical (no Mass celebrated), e.g. the aliturgical Fridays of Ambrosian Lent."
                 }
             },
             "required": [

--- a/jsondata/schemas/LitCalMetadata.json
+++ b/jsondata/schemas/LitCalMetadata.json
@@ -145,6 +145,20 @@
                     "items": {
                         "$ref": "./CommonDef.json#/definitions/Locale"
                     }
+                },
+                "ambrosian_calendars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/AmbrosianCalendarDef"
+                    }
+                },
+                "ambrosian_calendars_keys": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "enum": ["ambrosian"]
+                    }
                 }
             },
             "required": [
@@ -155,9 +169,34 @@
                 "diocesan_groups",
                 "wider_regions",
                 "wider_regions_keys",
-                "locales"
+                "locales",
+                "ambrosian_calendars",
+                "ambrosian_calendars_keys"
             ],
             "additionalProperties": false
+        },
+        "AmbrosianCalendarDef": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "calendar_id": {
+                    "type": "string",
+                    "description": "the path segment identifying the comune calendar, used as /calendar/{calendar_id}",
+                    "enum": ["ambrosian"]
+                },
+                "rite": {
+                    "type": "string",
+                    "description": "the liturgical rite this comune calendar is computed under",
+                    "enum": ["ambrosian"]
+                },
+                "locales": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "./CommonDef.json#/definitions/Locale"
+                    }
+                }
+            },
+            "required": ["calendar_id", "rite", "locales"]
         },
         "WiderRegionDef": {
             "type": "object",

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -4105,6 +4105,88 @@
         }
       }
     },
+    "/events/ambrosian": {
+      "get": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the Ambrosian comune calendar (Proprium de Tempore and comune sanctorale) even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "description": "The Ambrosian rite has no national calendars, and diocesan Ambrosian event catalogs are not yet supported; this endpoint serves only the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. A `national_calendar` or `diocesan_calendar` parameter combined with this endpoint returns 400 Bad Request.",
+        "operationId": "retrieveAmbrosianEventsGET",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in the Ambrosian comune calendar produced by the LitCal API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the Ambrosian comune calendar (Proprium de Tempore and comune sanctorale) even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "description": "The Ambrosian rite has no national calendars, and diocesan Ambrosian event catalogs are not yet supported; this endpoint serves only the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. A `national_calendar` or `diocesan_calendar` parameter combined with this endpoint returns 400 Bad Request.",
+        "operationId": "retrieveAmbrosianEventsPOST",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in the Ambrosian comune calendar produced by the LitCal API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      }
+    },
     "/events/nation/{calendar_id}": {
       "get": {
         "tags": [

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -933,9 +933,9 @@
         "security": [
           {}
         ],
-        "summary": "[Planned] Retrieve liturgical events for the Ambrosian calendar for each day of the current year (currently returns 501 Not Implemented)",
+        "summary": "Retrieve liturgical events for the Ambrosian calendar (comune ambrosiano) for each day of the current year",
         "operationId": "retrieveAmbrosianCalendarGET",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the current year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "description": "Retrieves liturgical events for the Ambrosian rite (comune ambrosiano only; no diocesan overlay) for each day of the current year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement. Readings are currently an empty placeholder (no Ambrosian lectionary yet); year cycles, first-vespers vigils, and psalter-week numbering are provisional pending ordo validation.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -960,8 +960,11 @@
           }
         ],
         "responses": {
-          "501": {
-            "$ref": "#/components/responses/NotImplemented501"
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -984,9 +987,9 @@
         "security": [
           {}
         ],
-        "summary": "[Planned] Retrieve liturgical events for the Ambrosian calendar for each day of the current year (currently returns 501 Not Implemented)",
+        "summary": "Retrieve liturgical events for the Ambrosian calendar (comune ambrosiano) for each day of the current year",
         "operationId": "retrieveAmbrosianCalendarPOST",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the current year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi request body parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement.",
+        "description": "Retrieves liturgical events for the Ambrosian rite (comune ambrosiano only; no diocesan overlay) for each day of the current year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi request body parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement. Readings are currently an empty placeholder (no Ambrosian lectionary yet); year cycles, first-vespers vigils, and psalter-week numbering are provisional pending ordo validation.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1027,8 +1030,11 @@
           }
         },
         "responses": {
-          "501": {
-            "$ref": "#/components/responses/NotImplemented501"
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1053,9 +1059,9 @@
         "security": [
           {}
         ],
-        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for each day of the given year (currently returns 501 Not Implemented)",
+        "summary": "Retrieve liturgical events from the Ambrosian calendar (comune ambrosiano) for each day of the given year",
         "operationId": "retrieveAmbrosianCalendarForYearGET",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
+        "description": "Retrieves liturgical events for the Ambrosian rite (comune ambrosiano only; no diocesan overlay) for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi query parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request. Readings are currently an empty placeholder (no Ambrosian lectionary yet); year cycles, first-vespers vigils, and psalter-week numbering are provisional pending ordo validation.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1083,8 +1089,11 @@
           }
         ],
         "responses": {
-          "501": {
-            "$ref": "#/components/responses/NotImplemented501"
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1107,9 +1116,9 @@
         "security": [
           {}
         ],
-        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for each day of the given year (currently returns 501 Not Implemented)",
+        "summary": "Retrieve liturgical events from the Ambrosian calendar (comune ambrosiano) for each day of the given year",
         "operationId": "retrieveAmbrosianCalendarForYearPOST",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for the Ambrosian rite for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi request body parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
+        "description": "Retrieves liturgical events for the Ambrosian rite (comune ambrosiano only; no diocesan overlay) for each day of the given year. There is no national layer for the Ambrosian rite. The epiphany, ascension, and corpus_christi request body parameters are accepted for consistency with the Roman rite endpoints but are IGNORED under the Ambrosian rite: Epiphany is fixed to January 6th, Ascension to the 40th day after Easter (Thursday), and Corpus Christi to its rite-fixed placement. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request. Readings are currently an empty placeholder (no Ambrosian lectionary yet); year cycles, first-vespers vigils, and psalter-week numbering are provisional pending ordo validation.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1161,8 +1170,11 @@
           }
         },
         "responses": {
-          "501": {
-            "$ref": "#/components/responses/NotImplemented501"
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianOrchestratorTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianOrchestratorTest.php
@@ -15,8 +15,8 @@ use LiturgicalCalendar\Api\Params\CalendarParams;
  * Plan 7 Task 9: `CalendarHandler::calculateAmbrosianCalendar()`, the single orchestrator that
  * assembles Tasks 3-8 (rite-aware Proprium de Tempore load, temporale engine, comune sanctorale,
  * season-stamping, precedence resolution, Holy Days of Obligation, year-cycles/vigils, psalter
- * week) into the exact call sequence the (still-501-gated) `/calendar/ambrosian` route will use
- * once Task 10 lifts the 501.
+ * week) into the exact call sequence the `/calendar/ambrosian` route now uses since Plan 7
+ * Task 10 lifted the 501 gate and wired this method into `handle()`.
  *
  * Unlike the per-task tests (`CalendarHandlerAmbrosianPrecedenceResolverTest`,
  * `LiturgicalEventCollectionAmbrosianPsalterWeekTest`, etc.), which manually chain the individual
@@ -26,9 +26,10 @@ use LiturgicalCalendar\Api\Params\CalendarParams;
  * `loadPropriumDeTemporeData()` + `TemporaleContext` + `RiteProfileFactory` construction) is
  * correct, not just that the individual passes work when chained by test code.
  *
- * The 501 gate in `handle()` is untouched: a real `/calendar/ambrosian` HTTP request still returns
- * 501. This test reaches the orchestrator only by reflection, exactly as the Task 5/6/7/8 tests
- * reach their respective methods.
+ * This test still reaches the orchestrator directly via reflection (rather than through
+ * `handle()`), exactly as the Task 5/6/7/8 tests reach their respective methods; the full
+ * `handle()` path (now live) is covered separately by `CalendarRiteRoutingTest`,
+ * `AmbrosianLitCalSchemaTest`, and `phpunit_tests/Routes/Readonly/AmbrosianCalendarTest`.
  */
 final class CalendarHandlerAmbrosianOrchestratorTest extends AbstractHandlerTestCase
 {

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianOrchestratorTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianOrchestratorTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\LocaleDateFormatter;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+
+/**
+ * Plan 7 Task 9: `CalendarHandler::calculateAmbrosianCalendar()`, the single orchestrator that
+ * assembles Tasks 3-8 (rite-aware Proprium de Tempore load, temporale engine, comune sanctorale,
+ * season-stamping, precedence resolution, Holy Days of Obligation, year-cycles/vigils, psalter
+ * week) into the exact call sequence the (still-501-gated) `/calendar/ambrosian` route will use
+ * once Task 10 lifts the 501.
+ *
+ * Unlike the per-task tests (`CalendarHandlerAmbrosianPrecedenceResolverTest`,
+ * `LiturgicalEventCollectionAmbrosianPsalterWeekTest`, etc.), which manually chain the individual
+ * passes together (each hand-building a `TemporaleContext` and invoking `AmbrosianTemporale`
+ * directly), this test invokes `calculateAmbrosianCalendar()` itself via reflection — it is the
+ * one seam that proves the orchestrator's own internal wiring (including its own
+ * `loadPropriumDeTemporeData()` + `TemporaleContext` + `RiteProfileFactory` construction) is
+ * correct, not just that the individual passes work when chained by test code.
+ *
+ * The 501 gate in `handle()` is untouched: a real `/calendar/ambrosian` HTTP request still returns
+ * 501. This test reaches the orchestrator only by reflection, exactly as the Task 5/6/7/8 tests
+ * reach their respective methods.
+ */
+final class CalendarHandlerAmbrosianOrchestratorTest extends AbstractHandlerTestCase
+{
+    private static string $originalPrimaryLanguage = '';
+    private static string $originalRuntimeLocale   = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$originalPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+        self::$originalRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = self::$originalPrimaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = self::$originalRuntimeLocale;
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * Builds a bare `CalendarHandler` with just enough state (`CalendarParams`, an empty `Cal`,
+     * and a `localeDateFormatter`) for `calculateAmbrosianCalendar()` to run — mirroring how
+     * `handle()` itself only ever calls `calculateUniversalCalendar()` after assigning
+     * `$this->Cal = new LiturgicalEventCollection($this->CalendarParams)`, and bypassing
+     * `prepareL10N()` (which needs a full request-locale round trip) in favour of setting
+     * `LitLocale::$PRIMARY_LANGUAGE`/`$RUNTIME_LOCALE` directly, exactly as the Task 5/6/7/8 tests
+     * do.
+     */
+    private function assembleHandler(int $year = 2025): CalendarHandler
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'it';
+        LitLocale::$RUNTIME_LOCALE   = 'it_IT';
+
+        $params = new CalendarParams();
+        $params->setRite(Rite::AMBROSIAN);
+        $params->setParams(['year' => $year, 'locale' => 'it']);
+
+        $handler = new CalendarHandler([], Rite::AMBROSIAN);
+
+        $handlerRef = new \ReflectionClass($handler);
+
+        $paramsProp = $handlerRef->getProperty('CalendarParams');
+        $paramsProp->setAccessible(true);
+        $paramsProp->setValue($handler, $params);
+
+        $calProp = $handlerRef->getProperty('Cal');
+        $calProp->setAccessible(true);
+        $calProp->setValue($handler, new LiturgicalEventCollection($params));
+
+        $localeDateFormatterProp = $handlerRef->getProperty('localeDateFormatter');
+        $localeDateFormatterProp->setAccessible(true);
+        $localeDateFormatterProp->setValue($handler, new LocaleDateFormatter(LitLocale::$RUNTIME_LOCALE));
+
+        return $handler;
+    }
+
+    private function runOrchestrator(CalendarHandler $handler): LiturgicalEventCollection
+    {
+        $handlerRef = new \ReflectionClass($handler);
+
+        $method = $handlerRef->getMethod('calculateAmbrosianCalendar');
+        $method->setAccessible(true);
+        $method->invoke($handler);
+
+        $calProp = $handlerRef->getProperty('Cal');
+        $calProp->setAccessible(true);
+        /** @var LiturgicalEventCollection $cal */
+        $cal = $calProp->getValue($handler);
+
+        return $cal;
+    }
+
+    /**
+     * The end-to-end proof: `StAmbrose` (7 December, a saint Solemnity in the Ambrosian comune
+     * sanctorale) coincides with `Advent4` (the fourth Ambrosian Advent Sunday) on 2025-12-07.
+     * Per the Tabella dei giorni liturgici, the privileged Sunday outranks the saint Solemnity, so
+     * `StAmbrose` transfers: 2025-12-08 is occupied by the Immaculate Conception (also a
+     * Solemnity), so `StAmbrose` anticipates instead to the preceding Saturday, 2025-12-06.
+     *
+     * This is the same result validated per-pass in
+     * `CalendarHandlerAmbrosianPrecedenceResolverTest`, now reached via the single orchestrator
+     * call.
+     */
+    public function testStAmbroseAnticipatesToDec6ViaSingleOrchestratorCall(): void
+    {
+        $handler = $this->assembleHandler(2025);
+        $cal     = $this->runOrchestrator($handler);
+
+        $stAmbrose = $cal->getLiturgicalEvent('StAmbrose');
+        self::assertNotNull($stAmbrose, 'Expected `StAmbrose` to survive the full orchestrator pipeline (transferred, not suppressed).');
+        self::assertFalse($cal->isSuppressed('StAmbrose'), 'Expected `StAmbrose` NOT to be suppressed.');
+        self::assertSame('2025-12-06', $stAmbrose->date->format('Y-m-d'));
+
+        $advent4 = $cal->getLiturgicalEvent('Advent4');
+        self::assertNotNull($advent4);
+        self::assertSame('2025-12-07', $advent4->date->format('Y-m-d'));
+    }
+
+    /**
+     * Completeness gate: every event surviving the full orchestrator pipeline has a non-null
+     * `liturgical_season` AND a non-null `psalter_week`. This is the handler-level analogue of the
+     * Plan 6 temporale-completeness gate and Task 8's psalter-week gap-free assertion, now checked
+     * against the fully assembled (temporale + sanctorale + resolved + cycled) collection.
+     */
+    public function testEveryEventHasSeasonAndPsalterWeekAfterOrchestrator(): void
+    {
+        $handler = $this->assembleHandler(2025);
+        $cal     = $this->runOrchestrator($handler);
+
+        $checked = 0;
+        foreach ($cal->getLiturgicalEvents() as $event) {
+            $checked++;
+            self::assertNotNull(
+                $event->liturgical_season,
+                sprintf(
+                    'Expected event `%s` (%s) to have a non-null liturgical_season after the full orchestrator pipeline.',
+                    $event->event_key ?? '(no event_key)',
+                    $event->date->format('Y-m-d')
+                )
+            );
+            self::assertNotNull(
+                $event->psalter_week,
+                sprintf(
+                    'Expected event `%s` (%s) to have a non-null psalter_week after the full orchestrator pipeline.',
+                    $event->event_key ?? '(no event_key)',
+                    $event->date->format('Y-m-d')
+                )
+            );
+        }
+
+        self::assertGreaterThan(0, $checked, 'Expected at least one liturgical event in the assembled collection.');
+    }
+
+    /**
+     * `Christmas` (25 December) must be marked as a Holy Day of Obligation once
+     * `setAmbrosianHolyDaysOfObligation()` has run as part of the orchestrator.
+     */
+    public function testChristmasIsMarkedHolyDayOfObligation(): void
+    {
+        $handler = $this->assembleHandler(2025);
+        $cal     = $this->runOrchestrator($handler);
+
+        $christmas = $cal->getLiturgicalEvent('Christmas');
+        self::assertNotNull($christmas, 'Expected a LiturgicalEvent for Christmas.');
+        self::assertTrue($christmas->holy_day_of_obligation, 'Expected Christmas to be marked as a Holy Day of Obligation.');
+    }
+
+    /**
+     * At least one Solemnity in the assembled collection has a synthesized `{key}_vigil` event,
+     * proving `setAmbrosianYearCyclesAndVigils()` ran as part of the orchestrator.
+     */
+    public function testAtLeastOneSolemnityHasAVigilEvent(): void
+    {
+        $handler = $this->assembleHandler(2025);
+        $cal     = $this->runOrchestrator($handler);
+
+        $vigilKeys = [];
+        foreach ($cal->getLiturgicalEvents() as $event) {
+            if (true === ( $event->is_vigil_mass ?? false )) {
+                $vigilKeys[] = $event->event_key;
+            }
+        }
+
+        self::assertNotEmpty($vigilKeys, 'Expected at least one synthesized `{key}_vigil` event after the orchestrator ran.');
+    }
+}

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianPrecedenceResolverTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianPrecedenceResolverTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\LocaleDateFormatter;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\AmbrosianTemporale;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleContext;
+use LiturgicalCalendar\Api\Models\PropriumDeTemporeMap;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use LiturgicalCalendar\Api\Utilities;
+
+/**
+ * Plan 7 Task 5: `CalendarHandler::resolveAmbrosianPrecedence()`.
+ *
+ * This is the end-to-end proof that the Ambrosian generation path — temporale (Task 3),
+ * comune sanctorale (Task 4), season-stamping (Task 6) — feeds real handler-assembled data
+ * into `AmbrosianPrecedenceResolver` (Plan 4) via a `PrecedenceContext`, and that the resolver
+ * fires correctly on it.
+ *
+ * For the 2025 Ambrosian year, `StAmbrose` (7 December, a saint Solemnity in the Ambrosian
+ * comune sanctorale) and `Advent4` (the fourth Sunday of Ambrosian Advent) both land on
+ * 2025-12-07 before resolution. Per the Tabella dei giorni liturgici, a privileged
+ * (Advent/Lent/Easter) Sunday outranks a saint Solemnity, so `StAmbrose` must transfer: the
+ * following Monday is 2025-12-08 (Immaculate Conception, itself a Solemnity, so occupied),
+ * which per the saint-Solemnity transfer rule means `StAmbrose` is instead anticipated to the
+ * preceding Saturday, 2025-12-06. This is the norm-correct result validated in Plan 6 and
+ * confirmed against the chiesadimilano.it ordo (see [[ambrosian-ordo-validation-source]]).
+ *
+ * The season-stamping pass (Task 6) MUST run before `resolve()`: the resolver's season-gated
+ * transfer rules read `liturgical_season`, which is `null` on every comune sanctorale event
+ * (including `StAmbrose`) until stamped.
+ */
+final class CalendarHandlerAmbrosianPrecedenceResolverTest extends AbstractHandlerTestCase
+{
+    private static string $originalPrimaryLanguage = '';
+    private static string $originalRuntimeLocale   = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$originalPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+        self::$originalRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = self::$originalPrimaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = self::$originalRuntimeLocale;
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * @param array<string> $messages
+     */
+    private function buildTemporaleContext(int $year, array &$messages): TemporaleContext
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'it';
+        LitLocale::$RUNTIME_LOCALE   = 'it_IT';
+
+        $dataFile = JsonData::AMBROSIAN_TEMPORALE_FILE->path();
+        $i18nFile = strtr(JsonData::AMBROSIAN_TEMPORALE_I18N_FILE->path(), ['{locale}' => 'it']);
+
+        $rawEvents = Utilities::jsonFileToObjectArray($dataFile);
+        /** @var array<string,string> $names */
+        $names = Utilities::jsonFileToArray($i18nFile);
+
+        $map = PropriumDeTemporeMap::fromObject($rawEvents);
+        $map->setNames($names);
+
+        $params = new CalendarParams();
+        $params->setParams(['year' => $year]);
+        $params->setRite(Rite::AMBROSIAN);
+
+        $cal = new LiturgicalEventCollection($params);
+
+        return new TemporaleContext(
+            $cal,
+            $params,
+            $map,
+            new LocaleDateFormatter(LitLocale::$RUNTIME_LOCALE),
+            $messages
+        );
+    }
+
+    /**
+     * Assembles the full 2025 Ambrosian temporale + comune sanctorale + season-stamping,
+     * returning the `CalendarHandler` instance itself (rather than just the collection) so the
+     * caller can also invoke `resolveAmbrosianPrecedence()` via reflection on the same instance
+     * (it reads `$this->Cal`, `$this->CalendarParams`, `$this->localeDateFormatter` internally).
+     *
+     * Mirrors `CalendarHandlerAmbrosianSeasonOnSanctoraleTest::assembleAmbrosianYear()`, adding
+     * the `stampAmbrosianSeasonOnSanctorale()` call that Task 6 introduced.
+     */
+    private function assembleAmbrosianYear(int $year = 2025): CalendarHandler
+    {
+        $messages = [];
+        $ctx      = $this->buildTemporaleContext($year, $messages);
+        ( new AmbrosianTemporale() )->buildTemporale($ctx);
+
+        $handler = new CalendarHandler([], Rite::AMBROSIAN);
+
+        $params = new CalendarParams();
+        $params->setRite(Rite::AMBROSIAN);
+        $params->setParams(['year' => $year, 'locale' => 'it']);
+
+        $handlerRef = new \ReflectionClass($handler);
+
+        $paramsProp = $handlerRef->getProperty('CalendarParams');
+        $paramsProp->setAccessible(true);
+        $paramsProp->setValue($handler, $params);
+
+        $calProp = $handlerRef->getProperty('Cal');
+        $calProp->setAccessible(true);
+        $calProp->setValue($handler, $ctx->cal);
+
+        $localeDateFormatterProp = $handlerRef->getProperty('localeDateFormatter');
+        $localeDateFormatterProp->setAccessible(true);
+        $localeDateFormatterProp->setValue($handler, new LocaleDateFormatter(LitLocale::$RUNTIME_LOCALE));
+
+        $sanctoraleMethod = $handlerRef->getMethod('addAmbrosianSanctoraleToCalendar');
+        $sanctoraleMethod->setAccessible(true);
+        $sanctoraleMethod->invoke($handler);
+
+        $ctx->cal->stampAmbrosianSeasonOnSanctorale();
+
+        return $handler;
+    }
+
+    public function testStAmbroseAnticipatesToDec6AfterResolvingAgainstAdvent4(): void
+    {
+        $handler    = $this->assembleAmbrosianYear(2025);
+        $handlerRef = new \ReflectionClass($handler);
+
+        $calProp = $handlerRef->getProperty('Cal');
+        $calProp->setAccessible(true);
+        /** @var LiturgicalEventCollection $cal */
+        $cal = $calProp->getValue($handler);
+
+        // BEFORE resolve(): StAmbrose and Advent4 both sit on 2025-12-07.
+        $stAmbroseBefore = $cal->getLiturgicalEvent('StAmbrose');
+        $advent4Before   = $cal->getLiturgicalEvent('Advent4');
+        self::assertNotNull($stAmbroseBefore, 'Expected `StAmbrose` to be present after the sanctorale step.');
+        self::assertNotNull($advent4Before, 'Expected `Advent4` to be present after the temporale step.');
+        self::assertSame('2025-12-07', $stAmbroseBefore->date->format('Y-m-d'));
+        self::assertSame('2025-12-07', $advent4Before->date->format('Y-m-d'));
+
+        $method = $handlerRef->getMethod('resolveAmbrosianPrecedence');
+        $method->setAccessible(true);
+        $method->invoke($handler);
+
+        // AFTER resolve(): StAmbrose has anticipated to 2025-12-06, and is not suppressed.
+        $stAmbroseAfter = $cal->getLiturgicalEvent('StAmbrose');
+        self::assertNotNull($stAmbroseAfter, 'Expected `StAmbrose` to still be present (transferred, not suppressed) after resolve().');
+        self::assertFalse($cal->isSuppressed('StAmbrose'), 'Expected `StAmbrose` NOT to be suppressed.');
+        self::assertSame('2025-12-06', $stAmbroseAfter->date->format('Y-m-d'));
+
+        // Advent4 itself is untouched (it is the winner of the coincidence).
+        $advent4After = $cal->getLiturgicalEvent('Advent4');
+        self::assertNotNull($advent4After);
+        self::assertSame('2025-12-07', $advent4After->date->format('Y-m-d'));
+
+        // StJuanDiego stays active on 2025-12-09, unaffected by the StAmbrose/Advent4 coincidence.
+        $stJuanDiego = $cal->getLiturgicalEvent('StJuanDiego');
+        self::assertNotNull($stJuanDiego, 'Expected `StJuanDiego` to be present.');
+        self::assertFalse($cal->isSuppressed('StJuanDiego'));
+        self::assertSame('2025-12-09', $stJuanDiego->date->format('Y-m-d'));
+    }
+}

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianResponseSchemaTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianResponseSchemaTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * Plan 7 Task 10 acceptance gate: the real, live `/calendar/ambrosian/{year}` response —
+ * generated end-to-end through `CalendarHandler::handle()` via `calculateAmbrosianCalendar()`
+ * (Task 9), now that the 501 gate is lifted — must validate against the full `LitCal.json`
+ * response schema, not just the `LiturgicalEvent` sub-schema exercised in isolation by
+ * `AmbrosianLitCalSchemaTest` (Task 1).
+ *
+ * This is what proves the Task 1 additions (the `AFTER_EPIPHANY`/`AFTER_PENTECOST` seasons and
+ * the optional `is_dominical`/`is_aliturgical` booleans) actually cover every event a real
+ * Ambrosian calculation produces — including the Task 9 empty-readings placeholder
+ * (`AmbrosianReadings::empty()`) on every temporale- and sanctorale-origin event, and the
+ * `psalter_week` value `LiturgicalEventCollection::calculatePsalterWeek()` back-fills.
+ */
+final class CalendarHandlerAmbrosianResponseSchemaTest extends AbstractHandlerTestCase
+{
+    private function handle(array $pathParts, string $uri): \Psr\Http\Message\ResponseInterface
+    {
+        // LiturgicalEvent::$internal_index (the source of event_idx) is a process-lifetime static
+        // counter — see GoldenMaster::normalize()'s docblock, which strips event_idx from golden
+        // fixture comparisons for the same reason. LitCal.json caps event_idx at 2000 (documented
+        // there as "starting from 0 for the first event that is calculated"), an assumption that
+        // only holds for a fresh process/request. Reset it here so this schema-validity assertion
+        // doesn't depend on how many other tests ran earlier in the same PHPUnit process.
+        $prop = new \ReflectionProperty(LiturgicalEvent::class, 'internal_index');
+        $prop->setValue(null, 0);
+
+        $handler = new CalendarHandler($pathParts, Rite::AMBROSIAN);
+        $handler->setAllowedReturnTypes([ReturnTypeParam::JSON]);
+        return $handler->handle($this->requestFor('GET', $uri, ['Accept' => 'application/json']));
+    }
+
+    public function testAmbrosianComune2025ResponseValidatesAgainstLitCalSchema(): void
+    {
+        $response = $this->handle(['2025'], '/calendar/ambrosian/2025');
+        self::assertSame(200, $response->getStatusCode());
+
+        $body = json_decode((string) $response->getBody(), flags: JSON_THROW_ON_ERROR);
+        self::assertInstanceOf(\stdClass::class, $body);
+        self::assertIsArray($body->litcal);
+        self::assertNotEmpty($body->litcal);
+
+        Schema::import(LitSchema::LITCAL->path())->in($body);
+        $this->addToAssertionCount(1);
+    }
+}

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianSanctoraleLoadTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianSanctoraleLoadTest.php
@@ -28,9 +28,10 @@ use LiturgicalCalendar\Api\Utilities;
  * would otherwise silently overwrite the temporale definition.
  *
  * These tests drive `addAmbrosianSanctoraleToCalendar()` directly via reflection (rather than
- * through `handle()`) because the Ambrosian rite still 501s at the top of `handle()` — this task
- * only builds a piece of the future Ambrosian generation path; a later orchestrator task (Task 9)
- * wires it into the real request flow and Task 10 removes the 501 gate.
+ * through `handle()`) because at the time this task was written the Ambrosian rite still 501-ed
+ * at the top of `handle()` — this task only built a piece of the future Ambrosian generation
+ * path; the orchestrator task (Task 9) wires it into the real request flow and Task 10 removed
+ * the 501 gate.
  *
  * The engine-wiring here (building a `TemporaleContext` and running
  * `AmbrosianTemporale::buildTemporale()`) is deliberately inlined rather than reusing

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianSanctoraleLoadTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianSanctoraleLoadTest.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\LocaleDateFormatter;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\AmbrosianTemporale;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleContext;
+use LiturgicalCalendar\Api\Models\Lectionary\AmbrosianReadings;
+use LiturgicalCalendar\Api\Models\PropriumDeTemporeMap;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use LiturgicalCalendar\Api\Utilities;
+
+/**
+ * Task 4 of Plan 7 (Ambrosian un-501 wiring): `CalendarHandler::addAmbrosianSanctoraleToCalendar()`
+ * loads the 254-row comune Ambrosian sanctorale (`AmbrosianSanctoraleLoader`) and adds every event
+ * to `$this->Cal`, unconditionally (the Ambrosian assembly model is "add everything, then resolve
+ * coincidences later" — unlike the Roman check-before-add convention). The only guard is an
+ * `event_key` collision against an event already present in `$this->Cal` (added earlier by the
+ * Proprium de Tempore load + temporale engine): `addLiturgicalEvent()` is keyed by `event_key` and
+ * would otherwise silently overwrite the temporale definition.
+ *
+ * These tests drive `addAmbrosianSanctoraleToCalendar()` directly via reflection (rather than
+ * through `handle()`) because the Ambrosian rite still 501s at the top of `handle()` — this task
+ * only builds a piece of the future Ambrosian generation path; a later orchestrator task (Task 9)
+ * wires it into the real request flow and Task 10 removes the 501 gate.
+ *
+ * The engine-wiring here (building a `TemporaleContext` and running
+ * `AmbrosianTemporale::buildTemporale()`) is deliberately inlined rather than reusing
+ * `AmbrosianTemporaleHarnessTrait` (used by the `Models/Calendar/Temporale` suite): that trait
+ * declares its own `setUpBeforeClass()`/`tearDownAfterClass()`, which would silently shadow
+ * `AbstractHandlerTestCase`'s (Router path pinning) instead of composing with it. Keeping the
+ * small amount of wiring local avoids that trap.
+ */
+final class CalendarHandlerAmbrosianSanctoraleLoadTest extends AbstractHandlerTestCase
+{
+    private static string $originalPrimaryLanguage = '';
+    private static string $originalRuntimeLocale   = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$originalPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+        self::$originalRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = self::$originalPrimaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = self::$originalRuntimeLocale;
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * Builds a `TemporaleContext` wired to the Ambrosian Proprium de Tempore for a given civil
+     * year, mirroring how `CalendarHandler` wires the temporale engine (and how
+     * `AmbrosianTemporaleHarnessTrait::buildContext()` does it for the `Models/Calendar/Temporale`
+     * suite).
+     *
+     * @param array<string> $messages
+     */
+    private function buildTemporaleContext(int $year, array &$messages): TemporaleContext
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'it';
+        LitLocale::$RUNTIME_LOCALE   = 'it_IT';
+
+        $dataFile = JsonData::AMBROSIAN_TEMPORALE_FILE->path();
+        $i18nFile = strtr(JsonData::AMBROSIAN_TEMPORALE_I18N_FILE->path(), ['{locale}' => 'it']);
+
+        $rawEvents = Utilities::jsonFileToObjectArray($dataFile);
+        /** @var array<string,string> $names */
+        $names = Utilities::jsonFileToArray($i18nFile);
+
+        $map = PropriumDeTemporeMap::fromObject($rawEvents);
+        $map->setNames($names);
+
+        $params = new CalendarParams();
+        $params->setParams(['year' => $year]);
+        $params->setRite(Rite::AMBROSIAN);
+
+        $cal = new LiturgicalEventCollection($params);
+
+        return new TemporaleContext(
+            $cal,
+            $params,
+            $map,
+            new LocaleDateFormatter(LitLocale::$RUNTIME_LOCALE),
+            $messages
+        );
+    }
+
+    /**
+     * Step 1 audit (Plan 7 Task 4): determine the ACTUAL overlap between the 254
+     * `propriumdesanctis_2024` sanctorale event_keys and the Ambrosian temporale keys — both the
+     * raw `propriumdetempore.json` keys and the full set of keys the temporale engine
+     * (`AmbrosianTemporale::buildTemporale()`) leaves in the calendar after running (i.e.
+     * including any keys the engine synthesizes/derives, and confirming none of the three
+     * raw-overlap keys are removed or renamed along the way).
+     *
+     * Finding: contrary to the Roman curation convention (where the sanctorale does not
+     * re-declare temporale-owned solemnities), the Ambrosian source data DOES declare
+     * `Christmas`, `Circoncisione`, and `Epiphany` in both
+     * `propriumdetempore/propriumdetempore.json` and
+     * `propriumdesanctis_2024/propriumdesanctis.json`. All three keys remain present in the
+     * temporale engine's output. This is exactly the overlap the task brief warned about, and it
+     * is real (not merely hypothetical) — `addAmbrosianSanctoraleToCalendar()`'s collision guard
+     * is exercised on every Ambrosian request, not just defensively.
+     */
+    public function testActualOverlapBetweenTemporaleAndSanctoraleKeysIsExactlyThreeKnownKeys(): void
+    {
+        $sanctoraleFile = JsonData::MISSALS_FOLDER->path() . '/ambrosian/propriumdesanctis_2024/propriumdesanctis.json';
+        $sanctoraleKeys = array_column(
+            json_decode((string) file_get_contents($sanctoraleFile), true, flags: JSON_THROW_ON_ERROR),
+            'event_key'
+        );
+        self::assertCount(254, $sanctoraleKeys, 'Expected 254 comune sanctorale event_keys in the source file.');
+
+        $rawTemporaleFile = JsonData::AMBROSIAN_TEMPORALE_FILE->path();
+        $rawTemporaleKeys = array_column(
+            json_decode((string) file_get_contents($rawTemporaleFile), true, flags: JSON_THROW_ON_ERROR),
+            'event_key'
+        );
+
+        $rawOverlap = array_values(array_intersect($rawTemporaleKeys, $sanctoraleKeys));
+        sort($rawOverlap);
+        self::assertSame(
+            ['Christmas', 'Circoncisione', 'Epiphany'],
+            $rawOverlap,
+            'Expected exactly these three keys to be declared in BOTH raw source files.'
+        );
+
+        // Confirm the engine doesn't remove/rename any of the three overlapping keys, and doesn't
+        // introduce any *other* synthesized key that also collides with the sanctorale.
+        $messages = [];
+        $ctx      = $this->buildTemporaleContext(2025, $messages);
+        ( new AmbrosianTemporale() )->buildTemporale($ctx);
+        $engineKeys = $ctx->cal->getLiturgicalEvents()->getKeys();
+
+        $engineOverlap = array_values(array_intersect($engineKeys, $sanctoraleKeys));
+        sort($engineOverlap);
+        self::assertSame(
+            ['Christmas', 'Circoncisione', 'Epiphany'],
+            $engineOverlap,
+            'Expected the temporale engine output to still collide with the sanctorale on exactly these three keys.'
+        );
+    }
+
+    /**
+     * Builds a `CalendarHandler` whose `$Cal` is pre-populated by the Ambrosian temporale engine
+     * (mirroring what will have already run, earlier in the real pipeline, by the time
+     * `addAmbrosianSanctoraleToCalendar()` executes), then invokes the new (private) method via
+     * reflection.
+     *
+     * @return array{0:LiturgicalEventCollection,1:array<int,string>}
+     */
+    private function runSanctoraleStep(int $year = 2025): array
+    {
+        $messages = [];
+        $ctx      = $this->buildTemporaleContext($year, $messages);
+        ( new AmbrosianTemporale() )->buildTemporale($ctx);
+
+        $handler = new CalendarHandler([], Rite::AMBROSIAN);
+
+        $params = new CalendarParams();
+        $params->setRite(Rite::AMBROSIAN);
+        $params->setParams(['year' => $year, 'locale' => 'it']);
+
+        $handlerRef = new \ReflectionClass($handler);
+
+        $paramsProp = $handlerRef->getProperty('CalendarParams');
+        $paramsProp->setAccessible(true);
+        $paramsProp->setValue($handler, $params);
+
+        $calProp = $handlerRef->getProperty('Cal');
+        $calProp->setAccessible(true);
+        $calProp->setValue($handler, $ctx->cal);
+
+        $method = $handlerRef->getMethod('addAmbrosianSanctoraleToCalendar');
+        $method->setAccessible(true);
+        $method->invoke($handler);
+
+        /** @var LiturgicalEventCollection $cal */
+        $cal = $calProp->getValue($handler);
+
+        $messagesProp = $handlerRef->getProperty('Messages');
+        $messagesProp->setAccessible(true);
+        /** @var array<int,string> $resultMessages */
+        $resultMessages = $messagesProp->getValue($handler);
+
+        return [$cal, $resultMessages];
+    }
+
+    public function testKnownComuneSaintIsAddedWithPlausibleDateAndGrade(): void
+    {
+        [$cal] = $this->runSanctoraleStep(2025);
+
+        $stAmbrose = $cal->getLiturgicalEvent('StAmbrose');
+        self::assertNotNull($stAmbrose, 'Expected `StAmbrose` to be present in the calendar after the sanctorale step.');
+        self::assertSame('2025-12-07', $stAmbrose->date->format('Y-m-d'));
+        self::assertSame(LitGrade::SOLEMNITY, $stAmbrose->grade);
+    }
+
+    public function testSanctoraleEventsCarryTheEmptyReadingsPlaceholder(): void
+    {
+        [$cal] = $this->runSanctoraleStep(2025);
+
+        $stAmbrose = $cal->getLiturgicalEvent('StAmbrose');
+        self::assertNotNull($stAmbrose);
+        self::assertTrue(isset($stAmbrose->readings), 'Expected `StAmbrose` to carry a readings object.');
+        self::assertSame(
+            AmbrosianReadings::empty()->jsonSerialize(),
+            $stAmbrose->readings->jsonSerialize(),
+            'Expected the readings to be the Task 2 empty-readings placeholder.'
+        );
+    }
+
+    public function testCollidingKeysAreSkippedAndTemporaleDefinitionWins(): void
+    {
+        $messages = [];
+        $ctx      = $this->buildTemporaleContext(2025, $messages);
+        ( new AmbrosianTemporale() )->buildTemporale($ctx);
+
+        // Capture the temporale-produced objects for the three colliding keys BEFORE running the
+        // sanctorale step, so we can assert identity (not merely equality) afterwards.
+        $temporaleChristmas     = $ctx->cal->getLiturgicalEvent('Christmas');
+        $temporaleCirconcisione = $ctx->cal->getLiturgicalEvent('Circoncisione');
+        $temporaleEpiphany      = $ctx->cal->getLiturgicalEvent('Epiphany');
+        self::assertNotNull($temporaleChristmas);
+        self::assertNotNull($temporaleCirconcisione);
+        self::assertNotNull($temporaleEpiphany);
+
+        $keysBefore = $ctx->cal->getLiturgicalEvents()->getKeys();
+
+        $handler = new CalendarHandler([], Rite::AMBROSIAN);
+
+        $params = new CalendarParams();
+        $params->setRite(Rite::AMBROSIAN);
+        $params->setParams(['year' => 2025, 'locale' => 'it']);
+
+        $handlerRef = new \ReflectionClass($handler);
+
+        $paramsProp = $handlerRef->getProperty('CalendarParams');
+        $paramsProp->setAccessible(true);
+        $paramsProp->setValue($handler, $params);
+
+        $calProp = $handlerRef->getProperty('Cal');
+        $calProp->setAccessible(true);
+        $calProp->setValue($handler, $ctx->cal);
+
+        $method = $handlerRef->getMethod('addAmbrosianSanctoraleToCalendar');
+        $method->setAccessible(true);
+        $method->invoke($handler);
+
+        /** @var LiturgicalEventCollection $cal */
+        $cal = $calProp->getValue($handler);
+
+        // The temporale definitions must NOT have been overwritten (same object identity).
+        self::assertSame($temporaleChristmas, $cal->getLiturgicalEvent('Christmas'));
+        self::assertSame($temporaleCirconcisione, $cal->getLiturgicalEvent('Circoncisione'));
+        self::assertSame($temporaleEpiphany, $cal->getLiturgicalEvent('Epiphany'));
+
+        // No duplicate/overwritten keys: exactly (254 - 3) new keys were added on top of the
+        // pre-existing temporale keys (3 sanctorale rows were skipped due to collision).
+        $keysAfter = $cal->getLiturgicalEvents()->getKeys();
+        self::assertCount(count($keysBefore) + ( 254 - 3 ), $keysAfter);
+        self::assertSame(count($keysAfter), count(array_unique($keysAfter)), 'Expected no duplicate event_keys in the collection.');
+
+        $messagesProp = $handlerRef->getProperty('Messages');
+        $messagesProp->setAccessible(true);
+        /** @var array<int,string> $resultMessages */
+        $resultMessages = $messagesProp->getValue($handler);
+
+        $joined = implode("\n", $resultMessages);
+        self::assertStringContainsString('Christmas', $joined);
+        self::assertStringContainsString('Circoncisione', $joined);
+        self::assertStringContainsString('Epiphany', $joined);
+    }
+}

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianSeasonOnSanctoraleTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianSeasonOnSanctoraleTest.php
@@ -35,8 +35,9 @@ use LiturgicalCalendar\Api\Utilities;
  *
  * This test builds the full 2025 Ambrosian temporale + comune sanctorale assembly exactly as
  * `CalendarHandlerAmbrosianSanctoraleLoadTest` does (temporale engine, then
- * `addAmbrosianSanctoraleToCalendar()` via reflection, since the Ambrosian rite still 501s before
- * `handle()` reaches this point in the real request flow — Task 9 wires the full pipeline).
+ * `addAmbrosianSanctoraleToCalendar()` via reflection) rather than through `handle()`, at the
+ * granularity of this single pass — the full pipeline is assembled by `calculateAmbrosianCalendar()`
+ * (Task 9) and wired into `handle()` by Task 10.
  */
 final class CalendarHandlerAmbrosianSeasonOnSanctoraleTest extends AbstractHandlerTestCase
 {

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianSeasonOnSanctoraleTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianSeasonOnSanctoraleTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\LitSeason;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\LocaleDateFormatter;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\AmbrosianTemporale;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleContext;
+use LiturgicalCalendar\Api\Models\PropriumDeTemporeMap;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use LiturgicalCalendar\Api\Utilities;
+
+/**
+ * Plan 7 Task 6, Part A: `LiturgicalEventCollection::stampAmbrosianSeasonOnSanctorale()`.
+ *
+ * The Ambrosian temporale engine (`AmbrosianTemporale::buildTemporale()`, Plan 7 Tasks 3/5)
+ * self-stamps `liturgical_season` on every temporale event it produces (via
+ * `LitSeason::forEventKey()`). The Ambrosian comune sanctorale
+ * (`CalendarHandler::addAmbrosianSanctoraleToCalendar()`, Plan 7 Task 4) carries no season
+ * information at all: sanctorale source rows have no `liturgical_season` field, so every
+ * sanctorale event lands in the collection with `liturgical_season === null`.
+ *
+ * `stampAmbrosianSeasonOnSanctorale()` closes that gap by copying the season from a co-located
+ * temporale event on the same date (`getCalEventsFromDate()`), falling back to
+ * `LitSeason::CHRISTMAS` for the one known gap date (Dec 26-31, where the deferred Ambrosian
+ * n.32 Christmas-octave-Sunday rule isn't implemented yet and so no seasoned temporale event
+ * exists on that date to copy from).
+ *
+ * This test builds the full 2025 Ambrosian temporale + comune sanctorale assembly exactly as
+ * `CalendarHandlerAmbrosianSanctoraleLoadTest` does (temporale engine, then
+ * `addAmbrosianSanctoraleToCalendar()` via reflection, since the Ambrosian rite still 501s before
+ * `handle()` reaches this point in the real request flow — Task 9 wires the full pipeline).
+ */
+final class CalendarHandlerAmbrosianSeasonOnSanctoraleTest extends AbstractHandlerTestCase
+{
+    private static string $originalPrimaryLanguage = '';
+    private static string $originalRuntimeLocale   = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$originalPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+        self::$originalRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = self::$originalPrimaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = self::$originalRuntimeLocale;
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * @param array<string> $messages
+     */
+    private function buildTemporaleContext(int $year, array &$messages): TemporaleContext
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'it';
+        LitLocale::$RUNTIME_LOCALE   = 'it_IT';
+
+        $dataFile = JsonData::AMBROSIAN_TEMPORALE_FILE->path();
+        $i18nFile = strtr(JsonData::AMBROSIAN_TEMPORALE_I18N_FILE->path(), ['{locale}' => 'it']);
+
+        $rawEvents = Utilities::jsonFileToObjectArray($dataFile);
+        /** @var array<string,string> $names */
+        $names = Utilities::jsonFileToArray($i18nFile);
+
+        $map = PropriumDeTemporeMap::fromObject($rawEvents);
+        $map->setNames($names);
+
+        $params = new CalendarParams();
+        $params->setParams(['year' => $year]);
+        $params->setRite(Rite::AMBROSIAN);
+
+        $cal = new LiturgicalEventCollection($params);
+
+        return new TemporaleContext(
+            $cal,
+            $params,
+            $map,
+            new LocaleDateFormatter(LitLocale::$RUNTIME_LOCALE),
+            $messages
+        );
+    }
+
+    /**
+     * Assembles the full 2025 Ambrosian temporale + comune sanctorale, mirroring
+     * `CalendarHandlerAmbrosianSanctoraleLoadTest::runSanctoraleStep()`.
+     */
+    private function assembleAmbrosianYear(int $year = 2025): LiturgicalEventCollection
+    {
+        $messages = [];
+        $ctx      = $this->buildTemporaleContext($year, $messages);
+        ( new AmbrosianTemporale() )->buildTemporale($ctx);
+
+        $handler = new CalendarHandler([], Rite::AMBROSIAN);
+
+        $params = new CalendarParams();
+        $params->setRite(Rite::AMBROSIAN);
+        $params->setParams(['year' => $year, 'locale' => 'it']);
+
+        $handlerRef = new \ReflectionClass($handler);
+
+        $paramsProp = $handlerRef->getProperty('CalendarParams');
+        $paramsProp->setAccessible(true);
+        $paramsProp->setValue($handler, $params);
+
+        $calProp = $handlerRef->getProperty('Cal');
+        $calProp->setAccessible(true);
+        $calProp->setValue($handler, $ctx->cal);
+
+        $method = $handlerRef->getMethod('addAmbrosianSanctoraleToCalendar');
+        $method->setAccessible(true);
+        $method->invoke($handler);
+
+        /** @var LiturgicalEventCollection $cal */
+        $cal = $calProp->getValue($handler);
+
+        return $cal;
+    }
+
+    /**
+     * `StJoseph` (19 March in the Ambrosian comune sanctorale) has no `liturgical_season` when
+     * first assembled (sanctorale rows carry none), and falls within Ambrosian Lent for 2025
+     * (Ambrosian `Lent1` 2025-03-09 .. `Easter` 2025-04-20): the temporale engine already produces
+     * a `LentWeekday*` ferial event on that same date (2025-03-19), which is where the season
+     * should be copied from.
+     */
+    public function testComuneSaintInLentHasNullSeasonBeforeStampingAndLentAfter(): void
+    {
+        $cal = $this->assembleAmbrosianYear(2025);
+
+        $stJoseph = $cal->getLiturgicalEvent('StJoseph');
+        self::assertNotNull($stJoseph, 'Expected `StJoseph` to be present after the sanctorale step.');
+        self::assertSame('2025-03-19', $stJoseph->date->format('Y-m-d'));
+        self::assertNull($stJoseph->liturgical_season, 'Expected the comune sanctorale event to carry no season before stamping.');
+
+        $cal->stampAmbrosianSeasonOnSanctorale();
+
+        self::assertSame(LitSeason::LENT, $stJoseph->liturgical_season);
+    }
+
+    /**
+     * Every event that already carries a `liturgical_season` (i.e. every temporale event) must be
+     * left untouched by the stamping pass.
+     */
+    public function testTemporaleEventsWithExistingSeasonAreNotOverwritten(): void
+    {
+        $cal = $this->assembleAmbrosianYear(2025);
+
+        $easter = $cal->getLiturgicalEvent('Easter');
+        self::assertNotNull($easter);
+        self::assertSame(LitSeason::EASTER, $easter->liturgical_season);
+
+        $cal->stampAmbrosianSeasonOnSanctorale();
+
+        self::assertSame(LitSeason::EASTER, $easter->liturgical_season);
+    }
+
+    /**
+     * `HolyInnocents` (28 December) is the one known date, for civil year 2025, with NO seasoned
+     * temporale event at all: 2025-12-28 is a Sunday, and the Ambrosian n.32
+     * Christmas-octave-Sunday rule (which would produce a proper Sunday-within-the-octave
+     * temporale event on that date) is deferred/not yet implemented, so the temporale engine
+     * leaves that date without a seasoned sibling. This exercises the `LitSeason::CHRISTMAS`
+     * fallback branch, which is correct regardless: Dec 26-31 is always within the Christmas
+     * octave.
+     */
+    public function testChristmasOctaveSundayGapFallsBackToChristmasSeason(): void
+    {
+        $cal = $this->assembleAmbrosianYear(2025);
+
+        // Sanity: confirm the known gap date has no seasoned sibling before asserting the fallback.
+        $holyInnocentsEvent = $cal->getLiturgicalEvent('HolyInnocents');
+        self::assertNotNull($holyInnocentsEvent);
+        self::assertSame('2025-12-28', $holyInnocentsEvent->date->format('Y-m-d'));
+        self::assertSame(7, (int) $holyInnocentsEvent->date->format('N'), 'Expected 2025-12-28 to be a Sunday for this fixture year.');
+
+        foreach ($cal->getCalEventsFromDate($holyInnocentsEvent->date) as $coincidingEvent) {
+            self::assertNull($coincidingEvent->liturgical_season, 'Expected no seasoned sibling event to already exist on the gap date.');
+        }
+
+        $cal->stampAmbrosianSeasonOnSanctorale();
+
+        self::assertSame(LitSeason::CHRISTMAS, $holyInnocentsEvent->liturgical_season);
+    }
+}

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianTemporeLoadTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianTemporeLoadTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Models\PropriumDeTemporeMap;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+
+/**
+ * Task 3 of Plan 7 (Ambrosian un-501 wiring): `CalendarHandler::loadPropriumDeTemporeData()`
+ * is called at the start of `calculateUniversalCalendar()`, BEFORE the rite dispatch that
+ * hands off to the rite's temporale engine. Prior to this task it was Roman-hardcoded, so an
+ * Ambrosian request would have calculated against the Roman Proprium de Tempore.
+ *
+ * These tests drive `loadPropriumDeTemporeData()` directly via reflection (rather than through
+ * `handle()`) because the Ambrosian rite still 501s at the top of `handle()` — this task only
+ * makes the tempore-load step rite-aware in preparation for the later orchestrator task that
+ * removes the 501 gate.
+ */
+final class CalendarHandlerAmbrosianTemporeLoadTest extends AbstractHandlerTestCase
+{
+    private static string $originalPrimaryLanguage = '';
+    private static string $originalRuntimeLocale   = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$originalPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+        self::$originalRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = self::$originalPrimaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = self::$originalRuntimeLocale;
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * Builds a CalendarHandler with CalendarParams wired for the given rite/locale/year via
+     * reflection (both `CalendarParams` and `loadPropriumDeTemporeData()` are private), then
+     * invokes the tempore-load step and returns the resulting `PropriumDeTempore` map.
+     */
+    private function loadTempore(Rite $rite, string $locale, int $year = 2025): PropriumDeTemporeMap
+    {
+        LitLocale::$PRIMARY_LANGUAGE = \Locale::getPrimaryLanguage($locale) ?? $locale;
+        LitLocale::$RUNTIME_LOCALE   = $locale;
+
+        $handler = new CalendarHandler([], $rite);
+
+        $params = new CalendarParams();
+        $params->setRite($rite);
+        $params->setParams(['year' => $year, 'locale' => $locale]);
+
+        $handlerRef = new \ReflectionClass($handler);
+        $paramsProp = $handlerRef->getProperty('CalendarParams');
+        $paramsProp->setAccessible(true);
+        $paramsProp->setValue($handler, $params);
+
+        $loadMethod = $handlerRef->getMethod('loadPropriumDeTemporeData');
+        $loadMethod->setAccessible(true);
+        $loadMethod->invoke($handler);
+
+        $temporeProp = $handlerRef->getProperty('PropriumDeTempore');
+        $temporeProp->setAccessible(true);
+        /** @var PropriumDeTemporeMap $tempore */
+        $tempore = $temporeProp->getValue($handler);
+        return $tempore;
+    }
+
+    public function testAmbrosianRiteLoadsAmbrosianTempore(): void
+    {
+        $tempore = $this->loadTempore(Rite::AMBROSIAN, 'it');
+
+        self::assertTrue(isset($tempore['Circoncisione']), 'Expected the Ambrosian-only key `Circoncisione` to be present.');
+        self::assertTrue(isset($tempore['DedicationDuomo']), 'Expected the Ambrosian-only key `DedicationDuomo` to be present.');
+        self::assertFalse(isset($tempore['AshWednesday']), 'Did not expect the Roman-only key `AshWednesday` to be present in the Ambrosian tempore.');
+    }
+
+    public function testAmbrosianRiteFallsBackToItalianForUnsupportedLocale(): void
+    {
+        // Ambrosian i18n only ships `it` and `la`; a requested locale outside that set
+        // (e.g. `en`) must fall back to Italian rather than erroring out.
+        $tempore = $this->loadTempore(Rite::AMBROSIAN, 'en');
+
+        self::assertTrue(isset($tempore['Circoncisione']));
+        self::assertSame('Circoncisione del Signore', $tempore['Circoncisione']->name);
+    }
+
+    public function testRomanRiteStillLoadsRomanTempore(): void
+    {
+        $tempore = $this->loadTempore(Rite::ROMAN, 'en');
+
+        self::assertTrue(isset($tempore['AshWednesday']), 'Expected the Roman-only key `AshWednesday` to be present.');
+        self::assertFalse(isset($tempore['Circoncisione']), 'Did not expect the Ambrosian-only key `Circoncisione` to be present in the Roman tempore.');
+    }
+}

--- a/phpunit_tests/Handlers/CalendarHandlerAmbrosianTemporeLoadTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerAmbrosianTemporeLoadTest.php
@@ -17,9 +17,9 @@ use LiturgicalCalendar\Api\Params\CalendarParams;
  * Ambrosian request would have calculated against the Roman Proprium de Tempore.
  *
  * These tests drive `loadPropriumDeTemporeData()` directly via reflection (rather than through
- * `handle()`) because the Ambrosian rite still 501s at the top of `handle()` — this task only
- * makes the tempore-load step rite-aware in preparation for the later orchestrator task that
- * removes the 501 gate.
+ * `handle()`) because at the time this task was written the Ambrosian rite still 501-ed at the
+ * top of `handle()` — this task only made the tempore-load step rite-aware in preparation for
+ * the later orchestrator task (Plan 7 Task 10) that removed the 501 gate.
  */
 final class CalendarHandlerAmbrosianTemporeLoadTest extends AbstractHandlerTestCase
 {

--- a/phpunit_tests/Handlers/CalendarRiteRoutingTest.php
+++ b/phpunit_tests/Handlers/CalendarRiteRoutingTest.php
@@ -42,14 +42,18 @@ final class CalendarRiteRoutingTest extends AbstractHandlerTestCase
         self::assertSame(200, $this->handle(['2025'], Rite::ROMAN, '/calendar/2025'));
     }
 
-    public function testAmbrosianComuneBaseReturns501(): void
+    /**
+     * Plan 7 Task 10 lifted the 501 gate: the comune ambrosiano now generates a real
+     * calendar via calculateAmbrosianCalendar() instead of throwing ImplementationException.
+     */
+    public function testAmbrosianComuneBaseReturns200(): void
     {
-        self::assertSame(StatusCode::NOT_IMPLEMENTED->value, $this->handle([], Rite::AMBROSIAN, '/calendar/ambrosian'));
+        self::assertSame(StatusCode::OK->value, $this->handle([], Rite::AMBROSIAN, '/calendar/ambrosian'));
     }
 
-    public function testAmbrosianComuneWithYearReturns501(): void
+    public function testAmbrosianComuneWithYearReturns200(): void
     {
-        self::assertSame(StatusCode::NOT_IMPLEMENTED->value, $this->handle(['2008'], Rite::AMBROSIAN, '/calendar/ambrosian/2008'));
+        self::assertSame(StatusCode::OK->value, $this->handle(['2008'], Rite::AMBROSIAN, '/calendar/ambrosian/2008'));
     }
 
     public function testAmbrosianRejectsNationalCalendarWith400(): void

--- a/phpunit_tests/Handlers/EventsHandlerRiteRoutingTest.php
+++ b/phpunit_tests/Handlers/EventsHandlerRiteRoutingTest.php
@@ -88,6 +88,14 @@ final class EventsHandlerRiteRoutingTest extends AbstractHandlerTestCase
         self::assertSame(StatusCode::BAD_REQUEST->value, $result['status']);
     }
 
+    public function testAmbrosianRejectsVANationalCalendarWith400(): void
+    {
+        // VA normalizes NationalCalendar to null in EventsParams, so this exercises the
+        // separate "VA was requested" marker rather than the plain non-null check.
+        $result = $this->handle(['nation', 'VA'], Rite::AMBROSIAN, '/events/ambrosian/nation/VA');
+        self::assertSame(StatusCode::BAD_REQUEST->value, $result['status']);
+    }
+
     public function testAmbrosianRejectsDiocesanCalendarWith400(): void
     {
         $result = $this->handle(['diocese', 'boston_us'], Rite::AMBROSIAN, '/events/ambrosian/diocese/boston_us');

--- a/phpunit_tests/Handlers/EventsHandlerRiteRoutingTest.php
+++ b/phpunit_tests/Handlers/EventsHandlerRiteRoutingTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\EventsHandler;
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use LiturgicalCalendar\Api\Http\Exception\ApiException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Plan 7 Task 12: the `/events` endpoint becomes rite-aware. `/events/ambrosian`
+ * must serve the Ambrosian comune catalog (temporale + comune sanctorale) instead
+ * of the Roman one, while a bare `/events` (Rite::ROMAN, the default) must remain
+ * byte-identical to its pre-Task-12 behavior.
+ *
+ * Mirrors {@see CalendarRiteRoutingTest}'s in-process handle()-with-Rite pattern.
+ */
+#[CoversClass(EventsHandler::class)]
+final class EventsHandlerRiteRoutingTest extends AbstractHandlerTestCase
+{
+    /**
+     * @param string[] $pathParts
+     * @return array{status:int,body:array<string,mixed>}
+     */
+    private function handle(array $pathParts, Rite $rite, string $uri): array
+    {
+        $handler = new EventsHandler($pathParts, $rite);
+        try {
+            $response = $handler->handle($this->requestFor('GET', $uri, ['Accept-Language' => 'en']));
+        } catch (ApiException $e) {
+            return ['status' => $e->getStatus(), 'body' => []];
+        }
+
+        return [
+            'status' => $response->getStatusCode(),
+            'body'   => $this->decodeJsonBody($response),
+        ];
+    }
+
+    /**
+     * @param array<int,array<string,mixed>> $events
+     * @return array<string,array<string,mixed>>
+     */
+    private static function byKey(array $events): array
+    {
+        $byKey = [];
+        foreach ($events as $event) {
+            $byKey[$event['event_key']] = $event;
+        }
+        return $byKey;
+    }
+
+    public function testRomanCatalogStillContainsRomanKeys(): void
+    {
+        // Regression guard: the Roman (default) branch must remain byte-identical.
+        $result = $this->handle([], Rite::ROMAN, '/events');
+        self::assertSame(200, $result['status']);
+
+        $byKey = self::byKey($result['body']['litcal_events']);
+        self::assertArrayHasKey('AshWednesday', $byKey, 'Roman-only temporale anchor must be present');
+        self::assertArrayNotHasKey('DedicationDuomo', $byKey, 'Ambrosian-only temporale event must NOT leak into the Roman catalog');
+    }
+
+    public function testAmbrosianCatalogContainsAmbrosianOnlyKeysNotRomanOnes(): void
+    {
+        $result = $this->handle([], Rite::AMBROSIAN, '/events/ambrosian');
+        self::assertSame(200, $result['status']);
+
+        $byKey = self::byKey($result['body']['litcal_events']);
+
+        // Ambrosian-only temporale anchor (Dedication of the Duomo of Milan) — absent from the Roman catalog.
+        self::assertArrayHasKey('DedicationDuomo', $byKey);
+        // Ambrosian comune sanctorale event.
+        self::assertArrayHasKey('Circoncisione', $byKey);
+        // Roman-only temporale anchor must NOT appear in the Ambrosian catalog.
+        self::assertArrayNotHasKey('AshWednesday', $byKey);
+
+        self::assertNull($result['body']['settings']['national_calendar']);
+        self::assertNull($result['body']['settings']['diocesan_calendar']);
+    }
+
+    public function testAmbrosianRejectsNationalCalendarWith400(): void
+    {
+        $result = $this->handle(['nation', 'US'], Rite::AMBROSIAN, '/events/ambrosian/nation/US');
+        self::assertSame(StatusCode::BAD_REQUEST->value, $result['status']);
+    }
+
+    public function testAmbrosianRejectsDiocesanCalendarWith400(): void
+    {
+        $result = $this->handle(['diocese', 'boston_us'], Rite::AMBROSIAN, '/events/ambrosian/diocese/boston_us');
+        self::assertSame(StatusCode::BAD_REQUEST->value, $result['status']);
+    }
+}

--- a/phpunit_tests/Handlers/MetadataHandlerTest.php
+++ b/phpunit_tests/Handlers/MetadataHandlerTest.php
@@ -37,8 +37,15 @@ final class MetadataHandlerTest extends AbstractHandlerTestCase
         self::assertArrayHasKey('diocesan_calendars_keys', $body['litcal_metadata']);
         self::assertArrayHasKey('wider_regions', $body['litcal_metadata']);
         self::assertArrayHasKey('locales', $body['litcal_metadata']);
+        self::assertArrayHasKey('ambrosian_calendars', $body['litcal_metadata']);
+        self::assertArrayHasKey('ambrosian_calendars_keys', $body['litcal_metadata']);
         // The "VA" General Roman calendar is always present.
         self::assertContains('VA', $body['litcal_metadata']['national_calendars_keys']);
+        // The Ambrosian comune calendar (/calendar/ambrosian) is always present.
+        self::assertContains('ambrosian', $body['litcal_metadata']['ambrosian_calendars_keys']);
+        self::assertContains('it', $body['litcal_metadata']['ambrosian_calendars'][0]['locales']);
+        self::assertContains('la', $body['litcal_metadata']['ambrosian_calendars'][0]['locales']);
+        self::assertSame('ambrosian', $body['litcal_metadata']['ambrosian_calendars'][0]['rite']);
     }
 
     public function testConditionalGetWithMatchingEtagReturns304(): void

--- a/phpunit_tests/Handlers/MetadataHandlerTest.php
+++ b/phpunit_tests/Handlers/MetadataHandlerTest.php
@@ -43,9 +43,15 @@ final class MetadataHandlerTest extends AbstractHandlerTestCase
         self::assertContains('VA', $body['litcal_metadata']['national_calendars_keys']);
         // The Ambrosian comune calendar (/calendar/ambrosian) is always present.
         self::assertContains('ambrosian', $body['litcal_metadata']['ambrosian_calendars_keys']);
-        self::assertContains('it', $body['litcal_metadata']['ambrosian_calendars'][0]['locales']);
-        self::assertContains('la', $body['litcal_metadata']['ambrosian_calendars'][0]['locales']);
-        self::assertSame('ambrosian', $body['litcal_metadata']['ambrosian_calendars'][0]['rite']);
+        // Locate the comune entry by calendar_id rather than assuming a fixed array index.
+        $ambrosianEntries = array_values(array_filter(
+            $body['litcal_metadata']['ambrosian_calendars'],
+            static fn (array $c): bool => ( $c['calendar_id'] ?? null ) === 'ambrosian'
+        ));
+        self::assertCount(1, $ambrosianEntries, 'Expected exactly one Ambrosian comune calendar entry');
+        self::assertContains('it', $ambrosianEntries[0]['locales']);
+        self::assertContains('la', $ambrosianEntries[0]['locales']);
+        self::assertSame('ambrosian', $ambrosianEntries[0]['rite']);
     }
 
     public function testConditionalGetWithMatchingEtagReturns304(): void

--- a/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianHdooTest.php
+++ b/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianHdooTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar;
+
+use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Plan 7 Task 6, Part B: `LiturgicalEventCollection::setAmbrosianHolyDaysOfObligation()`.
+ *
+ * Mirrors the rite-agnostic HDoO half of the Roman `setSeasonsAndHolyDaysOfObligation()`
+ * (`in_array($event_key, $HolyDaysOfObligation)` plus marking every Sunday), but sources its
+ * `event_key` set from `AmbrosianHolyDaysOfObligation::DEFAULT` (Ambrosian keys) instead of the
+ * Roman `CalendarParams::$HolyDaysOfObligation` default (Roman keys like `StJoseph` /
+ * `StsPeterPaulAp` / `CorpusChristi`, which don't exist in the Ambrosian calendar).
+ *
+ * This test builds a minimal, hand-populated `LiturgicalEventCollection` (three events: a known
+ * Ambrosian HDoO key on a weekday, an ordinary ferial weekday, and a Sunday that carries no HDoO
+ * key) rather than assembling a full Ambrosian year — the method under test only reads
+ * `event_key` and the date's day-of-week, so a minimal fixture is sufficient and keeps this test
+ * squarely a `Models/Calendar` unit test rather than a `Handlers` integration test.
+ *
+ * This still requires a real `CalendarParams` instance (required by the
+ * `LiturgicalEventCollection` constructor), which in turn needs `Router::$apiFilePath` pinned to
+ * read local source data - hence extending the `Handlers` layer's `AbstractHandlerTestCase`
+ * rather than plain `PHPUnit\Framework\TestCase`, even though this test lives under
+ * `Models/Calendar`.
+ */
+#[CoversClass(LiturgicalEventCollection::class)]
+final class LiturgicalEventCollectionAmbrosianHdooTest extends AbstractHandlerTestCase
+{
+    private function makeCollection(int $year = 2025): LiturgicalEventCollection
+    {
+        $params = new CalendarParams();
+        $params->setRite(Rite::AMBROSIAN);
+        $params->setParams(['year' => $year]);
+
+        return new LiturgicalEventCollection($params);
+    }
+
+    private function addEvent(LiturgicalEventCollection $cal, string $key, string $dayMonthYear): LiturgicalEvent
+    {
+        $event = new LiturgicalEvent($key, DateTime::fromFormat($dayMonthYear));
+        $cal->addLiturgicalEvent($key, $event);
+        return $event;
+    }
+
+    public function testKnownAmbrosianHdooKeyIsMarkedObligatory(): void
+    {
+        $cal = $this->makeCollection(2025);
+
+        // 25 December 2025 is a Thursday: this exercises the event_key branch of the HDoO check,
+        // not the Sunday branch.
+        $christmas = $this->addEvent($cal, 'Christmas', '25-12-2025');
+        self::assertFalse($christmas->holy_day_of_obligation);
+
+        $cal->setAmbrosianHolyDaysOfObligation();
+
+        self::assertTrue($christmas->holy_day_of_obligation);
+    }
+
+    public function testSundayIsMarkedObligatoryRegardlessOfEventKey(): void
+    {
+        $cal = $this->makeCollection(2025);
+
+        // 2 November 2025 is a Sunday; `AllSouls` is not in the Ambrosian HDoO key set, so this
+        // exercises the "every Sunday is obligatory" branch on its own.
+        $allSouls = $this->addEvent($cal, 'AllSouls', '2-11-2025');
+        self::assertSame(7, (int) $allSouls->date->format('N'));
+
+        $cal->setAmbrosianHolyDaysOfObligation();
+
+        self::assertTrue($allSouls->holy_day_of_obligation);
+    }
+
+    public function testOrdinaryFerialWeekdayIsNotMarkedObligatory(): void
+    {
+        $cal = $this->makeCollection(2025);
+
+        // 15 July 2025 is a Tuesday, and this fixture key is not in the Ambrosian HDoO key set.
+        $ferialWeekday = $this->addEvent($cal, 'OrdinaryFerialFixture', '15-7-2025');
+        self::assertSame(2, (int) $ferialWeekday->date->format('N'));
+
+        $cal->setAmbrosianHolyDaysOfObligation();
+
+        self::assertFalse($ferialWeekday->holy_day_of_obligation);
+    }
+}

--- a/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianPsalterWeekTest.php
+++ b/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianPsalterWeekTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\LocaleDateFormatter;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\AmbrosianTemporale;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleContext;
+use LiturgicalCalendar\Api\Models\Lectionary\AmbrosianReadings;
+use LiturgicalCalendar\Api\Models\PropriumDeTemporeMap;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use LiturgicalCalendar\Api\Utilities;
+use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Plan 7 Task 8: `LiturgicalEventCollection::calculatePsalterWeek()` run against the fully
+ * assembled Ambrosian collection (temporale -> comune sanctorale -> season-stamp -> precedence
+ * resolution -> year-cycles/vigils), the last of the per-event passes to exercise before Task 9's
+ * orchestrator wires them all into `CalendarHandler`'s request path (the Ambrosian `/calendar`
+ * route stays a 501 until then).
+ *
+ * `calculatePsalterWeek()` itself is a rite-agnostic gap-filler (it only fills `psalter_week`
+ * where it is still `null`: vigils inherit from the event they are a vigil for, Commemorations/
+ * Optional Memorials inherit from a same-day ferial event, everything else defaults to `0`) and
+ * needs no Ambrosian-specific change to work correctly on this collection. No change was made to
+ * `calculatePsalterWeek()` or to `addLiturgicalEvent()`'s psalter pre-stamp regex
+ * (`/(Advent|Lent|Easter)([1-7])/`, which also fires -- unguarded -- on Ambrosian
+ * `Advent1..6`/`Lent1..5`/`Easter2..7` keys); see the Task 8 report for the full rationale.
+ *
+ * **PROVISIONAL -- flagged for Plan 9 ordo validation.** The values the shared pre-stamp regex
+ * assigns to Ambrosian Advent/Lent/Easter Sunday keys come from the *Roman* `psalterWeek()`
+ * formula (`week % 4`, floored at 4), which is not necessarily how the Ambrosian psalter's own
+ * weekly cycle is numbered (Ambrosian Advent alone has 6 weeks, not 4, unlike Roman Advent's 4).
+ * Nothing downstream depends on this value being liturgically correct yet.
+ */
+#[CoversClass(LiturgicalEventCollection::class)]
+final class LiturgicalEventCollectionAmbrosianPsalterWeekTest extends AbstractHandlerTestCase
+{
+    private static string $originalPrimaryLanguage = '';
+    private static string $originalRuntimeLocale   = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        self::$originalPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+        self::$originalRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = self::$originalPrimaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = self::$originalRuntimeLocale;
+        parent::tearDownAfterClass();
+    }
+
+    /**
+     * @param array<string> $messages
+     */
+    private function buildTemporaleContext(int $year, array &$messages): TemporaleContext
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'it';
+        LitLocale::$RUNTIME_LOCALE   = 'it_IT';
+
+        $dataFile = JsonData::AMBROSIAN_TEMPORALE_FILE->path();
+        $i18nFile = strtr(JsonData::AMBROSIAN_TEMPORALE_I18N_FILE->path(), ['{locale}' => 'it']);
+
+        $rawEvents = Utilities::jsonFileToObjectArray($dataFile);
+        /** @var array<string,string> $names */
+        $names = Utilities::jsonFileToArray($i18nFile);
+
+        $map = PropriumDeTemporeMap::fromObject($rawEvents);
+        $map->setNames($names);
+
+        $params = new CalendarParams();
+        $params->setParams(['year' => $year]);
+        $params->setRite(Rite::AMBROSIAN);
+
+        $cal = new LiturgicalEventCollection($params);
+
+        return new TemporaleContext(
+            $cal,
+            $params,
+            $map,
+            new LocaleDateFormatter(LitLocale::$RUNTIME_LOCALE),
+            $messages
+        );
+    }
+
+    /**
+     * Assembles the full pipeline through `resolve()` for the given civil year: temporale (Plan
+     * 3) -> comune sanctorale (`CalendarHandler::addAmbrosianSanctoraleToCalendar()`, Plan 7 Task
+     * 4) -> season-stamping (`stampAmbrosianSeasonOnSanctorale()`, Task 6) -> precedence
+     * resolution (`resolveAmbrosianPrecedence()`, Task 5). Mirrors
+     * `CalendarHandlerAmbrosianPrecedenceResolverTest::assembleAmbrosianYear()` exactly, returning
+     * the bare `LiturgicalEventCollection` since this test only needs collection-level methods
+     * (`setAmbrosianYearCyclesAndVigils()`, `calculatePsalterWeek()`) afterwards.
+     */
+    private function assembleResolvedAmbrosianYear(int $year = 2025): LiturgicalEventCollection
+    {
+        $messages = [];
+        $ctx      = $this->buildTemporaleContext($year, $messages);
+        ( new AmbrosianTemporale() )->buildTemporale($ctx);
+
+        $handler = new CalendarHandler([], Rite::AMBROSIAN);
+
+        $params = new CalendarParams();
+        $params->setRite(Rite::AMBROSIAN);
+        $params->setParams(['year' => $year, 'locale' => 'it']);
+
+        $handlerRef = new \ReflectionClass($handler);
+
+        $paramsProp = $handlerRef->getProperty('CalendarParams');
+        $paramsProp->setAccessible(true);
+        $paramsProp->setValue($handler, $params);
+
+        $calProp = $handlerRef->getProperty('Cal');
+        $calProp->setAccessible(true);
+        $calProp->setValue($handler, $ctx->cal);
+
+        $localeDateFormatterProp = $handlerRef->getProperty('localeDateFormatter');
+        $localeDateFormatterProp->setAccessible(true);
+        $localeDateFormatterProp->setValue($handler, new LocaleDateFormatter(LitLocale::$RUNTIME_LOCALE));
+
+        $sanctoraleMethod = $handlerRef->getMethod('addAmbrosianSanctoraleToCalendar');
+        $sanctoraleMethod->setAccessible(true);
+        $sanctoraleMethod->invoke($handler);
+
+        $ctx->cal->stampAmbrosianSeasonOnSanctorale();
+
+        $resolveMethod = $handlerRef->getMethod('resolveAmbrosianPrecedence');
+        $resolveMethod->setAccessible(true);
+        $resolveMethod->invoke($handler);
+
+        return $ctx->cal;
+    }
+
+    /**
+     * Mirrors `LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest::
+     * assembleAmbrosianYearWithReadingsPlaceholder()`: in the real (future Task 9) pipeline every
+     * Ambrosian event carries a `readings` property (comune sanctorale rows get it from
+     * `addAmbrosianSanctoraleToCalendar()`; temporale-origin events don't yet, since nothing in
+     * the current, still-unwired pipeline stamps one onto them). `createVigilMassFor()` (reused
+     * as-is by `calculateAmbrosianVigilMass()`) reads `->readings` unconditionally, so this
+     * test-only helper closes that gap by stamping the same empty-readings placeholder onto any
+     * event that doesn't already have one.
+     */
+    private function withReadingsPlaceholder(LiturgicalEventCollection $cal): LiturgicalEventCollection
+    {
+        foreach ($cal->getLiturgicalEvents() as $event) {
+            if (false === isset($event->readings)) {
+                $event->setReadings(AmbrosianReadings::empty());
+            }
+        }
+
+        return $cal;
+    }
+
+    /**
+     * The acceptance gate: after the full pipeline (temporale -> sanctorale -> season-stamp ->
+     * resolve -> cycles/vigils) plus `calculatePsalterWeek()`, EVERY event in the collection has
+     * a non-null `psalter_week` (`0` is a valid, deliberate value from the gap-filler's default
+     * branch -- this asserts absence of `null`, not absence of `0`).
+     */
+    public function testEveryEventHasNonNullPsalterWeekAfterFullPipeline(): void
+    {
+        $cal = $this->assembleResolvedAmbrosianYear(2025);
+        $cal = $this->withReadingsPlaceholder($cal);
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+        $cal->calculatePsalterWeek();
+
+        foreach ($cal->getLiturgicalEvents() as $event) {
+            self::assertNotNull(
+                $event->psalter_week,
+                sprintf(
+                    'Expected event `%s` (%s) to have a non-null psalter_week after calculatePsalterWeek().',
+                    $event->event_key ?? '(no event_key)',
+                    $event->date->format('Y-m-d')
+                )
+            );
+        }
+    }
+
+    /**
+     * Spot-check: `Advent4` (2025-12-07, the fourth Ambrosian Advent Sunday -- see
+     * `AmbrosianRealYearPrecedenceTest`) already received a psalter_week at `addLiturgicalEvent()`
+     * time, via the shared (Roman-regex) pre-stamp `psalterWeek(4) === 4`. `calculatePsalterWeek()`
+     * is a gap-filler and must NOT overwrite an already-set value, so this value survives the full
+     * pipeline untouched. This documents the PROVISIONAL Roman-numbering value described in the
+     * class docblock, not a claim that `4` is the liturgically correct Ambrosian psalter week for
+     * Advent IV.
+     */
+    public function testAdventSundayKeepsProvisionalPreStampedPsalterWeek(): void
+    {
+        $cal = $this->assembleResolvedAmbrosianYear(2025);
+        $cal = $this->withReadingsPlaceholder($cal);
+
+        $advent4 = $cal->getLiturgicalEvent('Advent4');
+        self::assertNotNull($advent4, 'Expected a LiturgicalEvent for temporale key Advent4');
+        self::assertSame('2025-12-07', $advent4->date->format('Y-m-d'));
+        self::assertSame(
+            LiturgicalEventCollection::psalterWeek(4),
+            $advent4->psalter_week,
+            'Expected Advent4 to already carry the Roman-regex pre-stamped psalter_week before calculatePsalterWeek() runs.'
+        );
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+        $cal->calculatePsalterWeek();
+
+        self::assertSame(
+            LiturgicalEventCollection::psalterWeek(4),
+            $advent4->psalter_week,
+            'Expected calculatePsalterWeek() (a gap-filler) not to overwrite an already-set psalter_week.'
+        );
+    }
+
+    /**
+     * Spot-check: an after-Pentecost ferial weekday (`AfterPentecostWeekday1Tuesday`, 2025-06-10,
+     * grade WEEKDAY) does not match any of `addLiturgicalEvent()`'s psalter pre-stamp branches
+     * (its key contains neither `Advent`/`Lent`/`Easter` immediately followed by a digit 1-7, nor
+     * `OrdSunday`), so `psalter_week` is still `null` going into `calculatePsalterWeek()`. As a
+     * plain weekday (not a vigil, not a Commemoration/Optional Memorial), it falls through to the
+     * gap-filler's default branch and is assigned `0`.
+     *
+     * (The sibling key `AfterPentecostWeekday1Monday`, 2025-06-09, is NOT used here: once
+     * `resolveAmbrosianPrecedence()` runs, that particular Monday's ferial loses to a
+     * higher-precedence comune sanctorale event occupying the same date and ends up suppressed --
+     * a real precedence outcome, not a bug, but it means that key is no longer present in
+     * `getLiturgicalEvents()` by the time this test's assertions run, so it would be a poor choice
+     * of fixture for a psalter_week spot-check. `AfterPentecostWeekday1Tuesday` remains active and
+     * exercises the same gap-filler branch just as well.)
+     */
+    public function testAfterPentecostFerialWeekdayGetsZeroFromGapFiller(): void
+    {
+        $cal = $this->assembleResolvedAmbrosianYear(2025);
+        $cal = $this->withReadingsPlaceholder($cal);
+
+        $weekday = $cal->getLiturgicalEvent('AfterPentecostWeekday1Tuesday');
+        self::assertNotNull($weekday, 'Expected a LiturgicalEvent for AfterPentecostWeekday1Tuesday');
+        self::assertSame('2025-06-10', $weekday->date->format('Y-m-d'));
+        self::assertSame(LitGrade::WEEKDAY, $weekday->grade);
+        self::assertNull($weekday->psalter_week, 'Expected psalter_week to still be null before calculatePsalterWeek() runs.');
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+        $cal->calculatePsalterWeek();
+
+        self::assertSame(0, $weekday->psalter_week);
+    }
+
+    /**
+     * Spot-check: `Assumption` (2025-08-15, grade SOLEMNITY, not a Sunday, not week-numbered) has
+     * no pre-stamp and so is `null` going into the gap-filler, which sets it to `0`. Its
+     * synthesized `Assumption_vigil` (created by `setAmbrosianYearCyclesAndVigils()` via
+     * `calculateAmbrosianVigilMass()`, which adds directly to the events map and bypasses
+     * `addLiturgicalEvent()` entirely) is also `null` beforehand, exercising the
+     * vigil-inherits-from-parent branch of `calculatePsalterWeek()`.
+     */
+    public function testAssumptionVigilInheritsPsalterWeekFromParentEvent(): void
+    {
+        $cal = $this->assembleResolvedAmbrosianYear(2025);
+        $cal = $this->withReadingsPlaceholder($cal);
+
+        $assumption = $cal->getLiturgicalEvent('Assumption');
+        self::assertNotNull($assumption, 'Expected a LiturgicalEvent for comune sanctorale key Assumption');
+        self::assertNull($assumption->psalter_week);
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+
+        $vigil = $cal->getLiturgicalEvent('Assumption_vigil');
+        self::assertNotNull($vigil, 'Expected a LiturgicalEvent for the synthesized Assumption_vigil key');
+        self::assertNull($vigil->psalter_week, 'Expected the vigil to have no psalter_week yet (created outside addLiturgicalEvent()).');
+
+        $cal->calculatePsalterWeek();
+
+        self::assertNotNull($assumption->psalter_week);
+        self::assertSame(0, $assumption->psalter_week);
+        self::assertSame($assumption->psalter_week, $vigil->psalter_week);
+    }
+}

--- a/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest.php
+++ b/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar;
+
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Enum\LitSeason;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Models\Lectionary\AmbrosianReadings;
+use LiturgicalCalendar\Tests\Models\Calendar\Sanctorale\AmbrosianRealYearHarnessTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Plan 7 Task 7: `LiturgicalEventCollection::setAmbrosianYearCyclesAndVigils()` (Part A: A/B/C +
+ * I/II `liturgical_year` cycles) and `calculateAmbrosianVigilMass()` /
+ * `ambrosianEventCanHaveVigil()` (Part B: first-vespers vigils).
+ *
+ * Reuses `AmbrosianRealYearHarnessTrait::assembleAmbrosianYear()` (Plan 5 Task 8) to build a real
+ * civil-year Ambrosian `LiturgicalEventCollection` out of the temporale engine + comune
+ * sanctorale, exactly as `AmbrosianRealYearAssemblyTest` does. The temporale engine already
+ * self-stamps `liturgical_season` on every event it produces (`LitSeason::forEventKey()`), so the
+ * weekday-cycle guard (`liturgical_season` in {AFTER_EPIPHANY, AFTER_PENTECOST}) is already
+ * satisfiable without a separate `stampAmbrosianSeasonOnSanctorale()` pass for the temporale-origin
+ * events this test exercises.
+ *
+ * Both new methods are standalone/unit-testable and not yet wired into `CalendarHandler`'s request
+ * path (Task 9 wires them); the Ambrosian `/calendar` route stays a 501 until then.
+ */
+#[CoversClass(LiturgicalEventCollection::class)]
+final class LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest extends TestCase
+{
+    use AmbrosianRealYearHarnessTrait;
+
+    /**
+     * `createVigilMassFor()` (reused as-is by `calculateAmbrosianVigilMass()`) reads
+     * `$eventForWhichIsVigilMass->readings` to decide whether to copy a `->vigil` sub-schema, so
+     * every event needs an initialized `readings` property before `setAmbrosianYearCyclesAndVigils()`
+     * runs. In the real (future Task 9) request pipeline every Ambrosian event is given the Task
+     * 2/4 empty-readings placeholder ({@see AmbrosianReadings::empty()}) — `CalendarHandler::
+     * addAmbrosianSanctoraleToCalendar()` already does this for comune sanctorale rows, but the
+     * temporale-origin events assembled by `AmbrosianRealYearHarnessTrait` (which does not go
+     * through `CalendarHandler`) do not yet carry one. This test-only helper closes that gap by
+     * stamping the same placeholder onto any event that doesn't already have one, exactly
+     * mirroring what a full pipeline run would have already done.
+     */
+    private function assembleAmbrosianYearWithReadingsPlaceholder(int $year): LiturgicalEventCollection
+    {
+        $cal = $this->assembleAmbrosianYear($year);
+
+        foreach ($cal->getLiturgicalEvents() as $event) {
+            if (false === isset($event->readings)) {
+                $event->setReadings(AmbrosianReadings::empty());
+            }
+        }
+
+        return $cal;
+    }
+
+    // --- Part A: year cycles -------------------------------------------------------------
+
+    /**
+     * `PalmSun` (2025-04-13) is a Sunday that falls before `Advent1` (2025-11-16), so its festive
+     * cycle is computed from the "before Advent1" branch: `SUNDAY_CYCLE[(Year - 1) % 3]`.
+     */
+    public function testSunday2025HasCorrectFestiveCycleBeforeAdvent(): void
+    {
+        $cal = $this->assembleAmbrosianYearWithReadingsPlaceholder(2025);
+
+        $palmSun = $cal->getLiturgicalEvent('PalmSun');
+        self::assertNotNull($palmSun, 'Expected a LiturgicalEvent for temporale key PalmSun');
+        self::assertSame(7, (int) $palmSun->date->format('N'), 'Expected PalmSun to fall on a Sunday.');
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+
+        $expectedCycle = LiturgicalEventCollection::SUNDAY_CYCLE[( 2025 - 1 ) % 3];
+        self::assertNotNull($palmSun->liturgical_year);
+        self::assertStringEndsWith(' ' . $expectedCycle, $palmSun->liturgical_year);
+    }
+
+    /**
+     * `AfterPentecostWeekday1Monday` (2025-06-09) is a ferial weekday whose `liturgical_season` is
+     * `AFTER_PENTECOST` (stamped by the temporale engine itself), so it should receive the I/II
+     * weekday cycle: `WEEKDAY_CYCLE[(Year - 1) % 2]`.
+     */
+    public function testAfterPentecostFerialWeekday2025HasCorrectWeekdayCycle(): void
+    {
+        $cal = $this->assembleAmbrosianYearWithReadingsPlaceholder(2025);
+
+        $weekday = $cal->getLiturgicalEvent('AfterPentecostWeekday1Monday');
+        self::assertNotNull($weekday, 'Expected a LiturgicalEvent for AfterPentecostWeekday1Monday');
+        self::assertSame(LitGrade::WEEKDAY, $weekday->grade);
+        self::assertSame(LitSeason::AFTER_PENTECOST, $weekday->liturgical_season);
+        self::assertSame(1, (int) $weekday->date->format('N'), 'Expected AfterPentecostWeekday1Monday to fall on a Monday.');
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+
+        $expectedCycle = LiturgicalEventCollection::WEEKDAY_CYCLE[( 2025 - 1 ) % 2];
+        self::assertNotNull($weekday->liturgical_year);
+        self::assertStringEndsWith(' ' . $expectedCycle, $weekday->liturgical_year);
+    }
+
+    /**
+     * `Christmas`, `Circoncisione`, and `Epiphany` are fixed-date temporale events whose readings
+     * (and, by the same rule, their `liturgical_year`) do not follow a cycle — the Ambrosian
+     * equivalent of the Roman exclusion list (`Christmas`, `MaryMotherOfGod`, `Christmas2`,
+     * `Epiphany`, `AshWednesday`). All three still qualify for the Sunday/high-grade branch
+     * (grade > FEAST), so this specifically exercises the key-exclusion, not a grade mismatch.
+     */
+    public function testFixedDateTemporaleEventsHaveNullLiturgicalYear(): void
+    {
+        $cal = $this->assembleAmbrosianYearWithReadingsPlaceholder(2025);
+        $cal->setAmbrosianYearCyclesAndVigils();
+
+        foreach (['Christmas', 'Circoncisione', 'Epiphany'] as $key) {
+            $event = $cal->getLiturgicalEvent($key);
+            self::assertNotNull($event, "Expected a LiturgicalEvent for temporale key {$key}");
+            self::assertGreaterThan(LitGrade::FEAST->value, $event->grade->value, "Expected {$key} to qualify for the Sunday/high-grade branch.");
+            self::assertNull($event->liturgical_year, "Expected {$key} to have a null liturgical_year (fixed-date, no cycle).");
+        }
+    }
+
+    // --- Part B: first-vespers vigils ------------------------------------------------------
+
+    /**
+     * `Assumption` (2025-08-15, a Friday) is a Solemnity (`grade === LitGrade::SOLEMNITY`) that
+     * does NOT fall on a Sunday, so it specifically exercises the `grade >= SOLEMNITY` half of
+     * `ambrosianEventCanHaveVigil()`'s eligibility test, and falls well outside the Triduum
+     * exclusion window.
+     */
+    public function testAssumption2025GetsVigilMassAndVesperFlags(): void
+    {
+        $cal = $this->assembleAmbrosianYearWithReadingsPlaceholder(2025);
+
+        $assumption = $cal->getLiturgicalEvent('Assumption');
+        self::assertNotNull($assumption, 'Expected a LiturgicalEvent for comune sanctorale key Assumption');
+        self::assertSame('2025-08-15', $assumption->date->format('Y-m-d'));
+        self::assertSame(LitGrade::SOLEMNITY, $assumption->grade);
+        self::assertSame(5, (int) $assumption->date->format('N'), 'Expected 2025-08-15 to be a Friday for this fixture year.');
+        self::assertNull($assumption->has_vigil_mass);
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+
+        self::assertTrue($assumption->has_vigil_mass);
+        self::assertTrue($assumption->has_vesper_i);
+        self::assertTrue($assumption->has_vesper_ii);
+
+        $vigil = $cal->getLiturgicalEvent('Assumption_vigil');
+        self::assertNotNull($vigil, 'Expected a LiturgicalEvent for the synthesized Assumption_vigil key');
+        self::assertSame('2025-08-14', $vigil->date->format('Y-m-d'));
+        self::assertTrue($vigil->is_vigil_mass);
+        self::assertSame('Assumption', $vigil->is_vigil_for);
+    }
+
+    /**
+     * `DedicationDuomo` (2025-10-19, a Sunday) is a temporale anchor with grade
+     * `HIGHER_SOLEMNITY`; this specifically exercises the `dateIsSunday()` half of
+     * `ambrosianEventCanHaveVigil()`'s eligibility test.
+     */
+    public function testDedicationDuomo2025GetsVigilMassAndVesperFlags(): void
+    {
+        $cal = $this->assembleAmbrosianYearWithReadingsPlaceholder(2025);
+
+        $dedication = $cal->getLiturgicalEvent('DedicationDuomo');
+        self::assertNotNull($dedication, 'Expected a LiturgicalEvent for temporale key DedicationDuomo');
+        self::assertSame('2025-10-19', $dedication->date->format('Y-m-d'));
+        self::assertSame(7, (int) $dedication->date->format('N'), 'Expected DedicationDuomo 2025 to fall on a Sunday.');
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+
+        self::assertTrue($dedication->has_vigil_mass);
+        self::assertTrue($dedication->has_vesper_i);
+        self::assertTrue($dedication->has_vesper_ii);
+
+        $vigil = $cal->getLiturgicalEvent('DedicationDuomo_vigil');
+        self::assertNotNull($vigil, 'Expected a LiturgicalEvent for the synthesized DedicationDuomo_vigil key');
+        self::assertSame('2025-10-18', $vigil->date->format('Y-m-d'));
+        self::assertTrue($vigil->is_vigil_mass);
+        self::assertSame('DedicationDuomo', $vigil->is_vigil_for);
+    }
+
+    /**
+     * A plain ferial weekday outside the Ambrosian "ordinary" seasons (e.g. an Advent weekday)
+     * must NOT be eligible for a vigil: `ambrosianEventCanHaveVigil()` requires
+     * `dateIsSunday() || grade >= SOLEMNITY`, and a ferial weekday satisfies neither.
+     */
+    public function testAdventFerialWeekdayDoesNotGetVigilMass(): void
+    {
+        $cal = $this->assembleAmbrosianYearWithReadingsPlaceholder(2025);
+
+        $weekday = $cal->getLiturgicalEvent('AfterPentecostWeekday1Monday');
+        self::assertNotNull($weekday);
+        self::assertSame(LitGrade::WEEKDAY, $weekday->grade);
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+
+        self::assertNull($cal->getLiturgicalEvent('AfterPentecostWeekday1Monday_vigil'));
+    }
+}

--- a/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest.php
+++ b/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest.php
@@ -181,6 +181,29 @@ final class LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest extends Te
     }
 
     /**
+     * `Easter` and `Easter2` are anchored temporale events (Easter Sunday is preceded by its own
+     * `EasterVigil`; Easter II opens the octave), so `ambrosianEventCanHaveVigil()` excludes them
+     * by key — no synthesized `Easter_vigil`/`Easter2_vigil` may be created even though both are
+     * Sundays of grade HIGHER_SOLEMNITY that would otherwise pass the eligibility predicate.
+     */
+    public function testEasterAndEaster2GetNoSynthesizedVigil2025(): void
+    {
+        $cal = $this->assembleAmbrosianYearWithReadingsPlaceholder(2025);
+
+        $easter  = $cal->getLiturgicalEvent('Easter');
+        $easter2 = $cal->getLiturgicalEvent('Easter2');
+        self::assertNotNull($easter, 'Expected a LiturgicalEvent for temporale key Easter');
+        self::assertNotNull($easter2, 'Expected a LiturgicalEvent for temporale key Easter2');
+
+        $cal->setAmbrosianYearCyclesAndVigils();
+
+        self::assertNull($cal->getLiturgicalEvent('Easter_vigil'), 'Easter must not get a synthesized replacement vigil (EasterVigil already anchors it).');
+        self::assertNull($cal->getLiturgicalEvent('Easter2_vigil'), 'Easter2 must not get a synthesized replacement vigil.');
+        self::assertNull($easter->has_vigil_mass, 'Easter must not be flagged as having a vigil mass.');
+        self::assertNull($easter2->has_vigil_mass, 'Easter2 must not be flagged as having a vigil mass.');
+    }
+
+    /**
      * A plain ferial weekday outside the Ambrosian "ordinary" seasons (e.g. an Advent weekday)
      * must NOT be eligible for a vigil: `ambrosianEventCanHaveVigil()` requires
      * `dateIsSunday() || grade >= SOLEMNITY`, and a ferial weekday satisfies neither.

--- a/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest.php
+++ b/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest.php
@@ -182,7 +182,8 @@ final class LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest extends Te
 
     /**
      * `Easter` and `Easter2` are anchored temporale events (Easter Sunday is preceded by its own
-     * `EasterVigil`; Easter II opens the octave), so `ambrosianEventCanHaveVigil()` excludes them
+     * `EasterVigil`; Easter II is the octave day of Easter, whose eve is itself the Saturday within
+     * the Easter octave), so `ambrosianEventCanHaveVigil()` excludes them
      * by key — no synthesized `Easter_vigil`/`Easter2_vigil` may be created even though both are
      * Sundays of grade HIGHER_SOLEMNITY that would otherwise pass the eligibility predicate.
      */

--- a/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest.php
+++ b/phpunit_tests/Models/Calendar/LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest.php
@@ -195,6 +195,14 @@ final class LiturgicalEventCollectionAmbrosianYearCyclesAndVigilsTest extends Te
         self::assertNotNull($easter, 'Expected a LiturgicalEvent for temporale key Easter');
         self::assertNotNull($easter2, 'Expected a LiturgicalEvent for temporale key Easter2');
 
+        // Precondition: both would otherwise SATISFY the eligibility predicate (a Sunday of grade
+        // HIGHER_SOLEMNITY), so the absence of a vigil below proves the exclusion is by KEY, not
+        // an incidental consequence of the date/grade conditions.
+        self::assertSame(7, (int) $easter->date->format('N'), 'Expected Easter 2025 to fall on a Sunday.');
+        self::assertSame(7, (int) $easter2->date->format('N'), 'Expected Easter II 2025 to fall on a Sunday.');
+        self::assertSame(LitGrade::HIGHER_SOLEMNITY, $easter->grade);
+        self::assertSame(LitGrade::HIGHER_SOLEMNITY, $easter2->grade);
+
         $cal->setAmbrosianYearCyclesAndVigils();
 
         self::assertNull($cal->getLiturgicalEvent('Easter_vigil'), 'Easter must not get a synthesized replacement vigil (EasterVigil already anchors it).');

--- a/phpunit_tests/Models/Lectionary/AmbrosianReadingsTest.php
+++ b/phpunit_tests/Models/Lectionary/AmbrosianReadingsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Lectionary;
+
+use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use LiturgicalCalendar\Api\Models\Lectionary\AmbrosianReadings;
+use LiturgicalCalendar\Api\Models\Lectionary\ReadingsFerial;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * Unit tests for the Ambrosian empty-readings placeholder (Plan 7 / Task 2).
+ *
+ * There is no Ambrosian lectionary data source yet, but the `LitCal.json` response schema
+ * requires every `LiturgicalEvent` to carry a `readings` property that validates against
+ * `CommonDef.json#/definitions/Readings`. `AmbrosianReadings::empty()` produces a structurally
+ * valid, content-empty `ReadingsFerial` instance (the simplest of the `ReadingsAbstract`
+ * subclasses: only `first_reading`, `responsorial_psalm`, `gospel_acclamation`, and `gospel`,
+ * all plain strings) to serve as that placeholder until a real Ambrosian lectionary is wired in.
+ */
+#[CoversClass(AmbrosianReadings::class)]
+final class AmbrosianReadingsTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // LitSchema / JsonData path resolution depends on Router::$apiFilePath.
+        Router::getApiPaths();
+    }
+
+    private static function readingsSchema(): Schema
+    {
+        $commonDefPath = JsonData::SCHEMAS_FOLDER->path() . '/CommonDef.json';
+        return Schema::import($commonDefPath . '#/definitions/Readings');
+    }
+
+    public function testEmptyReturnsReadingsFerialInstance(): void
+    {
+        $readings = AmbrosianReadings::empty();
+
+        self::assertInstanceOf(ReadingsFerial::class, $readings);
+    }
+
+    public function testEmptyHasBlankStringFields(): void
+    {
+        $readings   = AmbrosianReadings::empty();
+        $serialized = $readings->jsonSerialize();
+
+        self::assertSame(
+            [
+                'first_reading'      => '',
+                'responsorial_psalm' => '',
+                'gospel_acclamation' => '',
+                'gospel'             => '',
+            ],
+            $serialized
+        );
+    }
+
+    public function testEmptyValidatesAgainstCommonDefReadingsSchema(): void
+    {
+        $readings = AmbrosianReadings::empty();
+
+        $json = json_encode($readings->jsonSerialize());
+        self::assertIsString($json);
+        $decoded = json_decode($json);
+        self::assertInstanceOf(\stdClass::class, $decoded);
+
+        self::readingsSchema()->in($decoded);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testEmptyCanBeAssignedToLiturgicalEventViaSetReadings(): void
+    {
+        $event            = new LiturgicalEvent(
+            'Test Ambrosian Event',
+            new DateTime('2026-07-20T00:00:00+00:00')
+        );
+        $event->event_key = 'TestAmbrosianEvent';
+
+        $event->setReadings(AmbrosianReadings::empty());
+
+        $serialized = $event->jsonSerialize();
+        self::assertArrayHasKey('readings', $serialized);
+        self::assertSame(
+            [
+                'first_reading'      => '',
+                'responsorial_psalm' => '',
+                'gospel_acclamation' => '',
+                'gospel'             => '',
+            ],
+            $serialized['readings']
+        );
+    }
+}

--- a/phpunit_tests/Models/Metadata/MetadataCalendarsTest.php
+++ b/phpunit_tests/Models/Metadata/MetadataCalendarsTest.php
@@ -264,5 +264,18 @@ final class MetadataCalendarsTest extends TestCase
         ]);
         $mc->pushAmbrosianCalendarMetadata($ac);
         self::assertSame(['ambrosian'], $mc->ambrosian_calendars_keys);
+
+        // Round-trip the whole container through fromArray/fromObject so the
+        // ambrosian_calendars deserialization paths are exercised (not just the item).
+        $arr = $mc->jsonSerialize();
+
+        $fromArr = MetadataCalendars::fromArray($arr);
+        self::assertSame(['ambrosian'], $fromArr->ambrosian_calendars_keys);
+        self::assertSame('ambrosian', $fromArr->ambrosian_calendars[0]->calendar_id);
+        self::assertSame(['it', 'la'], $fromArr->ambrosian_calendars[0]->locales);
+
+        $fromObj = MetadataCalendars::fromObject(json_decode(json_encode($arr, JSON_THROW_ON_ERROR), false, 512, JSON_THROW_ON_ERROR));
+        self::assertSame(['ambrosian'], $fromObj->ambrosian_calendars_keys);
+        self::assertSame('ambrosian', $fromObj->ambrosian_calendars[0]->rite);
     }
 }

--- a/phpunit_tests/Models/Metadata/MetadataCalendarsTest.php
+++ b/phpunit_tests/Models/Metadata/MetadataCalendarsTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests\Models\Metadata;
 use LiturgicalCalendar\Api\Enum\Ascension;
 use LiturgicalCalendar\Api\Enum\CorpusChristi;
 use LiturgicalCalendar\Api\Enum\Epiphany;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataAmbrosianCalendarItem;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanGroupItem;
@@ -16,6 +17,7 @@ use LiturgicalCalendar\Api\Models\Metadata\MetadataWiderRegionItem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(MetadataAmbrosianCalendarItem::class)]
 #[CoversClass(MetadataCalendars::class)]
 #[CoversClass(MetadataDiocesanCalendarItem::class)]
 #[CoversClass(MetadataDiocesanGroupItem::class)]
@@ -117,6 +119,29 @@ final class MetadataCalendarsTest extends TestCase
         self::assertSame('LatinAmerica', $wrObj->name);
     }
 
+    public function testAmbrosianCalendarItemRoundTrip(): void
+    {
+        $ac = MetadataAmbrosianCalendarItem::fromArray([
+            'calendar_id' => 'ambrosian',
+            'rite'        => 'ambrosian',
+            'locales'     => ['it', 'la'],
+        ]);
+        self::assertSame('ambrosian', $ac->calendar_id);
+        self::assertSame('ambrosian', $ac->rite);
+        self::assertSame(['it', 'la'], $ac->locales);
+        self::assertSame(
+            ['calendar_id' => 'ambrosian', 'rite' => 'ambrosian', 'locales' => ['it', 'la']],
+            $ac->jsonSerialize()
+        );
+
+        $acObj = MetadataAmbrosianCalendarItem::fromObject((object) [
+            'calendar_id' => 'ambrosian',
+            'rite'        => 'ambrosian',
+            'locales'     => ['it', 'la'],
+        ]);
+        self::assertSame('ambrosian', $acObj->calendar_id);
+    }
+
     public function testDiocesanCalendarItemRoundTrip(): void
     {
         $dc = MetadataDiocesanCalendarItem::fromArray([
@@ -170,9 +195,13 @@ final class MetadataCalendarsTest extends TestCase
         $mc = new MetadataCalendars();
         self::assertSame([], $mc->national_calendars);
         self::assertSame([], $mc->locales);
+        self::assertSame([], $mc->ambrosian_calendars);
+        self::assertSame([], $mc->ambrosian_calendars_keys);
         $arr = $mc->jsonSerialize();
         self::assertSame([], $arr['national_calendars']);
         self::assertSame([], $arr['locales']);
+        self::assertSame([], $arr['ambrosian_calendars']);
+        self::assertSame([], $arr['ambrosian_calendars_keys']);
     }
 
     public function testMetadataCalendarsPushAndSerialize(): void
@@ -226,5 +255,14 @@ final class MetadataCalendarsTest extends TestCase
         $wr = MetadataWiderRegionItem::fromArray(['name' => 'EU', 'locales' => ['it'], 'api_path' => 'p']);
         $mc->pushWiderRegionMetadata($wr);
         self::assertSame(['EU'], $mc->wider_regions_keys);
+
+        // Ambrosian comune calendar push.
+        $ac = MetadataAmbrosianCalendarItem::fromArray([
+            'calendar_id' => 'ambrosian',
+            'rite'        => 'ambrosian',
+            'locales'     => ['it', 'la'],
+        ]);
+        $mc->pushAmbrosianCalendarMetadata($ac);
+        self::assertSame(['ambrosian'], $mc->ambrosian_calendars_keys);
     }
 }

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Params;
 
 use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Params\EventsParams;
 use LiturgicalCalendar\Api\Router;
@@ -123,6 +124,29 @@ final class EventsParamsTest extends TestCase
         self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $params->baseLocale);
         self::assertFalse($params->EternalHighPriest);
         self::assertNull($params->NationalCalendar);
+    }
+
+    public function testAmbrosianRejectsVaNationalCalendar(): void
+    {
+        // national_calendar=VA (from ?national_calendar=VA or /events/ambrosian/nation/VA)
+        // normalizes NationalCalendar back to null, but an Ambrosian request must still be
+        // rejected — the Ambrosian rite has no national layer. Guards against VA slipping
+        // past the plain "NationalCalendar !== null" check.
+        $params = new EventsParams(['national_calendar' => 'VA']);
+        $params->setRite(Rite::AMBROSIAN);
+
+        $this->expectException(ValidationException::class);
+        $params->validateRiteCompatibility();
+    }
+
+    public function testRomanAcceptsVaNationalCalendar(): void
+    {
+        // VA is valid for the Roman rite (it selects the General Roman Calendar).
+        $params = new EventsParams(['national_calendar' => 'VA']);
+        $params->setRite(Rite::ROMAN);
+
+        $params->validateRiteCompatibility();
+        $this->addToAssertionCount(1); // reached only if no exception was thrown
     }
 
     /**

--- a/phpunit_tests/Params/EventsParamsTest.php
+++ b/phpunit_tests/Params/EventsParamsTest.php
@@ -149,6 +149,17 @@ final class EventsParamsTest extends TestCase
         $this->addToAssertionCount(1); // reached only if no exception was thrown
     }
 
+    public function testAmbrosianRejectsDiocesanCalendar(): void
+    {
+        // The Ambrosian rite serves only the comune catalog; a diocesan_calendar filter
+        // (from ?diocesan_calendar=… or /events/ambrosian/diocese/…) must be rejected.
+        $params = new EventsParams(['diocesan_calendar' => 'agrige_it']);
+        $params->setRite(Rite::AMBROSIAN);
+
+        $this->expectException(ValidationException::class);
+        $params->validateRiteCompatibility();
+    }
+
     /**
      * Regression for #576: when national_calendar=VA appears anywhere in the
      * input, its locale=la_VA / eternal_high_priest=false invariants must win

--- a/phpunit_tests/RouterRiteSegmentTest.php
+++ b/phpunit_tests/RouterRiteSegmentTest.php
@@ -10,10 +10,11 @@ use PHPUnit\Framework\Attributes\CoversMethod;
 use PHPUnit\Framework\TestCase;
 
 /**
- * The Router recognises an optional leading rite segment on the calendar route.
- * `/calendar` and `/calendar/roman` are equivalent (both Roman); `/calendar/ambrosian`
- * selects the Ambrosian rite. Any other leading segment (a year, `nation`, `diocese`)
- * is left untouched for the existing shape parsing.
+ * The Router recognises an optional leading rite segment on the calendar and events
+ * routes. `/calendar` and `/calendar/roman` are equivalent (both Roman); `/calendar/ambrosian`
+ * selects the Ambrosian rite — and likewise `/events/ambrosian` for the events route
+ * (Plan 7 Task 12). Any other leading segment (a year, `nation`, `diocese`) is left
+ * untouched for the existing shape parsing.
  */
 #[CoversMethod(Router::class, 'extractRiteSegment')]
 final class RouterRiteSegmentTest extends TestCase
@@ -60,11 +61,28 @@ final class RouterRiteSegmentTest extends TestCase
         self::assertSame(['nation', 'US'], $parts);
     }
 
-    public function testRiteSegmentOnlyAppliesToTheCalendarRoute(): void
+    public function testRiteSegmentOnlyAppliesToTheCalendarAndEventsRoutes(): void
     {
-        // A non-calendar route must never treat a leading 'ambrosian'/'roman' as a rite.
+        // A route that is neither calendar nor events must never treat a leading
+        // 'ambrosian'/'roman' as a rite.
         $parts = ['ambrosian'];
         self::assertSame(Rite::ROMAN, Router::extractRiteSegment('metadata', $parts));
         self::assertSame(['ambrosian'], $parts);
+    }
+
+    public function testEventsRouteAlsoSupportsAnAmbrosianRiteSegment(): void
+    {
+        // Plan 7 Task 12: the events route gained the same optional leading rite
+        // segment the calendar route already had.
+        $parts = ['ambrosian'];
+        self::assertSame(Rite::AMBROSIAN, Router::extractRiteSegment('events', $parts));
+        self::assertSame([], $parts);
+    }
+
+    public function testEventsRouteWithNoRiteSegmentDefaultsToRoman(): void
+    {
+        $parts = ['nation', 'US'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('events', $parts));
+        self::assertSame(['nation', 'US'], $parts);
     }
 }

--- a/phpunit_tests/Routes/Readonly/AmbrosianCalendarTest.php
+++ b/phpunit_tests/Routes/Readonly/AmbrosianCalendarTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Readonly;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+use PHPUnit\Framework\Attributes\Group;
+
+/**
+ * Live HTTP integration test for `/calendar/ambrosian/{year}`, the route Plan 7 Task 10 un-501s.
+ *
+ * Before this task, `CalendarHandler::handle()` threw `ImplementationException` (HTTP 501) as
+ * soon as `Rite::AMBROSIAN` was detected. Task 10 replaces that gate with a real generation
+ * branch that calls `calculateAmbrosianCalendar()` (Task 9), so this test hits the running API
+ * (skipped, per `ApiTestCase`, when localhost:8000 is unreachable) and asserts the endpoint now
+ * returns a full calendar instead of a 501.
+ *
+ * 2025 is chosen because it exercises the Ambrosian Advent/Christ-the-King transfer machinery:
+ * St Ambrose's dies natalis (Dec 7) falls on Advent IV Sunday that civil year, so the precedence
+ * resolver (Plan 4) must transfer it to Dec 6 — a good sanity check that the full pipeline (not
+ * just the isolated per-task passes) is wired correctly end to end.
+ */
+#[Group('slow')]
+final class AmbrosianCalendarTest extends ApiTestCase
+{
+    public function testGetAmbrosianCalendar2025ReturnsCalculatedCalendar(): void
+    {
+        // year_type=CIVIL requests a straight Jan-Dec 2025 calendar (rather than the default
+        // LITURGICAL view, which spans Advent-to-Advent across two civil years) so the spot-check
+        // dates below line up with a single, unambiguous civil year.
+        $response = self::$http->get('/calendar/ambrosian/2025?year_type=CIVIL', []);
+
+        self::assertSame(200, $response->getStatusCode(), 'Expected HTTP 200 OK, not the pre-Task-10 501: ' . $response->getBody());
+        self::assertStringStartsWith('application/json', $response->getHeaderLine('Content-Type'));
+
+        $data = json_decode((string) $response->getBody());
+        self::assertSame(JSON_ERROR_NONE, json_last_error(), 'Invalid JSON: ' . json_last_error_msg());
+
+        self::assertIsObject($data);
+        self::assertObjectHasProperty('litcal', $data);
+        self::assertIsArray($data->litcal);
+        self::assertNotEmpty($data->litcal, 'Expected a non-empty litcal array for the Ambrosian comune, 2025');
+
+        $byKey = [];
+        foreach ($data->litcal as $event) {
+            $byKey[$event->event_key] = $event;
+        }
+
+        self::assertArrayHasKey('DedicationDuomo', $byKey, 'Expected DedicationDuomo in the Ambrosian 2025 calendar');
+        self::assertStringStartsWith('2025-10-19', $byKey['DedicationDuomo']->date);
+
+        self::assertArrayHasKey('ChristKing', $byKey, 'Expected ChristKing in the Ambrosian 2025 calendar');
+        self::assertStringStartsWith('2025-11-09', $byKey['ChristKing']->date);
+
+        self::assertArrayHasKey('StAmbrose', $byKey, 'Expected StAmbrose in the Ambrosian 2025 calendar');
+        self::assertStringStartsWith(
+            '2025-12-06',
+            $byKey['StAmbrose']->date,
+            'StAmbrose (Dec 7) coincides with Advent IV Sunday in 2025 and should be transferred to Dec 6'
+        );
+    }
+
+    /**
+     * The default `year_type` is `LITURGICAL`, which drives the two-run + splice path in
+     * `handle()` (generate the requested year, generate year-1, purge/merge around Advent I —
+     * mirroring the Roman branch exactly, per Task 10). This is the riskiest part of the wiring,
+     * so assert directly on the spliced result: no duplicate event_keys (merge() must not
+     * double-add anything spanning the two runs), exactly one `Advent1` (the boundary event),
+     * and the civil-year date range implied by an Advent-to-Advent liturgical year.
+     */
+    public function testGetAmbrosianCalendarDefaultLiturgicalYearTypeSplicesWithoutDuplicates(): void
+    {
+        $response = self::$http->get('/calendar/ambrosian/2025', []);
+        self::assertSame(200, $response->getStatusCode(), 'Expected HTTP 200 OK: ' . $response->getBody());
+
+        $data = json_decode((string) $response->getBody());
+        self::assertSame(JSON_ERROR_NONE, json_last_error(), 'Invalid JSON: ' . json_last_error_msg());
+        self::assertSame('LITURGICAL', $data->settings->year_type);
+
+        $keyCounts = [];
+        foreach ($data->litcal as $event) {
+            $keyCounts[$event->event_key] = ( $keyCounts[$event->event_key] ?? 0 ) + 1;
+        }
+        $duplicates = array_filter($keyCounts, static fn (int $count): bool => $count > 1);
+        self::assertSame([], $duplicates, 'merge() must not produce duplicate event_keys across the two spliced runs');
+        self::assertArrayHasKey('Advent1', $keyCounts, 'Expected exactly one Advent1 (the splice boundary)');
+        self::assertSame(1, $keyCounts['Advent1']);
+    }
+
+    public function testGetAmbrosianCalendarComuneBaseYearAlsoReturns200(): void
+    {
+        // No year segment: defaults to the current year, mirroring /calendar's behaviour.
+        $response = self::$http->get('/calendar/ambrosian', []);
+        self::assertSame(200, $response->getStatusCode(), 'Expected HTTP 200 OK: ' . $response->getBody());
+    }
+}

--- a/phpunit_tests/Schemas/AmbrosianLitCalSchemaTest.php
+++ b/phpunit_tests/Schemas/AmbrosianLitCalSchemaTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\TestCase;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * Unit tests for the Ambrosian allowances in the LitCal.json response schema (Plan 7 / Task 1).
+ *
+ * The Ambrosian rite's calendar calculation (implemented in later tasks) needs the response
+ * schema's `LiturgicalEvent` and `LiturgicalEventVigil` definitions to accept:
+ * 1. `"AFTER_EPIPHANY"` and `"AFTER_PENTECOST"` as `liturgical_season` enum values (Ambrosian
+ *    seasons that have no Roman equivalent);
+ * 2. two OPTIONAL boolean properties, `is_dominical` and `is_aliturgical`, used by the Ambrosian
+ *    precedence classifier and by the aliturgical Fridays of Ambrosian Lent respectively.
+ *
+ * Both changes must be additive: existing Roman events (which use the pre-existing
+ * `liturgical_season` values and omit `is_dominical`/`is_aliturgical`) must keep validating, and
+ * `additionalProperties: false` must still reject genuinely unknown properties.
+ */
+final class AmbrosianLitCalSchemaTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // LitSchema::path() depends on Router::$apiFilePath; initialize it.
+        Router::getApiPaths();
+    }
+
+    private static function liturgicalEventSchema(): Schema
+    {
+        return Schema::import(LitSchema::LITCAL->path() . '#/definitions/LiturgicalEvent');
+    }
+
+    private function assertValid(\stdClass $event): void
+    {
+        self::liturgicalEventSchema()->in($event);
+        $this->addToAssertionCount(1);
+    }
+
+    private function assertInvalid(\stdClass $event): void
+    {
+        $this->expectException(\Swaggest\JsonSchema\Exception::class);
+        self::liturgicalEventSchema()->in($event);
+    }
+
+    private static function decode(string $json): \stdClass
+    {
+        $obj = json_decode($json);
+        assert($obj instanceof \stdClass);
+        return $obj;
+    }
+
+    /**
+     * A minimal, otherwise schema-valid `LiturgicalEvent` object shaped like an Ambrosian event:
+     * `liturgical_season` set to one of the new Ambrosian-only values, plus the two new optional
+     * booleans populated.
+     */
+    private static function minimalAmbrosianEvent(): \stdClass
+    {
+        return self::decode(<<<'JSON'
+        {
+            "event_idx": 0,
+            "event_key": "SundayAfterPentecost1",
+            "name": "First Sunday after Pentecost",
+            "date": "2026-06-07T00:00:00+00:00",
+            "color": ["green"],
+            "color_lcl": ["Green"],
+            "type": "mobile",
+            "grade": 4,
+            "grade_lcl": "Feast",
+            "grade_abbr": "F",
+            "grade_display": null,
+            "common": [],
+            "common_lcl": "",
+            "day_of_the_week_iso8601": 7,
+            "month": 6,
+            "day": 7,
+            "year": 2026,
+            "month_short": "Jun",
+            "month_long": "June",
+            "day_of_the_week_short": "Sun",
+            "day_of_the_week_long": "Sunday",
+            "liturgical_season": "AFTER_PENTECOST",
+            "liturgical_season_lcl": "After Pentecost",
+            "psalter_week": 1,
+            "readings": "Proper",
+            "is_dominical": true,
+            "is_aliturgical": true
+        }
+        JSON);
+    }
+
+    public function testMinimalAmbrosianEventIsValid(): void
+    {
+        $this->assertValid(self::minimalAmbrosianEvent());
+    }
+
+    public function testAfterEpiphanySeasonIsValid(): void
+    {
+        $event                    = self::minimalAmbrosianEvent();
+        $event->liturgical_season = 'AFTER_EPIPHANY';
+        $this->assertValid($event);
+    }
+
+    public function testUnknownLiturgicalSeasonIsRejected(): void
+    {
+        $event                    = self::minimalAmbrosianEvent();
+        $event->liturgical_season = 'NONSENSE';
+        $this->assertInvalid($event);
+    }
+
+    public function testRomanLiturgicalSeasonsStillValidateWithoutAmbrosianProperties(): void
+    {
+        // Existing Roman events omit is_dominical/is_aliturgical entirely and use the
+        // pre-existing liturgical_season values; both must keep validating unchanged.
+        $event = self::minimalAmbrosianEvent();
+        unset($event->is_dominical, $event->is_aliturgical);
+        $event->liturgical_season = 'ORDINARY_TIME';
+        $this->assertValid($event);
+    }
+
+    public function testIsDominicalMustBeBoolean(): void
+    {
+        $event               = self::minimalAmbrosianEvent();
+        $event->is_dominical = 'true';
+        $this->assertInvalid($event);
+    }
+
+    public function testIsAliturgicalMustBeBoolean(): void
+    {
+        $event                 = self::minimalAmbrosianEvent();
+        $event->is_aliturgical = 'true';
+        $this->assertInvalid($event);
+    }
+
+    public function testUnknownPropertyIsStillRejected(): void
+    {
+        // additionalProperties: false must still be enforced after adding the new properties.
+        $event              = self::minimalAmbrosianEvent();
+        $event->totally_new = 'unexpected';
+        $this->assertInvalid($event);
+    }
+}

--- a/phpunit_tests/Services/CalendarMetadataProviderTest.php
+++ b/phpunit_tests/Services/CalendarMetadataProviderTest.php
@@ -47,6 +47,27 @@ final class CalendarMetadataProviderTest extends TestCase
         self::assertCount(count($metadata->national_calendars), $metadata->national_calendars_keys);
         self::assertCount(count($metadata->diocesan_calendars), $metadata->diocesan_calendars_keys);
         self::assertCount(count($metadata->wider_regions), $metadata->wider_regions_keys);
+        self::assertCount(count($metadata->ambrosian_calendars), $metadata->ambrosian_calendars_keys);
+    }
+
+    /**
+     * The comune `/calendar/ambrosian` has no representation as a nation,
+     * diocese, or wider region — it's announced through its own
+     * `ambrosian_calendars` surface so clients can discover it.
+     */
+    public function testCreateAnnouncesTheAmbrosianComuneCalendar(): void
+    {
+        $metadata = CalendarMetadataProvider::create();
+
+        self::assertContains('ambrosian', $metadata->ambrosian_calendars_keys);
+        $ambrosian = current(array_filter(
+            $metadata->ambrosian_calendars,
+            fn ($item) => $item->calendar_id === 'ambrosian'
+        ));
+        self::assertNotFalse($ambrosian);
+        self::assertSame('ambrosian', $ambrosian->rite);
+        self::assertContains('it', $ambrosian->locales);
+        self::assertContains('la', $ambrosian->locales);
     }
 
     /**

--- a/src/Enum/AmbrosianHolyDaysOfObligation.php
+++ b/src/Enum/AmbrosianHolyDaysOfObligation.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Enum;
+
+/**
+ * Default set of Ambrosian rite Holy Days of Obligation (`event_key` values).
+ *
+ * **Provisional / ordo-validation-pending (Plan 7 Task 6, Plan 9 follow-up):** unlike the Roman
+ * `CalendarParams::$HolyDaysOfObligation` default (Can. 1246 §1 plus the Italian episcopal
+ * conference concessions, keyed on Roman event keys such as `StJoseph`, `StsPeterPaulAp`, and
+ * `CorpusChristi`), the Ambrosian rite does not share those keys and has its own liturgical
+ * calendar of precepts (the Ambrosian `Circoncisione` on 1 January instead of `MaryMotherOfGod`,
+ * no `CorpusChristi`/`StJoseph`/`StsPeterPaulAp` as Ambrosian precept days, plus the
+ * Milan-specific `StAmbrose` and `DedicationDuomo` solemnities). This list is a reasonable
+ * provisional set assembled from the Ambrosian Proprium de Tempore/Sanctis `event_key`s
+ * (verified against `jsondata/sourcedata/missals/ambrosian/propriumdetempore/propriumdetempore.json`
+ * and `.../propriumdesanctis_2024/propriumdesanctis.json`); it must be reconciled against an
+ * authoritative Ambrosian ordo before this becomes a source of truth for production HDoO display.
+ *
+ * Every Sunday is also a holy day of obligation in the Ambrosian rite (as in the Roman rite);
+ * that rule is applied separately in
+ * `LiturgicalEventCollection::setAmbrosianHolyDaysOfObligation()` and is not part of this list.
+ */
+final class AmbrosianHolyDaysOfObligation
+{
+    /**
+     * @var array<string,bool>
+     */
+    public const array DEFAULT = [
+        'Christmas'            => true,
+        'Circoncisione'        => true,
+        'Epiphany'             => true,
+        'Ascension'            => true,
+        'Pentecost'            => true,
+        'ImmaculateConception' => true,
+        'Assumption'           => true,
+        'AllSaints'            => true,
+        'StAmbrose'            => true,
+        'DedicationDuomo'      => true,
+    ];
+}

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -929,12 +929,11 @@ final class CalendarHandler extends AbstractHandler
      * source in this codebase and the response schema requires every `LiturgicalEvent` to carry
      * a `readings` property.
      *
-     * Not yet called from `calculateUniversalCalendar()` (that method is Roman-only and Task 4
-     * must not touch it) — Plan 7 Task 9's `calculateAmbrosianCalendar()` orchestrator is the
-     * method that will call this by name, assembling it together with Tasks 3, 5-8. Until then
-     * it is exercised only by `CalendarHandlerAmbrosianSanctoraleLoadTest` via reflection.
+     * Not called from `calculateUniversalCalendar()` (that method is Roman-only and Task 4 must
+     * not touch it) — called from Plan 7 Task 9's `calculateAmbrosianCalendar()` orchestrator,
+     * assembled together with Tasks 3, 5-8. Also exercised directly (via reflection) by
+     * `CalendarHandlerAmbrosianSanctoraleLoadTest`.
      */
-    // @phpstan-ignore method.unused (call site lands in Task 9's calculateAmbrosianCalendar() orchestrator)
     private function addAmbrosianSanctoraleToCalendar(): void
     {
         $year    = $this->CalendarParams->Year;
@@ -985,13 +984,11 @@ final class CalendarHandler extends AbstractHandler
      * which is `null` on every comune sanctorale event until that pass stamps it from a co-located
      * temporale event.
      *
-     * Not yet called from `calculateUniversalCalendar()` (that method is Roman-only) — Plan 7
-     * Task 9's `calculateAmbrosianCalendar()` orchestrator is the method that will call this by
-     * name, sequencing it after Tasks 3/4/6 (Proprium de Tempore load, temporale engine, comune
-     * sanctorale, season stamping). Until then it is exercised only by
-     * `CalendarHandlerAmbrosianPrecedenceResolverTest` via reflection.
+     * Not called from `calculateUniversalCalendar()` (that method is Roman-only) — called from
+     * Plan 7 Task 9's `calculateAmbrosianCalendar()` orchestrator, sequenced after Tasks 3/4/6
+     * (Proprium de Tempore load, temporale engine, comune sanctorale, season stamping). Also
+     * exercised directly (via reflection) by `CalendarHandlerAmbrosianPrecedenceResolverTest`.
      */
-    // @phpstan-ignore method.unused (call site lands in Task 9's calculateAmbrosianCalendar() orchestrator)
     private function resolveAmbrosianPrecedence(): void
     {
         $ctx = new PrecedenceContext(
@@ -1002,6 +999,118 @@ final class CalendarHandler extends AbstractHandler
         );
 
         ( new AmbrosianPrecedenceResolver() )->resolve($ctx);
+    }
+
+    /**
+     * Ambrosian rite only: orchestrates the full Ambrosian calendar calculation for
+     * `$this->CalendarParams->Year`, assembling the passes built by Plan 7 Tasks 3-8 into the
+     * single call `handle()` will eventually make once the `/calendar/ambrosian` 501 is lifted
+     * (Task 10).
+     *
+     * Call order (load-bearing — do not reorder):
+     *
+     * 1. {@see self::loadPropriumDeTemporeData()} (Task 3, rite-aware): loads the Ambrosian
+     *    Proprium de Tempore into `$this->PropriumDeTempore` because `$this->CalendarParams->Rite`
+     *    is {@see Rite::AMBROSIAN}.
+     * 2. Builds a {@see TemporaleContext} over `$this->Cal` and runs
+     *    `RiteProfileFactory::forRite(AMBROSIAN)->temporaleEngine()->buildTemporale()` (mirrors the
+     *    Roman temporale seam in {@see self::calculateUniversalCalendar()}), which self-stamps
+     *    `liturgical_season` on every temporale event it produces.
+     * 3. {@see self::addAmbrosianSanctoraleToCalendar()} (Task 4): adds every comune Ambrosian
+     *    sanctorale event, skipping any `event_key` already added by the temporale engine.
+     * 3a. {@see self::backfillAmbrosianReadingsPlaceholder()}: a gap discovered while wiring this
+     *    orchestrator (not one of the originally scoped Task 3-8 passes) — see that method's
+     *    docblock for why it is load-bearing here.
+     * 4. {@see LiturgicalEventCollection::stampAmbrosianSeasonOnSanctorale()} (Task 6): copies
+     *    `liturgical_season` onto sanctorale events from a co-located temporale event. MUST run
+     *    before resolution — the resolver's season-gated transfer rules read `liturgical_season`.
+     * 5. {@see self::resolveAmbrosianPrecedence()} (Task 5): same-day coincidence ranking,
+     *    suppression, and transfer per the Tabella dei giorni liturgici.
+     * 6. {@see LiturgicalEventCollection::setAmbrosianHolyDaysOfObligation()} (Task 6).
+     * 7. {@see LiturgicalEventCollection::setAmbrosianYearCyclesAndVigils()} (Task 7): festive
+     *    (A/B/C) and ferial (I/II) cycles, plus first-vespers vigil Masses.
+     * 8. {@see LiturgicalEventCollection::calculatePsalterWeek()} (rite-agnostic gap-filler,
+     *    validated against the assembled Ambrosian collection in Task 8).
+     * 9. {@see LiturgicalEventCollection::sortLiturgicalEvents()}.
+     *
+     * Does NOT call {@see self::calculateUniversalCalendar()} (the Roman pipeline) and does not
+     * modify any Roman method. `$this->Cal` must already be initialized by the caller (mirroring
+     * how `calculateUniversalCalendar()` is only ever called after `$this->Cal = new
+     * LiturgicalEventCollection(...)` in `handle()`).
+     *
+     * Not yet called from `handle()` — the `/calendar/ambrosian` route still returns 501 there
+     * (Plan 7 Task 10 lifts that gate and wires this method in). Until then it is exercised only
+     * by `CalendarHandlerAmbrosianOrchestratorTest` via reflection.
+     *
+     * @return void
+     */
+    // @phpstan-ignore method.unused (call site lands in Task 10, when the 501 gate is lifted)
+    private function calculateAmbrosianCalendar(): void
+    {
+        $this->loadPropriumDeTemporeData();
+
+        $riteProfile      = RiteProfileFactory::forRite($this->CalendarParams->Rite);
+        $temporaleContext = new TemporaleContext(
+            $this->Cal,
+            $this->CalendarParams,
+            $this->PropriumDeTempore,
+            $this->localeDateFormatter,
+            $this->Messages
+        );
+        $riteProfile->temporaleEngine()->buildTemporale($temporaleContext);
+
+        $this->addAmbrosianSanctoraleToCalendar();
+
+        $this->backfillAmbrosianReadingsPlaceholder();
+
+        $this->Cal->stampAmbrosianSeasonOnSanctorale();
+
+        $this->resolveAmbrosianPrecedence();
+
+        $this->Cal->setAmbrosianHolyDaysOfObligation();
+
+        $this->Cal->setAmbrosianYearCyclesAndVigils();
+
+        $this->Cal->calculatePsalterWeek();
+
+        $this->Cal->sortLiturgicalEvents();
+    }
+
+    /**
+     * Ambrosian rite only: backfills the Task 2/4 empty-readings placeholder
+     * ({@see AmbrosianReadings::empty()}) onto every temporale-origin event in `$this->Cal` that
+     * does not yet carry a `readings` property.
+     *
+     * `addAmbrosianSanctoraleToCalendar()` (Task 4) already stamps this placeholder onto every
+     * comune sanctorale event it adds, but the Ambrosian temporale engine
+     * (`AmbrosianTemporale::buildTemporale()`, Plan 3) does not — there is currently no Ambrosian
+     * lectionary data source for the temporale either. `LiturgicalEvent::$readings` is a typed
+     * property with no default, so any read of it before `setReadings()` is called throws a fatal
+     * `Error`. `LiturgicalEventCollection::createVigilMassFor()` (reused verbatim by
+     * `calculateAmbrosianVigilMass()`, Task 7, itself called from
+     * `setAmbrosianYearCyclesAndVigils()`) reads `->readings` unconditionally for any
+     * Sunday/Solemnity-grade event eligible for a vigil — which includes temporale-origin Sundays
+     * and fixed solemnities (Advent Sundays, Easter, Christmas, ...). This backfill MUST therefore
+     * run before `setAmbrosianYearCyclesAndVigils()`, and is placed immediately after
+     * `addAmbrosianSanctoraleToCalendar()` so every event already in `$this->Cal` — temporale and
+     * sanctorale alike — carries a `readings` property from this point onward (the response schema
+     * also requires every `LiturgicalEvent` to carry one).
+     *
+     * This gap was not caught by the per-task tests (Task 5/6/7/8) because each of those tests
+     * hand-assembles only the events it needs and/or (Task 8) applies its own
+     * `withReadingsPlaceholder()` test-only helper before calling
+     * `setAmbrosianYearCyclesAndVigils()`. Running the real, single `calculateAmbrosianCalendar()`
+     * orchestrator surfaced it.
+     *
+     * @return void
+     */
+    private function backfillAmbrosianReadingsPlaceholder(): void
+    {
+        foreach ($this->Cal->getLiturgicalEvents() as $event) {
+            if (false === isset($event->readings)) {
+                $event->setReadings(AmbrosianReadings::empty());
+            }
+        }
     }
 
     /**

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -7,6 +7,7 @@ use LiturgicalCalendar\Api\LatinUtils;
 use LiturgicalCalendar\Api\LocaleDateFormatter;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Utilities;
+use LiturgicalCalendar\Api\Enum\AmbrosianMissal;
 use LiturgicalCalendar\Api\Enum\Ascension;
 use LiturgicalCalendar\Api\Enum\CalEventAction;
 use LiturgicalCalendar\Api\Enum\CorpusChristi;
@@ -44,7 +45,9 @@ use LiturgicalCalendar\Api\Models\PropriumDeTemporeEvent;
 use LiturgicalCalendar\Api\Models\RelativeLiturgicalDate;
 use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
 use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Models\Calendar\Missal\AmbrosianMissalResolver;
 use LiturgicalCalendar\Api\Models\Calendar\Rite\RiteProfileFactory;
+use LiturgicalCalendar\Api\Models\Calendar\Sanctorale\AmbrosianSanctoraleLoader;
 use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleContext;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItem;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemCollection;
@@ -56,6 +59,7 @@ use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyGrade;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyGradeMetadata;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyName;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyNameMetadata;
+use LiturgicalCalendar\Api\Models\Lectionary\AmbrosianReadings;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarSettings;
 use LiturgicalCalendar\Api\Models\ConditionalRule;
 use LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanData;
@@ -897,6 +901,72 @@ final class CalendarHandler extends AbstractHandler
         $PropriumDeTemporeI18n   = $this->loadAmbrosianPropriumDeTemporeI18nData($locale);
         $this->PropriumDeTempore = PropriumDeTemporeMap::fromObject($PropriumDeTempore);
         $this->PropriumDeTempore->setNames($PropriumDeTemporeI18n);
+    }
+
+    /**
+     * Adds every comune Ambrosian sanctorale event to `$this->Cal`.
+     *
+     * Unlike the Roman check-before-add convention (`inSolemnities()` / `handleCoincidence()`),
+     * the Ambrosian assembly model adds every sanctorale row unconditionally and defers
+     * coincidence resolution to a later precedence-resolution pass (Plan 7, Task 5). The only
+     * thing guarded here is an `event_key` collision against an event already present in
+     * `$this->Cal` — i.e. one added by the Proprium de Tempore load/engine that runs earlier in
+     * the pipeline — because `LiturgicalEventCollection::addLiturgicalEvent()` is keyed by
+     * `event_key` and would otherwise silently overwrite the earlier (temporale) definition.
+     *
+     * Audit finding (Plan 7 Task 4, Step 1): three keys are declared in BOTH
+     * `propriumdesanctis_2024/propriumdesanctis.json` and `propriumdetempore/propriumdetempore.json`
+     * — `Christmas`, `Circoncisione`, `Epiphany` — and all three remain present in
+     * `$this->Cal` after `AmbrosianTemporale::buildTemporale()` runs (verified: none of them are
+     * later removed/renamed by the temporale engine). So the skip branch below is not merely
+     * defensive: for a real Ambrosian request it is expected to trigger on exactly these three
+     * keys, with the temporale definition (added earlier in the pipeline) winning each time.
+     *
+     * Every added event is given the Task 2 empty-readings placeholder
+     * ({@see AmbrosianReadings::empty()}), since there is currently no Ambrosian lectionary data
+     * source in this codebase and the response schema requires every `LiturgicalEvent` to carry
+     * a `readings` property.
+     *
+     * Not yet called from `calculateUniversalCalendar()` (that method is Roman-only and Task 4
+     * must not touch it) — Plan 7 Task 9's `calculateAmbrosianCalendar()` orchestrator is the
+     * method that will call this by name, assembling it together with Tasks 3, 5-8. Until then
+     * it is exercised only by `CalendarHandlerAmbrosianSanctoraleLoadTest` via reflection.
+     */
+    // @phpstan-ignore method.unused (call site lands in Task 9's calculateAmbrosianCalendar() orchestrator)
+    private function addAmbrosianSanctoraleToCalendar(): void
+    {
+        $year    = $this->CalendarParams->Year;
+        $edition = ( new AmbrosianMissalResolver() )->resolve($year)[0];
+
+        $locale = LitLocale::$PRIMARY_LANGUAGE;
+        if (false === in_array($locale, ['it', 'la'], true)) {
+            $locale = 'it';
+        }
+
+        $sanctoraleMap = ( new AmbrosianSanctoraleLoader() )->load($edition, $locale);
+
+        foreach ($sanctoraleMap as $key => $propriumDeSanctisEvent) {
+            if (null !== $this->Cal->getLiturgicalEvent($key)) {
+                /**translators:
+                 * 1. Event key of the Ambrosian comune sanctorale event that was skipped
+                 * 2. Name of the Ambrosian Missal edition the sanctorale event was read from
+                 */
+                $this->Messages[] = sprintf(
+                    _('The Ambrosian comune sanctorale event `%1$s` from the %2$s was skipped because a liturgical event with the same key was already defined by the Proprium de Tempore, which takes precedence.'),
+                    $key,
+                    AmbrosianMissal::getName($edition)
+                );
+                continue;
+            }
+
+            $propriumDeSanctisEvent->setDate(
+                DateTime::fromFormat($propriumDeSanctisEvent->day . '-' . $propriumDeSanctisEvent->month . '-' . $year)
+            );
+
+            $litEvent = LiturgicalEvent::fromObject($propriumDeSanctisEvent);
+            $litEvent->setReadings(AmbrosianReadings::empty());
+            $this->Cal->addLiturgicalEvent($key, $litEvent);
+        }
     }
 
     /**

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -46,6 +46,8 @@ use LiturgicalCalendar\Api\Models\RelativeLiturgicalDate;
 use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
 use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
 use LiturgicalCalendar\Api\Models\Calendar\Missal\AmbrosianMissalResolver;
+use LiturgicalCalendar\Api\Models\Calendar\Precedence\AmbrosianPrecedenceResolver;
+use LiturgicalCalendar\Api\Models\Calendar\Precedence\PrecedenceContext;
 use LiturgicalCalendar\Api\Models\Calendar\Rite\RiteProfileFactory;
 use LiturgicalCalendar\Api\Models\Calendar\Sanctorale\AmbrosianSanctoraleLoader;
 use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleContext;
@@ -967,6 +969,39 @@ final class CalendarHandler extends AbstractHandler
             $litEvent->setReadings(AmbrosianReadings::empty());
             $this->Cal->addLiturgicalEvent($key, $litEvent);
         }
+    }
+
+    /**
+     * Runs Ambrosian same-day precedence resolution (coincidence ranking, suppression, and the
+     * Tabella dei giorni liturgici transfer rules) over `$this->Cal`.
+     *
+     * Builds a `PrecedenceContext` wrapping `$this->Cal`, `$this->CalendarParams`,
+     * `$this->localeDateFormatter`, and the by-ref `$this->Messages` sink, and hands it to
+     * `AmbrosianPrecedenceResolver::resolve()` (Plan 4).
+     *
+     * **Ordering:** this MUST run AFTER `LiturgicalEventCollection::stampAmbrosianSeasonOnSanctorale()`
+     * (Plan 7 Task 6) — the resolver's season-gated transfer rules (e.g. the privileged-Sunday
+     * checks that gate the Advent/Lent/Easter Solemnity transfer branches) read `liturgical_season`,
+     * which is `null` on every comune sanctorale event until that pass stamps it from a co-located
+     * temporale event.
+     *
+     * Not yet called from `calculateUniversalCalendar()` (that method is Roman-only) — Plan 7
+     * Task 9's `calculateAmbrosianCalendar()` orchestrator is the method that will call this by
+     * name, sequencing it after Tasks 3/4/6 (Proprium de Tempore load, temporale engine, comune
+     * sanctorale, season stamping). Until then it is exercised only by
+     * `CalendarHandlerAmbrosianPrecedenceResolverTest` via reflection.
+     */
+    // @phpstan-ignore method.unused (call site lands in Task 9's calculateAmbrosianCalendar() orchestrator)
+    private function resolveAmbrosianPrecedence(): void
+    {
+        $ctx = new PrecedenceContext(
+            $this->Cal,
+            $this->CalendarParams,
+            $this->localeDateFormatter,
+            $this->Messages
+        );
+
+        ( new AmbrosianPrecedenceResolver() )->resolve($ctx);
     }
 
     /**

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -27,7 +27,6 @@ use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Enum\StatusCode;
 use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
-use LiturgicalCalendar\Api\Http\Exception\ImplementationException;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Http\Exception\YamlException;
@@ -1038,13 +1037,13 @@ final class CalendarHandler extends AbstractHandler
      * how `calculateUniversalCalendar()` is only ever called after `$this->Cal = new
      * LiturgicalEventCollection(...)` in `handle()`).
      *
-     * Not yet called from `handle()` — the `/calendar/ambrosian` route still returns 501 there
-     * (Plan 7 Task 10 lifts that gate and wires this method in). Until then it is exercised only
-     * by `CalendarHandlerAmbrosianOrchestratorTest` via reflection.
+     * Called from `handle()` (Plan 7 Task 10) as the per-run generator for the Ambrosian branch,
+     * once for the requested year, and — when `YearType::LITURGICAL` — once more for the
+     * previous year, exactly mirroring the Roman branch's two-run + splice structure. Also
+     * exercised directly (via reflection) by `CalendarHandlerAmbrosianOrchestratorTest`.
      *
      * @return void
      */
-    // @phpstan-ignore method.unused (call site lands in Task 10, when the 501 gate is lifted)
     private function calculateAmbrosianCalendar(): void
     {
         $this->loadPropriumDeTemporeData();
@@ -5290,12 +5289,6 @@ final class CalendarHandler extends AbstractHandler
 
         $this->validateRequestMethod($request);
 
-        if ($this->CalendarParams->Rite === Rite::AMBROSIAN) {
-            throw new ImplementationException(
-                'The Ambrosian rite is planned but not yet available; only the Roman rite is currently implemented.'
-            );
-        }
-
         $this->loadDiocesanCalendarData();
         $this->loadNationalCalendarData();
         $this->updateSettingsBasedOnNationalCalendar();
@@ -5341,43 +5334,54 @@ final class CalendarHandler extends AbstractHandler
 
             $this->prepareL10N();
 
-            $this->Cal = new LiturgicalEventCollection($this->CalendarParams);
+            if ($this->CalendarParams->Rite === Rite::AMBROSIAN) {
+                // Ambrosian rite: no national/diocesan layer yet (comune only; dioceses are Plan 8),
+                // so calculateAmbrosianCalendar() is the entire per-run generator. It already runs
+                // setAmbrosianHolyDaysOfObligation(), setAmbrosianYearCyclesAndVigils(),
+                // calculatePsalterWeek(), and sortLiturgicalEvents() internally (see its docblock),
+                // so none of those Roman-branch calls are repeated here.
+                $this->Cal = new LiturgicalEventCollection($this->CalendarParams);
 
-            $this->calculateUniversalCalendar();
+                $this->calculateAmbrosianCalendar();
 
-            // Prepare the localization data for national and diocesan calendars, if applicable
-            $this->applyCalendarI18nData();
+                if ($this->CalendarParams->YearType === YearType::LITURGICAL) {
+                    // Save the state of the current Calendar calculation
+                    $CalBackup      = clone( $this->Cal );
+                    $Messages       = $this->Messages;
+                    $this->Messages = [];
 
-            if ($this->CalendarParams->NationalCalendar !== null && $this->NationalData !== null) {
-                $this->applyNationalCalendar();
-            }
+                    // Calculate the calendar for the previous year
+                    $this->CalendarParams->Year--;
+                    $this->Cal = new LiturgicalEventCollection($this->CalendarParams);
 
-            // :SATURDAY_MEMORIAL_BVM
-            $this->calculateSaturdayMemorialBVM();
+                    $this->calculateAmbrosianCalendar();
 
-            if ($this->CalendarParams->DiocesanCalendar !== null && $this->DiocesanData !== null) {
-                $this->applyDiocesanCalendar();
-            }
+                    $this->Cal->purgeDataBeforeAdvent();
+                    $CalBackup->purgeDataAdventChristmas();
 
-            $this->Cal->setSeasonsAndHolyDaysOfObligation();
+                    // Now we have to combine the two.
+                    // The backup (which represents the main portion) should be appended to the calendar that was just generated
+                    $this->Cal->merge($CalBackup);
 
-            $this->Cal->setYearCyclesAndVigils();
+                    // Reset the year back to the original request before outputting results
+                    $this->CalendarParams->Year++;
 
-            // For any celebrations that do not yet have a psalter_week property, make an attempt to calculate the value if applicable
-            $this->Cal->calculatePsalterWeek();
+                    // Append the messages from the backup calendar (current year) to the current messages (previous year)
+                    // Unfortunately, we don't have a way of purging messages that regard events from the civil year calculations
+                    //   that fall outside of the range of the current liturgical year.
+                    array_push($this->Messages, ...$Messages);
 
-            if ($this->CalendarParams->YearType === YearType::LITURGICAL) {
-                // Save the state of the current Calendar calculation
-                $this->Cal->sortLiturgicalEvents();
-                $CalBackup      = clone( $this->Cal );
-                $Messages       = $this->Messages;
-                $this->Messages = [];
-
-                // Calculate the calendar for the previous year
-                $this->CalendarParams->Year--;
+                    $response = $this->prepareResponseBody($request, $response);
+                } else {
+                    $response = $this->prepareResponseBody($request, $response);
+                }
+            } else {
                 $this->Cal = new LiturgicalEventCollection($this->CalendarParams);
 
                 $this->calculateUniversalCalendar();
+
+                // Prepare the localization data for national and diocesan calendars, if applicable
+                $this->applyCalendarI18nData();
 
                 if ($this->CalendarParams->NationalCalendar !== null && $this->NationalData !== null) {
                     $this->applyNationalCalendar();
@@ -5391,29 +5395,61 @@ final class CalendarHandler extends AbstractHandler
                 }
 
                 $this->Cal->setSeasonsAndHolyDaysOfObligation();
+
                 $this->Cal->setYearCyclesAndVigils();
+
+                // For any celebrations that do not yet have a psalter_week property, make an attempt to calculate the value if applicable
                 $this->Cal->calculatePsalterWeek();
-                $this->Cal->sortLiturgicalEvents();
 
-                $this->Cal->purgeDataBeforeAdvent();
-                $CalBackup->purgeDataAdventChristmas();
+                if ($this->CalendarParams->YearType === YearType::LITURGICAL) {
+                    // Save the state of the current Calendar calculation
+                    $this->Cal->sortLiturgicalEvents();
+                    $CalBackup      = clone( $this->Cal );
+                    $Messages       = $this->Messages;
+                    $this->Messages = [];
 
-                // Now we have to combine the two.
-                // The backup (which represents the main portion) should be appended to the calendar that was just generated
-                $this->Cal->merge($CalBackup);
+                    // Calculate the calendar for the previous year
+                    $this->CalendarParams->Year--;
+                    $this->Cal = new LiturgicalEventCollection($this->CalendarParams);
 
-                // Reset the year back to the original request before outputting results
-                $this->CalendarParams->Year++;
+                    $this->calculateUniversalCalendar();
 
-                // Append the messages from the backup calendar (current year) to the current messages (previous year)
-                // Unfortunately, we don't have a way of purging messages that regard events from the civil year calculations
-                //   that fall outside of the range of the current liturgical year.
-                array_push($this->Messages, ...$Messages);
+                    if ($this->CalendarParams->NationalCalendar !== null && $this->NationalData !== null) {
+                        $this->applyNationalCalendar();
+                    }
 
-                $response = $this->prepareResponseBody($request, $response);
-            } else {
-                $this->Cal->sortLiturgicalEvents();
-                $response = $this->prepareResponseBody($request, $response);
+                    // :SATURDAY_MEMORIAL_BVM
+                    $this->calculateSaturdayMemorialBVM();
+
+                    if ($this->CalendarParams->DiocesanCalendar !== null && $this->DiocesanData !== null) {
+                        $this->applyDiocesanCalendar();
+                    }
+
+                    $this->Cal->setSeasonsAndHolyDaysOfObligation();
+                    $this->Cal->setYearCyclesAndVigils();
+                    $this->Cal->calculatePsalterWeek();
+                    $this->Cal->sortLiturgicalEvents();
+
+                    $this->Cal->purgeDataBeforeAdvent();
+                    $CalBackup->purgeDataAdventChristmas();
+
+                    // Now we have to combine the two.
+                    // The backup (which represents the main portion) should be appended to the calendar that was just generated
+                    $this->Cal->merge($CalBackup);
+
+                    // Reset the year back to the original request before outputting results
+                    $this->CalendarParams->Year++;
+
+                    // Append the messages from the backup calendar (current year) to the current messages (previous year)
+                    // Unfortunately, we don't have a way of purging messages that regard events from the civil year calculations
+                    //   that fall outside of the range of the current liturgical year.
+                    array_push($this->Messages, ...$Messages);
+
+                    $response = $this->prepareResponseBody($request, $response);
+                } else {
+                    $this->Cal->sortLiturgicalEvents();
+                    $response = $this->prepareResponseBody($request, $response);
+                }
             }
         }
 

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -828,6 +828,11 @@ final class CalendarHandler extends AbstractHandler
      */
     private function loadPropriumDeTemporeData(): void
     {
+        if ($this->CalendarParams->Rite === Rite::AMBROSIAN) {
+            $this->loadAmbrosianPropriumDeTemporeData();
+            return;
+        }
+
         $propriumDeTemporeFile = strtr(
             JsonData::MISSAL_FILE->path(),
             ['{missal_folder}' => 'propriumdetempore']
@@ -835,6 +840,61 @@ final class CalendarHandler extends AbstractHandler
 
         $PropriumDeTempore       = Utilities::jsonFileToObjectArray($propriumDeTemporeFile);
         $PropriumDeTemporeI18n   = $this->loadPropriumDeTemporeI18nData();
+        $this->PropriumDeTempore = PropriumDeTemporeMap::fromObject($PropriumDeTempore);
+        $this->PropriumDeTempore->setNames($PropriumDeTemporeI18n);
+    }
+
+    /**
+     * Loads localization data stored in JSON format from a file in the
+     * `{JsonData::AMBROSIAN_TEMPORALE_I18N_FOLDER}` directory, named according to
+     * the given locale.
+     *
+     * If the file does not exist, or if there is an error decoding the
+     * JSON data, a 503 Service Unavailable error is thrown.
+     *
+     * @param string $locale The locale to load the i18n data for (must be one of the
+     *                       locales the Ambrosian Proprium de Tempore i18n data ships with).
+     * @return array<string,string> The loaded data.
+     */
+    private function loadAmbrosianPropriumDeTemporeI18nData(string $locale): array
+    {
+        $ambrosianPropriumDeTemporeI18nFile = strtr(
+            JsonData::AMBROSIAN_TEMPORALE_I18N_FILE->path(),
+            ['{locale}' => $locale]
+        );
+
+        $ambrosianPropriumDeTemporeI18nArr = Utilities::jsonFileToArray($ambrosianPropriumDeTemporeI18nFile);
+        if (array_filter(array_keys($ambrosianPropriumDeTemporeI18nArr), 'is_string') !== array_keys($ambrosianPropriumDeTemporeI18nArr)) {
+            throw new \Exception('We expected all the keys of the array to be strings.');
+        }
+        if (array_filter($ambrosianPropriumDeTemporeI18nArr, 'is_string') !== $ambrosianPropriumDeTemporeI18nArr) {
+            throw new \Exception('We expected all the values of the array to be strings.');
+        }
+        /** @var array<string,string> $ambrosianPropriumDeTemporeI18nArr */
+        return $ambrosianPropriumDeTemporeI18nArr;
+    }
+
+    /**
+     * Retrieve the Ambrosian Proprium de Tempore data, along with its i18n data.
+     *
+     * The Ambrosian Proprium de Tempore i18n data only ships `it` and `la` locales
+     * (see `jsondata/sourcedata/missals/ambrosian/propriumdetempore/i18n`). If the
+     * requested primary language isn't one of those, we fall back to Italian (`it`)
+     * rather than failing the request, mirroring how the Vatican/General Roman
+     * Calendar distinction elsewhere in this handler defaults to a sensible locale
+     * instead of forcing an unavailable one.
+     */
+    private function loadAmbrosianPropriumDeTemporeData(): void
+    {
+        $ambrosianPropriumDeTemporeFile = JsonData::AMBROSIAN_TEMPORALE_FILE->path();
+
+        $locale = LitLocale::$PRIMARY_LANGUAGE;
+        if (false === in_array($locale, ['it', 'la'], true)) {
+            $locale = 'it';
+        }
+
+        $PropriumDeTempore       = Utilities::jsonFileToObjectArray($ambrosianPropriumDeTemporeFile);
+        $PropriumDeTemporeI18n   = $this->loadAmbrosianPropriumDeTemporeI18nData($locale);
         $this->PropriumDeTempore = PropriumDeTemporeMap::fromObject($PropriumDeTempore);
         $this->PropriumDeTempore->setNames($PropriumDeTemporeI18n);
     }

--- a/src/Handlers/EventsHandler.php
+++ b/src/Handlers/EventsHandler.php
@@ -2,9 +2,11 @@
 
 namespace LiturgicalCalendar\Api\Handlers;
 
+use LiturgicalCalendar\Api\Enum\AmbrosianMissal;
 use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
 use LiturgicalCalendar\Api\Http\Enum\StatusCode;
 use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
@@ -18,6 +20,7 @@ use LiturgicalCalendar\Api\Models\Decrees\DecreeItemCreateNewMobile;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemMakeDoctor;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyGrade;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyName;
+use LiturgicalCalendar\Api\Models\Calendar\Missal\AmbrosianMissalResolver;
 use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventAbstract;
 use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventFixed;
 use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventMap;
@@ -60,6 +63,7 @@ final class EventsHandler extends AbstractHandler
     private static ?NationalData $NationalData       = null;
     private static ?WiderRegionData $WiderRegionData = null;
     private EventsParams $EventsParams;
+    private Rite $rite = Rite::ROMAN;
 
     /**
      * Initializes the EventsHandler.
@@ -68,10 +72,13 @@ final class EventsHandler extends AbstractHandler
      * to hold the liturgical events that will be populated during request handling.
      *
      * @param string[] $requestPathParams The path parameters from the request.
+     * @param Rite     $rite              The liturgical rite for which the events catalog should be
+     *                                    built (ROMAN or AMBROSIAN). Mirrors {@see CalendarHandler::__construct()}.
      */
-    public function __construct(array $requestPathParams = [])
+    public function __construct(array $requestPathParams = [], Rite $rite = Rite::ROMAN)
     {
         parent::__construct($requestPathParams);
+        $this->rite = $rite;
 
         self::$liturgicalEvents = new LiturgicalEventMap();
         self::$temporaleEvents  = [];
@@ -303,6 +310,11 @@ final class EventsHandler extends AbstractHandler
      */
     private function processSanctoraleEvents(): void
     {
+        if ($this->EventsParams->Rite === Rite::AMBROSIAN) {
+            $this->processAmbrosianSanctoraleEvents();
+            return;
+        }
+
         foreach (RomanMissal::getLatinMissalIds() as $LatinMissalId) {
             $MissalDataFile = RomanMissal::getSanctoraleFileName($LatinMissalId);
             $i18nPath       = RomanMissal::getSanctoraleI18nFilePath($LatinMissalId);
@@ -331,6 +343,62 @@ final class EventsHandler extends AbstractHandler
         }
     }
 
+    /**
+     * Ambrosian rite only: processes the comune Ambrosian Proprium de Sanctis (sanctorale) data
+     * and adds it to the catalog.
+     *
+     * Rite-scoped mirror of the Roman branch of {@see self::processSanctoraleEvents()} above: same
+     * raw-array read-and-name-lookup shape, but reading the single comune Ambrosian sanctorale
+     * (`{@see JsonData::AMBROSIAN_SANCTORALE_FILE}` / `_I18N_FILE`) resolved for the request year via
+     * {@see AmbrosianMissalResolver}, instead of looping {@see RomanMissal::getLatinMissalIds()}.
+     * There is no per-key skip-on-collision here (unlike
+     * `CalendarHandler::addAmbrosianSanctoraleToCalendar()`): temporale and sanctorale catalog
+     * entries are kept in separate buckets (`self::$temporaleEvents` vs. `self::$liturgicalEvents`),
+     * so the three keys shared between the two source files (`Christmas`, `Circoncisione`,
+     * `Epiphany`) never collide here the way they would in a single dated collection.
+     *
+     * Only called for {@see Rite::AMBROSIAN} requests, which `EventsParams::validateRiteCompatibility()`
+     * has already confirmed carry no national/diocesan calendar.
+     */
+    private function processAmbrosianSanctoraleEvents(): void
+    {
+        $edition = ( new AmbrosianMissalResolver() )->resolve($this->EventsParams->Year)[0];
+
+        $MissalDataFile = JsonData::AMBROSIAN_SANCTORALE_FILE->path();
+        $i18nFile       = strtr(JsonData::AMBROSIAN_SANCTORALE_I18N_FILE->path(), ['{locale}' => $this->resolveAmbrosianLocale()]);
+
+        $names      = Utilities::jsonFileToArray($i18nFile);
+        $MissalData = Utilities::jsonFileToArray($MissalDataFile);
+
+        /** @var array{event_key:string,month:integer,day:integer,grade:integer,color:string[],type:string,common?:string[],grade_display?:string} $liturgicalEvent */
+        foreach ($MissalData as $liturgicalEvent) {
+            $key = $liturgicalEvent['event_key'];
+            if (array_key_exists($key, $names)) {
+                $liturgicalEvent['name'] = $names[$key];
+            }
+            if (false === isset($liturgicalEvent['name'])) {
+                throw new \RuntimeException('Could not find name for liturgical event ' . $key . ' in the ' . AmbrosianMissal::getName($edition) . '.');
+            }
+            /** @var array{event_key:string,name:string,month:integer,day:integer,grade:integer,color:string[],type:string,common?:string[],grade_display?:string} $liturgicalEvent */
+            self::$liturgicalEvents->addEvent(LiturgicalEventFixed::fromArray($liturgicalEvent));
+        }
+    }
+
+    /**
+     * Ambrosian rite only: resolves the locale to use for the Ambrosian source data i18n files.
+     *
+     * The Ambrosian temporale and sanctorale i18n data only ship `it` and `la` locale files (see
+     * `jsondata/sourcedata/missals/ambrosian/propriumdetempore/i18n` and
+     * `jsondata/sourcedata/missals/ambrosian/propriumdesanctis_2024/i18n`). If the request's base
+     * locale isn't one of those, fall back to Italian (`it`), mirroring
+     * `CalendarHandler::loadAmbrosianPropriumDeTemporeData()` / `addAmbrosianSanctoraleToCalendar()`.
+     */
+    private function resolveAmbrosianLocale(): string
+    {
+        return in_array($this->EventsParams->baseLocale, ['it', 'la'], true)
+            ? $this->EventsParams->baseLocale
+            : 'it';
+    }
 
     /**
      * Processes the Temporale (Proprium de Tempore) events and adds them to the catalog.
@@ -340,11 +408,22 @@ final class EventsHandler extends AbstractHandler
      * entries and merged into the response. They matter to the catalog because they are the anchors a
      * decree's relative `strtotime` references (e.g. "Monday after Pentecost"). Reads the source list and
      * the localized names for the request's base locale.
+     *
+     * Ambrosian requests read the Ambrosian Proprium de Tempore source
+     * ({@see JsonData::AMBROSIAN_TEMPORALE_FILE} / `_I18N_FILE`) instead, with the same `it`/`la`
+     * (fallback `it`) locale resolution as
+     * `CalendarHandler::loadAmbrosianPropriumDeTemporeData()`. There is no per-edition resolution
+     * for the temporale (it is rite-wide, not Missal-edition-specific), mirroring that handler.
      */
     private function processTemporaleEvents(): void
     {
-        $dataFile = JsonData::TEMPORALE_FILE->path();
-        $i18nFile = strtr(JsonData::TEMPORALE_I18N_FILE->path(), ['{locale}' => $this->EventsParams->baseLocale]);
+        if ($this->EventsParams->Rite === Rite::AMBROSIAN) {
+            $dataFile = JsonData::AMBROSIAN_TEMPORALE_FILE->path();
+            $i18nFile = strtr(JsonData::AMBROSIAN_TEMPORALE_I18N_FILE->path(), ['{locale}' => $this->resolveAmbrosianLocale()]);
+        } else {
+            $dataFile = JsonData::TEMPORALE_FILE->path();
+            $i18nFile = strtr(JsonData::TEMPORALE_I18N_FILE->path(), ['{locale}' => $this->EventsParams->baseLocale]);
+        }
         if (false === file_exists($dataFile) || false === file_exists($i18nFile)) {
             return;
         }
@@ -663,9 +742,11 @@ final class EventsHandler extends AbstractHandler
         }
 
         $this->EventsParams = new EventsParams($params);
+        $this->EventsParams->setRite($this->rite);
         if (count($this->requestPathParams)) {
             $this->validateRequestPathParams();
         }
+        $this->EventsParams->validateRiteCompatibility();
 
         $this->validateRequestMethod($request);
 
@@ -674,9 +755,15 @@ final class EventsHandler extends AbstractHandler
         $this->setLocale();
         $this->processTemporaleEvents();
         $this->processSanctoraleEvents();
-        $this->processMemorialsFromDecreesData();
-        $this->processNationalCalendarData();
-        $this->processDiocesanCalendarData();
+        if ($this->EventsParams->Rite === Rite::ROMAN) {
+            // The Ambrosian rite has no national/diocesan layer or decrees data yet
+            // (comune ambrosiano only, for now); EventsParams::validateRiteCompatibility()
+            // above has already rejected any Ambrosian request carrying a national or
+            // diocesan calendar, so these three processors are Roman-only.
+            $this->processMemorialsFromDecreesData();
+            $this->processNationalCalendarData();
+            $this->processDiocesanCalendarData();
+        }
 
         $responseObj  = [
             // Temporale entries are date-less and live outside the (Fixed/Mobile) event map, so merge them in.

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -1560,7 +1560,8 @@ final class LiturgicalEventCollection
         }
 
         // `Easter` and `Easter2` are themselves anchored temporale events (Easter Sunday is
-        // preceded by its own `EasterVigil`; Easter II opens with the octave), so they must
+        // preceded by its own `EasterVigil`; Easter II is the octave day of Easter — its eve is
+        // itself the Saturday within the Easter octave, not a vigil), so they must
         // not receive a synthesized replacement vigil. The strict-inequality window checks
         // below exclude the days *inside* the octave but not these two boundary dates, so
         // exclude them explicitly by key.

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -1540,11 +1540,11 @@ final class LiturgicalEventCollection
      *   Roman, this method is not additionally guarded by a caller-side split on `HolyThurs`..
      *   `Easter2` (Roman's `setYearCyclesAndVigils()` only calls `calculateVigilMass()` for events
      *   strictly before `HolyThurs` or at/after `Easter2`), so `Easter` and `Easter2` themselves
-     *   remain nominally "eligible" here (they are Sundays with grade `HIGHER_SOLEMNITY`, and
-     *   `date > X->date` is false when the date IS `X->date`). This could generate a redundant
-     *   `Easter_vigil`/`Easter2_vigil` event alongside the already-anchored `EasterVigil` temporale
-     *   event. Left as-is pending Plan 9 ordo validation rather than silently guessing at an
-     *   additional exclusion rule not specified by the task brief.
+     *   would otherwise remain nominally "eligible" here (they are Sundays with grade
+     *   `HIGHER_SOLEMNITY`, and `date > X->date` is false when the date IS `X->date`), generating a
+     *   redundant `Easter_vigil`/`Easter2_vigil` event alongside the already-anchored `EasterVigil`
+     *   temporale event. They are therefore excluded explicitly by key below; the remaining
+     *   eligibility rules stay provisional pending Plan 9 ordo validation.
      *
      * @param LiturgicalEvent $litEvent The liturgical event object to test for vigil eligibility.
      * @return bool True if the liturgical event should have a vigil mass, false otherwise.
@@ -1557,6 +1557,15 @@ final class LiturgicalEventCollection
 
         if (null === $PalmSun || null === $Easter || null === $Easter2) {
             throw new \InvalidArgumentException('Missing liturgical events: PalmSun, Easter, or Easter2.');
+        }
+
+        // `Easter` and `Easter2` are themselves anchored temporale events (Easter Sunday is
+        // preceded by its own `EasterVigil`; Easter II opens with the octave), so they must
+        // not receive a synthesized replacement vigil. The strict-inequality window checks
+        // below exclude the days *inside* the octave but not these two boundary dates, so
+        // exclude them explicitly by key.
+        if ('Easter' === $litEvent->event_key || 'Easter2' === $litEvent->event_key) {
+            return false;
         }
 
         return (

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -1413,6 +1413,68 @@ final class LiturgicalEventCollection
     }
 
     /**
+     * Ambrosian rite only: sets the festive (A/B/C) and ferial (I/II) year cycles, and computes
+     * first-vespers vigil Masses, for each liturgical event in the collection.
+     *
+     * Mirrors the rite-agnostic arithmetic half of the Roman `setYearCyclesAndVigils()`:
+     *
+     * - The A/B/C festive cycle and I/II ferial cycle formulas (keyed off `Advent1`'s date and
+     *   `$this->CalendarParams->Year`, using the same {@see self::SUNDAY_CYCLE} /
+     *   {@see self::WEEKDAY_CYCLE} constants) are rite-agnostic and are reused verbatim.
+     * - The weekday-cycle guard, however, cannot reuse `inOrdinaryTime()`: that method requires an
+     *   `AshWednesday` event, which does not exist in the Ambrosian temporale. Instead, this method
+     *   only assigns a weekday cycle to events whose `liturgical_season` is
+     *   {@see LitSeason::AFTER_EPIPHANY} or {@see LitSeason::AFTER_PENTECOST} — the Ambrosian
+     *   analogue of Roman "Ordinary Time" (see `stampAmbrosianSeasonOnSanctorale()` for how
+     *   `liturgical_season` is populated).
+     * - The ~150 lines of Roman lectionary-readings retrieval (`ReadingsGeneralRoman`,
+     *   `getSanctoraleReadings()`, `getCycle()`, etc.) are deliberately OMITTED: there is no
+     *   Ambrosian lectionary source yet, and every Ambrosian event already carries the
+     *   empty-readings placeholder set by `AmbrosianReadings::empty()` (Plan 7 Task 2/4).
+     * - As in the Roman method, the fixed-date temporale events that share their readings/cycle
+     *   every year do not get a `liturgical_year` string: the Roman exclusion list
+     *   (`Christmas`, `MaryMotherOfGod`, `Christmas2`, `Epiphany`, `AshWednesday`) is adapted to
+     *   its Ambrosian equivalents (`Christmas`, `Circoncisione`, `Epiphany`).
+     * - Vigil Mass computation ({@see self::calculateAmbrosianVigilMass()}) is attempted for every
+     *   Sunday/solemnity/feast-of-the-Lord-grade event, exactly mirroring where the Roman method
+     *   calls `calculateVigilMass()`.
+     *
+     * Must run after `stampAmbrosianSeasonOnSanctorale()` (which this method depends on for the
+     * weekday-cycle guard) and `setAmbrosianHolyDaysOfObligation()`.
+     *
+     * @return void
+     */
+    public function setAmbrosianYearCyclesAndVigils(): void
+    {
+        $Advent1 = $this->liturgicalEvents->getEvent('Advent1');
+        if (null === $Advent1) {
+            throw new \InvalidArgumentException('Missing liturgical event: Advent1.');
+        }
+
+        foreach ($this->liturgicalEvents as $litEvent) {
+            if (self::dateIsNotSunday($litEvent->date) && $litEvent->grade === LitGrade::WEEKDAY) {
+                // Ambrosian "Ordinary Time" analogue: only weekdays after Epiphany or after
+                // Pentecost follow a ferial (I/II) cycle; weekdays of Advent, Christmas, Lent
+                // and Easter (and the various de Exceptato / Martyrdom / Dedication sub-blocks,
+                // which are NOT after-Epiphany/after-Pentecost) do not.
+                if ($litEvent->liturgical_season === LitSeason::AFTER_EPIPHANY || $litEvent->liturgical_season === LitSeason::AFTER_PENTECOST) {
+                    $weekdayCycle              = self::WEEKDAY_CYCLE[( $this->CalendarParams->Year - 1 ) % 2];
+                    $litEvent->liturgical_year = $this->T['YEAR'] . ' ' . $weekdayCycle;
+                }
+            } elseif (self::dateIsSunday($litEvent->date) || $litEvent->grade->value > LitGrade::FEAST->value) {
+                if (false === in_array($litEvent->event_key, ['Christmas', 'Circoncisione', 'Epiphany'], true)) {
+                    $festiveCycle              = $litEvent->date < $Advent1->date
+                        ? self::SUNDAY_CYCLE[( $this->CalendarParams->Year - 1 ) % 3]
+                        : self::SUNDAY_CYCLE[$this->CalendarParams->Year % 3];
+                    $litEvent->liturgical_year = $this->T['YEAR'] . ' ' . $festiveCycle;
+                }
+
+                $this->calculateAmbrosianVigilMass($litEvent);
+            }
+        }
+    }
+
+    /**
      * Determines if a given liturgical event can have a vigil mass.
      *
      * This function evaluates whether a liturgical event, identified by its key and date, is eligible for a vigil mass.
@@ -1446,6 +1508,62 @@ final class LiturgicalEventCollection
                 && false === ( $litEvent->event->date > $Easter->date && $litEvent->event->date < $Easter2->date )
             );
         }
+    }
+
+    /**
+     * Ambrosian rite only: determines if a given liturgical event should have a first-vespers
+     * vigil Mass.
+     *
+     * **PROVISIONAL — flagged for Plan 9 ordo validation.** This is a deliberately simplified
+     * adaptation of the Roman `liturgicalEventCanHaveVigil()`, not a faithful transcription of the
+     * actual Ambrosian rubrics governing First/Second Vespers, which have not yet been reviewed
+     * against a real Ambrosian ordo:
+     *
+     * - Eligibility is `dateIsSunday() || grade >= LitGrade::SOLEMNITY`, i.e. every Sunday plus
+     *   every Solemnity (comune or proper), regardless of `is_dominical`. The Roman
+     *   `SOLEMNITIES_LORD_BVM` precedence list and the one-off `Year === 2022` decree special case
+     *   (both used only to resolve *coincidences* between a vigil and another Solemnity landing on
+     *   the same date) are intentionally NOT ported: this method (and
+     *   {@see self::calculateAmbrosianVigilMass()}) does not attempt coincidence resolution at all
+     *   — it unconditionally creates the vigil event once eligibility is established. `is_dominical`
+     *   is available on `LiturgicalEvent` (see `AmbrosianLiturgicalDayRank::isDominicalSunday()`)
+     *   should a future Plan 9 pass need to distinguish "of the Lord" solemnities from others when
+     *   resolving such coincidences.
+     * - The Roman `AllSouls` and `AshWednesday` key exclusions do not apply: the Ambrosian
+     *   calendar has no `AshWednesday`, and `AllSouls` is not itself excluded from a vigil in the
+     *   Ambrosian rite (unlike Roman, where it is excluded because it is not, in the Roman rite, a
+     *   day that has Vespers I).
+     * - The Triduum exclusion window is adapted to the Ambrosian anchors `PalmSun`/`Easter`/
+     *   `Easter2` (which, unlike Roman's `AshWednesday`, DO exist in the Ambrosian temporale), but
+     *   only excludes dates *strictly inside* `PalmSun`..`Easter` and *strictly inside*
+     *   `Easter`..`Easter2` — exactly mirroring the Roman method's own boundary semantics. Unlike
+     *   Roman, this method is not additionally guarded by a caller-side split on `HolyThurs`..
+     *   `Easter2` (Roman's `setYearCyclesAndVigils()` only calls `calculateVigilMass()` for events
+     *   strictly before `HolyThurs` or at/after `Easter2`), so `Easter` and `Easter2` themselves
+     *   remain nominally "eligible" here (they are Sundays with grade `HIGHER_SOLEMNITY`, and
+     *   `date > X->date` is false when the date IS `X->date`). This could generate a redundant
+     *   `Easter_vigil`/`Easter2_vigil` event alongside the already-anchored `EasterVigil` temporale
+     *   event. Left as-is pending Plan 9 ordo validation rather than silently guessing at an
+     *   additional exclusion rule not specified by the task brief.
+     *
+     * @param LiturgicalEvent $litEvent The liturgical event object to test for vigil eligibility.
+     * @return bool True if the liturgical event should have a vigil mass, false otherwise.
+     */
+    private function ambrosianEventCanHaveVigil(LiturgicalEvent $litEvent): bool
+    {
+        $PalmSun = $this->liturgicalEvents->getEvent('PalmSun');
+        $Easter  = $this->liturgicalEvents->getEvent('Easter');
+        $Easter2 = $this->liturgicalEvents->getEvent('Easter2');
+
+        if (null === $PalmSun || null === $Easter || null === $Easter2) {
+            throw new \InvalidArgumentException('Missing liturgical events: PalmSun, Easter, or Easter2.');
+        }
+
+        return (
+            ( self::dateIsSunday($litEvent->date) || $litEvent->grade->value >= LitGrade::SOLEMNITY->value )
+            && false === ( $litEvent->date > $PalmSun->date && $litEvent->date < $Easter->date )
+            && false === ( $litEvent->date > $Easter->date && $litEvent->date < $Easter2->date )
+        );
     }
 
     /**
@@ -1681,6 +1799,37 @@ final class LiturgicalEventCollection
                 $litEvent->has_vesper_i   = false;
             }
         }
+    }
+
+    /**
+     * Ambrosian rite only: given a liturgical event, determines whether it should have a
+     * first-vespers vigil Mass and, if so, creates it.
+     *
+     * Unlike the Roman `calculateVigilMass()`, this method does NOT attempt to resolve a
+     * coincidence between the newly-created vigil and another Solemnity that might already occupy
+     * the vigil date (no `SOLEMNITIES_LORD_BVM` precedence list, no `Year === 2022` decree special
+     * case — see {@see self::ambrosianEventCanHaveVigil()}'s docblock for the full rationale).
+     * It reuses the Roman `createVigilMassFor()` verbatim for the actual event creation and
+     * field-stamping (new `{key}_vigil` event, `is_vigil_mass`/`is_vigil_for` on the vigil,
+     * `has_vigil_mass`/`has_vesper_i`/`has_vesper_ii` on the parent, and the readings placeholder
+     * copied across), keeping this a thin day-granularity wrapper around the shared mechanism.
+     *
+     * **PROVISIONAL — flagged for Plan 9 ordo validation**, per
+     * {@see self::ambrosianEventCanHaveVigil()}.
+     *
+     * @param LiturgicalEvent $litEvent The liturgical event object to (potentially) create a vigil for.
+     * @return void
+     */
+    private function calculateAmbrosianVigilMass(LiturgicalEvent $litEvent): void
+    {
+        if (false === $this->ambrosianEventCanHaveVigil($litEvent)) {
+            return;
+        }
+
+        $VigilDate = clone( $litEvent->date );
+        $VigilDate->sub(new \DateInterval('P1D'));
+
+        $this->createVigilMassFor($litEvent, $VigilDate);
     }
 
     /**

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -3,6 +3,7 @@
 namespace LiturgicalCalendar\Api\Models\Calendar;
 
 use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\AmbrosianHolyDaysOfObligation;
 use LiturgicalCalendar\Api\Enum\LitCommon;
 use LiturgicalCalendar\Api\Enum\LitGrade;
 use LiturgicalCalendar\Api\Enum\LitLocale;
@@ -1093,6 +1094,89 @@ final class LiturgicalEventCollection
             }
 
             if (in_array($litEvent->event_key, $HolyDaysofObligation)) {
+                $litEvent->holy_day_of_obligation = true;
+            }
+        }
+    }
+
+    /**
+     * Ambrosian rite only: stamps a `liturgical_season` on every liturgical event that doesn't
+     * already have one.
+     *
+     * Unlike the Roman rite, where `setSeasonsAndHolyDaysOfObligation()` derives the season
+     * purely from the date (relative to `AshWednesday`, `Pentecost`, etc. — none of which exist
+     * as such in the Ambrosian calendar), the Ambrosian `AmbrosianTemporale` engine (Plan 7 Task
+     * 3/5) already self-stamps `liturgical_season` on every temporale event it produces, via
+     * `LitSeason::forEventKey()`. That engine is gap-free: it produces a ferial or festive
+     * temporale event for essentially every date of the year. The Ambrosian comune sanctorale
+     * (Plan 7 Task 4, `CalendarHandler::addAmbrosianSanctoraleToCalendar()`), by contrast, carries
+     * no season information at all — sanctorale source data has no `liturgical_season` field.
+     *
+     * This method fills that gap: for every event with a null `liturgical_season`, it looks for
+     * another event already occupying the same date (via `getCalEventsFromDate()`) that DOES carry
+     * a season, and copies that season over. This works for the overwhelming majority of dates
+     * because the temporale engine already covers them.
+     *
+     * The one known exception is the Ambrosian n.32 rule (deferred, not yet implemented): when a
+     * Sunday falls within the Christmas octave (Dec 26-31), the Ambrosian temporale engine does
+     * not currently produce a Sunday event for that date (the rule that would replace the ferial
+     * `ChristmasWeekday*` entry with a proper Sunday-within-the-octave celebration hasn't been
+     * implemented yet), so no seasoned event exists on that date to copy from. For that narrow gap
+     * this method falls back to `LitSeason::CHRISTMAS`, since Dec 26-31 always falls within the
+     * Christmas octave regardless of which weekday Dec 25 lands on.
+     *
+     * Must run before any coincidence/precedence resolution that depends on `liturgical_season`
+     * being populated (e.g. a future `resolve()` step), and does not touch Holy-Day-of-Obligation
+     * markers (see `setAmbrosianHolyDaysOfObligation()`).
+     *
+     * @return void
+     */
+    public function stampAmbrosianSeasonOnSanctorale(): void
+    {
+        foreach ($this->liturgicalEvents as $litEvent) {
+            if (null !== $litEvent->liturgical_season) {
+                continue;
+            }
+
+            $season = null;
+            foreach ($this->getCalEventsFromDate($litEvent->date) as $coincidingEvent) {
+                if (null !== $coincidingEvent->liturgical_season) {
+                    $season = $coincidingEvent->liturgical_season;
+                    break;
+                }
+            }
+
+            // Fallback for the deferred n.32 Christmas-octave-Sunday gap (Dec 26-31): no
+            // seasoned temporale event exists on that date yet, but the date is still
+            // unambiguously within the Christmas season.
+            $litEvent->liturgical_season = $season ?? LitSeason::CHRISTMAS;
+        }
+    }
+
+    /**
+     * Ambrosian rite only: marks Holy Days of Obligation.
+     *
+     * Mirrors the rite-agnostic HDoO half of the Roman `setSeasonsAndHolyDaysOfObligation()`
+     * (`in_array($event_key, $HolyDaysOfObligation)`, plus marking every Sunday), but sources the
+     * `event_key` set from `AmbrosianHolyDaysOfObligation::DEFAULT` instead of the Roman
+     * `CalendarParams::$HolyDaysOfObligation` default, since the two calendars don't share event
+     * keys for their days of precept (see `AmbrosianHolyDaysOfObligation` for the provisional,
+     * ordo-validation-pending set and its rationale).
+     *
+     * As in the Roman rite, every Sunday is also a holy day of obligation regardless of
+     * `event_key`.
+     *
+     * @return void
+     */
+    public function setAmbrosianHolyDaysOfObligation(): void
+    {
+        // Unlike the Roman `CalendarParams::$HolyDaysOfObligation` (a mutable instance property
+        // that request params can toggle, hence the `array_filter()` there), the Ambrosian
+        // default is a fixed `const` with every value `true`, so its keys are exactly its HDoO set.
+        $holyDaysOfObligation = array_keys(AmbrosianHolyDaysOfObligation::DEFAULT);
+
+        foreach ($this->liturgicalEvents as $litEvent) {
+            if (in_array($litEvent->event_key, $holyDaysOfObligation, true) || (int) $litEvent->date->format('N') === 7) {
                 $litEvent->holy_day_of_obligation = true;
             }
         }

--- a/src/Models/Lectionary/AmbrosianReadings.php
+++ b/src/Models/Lectionary/AmbrosianReadings.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Models\Lectionary;
+
+/**
+ * Factory for the Ambrosian empty-readings placeholder (Plan 7 / Task 2).
+ *
+ * There is currently no Ambrosian lectionary data source in this codebase, but the `LitCal.json`
+ * response schema requires every `LiturgicalEvent` to carry a `readings` property that validates
+ * against `CommonDef.json#/definitions/Readings`. Until a real Ambrosian lectionary is wired in,
+ * Ambrosian events (both sanctorale and temporale) are given the placeholder produced by
+ * {@see self::empty()} so that calendar generation and schema validation both succeed.
+ *
+ * `ReadingsFerial` is deliberately reused rather than inventing a new shape: it is the simplest
+ * of the `ReadingsAbstract` subclasses accepted by `CommonDef.json#/definitions/Readings`
+ * (only `first_reading`, `responsorial_psalm`, `gospel_acclamation`, and `gospel`, all plain
+ * strings, `additionalProperties: false`), so populating all four required fields with empty
+ * strings is sufficient to be schema-valid without implying any actual liturgical content.
+ */
+final class AmbrosianReadings
+{
+    private function __construct()
+    {
+        // Not instantiable; use self::empty() to obtain the placeholder.
+    }
+
+    /**
+     * Builds a schema-valid, content-empty `ReadingsFerial` instance to serve as the Ambrosian
+     * readings placeholder.
+     *
+     * @return ReadingsFerial A `ReadingsAbstract` instance with all required fields set to `""`.
+     */
+    public static function empty(): ReadingsFerial
+    {
+        return ReadingsFerial::fromArray([
+            'first_reading'      => '',
+            'responsorial_psalm' => '',
+            'gospel_acclamation' => '',
+            'gospel'             => '',
+        ]);
+    }
+}

--- a/src/Models/Metadata/MetadataAmbrosianCalendarItem.php
+++ b/src/Models/Metadata/MetadataAmbrosianCalendarItem.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Models\Metadata;
+
+use LiturgicalCalendar\Api\Models\AbstractJsonRepresentation;
+
+/**
+ * Metadata for a non-Roman-rite comune calendar (currently only the
+ * Ambrosian rite's `/calendar/ambrosian` comune).
+ *
+ * Unlike {@see MetadataNationalCalendarItem} and
+ * {@see MetadataDiocesanCalendarItem} (which are always implicitly Roman
+ * rite), items in this collection carry an explicit `rite` value because
+ * they exist specifically to represent a non-Roman rite's calendar.
+ *
+ * @see \LiturgicalCalendar\Api\Enum\Rite
+ */
+final class MetadataAmbrosianCalendarItem extends AbstractJsonRepresentation
+{
+    public string $calendar_id;
+
+    public string $rite;
+
+    /** @var string[] */
+    public array $locales;
+
+    /**
+     * Initializes a MetadataAmbrosianCalendarItem object.
+     *
+     * @param string $calendar_id The path segment identifying the comune calendar (e.g. `ambrosian`, used as `/calendar/{$calendar_id}`).
+     * @param string $rite The {@see \LiturgicalCalendar\Api\Enum\Rite} value this comune calendar is computed under.
+     * @param string[] $locales The locales supported by the comune calendar.
+     */
+    public function __construct(
+        string $calendar_id,
+        string $rite,
+        array $locales
+    ) {
+        $this->calendar_id = $calendar_id;
+        $this->rite        = $rite;
+        $this->locales     = $locales;
+    }
+
+    /**
+     * Converts the MetadataAmbrosianCalendarItem object to an associative array
+     * for JSON serialization.
+     *
+     * The array contains the following keys:
+     * - calendar_id: The path segment identifying the comune calendar.
+     * - rite: The rite this comune calendar is computed under.
+     * - locales: An array of locales supported by the comune calendar.
+     *
+     * @return array{calendar_id:string,rite:string,locales:string[]} The associative array representation of the object.
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'calendar_id' => $this->calendar_id,
+            'rite'        => $this->rite,
+            'locales'     => $this->locales,
+        ];
+    }
+
+    /**
+     * Creates an instance of MetadataAmbrosianCalendarItem from an associative array.
+     *
+     * The array must have the following keys:
+     * - calendar_id (string): The path segment identifying the comune calendar.
+     * - rite (string): The rite this comune calendar is computed under.
+     * - locales (string[]): The locales supported by the comune calendar.
+     *
+     * @param array{calendar_id:string,rite:string,locales:string[]} $data
+     * @return static
+     */
+    protected static function fromArrayInternal(array $data): static
+    {
+        return new static(
+            $data['calendar_id'],
+            $data['rite'],
+            $data['locales']
+        );
+    }
+
+    /**
+     * Creates an instance of MetadataAmbrosianCalendarItem from a stdClass object.
+     *
+     * The object should have the following properties:
+     * - calendar_id (string): The path segment identifying the comune calendar.
+     * - rite (string): The rite this comune calendar is computed under.
+     * - locales (string[]): The locales supported by the comune calendar.
+     *
+     * @param \stdClass&object{calendar_id:string,rite:string,locales:string[]} $data
+     * @return static
+     */
+    protected static function fromObjectInternal(\stdClass $data): static
+    {
+        return new static(
+            $data->calendar_id,
+            $data->rite,
+            $data->locales
+        );
+    }
+}

--- a/src/Models/Metadata/MetadataCalendars.php
+++ b/src/Models/Metadata/MetadataCalendars.php
@@ -35,7 +35,13 @@ use LiturgicalCalendar\Api\Models\AbstractJsonRepresentation;
  *         api_path:string
  *     }>,
  *     wider_regions_keys:string[],
- *     locales:string[]
+ *     locales:string[],
+ *     ambrosian_calendars:array<\stdClass&object{
+ *         calendar_id:string,
+ *         rite:string,
+ *         locales:string[]
+ *     }>,
+ *     ambrosian_calendars_keys:string[]
  * }
  *
  * @phpstan-type MetadataCalendarsArray array{
@@ -68,7 +74,13 @@ use LiturgicalCalendar\Api\Models\AbstractJsonRepresentation;
  *         api_path:string
  *     }>,
  *     wider_regions_keys:string[],
- *     locales:string[]
+ *     locales:string[],
+ *     ambrosian_calendars:array<array{
+ *         calendar_id:string,
+ *         rite:string,
+ *         locales:string[]
+ *     }>,
+ *     ambrosian_calendars_keys:string[]
  * }
  */
 final class MetadataCalendars extends AbstractJsonRepresentation
@@ -97,6 +109,12 @@ final class MetadataCalendars extends AbstractJsonRepresentation
     /** @var string[] */
     public array $locales;
 
+    /** @var MetadataAmbrosianCalendarItem[] */
+    public array $ambrosian_calendars;
+
+    /** @var string[] */
+    public array $ambrosian_calendars_keys;
+
     /**
      * Constructs a MetadataCalendars object.
      *
@@ -108,6 +126,8 @@ final class MetadataCalendars extends AbstractJsonRepresentation
      * @param MetadataWiderRegionItem[] $wider_regions Wider regions, each serialized to an array.
      * @param string[] $wider_regions_keys The keys for the wider regions.
      * @param string[] $locales The locales supported by the national calendars.
+     * @param MetadataAmbrosianCalendarItem[] $ambrosian_calendars Non-Roman-rite comune calendars (e.g. the Ambrosian `/calendar/ambrosian` comune), each serialized to an array.
+     * @param string[] $ambrosian_calendars_keys The keys for the ambrosian calendars.
      */
     public function __construct(
         array $national_calendars      = [],
@@ -117,16 +137,20 @@ final class MetadataCalendars extends AbstractJsonRepresentation
         array $diocesan_groups         = [],
         array $wider_regions           = [],
         array $wider_regions_keys      = [],
-        array $locales                 = []
+        array $locales                 = [],
+        array $ambrosian_calendars      = [],
+        array $ambrosian_calendars_keys = []
     ) {
-        $this->national_calendars      = $national_calendars;
-        $this->national_calendars_keys = $national_calendars_keys;
-        $this->diocesan_calendars      = $diocesan_calendars;
-        $this->diocesan_calendars_keys = $diocesan_calendars_keys;
-        $this->diocesan_groups         = $diocesan_groups;
-        $this->wider_regions           = $wider_regions;
-        $this->wider_regions_keys      = $wider_regions_keys;
-        $this->locales                 = $locales;
+        $this->national_calendars       = $national_calendars;
+        $this->national_calendars_keys  = $national_calendars_keys;
+        $this->diocesan_calendars       = $diocesan_calendars;
+        $this->diocesan_calendars_keys  = $diocesan_calendars_keys;
+        $this->diocesan_groups          = $diocesan_groups;
+        $this->wider_regions            = $wider_regions;
+        $this->wider_regions_keys       = $wider_regions_keys;
+        $this->locales                  = $locales;
+        $this->ambrosian_calendars      = $ambrosian_calendars;
+        $this->ambrosian_calendars_keys = $ambrosian_calendars_keys;
     }
 
 
@@ -141,6 +165,8 @@ final class MetadataCalendars extends AbstractJsonRepresentation
      * - wider_regions: The wider regions, each serialized to an array.
      * - wider_regions_keys: The keys for the wider regions.
      * - locales: The locales supported by the national calendars.
+     * - ambrosian_calendars: The non-Roman-rite comune calendars, each serialized to an array.
+     * - ambrosian_calendars_keys: The keys for the ambrosian calendars.
      *
      * @return MetadataCalendarsArray The associative array containing the metadata or index of all available calendars (whether General Roman, national, or diocesan), diocesan groups, wider regions, and locales.
      *
@@ -148,38 +174,46 @@ final class MetadataCalendars extends AbstractJsonRepresentation
     public function jsonSerialize(): array
     {
         return [
-            'national_calendars'      => array_map(
+            'national_calendars'       => array_map(
                 /** @return array{calendar_id:string,locales:string[],missals:string[],settings:array{epiphany:string,ascension:string,corpus_christi:string,eternal_high_priest:bool},wider_region?:string,dioceses?:string[]} */
                 function (MetadataNationalCalendarItem $nc): array {
                     return $nc->jsonSerialize();
                 },
                 $this->national_calendars
             ),
-            'national_calendars_keys' => $this->national_calendars_keys,
-            'diocesan_calendars'      => array_map(
+            'national_calendars_keys'  => $this->national_calendars_keys,
+            'diocesan_calendars'       => array_map(
                 /** @return array{calendar_id:string,diocese:string,nation:string,locales:string[],timezone:string,group?:string,settings?:array{epiphany?:string,ascension?:string,corpus_christi?:string,eternal_high_priest?:bool}} */
                 function (MetadataDiocesanCalendarItem $dc): array {
                     return $dc->jsonSerialize();
                 },
                 $this->diocesan_calendars
             ),
-            'diocesan_calendars_keys' => $this->diocesan_calendars_keys,
-            'diocesan_groups'         => array_map(
+            'diocesan_calendars_keys'  => $this->diocesan_calendars_keys,
+            'diocesan_groups'          => array_map(
                 /** @return array{group_name:string,dioceses:string[]} */
                 function (MetadataDiocesanGroupItem $dg): array {
                     return $dg->jsonSerialize();
                 },
                 $this->diocesan_groups
             ),
-            'wider_regions'           => array_map(
+            'wider_regions'            => array_map(
                 /** @return array{name:string,locales:string[],api_path:string} */
                 function (MetadataWiderRegionItem $wr): array {
                     return $wr->jsonSerialize();
                 },
                 $this->wider_regions
             ),
-            'wider_regions_keys'      => $this->wider_regions_keys,
-            'locales'                 => $this->locales
+            'wider_regions_keys'       => $this->wider_regions_keys,
+            'locales'                  => $this->locales,
+            'ambrosian_calendars'      => array_map(
+                /** @return array{calendar_id:string,rite:string,locales:string[]} */
+                function (MetadataAmbrosianCalendarItem $ac): array {
+                    return $ac->jsonSerialize();
+                },
+                $this->ambrosian_calendars
+            ),
+            'ambrosian_calendars_keys' => $this->ambrosian_calendars_keys
         ];
     }
 
@@ -195,6 +229,8 @@ final class MetadataCalendars extends AbstractJsonRepresentation
      * - wider_regions (array): An array of associative arrays that can be used to create MetadataWiderRegionItem objects.
      * - wider_regions_keys (string[]): An array of strings that are the keys of the wider regions.
      * - locales (string[]): An array of strings that are the locales supported by this set of calendars.
+     * - ambrosian_calendars (array): An array of associative arrays that can be used to create MetadataAmbrosianCalendarItem objects.
+     * - ambrosian_calendars_keys (string[]): An array of strings that are the keys of the ambrosian calendars.
      *
      * @param MetadataCalendarsArray $data The associative array containing the metadata or index of all available calendars (whether General Roman, national, or diocesan), diocesan groups, wider regions, and locales.
      * @return static
@@ -209,7 +245,9 @@ final class MetadataCalendars extends AbstractJsonRepresentation
             array_map([MetadataDiocesanGroupItem::class, 'fromArray'], $data['diocesan_groups']),
             array_map([MetadataWiderRegionItem::class, 'fromArray'], $data['wider_regions']),
             $data['wider_regions_keys'],
-            $data['locales']
+            $data['locales'],
+            array_map([MetadataAmbrosianCalendarItem::class, 'fromArray'], $data['ambrosian_calendars']),
+            $data['ambrosian_calendars_keys']
         );
     }
 
@@ -225,6 +263,8 @@ final class MetadataCalendars extends AbstractJsonRepresentation
      * - wider_regions: The wider regions, each serialized to an object.
      * - wider_regions_keys: The keys for the wider regions.
      * - locales: The locales supported by the national calendars.
+     * - ambrosian_calendars: The non-Roman-rite comune calendars, each serialized to an object.
+     * - ambrosian_calendars_keys: The keys for the ambrosian calendars.
      *
      * @param MetadataCalendarsObject $data The \stdClass object containing the metadata or index of all available calendars (whether General Roman, national, or diocesan), diocesan groups, wider regions, and locales.
      * @return static
@@ -239,7 +279,9 @@ final class MetadataCalendars extends AbstractJsonRepresentation
             array_map([MetadataDiocesanGroupItem::class, 'fromObject'], $data->diocesan_groups),
             array_map([MetadataWiderRegionItem::class, 'fromObject'], $data->wider_regions),
             $data->wider_regions_keys,
-            $data->locales
+            $data->locales,
+            array_map([MetadataAmbrosianCalendarItem::class, 'fromObject'], $data->ambrosian_calendars),
+            $data->ambrosian_calendars_keys
         );
     }
 
@@ -297,5 +339,18 @@ final class MetadataCalendars extends AbstractJsonRepresentation
     {
         $this->wider_regions[]      = $metadata;
         $this->wider_regions_keys[] = $metadata->name;
+    }
+
+    /**
+     * Adds a non-Roman-rite comune calendar metadata item to the collection
+     * (e.g. the Ambrosian `/calendar/ambrosian` comune).
+     *
+     * @param MetadataAmbrosianCalendarItem $metadata The ambrosian calendar
+     *                                                 metadata item to add.
+     */
+    public function pushAmbrosianCalendarMetadata(MetadataAmbrosianCalendarItem $metadata): void
+    {
+        $this->ambrosian_calendars[]      = $metadata;
+        $this->ambrosian_calendars_keys[] = $metadata->calendar_id;
     }
 }

--- a/src/Params/EventsParams.php
+++ b/src/Params/EventsParams.php
@@ -31,6 +31,15 @@ class EventsParams implements ParamsInterface
     public ?string $DiocesanCalendar = null;
     public Rite $Rite                = Rite::ROMAN;
 
+    /**
+     * True when a `national_calendar=VA` filter was supplied on this request.
+     * VA normalizes `$NationalCalendar` back to null (it selects the General Roman
+     * Calendar, which has no national override), so this marker preserves the fact
+     * that a national filter WAS requested — needed to reject an Ambrosian request
+     * that (nonsensically) also asks for the VA national calendar.
+     */
+    private bool $vaNationalRequested = false;
+
     public readonly MetadataCalendars $calendarsMetadata;
 
     public const ALLOWED_PARAMS = [
@@ -155,7 +164,8 @@ class EventsParams implements ParamsInterface
                             throw new ValidationException($description);
                         }
                         if ($value === 'VA') {
-                            $forceVaInvariants = true;
+                            $forceVaInvariants         = true;
+                            $this->vaNationalRequested = true;
                         } else {
                             $this->NationalCalendar = strtoupper($value);
                         }
@@ -251,7 +261,7 @@ class EventsParams implements ParamsInterface
             return;
         }
 
-        if ($this->NationalCalendar !== null) {
+        if ($this->NationalCalendar !== null || $this->vaNationalRequested) {
             throw new ValidationException(
                 'The Ambrosian rite has no national calendars; request the comune ambrosiano events catalog (`/events/ambrosian`).'
             );

--- a/src/Params/EventsParams.php
+++ b/src/Params/EventsParams.php
@@ -3,6 +3,7 @@
 namespace LiturgicalCalendar\Api\Params;
 
 use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
@@ -28,6 +29,7 @@ class EventsParams implements ParamsInterface
     public bool $EternalHighPriest   = false;
     public ?string $NationalCalendar = null;
     public ?string $DiocesanCalendar = null;
+    public Rite $Rite                = Rite::ROMAN;
 
     public readonly MetadataCalendars $calendarsMetadata;
 
@@ -220,5 +222,45 @@ class EventsParams implements ParamsInterface
     private function isValidDiocesanCalendar(string $calendar): bool
     {
         return in_array($calendar, $this->calendarsMetadata->diocesan_calendars_keys);
+    }
+
+    /**
+     * Sets the liturgical rite for which the events catalog should be built.
+     *
+     * @param Rite $rite the liturgical rite (ROMAN or AMBROSIAN)
+     */
+    public function setRite(Rite $rite): void
+    {
+        $this->Rite = $rite;
+    }
+
+    /**
+     * Cross-field validation of the rite against the requested calendar. Roman accepts
+     * every calendar shape. The Ambrosian rite has no national layer and, for the events
+     * catalog, no diocesan layer either (comune ambrosiano only, for now) — a national or
+     * diocesan calendar request combined with the Ambrosian rite is rejected. Mirrors
+     * {@see \LiturgicalCalendar\Api\Params\CalendarParams::validateRiteCompatibility()}, minus the
+     * year-floor check (the events catalog is year-agnostic). Must be called after the rite
+     * and any `national_calendar`/`diocesan_calendar` parameters have been set.
+     *
+     * @throws ValidationException
+     */
+    public function validateRiteCompatibility(): void
+    {
+        if ($this->Rite === Rite::ROMAN) {
+            return;
+        }
+
+        if ($this->NationalCalendar !== null) {
+            throw new ValidationException(
+                'The Ambrosian rite has no national calendars; request the comune ambrosiano events catalog (`/events/ambrosian`).'
+            );
+        }
+
+        if ($this->DiocesanCalendar !== null) {
+            throw new ValidationException(
+                'The Ambrosian rite does not yet support diocesan event catalogs; request the comune ambrosiano events catalog (`/events/ambrosian`).'
+            );
+        }
     }
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -105,22 +105,24 @@ class Router
 
     /**
      * Determines the liturgical rite from an optional leading rite segment on the
-     * calendar route, stripping that segment from the request-path parts when present.
+     * calendar or events route, stripping that segment from the request-path parts
+     * when present.
      *
-     * Only the calendar route (`calendar`, or the empty root route) carries a rite
-     * segment. A leading segment whose value is a valid {@see Rite} case (`roman`,
-     * `ambrosian`) selects that rite and is removed from `$requestPathParts` so the
-     * remaining 0/1/2/3-part shape parsing runs identically to an un-prefixed request;
-     * `/calendar` and `/calendar/roman` are therefore equivalent, symmetric with
-     * `/calendar/ambrosian`. Absence of a rite segment defaults to Roman. No nation or
-     * diocese identifier collides with a rite value, so this is unambiguous.
+     * Only the calendar route (`calendar`, or the empty root route) and the events
+     * route (`events`) carry a rite segment. A leading segment whose value is a valid
+     * {@see Rite} case (`roman`, `ambrosian`) selects that rite and is removed from
+     * `$requestPathParts` so the remaining 0/1/2/3-part shape parsing runs identically
+     * to an un-prefixed request; `/calendar` and `/calendar/roman` are therefore
+     * equivalent, symmetric with `/calendar/ambrosian` (and likewise for `/events`).
+     * Absence of a rite segment defaults to Roman. No nation or diocese identifier
+     * collides with a rite value, so this is unambiguous.
      *
      * @param string       $route            the first path segment (the endpoint), already shifted off
      * @param list<string> $requestPathParts the remaining path segments; the rite segment is removed in place when present
      */
     public static function extractRiteSegment(string $route, array &$requestPathParts): Rite
     {
-        if ($route === 'calendar' || $route === '') {
+        if ($route === 'calendar' || $route === '' || $route === 'events') {
             $maybeRite = Rite::tryFrom((string) ( $requestPathParts[0] ?? '' ));
             if ($maybeRite !== null) {
                 array_shift($requestPathParts);
@@ -321,7 +323,7 @@ class Router
                 $this->handler = $easterHandler;
                 break;
             case 'events':
-                $eventsHandler = new EventsHandler($requestPathParts);
+                $eventsHandler = new EventsHandler($requestPathParts, $rite);
                 if (count($requestPathParts) === 0) {
                     $eventsHandler->setAllowedRequestMethods([
                         RequestMethod::GET,

--- a/src/Services/CalendarMetadataProvider.php
+++ b/src/Services/CalendarMetadataProvider.php
@@ -7,8 +7,10 @@ namespace LiturgicalCalendar\Api\Services;
 use LiturgicalCalendar\Api\Enum\Ascension;
 use LiturgicalCalendar\Api\Enum\Epiphany;
 use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Models\CatholicDiocesesLatinRite\CatholicDiocesesMap;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataAmbrosianCalendarItem;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataNationalCalendarItem;
@@ -62,6 +64,7 @@ final class CalendarMetadataProvider
         self::buildDiocesanCalendarData($metadata);
         self::buildWiderRegionData($metadata);
         self::buildLocales($metadata);
+        self::buildAmbrosianCalendarData($metadata);
         return $metadata;
     }
 
@@ -272,5 +275,38 @@ final class CalendarMetadataProvider
             array_merge(['en'], array_map('basename', $folderGlob)),
             self::FULLY_TRANSLATED_LOCALES
         )));
+    }
+
+    /**
+     * Announces the comune `/calendar/ambrosian` calendar.
+     *
+     * Unlike the General Roman Calendar as used in the Vatican (which is
+     * added to the National calendars as a special case, since it is still
+     * Roman rite), the Ambrosian comune has no representation as a nation,
+     * diocese, or wider region: it is a distinct liturgical rite reachable
+     * only via the `ambrosian` rite segment on the calendar route (see
+     * {@see \LiturgicalCalendar\Api\Router::extractRiteSegment()}). This
+     * builds the `ambrosian_calendars` surface so that `/calendars`
+     * discovery clients can find it, alongside the locales it supports
+     * (derived from the Ambrosian Proprium de Tempore's `i18n` folder, the
+     * same source used at request time by {@see \LiturgicalCalendar\Api\Handlers\CalendarHandler}).
+     *
+     * @return void
+     */
+    private static function buildAmbrosianCalendarData(MetadataCalendars $metadata): void
+    {
+        $folderGlob = self::globOrThrow(JsonData::AMBROSIAN_TEMPORALE_I18N_FOLDER->path() . '/*.json', 0, 'CalendarMetadataProvider::buildAmbrosianCalendarData');
+
+        $locales = array_map(
+            fn (string $filename) => pathinfo($filename, PATHINFO_FILENAME),
+            $folderGlob
+        );
+
+        $metadataAmbrosianCalendarItem = MetadataAmbrosianCalendarItem::fromArray([
+            'calendar_id' => Rite::AMBROSIAN->value,
+            'rite'        => Rite::AMBROSIAN->value,
+            'locales'     => $locales
+        ]);
+        $metadata->pushAmbrosianCalendarMetadata($metadataAmbrosianCalendarItem);
     }
 }


### PR DESCRIPTION
## Ambrosian un-501 wiring (Plan 7)

Wires the Ambrosian rite into the calendar handler so **`/calendar/ambrosian/{year}` returns a real comune-ambrosiano calendar** (previously HTTP 501), and makes `/calendars` and `/events` rite-aware. The Roman path is untouched and byte-identical.

### Architecture

The handler's Roman pipeline is "check-before-add"; the Ambrosian precedence resolver is "add-all, then resolve to a fixpoint" — incompatible models. So this adds a **separate Ambrosian generation path**, `calculateAmbrosianCalendar()`, branched at the (now-removed) 501 gate rather than threading rite-`if`s through the Roman `calculate*` methods. Its ordered pipeline:

1. rite-aware Proprium de Tempore load (Ambrosian tempore, not Roman)
2. `AmbrosianTemporale::buildTemporale()` (self-stamps `liturgical_season`)
3. comune sanctorale assembled (add-all; temporale-wins de-dup on `Christmas`/`Circoncisione`/`Epiphany`)
4. backfill empty-readings placeholder on temporale events
5. season-on-sanctorale (copies the co-located temporale season)
6. `AmbrosianPrecedenceResolver::resolve()`
7. Ambrosian Holy-Days-of-Obligation
8. year cycles (A/B/C + I/II) + first-vespers vigils
9. psalter week
10. sort

`handle()` honours `YearType::LITURGICAL` with the same two-run + splice as the Roman branch (dynamic `Advent1` boundary).

### What's live

- **`/calendar/ambrosian/{year}`** — full comune calendar (200, was 501), with year cycles, first-vespers vigils, psalter week, holy-days-of-obligation, and seasons. **Readings are an empty placeholder** (no Ambrosian lectionary yet — a dedicated future plan).
- **`/calendars`** — announces the comune under a new additive `ambrosian_calendars` key (locales `it`, `la`).
- **`/events/ambrosian`** — the Ambrosian event catalog (temporale + comune sanctorale).

### Correctness highlight

Season-stamping now makes the resolver's season-gated rules fire on real handler-assembled data: **St Ambrose** (patron of Milan) on Advent IV Sunday correctly **anticipates to Sat 6 Dec 2025** (saint-solemnity → Monday → Immaculate Conception occupied → Saturday), proven end-to-end through the live handler path and matching the Milan ordo.

### Verification

- `CalendarGoldenMasterTest` **9/9** (Roman byte-identical) — the gate on every one of the 13 tasks.
- Ambrosian suite **192 tests / 19,028 assertions** green; PHPStan level 10 clean (308/308); phpcs + `lint:openapi` valid.
- A new response-schema test validates the full live Ambrosian response against `LitCal.json` (the schema gained the `AFTER_EPIPHANY`/`AFTER_PENTECOST` seasons + optional `is_dominical`/`is_aliturgical`).
- A `Routes` integration test hits `GET /calendar/ambrosian/2025` (200; spot-checks Dedication of the Duomo, Christ the King, St Ambrose → Dec 6). This and a no-duplicate-across-splice assertion require a live server, so they run in **CI** (skipped in the local sandbox).

### Deferred

- **Plan 8 (diocesan overlays):** the 4 Ambrosian dioceses + the `lugano_ch` no-Swiss-national-tier fix. The `/calendar/ambrosian/diocese/...` paths remain 501.
- **Plan 9 (ordo-validation + 1976 backfill):** the holy-days-of-obligation membership set, vigil-eligibility rules (incl. the Easter/Easter2 edge), and psalter-week numbering are provisional (docblock-flagged); pre-2008/1976 edition branch.
- **Dedicated lectionary plan:** real readings replace the placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Ambrosian comune calendar generation for years from 1976 onward, including the `/calendar/ambrosian` and `/calendar/ambrosian/{year}` endpoints.
  * Added the `/events/ambrosian` catalog endpoint, with Ambrosian-only events and updated calendar discovery/metadata.
* **Documentation**
  * Updated README to describe supported Ambrosian endpoints, current reading limitations, provisional cycle details, and year availability.
* **Bug Fixes**
  * Ambrosian endpoints now return successful `200` responses instead of `501 Not Implemented`; requests for pre-1976 years return `400 Bad Request`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->