### PR TITLE
fix(calendar): reset locale in prepareL10N Latin branch to stop LANGUAGE leak (#739)

### DIFF
--- a/phpunit_tests/Handlers/CalendarHandlerLocaleLeakTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerLocaleLeakTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Handlers;
 
+use LiturgicalCalendar\Api\Enum\LitLocale;
 use LiturgicalCalendar\Api\Handlers\CalendarHandler;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Tests\Support\GoldenMaster;
@@ -17,9 +18,30 @@ use LiturgicalCalendar\Tests\Support\GoldenMaster;
  */
 final class CalendarHandlerLocaleLeakTest extends AbstractHandlerTestCase
 {
+    private string $savedLocale;
+    private ?string $savedLanguageEnv;
+    private string $savedIcuDefault;
+    private string $savedPrimaryLanguage;
+    private string $savedRuntimeLocale;
+    private bool $hadServerName;
+    private ?string $savedServerName;
+
     protected function setUp(): void
     {
         parent::setUp();
+
+        // Snapshot every process-global bit of state this test (and the handlers it
+        // invokes) will mutate, so tearDown() can restore the world exactly as it was
+        // found rather than unconditionally clobbering values another test may rely on.
+        $this->savedLocale          = setlocale(LC_ALL, 0) ?: 'C';
+        $languageEnv                = getenv('LANGUAGE');
+        $this->savedLanguageEnv     = false === $languageEnv ? null : $languageEnv;
+        $this->savedIcuDefault      = \Locale::getDefault();
+        $this->savedPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+        $this->savedRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
+        $this->hadServerName        = array_key_exists('SERVER_NAME', $_SERVER);
+        $this->savedServerName      = $this->hadServerName ? (string) $_SERVER['SERVER_NAME'] : null;
+
         // Force Router::isLocalhost() true so handle() bypasses the response cache and
         // actually runs prepareL10N() for every request (the leak is invisible when a
         // request is served from ServerCache).
@@ -28,10 +50,19 @@ final class CalendarHandlerLocaleLeakTest extends AbstractHandlerTestCase
 
     protected function tearDown(): void
     {
-        unset($_SERVER['SERVER_NAME']);
-        // Never let this test's deliberate locale pollution leak into later tests.
-        setlocale(LC_ALL, 'C');
-        putenv('LANGUAGE');
+        // Restore the snapshot taken in setUp() so this test's deliberate locale
+        // pollution can never leak into later tests.
+        if ($this->hadServerName) {
+            $_SERVER['SERVER_NAME'] = $this->savedServerName;
+        } else {
+            unset($_SERVER['SERVER_NAME']);
+        }
+        setlocale(LC_ALL, $this->savedLocale);
+        putenv(null === $this->savedLanguageEnv ? 'LANGUAGE' : 'LANGUAGE=' . $this->savedLanguageEnv);
+        \Locale::setDefault($this->savedIcuDefault);
+        LitLocale::$PRIMARY_LANGUAGE = $this->savedPrimaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = $this->savedRuntimeLocale;
+
         parent::tearDown();
     }
 

--- a/phpunit_tests/Handlers/CalendarHandlerLocaleLeakTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerLocaleLeakTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Tests\Support\GoldenMaster;
+
+/**
+ * Regression for issue #739: CalendarHandler::prepareL10N() leaks LANGUAGE across
+ * requests. A Latin (default) calendar request that follows a translated request in
+ * the same process must still emit Latin/English message templates, not the previous
+ * request's language — the situation a persistent PHP_CLI_SERVER worker creates when
+ * two consecutive requests both miss the response cache.
+ */
+final class CalendarHandlerLocaleLeakTest extends AbstractHandlerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Force Router::isLocalhost() true so handle() bypasses the response cache and
+        // actually runs prepareL10N() for every request (the leak is invisible when a
+        // request is served from ServerCache).
+        $_SERVER['SERVER_NAME'] = 'localhost';
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['SERVER_NAME']);
+        // Never let this test's deliberate locale pollution leak into later tests.
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+        parent::tearDown();
+    }
+
+    public function testLatinCalendarAfterItalianRequestKeepsLatinMessages(): void
+    {
+        $returnTypes = [ReturnTypeParam::JSON, ReturnTypeParam::YAML, ReturnTypeParam::XML, ReturnTypeParam::ICS];
+
+        // 1) A translated (Italian) request first — prepareL10N sets setlocale(it_IT)
+        //    and putenv(LANGUAGE=it_IT:...).
+        $itHandler = new CalendarHandler(['nation', 'IT', '2024']);
+        $itHandler->setAllowedReturnTypes($returnTypes);
+        $itResponse = $itHandler->handle($this->requestFor('GET', '/calendar/nation/IT/2024', ['Accept' => 'application/json', 'Accept-Language' => 'it']));
+        self::assertSame(200, $itResponse->getStatusCode());
+
+        // 2) Then the General (Latin) calendar in the SAME process.
+        $latinHandler = new CalendarHandler(['2024']);
+        $latinHandler->setAllowedReturnTypes($returnTypes);
+        $latinResponse = $latinHandler->handle($this->requestFor('GET', '/calendar/2024', ['Accept' => 'application/json']));
+        self::assertSame(200, $latinResponse->getStatusCode());
+
+        // Strongest possible check: the Latin calendar must be byte-identical to its
+        // frozen golden master. If LANGUAGE leaked from the Italian request, the
+        // gettext-translated message templates come back Italian and this diverges.
+        $actual   = GoldenMaster::normalize($this->decodeJsonBody($latinResponse));
+        $expected = json_decode((string) file_get_contents(GoldenMaster::fixturePath('general-2024')), true, 512, JSON_THROW_ON_ERROR);
+        self::assertEquals($expected, $actual, 'Latin calendar leaked the previous request language (#739).');
+    }
+}

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -5062,6 +5062,15 @@ final class CalendarHandler extends AbstractHandler
 
             LitLocale::$RUNTIME_LOCALE = $normalizedLocale;
         } else {
+            // Latin (or default): a prior translated request handled by this same
+            // (long-lived) worker process may have left the process-global locale set —
+            // setlocale(LC_MESSAGES) and the LANGUAGE env var, both of which gettext reads.
+            // Reset them so the Latin calendar's message templates fall through to the
+            // untranslated (English) base instead of leaking the previous request's
+            // language (#739). This mirrors, in reverse, the translated branch above.
+            setlocale(LC_ALL, 'C');
+            putenv('LANGUAGE');
+            \Locale::setDefault(LitLocale::LATIN_PRIMARY_LANGUAGE);
             LitLocale::$RUNTIME_LOCALE = LitLocale::LATIN_PRIMARY_LANGUAGE;
         }
 


### PR DESCRIPTION
Fixes #739.

## Root cause

`CalendarHandler::prepareL10N()` sets process-global locale state for **translated** requests — `setlocale(LC_ALL, …)`, `putenv("LANGUAGE=…")`, `\Locale::setDefault(…)` — but its **Latin/default** `else` branch only assigned `LitLocale::$RUNTIME_LOCALE` and left that global state untouched.

The API runs persistent workers (`PHP_CLI_SERVER_WORKERS`), so a Latin calendar request handled by a worker that previously handled a translated request inherited the earlier `LANGUAGE`. gettext then returned that language for the Latin calendar's **message templates** — producing Latin event names wrapped in, e.g., Italian text: `"La Solennità 'Sancti Ioseph Sponsi Beatæ Mariæ Virginis' cade di …"`.

**Why it's usually invisible:** `handle()` serves standard years from `ServerCache`, which bypasses `prepareL10N()` entirely. The leak only surfaces on a **cache miss** — an uncached/new year, or after a source-data cache-version invalidation. That invalidation is exactly what made `CalendarGoldenMasterTest` flake during the 8b work when an `EventsHandler` test ran earlier in the same process.

## Fix

The Latin branch now resets the process-global gettext state (and the ICU default) — a mirror image of the translated branch:

```php
} else {
    setlocale(LC_ALL, 'C');
    putenv('LANGUAGE');
    \Locale::setDefault(LitLocale::LATIN_PRIMARY_LANGUAGE);
    LitLocale::$RUNTIME_LOCALE = LitLocale::LATIN_PRIMARY_LANGUAGE;
}
```

So a Latin calendar's message templates deterministically fall through to the untranslated (English) base regardless of what a prior request left behind. The translated (hot) path is unchanged.

## Test

Adds `CalendarHandlerLocaleLeakTest`: issue an Italian calendar request, then the General (Latin) 2024 calendar **in the same process**, and assert the Latin response is byte-identical to the `general-2024` golden master. It forces `Router::isLocalhost()` true so `handle()` bypasses the response cache and actually runs `prepareL10N()` (the leak is invisible against `ServerCache`), and resets locale state in `tearDown()` so it can't pollute later tests.

Verified **red → green** (fails without the fix, passes with it).

## Validation

- New regression test: green with the fix, red without.
- **Golden-master 9/9** in *both* invocation modes (`--filter` and direct-file).
- The prior `EventsHandlerTest` → `CalendarGoldenMasterTest` order-flake (was 5/9) is **cured at the source** (16/16) — the Latin branch now self-corrects regardless of prior handler state.
- Full `Handlers/` suite passes (only the pre-existing no-Postgres `RegionalDataHandlerTest` error, environmental).
- PHPStan level 10, phpcs, php-parallel-lint all clean.

## Follow-up (out of scope, not fixed here)

`EventsHandler::setLocale()` has an analogous non-resetting pattern (no `putenv`/reset for the Latin path). It's a separate surface (`/events` catalog, which has far fewer translated message templates) and a separate issue from #739; noting it here for a possible follow-up rather than bundling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where language settings from a previous request could affect subsequent Latin calendar responses.
  * Latin calendar messages now consistently use the correct language, even after an Italian calendar request.

* **Tests**
  * Added regression coverage to verify language settings remain isolated between requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->