### PR TITLE
fix(events): manage LANGUAGE in EventsHandler::setLocale to stop locale leak (#743)

### DIFF
--- a/phpunit_tests/Handlers/EventsHandlerLocaleLeakTest.php
+++ b/phpunit_tests/Handlers/EventsHandlerLocaleLeakTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Handlers\EventsHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * Regression for issue #743: EventsHandler::setLocale() leaks the LANGUAGE env var
+ * across requests. glibc gettext() reads LANGUAGE above LC_MESSAGES, so a LANGUAGE
+ * value left by a prior request in the same persistent worker (e.g. a translated
+ * /calendar request, whose CalendarHandler::prepareL10N() sets it) would leak into a
+ * later /events response's gettext-backed localized fields (grade_lcl, common_lcl) —
+ * the /events analog of #739. Unlike /calendar, /events has no ServerCache
+ * short-circuit, so this surfaces on ordinary consecutive requests.
+ */
+final class EventsHandlerLocaleLeakTest extends AbstractHandlerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Force Router::isLocalhost() true so CalendarHandler::handle() bypasses the
+        // response cache and actually runs prepareL10N() (which sets LANGUAGE) — the
+        // pollution the leak requires.
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        // Start each test from a clean process-global locale so the French baseline
+        // below is genuinely French regardless of what earlier tests in this process
+        // left behind.
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['SERVER_NAME']);
+        // Never let this test's deliberate locale pollution leak into later tests.
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+        parent::tearDown();
+    }
+
+    /**
+     * Map each event to its gettext-backed localized fields — the fields that leak.
+     *
+     * @return array<string,array{grade_lcl:?string,common_lcl:?string}>
+     */
+    private function localizedFields(ResponseInterface $response): array
+    {
+        $events = $this->decodeJsonBody($response)['litcal_events'];
+        self::assertIsArray($events);
+        self::assertNotEmpty($events);
+
+        $out = [];
+        foreach ($events as $event) {
+            self::assertIsArray($event);
+            $out[$event['event_key']] = [
+                'grade_lcl'  => $event['grade_lcl'] ?? null,
+                'common_lcl' => $event['common_lcl'] ?? null,
+            ];
+        }
+        return $out;
+    }
+
+    public function testFrenchEventsKeepTheirLanguageAfterAnItalianRequest(): void
+    {
+        // Baseline: a French /events request with no prior pollution → French fields.
+        $frBaseline = $this->localizedFields(
+            ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'fr']))
+        );
+
+        // Pollute the worker: a translated (Italian) /calendar request leaves
+        // LANGUAGE=it_IT:... via CalendarHandler::prepareL10N().
+        $itCalendar = new CalendarHandler(['nation', 'IT', '2024']);
+        $itCalendar->setAllowedReturnTypes([ReturnTypeParam::JSON]);
+        $itResponse = $itCalendar->handle(
+            $this->requestFor('GET', '/calendar/nation/IT/2024', ['Accept' => 'application/json', 'Accept-Language' => 'it'])
+        );
+        self::assertSame(200, $itResponse->getStatusCode());
+
+        // The same French /events request, now in a polluted process, must still be
+        // French — not the leaked Italian.
+        $frAfter = $this->localizedFields(
+            ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'fr']))
+        );
+
+        self::assertSame($frBaseline, $frAfter, '/events localized fields leaked the prior request language (#743).');
+    }
+
+    public function testEnglishEventsKeepTheirLanguageAfterAnItalianRequest(): void
+    {
+        // English is the source language: it has no gettext catalog of its own and,
+        // on hosts where no bare 'en' system locale is installed, setlocale() fails —
+        // the very path where a leaked LANGUAGE (from a prior translated request) used
+        // to bleed Italian into an English /events response. The fix must degrade to
+        // the English msgid base regardless.
+        $enBaseline = $this->localizedFields(
+            ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'en']))
+        );
+
+        // Pollute the worker with a translated (Italian) /calendar request.
+        $itCalendar = new CalendarHandler(['nation', 'IT', '2024']);
+        $itCalendar->setAllowedReturnTypes([ReturnTypeParam::JSON]);
+        $itCalendar->handle(
+            $this->requestFor('GET', '/calendar/nation/IT/2024', ['Accept' => 'application/json', 'Accept-Language' => 'it'])
+        );
+
+        $enAfter = $this->localizedFields(
+            ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'en']))
+        );
+
+        self::assertSame($enBaseline, $enAfter, 'English /events localized fields leaked the prior request language (#743).');
+    }
+
+    public function testLatinEventsRequestClearsLeakedLanguage(): void
+    {
+        // A translated (Italian) /calendar request leaves LANGUAGE=it_IT:... set.
+        $itCalendar = new CalendarHandler(['nation', 'IT', '2024']);
+        $itCalendar->setAllowedReturnTypes([ReturnTypeParam::JSON]);
+        $itCalendar->handle(
+            $this->requestFor('GET', '/calendar/nation/IT/2024', ['Accept' => 'application/json', 'Accept-Language' => 'it'])
+        );
+        self::assertNotFalse(getenv('LANGUAGE'), 'Precondition: the Italian /calendar request should have set LANGUAGE.');
+
+        // A Latin /events request must reset the leaked LANGUAGE so gettext-backed
+        // output deterministically falls through to the untranslated base.
+        $response = ( new EventsHandler() )->handle(
+            $this->requestFor('GET', '/events', ['Accept-Language' => 'la'])
+        );
+        self::assertSame(200, $response->getStatusCode());
+        self::assertFalse(getenv('LANGUAGE'), 'Latin /events must clear the leaked LANGUAGE env var (#743).');
+    }
+}

--- a/phpunit_tests/Handlers/EventsHandlerLocaleLeakTest.php
+++ b/phpunit_tests/Handlers/EventsHandlerLocaleLeakTest.php
@@ -68,9 +68,9 @@ final class EventsHandlerLocaleLeakTest extends AbstractHandlerTestCase
     public function testFrenchEventsKeepTheirLanguageAfterAnItalianRequest(): void
     {
         // Baseline: a French /events request with no prior pollution → French fields.
-        $frBaseline = $this->localizedFields(
-            ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'fr']))
-        );
+        $frBaselineResponse = ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'fr']));
+        self::assertSame(200, $frBaselineResponse->getStatusCode());
+        $frBaseline = $this->localizedFields($frBaselineResponse);
 
         // Pollute the worker: a translated (Italian) /calendar request leaves
         // LANGUAGE=it_IT:... via CalendarHandler::prepareL10N().
@@ -83,9 +83,9 @@ final class EventsHandlerLocaleLeakTest extends AbstractHandlerTestCase
 
         // The same French /events request, now in a polluted process, must still be
         // French — not the leaked Italian.
-        $frAfter = $this->localizedFields(
-            ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'fr']))
-        );
+        $frAfterResponse = ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'fr']));
+        self::assertSame(200, $frAfterResponse->getStatusCode());
+        $frAfter = $this->localizedFields($frAfterResponse);
 
         self::assertSame($frBaseline, $frAfter, '/events localized fields leaked the prior request language (#743).');
     }
@@ -97,9 +97,9 @@ final class EventsHandlerLocaleLeakTest extends AbstractHandlerTestCase
         // the very path where a leaked LANGUAGE (from a prior translated request) used
         // to bleed Italian into an English /events response. The fix must degrade to
         // the English msgid base regardless.
-        $enBaseline = $this->localizedFields(
-            ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'en']))
-        );
+        $enBaselineResponse = ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'en']));
+        self::assertSame(200, $enBaselineResponse->getStatusCode());
+        $enBaseline = $this->localizedFields($enBaselineResponse);
 
         // Pollute the worker with a translated (Italian) /calendar request.
         $itCalendar = new CalendarHandler(['nation', 'IT', '2024']);
@@ -108,9 +108,9 @@ final class EventsHandlerLocaleLeakTest extends AbstractHandlerTestCase
             $this->requestFor('GET', '/calendar/nation/IT/2024', ['Accept' => 'application/json', 'Accept-Language' => 'it'])
         );
 
-        $enAfter = $this->localizedFields(
-            ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'en']))
-        );
+        $enAfterResponse = ( new EventsHandler() )->handle($this->requestFor('GET', '/events', ['Accept-Language' => 'en']));
+        self::assertSame(200, $enAfterResponse->getStatusCode());
+        $enAfter = $this->localizedFields($enAfterResponse);
 
         self::assertSame($enBaseline, $enAfter, 'English /events localized fields leaked the prior request language (#743).');
     }
@@ -123,7 +123,12 @@ final class EventsHandlerLocaleLeakTest extends AbstractHandlerTestCase
         $itCalendar->handle(
             $this->requestFor('GET', '/calendar/nation/IT/2024', ['Accept' => 'application/json', 'Accept-Language' => 'it'])
         );
-        self::assertNotFalse(getenv('LANGUAGE'), 'Precondition: the Italian /calendar request should have set LANGUAGE.');
+        // On a host without the it_IT locale the Italian /calendar request can't set
+        // LANGUAGE (setlocale fails), so there's nothing to leak and nothing to assert.
+        // Skip rather than fail: the precondition for this leak scenario is unavailable.
+        if (false === getenv('LANGUAGE')) {
+            self::markTestSkipped('The Italian /calendar request did not set LANGUAGE (the it_IT locale is likely not installed on this host).');
+        }
 
         // A Latin /events request must reset the leaked LANGUAGE so gettext-backed
         // output deterministically falls through to the untranslated base.

--- a/src/Handlers/EventsHandler.php
+++ b/src/Handlers/EventsHandler.php
@@ -319,68 +319,94 @@ final class EventsHandler extends AbstractHandler
         $baseLocale = $this->EventsParams->baseLocale;
 
         if ($baseLocale !== LitLocale::LATIN_PRIMARY_LANGUAGE) {
-            $localeArray = [
-                $this->EventsParams->Locale . '.utf8',
-                $this->EventsParams->Locale . '.UTF-8',
-                $this->EventsParams->Locale,
-                $baseLocale . '_' . strtoupper($baseLocale) . '.utf8',
-                $baseLocale . '_' . strtoupper($baseLocale) . '.UTF-8',
-                $baseLocale . '_' . strtoupper($baseLocale),
-                $baseLocale . '.utf8',
-                $baseLocale . '.UTF-8',
-                $baseLocale
-            ];
-
-            $runtimeLocale = setlocale(LC_ALL, $localeArray);
-            if (false === $runtimeLocale) {
-                // The requested locale isn't installed on this host. glibc gettext()
-                // can't load a catalog without a non-C locale, so localized output
-                // falls through to the (English) msgid base — correct for an English
-                // request (English is the source language, with no catalog of its own),
-                // and graceful degradation for any other uninstalled locale. Still reset
-                // the leak vector so a LANGUAGE / locale left by a prior request in this
-                // persistent worker can't bleed into this response (#743).
-                setlocale(LC_ALL, 'C');
-                putenv('LANGUAGE');
-                \Locale::setDefault($baseLocale);
-            } else {
-                // Example: "it_IT.UTF-8" → "it_IT"
-                $normalizedLocale = strtok($runtimeLocale, '.') ?: $runtimeLocale;
-                if ($normalizedLocale === 'C' || $normalizedLocale === 'POSIX') {
-                    $normalizedLocale = $baseLocale;
-                }
-
-                // Pin gettext's catalog for THIS request. glibc gettext() reads LANGUAGE
-                // above LC_MESSAGES, so — in a persistent worker — a LANGUAGE value left by
-                // a prior request (e.g. CalendarHandler::prepareL10N() or an earlier /events
-                // request in another language) would otherwise win and leak into this
-                // response's localized fields (#743).
-                $languageEnv = implode(':', array_unique([
-                    $runtimeLocale,
-                    $normalizedLocale,
-                    $baseLocale,
-                    'en'
-                ]));
-                putenv("LANGUAGE={$languageEnv}");
-
-                // also update ICU’s default locale
-                \Locale::setDefault($normalizedLocale);
-            }
+            $this->applyTranslatedLocale($baseLocale);
         } else {
-            // Latin (or default): a prior translated request handled by this same
-            // (long-lived) worker process may have left the process-global locale set —
-            // setlocale(LC_MESSAGES) and the LANGUAGE env var, both of which gettext reads.
-            // Reset them so the Latin catalog's message templates fall through to the
-            // untranslated (English) base instead of leaking the previous request's
-            // language (#743). This mirrors, in reverse, the translated branch above.
-            setlocale(LC_ALL, 'C');
-            putenv('LANGUAGE');
-            \Locale::setDefault(LitLocale::LATIN_PRIMARY_LANGUAGE);
+            // Latin (or default): reset the process-global locale left by a prior
+            // request in this long-lived worker so gettext-backed output falls through
+            // to the untranslated (English) base rather than leaking it (#743).
+            $this->resetToUntranslatedLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
         }
 
         bindtextdomain('litcal', Router::$apiFilePath . 'i18n');
         textdomain('litcal');
         LiturgicalEventAbstract::setLocale($this->EventsParams->Locale);
+    }
+
+    /**
+     * Resolve and pin the process-global locale + gettext catalog for a translated
+     * request. Builds the locale-candidate list from the request locale; on a
+     * successful setlocale() it pins the current request's gettext catalog via
+     * LANGUAGE (which glibc gettext reads above LC_MESSAGES) and updates ICU's
+     * default. If the requested locale isn't installed on this host — e.g. bare 'en',
+     * the source language — setlocale() fails and localized output degrades to the
+     * untranslated (English) msgid base. Either way the leak vector is reset (#743).
+     *
+     * @param string $baseLocale The primary language subtag of the request locale.
+     * @return void
+     */
+    private function applyTranslatedLocale(string $baseLocale): void
+    {
+        $localeArray = [
+            $this->EventsParams->Locale . '.utf8',
+            $this->EventsParams->Locale . '.UTF-8',
+            $this->EventsParams->Locale,
+            $baseLocale . '_' . strtoupper($baseLocale) . '.utf8',
+            $baseLocale . '_' . strtoupper($baseLocale) . '.UTF-8',
+            $baseLocale . '_' . strtoupper($baseLocale),
+            $baseLocale . '.utf8',
+            $baseLocale . '.UTF-8',
+            $baseLocale
+        ];
+
+        $runtimeLocale = setlocale(LC_ALL, $localeArray);
+        if (false === $runtimeLocale) {
+            // The requested locale isn't installed on this host. glibc gettext() can't
+            // load a catalog without a non-C locale, so localized output falls through
+            // to the (English) msgid base — correct for an English request (the source
+            // language, with no catalog of its own), and graceful degradation for any
+            // other uninstalled locale. Still reset the leak vector (#743).
+            $this->resetToUntranslatedLocale($baseLocale);
+            return;
+        }
+
+        // Example: "it_IT.UTF-8" → "it_IT"
+        $normalizedLocale = strtok($runtimeLocale, '.') ?: $runtimeLocale;
+        if ($normalizedLocale === 'C' || $normalizedLocale === 'POSIX') {
+            $normalizedLocale = $baseLocale;
+        }
+
+        // Pin gettext's catalog for THIS request. glibc gettext() reads LANGUAGE above
+        // LC_MESSAGES, so — in a persistent worker — a LANGUAGE value left by a prior
+        // request (e.g. CalendarHandler::prepareL10N() or an earlier /events request in
+        // another language) would otherwise win and leak into this response (#743).
+        $languageEnv = implode(':', array_unique([
+            $runtimeLocale,
+            $normalizedLocale,
+            $baseLocale,
+            'en'
+        ]));
+        putenv("LANGUAGE={$languageEnv}");
+
+        // also update ICU’s default locale
+        \Locale::setDefault($normalizedLocale);
+    }
+
+    /**
+     * Reset the process-global locale state — setlocale(LC_MESSAGES) and the LANGUAGE
+     * env var, both of which gettext reads — that a prior request in this long-lived
+     * worker may have left behind, so localized output falls through deterministically
+     * to the untranslated (English) base instead of leaking the previous request's
+     * language (#743). Mirrors, in reverse, applyTranslatedLocale()'s translated path.
+     *
+     * @param string $icuDefaultLocale Locale to set as ICU's default (the request's
+     *                                 primary language, or Latin for a Latin request).
+     * @return void
+     */
+    private function resetToUntranslatedLocale(string $icuDefaultLocale): void
+    {
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+        \Locale::setDefault($icuDefaultLocale);
     }
 
     /**

--- a/src/Handlers/EventsHandler.php
+++ b/src/Handlers/EventsHandler.php
@@ -299,31 +299,85 @@ final class EventsHandler extends AbstractHandler
     }
 
     /**
-     * Sets the locale for the current instance, affecting date formatting
-     * and translations of liturgical texts.
+     * Set up the process-global locale for this request in a deterministic,
+     * leak-proof way.
      *
-     * This method retrieves the primary language from the current locale,
-     * constructs an array of potential locale strings, and sets the locale
-     * for PHP's internationalization functions. It also configures the domain
-     * for gettext translations and initializes LitGrade and LitCommon instances
-     * with the specified locale.
+     * For a translated locale whose system locale is installed, this pins the
+     * current request's gettext catalog via LANGUAGE (which glibc gettext reads
+     * above LC_MESSAGES) and updates ICU's default. If setlocale() fails (the
+     * locale isn't installed — e.g. bare 'en', the source language) or the request
+     * is Latin/default, it resets setlocale()/LANGUAGE/ICU so localized output
+     * falls through to the untranslated (English) base. Every branch overrides
+     * whatever a prior request in the same persistent worker left behind, then
+     * binds the gettext text domain and configures the LiturgicalEventAbstract
+     * locale. Mirrors CalendarHandler::prepareL10N() (#743).
      *
      * @return void
      */
     private function setLocale(): void
     {
-        $localeArray = [
-            $this->EventsParams->Locale . '.utf8',
-            $this->EventsParams->Locale . '.UTF-8',
-            $this->EventsParams->Locale,
-            $this->EventsParams->baseLocale . '_' . strtoupper($this->EventsParams->baseLocale) . '.utf8',
-            $this->EventsParams->baseLocale . '_' . strtoupper($this->EventsParams->baseLocale) . '.UTF-8',
-            $this->EventsParams->baseLocale . '_' . strtoupper($this->EventsParams->baseLocale),
-            $this->EventsParams->baseLocale . '.utf8',
-            $this->EventsParams->baseLocale . '.UTF-8',
-            $this->EventsParams->baseLocale
-        ];
-        setlocale(LC_ALL, $localeArray);
+        $baseLocale = $this->EventsParams->baseLocale;
+
+        if ($baseLocale !== LitLocale::LATIN_PRIMARY_LANGUAGE) {
+            $localeArray = [
+                $this->EventsParams->Locale . '.utf8',
+                $this->EventsParams->Locale . '.UTF-8',
+                $this->EventsParams->Locale,
+                $baseLocale . '_' . strtoupper($baseLocale) . '.utf8',
+                $baseLocale . '_' . strtoupper($baseLocale) . '.UTF-8',
+                $baseLocale . '_' . strtoupper($baseLocale),
+                $baseLocale . '.utf8',
+                $baseLocale . '.UTF-8',
+                $baseLocale
+            ];
+
+            $runtimeLocale = setlocale(LC_ALL, $localeArray);
+            if (false === $runtimeLocale) {
+                // The requested locale isn't installed on this host. glibc gettext()
+                // can't load a catalog without a non-C locale, so localized output
+                // falls through to the (English) msgid base — correct for an English
+                // request (English is the source language, with no catalog of its own),
+                // and graceful degradation for any other uninstalled locale. Still reset
+                // the leak vector so a LANGUAGE / locale left by a prior request in this
+                // persistent worker can't bleed into this response (#743).
+                setlocale(LC_ALL, 'C');
+                putenv('LANGUAGE');
+                \Locale::setDefault($baseLocale);
+            } else {
+                // Example: "it_IT.UTF-8" → "it_IT"
+                $normalizedLocale = strtok($runtimeLocale, '.') ?: $runtimeLocale;
+                if ($normalizedLocale === 'C' || $normalizedLocale === 'POSIX') {
+                    $normalizedLocale = $baseLocale;
+                }
+
+                // Pin gettext's catalog for THIS request. glibc gettext() reads LANGUAGE
+                // above LC_MESSAGES, so — in a persistent worker — a LANGUAGE value left by
+                // a prior request (e.g. CalendarHandler::prepareL10N() or an earlier /events
+                // request in another language) would otherwise win and leak into this
+                // response's localized fields (#743).
+                $languageEnv = implode(':', array_unique([
+                    $runtimeLocale,
+                    $normalizedLocale,
+                    $baseLocale,
+                    'en'
+                ]));
+                putenv("LANGUAGE={$languageEnv}");
+
+                // also update ICU’s default locale
+                \Locale::setDefault($normalizedLocale);
+            }
+        } else {
+            // Latin (or default): a prior translated request handled by this same
+            // (long-lived) worker process may have left the process-global locale set —
+            // setlocale(LC_MESSAGES) and the LANGUAGE env var, both of which gettext reads.
+            // Reset them so the Latin catalog's message templates fall through to the
+            // untranslated (English) base instead of leaking the previous request's
+            // language (#743). This mirrors, in reverse, the translated branch above.
+            setlocale(LC_ALL, 'C');
+            putenv('LANGUAGE');
+            \Locale::setDefault(LitLocale::LATIN_PRIMARY_LANGUAGE);
+        }
+
         bindtextdomain('litcal', Router::$apiFilePath . 'i18n');
         textdomain('litcal');
         LiturgicalEventAbstract::setLocale($this->EventsParams->Locale);


### PR DESCRIPTION
## Summary

Fixes #743 — the `/events` analog of #739. `EventsHandler::setLocale()` set the process locale per request but never managed the `LANGUAGE` env var. Because glibc `gettext()` reads `LANGUAGE` **above** `LC_MESSAGES`, a value left by a prior request in the same persistent worker (e.g. `CalendarHandler::prepareL10N()` sets `LANGUAGE=it_IT:…` for a translated `/calendar` request) leaked into a later `/events` response's gettext-backed localized fields (`grade_lcl`, `common_lcl`). Unlike `/calendar`, `/events` has **no `ServerCache` short-circuit**, so this surfaces on ordinary consecutive requests.

## Fix

`setLocale()` is now deterministic per request, mirroring the fixed `prepareL10N()`:

- **Translated locale with an installed system locale** → pin the current request's gettext catalog via `putenv("LANGUAGE=…")` and update ICU's default (`\Locale::setDefault`).
- **`setlocale()` fails, or Latin/default** → reset `setlocale(LC_ALL, 'C')`, clear `LANGUAGE`, reset ICU so localized output falls through to the untranslated (English) msgid base.

### Deliberate divergence from `prepareL10N()`

A failed `setlocale()` **degrades gracefully instead of throwing 503**, because:

1. **English is the source language** — no catalog of its own, and on many hosts bare `en` is not an installed system locale (only `en_US.utf8` etc.), so `setlocale()` returns `false`.
2. **`/events` has no cache**, so `setLocale()` runs on every request — a strict throw would 503 every English `/events` request.

The reset-on-failure path still clears the leak vector, so an English (or any uninstalled-locale) request no longer inherits a prior request's `LANGUAGE`. Adopting the strict throw first surfaced this — it broke existing `EventsHandlerRiteRoutingTest` cases with `503 instead of 200`.

## Tests

Adds `EventsHandlerLocaleLeakTest` (analogous to `CalendarHandlerLocaleLeakTest`), each case verified **red → green**:

- After a translated Italian `/calendar` request pollutes the worker, a **French** `/events` request returns French (not the leaked Italian).
- Same for an **English** `/events` request (covers the `setlocale`-failure path).
- A **Latin** `/events` request clears the leaked `LANGUAGE` env var.

## Verification

- New leak tests: 3/3 (fail on pre-fix code).
- `EventsHandlerTest` + `EventsHandlerRiteRoutingTest`: pass (previously-failing rite tests recovered).
- Full suite: **0 failures** (remaining errors are pre-existing, live-server/DB-dependent integration tests).
- PHPStan level 10 clean · phpcs clean · php-parallel-lint clean.

## Follow-up (deferred)

Extracting the shared `$localeArray` + `LANGUAGE` handling so `CalendarHandler` and `EventsHandler` don't drift is intentionally **not** in this PR — the two build `$localeArray` differently, #742 (the `prepareL10N()` Latin-reset) isn't merged to `development` yet, and the two now intentionally diverge on `setlocale()`-failure handling. Recommend a dedicated follow-up once #742 lands, standardizing on graceful degradation (which would also fix the latent `en`-on-cache-miss 503 in `CalendarHandler`). Detailed in the [issue comment](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/743#issuecomment-5073180844).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed language settings persisting between requests in long-running workers.
  * Ensured translated event responses consistently honor the requested language after requests in other languages.
  * Prevented Latin-language requests from inheriting translations from previous requests.
  * Improved fallback behavior when a requested locale cannot be initialized.

* **Tests**
  * Added regression coverage for sequential Italian, French, English, and Latin requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->