### PR TITLE
refactor(locale): shared LocaleConfigurator across handlers (#745)

### DIFF
--- a/docs/superpowers/plans/2026-07-28-shared-locale-configurator.md
+++ b/docs/superpowers/plans/2026-07-28-shared-locale-configurator.md
@@ -1,0 +1,599 @@
+# Shared LocaleConfigurator Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps
+> use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the process-global locale/`LANGUAGE`/ICU setup duplicated across three sites into one shared `Services\LocaleConfigurator`, standardizing region resolution on
+CLDR likely subtags and the failure policy (resolve-or-throw; Latin the sole reset).
+
+**Architecture:** A stateless `LocaleConfigurator::configure(string): ConfiguredLocale` owns `setlocale` + `LANGUAGE` + ICU default and returns the resolved runtime info.
+`CalendarHandler::prepareL10N()`, `EventsHandler::setLocale()`, and `FerialEventNameGenerator::initializeGettext()` each call it, then keep their own tail (formatters,
+`LitLocale` statics, text-domain binding, model `setLocale`).
+
+**Tech Stack:** PHP 8.4, `ext-intl` (`\Locale`), gettext, PHPUnit 12, PHPStan level 10, phpcs (PSR-12).
+
+## Global Constraints
+
+- PHP >= 8.4; PSR-12; short array syntax; single quotes unless interpolating.
+- PHPStan level 10 clean (`composer analyse`, scans `src` only); phpcs clean (`composer lint`).
+- Never `--no-verify`; CaptainHook pre-commit runs lint + lint:md.
+- Region resolution MUST use `jsondata/likelySubtags.json` (region subtag only — glibc rejects script-bearing names like `en_Latn_US`).
+- Failure policy: a non-Latin language with no installed system locale MUST throw `ServiceUnavailableException`; it must never silently produce English. Latin (`la`/`la_VA`) MUST
+  take the reset branch and never throw.
+- Work happens in the existing worktree `.claude/worktrees/locale-configurator-745` (branch `feature/locale-configurator-745`, off `development`). Run all commands there.
+- `LitLocale::LATIN_PRIMARY_LANGUAGE === 'la'`.
+
+---
+
+### Task 1: `LocaleConfigurator` service + `ConfiguredLocale` result
+
+**Files:**
+
+- Create: `src/Services/ConfiguredLocale.php`
+- Create: `src/Services/LocaleConfigurator.php`
+- Test: `phpunit_tests/Services/LocaleConfiguratorTest.php`
+
+**Interfaces:**
+
+- Produces:
+  - `final class ConfiguredLocale` with `public readonly string $primaryLanguage`, `public readonly string $runtimeLocale`, `public readonly bool $isLatin`.
+  - `LocaleConfigurator::configure(string $requestLocale): ConfiguredLocale` — applies process-global locale state and returns the result; throws `ServiceUnavailableException`
+    for a non-Latin language with no installed locale.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `phpunit_tests/Services/LocaleConfiguratorTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\LocaleConfigurator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LocaleConfigurator::class)]
+final class LocaleConfiguratorTest extends TestCase
+{
+    private string $savedApiFilePath = '';
+    private string|false $savedLanguage = false;
+    private string $savedIcuDefault = 'en';
+
+    protected function setUp(): void
+    {
+        $this->savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        $this->savedLanguage    = getenv('LANGUAGE');
+        $this->savedIcuDefault  = \Locale::getDefault();
+
+        // JsonData::FOLDER->path() prefixes Router::$apiFilePath; point it at the repo root.
+        Router::$apiFilePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+
+        // Start from a clean process-global locale.
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+    }
+
+    protected function tearDown(): void
+    {
+        Router::$apiFilePath = $this->savedApiFilePath;
+        setlocale(LC_ALL, 'C');
+        if ($this->savedLanguage === false) {
+            putenv('LANGUAGE');
+        } else {
+            putenv('LANGUAGE=' . $this->savedLanguage);
+        }
+        \Locale::setDefault($this->savedIcuDefault);
+    }
+
+    public function testRegionlessLanguageResolvesViaLikelySubtags(): void
+    {
+        $result = LocaleConfigurator::configure('en');
+        self::assertSame('en', $result->primaryLanguage);
+        self::assertSame('en_US', $result->runtimeLocale);
+        self::assertFalse($result->isLatin);
+        self::assertStringStartsWith('en_US', (string) getenv('LANGUAGE'));
+    }
+
+    public function testFrenchResolvesToInstalledRegionVariant(): void
+    {
+        $result = LocaleConfigurator::configure('fr');
+        self::assertSame('fr', $result->primaryLanguage);
+        self::assertSame('fr_FR', $result->runtimeLocale);
+        self::assertFalse($result->isLatin);
+    }
+
+    public function testRegionBearingLocaleIsPreserved(): void
+    {
+        $result = LocaleConfigurator::configure('it_IT');
+        self::assertSame('it', $result->primaryLanguage);
+        self::assertSame('it_IT', $result->runtimeLocale);
+    }
+
+    public function testLatinResetsAndClearsLanguage(): void
+    {
+        putenv('LANGUAGE=it_IT.utf8:it_IT:it:en'); // simulate a prior translated request
+        foreach (['la', 'la_VA'] as $latin) {
+            $result = LocaleConfigurator::configure($latin);
+            self::assertTrue($result->isLatin, "{$latin} should take the Latin reset branch");
+            self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $result->primaryLanguage);
+            self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $result->runtimeLocale);
+            self::assertFalse(getenv('LANGUAGE'), 'Latin must clear the leaked LANGUAGE env var');
+        }
+    }
+
+    public function testOverridesLeakedLanguageFromPriorRequest(): void
+    {
+        putenv('LANGUAGE=it_IT.utf8:it_IT:it:en');
+        LocaleConfigurator::configure('fr');
+        self::assertStringStartsWith('fr', (string) getenv('LANGUAGE'));
+    }
+
+    public function testThrowsWhenNoInstalledLocaleForLanguage(): void
+    {
+        $this->expectException(ServiceUnavailableException::class);
+        LocaleConfigurator::configure('zz');
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/LocaleConfiguratorTest.php`
+Expected: FAIL/ERROR — `Class "LiturgicalCalendar\Api\Services\LocaleConfigurator" not found`.
+
+- [ ] **Step 3: Create the `ConfiguredLocale` result object**
+
+Create `src/Services/ConfiguredLocale.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+/**
+ * Immutable result of {@see LocaleConfigurator::configure()}: the process-global
+ * locale state that was applied for a request.
+ */
+final class ConfiguredLocale
+{
+    /**
+     * @param string $primaryLanguage Primary language subtag (e.g. 'it', 'en', 'la').
+     * @param string $runtimeLocale   Normalized runtime locale in effect (e.g. 'it_IT',
+     *                                 'en_US', or 'la' for the Latin reset branch).
+     * @param bool   $isLatin         True when the Latin/reset branch was taken.
+     */
+    public function __construct(
+        public readonly string $primaryLanguage,
+        public readonly string $runtimeLocale,
+        public readonly bool $isLatin
+    ) {
+    }
+}
+```
+
+- [ ] **Step 4: Create the `LocaleConfigurator` service**
+
+Create `src/Services/LocaleConfigurator.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\Utilities;
+
+/**
+ * Deterministically applies the process-global locale state — setlocale(LC_ALL),
+ * the LANGUAGE env var (which glibc gettext() reads above LC_MESSAGES), and ICU's
+ * default — for a single request, in a leak-free way.
+ *
+ * Region resolution uses CLDR likely subtags (jsondata/likelySubtags.json) so a
+ * region-less request locale (e.g. 'en', 'fr') maps to the installed system locale
+ * ('en_US', 'fr_FR'). A real language whose system locale is not installed at all
+ * throws — it must never silently fall through to English. Latin ('la'/'la_VA') is
+ * the sole special case: it cannot be installed, so it takes the reset branch and
+ * never throws (downstream code emits hardcoded Latin).
+ *
+ * Centralizes logic previously duplicated across CalendarHandler::prepareL10N(),
+ * EventsHandler::setLocale(), and FerialEventNameGenerator::initializeGettext() (#745).
+ */
+final class LocaleConfigurator
+{
+    /** @var array<string,string>|null Cached CLDR likelySubtags map (language => "lang-Script-Region"). */
+    private static ?array $likelySubtags = null;
+
+    /**
+     * Apply the process-global locale for the given request locale and return the
+     * resolved runtime information.
+     *
+     * @param string $requestLocale The request locale (e.g. 'it_IT', 'en', 'la_VA').
+     * @throws ServiceUnavailableException When a non-Latin language has no installed system locale.
+     */
+    public static function configure(string $requestLocale): ConfiguredLocale
+    {
+        $canonical       = \Locale::canonicalize($requestLocale);
+        $canonical       = ( $canonical === null || $canonical === '' ) ? $requestLocale : $canonical;
+        $primaryLanguage = \Locale::getPrimaryLanguage($canonical);
+        $primaryLanguage = ( $primaryLanguage === null || $primaryLanguage === '' ) ? $canonical : $primaryLanguage;
+
+        if ($primaryLanguage === LitLocale::LATIN_PRIMARY_LANGUAGE) {
+            self::reset(LitLocale::LATIN_PRIMARY_LANGUAGE);
+            return new ConfiguredLocale(LitLocale::LATIN_PRIMARY_LANGUAGE, LitLocale::LATIN_PRIMARY_LANGUAGE, true);
+        }
+
+        $region = \Locale::getRegion($canonical);
+        if ($region === null || $region === '') {
+            $region = self::likelyRegion($primaryLanguage);
+        }
+
+        $candidates = [];
+        if ($region !== '') {
+            $langRegion = $primaryLanguage . '_' . $region;
+            $candidates = [$langRegion . '.utf8', $langRegion . '.UTF-8', $langRegion];
+        }
+        $candidates = array_merge($candidates, [
+            $primaryLanguage . '.utf8',
+            $primaryLanguage . '.UTF-8',
+            $primaryLanguage,
+        ]);
+
+        $runtimeLocale = setlocale(LC_ALL, $candidates);
+        if ($runtimeLocale === false) {
+            throw new ServiceUnavailableException('Could not set locale to ' . $requestLocale . '.');
+        }
+
+        // Example: "it_IT.UTF-8" → "it_IT"
+        $normalizedLocale = strtok($runtimeLocale, '.') ?: $runtimeLocale;
+        if ($normalizedLocale === 'C' || $normalizedLocale === 'POSIX') {
+            $normalizedLocale = $region !== '' ? $primaryLanguage . '_' . $region : $primaryLanguage;
+        }
+
+        // Pin gettext's catalog for THIS request, overriding any LANGUAGE a prior
+        // request in this persistent worker left behind (glibc reads it above LC_MESSAGES).
+        $languageEnv = implode(':', array_unique([
+            $runtimeLocale,
+            $normalizedLocale,
+            $primaryLanguage,
+            'en',
+        ]));
+        putenv("LANGUAGE={$languageEnv}");
+        \Locale::setDefault($normalizedLocale);
+
+        return new ConfiguredLocale($primaryLanguage, $normalizedLocale, false);
+    }
+
+    /**
+     * Reset the process-global locale state so gettext output falls through to the
+     * untranslated (English) msgid base, and update ICU's default. Used for Latin.
+     */
+    private static function reset(string $icuDefaultLocale): void
+    {
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+        \Locale::setDefault($icuDefaultLocale);
+    }
+
+    /**
+     * Resolve the likely region subtag for a region-less language via CLDR likely
+     * subtags (e.g. 'en' → 'US', 'pt' → 'BR'). Returns '' when unknown.
+     *
+     * Only the region subtag is used: glibc rejects script-bearing locale names
+     * like "en_Latn_US", so the caller builds "en_US" from language + region.
+     */
+    private static function likelyRegion(string $language): string
+    {
+        if (self::$likelySubtags === null) {
+            /** @var array{supplemental:array{likelySubtags:array<string,string>}} $data */
+            $data                = Utilities::jsonFileToArray(JsonData::FOLDER->path() . '/likelySubtags.json');
+            self::$likelySubtags = $data['supplemental']['likelySubtags'];
+        }
+
+        $maximized = self::$likelySubtags[$language] ?? null;
+        if ($maximized === null) {
+            return '';
+        }
+
+        $canonical = \Locale::canonicalize($maximized);
+        $region    = \Locale::getRegion(( $canonical === null || $canonical === '' ) ? $maximized : $canonical);
+        return ( $region === null ) ? '' : $region;
+    }
+}
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/LocaleConfiguratorTest.php`
+Expected: PASS (7 tests).
+
+- [ ] **Step 6: Static analysis + lint on the new files**
+
+Run: `composer analyse` — Expected: `[OK] No errors`.
+Run: `vendor/bin/phpcs src/Services/LocaleConfigurator.php src/Services/ConfiguredLocale.php phpunit_tests/Services/LocaleConfiguratorTest.php` — Expected: exit 0.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Services/LocaleConfigurator.php src/Services/ConfiguredLocale.php phpunit_tests/Services/LocaleConfiguratorTest.php
+git commit -m "feat(locale): add shared LocaleConfigurator service (#745)"
+```
+
+---
+
+### Task 2: Rewire `CalendarHandler::prepareL10N()`
+
+**Files:**
+
+- Modify: `src/Handlers/CalendarHandler.php` (add import; replace `prepareL10N()` body)
+- Test: `phpunit_tests/Handlers/CalendarHandlerLocaleLeakTest.php` (existing — must stay green), golden master (existing).
+
+**Interfaces:**
+
+- Consumes: `LocaleConfigurator::configure(string): ConfiguredLocale` from Task 1.
+
+- [ ] **Step 1: Add the import**
+
+In `src/Handlers/CalendarHandler.php`, add to the `use` block (alongside the other `use LiturgicalCalendar\Api\...` imports):
+
+```php
+use LiturgicalCalendar\Api\Services\LocaleConfigurator;
+```
+
+- [ ] **Step 2: Replace the `prepareL10N()` body**
+
+Replace the entire current `prepareL10N()` method with:
+
+```php
+    /**
+     * Set up the locale for this API request.
+     *
+     * Delegates process-global locale/LANGUAGE/ICU setup to the shared
+     * LocaleConfigurator (deterministic + leak-free, #745), then sets the
+     * LitLocale statics, the LiturgicalEvent locale, the date/ordinal formatters,
+     * and binds the gettext text domain.
+     */
+    private function prepareL10N(): void
+    {
+        $baseLocale = \Locale::getPrimaryLanguage($this->CalendarParams->Locale);
+        if (null === $baseLocale) {
+            throw new ServiceUnavailableException('“Pride was the reason for the division of tongues, humility the reason they were reunited.” - St. Augustine, The City of God, Book XVI, Chapter 4');
+        }
+
+        $configured                 = LocaleConfigurator::configure($this->CalendarParams->Locale);
+        LitLocale::$PRIMARY_LANGUAGE = $configured->primaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = $configured->runtimeLocale;
+
+        LiturgicalEvent::setLocale(LitLocale::$RUNTIME_LOCALE);
+
+        $this->createFormatters();
+
+        if (false === is_dir(Router::$apiFilePath . 'i18n')) {
+            throw new ServiceUnavailableException('The i18n folder does not exist at path: ' . Router::$apiFilePath . 'i18n' . '.');
+        }
+
+        if (false === bindtextdomain('litcal', Router::$apiFilePath . 'i18n')) {
+            throw new ServiceUnavailableException('Could not bind text domain for translations to path: ' . Router::$apiFilePath . 'i18n' . '.');
+        } else {
+            bind_textdomain_codeset('litcal', 'UTF-8');
+            $textDomain = textdomain('litcal');
+        }
+
+        if ($textDomain !== 'litcal') {
+            throw new ServiceUnavailableException('Could not set text domain for translations to \'litcal\'.');
+        }
+    }
+```
+
+- [ ] **Step 3: Run the Calendar leak test + golden master**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/CalendarHandlerLocaleLeakTest.php phpunit_tests/Handlers/CalendarGoldenMasterTest.php`
+Expected: PASS (leak test byte-identical to golden master; golden master 9/9). If the `.env.local`/`it_IT`-availability preconditions are missing the leak test may skip — that is
+acceptable, but the golden master must pass.
+
+- [ ] **Step 4: Static analysis + lint**
+
+Run: `composer analyse` — Expected: `[OK] No errors`.
+Run: `vendor/bin/phpcs src/Handlers/CalendarHandler.php` — Expected: exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Handlers/CalendarHandler.php
+git commit -m "refactor(calendar): use shared LocaleConfigurator in prepareL10N (#745)"
+```
+
+---
+
+### Task 3: Rewire `EventsHandler::setLocale()` (delete #744 helpers)
+
+**Files:**
+
+- Modify: `src/Handlers/EventsHandler.php` (add import; replace `setLocale()` body; delete `applyTranslatedLocale()` and `resetToUntranslatedLocale()`)
+- Test: `phpunit_tests/Handlers/EventsHandlerLocaleLeakTest.php` (existing — must stay green).
+
+**Interfaces:**
+
+- Consumes: `LocaleConfigurator::configure(string): ConfiguredLocale` from Task 1.
+
+- [ ] **Step 1: Add the import**
+
+In `src/Handlers/EventsHandler.php`, add to the `use` block:
+
+```php
+use LiturgicalCalendar\Api\Services\LocaleConfigurator;
+```
+
+- [ ] **Step 2: Replace `setLocale()` and delete the two helpers**
+
+Replace the `setLocale()` method (its docblock + body) with:
+
+```php
+    /**
+     * Set up the process-global locale for this request via the shared
+     * LocaleConfigurator (deterministic + leak-free, #745), then bind the gettext
+     * text domain and configure the LiturgicalEventAbstract locale.
+     */
+    private function setLocale(): void
+    {
+        LocaleConfigurator::configure($this->EventsParams->Locale);
+        bindtextdomain('litcal', Router::$apiFilePath . 'i18n');
+        textdomain('litcal');
+        LiturgicalEventAbstract::setLocale($this->EventsParams->Locale);
+    }
+```
+
+Then delete the two now-unused private methods added in #744, in their entirety: `private function applyTranslatedLocale(string $baseLocale): void { ... }` and `private function
+resetToUntranslatedLocale(string $icuDefaultLocale): void { ... }`.
+
+- [ ] **Step 3: Verify no dangling references to the deleted helpers**
+
+Run: `grep -n "applyTranslatedLocale\|resetToUntranslatedLocale" src/Handlers/EventsHandler.php`
+Expected: no output (both methods gone, no callers).
+
+- [ ] **Step 4: Run the Events leak test + Events tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/EventsHandlerLocaleLeakTest.php phpunit_tests/Handlers/EventsHandlerTest.php
+phpunit_tests/Handlers/EventsHandlerRiteRoutingTest.php`
+Expected: PASS. (English now resolves via `en_US` instead of the #744 degrade path; output identical. The `it_IT`-availability skip guard in the leak test still applies.)
+
+- [ ] **Step 5: Static analysis + lint**
+
+Run: `composer analyse` — Expected: `[OK] No errors`.
+Run: `vendor/bin/phpcs src/Handlers/EventsHandler.php` — Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Handlers/EventsHandler.php
+git commit -m "refactor(events): use shared LocaleConfigurator in setLocale (#745)"
+```
+
+---
+
+### Task 4: Fold in `FerialEventNameGenerator::initializeGettext()`
+
+**Files:**
+
+- Modify: `src/FerialEventNameGenerator.php` (add import; replace `initializeGettext()` body)
+- Test: `phpunit_tests/Handlers/TemporaleHandlerTest.php` (existing — must stay green).
+
+**Interfaces:**
+
+- Consumes: `LocaleConfigurator::configure(string): ConfiguredLocale` from Task 1.
+
+- [ ] **Step 1: Add the import**
+
+In `src/FerialEventNameGenerator.php`, add to the `use` block (it already has `use LiturgicalCalendar\Api\Router;` etc.):
+
+```php
+use LiturgicalCalendar\Api\Services\LocaleConfigurator;
+```
+
+- [ ] **Step 2: Replace the `initializeGettext()` body**
+
+Replace the entire current `initializeGettext()` method (the Latin early-return, `$localeArray`, `$regionMap`, `setlocale`, `LANGUAGE` block, and text-domain binding) with:
+
+```php
+    /**
+     * Initialize gettext for the locale.
+     *
+     * Delegates process-global locale/LANGUAGE/ICU setup to the shared
+     * LocaleConfigurator (#745) — which resets for Latin and pins the catalog for
+     * translated locales, overriding any state a prior request left in this worker —
+     * then binds the gettext text domain. Latin phrase templates fall through to the
+     * English msgid base (there is no installable Latin locale); Latin day names and
+     * ordinals are emitted from hardcoded tables elsewhere in this class.
+     */
+    private function initializeGettext(): void
+    {
+        LocaleConfigurator::configure($this->locale);
+
+        // Bind textdomain using Router::$apiFilePath if available, else fall back.
+        $i18nPath = Router::$apiFilePath . 'i18n';
+        if (!is_dir($i18nPath)) {
+            $i18nPath = dirname(__DIR__) . '/i18n';
+        }
+
+        bindtextdomain('litcal', $i18nPath);
+        bind_textdomain_codeset('litcal', 'UTF-8');
+        textdomain('litcal');
+    }
+```
+
+- [ ] **Step 3: Verify the dropped `$regionMap` heuristic is gone**
+
+Run: `grep -n "regionMap\|strtoupper" src/FerialEventNameGenerator.php`
+Expected: no output.
+
+- [ ] **Step 4: Run the Temporale tests**
+
+Run: `vendor/bin/phpunit phpunit_tests/Handlers/TemporaleHandlerTest.php`
+Expected: PASS (3 tests — Latin `/temporale` still returns 200 with a non-empty body; invalid-locale still raises `ValidationException`).
+
+- [ ] **Step 5: Static analysis + lint**
+
+Run: `composer analyse` — Expected: `[OK] No errors`.
+Run: `vendor/bin/phpcs src/FerialEventNameGenerator.php` — Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/FerialEventNameGenerator.php
+git commit -m "refactor(ferial): use shared LocaleConfigurator in initializeGettext (#745)"
+```
+
+---
+
+### Task 5: Full validation
+
+**Files:** none (validation + optional PR).
+
+- [ ] **Step 1: Full static analysis + code style**
+
+Run: `composer analyse` — Expected: `[OK] No errors`.
+Run: `composer lint` — Expected: no phpcs violations.
+Run: `composer parallel-lint` — Expected: `No syntax error found`.
+
+- [ ] **Step 2: Run the full local suite**
+
+Run: `composer test`
+Expected: 0 failures. Pre-existing environmental errors are acceptable and unrelated to this change: tests under `phpunit_tests/Routes/**` error with `Could not detect API
+binding on http://localhost:8000` (need a live server) and DB-gated tests report `connection ... refused` when Postgres is absent. Confirm there are **no failures** and no new
+errors outside those two categories.
+
+- [ ] **Step 3: Confirm the three old duplications are gone**
+
+Run: `grep -rn "putenv(\"LANGUAGE=" src/`
+Expected: only `src/Services/LocaleConfigurator.php` (the three former sites — CalendarHandler, EventsHandler, FerialEventNameGenerator — no longer set `LANGUAGE` directly).
+
+- [ ] **Step 4: Push and open the PR (optional — confirm with the user first)**
+
+```bash
+git push -u origin feature/locale-configurator-745
+gh pr create --base development --head feature/locale-configurator-745 \
+  --title "refactor(locale): shared LocaleConfigurator across handlers (#745)" \
+  --body "Closes #745. Extracts the process-global locale/LANGUAGE/ICU setup duplicated in CalendarHandler::prepareL10N(), EventsHandler::setLocale(), and FerialEventNameGenerator::initializeGettext() into Services\\LocaleConfigurator. Region resolution standardized on CLDR likelySubtags; failure policy is resolve-or-throw with Latin the sole reset. See docs/superpowers/specs/2026-07-28-shared-locale-configurator-design.md."
+```
+
+---
+
+## Notes for the implementer
+
+- **Do not** modify `CalendarParams::maximizeLocale()` — it maximizes at the Params layer for the response's echoed `settings.locale`; the service resolves region independently
+  and both can coexist. (Follow-up #745 notes a possible later consolidation.)
+- **Do not** change the argument each handler passes to its model `setLocale()` (`CalendarHandler` → `LitLocale::$RUNTIME_LOCALE`; `EventsHandler` →
+  `$this->EventsParams->Locale`). Preserving these avoids shifting Latin model-branching/output.
+- Behavior change to be aware of while validating: a real language with **zero** installed system locales now throws 503 (was: Events degraded to English, Ferial silent). For the
+  locales the test host ships (`en_US`, `fr_FR`, `it_IT`, …) nothing observable changes.

--- a/docs/superpowers/plans/2026-07-28-shared-locale-configurator.md
+++ b/docs/superpowers/plans/2026-07-28-shared-locale-configurator.md
@@ -316,7 +316,7 @@ final class LocaleConfigurator
 - [ ] **Step 5: Run the test to verify it passes**
 
 Run: `vendor/bin/phpunit phpunit_tests/Services/LocaleConfiguratorTest.php`
-Expected: PASS (7 tests).
+Expected: PASS (6 tests).
 
 - [ ] **Step 6: Static analysis + lint on the new files**
 

--- a/docs/superpowers/specs/2026-07-28-shared-locale-configurator-design.md
+++ b/docs/superpowers/specs/2026-07-28-shared-locale-configurator-design.md
@@ -209,8 +209,9 @@ missing-Latin-reset gap.
 
 - **New `LocaleConfiguratorTest`** (unit, no handler needed), each with locale-state
   reset in `setUp`/`tearDown`:
-  - region from likelySubtags: `en`→ runtime `en_US`, `pt`→ `pt_BR` (assert
-    `getenv('LANGUAGE')` and the returned `runtimeLocale`).
+  - region from likelySubtags: `en`→ runtime `en_US`, `fr`→ `fr_FR`; a
+    region-bearing locale (`it_IT`) is preserved (assert `getenv('LANGUAGE')`
+    and the returned `runtimeLocale`).
   - Latin: `configure('la')` / `configure('la_VA')` → `isLatin` true,
     `getenv('LANGUAGE') === false`, ICU default `la`.
   - leak override: pre-set `putenv('LANGUAGE=it_IT:it')`, `configure('fr')` →

--- a/docs/superpowers/specs/2026-07-28-shared-locale-configurator-design.md
+++ b/docs/superpowers/specs/2026-07-28-shared-locale-configurator-design.md
@@ -179,6 +179,15 @@ LiturgicalEventAbstract::setLocale($this->EventsParams->Locale);
 `is_dir` fallback path, `bindtextdomain`, `bind_textdomain_codeset`, `textdomain`.
 `initializeFormatters()` is unaffected.
 
+`FerialEventNameGenerator` is independent of the other two handlers: it is
+constructed only by `TemporaleHandler::generateFerialEvents()` (with the request
+locale), and `TemporaleHandler` performs no other `setlocale`/`LANGUAGE`/gettext
+setup — its main temporale names come from a per-locale i18n JSON file, and only
+the ferial sub-part uses gettext. Routes are mutually exclusive per request, so
+this is not a re-set layered on top of another handler's locale; it is the sole
+gettext gate for `/temporale`. Folding it in additionally closes its current
+missing-Latin-reset gap.
+
 ## Behavior changes and risks (intentional)
 
 - **`CalendarHandler`**: region resolution now happens inside the service and no

--- a/docs/superpowers/specs/2026-07-28-shared-locale-configurator-design.md
+++ b/docs/superpowers/specs/2026-07-28-shared-locale-configurator-design.md
@@ -1,0 +1,223 @@
+# Shared request-locale configurator
+
+- **Issue:** [#745](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/745)
+- **Date:** 2026-07-28
+- **Status:** Approved (pending spec review)
+- **Follows:** #742 (`CalendarHandler` leak fix, #739), #744 (`EventsHandler` leak fix, #743)
+
+## Context and problem
+
+Four sites independently set up the process-global locale for a request — build a
+locale-candidate list, call `setlocale()`, pin the `LANGUAGE` env var (glibc
+`gettext()` reads it above `LC_MESSAGES`), and update ICU's default:
+
+Four sites do this, each differently:
+
+- **`CalendarHandler::prepareL10N()`** — region via `\Locale::getRegion()` (Params
+  already maximized through likelySubtags); **throws 503** on `setlocale()` failure;
+  resets on Latin (#739).
+- **`EventsHandler::setLocale()`** (via `applyTranslatedLocale()` /
+  `resetToUntranslatedLocale()`) — `strtoupper(baseLocale)` region guess
+  (`en`→`en_EN`, broken); **degrades to English** on failure (#744); resets on
+  Latin (#743).
+- **`FerialEventNameGenerator::initializeGettext()`** (used by `TemporaleHandler`) —
+  hardcoded `$regionMap` (`en`→`US`, …); **silent no-op** on failure; **no** Latin
+  reset (leak-prone).
+- **`CalendarParams::maximizeLocale()`** — resolves region via likelySubtags at the
+  *Params* layer, feeding `CalendarHandler`.
+
+This has already drifted: three different region-resolution strategies, three
+different failure policies, and only two of the three runtime sites reset the leak
+vector. The logic should live in **one** shared, independently testable unit.
+
+## Policy (decided)
+
+1. **Resolve the region deterministically.** Canonicalize the request locale; if it
+   carries no region, derive the likely region from CLDR **likely subtags**
+   (`jsondata/likelySubtags.json`), taking only the **region** subtag
+   (`en`→`US`; never the script-bearing `en_Latn_US`, which glibc rejects). This
+   replaces both the `strtoupper` guess and the hardcoded `$regionMap`.
+2. **A real language must resolve or fail — never silently become English.** Build
+   candidates from the resolved language/region and `setlocale()` them. If no
+   installed form of that language exists at all, **throw** (`ServiceUnavailableException`
+   → 503). A request for French must not produce English.
+3. **Latin is the sole special case.** `la`/`la_VA` cannot be installed on any host,
+   so it takes the reset branch (`setlocale(LC_ALL,'C')`, clear `LANGUAGE`, ICU
+   default `la`) and never throws; downstream helpers already emit hardcoded Latin.
+4. **English is not special** — it resolves like any language: likelySubtags gives
+   `en`→`US`, `en_US.utf8` is installed, `setlocale()` succeeds, and because there is
+   no `i18n/en` catalog `gettext()` returns the (English) msgids. This replaces the
+   #744 "degrade to msgid base" path for `EventsHandler` with a genuine resolution.
+5. **Every branch overrides prior process state**, so a `LANGUAGE`/locale left by an
+   earlier request in the same persistent worker cannot leak.
+
+## Goals
+
+- One shared unit that owns process-global locale state (`setlocale` + `LANGUAGE` +
+  ICU default) and returns the resolved runtime info.
+- Consistent region resolution (likelySubtags) and failure policy across
+  `CalendarHandler`, `EventsHandler`, and `FerialEventNameGenerator`.
+- No change to observable output for locales that are installed (the common case);
+  the golden master and both existing leak tests stay green.
+
+## Non-goals / out of scope
+
+- **`CalendarParams::maximizeLocale()`** stays as-is (it maximizes at the *Params*
+  layer for response `settings.locale`; changing it would alter the API's echoed
+  locale). The new service resolves region itself so it is correct regardless of
+  whether the Params layer maximized. Consolidating the two readers of
+  `likelySubtags.json` is a possible later cleanup, noted below.
+- **Model `setLocale()` arguments are unchanged.** Each handler keeps passing what it
+  passes today (`CalendarHandler` → `runtimeLocale`; `EventsHandler` →
+  `EventsParams->Locale`) to avoid shifting model-side Latin branching and output.
+- No change to text-domain binding style, formatter setup, or `LitLocale` statics —
+  those remain each caller's tail.
+
+## Design
+
+### New unit: `LocaleConfigurator` (+ `ConfiguredLocale`)
+
+`src/Services/LocaleConfigurator.php` — `final class`, namespace
+`LiturgicalCalendar\Api\Services`. Stateless except a private static cache of the
+likelySubtags map. Single public entry point:
+
+```php
+public static function configure(string $requestLocale): ConfiguredLocale
+```
+
+`src/Services/ConfiguredLocale.php` — readonly value object returned to callers:
+
+```php
+final class ConfiguredLocale
+{
+    public function __construct(
+        public readonly string $primaryLanguage, // e.g. 'it', 'en', 'la'
+        public readonly string $runtimeLocale,   // normalized, e.g. 'it_IT' or 'la'
+        public readonly bool   $isLatin,         // true => reset branch was taken
+    ) {}
+}
+```
+
+### `configure()` contract
+
+```text
+canonical        = \Locale::canonicalize(requestLocale) ?: requestLocale
+primaryLanguage  = \Locale::getPrimaryLanguage(canonical) ?: canonical
+
+if primaryLanguage === LitLocale::LATIN_PRIMARY_LANGUAGE:      // 'la'
+    reset('la')                                               // C locale, unset LANGUAGE, ICU=la
+    return ConfiguredLocale('la', 'la', isLatin: true)
+
+region = \Locale::getRegion(canonical)
+if region === '':
+    region = likelyRegion(primaryLanguage)                    // from likelySubtags, may be ''
+
+candidates = []
+if region !== '':
+    lr = primaryLanguage . '_' . region                       // e.g. 'en_US'
+    candidates = [ lr.'.utf8', lr.'.UTF-8', lr ]
+candidates = candidates + [ primaryLanguage.'.utf8', primaryLanguage.'.UTF-8', primaryLanguage ]
+
+runtimeLocale = setlocale(LC_ALL, candidates)
+if runtimeLocale === false:
+    throw new ServiceUnavailableException("Could not set locale to {requestLocale}.")
+
+normalized = strtok(runtimeLocale, '.') ?: runtimeLocale       // 'it_IT.UTF-8' -> 'it_IT'
+if normalized in ('C','POSIX'):
+    normalized = region !== '' ? primaryLanguage.'_'.region : primaryLanguage
+
+putenv('LANGUAGE=' . implode(':', array_unique([runtimeLocale, normalized, primaryLanguage, 'en'])))
+\Locale::setDefault(normalized)
+return ConfiguredLocale(primaryLanguage, normalized, isLatin: false)
+```
+
+`reset($icuDefault)`: `setlocale(LC_ALL,'C'); putenv('LANGUAGE'); \Locale::setDefault($icuDefault);`
+
+`likelyRegion($language)`: lazy-load `jsondata/likelySubtags.json`
+(`Utilities::jsonFileToArray(JsonData::FOLDER->path() . '/likelySubtags.json')`,
+`['supplemental']['likelySubtags']`, cached in a static — mirroring
+`CalendarParams::maximizeLocale`); return
+`\Locale::getRegion(\Locale::canonicalize($map[$language]) ?: $map[$language])` or `''`
+when the language is absent.
+
+Notes:
+
+- The raw canonical string (which may carry a script subtag, e.g. `en_Latn_US`) is
+  intentionally **not** offered to `setlocale()` — glibc rejects script-bearing
+  names. Candidates are built from `primaryLanguage` + extracted `region` only.
+- `ServiceUnavailableException` (an HTTP exception) thrown from a service matches the
+  existing behavior in `CalendarHandler` and the codebase's convention; callers let
+  it propagate to the router's error handling.
+
+### Caller integration
+
+**`CalendarHandler::prepareL10N()`** — keep its `null`-primary-language guard (the
+St-Augustine 503 message) as a pre-check, then:
+
+```php
+$configured = LocaleConfigurator::configure($this->CalendarParams->Locale);
+LitLocale::$PRIMARY_LANGUAGE = $configured->primaryLanguage;
+LitLocale::$RUNTIME_LOCALE   = $configured->runtimeLocale;
+LiturgicalEvent::setLocale(LitLocale::$RUNTIME_LOCALE);
+$this->createFormatters();
+// existing is_dir + error-checked bindtextdomain + bind_textdomain_codeset + textdomain checks
+```
+
+**`EventsHandler::setLocale()`** — replace the body (and delete the
+`applyTranslatedLocale()` / `resetToUntranslatedLocale()` helpers added in #744):
+
+```php
+LocaleConfigurator::configure($this->EventsParams->Locale);
+bindtextdomain('litcal', Router::$apiFilePath . 'i18n');
+textdomain('litcal');
+LiturgicalEventAbstract::setLocale($this->EventsParams->Locale);
+```
+
+**`FerialEventNameGenerator::initializeGettext()`** — replace the
+`$localeArray` + `$regionMap` + `setlocale` + `LANGUAGE` block with
+`LocaleConfigurator::configure($this->locale);`, keeping its existing tail: the
+`is_dir` fallback path, `bindtextdomain`, `bind_textdomain_codeset`, `textdomain`.
+`initializeFormatters()` is unaffected.
+
+## Behavior changes and risks (intentional)
+
+- **`CalendarHandler`**: region resolution now happens inside the service and no
+  longer depends on the Params layer having maximized the locale — strictly more
+  robust. No output change for installed locales.
+- **`EventsHandler`**: English now resolves via `en_US` rather than the #744
+  degrade-to-msgid path (same English output); a real language with **zero**
+  installed locales now **throws** 503 instead of silently degrading to English —
+  the intended stricter policy.
+- **`FerialEventNameGenerator` / `TemporaleHandler`**: gains likelySubtags region
+  resolution, the Latin reset, `LANGUAGE` leak-proofing, and the throw-on-unresolvable
+  policy (previously silent). The throw path is not expected to fire for
+  already-validated route locales.
+- All three sites now reset the leak vector, closing the `FerialEventNameGenerator`
+  gap where a Latin `/temporale` request after a translated request could inherit a
+  stale `LANGUAGE`.
+
+## Testing
+
+- **New `LocaleConfiguratorTest`** (unit, no handler needed), each with locale-state
+  reset in `setUp`/`tearDown`:
+  - region from likelySubtags: `en`→ runtime `en_US`, `pt`→ `pt_BR` (assert
+    `getenv('LANGUAGE')` and the returned `runtimeLocale`).
+  - Latin: `configure('la')` / `configure('la_VA')` → `isLatin` true,
+    `getenv('LANGUAGE') === false`, ICU default `la`.
+  - leak override: pre-set `putenv('LANGUAGE=it_IT:it')`, `configure('fr')` →
+    `LANGUAGE` starts with a French entry (not Italian).
+  - throw path: `configure()` on a guaranteed-absent language (e.g. `zz`) throws
+    `ServiceUnavailableException`.
+- **Keep** `CalendarHandlerLocaleLeakTest` and `EventsHandlerLocaleLeakTest` green —
+  they now exercise the shared path. The Events English test still passes (English
+  resolves rather than degrades). The `it_IT`-availability skip guard added in #744
+  is retained.
+- Golden master unchanged; PHPStan level 10 + phpcs clean; `TemporaleHandlerTest`
+  and the ferial-name paths stay green.
+
+## Follow-ups (not in this change)
+
+- Consolidate the two readers of `likelySubtags.json` (`CalendarParams::maximizeLocale`
+  and `LocaleConfigurator::likelyRegion`) behind one small helper.
+- Consider unifying the model `setLocale()` argument (`runtimeLocale` vs raw
+  `Locale`) once its effect on Latin model-branching is characterized.

--- a/phpunit_tests/Services/LocaleConfiguratorTest.php
+++ b/phpunit_tests/Services/LocaleConfiguratorTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\LocaleConfigurator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LocaleConfigurator::class)]
+final class LocaleConfiguratorTest extends TestCase
+{
+    private string $savedApiFilePath    = '';
+    private string|false $savedLanguage = false;
+    private string $savedIcuDefault     = 'en';
+
+    protected function setUp(): void
+    {
+        $this->savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        $this->savedLanguage    = getenv('LANGUAGE');
+        $this->savedIcuDefault  = \Locale::getDefault();
+
+        // JsonData::FOLDER->path() prefixes Router::$apiFilePath; point it at the repo root.
+        Router::$apiFilePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+
+        // Start from a clean process-global locale.
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+    }
+
+    protected function tearDown(): void
+    {
+        Router::$apiFilePath = $this->savedApiFilePath;
+        setlocale(LC_ALL, 'C');
+        if ($this->savedLanguage === false) {
+            putenv('LANGUAGE');
+        } else {
+            putenv('LANGUAGE=' . $this->savedLanguage);
+        }
+        \Locale::setDefault($this->savedIcuDefault);
+    }
+
+    public function testRegionlessLanguageResolvesViaLikelySubtags(): void
+    {
+        $result = LocaleConfigurator::configure('en');
+        self::assertSame('en', $result->primaryLanguage);
+        self::assertSame('en_US', $result->runtimeLocale);
+        self::assertFalse($result->isLatin);
+        self::assertStringStartsWith('en_US', (string) getenv('LANGUAGE'));
+    }
+
+    public function testFrenchResolvesToInstalledRegionVariant(): void
+    {
+        $result = LocaleConfigurator::configure('fr');
+        self::assertSame('fr', $result->primaryLanguage);
+        self::assertSame('fr_FR', $result->runtimeLocale);
+        self::assertFalse($result->isLatin);
+    }
+
+    public function testRegionBearingLocaleIsPreserved(): void
+    {
+        $result = LocaleConfigurator::configure('it_IT');
+        self::assertSame('it', $result->primaryLanguage);
+        self::assertSame('it_IT', $result->runtimeLocale);
+    }
+
+    public function testLatinResetsAndClearsLanguage(): void
+    {
+        putenv('LANGUAGE=it_IT.utf8:it_IT:it:en'); // simulate a prior translated request
+        foreach (['la', 'la_VA'] as $latin) {
+            $result = LocaleConfigurator::configure($latin);
+            self::assertTrue($result->isLatin, "{$latin} should take the Latin reset branch");
+            self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $result->primaryLanguage);
+            self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, $result->runtimeLocale);
+            self::assertFalse(getenv('LANGUAGE'), 'Latin must clear the leaked LANGUAGE env var');
+        }
+    }
+
+    public function testOverridesLeakedLanguageFromPriorRequest(): void
+    {
+        putenv('LANGUAGE=it_IT.utf8:it_IT:it:en');
+        LocaleConfigurator::configure('fr');
+        self::assertStringStartsWith('fr', (string) getenv('LANGUAGE'));
+    }
+
+    public function testThrowsWhenNoInstalledLocaleForLanguage(): void
+    {
+        $this->expectException(ServiceUnavailableException::class);
+        LocaleConfigurator::configure('zz');
+    }
+}

--- a/phpunit_tests/Services/LocaleConfiguratorTest.php
+++ b/phpunit_tests/Services/LocaleConfiguratorTest.php
@@ -17,12 +17,14 @@ final class LocaleConfiguratorTest extends TestCase
     private string $savedApiFilePath    = '';
     private string|false $savedLanguage = false;
     private string $savedIcuDefault     = 'en';
+    private string|false $savedLocale   = false;
 
     protected function setUp(): void
     {
         $this->savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
         $this->savedLanguage    = getenv('LANGUAGE');
         $this->savedIcuDefault  = \Locale::getDefault();
+        $this->savedLocale      = setlocale(LC_ALL, 0);
 
         // JsonData::FOLDER->path() prefixes Router::$apiFilePath; point it at the repo root.
         Router::$apiFilePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
@@ -35,7 +37,9 @@ final class LocaleConfiguratorTest extends TestCase
     protected function tearDown(): void
     {
         Router::$apiFilePath = $this->savedApiFilePath;
-        setlocale(LC_ALL, 'C');
+        if ($this->savedLocale !== false) {
+            setlocale(LC_ALL, $this->savedLocale);
+        }
         if ($this->savedLanguage === false) {
             putenv('LANGUAGE');
         } else {

--- a/src/FerialEventNameGenerator.php
+++ b/src/FerialEventNameGenerator.php
@@ -2,7 +2,6 @@
 
 namespace LiturgicalCalendar\Api;
 
-use LiturgicalCalendar\Api\Enum\LitLocale;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\LocaleConfigurator;
 

--- a/src/FerialEventNameGenerator.php
+++ b/src/FerialEventNameGenerator.php
@@ -4,6 +4,7 @@ namespace LiturgicalCalendar\Api;
 
 use LiturgicalCalendar\Api\Enum\LitLocale;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\LocaleConfigurator;
 
 /**
  * Generates localized names for ferial (weekday) liturgical events.
@@ -176,74 +177,20 @@ class FerialEventNameGenerator
     /**
      * Initialize gettext for the locale.
      *
-     * Uses the same initialization pattern as CalendarHandler for consistency.
+     * Delegates process-global locale/LANGUAGE/ICU setup to the shared
+     * LocaleConfigurator (#745) — which resets for Latin and pins the catalog for
+     * translated locales, overriding any state a prior request left in this worker —
+     * then binds the gettext text domain. Latin phrase templates fall through to the
+     * English msgid base (there is no installable Latin locale); Latin day names and
+     * ordinals are emitted from hardcoded tables elsewhere in this class.
      */
     private function initializeGettext(): void
     {
-        // Skip gettext initialization for Latin (no .mo file needed, hardcoded strings)
-        if ($this->primaryLanguage === 'la') {
-            return;
-        }
+        LocaleConfigurator::configure($this->locale);
 
-        // Build locale variants to try (same pattern as CalendarHandler)
-        $localeArray = [
-            $this->locale . '.utf8',
-            $this->locale . '.UTF-8',
-            $this->locale,
-            $this->primaryLanguage . '.utf8',
-            $this->primaryLanguage . '.UTF-8',
-            $this->primaryLanguage
-        ];
-
-        // Map primary language to region if not already included
-        $regionMap = [
-            'en' => 'US',
-            'it' => 'IT',
-            'es' => 'ES',
-            'de' => 'DE',
-            'fr' => 'FR',
-            'pt' => 'PT',
-            'nl' => 'NL',
-            'hu' => 'HU',
-            'pl' => 'PL',
-            'sk' => 'SK',
-            'vi' => 'VN',
-            'hr' => 'HR',
-            'id' => 'ID',
-        ];
-
-        if (isset($regionMap[$this->primaryLanguage])) {
-            $region = $regionMap[$this->primaryLanguage];
-            array_splice($localeArray, 3, 0, [
-                $this->primaryLanguage . '_' . $region . '.utf8',
-                $this->primaryLanguage . '_' . $region . '.UTF-8',
-                $this->primaryLanguage . '_' . $region
-            ]);
-        }
-
-        // Set locale for gettext
-        $runtimeLocale = setlocale(LC_ALL, $localeArray);
-
-        // Set LANGUAGE environment variable for gettext fallback
-        if ($runtimeLocale !== false) {
-            $normalizedLocale = strtok($runtimeLocale, '.') ?: $runtimeLocale;
-            if ($normalizedLocale === 'C' || $normalizedLocale === 'POSIX') {
-                $normalizedLocale = $this->primaryLanguage;
-            }
-
-            $languageEnv = implode(':', array_unique([
-                $runtimeLocale,
-                $normalizedLocale,
-                $this->primaryLanguage,
-                'en'
-            ]));
-            putenv("LANGUAGE={$languageEnv}");
-        }
-
-        // Bind textdomain using Router::$apiFilePath if available
+        // Bind textdomain using Router::$apiFilePath if available, else fall back.
         $i18nPath = Router::$apiFilePath . 'i18n';
         if (!is_dir($i18nPath)) {
-            // Fallback to relative path
             $i18nPath = dirname(__DIR__) . '/i18n';
         }
 

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -81,6 +81,7 @@ use LiturgicalCalendar\Api\Models\RegionalData\NationalData\LitCalItemSetPropert
 use LiturgicalCalendar\Api\Models\RegionalData\WiderRegionData\WiderRegionData;
 use LiturgicalCalendar\Api\Models\CatholicDiocesesLatinRite\CatholicDiocesesMap;
 use LiturgicalCalendar\Api\Params\CalendarParams;
+use LiturgicalCalendar\Api\Services\LocaleConfigurator;
 use Nyholm\Psr7\Stream;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -5007,72 +5008,21 @@ final class CalendarHandler extends AbstractHandler
     /**
      * Set up the locale for this API request.
      *
-     * Uses the passed-in locale to set the locale for PHP's built-in
-     * internationalization functions. Also sets up the formatters for the
-     * dates and ordinals, and loads the translation files for the
-     * requested locale.
+     * Delegates process-global locale/LANGUAGE/ICU setup to the shared
+     * LocaleConfigurator (deterministic + leak-free, #745), then sets the
+     * LitLocale statics, the LiturgicalEvent locale, the date/ordinal formatters,
+     * and binds the gettext text domain.
      */
     private function prepareL10N(): void
     {
-        $region     = \Locale::getRegion($this->CalendarParams->Locale);
         $baseLocale = \Locale::getPrimaryLanguage($this->CalendarParams->Locale);
         if (null === $baseLocale) {
             throw new ServiceUnavailableException('“Pride was the reason for the division of tongues, humility the reason they were reunited.” - St. Augustine, The City of God, Book XVI, Chapter 4');
         }
 
-        LitLocale::$PRIMARY_LANGUAGE = $baseLocale;
-        if ($baseLocale !== LitLocale::LATIN_PRIMARY_LANGUAGE) {
-            $localeArray = [
-                $this->CalendarParams->Locale . '.utf8',
-                $this->CalendarParams->Locale . '.UTF-8',
-                $this->CalendarParams->Locale,
-                $baseLocale . '.utf8',
-                $baseLocale . '.UTF-8',
-                $baseLocale
-            ];
-            if ($region !== null && $region !== '') {
-                array_splice($localeArray, 3, 0, [
-                    $baseLocale . '_' . $region . '.utf8',
-                    $baseLocale . '_' . $region . '.UTF-8',
-                    $baseLocale . '_' . $region
-                ]);
-            }
-
-            $runtimeLocale = setlocale(LC_ALL, $localeArray);
-            if (false === $runtimeLocale) {
-                throw new ServiceUnavailableException('Could not set locale to ' . $this->CalendarParams->Locale . '.');
-            }
-
-            // Example: "it_IT.UTF-8" → "it_IT"
-            $normalizedLocale = strtok($runtimeLocale, '.') ?: $runtimeLocale;
-            if ($normalizedLocale === 'C' || $normalizedLocale === 'POSIX') {
-                $normalizedLocale = $baseLocale;
-            }
-
-            $languageEnv = implode(':', array_unique([
-                $runtimeLocale,
-                $normalizedLocale,
-                $baseLocale,
-                'en'
-            ]));
-            putenv("LANGUAGE={$languageEnv}");
-
-            // also update ICU’s default locale
-            \Locale::setDefault($normalizedLocale);
-
-            LitLocale::$RUNTIME_LOCALE = $normalizedLocale;
-        } else {
-            // Latin (or default): a prior translated request handled by this same
-            // (long-lived) worker process may have left the process-global locale set —
-            // setlocale(LC_MESSAGES) and the LANGUAGE env var, both of which gettext reads.
-            // Reset them so the Latin calendar's message templates fall through to the
-            // untranslated (English) base instead of leaking the previous request's
-            // language (#739). This mirrors, in reverse, the translated branch above.
-            setlocale(LC_ALL, 'C');
-            putenv('LANGUAGE');
-            \Locale::setDefault(LitLocale::LATIN_PRIMARY_LANGUAGE);
-            LitLocale::$RUNTIME_LOCALE = LitLocale::LATIN_PRIMARY_LANGUAGE;
-        }
+        $configured                  = LocaleConfigurator::configure($this->CalendarParams->Locale);
+        LitLocale::$PRIMARY_LANGUAGE = $configured->primaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = $configured->runtimeLocale;
 
         LiturgicalEvent::setLocale(LitLocale::$RUNTIME_LOCALE);
 

--- a/src/Handlers/EventsHandler.php
+++ b/src/Handlers/EventsHandler.php
@@ -40,6 +40,7 @@ use LiturgicalCalendar\Api\Models\RegionalData\NationalData\NationalData;
 use LiturgicalCalendar\Api\Models\RegionalData\WiderRegionData\WiderRegionData;
 use LiturgicalCalendar\Api\Params\EventsParams;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\LocaleConfigurator;
 use LiturgicalCalendar\Api\Utilities;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -299,114 +300,16 @@ final class EventsHandler extends AbstractHandler
     }
 
     /**
-     * Set up the process-global locale for this request in a deterministic,
-     * leak-proof way.
-     *
-     * For a translated locale whose system locale is installed, this pins the
-     * current request's gettext catalog via LANGUAGE (which glibc gettext reads
-     * above LC_MESSAGES) and updates ICU's default. If setlocale() fails (the
-     * locale isn't installed — e.g. bare 'en', the source language) or the request
-     * is Latin/default, it resets setlocale()/LANGUAGE/ICU so localized output
-     * falls through to the untranslated (English) base. Every branch overrides
-     * whatever a prior request in the same persistent worker left behind, then
-     * binds the gettext text domain and configures the LiturgicalEventAbstract
-     * locale. Mirrors CalendarHandler::prepareL10N() (#743).
-     *
-     * @return void
+     * Set up the process-global locale for this request via the shared
+     * LocaleConfigurator (deterministic + leak-free, #745), then bind the gettext
+     * text domain and configure the LiturgicalEventAbstract locale.
      */
     private function setLocale(): void
     {
-        $baseLocale = $this->EventsParams->baseLocale;
-
-        if ($baseLocale !== LitLocale::LATIN_PRIMARY_LANGUAGE) {
-            $this->applyTranslatedLocale($baseLocale);
-        } else {
-            // Latin (or default): reset the process-global locale left by a prior
-            // request in this long-lived worker so gettext-backed output falls through
-            // to the untranslated (English) base rather than leaking it (#743).
-            $this->resetToUntranslatedLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
-        }
-
+        LocaleConfigurator::configure($this->EventsParams->Locale);
         bindtextdomain('litcal', Router::$apiFilePath . 'i18n');
         textdomain('litcal');
         LiturgicalEventAbstract::setLocale($this->EventsParams->Locale);
-    }
-
-    /**
-     * Resolve and pin the process-global locale + gettext catalog for a translated
-     * request. Builds the locale-candidate list from the request locale; on a
-     * successful setlocale() it pins the current request's gettext catalog via
-     * LANGUAGE (which glibc gettext reads above LC_MESSAGES) and updates ICU's
-     * default. If the requested locale isn't installed on this host — e.g. bare 'en',
-     * the source language — setlocale() fails and localized output degrades to the
-     * untranslated (English) msgid base. Either way the leak vector is reset (#743).
-     *
-     * @param string $baseLocale The primary language subtag of the request locale.
-     * @return void
-     */
-    private function applyTranslatedLocale(string $baseLocale): void
-    {
-        $localeArray = [
-            $this->EventsParams->Locale . '.utf8',
-            $this->EventsParams->Locale . '.UTF-8',
-            $this->EventsParams->Locale,
-            $baseLocale . '_' . strtoupper($baseLocale) . '.utf8',
-            $baseLocale . '_' . strtoupper($baseLocale) . '.UTF-8',
-            $baseLocale . '_' . strtoupper($baseLocale),
-            $baseLocale . '.utf8',
-            $baseLocale . '.UTF-8',
-            $baseLocale
-        ];
-
-        $runtimeLocale = setlocale(LC_ALL, $localeArray);
-        if (false === $runtimeLocale) {
-            // The requested locale isn't installed on this host. glibc gettext() can't
-            // load a catalog without a non-C locale, so localized output falls through
-            // to the (English) msgid base — correct for an English request (the source
-            // language, with no catalog of its own), and graceful degradation for any
-            // other uninstalled locale. Still reset the leak vector (#743).
-            $this->resetToUntranslatedLocale($baseLocale);
-            return;
-        }
-
-        // Example: "it_IT.UTF-8" → "it_IT"
-        $normalizedLocale = strtok($runtimeLocale, '.') ?: $runtimeLocale;
-        if ($normalizedLocale === 'C' || $normalizedLocale === 'POSIX') {
-            $normalizedLocale = $baseLocale;
-        }
-
-        // Pin gettext's catalog for THIS request. glibc gettext() reads LANGUAGE above
-        // LC_MESSAGES, so — in a persistent worker — a LANGUAGE value left by a prior
-        // request (e.g. CalendarHandler::prepareL10N() or an earlier /events request in
-        // another language) would otherwise win and leak into this response (#743).
-        $languageEnv = implode(':', array_unique([
-            $runtimeLocale,
-            $normalizedLocale,
-            $baseLocale,
-            'en'
-        ]));
-        putenv("LANGUAGE={$languageEnv}");
-
-        // also update ICU’s default locale
-        \Locale::setDefault($normalizedLocale);
-    }
-
-    /**
-     * Reset the process-global locale state — setlocale(LC_MESSAGES) and the LANGUAGE
-     * env var, both of which gettext reads — that a prior request in this long-lived
-     * worker may have left behind, so localized output falls through deterministically
-     * to the untranslated (English) base instead of leaking the previous request's
-     * language (#743). Mirrors, in reverse, applyTranslatedLocale()'s translated path.
-     *
-     * @param string $icuDefaultLocale Locale to set as ICU's default (the request's
-     *                                 primary language, or Latin for a Latin request).
-     * @return void
-     */
-    private function resetToUntranslatedLocale(string $icuDefaultLocale): void
-    {
-        setlocale(LC_ALL, 'C');
-        putenv('LANGUAGE');
-        \Locale::setDefault($icuDefaultLocale);
     }
 
     /**

--- a/src/Services/ConfiguredLocale.php
+++ b/src/Services/ConfiguredLocale.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+/**
+ * Immutable result of {@see LocaleConfigurator::configure()}: the process-global
+ * locale state that was applied for a request.
+ */
+final class ConfiguredLocale
+{
+    /**
+     * @param string $primaryLanguage Primary language subtag (e.g. 'it', 'en', 'la').
+     * @param string $runtimeLocale   Normalized runtime locale in effect (e.g. 'it_IT',
+     *                                 'en_US', or 'la' for the Latin reset branch).
+     * @param bool   $isLatin         True when the Latin/reset branch was taken.
+     */
+    public function __construct(
+        public readonly string $primaryLanguage,
+        public readonly string $runtimeLocale,
+        public readonly bool $isLatin
+    ) {
+    }
+}

--- a/src/Services/LocaleConfigurator.php
+++ b/src/Services/LocaleConfigurator.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\Utilities;
+
+/**
+ * Deterministically applies the process-global locale state — setlocale(LC_ALL),
+ * the LANGUAGE env var (which glibc gettext() reads above LC_MESSAGES), and ICU's
+ * default — for a single request, in a leak-free way.
+ *
+ * Region resolution uses CLDR likely subtags (jsondata/likelySubtags.json) so a
+ * region-less request locale (e.g. 'en', 'fr') maps to the installed system locale
+ * ('en_US', 'fr_FR'). A real language whose system locale is not installed at all
+ * throws — it must never silently fall through to English. Latin ('la'/'la_VA') is
+ * the sole special case: it cannot be installed, so it takes the reset branch and
+ * never throws (downstream code emits hardcoded Latin).
+ *
+ * Centralizes logic previously duplicated across CalendarHandler::prepareL10N(),
+ * EventsHandler::setLocale(), and FerialEventNameGenerator::initializeGettext() (#745).
+ */
+final class LocaleConfigurator
+{
+    /** @var array<string,string>|null Cached CLDR likelySubtags map (language => "lang-Script-Region"). */
+    private static ?array $likelySubtags = null;
+
+    /**
+     * Apply the process-global locale for the given request locale and return the
+     * resolved runtime information.
+     *
+     * @param string $requestLocale The request locale (e.g. 'it_IT', 'en', 'la_VA').
+     * @throws ServiceUnavailableException When a non-Latin language has no installed system locale.
+     */
+    public static function configure(string $requestLocale): ConfiguredLocale
+    {
+        $canonical       = \Locale::canonicalize($requestLocale);
+        $canonical       = ( $canonical === null || $canonical === '' ) ? $requestLocale : $canonical;
+        $primaryLanguage = \Locale::getPrimaryLanguage($canonical);
+        $primaryLanguage = ( $primaryLanguage === null || $primaryLanguage === '' ) ? $canonical : $primaryLanguage;
+
+        if ($primaryLanguage === LitLocale::LATIN_PRIMARY_LANGUAGE) {
+            self::reset(LitLocale::LATIN_PRIMARY_LANGUAGE);
+            return new ConfiguredLocale(LitLocale::LATIN_PRIMARY_LANGUAGE, LitLocale::LATIN_PRIMARY_LANGUAGE, true);
+        }
+
+        $region = \Locale::getRegion($canonical);
+        if ($region === null || $region === '') {
+            $region = self::likelyRegion($primaryLanguage);
+        }
+
+        $candidates = [];
+        if ($region !== '') {
+            $langRegion = $primaryLanguage . '_' . $region;
+            $candidates = [$langRegion . '.utf8', $langRegion . '.UTF-8', $langRegion];
+        }
+        $candidates = array_merge($candidates, [
+            $primaryLanguage . '.utf8',
+            $primaryLanguage . '.UTF-8',
+            $primaryLanguage,
+        ]);
+
+        $runtimeLocale = setlocale(LC_ALL, $candidates);
+        if ($runtimeLocale === false) {
+            throw new ServiceUnavailableException('Could not set locale to ' . $requestLocale . '.');
+        }
+
+        // Example: "it_IT.UTF-8" → "it_IT"
+        $normalizedLocale = strtok($runtimeLocale, '.') ?: $runtimeLocale;
+        if ($normalizedLocale === 'C' || $normalizedLocale === 'POSIX') {
+            $normalizedLocale = $region !== '' ? $primaryLanguage . '_' . $region : $primaryLanguage;
+        }
+
+        // Pin gettext's catalog for THIS request, overriding any LANGUAGE a prior
+        // request in this persistent worker left behind (glibc reads it above LC_MESSAGES).
+        $languageEnv = implode(':', array_unique([
+            $runtimeLocale,
+            $normalizedLocale,
+            $primaryLanguage,
+            'en',
+        ]));
+        putenv("LANGUAGE={$languageEnv}");
+        \Locale::setDefault($normalizedLocale);
+
+        return new ConfiguredLocale($primaryLanguage, $normalizedLocale, false);
+    }
+
+    /**
+     * Reset the process-global locale state so gettext output falls through to the
+     * untranslated (English) msgid base, and update ICU's default. Used for Latin.
+     */
+    private static function reset(string $icuDefaultLocale): void
+    {
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+        \Locale::setDefault($icuDefaultLocale);
+    }
+
+    /**
+     * Resolve the likely region subtag for a region-less language via CLDR likely
+     * subtags (e.g. 'en' → 'US', 'pt' → 'BR'). Returns '' when unknown.
+     *
+     * Only the region subtag is used: glibc rejects script-bearing locale names
+     * like "en_Latn_US", so the caller builds "en_US" from language + region.
+     */
+    private static function likelyRegion(string $language): string
+    {
+        if (self::$likelySubtags === null) {
+            /** @var array{supplemental:array{likelySubtags:array<string,string>}} $data */
+            $data                = Utilities::jsonFileToArray(JsonData::FOLDER->path() . '/likelySubtags.json');
+            self::$likelySubtags = $data['supplemental']['likelySubtags'];
+        }
+
+        $maximized = self::$likelySubtags[$language] ?? null;
+        if ($maximized === null) {
+            return '';
+        }
+
+        $canonical = \Locale::canonicalize($maximized);
+        $region    = \Locale::getRegion(( $canonical === null || $canonical === '' ) ? $maximized : $canonical);
+        return ( $region === null ) ? '' : $region;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #745. Extracts the process-global locale setup (`setlocale` + `LANGUAGE` env + ICU default) that had **drifted across three runtime sites** into one shared, stateless service `Services\LocaleConfigurator` (+ readonly `ConfiguredLocale` result).

Before this PR, four different region-resolution strategies and three different `setlocale`-failure policies coexisted:

- `CalendarHandler::prepareL10N()` — real region via `\Locale::getRegion()`; threw 503 on failure.
- `EventsHandler::setLocale()` — `strtoupper(baseLocale)` guess (`en`→`en_EN`, broken); degraded to English.
- `FerialEventNameGenerator::initializeGettext()` (the `/temporale` gate) — hardcoded `$regionMap`; silent no-op on failure; **no Latin reset** (leak-prone).
- `CalendarParams::maximizeLocale()` — likelySubtags at the Params layer.

## What changed

`LocaleConfigurator::configure(string): ConfiguredLocale` now owns the whole concern; each site delegates and keeps its own tail (formatters, `LitLocale` statics, text-domain binding, model `setLocale`).

- **Region resolution** standardized on CLDR likely subtags (`jsondata/likelySubtags.json`), using the **region subtag only** (`en`→`en_US`) — never the script-bearing `en_Latn_US`, which glibc rejects.
- **Failure policy:** a real language with no installed system locale **throws** `ServiceUnavailableException` — it must never silently become English. **Latin (`la`/`la_VA`) is the sole special case:** it can't be installed, so it takes the reset branch and never throws.
- **Leak-proof:** every branch overrides prior worker state. This also **closes a `FerialEventNameGenerator` gap** — its old Latin early-return never reset `LANGUAGE`, so a Latin `/temporale` after a translated request could inherit a stale language.

## Behavior

- **Installed locales (the common case): no observable change.** The Calendar Latin golden master is **byte-identical** (9/9).
- `EventsHandler` English now genuinely resolves via `en_US` (same English output) instead of the #744 degrade path.
- The stricter throw policy cannot fire in production: the Docker image installs `locales-all`, so every supported language resolves.

## Out of scope (deliberately unchanged)

- `CalendarParams::maximizeLocale()` (maximizes at the Params layer for the echoed `settings.locale`).
- The argument each handler passes to its model `setLocale()` (`CalendarHandler` → `LitLocale::$RUNTIME_LOCALE`; `EventsHandler` → `EventsParams->Locale`).

Two follow-up cleanups noted in the spec: consolidating the two `likelySubtags.json` readers, and unifying the model `setLocale()` argument.

## Tests

- New `LocaleConfiguratorTest` (region-via-likelySubtags, region-bearing preserved, Latin reset, leak override, throw-on-unresolvable).
- `CalendarHandlerLocaleLeakTest` + golden master (byte-identical), `EventsHandlerLocaleLeakTest` + Events suites, `TemporaleHandlerTest` — all green.
- Full local suite: **0 failures** (remaining errors are pre-existing live-server/DB integration tests). PHPStan L10 + phpcs + parallel-lint clean.

Design & plan: `docs/superpowers/specs/2026-07-28-shared-locale-configurator-design.md`, `docs/superpowers/plans/2026-07-28-shared-locale-configurator.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent, deterministic locale handling across calendar, events, and ferial event naming, including better region resolution for language-only inputs.
- **Bug Fixes**
  - Prevented locale and translation state from leaking between requests.
  - Improved Latin-language behavior and now returns a clearer service-unavailable outcome for unsupported languages with no installed locales (instead of silent fallback).
- **Refactor**
  - Unified locale setup and gettext initialization via a shared locale configurator used by multiple features.
- **Tests**
  - Added automated coverage for locale resolution, env-var behavior, and failure cases.
- **Documentation**
  - Added shared locale configuration design and spec docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->