### PR TITLE
Bump OpenFGA to v1.18.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -232,7 +232,7 @@ services:
   # HTTP API: http://localhost:3001 (Playground), http://localhost:8083 (API)
   # Pin to a specific version for reproducible deployments.
   openfga-migrate:
-    image: openfga/openfga:v1.8.12
+    image: openfga/openfga:v1.18.2
     command: migrate
     environment:
       OPENFGA_DATASTORE_ENGINE: postgres
@@ -245,7 +245,7 @@ services:
 
   openfga:
     restart: unless-stopped
-    image: openfga/openfga:v1.8.12
+    image: openfga/openfga:v1.18.2
     command: run
     environment:
       OPENFGA_DATASTORE_ENGINE: postgres


### PR DESCRIPTION
Local dev stack only. Applies Postgres migration 006 (`add_collate_index`) on first up; confirmed via `goose_db_version` and the `idx_user_lookup` index picking up `object_id COLLATE "C"`. The v1.18.0 lock warning is MySQL-specific and does not apply to this Postgres stack.

Note: PR #755 (`feat/consume-cdcf-infra-openfga-model`) also touches `docker-compose.yml` (adds an `authz-seed` service). This PR only changes the two `openfga/openfga:` image lines, so whichever merges second should have a trivial conflict at worst.