### PR TITLE
fix(ambrosian): correct published artifacts still claiming 501

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,13 @@ Some characteristics of this API:
   and `PATCH`/`DELETE` likewise address resources by path (e.g. `PUT /data/nation/IT`, `PATCH /tests/MaryMotherChurchTest`).
   One deliberate exception: on read endpoints this API uses `POST` as a body-parameterized synonym of `GET` (not as collection-create),
   pending possible adoption of the [`QUERY` method](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/) when it becomes standard.
-* **Ambrosian rite support (comune ambrosiano) is live**: `GET/POST /calendar/ambrosian` and `/calendar/ambrosian/{year}` calculate the calendar for the
-  Ambrosian rite as celebrated in common (no diocesan overlay yet — the Ambrosian dioceses of Milano, Bergamo, Novara, and Lugano are planned for a future
-  release), `/events/ambrosian` returns its event catalog, and the `/calendars` discovery endpoint announces it under `ambrosian_calendars`. A few notes on
-  the current state of this data:
+* **Ambrosian rite support is live**: `GET/POST /calendar/ambrosian` and `/calendar/ambrosian/{year}` calculate the calendar for the Ambrosian rite as
+  celebrated in common (the *comune ambrosiano*), while `/calendar/ambrosian/diocese/{calendar_id}` and `/calendar/ambrosian/diocese/{calendar_id}/{year}`
+  layer the proper of one of the four Ambrosian dioceses — Milano (`milano_it`), Bergamo (`bergam_it`), Novara (`novara_it`) and Lugano (`lugano_ch`) —
+  directly over it. `/events/ambrosian` and `/events/ambrosian/diocese/{calendar_id}` return the corresponding event catalogs, and the `/calendars`
+  discovery endpoint announces all of them under `ambrosian_calendars`. A few notes on the current state of this data:
+  * **The Ambrosian rite has no national calendar layer.** Its dioceses depend directly on the rite, so there is no `/calendar/ambrosian/nation/…` route:
+    combining the Ambrosian rite with a national calendar returns `400 Bad Request`, as does requesting a Roman diocese under the Ambrosian rite (or vice versa).
   * **Readings are a placeholder**: the Ambrosian rite does not yet have its own lectionary wired up, so `readings` is always empty for Ambrosian events.
   * **Year cycles, first-vespers vigils, and psalter-week numbering are provisional**, pending validation against the official Ambrosian ordo.
   * The Ambrosian rite is only available from **1976 onward** (the first reformed Ambrosian Missal); earlier years return `400 Bad Request`.

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -11,7 +11,7 @@
     }
   ],
   "info": {
-    "description": "An API which allows to retrieve data about the **Roman Calendar** for any given year, between 1970 and 9999. The data strives for historical accuracy (memorials and feast days are only generated from the year in which they were effectively introduced). The data is based on original sources (Roman Missals, Decrees of the Dicastery for Divine Worship and the Discipline of the Sacraments, Mysterii Paschalis, etc.), not on data copied or retrieved from online sources which may not be accurate. The API offers multiple locales and multiple calendars, from the **General Roman Calendar** to national or diocesan calendars. The Roman rite is the default and may also be requested explicitly with a `/calendar/roman` prefix (equivalent to no prefix); a `/calendar/ambrosian` prefix selects the Ambrosian rite (currently returns `501 Not Implemented` — see the `/calendar/ambrosian` paths).",
+    "description": "An API which allows to retrieve data about the **Roman Calendar** for any given year, between 1970 and 9999. The data strives for historical accuracy (memorials and feast days are only generated from the year in which they were effectively introduced). The data is based on original sources (Roman Missals, Decrees of the Dicastery for Divine Worship and the Discipline of the Sacraments, Mysterii Paschalis, etc.), not on data copied or retrieved from online sources which may not be accurate. The API offers multiple locales and multiple calendars, from the **General Roman Calendar** to national or diocesan calendars. The Roman rite is the default and may also be requested explicitly with a `/calendar/roman` prefix (equivalent to no prefix); a `/calendar/ambrosian` prefix selects the Ambrosian rite, available from 1976 onward. The Ambrosian rite has no national calendars: its dioceses (Milano, Bergamo, Novara, Lugano) are layered directly on the comune ambrosiano.",
     "version": "5.7",
     "title": "Liturgical Calendar",
     "contact": {
@@ -1199,9 +1199,9 @@
         "security": [
           {}
         ],
-        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of the current year (currently returns 501 Not Implemented)",
+        "summary": "Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of the current year",
         "operationId": "retrieveAmbrosianDiocesanCalendarGET",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of the current year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
+        "description": "Retrieve liturgical events for a given diocese under the Ambrosian rite for each day of the current year. Ambrosian dioceses are not layered on a national calendar: the diocesan proper is applied directly over the comune ambrosiano. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1217,8 +1217,11 @@
           }
         ],
         "responses": {
-          "501": {
-            "$ref": "#/components/responses/NotImplemented501"
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1241,9 +1244,9 @@
         "security": [
           {}
         ],
-        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of the current year (currently returns 501 Not Implemented)",
+        "summary": "Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of the current year",
         "operationId": "retrieveAmbrosianDiocesanCalendarPOST",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of the current year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
+        "description": "Retrieve liturgical events for a given diocese under the Ambrosian rite for each day of the current year. Ambrosian dioceses are not layered on a national calendar: the diocesan proper is applied directly over the comune ambrosiano. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1292,8 +1295,11 @@
           }
         },
         "responses": {
-          "501": {
-            "$ref": "#/components/responses/NotImplemented501"
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1318,9 +1324,9 @@
         "security": [
           {}
         ],
-        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of a given year (currently returns 501 Not Implemented)",
+        "summary": "Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of a given year",
         "operationId": "retrieveAmbrosianDiocesanCalendarForYearGET",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
+        "description": "Retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Ambrosian dioceses are not layered on a national calendar: the diocesan proper is applied directly over the comune ambrosiano. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1339,8 +1345,11 @@
           }
         ],
         "responses": {
-          "501": {
-            "$ref": "#/components/responses/NotImplemented501"
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1363,9 +1372,9 @@
         "security": [
           {}
         ],
-        "summary": "[Planned] Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of a given year (currently returns 501 Not Implemented)",
+        "summary": "Retrieve liturgical events from the Ambrosian calendar for a given diocese for each day of a given year",
         "operationId": "retrieveAmbrosianDiocesanCalendarForYearPOST",
-        "description": "Planned; currently returns 501 Not Implemented. Once implemented, this endpoint will retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
+        "description": "Retrieve liturgical events for a given diocese under the Ambrosian rite for each day of a given year. Ambrosian dioceses are not layered on a national calendar: the diocesan proper is applied directly over the comune ambrosiano. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request. The Ambrosian rite is available only from 1976 onward (the first reformed Ambrosian Missal); earlier years return 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -1425,8 +1434,11 @@
           }
         },
         "responses": {
-          "501": {
-            "$ref": "#/components/responses/NotImplemented501"
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -4126,7 +4138,7 @@
           {}
         ],
         "summary": "Retrieve all possible liturgical events from the Ambrosian comune calendar (Proprium de Tempore and comune sanctorale) even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
-        "description": "The Ambrosian rite has no national calendars, and diocesan Ambrosian event catalogs are not yet supported; this endpoint serves only the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. A `national_calendar` or `diocesan_calendar` parameter combined with this endpoint returns 400 Bad Request.",
+        "description": "The Ambrosian rite has no national calendars; this endpoint serves the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. For a diocesan Ambrosian catalog, use `/events/ambrosian/diocese/{calendar_id}`. A `national_calendar` or `diocesan_calendar` parameter combined with this endpoint returns 400 Bad Request.",
         "operationId": "retrieveAmbrosianEventsGET",
         "parameters": [
           {
@@ -4166,7 +4178,7 @@
           {}
         ],
         "summary": "Retrieve all possible liturgical events from the Ambrosian comune calendar (Proprium de Tempore and comune sanctorale) even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
-        "description": "The Ambrosian rite has no national calendars, and diocesan Ambrosian event catalogs are not yet supported; this endpoint serves only the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. A `national_calendar` or `diocesan_calendar` parameter combined with this endpoint returns 400 Bad Request.",
+        "description": "The Ambrosian rite has no national calendars; this endpoint serves the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. For a diocesan Ambrosian catalog, use `/events/ambrosian/diocese/{calendar_id}`. A `national_calendar` or `diocesan_calendar` parameter combined with this endpoint returns 400 Bad Request.",
         "operationId": "retrieveAmbrosianEventsPOST",
         "parameters": [
           {
@@ -4176,6 +4188,104 @@
         "responses": {
           "200": {
             "description": "OK: A collection of all possible liturgical events that can be found in the Ambrosian comune calendar produced by the LitCal API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      }
+    },
+    "/events/ambrosian/diocese/{calendar_id}": {
+      "get": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the given Ambrosian diocesan calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "description": "The diocesan proper is layered directly over the comune ambrosiano; the Ambrosian rite has no national calendars. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
+        "operationId": "retrieveAmbrosianEventsForDiocesanCalendarGET",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in the given Ambrosian diocesan calendar produced by the LitCal API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the given Ambrosian diocesan calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "description": "The diocesan proper is layered directly over the comune ambrosiano; the Ambrosian rite has no national calendars. Only the Ambrosian dioceses are valid for this path: Milano (milano_it), Bergamo (bergam_it), Novara (novara_it), and Lugano (lugano_ch); any other calendar_id combined with the ambrosian rite segment returns 400 Bad Request.",
+        "operationId": "retrieveAmbrosianEventsForDiocesanCalendarPOST",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in the given Ambrosian diocesan calendar produced by the LitCal API",
             "content": {
               "application/json": {
                 "schema": {
@@ -10097,22 +10207,6 @@
               "status": 429,
               "detail": "Too many login attempts. Please try again later.",
               "retryAfter": 847
-            }
-          }
-        }
-      },
-      "NotImplemented501": {
-        "description": "501 Not Implemented. The request was valid and routable, but the requested calendar computation has not yet been implemented on the server.",
-        "content": {
-          "application/problem+json": {
-            "schema": {
-              "$ref": "./Problem.json"
-            },
-            "example": {
-              "type": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/501",
-              "title": "Not Implemented",
-              "status": 501,
-              "detail": "This calendar computation has not yet been implemented"
             }
           }
         }

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -4138,7 +4138,7 @@
           {}
         ],
         "summary": "Retrieve all possible liturgical events from the Ambrosian comune calendar (Proprium de Tempore and comune sanctorale) even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
-        "description": "The Ambrosian rite has no national calendars; this endpoint serves the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. For a diocesan Ambrosian catalog, use `/events/ambrosian/diocese/{calendar_id}`. A `national_calendar` or `diocesan_calendar` parameter combined with this endpoint returns 400 Bad Request.",
+        "description": "The Ambrosian rite has no national calendars; this endpoint serves the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. For a diocesan Ambrosian catalog, use `/events/ambrosian/diocese/{calendar_id}`. A `national_calendar` parameter combined with this endpoint returns 400 Bad Request, as does any diocese belonging to a different rite than the one requested.",
         "operationId": "retrieveAmbrosianEventsGET",
         "parameters": [
           {
@@ -4178,7 +4178,7 @@
           {}
         ],
         "summary": "Retrieve all possible liturgical events from the Ambrosian comune calendar (Proprium de Tempore and comune sanctorale) even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
-        "description": "The Ambrosian rite has no national calendars; this endpoint serves the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. For a diocesan Ambrosian catalog, use `/events/ambrosian/diocese/{calendar_id}`. A `national_calendar` or `diocesan_calendar` parameter combined with this endpoint returns 400 Bad Request.",
+        "description": "The Ambrosian rite has no national calendars; this endpoint serves the comune ambrosiano (Proprium de Tempore + comune sanctorale) catalog. For a diocesan Ambrosian catalog, use `/events/ambrosian/diocese/{calendar_id}`. A `national_calendar` parameter combined with this endpoint returns 400 Bad Request, as does any diocese belonging to a different rite than the one requested.",
         "operationId": "retrieveAmbrosianEventsPOST",
         "parameters": [
           {

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -1158,8 +1158,8 @@ final class CalendarHandler extends AbstractHandler
     /**
      * Ambrosian rite only: orchestrates the full Ambrosian calendar calculation for
      * `$this->CalendarParams->Year`, assembling the passes built by Plan 7 Tasks 3-8 into the
-     * single call `handle()` will eventually make once the `/calendar/ambrosian` 501 is lifted
-     * (Task 10).
+     * single call `handle()` makes for an Ambrosian request (see the {@see Rite::AMBROSIAN}
+     * branch in `handle()`).
      *
      * Call order (load-bearing — do not reorder):
      *
@@ -4315,8 +4315,9 @@ final class CalendarHandler extends AbstractHandler
         // Solemnities of the Lord) is delegated to the rite's temporale engine,
         // obtained via the RiteProfile seam, which mutates the shared calendar
         // and message sink through the context. This is only ever reached for
-        // Rite::ROMAN today: an Ambrosian request short-circuits with a 501
-        // earlier in handle() (Plans 3-5 will implement the Ambrosian engine).
+        // Rite::ROMAN: handle() routes an Ambrosian request to
+        // calculateAmbrosianCalendar() instead, which drives AmbrosianTemporale
+        // through this same RiteProfile seam.
         $riteProfile      = RiteProfileFactory::forRite($this->CalendarParams->Rite);
         $temporaleContext = new TemporaleContext(
             $this->Cal,


### PR DESCRIPTION
## Context

The Ambrosian diocesan calendar endpoints have returned `200` since #738, but `openapi.json` still documented all four operations with `501` and **no `200` at all** — so a generated client, or anyone reading the spec, would model those endpoints as incapable of success. This came up while an agent working on `liturgy-components-js` was building rite-aware paths against a table that annotated `/calendar/ambrosian/diocese/lugano_ch` as "501 today".

Looking into it turned up several more places carrying the same stale claim, including the top-level API description and the README.

## Changes

**`jsondata/schemas/openapi.json`**

- The four `/calendar/ambrosian/diocese/{calendar_id}{,/{year}}` operations now document `200`/`304`, matching their Roman counterparts. Summaries lose the `[Planned] … (currently returns 501 Not Implemented)` prefix; descriptions state the no-national-tier rule instead of a planned status.
- The **top-level API description** claimed the whole `/calendar/ambrosian` prefix returns `501` — wrong since #735, and the first thing a client author reads.
- Documented `/events/ambrosian/diocese/{calendar_id}`, added in e52a33be but never described, and dropped the "diocesan Ambrosian event catalogs are not yet supported" claim from `/events/ambrosian`.
- Removed the now-unused `NotImplemented501` component (redocly's `no-unused-components` flagged it once the last reference went).

**`README.md`** — replaced "no diocesan overlay yet — … planned for a future release" with the four live dioceses, and stated the no-national-tier rule explicitly.

**`src/Handlers/CalendarHandler.php`** — two comments (`:1161`, `:4318`) described the `501` as still in force; `handle()` has routed Ambrosian requests to `calculateAmbrosianCalendar()` since Plan 7 Task 10. **Comments only — no executable change.**

## Verification

Linters: `composer lint:openapi` clean (was 1 warning, now 0), `composer lint:md` clean across 67 files, `composer lint` / phpcs clean.

Tests: 1234 non-Routes tests green, 19,028 assertions.

Live against a local server, confirming what the schema now claims:

| Request | Result |
|---|---|
| `/calendar/ambrosian/diocese/milano_it` | 200 |
| `/calendar/ambrosian/diocese/bergam_it/2026` | 200 |
| `/calendar/ambrosian/diocese/novara_it/2026` | 200 |
| `/calendar/ambrosian/diocese/lugano_ch/2026` | 200 |
| `/events/ambrosian/diocese/milano_it` | 200 |
| `/calendar/ambrosian/nation/IT/2026` | 400 |
| `/calendar/diocese/milano_it/2026` | 400 |
| `/calendar/ambrosian/1975` | 400 |

`Routes/*` and `Repositories/*` are CI-covered; they can't run in this sandbox (port 8000 and 5432 are occupied by a different project's containers).

## Follow-ups (not in this PR)

- Five celebrations the Missal anchors to Pentecost are missing from the Ambrosian temporale entirely — Trinity, Corpus Domini, Sacred Heart, Immaculate Heart, Mary Mother of the Church. Spec written; implementation next.
- `/data` is not rite-aware, so Ambrosian diocesan definitions can't be read or written through it.
- `epiphany` / `ascension` / `corpus_christi` / `eternal_high_priest` are advertised on the Ambrosian operations but cannot take effect; the praenotanda fix these in the rite's own books, so they should be rejected rather than silently ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ambrosian diocesan calendar endpoints are now available for Milano, Bergamo, Novara, and Lugano.
  * Added event catalog endpoints for Ambrosian dioceses.
  * Calendars support diocesan overlays and applicable historical dates from 1976 onward.

* **Documentation**
  * Updated API documentation with supported dioceses, calendar discovery, and validation errors for unsupported combinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->