### PR TITLE
Make the explicit rite segment the canonical URL form

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,16 @@ Some characteristics of this API:
   and `PATCH`/`DELETE` likewise address resources by path (e.g. `PUT /data/nation/IT`, `PATCH /tests/MaryMotherChurchTest`).
   One deliberate exception: on read endpoints this API uses `POST` as a body-parameterized synonym of `GET` (not as collection-create),
   pending possible adoption of the [`QUERY` method](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/) when it becomes standard.
+* **The explicit rite segment is the canonical URL form**: `/calendar/roman/{year}` states the rite outright, symmetric with `/calendar/ambrosian/{year}`, and
+  the explicit Roman form is accepted everywhere the bare form is — `/calendar/roman`, `/calendar/roman/nation/{calendar_id}`,
+  `/calendar/roman/diocese/{calendar_id}`, and `/events/roman`. The bare paths (`/calendar/{year}`, `/events`, …) are retained for backwards compatibility and
+  return an identical response. They are deliberately **not** redirected: these routes accept `POST`, so a redirect would both downgrade `POST` to `GET`
+  (dropping the request body) and, per the [Fetch standard](https://fetch.spec.whatwg.org/#http-redirect-fetch), turn any preflighted cross-origin request into
+  a network error. Instead, responses to the bare form carry an [RFC 6596](https://www.rfc-editor.org/rfc/rfc6596) `Link: <...>; rel="canonical"` header naming
+  the canonical URL (query string preserved), exposed to browser clients via `Access-Control-Expose-Headers`.
+* **Response headers are readable by cross-origin browser clients**: only the CORS-safelisted headers are visible to JavaScript by default, so the API names
+  its own in `Access-Control-Expose-Headers` — always `X-Request-Id` (so a browser client can quote it in a bug report), plus `ETag` (so a client can echo it
+  back as `If-None-Match`) and the canonical `Link`, each named only on the responses that actually carry them.
 * **Ambrosian rite support is live**: `GET/POST /calendar/ambrosian` and `/calendar/ambrosian/{year}` calculate the calendar for the Ambrosian rite as
   celebrated in common (the *comune ambrosiano*), while `/calendar/ambrosian/diocese/{calendar_id}` and `/calendar/ambrosian/diocese/{calendar_id}/{year}`
   layer the proper of one of the four Ambrosian dioceses — Milano (`milano_it`), Bergamo (`bergam_it`), Novara (`novara_it`) and Lugano (`lugano_ch`) —

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ Some characteristics of this API:
 * **Response headers are readable by cross-origin browser clients**: only the CORS-safelisted headers are visible to JavaScript by default, so the API names
   its own in `Access-Control-Expose-Headers` — always `X-Request-Id` (so a browser client can quote it in a bug report), plus `ETag` (so a client can echo it
   back as `If-None-Match`) and the canonical `Link`, each named only on the responses that actually carry them.
+* **The calendar `ETag` is a weak validator** (`W/"..."`): a calendar representation embeds its own generation stamp (`metadata.timestamp` / `metadata.date_time`,
+  or `DTSTAMP` in ICS), which changes on every regeneration while saying nothing about the calendar. The validator is computed with those stamps neutralised, so
+  an unchanged calendar keeps the same `ETag` across regenerations and a conditional request actually revalidates into a `304` instead of re-sending the whole
+  body. It is weak precisely because two bodies sharing a validator may still differ in those stamps ([RFC 9110 §8.8.1](https://www.rfc-editor.org/rfc/rfc9110#name-validator-fields)).
 * **Ambrosian rite support is live**: `GET/POST /calendar/ambrosian` and `/calendar/ambrosian/{year}` calculate the calendar for the Ambrosian rite as
   celebrated in common (the *comune ambrosiano*), while `/calendar/ambrosian/diocese/{calendar_id}` and `/calendar/ambrosian/diocese/{calendar_id}/{year}`
   layer the proper of one of the four Ambrosian dioceses — Milano (`milano_it`), Bergamo (`bergam_it`), Novara (`novara_it`) and Lugano (`lugano_ch`) —

--- a/README.md
+++ b/README.md
@@ -96,10 +96,11 @@ Some characteristics of this API:
 * **Response headers are readable by cross-origin browser clients**: only the CORS-safelisted headers are visible to JavaScript by default, so the API names
   its own in `Access-Control-Expose-Headers` — always `X-Request-Id` (so a browser client can quote it in a bug report), plus `ETag` (so a client can echo it
   back as `If-None-Match`) and the canonical `Link`, each named only on the responses that actually carry them.
-* **The calendar `ETag` is a weak validator** (`W/"..."`): a calendar representation embeds its own generation stamp (`metadata.timestamp` / `metadata.date_time`,
-  or `DTSTAMP` in ICS), which changes on every regeneration while saying nothing about the calendar. The validator is computed with those stamps neutralised, so
-  an unchanged calendar keeps the same `ETag` across regenerations and a conditional request actually revalidates into a `304` instead of re-sending the whole
-  body. It is weak precisely because two bodies sharing a validator may still differ in those stamps ([RFC 9110 §8.8.1](https://www.rfc-editor.org/rfc/rfc9110#name-validator-fields)).
+* **The calendar `ETag` is a weak validator** (`W/"..."`): every calendar representation embeds its own generation stamp — `timestamp` / `date_time` in JSON
+  and YML, `<Timestamp>` / `<DateTime>` in XML, `DTSTAMP` in ICS — which changes on every regeneration while saying nothing about the calendar. The validator
+  is computed with those stamps neutralised, so an unchanged calendar keeps the same `ETag` across regenerations and a conditional request actually revalidates
+  into a `304` instead of re-sending the whole body. It is weak precisely because two bodies sharing a validator may still differ in those stamps
+  ([RFC 9110 §8.8.1](https://www.rfc-editor.org/rfc/rfc9110#name-validator-fields)).
 * **Ambrosian rite support is live**: `GET/POST /calendar/ambrosian` and `/calendar/ambrosian/{year}` calculate the calendar for the Ambrosian rite as
   celebrated in common (the *comune ambrosiano*), while `/calendar/ambrosian/diocese/{calendar_id}` and `/calendar/ambrosian/diocese/{calendar_id}/{year}`
   layer the proper of one of the four Ambrosian dioceses — Milano (`milano_it`), Bergamo (`bergam_it`), Novara (`novara_it`) and Lugano (`lugano_ch`) —

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -4927,7 +4927,7 @@
           }
         },
         "deprecated": true,
-        "description": "\n\n**Deprecated in favour of the explicit-rite form `/events/roman`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL."
+        "description": "**Deprecated in favour of the explicit-rite form `/events/roman`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL."
       },
       "post": {
         "tags": [
@@ -4965,7 +4965,7 @@
           }
         },
         "deprecated": true,
-        "description": "\n\n**Deprecated in favour of the explicit-rite form `/events/roman`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL."
+        "description": "**Deprecated in favour of the explicit-rite form `/events/roman`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL."
       }
     },
     "/events/roman": {
@@ -5004,7 +5004,7 @@
             "$ref": "#/components/responses/ServiceUnavailable503"
           }
         },
-        "description": "\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/events/ambrosian` variant. The equivalent bare path (`/events`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header."
+        "description": "This is the canonical form of this route: the rite is stated explicitly, symmetric with the `/events/ambrosian` variant. The equivalent bare path (`/events`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header."
       },
       "post": {
         "tags": [
@@ -5041,7 +5041,7 @@
             "$ref": "#/components/responses/ServiceUnavailable503"
           }
         },
-        "description": "\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/events/ambrosian` variant. The equivalent bare path (`/events`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header."
+        "description": "This is the canonical form of this route: the rite is stated explicitly, symmetric with the `/events/ambrosian` variant. The equivalent bare path (`/events`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header."
       }
     },
     "/events/ambrosian": {

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -112,7 +112,141 @@
         ],
         "summary": "Retrieve liturgical events for the General Roman Calendar for each day of the current year",
         "operationId": "retrieveGeneralRomanCalendarGET",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          },
+          {
+            "$ref": "#/components/parameters/EpiphanyParam"
+          },
+          {
+            "$ref": "#/components/parameters/AscensionParam"
+          },
+          {
+            "$ref": "#/components/parameters/CorpusChristiParam"
+          },
+          {
+            "$ref": "#/components/parameters/EternalHighPriestParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events for the General Roman Calendar for each day of the current year",
+        "operationId": "retrieveGeneralRomanCalendarPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveCalendarRequestBody"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                },
+                "GeneralRomanCalendarTweaked": {
+                  "$ref": "#/components/examples/GeneralRomanCalendarTweakedRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveCalendarRequestBody"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                },
+                "GeneralRomanCalendarTweaked": {
+                  "$ref": "#/components/examples/GeneralRomanCalendarTweakedRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/calendar/roman": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events for the General Roman Calendar for each day of the current year",
+        "operationId": "retrieveRomanRiteCalendarGET",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian` variant. The equivalent bare path (`/calendar`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -165,8 +299,8 @@
           {}
         ],
         "summary": "Retrieve liturgical events for the General Roman Calendar for each day of the current year",
-        "operationId": "retrieveGeneralRomanCalendarPOST",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "operationId": "retrieveRomanRiteCalendarPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian` variant. The equivalent bare path (`/calendar`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -244,7 +378,155 @@
         ],
         "summary": "Retrieve liturgical events from the General Roman Calendar for each day of the given year",
         "operationId": "retrieveGeneralRomanCalendarForYearGET",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/{year}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/YearPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          },
+          {
+            "$ref": "#/components/parameters/EpiphanyParam"
+          },
+          {
+            "$ref": "#/components/parameters/AscensionParam"
+          },
+          {
+            "$ref": "#/components/parameters/CorpusChristiParam"
+          },
+          {
+            "$ref": "#/components/parameters/EternalHighPriestParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the General Roman Calendar for each day of the given year",
+        "operationId": "retrieveGeneralRomanCalendarForYearPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/{year}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1970,
+              "maximum": 9999
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveCalendarRequestBody"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                },
+                "GeneralRomanCalendarTweaked": {
+                  "$ref": "#/components/examples/GeneralRomanCalendarTweakedRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetrieveCalendarRequestBody"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                },
+                "GeneralRomanCalendarTweaked": {
+                  "$ref": "#/components/examples/GeneralRomanCalendarTweakedRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/calendar/roman/{year}": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the General Roman Calendar for each day of the given year",
+        "operationId": "retrieveRomanRiteCalendarForYearGET",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian/{year}` variant. The equivalent bare path (`/calendar/{year}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -300,8 +582,8 @@
           {}
         ],
         "summary": "Retrieve liturgical events from the General Roman Calendar for each day of the given year",
-        "operationId": "retrieveGeneralRomanCalendarForYearPOST",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "operationId": "retrieveRomanRiteCalendarForYearPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian/{year}` variant. The equivalent bare path (`/calendar/{year}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -390,7 +672,143 @@
         ],
         "summary": "Retrieve liturgical events from the liturgical calendar for a given nation for each day of the current year",
         "operationId": "retrieveNationalCalendarGET",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/nation/{calendar_id}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/NationalCalendarIdPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the liturgical calendar for a given nation for each day of the current year",
+        "operationId": "retrieveNationalCalendarPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/nation/{calendar_id}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "CA",
+                "HR",
+                "IT",
+                "NL",
+                "US",
+                "VA"
+              ],
+              "summary": "uppercase two letter ISO 3166 code of a nation for which the liturgical calendar has been defined"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/calendar/roman/nation/{calendar_id}": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the liturgical calendar for a given nation for each day of the current year",
+        "operationId": "retrieveRomanRiteNationalCalendarGET",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian` variant. The equivalent bare path (`/calendar/nation/{calendar_id}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -434,8 +852,8 @@
           {}
         ],
         "summary": "Retrieve liturgical events from the liturgical calendar for a given nation for each day of the current year",
-        "operationId": "retrieveNationalCalendarPOST",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "operationId": "retrieveRomanRiteNationalCalendarPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian` variant. The equivalent bare path (`/calendar/nation/{calendar_id}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -524,7 +942,156 @@
         ],
         "summary": "Retrieve liturgical events from the liturgical calendar for a given nation for each day of a given year",
         "operationId": "retrieveNationalCalendarForYearGET",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/nation/{calendar_id}/{year}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/NationalCalendarIdPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the liturgical calendar for a given nation for each day of a given year",
+        "operationId": "retrieveNationalCalendarForYearPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/nation/{calendar_id}/{year}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "CA",
+                "HR",
+                "IT",
+                "NL",
+                "US",
+                "VA"
+              ]
+            }
+          },
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1970,
+              "maximum": 9999
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/calendar/roman/nation/{calendar_id}/{year}": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the liturgical calendar for a given nation for each day of a given year",
+        "operationId": "retrieveRomanRiteNationalCalendarForYearGET",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian` variant. The equivalent bare path (`/calendar/nation/{calendar_id}/{year}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -571,8 +1138,8 @@
           {}
         ],
         "summary": "Retrieve liturgical events from the liturgical calendar for a given nation for each day of a given year",
-        "operationId": "retrieveNationalCalendarForYearPOST",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "operationId": "retrieveRomanRiteNationalCalendarForYearPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian` variant. The equivalent bare path (`/calendar/nation/{calendar_id}/{year}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -671,7 +1238,134 @@
         ],
         "summary": "Retrieve liturgical events from the liturgical calendar for a given diocese for each day of the current year",
         "operationId": "retrieveDiocesanCalendarGET",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/diocese/{calendar_id}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/DiocesanCalendarIdPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the liturgical calendar for a given diocese for each day of the current year",
+        "operationId": "retrieveDiocesanCalendarPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/diocese/{calendar_id}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/calendar/roman/diocese/{calendar_id}": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the liturgical calendar for a given diocese for each day of the current year",
+        "operationId": "retrieveRomanRiteDiocesanCalendarGET",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian/diocese/{calendar_id}` variant. The equivalent bare path (`/calendar/diocese/{calendar_id}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -715,8 +1409,8 @@
           {}
         ],
         "summary": "Retrieve liturgical events from the liturgical calendar for a given diocese for each day of the current year",
-        "operationId": "retrieveDiocesanCalendarPOST",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "operationId": "retrieveRomanRiteDiocesanCalendarPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian/diocese/{calendar_id}` variant. The equivalent bare path (`/calendar/diocese/{calendar_id}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -796,7 +1490,148 @@
         ],
         "summary": "Retrieve liturgical events from the liturgical calendar for a given diocese for each day of a given year",
         "operationId": "retrieveDiocesanCalendarForYearGET",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/diocese/{calendar_id}/{year}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "$ref": "#/components/parameters/DiocesanCalendarIdPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearPathParam"
+          },
+          {
+            "$ref": "#/components/parameters/YearTypeParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      },
+      "post": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the liturgical calendar for a given diocese for each day of a given year",
+        "operationId": "retrieveDiocesanCalendarForYearPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\n**Deprecated in favour of the explicit-rite form `/calendar/roman/diocese/{calendar_id}/{year}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/AcceptHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          },
+          {
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1970,
+              "maximum": 9999
+            }
+          }
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CivilOrLiturgicalYear"
+              },
+              "examples": {
+                "LiturgicalYearCalendar": {
+                  "$ref": "#/components/examples/LiturgicalYearRequestBody"
+                },
+                "CivilYearCalendar": {
+                  "$ref": "#/components/examples/CivilYearRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/LitCal200"
+          },
+          "304": {
+            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "406": {
+            "$ref": "#/components/responses/NotAcceptable406"
+          },
+          "415": {
+            "$ref": "#/components/responses/UnsupportedMediaType415"
+          },
+          "418": {
+            "$ref": "#/components/responses/IMATeapot418"
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/calendar/roman/diocese/{calendar_id}/{year}": {
+      "get": {
+        "tags": [
+          "Main API endpoint"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve liturgical events from the liturgical calendar for a given diocese for each day of a given year",
+        "operationId": "retrieveRomanRiteDiocesanCalendarForYearGET",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian/diocese/{calendar_id}/{year}` variant. The equivalent bare path (`/calendar/diocese/{calendar_id}/{year}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -843,8 +1678,8 @@
           {}
         ],
         "summary": "Retrieve liturgical events from the liturgical calendar for a given diocese for each day of a given year",
-        "operationId": "retrieveDiocesanCalendarForYearPOST",
-        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year",
+        "operationId": "retrieveRomanRiteDiocesanCalendarForYearPOST",
+        "description": "By passing in the appropriate options, you can retrieve data for the liturgical calendar for any given year\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/calendar/ambrosian/diocese/{calendar_id}/{year}` variant. The equivalent bare path (`/calendar/diocese/{calendar_id}/{year}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -4090,7 +4925,9 @@
           "503": {
             "$ref": "#/components/responses/ServiceUnavailable503"
           }
-        }
+        },
+        "deprecated": true,
+        "description": "\n\n**Deprecated in favour of the explicit-rite form `/events/roman`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL."
       },
       "post": {
         "tags": [
@@ -4126,7 +4963,85 @@
           "503": {
             "$ref": "#/components/responses/ServiceUnavailable503"
           }
-        }
+        },
+        "deprecated": true,
+        "description": "\n\n**Deprecated in favour of the explicit-rite form `/events/roman`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL."
+      }
+    },
+    "/events/roman": {
+      "get": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the General Roman Calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "operationId": "retrieveRomanRiteEventsGET",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in a liturgical calendar produced by the LitCal API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        },
+        "description": "\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/events/ambrosian` variant. The equivalent bare path (`/events`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header."
+      },
+      "post": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the General Roman Calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "operationId": "retrieveRomanRiteEventsPOST",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in a liturgical calendar produced by the LitCal API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        },
+        "description": "\n\nThis is the canonical form of this route: the rite is stated explicitly, symmetric with the `/events/ambrosian` variant. The equivalent bare path (`/events`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header."
       }
     },
     "/events/ambrosian": {

--- a/phpunit_tests/RouterCanonicalRiteLinkTest.php
+++ b/phpunit_tests/RouterCanonicalRiteLinkTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The explicit rite form (`/calendar/roman/2026`) is the canonical form; the bare form
+ * (`/calendar/2026`) is retained for backwards compatibility and advertises the canonical
+ * form with an RFC 6596 `Link: rel="canonical"` header rather than a redirect.
+ *
+ * A redirect is not usable here: the calendar routes accept POST, a 301/302 would downgrade
+ * POST to GET and drop the body, and per the Fetch standard a browser treats any redirect
+ * response to a preflighted cross-origin request as a network error.
+ */
+#[CoversMethod(Router::class, 'canonicalRiteUrl')]
+final class RouterCanonicalRiteLinkTest extends TestCase
+{
+    /**
+     * Router::$apiPath is global static state shared with every other test in the process,
+     * so it is restored afterwards (same pattern as AbstractHandlerTestCase).
+     */
+    private static string $savedApiPath = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$savedApiPath = isset(Router::$apiPath) ? Router::$apiPath : '';
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath = self::$savedApiPath;
+    }
+
+    protected function setUp(): void
+    {
+        Router::$apiPath = 'https://example.test/api/dev';
+    }
+
+    public function testBareCalendarYearAdvertisesTheExplicitRomanForm(): void
+    {
+        self::assertSame(
+            'https://example.test/api/dev/calendar/roman/2026',
+            Router::canonicalRiteUrl('calendar', false, Rite::ROMAN, ['2026'])
+        );
+    }
+
+    public function testBareCalendarWithNoFurtherSegmentsAdvertisesTheRiteRoot(): void
+    {
+        self::assertSame(
+            'https://example.test/api/dev/calendar/roman',
+            Router::canonicalRiteUrl('calendar', false, Rite::ROMAN, [])
+        );
+    }
+
+    public function testBareNationalCalendarKeepsTheRemainingSegments(): void
+    {
+        self::assertSame(
+            'https://example.test/api/dev/calendar/roman/nation/IT/2026',
+            Router::canonicalRiteUrl('calendar', false, Rite::ROMAN, ['nation', 'IT', '2026'])
+        );
+    }
+
+    public function testBareEventsRouteAdvertisesTheExplicitRomanForm(): void
+    {
+        self::assertSame(
+            'https://example.test/api/dev/events/roman',
+            Router::canonicalRiteUrl('events', false, Rite::ROMAN, [])
+        );
+    }
+
+    public function testQueryStringIsPreservedOnTheCanonicalUrl(): void
+    {
+        self::assertSame(
+            'https://example.test/api/dev/calendar/roman/2026?year_type=CIVIL&locale=it',
+            Router::canonicalRiteUrl('calendar', false, Rite::ROMAN, ['2026'], 'year_type=CIVIL&locale=it')
+        );
+    }
+
+    public function testAnExplicitRiteRequestIsAlreadyCanonicalSoNoLinkIsAdvertised(): void
+    {
+        self::assertNull(Router::canonicalRiteUrl('calendar', true, Rite::ROMAN, ['2026']));
+        self::assertNull(Router::canonicalRiteUrl('calendar', true, Rite::AMBROSIAN, ['diocese', 'milano_it']));
+    }
+
+    public function testRoutesWithoutARiteSegmentAdvertiseNoCanonicalForm(): void
+    {
+        // Only the calendar and events routes carry a rite segment (see extractRiteSegment()).
+        self::assertNull(Router::canonicalRiteUrl('metadata', false, Rite::ROMAN, []));
+        self::assertNull(Router::canonicalRiteUrl('missals', false, Rite::ROMAN, ['EDITIO_TYPICA_1970']));
+    }
+
+    public function testTheRootRouteAdvertisesNoCanonicalForm(): void
+    {
+        // `/` resolves to the calendar handler, but canonicalising it to `/calendar/roman`
+        // would rename the endpoint rather than merely make the rite explicit.
+        self::assertNull(Router::canonicalRiteUrl('', false, Rite::ROMAN, []));
+    }
+}

--- a/phpunit_tests/Routes/Readonly/CalendarEtagStabilityTest.php
+++ b/phpunit_tests/Routes/Readonly/CalendarEtagStabilityTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Readonly;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+/**
+ * Live HTTP integration test for the calendar route's ETag.
+ *
+ * A calendar representation embeds its own generation stamp — `metadata.timestamp` and
+ * `metadata.date_time` in JSON/YML, `DTSTAMP` in ICS — which changes on every generation but
+ * says nothing about the calendar itself. Hashing the raw body therefore produced a validator
+ * that changed whenever the response was regenerated: on every request where the server cache
+ * is bypassed (localhost), and on every server-cache regeneration in production, even though
+ * the calendar content was byte-for-byte the same. A conditional request then re-transferred
+ * the whole ~500 KB body for nothing.
+ *
+ * The validator is now computed over the representation with those generation stamps
+ * neutralised, and is therefore weak (`W/`): two responses sharing an ETag are semantically
+ * equivalent but not necessarily byte-identical (RFC 9110 §8.8.1).
+ */
+final class CalendarEtagStabilityTest extends ApiTestCase
+{
+    /**
+     * The generation stamps have one-second granularity, so two back-to-back requests usually
+     * land in the same second and would agree even with the stamp folded into the validator.
+     * Crossing a second boundary is what makes this a regression guard rather than a coin flip.
+     */
+    private const GENERATION_STAMP_TICK_MICROSECONDS = 1_100_000;
+
+    public function testTheCalendarEtagIsStableAcrossIdenticalRequests(): void
+    {
+        $first = self::$http->get('/calendar/2026', []);
+        usleep(self::GENERATION_STAMP_TICK_MICROSECONDS);
+        $second = self::$http->get('/calendar/2026', []);
+
+        self::assertSame(200, $first->getStatusCode());
+        self::assertSame(200, $second->getStatusCode());
+        self::assertNotSame('', $first->getHeaderLine('ETag'));
+        self::assertSame(
+            $first->getHeaderLine('ETag'),
+            $second->getHeaderLine('ETag'),
+            'the generation stamp embedded in the body must not leak into the validator'
+        );
+    }
+
+    public function testTheCalendarEtagIsWeak(): void
+    {
+        // The bodies behind two equal validators differ in their generation stamp, so a strong
+        // validator would be a lie (RFC 9110 §8.8.1).
+        $response = self::$http->get('/calendar/2026', []);
+
+        self::assertMatchesRegularExpression('#^W/"[0-9a-f]+"$#', $response->getHeaderLine('ETag'));
+    }
+
+    public function testAConditionalCalendarRequestRevalidatesWithA304(): void
+    {
+        $first = self::$http->get('/calendar/2026', []);
+        $etag  = $first->getHeaderLine('ETag');
+        self::assertNotSame('', $etag);
+
+        // A client revalidates some time after it cached, not within the same second.
+        usleep(self::GENERATION_STAMP_TICK_MICROSECONDS);
+
+        // Echoed back exactly as received, W/ prefix included, as a conforming client would.
+        $second = self::$http->get('/calendar/2026', ['headers' => ['If-None-Match' => $etag]]);
+
+        self::assertSame(304, $second->getStatusCode());
+        self::assertSame('', (string) $second->getBody());
+    }
+
+    public function testTheIcsRepresentationAlsoHasAStableEtag(): void
+    {
+        // ICS carries its generation stamp as DTSTAMP rather than in a metadata object.
+        $first = self::$http->get('/calendar/2026?return_type=ICS', []);
+        usleep(self::GENERATION_STAMP_TICK_MICROSECONDS);
+        $second = self::$http->get('/calendar/2026?return_type=ICS', []);
+
+        self::assertSame(200, $first->getStatusCode());
+        self::assertSame($first->getHeaderLine('ETag'), $second->getHeaderLine('ETag'));
+    }
+
+    public function testDifferentCalendarsStillGetDifferentEtags(): void
+    {
+        // Guards the neutralisation against being too broad: it must blank the generation stamp,
+        // not the content around it.
+        $y2026 = self::$http->get('/calendar/2026', []);
+        $y2027 = self::$http->get('/calendar/2027', []);
+
+        self::assertNotSame($y2026->getHeaderLine('ETag'), $y2027->getHeaderLine('ETag'));
+    }
+
+    public function testDifferentRepresentationsOfTheSameCalendarGetDifferentEtags(): void
+    {
+        $json = self::$http->get('/calendar/2026', []);
+        $yml  = self::$http->get('/calendar/2026?return_type=YML', []);
+
+        self::assertNotSame($json->getHeaderLine('ETag'), $yml->getHeaderLine('ETag'));
+    }
+}

--- a/phpunit_tests/Routes/Readonly/CalendarEtagStabilityTest.php
+++ b/phpunit_tests/Routes/Readonly/CalendarEtagStabilityTest.php
@@ -9,9 +9,9 @@ use LiturgicalCalendar\Tests\ApiTestCase;
 /**
  * Live HTTP integration test for the calendar route's ETag.
  *
- * A calendar representation embeds its own generation stamp — `metadata.timestamp` and
- * `metadata.date_time` in JSON/YML, `DTSTAMP` in ICS — which changes on every generation but
- * says nothing about the calendar itself. Hashing the raw body therefore produced a validator
+ * A calendar representation embeds its own generation stamp — `timestamp` / `date_time` in JSON
+ * and YML, `<Timestamp>` / `<DateTime>` in XML, `DTSTAMP` in ICS — which changes on every
+ * generation but says nothing about the calendar itself. Hashing the raw body therefore produced a validator
  * that changed whenever the response was regenerated: on every request where the server cache
  * is bypassed (localhost), and on every server-cache regeneration in production, even though
  * the calendar content was byte-for-byte the same. A conditional request then re-transferred
@@ -80,6 +80,49 @@ final class CalendarEtagStabilityTest extends ApiTestCase
 
         self::assertSame(200, $first->getStatusCode());
         self::assertSame($first->getHeaderLine('ETag'), $second->getHeaderLine('ETag'));
+    }
+
+    public function testTheXmlRepresentationAlsoHasAStableEtag(): void
+    {
+        // XML carries the same stamp as JSON but under PascalCase element names,
+        // `<Timestamp>` / `<DateTime>`.
+        $first = self::$http->get('/calendar/2026?return_type=XML', []);
+        usleep(self::GENERATION_STAMP_TICK_MICROSECONDS);
+        $second = self::$http->get('/calendar/2026?return_type=XML', []);
+
+        self::assertSame(200, $first->getStatusCode());
+        self::assertSame($first->getHeaderLine('ETag'), $second->getHeaderLine('ETag'));
+    }
+
+    public function testAnEntityTagWhoseOpaqueValueContainsACommaIsNotSplitIntoSeparateTags(): void
+    {
+        // An entity-tag's opaque value may itself contain a comma (RFC 9110 §8.8.3 permits any
+        // visible character except `"`), so splitting the field on commas can synthesise a
+        // fragment equal to our own validator and answer 304 to a client that holds nothing of
+        // the sort. This sends ONE tag that merely contains the validator, so it must not match.
+        $first     = self::$http->get('/calendar/2026', []);
+        $validator = trim(preg_replace('/^W\//', '', $first->getHeaderLine('ETag')) ?? '', '"');
+        self::assertNotSame('', $validator);
+
+        $response = self::$http->get('/calendar/2026', [
+            'headers' => ['If-None-Match' => '"unrelated,' . $validator . '"']
+        ]);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    public function testAValidatorListedAmongSeveralEntityTagsStillMatches(): void
+    {
+        // The converse of the test above: a genuine comma-separated list must still match.
+        $first = self::$http->get('/calendar/2026', []);
+        $etag  = $first->getHeaderLine('ETag');
+        self::assertNotSame('', $etag);
+
+        $response = self::$http->get('/calendar/2026', [
+            'headers' => ['If-None-Match' => '"somethingelse", ' . $etag]
+        ]);
+
+        self::assertSame(304, $response->getStatusCode());
     }
 
     public function testDifferentCalendarsStillGetDifferentEtags(): void

--- a/phpunit_tests/Routes/Readonly/CanonicalRiteLinkHeaderTest.php
+++ b/phpunit_tests/Routes/Readonly/CanonicalRiteLinkHeaderTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Readonly;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+/**
+ * Live HTTP integration test for the RFC 6596 `Link: rel="canonical"` header on the calendar
+ * and events routes.
+ *
+ * The explicit rite form (`/calendar/roman/2026`) is the canonical form; the bare form
+ * (`/calendar/2026`) is retained for backwards compatibility and points at the canonical form
+ * with a `Link` header rather than a redirect. A redirect is not usable here: these routes
+ * accept POST, a 301/302 would downgrade POST to GET and drop the body, and per the Fetch
+ * standard a browser treats any redirect response to a preflighted cross-origin request as a
+ * network error — which would break the browser clients that build the bare paths.
+ *
+ * `Link` is not a CORS-safelisted response header, so it is only readable by a cross-origin
+ * browser client when the API also names it in `Access-Control-Expose-Headers`.
+ */
+final class CanonicalRiteLinkHeaderTest extends ApiTestCase
+{
+    /**
+     * Regex fragment matching the API origin as the running dev server reports it.
+     */
+    private static function originPattern(): string
+    {
+        return 'https?://' . self::hostRegex() . '(?::\d+)?';
+    }
+
+    public function testBareCalendarForYearAdvertisesTheExplicitRomanFormAsCanonical(): void
+    {
+        $response = self::$http->get('/calendar/2026', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '#^<' . self::originPattern() . '/calendar/roman/2026>; rel="canonical"$#',
+            $response->getHeaderLine('Link')
+        );
+    }
+
+    public function testBareNationalCalendarKeepsItsRemainingSegmentsInTheCanonicalUrl(): void
+    {
+        $response = self::$http->get('/calendar/nation/IT/2026', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '#^<' . self::originPattern() . '/calendar/roman/nation/IT/2026>; rel="canonical"$#',
+            $response->getHeaderLine('Link')
+        );
+    }
+
+    public function testBareEventsRouteAdvertisesTheExplicitRomanForm(): void
+    {
+        $response = self::$http->get('/events', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '#^<' . self::originPattern() . '/events/roman>; rel="canonical"$#',
+            $response->getHeaderLine('Link')
+        );
+    }
+
+    public function testTheCanonicalUrlPreservesTheQueryString(): void
+    {
+        $response = self::$http->get('/calendar/2026?year_type=CIVIL', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '#^<' . self::originPattern() . '/calendar/roman/2026\?year_type=CIVIL>; rel="canonical"$#',
+            $response->getHeaderLine('Link')
+        );
+    }
+
+    public function testTheCanonicalLinkIsReadableByCrossOriginBrowserClients(): void
+    {
+        $response = self::$http->get('/calendar/2026', ['headers' => ['Origin' => 'https://example.test']]);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotSame('', $response->getHeaderLine('Link'));
+        self::assertStringContainsStringIgnoringCase(
+            'Link',
+            $response->getHeaderLine('Access-Control-Expose-Headers'),
+            'Link is not CORS-safelisted, so it must be exposed explicitly or browser clients cannot read it'
+        );
+    }
+
+    public function testAnExplicitRomanRequestIsAlreadyCanonicalSoCarriesNoLink(): void
+    {
+        $response = self::$http->get('/calendar/roman/2026', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('', $response->getHeaderLine('Link'));
+    }
+
+    public function testAnExplicitAmbrosianRequestIsAlreadyCanonicalSoCarriesNoLink(): void
+    {
+        $response = self::$http->get('/calendar/ambrosian/2026', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('', $response->getHeaderLine('Link'));
+    }
+
+    public function testAPreflightResponseCarriesNoCanonicalLink(): void
+    {
+        // A CORS preflight is a control response, not a representation of the resource, so a
+        // rel="canonical" naming the resource has no meaning on it.
+        $response = self::$http->options('/calendar/2026', [
+            'headers' => [
+                'Origin'                        => 'https://example.test',
+                'Access-Control-Request-Method' => 'POST'
+            ]
+        ]);
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertSame('', $response->getHeaderLine('Link'));
+    }
+
+    public function testARouteWithoutARiteSegmentCarriesNoCanonicalLink(): void
+    {
+        $response = self::$http->get('/calendars', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('', $response->getHeaderLine('Link'));
+    }
+
+    public function testAnErrorResponseCarriesNoCanonicalLink(): void
+    {
+        // `XX` is a well-formed but unsupported national calendar id (valid: VA, CA, HR, IT, NL,
+        // US), so this is a deterministic 400. Advertising a canonical URL for a request that did
+        // not resolve would point clients at an equally invalid URL.
+        $response = self::$http->get('/calendar/nation/XX/2026', ['http_errors' => false]);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('', $response->getHeaderLine('Link'));
+    }
+}

--- a/phpunit_tests/Routes/Readonly/CanonicalRiteLinkHeaderTest.php
+++ b/phpunit_tests/Routes/Readonly/CanonicalRiteLinkHeaderTest.php
@@ -103,6 +103,29 @@ final class CanonicalRiteLinkHeaderTest extends ApiTestCase
         self::assertSame('', $response->getHeaderLine('Link'));
     }
 
+    public function testAResolvedConditionalRequestStillCarriesTheCanonicalLink(): void
+    {
+        // A 304 stands in for the 200 it would otherwise have been, describing the same resource,
+        // so a client driving its own conditional requests should not lose the canonical URL
+        // merely because its cache was still fresh.
+        //
+        // `/events` rather than `/calendar/{year}` because only the former has a stable validator:
+        // a calendar response body embeds its own generation timestamp, so its ETag changes on
+        // every request and a conditional request against it only yields a 304 when both requests
+        // land in the same wall-clock second.
+        $first = self::$http->get('/events', []);
+        $etag  = $first->getHeaderLine('ETag');
+        self::assertNotSame('', $etag, 'precondition: the bare events route is ETag-bearing');
+
+        $second = self::$http->get('/events', ['headers' => ['If-None-Match' => $etag]]);
+
+        self::assertSame(304, $second->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '#^<' . self::originPattern() . '/events/roman>; rel="canonical"$#',
+            $second->getHeaderLine('Link')
+        );
+    }
+
     public function testAPreflightResponseCarriesNoCanonicalLink(): void
     {
         // A CORS preflight is a control response, not a representation of the resource, so a

--- a/phpunit_tests/Routes/Readonly/CorsExposedHeadersTest.php
+++ b/phpunit_tests/Routes/Readonly/CorsExposedHeadersTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Routes\Readonly;
+
+use LiturgicalCalendar\Tests\ApiTestCase;
+
+/**
+ * Live HTTP integration test for `Access-Control-Expose-Headers`.
+ *
+ * A cross-origin browser client can only read the CORS-safelisted response headers
+ * (Cache-Control, Content-Language, Content-Type, Expires, Last-Modified, Pragma). Every header
+ * this API sets itself — `X-Request-Id`, `ETag`, and the canonical `Link` — is invisible to
+ * JavaScript unless it is named in `Access-Control-Expose-Headers`. Without it, `X-Request-Id`
+ * cannot be quoted in a bug report from the browser and `ETag` cannot be echoed back as
+ * `If-None-Match` by a client doing its own conditional requests.
+ */
+final class CorsExposedHeadersTest extends ApiTestCase
+{
+    /**
+     * @return list<string> the exposed header names, lowercased
+     */
+    private static function exposed(string $headerLine): array
+    {
+        if (trim($headerLine) === '') {
+            return [];
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (string $name): string => strtolower(trim($name)),
+            explode(',', $headerLine)
+        )));
+    }
+
+    public function testEveryResponseExposesTheRequestIdHeader(): void
+    {
+        $response = self::$http->get('/calendars', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotSame('', $response->getHeaderLine('X-Request-Id'));
+        self::assertContains('x-request-id', self::exposed($response->getHeaderLine('Access-Control-Expose-Headers')));
+    }
+
+    public function testAResponseCarryingAnETagExposesIt(): void
+    {
+        $response = self::$http->get('/calendars', []);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotSame('', $response->getHeaderLine('ETag'), 'precondition: /calendars is an ETag-bearing route');
+        self::assertContains('etag', self::exposed($response->getHeaderLine('Access-Control-Expose-Headers')));
+    }
+
+    public function testTheBareCalendarRouteExposesRequestIdETagAndCanonicalLinkTogether(): void
+    {
+        $response = self::$http->get('/calendar/2026', []);
+        $exposed  = self::exposed($response->getHeaderLine('Access-Control-Expose-Headers'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertContains('x-request-id', $exposed);
+        self::assertContains('etag', $exposed);
+        self::assertContains('link', $exposed);
+    }
+
+    public function testTheCanonicalFormExposesRequestIdAndETagButNamesNoLink(): void
+    {
+        // The explicit-rite form carries no canonical Link, so naming one here would advertise a
+        // header that is never sent.
+        $response = self::$http->get('/calendar/roman/2026', []);
+        $exposed  = self::exposed($response->getHeaderLine('Access-Control-Expose-Headers'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('', $response->getHeaderLine('Link'));
+        self::assertContains('x-request-id', $exposed);
+        self::assertContains('etag', $exposed);
+        self::assertNotContains('link', $exposed);
+    }
+
+    public function testAnErrorResponseStillExposesItsRequestId(): void
+    {
+        // The request id is the one thing a client needs most on a failure, and error responses
+        // carry neither an ETag nor a canonical Link. `XX` is a well-formed but unsupported
+        // national calendar id (valid: VA, CA, HR, IT, NL, US), so it is a deterministic 400.
+        $response = self::$http->get('/calendar/nation/XX/2026', ['http_errors' => false]);
+        $exposed  = self::exposed($response->getHeaderLine('Access-Control-Expose-Headers'));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertContains('x-request-id', $exposed);
+        self::assertNotContains('etag', $exposed);
+        self::assertNotContains('link', $exposed);
+    }
+}

--- a/src/Enum/Rite.php
+++ b/src/Enum/Rite.php
@@ -8,6 +8,10 @@ namespace LiturgicalCalendar\Api\Enum;
  * The liturgical rite a calendar request is computed under.
  * ROMAN is the default and applies to every existing route; AMBROSIAN
  * is selected by an optional leading `ambrosian` path segment.
+ *
+ * Stating the rite explicitly (`/calendar/roman/...`) is the canonical URL form. The bare
+ * form (`/calendar/...`) stays valid for backwards compatibility and advertises the canonical
+ * URL through a `Link: rel="canonical"` header — see {@see \LiturgicalCalendar\Api\Router::canonicalRiteUrl()}.
  */
 enum Rite: string
 {

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4816,11 +4816,12 @@ final class CalendarHandler extends AbstractHandler
      * Blank out the generation stamps a representation embeds about itself, so that the ETag
      * identifies the calendar rather than the moment it was serialized.
      *
-     * `metadata.timestamp` / `metadata.date_time` (JSON, YML) and `DTSTAMP` (ICS) change on every
-     * generation while saying nothing about the calendar. Hashing the raw body therefore handed an
-     * unchanged calendar a fresh validator on every regeneration — every request where the server
-     * cache is bypassed, and every cache rebuild otherwise — so a conditional request re-sent the
-     * whole body for nothing. XML embeds no such stamp and is returned unchanged.
+     * Every representation carries the same stamp under a different spelling: `timestamp` /
+     * `date_time` in JSON and YML, `<Timestamp>` / `<DateTime>` in XML, and `DTSTAMP` in ICS. All
+     * of them change on every generation while saying nothing about the calendar. Hashing the raw
+     * body therefore handed an unchanged calendar a fresh validator on every regeneration — every
+     * request where the server cache is bypassed, and every cache rebuild otherwise — so a
+     * conditional request re-sent the whole body for nothing.
      *
      * Two bodies reduced to the same source may still differ in those stamps, which is exactly why
      * the resulting validator is weak at the call sites (RFC 9110 §8.8.1).
@@ -4828,7 +4829,10 @@ final class CalendarHandler extends AbstractHandler
     private function validatorSource(string $responseBody): string
     {
         $substitutions = match ($this->CalendarParams->ReturnType) {
-            ReturnTypeParam::XML => [],
+            ReturnTypeParam::XML => [
+                '#<Timestamp>[^<]*</Timestamp>#' => '<Timestamp></Timestamp>',
+                '#<DateTime>[^<]*</DateTime>#'   => '<DateTime></DateTime>'
+            ],
             ReturnTypeParam::ICS => ['/DTSTAMP:\d{8}T\d{6}Z/' => 'DTSTAMP:'],
             ReturnTypeParam::YAML => [
                 '/^(\s*)timestamp:\s*\d+$/m'     => '$1timestamp:',
@@ -4840,10 +4844,6 @@ final class CalendarHandler extends AbstractHandler
             ]
         };
 
-        if ([] === $substitutions) {
-            return $responseBody;
-        }
-
         return preg_replace(array_keys($substitutions), array_values($substitutions), $responseBody) ?? $responseBody;
     }
 
@@ -4853,6 +4853,11 @@ final class CalendarHandler extends AbstractHandler
      * `If-None-Match` uses the weak comparison function (RFC 9110 §8.8.3.2), so a `W/` prefix on
      * either side is ignored, and the field may carry `*` or a comma-separated list rather than a
      * single entity-tag.
+     *
+     * The list is tokenised on the quotes rather than split on commas: an entity-tag's opaque
+     * value may itself contain a comma (`etagc` admits any visible character except `"`, RFC 9110
+     * §8.8.3), so splitting on commas can carve a fragment equal to `$validator` out of one
+     * unrelated tag and answer `304` to a client that does not hold the representation at all.
      */
     private static function ifNoneMatchSatisfiedBy(string $headerLine, string $validator): bool
     {
@@ -4860,19 +4865,15 @@ final class CalendarHandler extends AbstractHandler
             return false;
         }
 
-        foreach (explode(',', $headerLine) as $candidate) {
-            $candidate = trim($candidate);
-            if ('*' === $candidate) {
-                return true;
-            }
-
-            $candidate = preg_replace('/^W\//i', '', $candidate) ?? $candidate;
-            if (trim($candidate, " \t\"") === $validator) {
-                return true;
-            }
+        if ('*' === trim($headerLine)) {
+            return true;
         }
 
-        return false;
+        if (preg_match_all('/(?:W\/)?"([^"]*)"/i', $headerLine, $matches) < 1) {
+            return false;
+        }
+
+        return in_array($validator, $matches[1], true);
     }
 
     /**

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4813,6 +4813,69 @@ final class CalendarHandler extends AbstractHandler
     }
 
     /**
+     * Blank out the generation stamps a representation embeds about itself, so that the ETag
+     * identifies the calendar rather than the moment it was serialized.
+     *
+     * `metadata.timestamp` / `metadata.date_time` (JSON, YML) and `DTSTAMP` (ICS) change on every
+     * generation while saying nothing about the calendar. Hashing the raw body therefore handed an
+     * unchanged calendar a fresh validator on every regeneration — every request where the server
+     * cache is bypassed, and every cache rebuild otherwise — so a conditional request re-sent the
+     * whole body for nothing. XML embeds no such stamp and is returned unchanged.
+     *
+     * Two bodies reduced to the same source may still differ in those stamps, which is exactly why
+     * the resulting validator is weak at the call sites (RFC 9110 §8.8.1).
+     */
+    private function validatorSource(string $responseBody): string
+    {
+        $substitutions = match ($this->CalendarParams->ReturnType) {
+            ReturnTypeParam::XML => [],
+            ReturnTypeParam::ICS => ['/DTSTAMP:\d{8}T\d{6}Z/' => 'DTSTAMP:'],
+            ReturnTypeParam::YAML => [
+                '/^(\s*)timestamp:\s*\d+$/m'     => '$1timestamp:',
+                "/^(\s*)date_time:\s*'[^']*'$/m" => '$1date_time:'
+            ],
+            default => [
+                '/"timestamp":\s*\d+/'     => '"timestamp":',
+                '/"date_time":\s*"[^"]*"/' => '"date_time":'
+            ]
+        };
+
+        if ([] === $substitutions) {
+            return $responseBody;
+        }
+
+        return preg_replace(array_keys($substitutions), array_values($substitutions), $responseBody) ?? $responseBody;
+    }
+
+    /**
+     * Whether an `If-None-Match` header selects the given validator.
+     *
+     * `If-None-Match` uses the weak comparison function (RFC 9110 §8.8.3.2), so a `W/` prefix on
+     * either side is ignored, and the field may carry `*` or a comma-separated list rather than a
+     * single entity-tag.
+     */
+    private static function ifNoneMatchSatisfiedBy(string $headerLine, string $validator): bool
+    {
+        if ('' === trim($headerLine)) {
+            return false;
+        }
+
+        foreach (explode(',', $headerLine) as $candidate) {
+            $candidate = trim($candidate);
+            if ('*' === $candidate) {
+                return true;
+            }
+
+            $candidate = preg_replace('/^W\//i', '', $candidate) ?? $candidate;
+            if (trim($candidate, " \t\"") === $validator) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Splices request_headers into a YAML body. Only the tiny request_headers map is
      * (re)dumped — cheap and byte-identical to Symfony's own scalar quoting — then indented
      * two spaces to sit under `metadata` and spliced over the existing entry. The pattern
@@ -4980,8 +5043,8 @@ final class CalendarHandler extends AbstractHandler
             }
         }
 
-        $responseHash  = md5($responseBody);
-        $etag          = '"' . $responseHash . '"';
+        $responseHash  = md5($this->validatorSource($responseBody));
+        $etag          = 'W/"' . $responseHash . '"';
         $this->endTime = hrtime(true);
         $executionTime = $this->endTime - $this->startTime;
         $response      = $response->withHeader('X-LitCal-Starttime', $this->startTime . '')
@@ -4990,10 +5053,7 @@ final class CalendarHandler extends AbstractHandler
                                   ->withHeader('Etag', $etag)
                                   ->withHeader('Vary', 'Accept, Accept-Language');
 
-        if (
-            $request->getHeaderLine('If-None-Match') !== ''
-            && trim($request->getHeaderLine('If-None-Match'), " \t\"") === $responseHash
-        ) {
+        if (self::ifNoneMatchSatisfiedBy($request->getHeaderLine('If-None-Match'), $responseHash)) {
             return $response->withStatus(StatusCode::NOT_MODIFIED->value, StatusCode::NOT_MODIFIED->reason())
                                  ->withHeader('Content-Length', '0')
                                  ->withHeader('X-LitCal-Generated', 'ClientCache');
@@ -5425,8 +5485,8 @@ final class CalendarHandler extends AbstractHandler
             //   request headers), so re-inject THIS request's headers into
             //   metadata.request_headers before serving; see injectRequestHeaders() and #684.
             $responseBody  = $this->injectRequestHeaders(Utilities::rawContentsFromFile($this->CacheFile));
-            $responseHash  = md5($responseBody);
-            $etag          = '"' . $responseHash . '"';
+            $responseHash  = md5($this->validatorSource($responseBody));
+            $etag          = 'W/"' . $responseHash . '"';
             $this->endTime = hrtime(true);
             $executionTime = $this->endTime - $this->startTime;
             $response      = $response
@@ -5436,10 +5496,7 @@ final class CalendarHandler extends AbstractHandler
                 ->withHeader('Etag', $etag)
                 ->withHeader('Vary', 'Accept, Accept-Language');
 
-            if (
-                $request->getHeaderLine('If-None-Match') !== ''
-                && trim($request->getHeaderLine('If-None-Match'), " \t\"") === $responseHash
-            ) {
+            if (self::ifNoneMatchSatisfiedBy($request->getHeaderLine('If-None-Match'), $responseHash)) {
                 return $response
                     ->withStatus(StatusCode::NOT_MODIFIED->value, StatusCode::NOT_MODIFIED->reason())
                     ->withHeader('Content-Length', '0')

--- a/src/Router.php
+++ b/src/Router.php
@@ -754,7 +754,12 @@ class Router
                 $canonicalPathParts,
                 $this->request->getUri()->getQuery()
             );
-        if (null !== $canonicalUrl && $this->response->getStatusCode() >= 200 && $this->response->getStatusCode() < 300) {
+        // 304 is included alongside 2xx: a resolved conditional request stands in for the 200 it
+        // would otherwise have been and describes the same resource, so a client driving its own
+        // conditional requests should not lose the canonical URL merely because its cache was
+        // still fresh.
+        $status = $this->response->getStatusCode();
+        if (null !== $canonicalUrl && ( ( $status >= 200 && $status < 300 ) || $status === StatusCode::NOT_MODIFIED->value )) {
             $this->response = $this->response->withHeader('Link', '<' . $canonicalUrl . '>; rel="canonical"');
         }
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -117,6 +117,10 @@ class Router
      * Absence of a rite segment defaults to Roman. No nation or diocese identifier
      * collides with a rite value, so this is unambiguous.
      *
+     * Of the two equivalent forms, the explicit one is canonical: a request that omits the
+     * rite segment is answered with a `Link: rel="canonical"` header naming the explicit URL
+     * (see {@see self::canonicalRiteUrl()}).
+     *
      * @param string       $route            the first path segment (the endpoint), already shifted off
      * @param list<string> $requestPathParts the remaining path segments; the rite segment is removed in place when present
      */
@@ -131,6 +135,40 @@ class Router
         }
 
         return Rite::default();
+    }
+
+    /**
+     * Build the absolute canonical URL for a request that omitted the optional rite segment.
+     *
+     * The explicit rite form (`/calendar/roman/2026`, `/calendar/ambrosian/2026`) is canonical;
+     * the bare form (`/calendar/2026`) is retained for backwards compatibility and advertises the
+     * canonical form through an RFC 6596 `Link: rel="canonical"` header rather than a redirect.
+     *
+     * A redirect is deliberately not used: these routes accept POST, a 301/302 would downgrade
+     * POST to GET and silently drop the request body, and per the Fetch standard a browser treats
+     * any redirect response to a preflighted cross-origin request as a network error — which would
+     * break the browser clients that build the bare paths (liturgy-components-js `PathBuilder`).
+     *
+     * Returns null when no canonical form applies: the request already carried an explicit rite
+     * segment, or the route carries no rite segment at all.
+     *
+     * @param string       $route               the first path segment (the endpoint), already shifted off
+     * @param bool         $riteSegmentExplicit whether the request already carried a rite segment
+     * @param Rite         $rite                the rite resolved for this request
+     * @param list<string> $pathParts           the path segments following the route, rite segment already stripped
+     * @param string       $query               the raw request query string, preserved on the canonical URL
+     */
+    public static function canonicalRiteUrl(string $route, bool $riteSegmentExplicit, Rite $rite, array $pathParts, string $query = ''): ?string
+    {
+        // The root route resolves to the calendar handler, but canonicalising `/` to
+        // `/calendar/roman` would rename the endpoint rather than merely make the rite explicit.
+        if ($riteSegmentExplicit || false === in_array($route, ['calendar', 'events'], true)) {
+            return null;
+        }
+
+        $url = self::$apiPath . '/' . implode('/', array_merge([$route, $rite->value], $pathParts));
+
+        return '' === $query ? $url : $url . '?' . $query;
     }
 
     /**
@@ -153,7 +191,14 @@ class Router
         // An optional leading rite segment on the calendar route selects the rite;
         // it is stripped so the existing 0/1/2/3-part shape parsing below runs
         // unchanged on the remainder (see extractRiteSegment()).
-        $rite = self::extractRiteSegment($route, $requestPathParts);
+        $partCountBeforeRite = count($requestPathParts);
+        $rite                = self::extractRiteSegment($route, $requestPathParts);
+        $riteSegmentExplicit = count($requestPathParts) < $partCountBeforeRite;
+
+        // Snapshot the post-rite remainder for the canonical URL below: the handlers configured
+        // in the switch may consume $requestPathParts, and the canonical form has to mirror the
+        // request as it arrived.
+        $canonicalPathParts = $requestPathParts;
 
         // Parse allowed origins from environment (comma-separated list, or '*' for all)
         // This is used for both handler-level CORS and error response CORS
@@ -694,6 +739,38 @@ class Router
 
         $this->response = $pipeline->handle($this->request)
             ->withHeader('X-Request-Id', $this->requestId);
+
+        // A request that omitted the optional rite segment advertises the canonical explicit-rite
+        // form (RFC 6596). Only on success: pointing at a canonical URL for a request that did not
+        // resolve would just name an equally invalid URL. Never on a CORS preflight, which is a
+        // control response rather than a representation of the resource.
+        $isPreflight  = $this->request->getMethod() === RequestMethod::OPTIONS->value;
+        $canonicalUrl = $isPreflight
+            ? null
+            : self::canonicalRiteUrl(
+                $route,
+                $riteSegmentExplicit,
+                $rite,
+                $canonicalPathParts,
+                $this->request->getUri()->getQuery()
+            );
+        if (null !== $canonicalUrl && $this->response->getStatusCode() >= 200 && $this->response->getStatusCode() < 300) {
+            $this->response = $this->response->withHeader('Link', '<' . $canonicalUrl . '>; rel="canonical"');
+        }
+
+        // A cross-origin browser client can only read the CORS-safelisted response headers, so
+        // every header this API sets itself is invisible to JavaScript unless named here (Fetch
+        // standard). Without this, a browser client cannot quote `X-Request-Id` in a bug report,
+        // nor echo an `ETag` back as `If-None-Match` when driving its own conditional requests.
+        // `ETag` and `Link` are only advertised on the responses that actually carry them.
+        $exposedHeaders = ['X-Request-Id'];
+        foreach (['ETag', 'Link'] as $conditionalHeader) {
+            if ($this->response->hasHeader($conditionalHeader)) {
+                $exposedHeaders[] = $conditionalHeader;
+            }
+        }
+        $this->response = $this->response->withHeader('Access-Control-Expose-Headers', implode(', ', $exposedHeaders));
+
         $this->emitResponse();
     }
 


### PR DESCRIPTION
## Why

`/calendar/roman/2026` has always returned 200 — `Router::extractRiteSegment()` strips any leading path segment matching a `Rite` case, and `roman` is one of them. The same holds for `/calendar/roman/nation/{id}`, `/calendar/roman/diocese/{id}` and `/events/roman`. Only the `ambrosian` variants were ever documented, so there were seven working but undocumented URLs, and two equivalent forms per resource with nothing indicating which to prefer.

This declares the **explicit rite segment the canonical form**, with the bare paths kept for backwards compatibility.

## Why a `Link` header and not a redirect

Inverting the canonical form suggests redirecting `/calendar/2026` → `/calendar/roman/2026`. That is not usable on these routes:

1. **`POST` is documented on every calendar path.** A `301`/`302` downgrades `POST` to `GET` in most clients and silently drops the request body, so a body-parameterised calendar request would return a valid-looking 200 for the wrong request. Only `308` preserves method and body.
2. **A redirect breaks preflighted CORS outright.** `POST` with `Content-Type: application/json` triggers a preflight, and per the [Fetch standard](https://fetch.spec.whatwg.org/#http-redirect-fetch) a browser treats *any* redirect response to a preflighted request as a network error. No redirect status avoids this — including `308`. It would break `liturgy-components-js`, whose `PathBuilder` offers the bare paths as first-class options.

[RFC 6596](https://www.rfc-editor.org/rfc/rfc6596) `rel="canonical"` is the mechanism designed for exactly this situation — two working URLs, one preferred — and costs existing clients nothing.

## What changed

**`src/Router.php`** — new `canonicalRiteUrl()`, applied at the existing post-pipeline seam where `X-Request-Id` is already appended, so no handler changed:

```
GET /calendar/2026
→ 200 OK
   Link: <https://.../calendar/roman/2026>; rel="canonical"
   Access-Control-Expose-Headers: X-Request-Id, ETag, Link
   { "litcal": [ …548 events… ] }        ← full response, unchanged
```

Emitted only on 2xx (advertising a canonical URL for a request that did not resolve would just name an equally invalid URL), never on a CORS preflight (a control response, not a representation), absent when the request already used an explicit rite, query string preserved. The root route `/` is excluded deliberately: canonicalising it to `/calendar/roman` would rename the endpoint rather than merely make the rite explicit.

**Cross-origin header exposure.** Only CORS-safelisted headers are readable by cross-origin JavaScript, so `X-Request-Id` could not be quoted in a bug report from the browser and `ETag` could not be echoed back as `If-None-Match`. `X-Request-Id` is now always named; `ETag` and `Link` only on responses that carry them, so the header never advertises something that isn't sent.

**`jsondata/schemas/openapi.json`** — the seven canonical paths added, their bare counterparts marked `deprecated: true` with a note naming the canonical path and explaining why it is not redirected.

**`README.md`, `src/Enum/Rite.php`, `extractRiteSegment` docblock** — document the contract.

## Compatibility

No existing client changes. The bare paths return an identical body with an identical status; unknown response headers are ignored by default. The only visible change for spec consumers is the `deprecated: true` flag, which is a documentation signal — Swagger UI strikes the path through and some generators emit a warning. Runtime behaviour of the bare paths is untouched, and they remain supported indefinitely.

`liturgy-components-js` already emits the canonical form: `CurrentEndpoint.js:141` includes the rite segment whenever `explicitRite` is set, and both wiring paths (`linkToRiteSelect()`, and the deprecated second argument of `linkToCalendarSelect()`) set it. No client change needed there.

## Verification

- **1945 tests, 1 failure** — `WebSocket/ExecuteValidationTest::testResourceDataCheckMetadataDecodesAsJson`, environmental and not a regression: it asks the Dockerised WS server to fetch `http://localhost:{API_PORT}/metadata`, and a worktree API server on a spare port is unreachable from inside that container. It passes when `API_PORT` points at a container-reachable API.
- PHPStan level 10 clean, phpcs clean, markdownlint clean.
- Redocly: valid; the 4 warnings are pre-existing `operation-2xx-response` on the ambrosian-diocese 501s — the 501-only operation set is unchanged.
- The OpenAPI diff reads large, but that is diff alignment. Verified structurally: non-`paths` sections identical, exactly 7 paths added and none removed, all 54 unrelated paths byte-equal, bare paths differ only by `deprecated` + appended description, canonical paths are faithful copies of their sources apart from `operationId`/`description`, and all 118 operationIds unique.
- 32 new/related tests covering the header on bare, canonical, national, events, query-string, error, preflight, and non-rite routes.

## Note

The top-level `info.description` still says the ambrosian prefix returns `501 Not Implemented`, which is stale. Left untouched — `fix/ambrosian-stale-openapi-501` owns it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit canonical Roman-rite calendar and events URLs.
  * Existing bare URLs remain supported and now provide canonical `Link` headers.
  * Canonical links preserve calendar path details and query parameters.
  * Browser clients can access `X-Request-Id`, `ETag`, and canonical `Link` headers through CORS.

* **Bug Fixes**
  * Calendar ETags now remain stable across regenerations and support reliable conditional `304` responses.

* **Documentation**
  * Updated API documentation with canonical routes, deprecated aliases, diocesan parameters, and events endpoint changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->