### PR TITLE
Fix the stranded POT auto-merge against required status checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,11 +120,18 @@ jobs:
                    -o i18n/litcal.pot $(git ls-files '*.php')
           echo "POT_LINES_CHANGED=$(git diff -U0 | grep '^[+|-][^+|-]' | grep -Ev '^[+-]"POT-Creation-Date' | wc -l)" >> $GITHUB_OUTPUT
 
+      # Opened with WORKFLOW_AUTOMERGE_PAT rather than the default GITHUB_TOKEN.
+      # A PR opened by GITHUB_TOKEN does not trigger further workflows, so the
+      # `static_analysis` and `phpunit_tests` contexts that branch protection on
+      # development requires would never report on it, and the merge was refused
+      # forever with "the base branch policy prohibits the merge" (see #759).
+      # Opening it as a real identity makes both required checks run.
       - name: Create Pull Request
         id: cpr
         if: ${{ steps.update_pot.outputs.POT_LINES_CHANGED > 0 }}
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
+          token: ${{ secrets.WORKFLOW_AUTOMERGE_PAT }}
           commit-message: "chore: regenerate i18n/litcal.pot from source files"
           branch: automated/update-pot
           title: "chore: regenerate i18n/litcal.pot from source files"
@@ -136,34 +143,34 @@ jobs:
             behavioural code, so there is nothing for CI to validate.
           add-paths: i18n/litcal.pot
 
-      # The .pot PR is created with the default GITHUB_TOKEN, which by design
-      # does not trigger further workflows — so a separate pull_request-based
-      # auto-merge job (like the Dependabot one) would never fire. Instead we
-      # merge here, in the same push-triggered run that opened the PR.
+      # Hand the merge to GitHub rather than performing it inline. Branch
+      # protection on development requires the `static_analysis` and
+      # `phpunit_tests` contexts, and phpunit_tests alone runs for ~5 minutes, so
+      # the previous approach — `gh pr merge` with six 5-second retries in the
+      # same run that opened the PR — could never win that race. It failed every
+      # time with "the base branch policy prohibits the merge", leaving the .pot
+      # PR stranded and this job red (#759). `--auto` finishes immediately and
+      # lets GitHub merge once both contexts are green.
       #
-      # Branch protection on the base requires neither reviews nor status checks,
-      # so the PR is immediately mergeable ("clean"). We must NOT use
-      # `gh pr merge --auto` here: enabling auto-merge on an already-clean PR
-      # fails with "Pull request is in clean status (enablePullRequestAutoMerge)",
-      # which left every .pot PR stranded (see issue #684 follow-up). Merge
-      # directly instead, retrying to cover the brief window after creation while
-      # GitHub is still computing mergeability. --delete-branch removes the
-      # automated/update-pot head branch (explicit, not relying on the repo's
-      # delete_branch_on_merge setting). The github.ref guard pins the merge to
-      # development, so widening the push filter above can never cause an
-      # accidental merge into another branch (e.g. stable).
+      # The earlier comment here warned that --auto is rejected on an
+      # already-clean PR ("Pull request is in clean status"). That is still true,
+      # and is exactly what happens if branch protection ever stops requiring
+      # checks — so fall back to merging directly in that case, which keeps this
+      # working under either policy.
+      #
+      # --delete-branch removes the automated/update-pot head branch (explicit,
+      # not relying on the repo's delete_branch_on_merge setting). The github.ref
+      # guard pins the merge to development, so widening the push filter above can
+      # never cause an accidental merge into another branch (e.g. stable).
       - name: Auto-merge the POT update PR
         if: ${{ steps.cpr.outputs.pull-request-number && github.ref == 'refs/heads/development' }}
         run: |
-          for attempt in 1 2 3 4 5 6; do
-            if gh pr merge "$PR_NUMBER" --merge --delete-branch; then
-              exit 0
-            fi
-            echo "Merge attempt $attempt failed (PR not yet mergeable?); retrying in 5s…"
-            sleep 5
-          done
-          echo "::error::Failed to merge POT update PR #$PR_NUMBER after 6 attempts"
-          exit 1
+          if gh pr merge "$PR_NUMBER" --auto --merge --delete-branch; then
+            echo "Auto-merge enabled; GitHub will merge PR #$PR_NUMBER once the required checks pass."
+            exit 0
+          fi
+          echo "Could not enable auto-merge — the PR is likely already mergeable. Merging directly."
+          gh pr merge "$PR_NUMBER" --merge --delete-branch
         env:
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_AUTOMERGE_PAT }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -155,8 +155,9 @@ jobs:
       # The earlier comment here warned that --auto is rejected on an
       # already-clean PR ("Pull request is in clean status"). That is still true,
       # and is exactly what happens if branch protection ever stops requiring
-      # checks — so fall back to merging directly in that case, which keeps this
-      # working under either policy.
+      # checks — so fall back to merging directly in that case, and only in that
+      # case, which keeps this working under either policy without swallowing
+      # genuine failures.
       #
       # --delete-branch removes the automated/update-pot head branch (explicit,
       # not relying on the repo's delete_branch_on_merge setting). The github.ref
@@ -169,7 +170,20 @@ jobs:
             echo "Auto-merge enabled; GitHub will merge PR #$PR_NUMBER once the required checks pass."
             exit 0
           fi
-          echo "Could not enable auto-merge — the PR is likely already mergeable. Merging directly."
+
+          # --auto failing is only benign in one case: the PR needs no checks and
+          # is therefore already CLEAN, which GitHub rejects with "Pull request is
+          # in clean status". Confirm that before merging directly, so a failure
+          # from a missing or under-scoped token, an API error, or auto-merge being
+          # disabled on the repo surfaces as itself instead of being masked by a
+          # second attempt that fails for an unrelated-looking reason.
+          MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus --jq .mergeStateStatus)
+          if [ "$MERGE_STATE" != "CLEAN" ]; then
+            echo "::error::Could not enable auto-merge on PR #$PR_NUMBER, and its merge state is ${MERGE_STATE:-unavailable} rather than CLEAN. Not attempting a direct merge; see the gh error above."
+            exit 1
+          fi
+
+          echo "PR #$PR_NUMBER requires no checks and is already CLEAN; merging directly."
           gh pr merge "$PR_NUMBER" --merge --delete-branch
         env:
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}


### PR DESCRIPTION
## Symptom

`gettext_update` has failed on **every** push to `development` since 2026-08-06 (last success was #757 on 08-05), and the POT PR #759 has sat open since. The step log repeats six times:

```text
X Pull request …#759 is not mergeable: the base branch policy prohibits the merge.
```

## Diagnosis

Branch protection on `development` requires two status contexts:

```text
required_status_checks.contexts = ['static_analysis', 'phpunit_tests']
required_approving_review_count = 0
```

PR #759 has **zero check-runs** on its head SHA — only CodeFactor, an external app, reports. That is not an accident, and `main.yml` documented the cause itself:

> The .pot PR is created with the default GITHUB_TOKEN, which by design does not trigger further workflows

So the two required contexts can never report on a POT PR, and the merge is refused permanently. The job's other comment recorded the assumption that has since gone stale:

> Branch protection on the base requires neither reviews nor status checks, so the PR is immediately mergeable ("clean")

True when written; false since the contexts were added between 08-05 and 08-06.

## Fix

Two changes, because two things were broken:

**1. Open the PR with `WORKFLOW_AUTOMERGE_PAT` instead of `GITHUB_TOKEN`.** A PR opened by a real identity triggers workflows, so both required contexts actually run. Verified that they will: `main.yml` (providing `static_analysis`) and `phpunit.yml` (providing `phpunit_tests`) each trigger on `pull_request` to `development` with **no path filter**, so a `.pot`-only PR matches both.

**2. Enable auto-merge instead of merging inline.** Even with the checks running, the old approach could not work: `phpunit_tests` takes about **five minutes**, while the step retried six times at five-second intervals — about thirty seconds. `--auto` returns immediately and lets GitHub merge once both contexts are green.

The comment that previously forbade `--auto` was right for its time — enabling it on an already-clean PR is rejected with *"Pull request is in clean status"*. That is now the exceptional case, so it is handled as a fallback: try `--auto`, merge directly if the PR turns out to need no checks. The job then works under either protection policy.

## Safety

- `allow_auto_merge` is enabled on the repo, so `--auto` is available.
- `gettext_update` is guarded by `if: github.event_name == 'push'`, so the PR it opens cannot re-enter this job.
- Regenerating the `.pot` after the merge is a no-op (`POT_LINES_CHANGED = 0`), so no loop.
- The `github.ref == 'refs/heads/development'` guard is retained.
- No `${{ }}` is interpolated into any `run:` block — `PR_NUMBER` and `GH_TOKEN` are passed via `env:`, per the workflow-injection guidance.

## Verification limits

This cannot be fully proven until it runs on `development`, since the behaviour only exists after merge. What has been checked here: the YAML parses, the token is wired into both the create and merge steps, both required workflows trigger on `pull_request` to `development`, and `allow_auto_merge` is on.

## Note on #759

#759 stays blocked until either a push updates its branch under the new token (which fires its checks), or an administrator merges it directly — `enforce_admins` is `false`, so that route is open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automatic POT update pull request handling.
  * Enabled GitHub auto-merge with a direct-merge fallback when applicable.
  * Continued enforcing the development branch as the merge target.
  * Source branches are now explicitly deleted after merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->