### PR TITLE
Echo the rite in /calendar and /events settings

### DIFF
--- a/jsondata/schemas/CommonDef.json
+++ b/jsondata/schemas/CommonDef.json
@@ -407,6 +407,15 @@
                 "mobile"
             ]
         },
+        "Rite": {
+            "type": "string",
+            "title": "Rite",
+            "description": "the liturgical rite the calendar was computed under, as selected by the optional leading rite path segment (`roman` when the segment is absent)",
+            "enum": [
+                "roman",
+                "ambrosian"
+            ]
+        },
         "Epiphany": {
             "type": "string",
             "title": "Epiphany",

--- a/jsondata/schemas/LitCal.json
+++ b/jsondata/schemas/LitCal.json
@@ -196,7 +196,8 @@
                     "StJoseph": false,
                     "StsPeterPaulAp": false,
                     "AllSaints": true
-                }
+                },
+                "rite": "roman"
             },
             "metadata": {
                 "version": "5.3",
@@ -896,6 +897,9 @@
                 },
                 "holydays_of_obligation": {
                     "$ref": "./CommonDef.json#/definitions/HolyDaysOfObligation"
+                },
+                "rite": {
+                    "$ref": "./CommonDef.json#/definitions/Rite"
                 }
             },
             "required": [
@@ -907,7 +911,8 @@
                 "return_type",
                 "year_type",
                 "eternal_high_priest",
-                "holydays_of_obligation"
+                "holydays_of_obligation",
+                "rite"
             ]
         },
         "NationalCalendarSettings": {
@@ -953,6 +958,9 @@
                 "holydays_of_obligation": {
                     "$ref": "./CommonDef.json#/definitions/HolyDaysOfObligation"
                 },
+                "rite": {
+                    "$ref": "./CommonDef.json#/definitions/Rite"
+                },
                 "national_calendar": {
                     "$ref": "./CommonDef.json#/definitions/Nation"
                 }
@@ -967,7 +975,8 @@
                 "year_type",
                 "eternal_high_priest",
                 "national_calendar",
-                "holydays_of_obligation"
+                "holydays_of_obligation",
+                "rite"
             ]
         },
         "DiocesanCalendarSettings": {
@@ -1013,6 +1022,9 @@
                 "holydays_of_obligation": {
                     "$ref": "./CommonDef.json#/definitions/HolyDaysOfObligation"
                 },
+                "rite": {
+                    "$ref": "./CommonDef.json#/definitions/Rite"
+                },
                 "national_calendar": {
                     "$ref": "./CommonDef.json#/definitions/Nation"
                 },
@@ -1030,6 +1042,7 @@
                 "year_type",
                 "eternal_high_priest",
                 "holydays_of_obligation",
+                "rite",
                 "national_calendar",
                 "diocesan_calendar"
             ]

--- a/jsondata/schemas/LitCalEventsPath.json
+++ b/jsondata/schemas/LitCalEventsPath.json
@@ -22,10 +22,13 @@
                   "diocesan_calendar": {
                     "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId",
                     "description": "indicates the Diocesan Calendar used to produce the data in `litcal_events`"
+                  },
+                  "rite": {
+                    "$ref": "./CommonDef.json#/definitions/Rite"
                   }
                 },
                 "additionalProperties": false,
-                "required": [ "locale", "national_calendar", "diocesan_calendar" ]
+                "required": [ "locale", "national_calendar", "diocesan_calendar", "rite" ]
               },
               {
                 "properties": {
@@ -39,10 +42,13 @@
                   },
                   "diocesan_calendar": {
                     "type": "null"
+                  },
+                  "rite": {
+                    "$ref": "./CommonDef.json#/definitions/Rite"
                   }
                 },
                 "additionalProperties": false,
-                "required": [ "locale", "national_calendar", "diocesan_calendar" ]
+                "required": [ "locale", "national_calendar", "diocesan_calendar", "rite" ]
               },
               {
                 "properties": {
@@ -54,10 +60,13 @@
                   },
                   "diocesan_calendar": {
                     "type": "null"
+                  },
+                  "rite": {
+                    "$ref": "./CommonDef.json#/definitions/Rite"
                   }
                 },
                 "additionalProperties": false,
-                "required": [ "locale", "national_calendar", "diocesan_calendar" ]
+                "required": [ "locale", "national_calendar", "diocesan_calendar", "rite" ]
               }
             ]
         }

--- a/jsondata/schemas/LiturgicalCalendar.xsd
+++ b/jsondata/schemas/LiturgicalCalendar.xsd
@@ -222,6 +222,14 @@
                   </xs:sequence>
                 </xs:complexType>
               </xs:element>
+              <xs:element name="Rite">
+                <xs:simpleType>
+                  <xs:restriction base="xs:string">
+                    <xs:enumeration value="roman" />
+                    <xs:enumeration value="ambrosian" />
+                  </xs:restriction>
+                </xs:simpleType>
+              </xs:element>
               <xs:element name="NationalCalendar" minOccurs="0" type="xs:string" />
               <xs:element name="DiocesanCalendar" minOccurs="0" type="xs:string" />
             </xs:sequence>

--- a/phpunit_tests/Handlers/SettingsRiteEchoTest.php
+++ b/phpunit_tests/Handlers/SettingsRiteEchoTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Handlers\EventsHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Issue #760: `/calendar` and `/events` echo the rite they were computed under in
+ * their `settings` block.
+ *
+ * The rite-level Ambrosian calendar is the case that makes this necessary: it sets
+ * neither `national_calendar` nor `diocesan_calendar` (correctly — it is neither), so
+ * before this field a `/calendar/ambrosian` response was indistinguishable from a
+ * `/calendar` response by payload alone. `settings.rite` is emitted for every rite,
+ * `roman` included, so consumers can read it without a presence check.
+ */
+#[CoversClass(CalendarHandler::class)]
+#[CoversClass(EventsHandler::class)]
+final class SettingsRiteEchoTest extends AbstractHandlerTestCase
+{
+    /**
+     * `EventsHandler::setLocale()` calls the process-global `setlocale(LC_ALL, ...)`
+     * unconditionally, and the Milan diocesan catalog forces `it_IT`. Left pinned, it
+     * breaks later tests that rely on gettext falling through to the untranslated
+     * (Latin) msgid. Reset to `C` — no catalog binds to it, so lookups pass through
+     * unchanged. Same rationale as {@see EventsHandlerRiteRoutingTest::tearDown()}.
+     */
+    protected function tearDown(): void
+    {
+        setlocale(LC_ALL, 'C');
+        parent::tearDown();
+    }
+
+    /**
+     * @param string[] $pathParts
+     * @return array<string,mixed>
+     */
+    private function calendarSettings(array $pathParts, Rite $rite, string $uri): array
+    {
+        $handler = new CalendarHandler($pathParts, $rite);
+        $handler->setAllowedReturnTypes([
+            ReturnTypeParam::JSON,
+            ReturnTypeParam::YAML,
+            ReturnTypeParam::XML,
+            ReturnTypeParam::ICS,
+        ]);
+        $response = $handler->handle($this->requestFor('GET', $uri, ['Accept' => 'application/json']));
+        $body     = $this->decodeJsonBody($response);
+
+        self::assertArrayHasKey('settings', $body, 'Calendar response should carry a settings block');
+        self::assertIsArray($body['settings']);
+        return $body['settings'];
+    }
+
+    /**
+     * @param string[] $pathParts
+     * @return array<string,mixed>
+     */
+    private function eventsSettings(array $pathParts, Rite $rite, string $uri): array
+    {
+        $handler  = new EventsHandler($pathParts, $rite);
+        $response = $handler->handle($this->requestFor('GET', $uri, ['Accept-Language' => 'en']));
+        $body     = $this->decodeJsonBody($response);
+
+        self::assertArrayHasKey('settings', $body, 'Events response should carry a settings block');
+        self::assertIsArray($body['settings']);
+        return $body['settings'];
+    }
+
+    /**
+     * @return array<string,array{0:string[],1:Rite,2:string,3:string}>
+     */
+    public static function calendarRoutes(): array
+    {
+        return [
+            'general roman calendar'  => [['2025'], Rite::ROMAN, '/calendar/2025', 'roman'],
+            'explicit roman segment'  => [['2025'], Rite::ROMAN, '/calendar/roman/2025', 'roman'],
+            'national calendar'       => [['nation', 'IT'], Rite::ROMAN, '/calendar/nation/IT', 'roman'],
+            'diocesan calendar'       => [['diocese', 'romamo_it'], Rite::ROMAN, '/calendar/diocese/romamo_it', 'roman'],
+            'ambrosian comune'        => [[], Rite::AMBROSIAN, '/calendar/ambrosian', 'ambrosian'],
+            'ambrosian comune w/year' => [['2025'], Rite::AMBROSIAN, '/calendar/ambrosian/2025', 'ambrosian'],
+            'ambrosian diocese'       => [['diocese', 'milano_it'], Rite::AMBROSIAN, '/calendar/ambrosian/diocese/milano_it', 'ambrosian'],
+        ];
+    }
+
+    /**
+     * @param string[] $pathParts
+     */
+    #[DataProvider('calendarRoutes')]
+    public function testCalendarSettingsEchoTheRite(array $pathParts, Rite $rite, string $uri, string $expected): void
+    {
+        $settings = $this->calendarSettings($pathParts, $rite, $uri);
+
+        self::assertArrayHasKey('rite', $settings, "$uri should echo settings.rite");
+        self::assertSame($expected, $settings['rite']);
+    }
+
+    /**
+     * The whole point of the field: a rite-level Ambrosian response has no
+     * national_calendar and no diocesan_calendar to identify it by, so without
+     * settings.rite it is indistinguishable from the General Roman Calendar.
+     */
+    public function testAmbrosianComuneIsIdentifiableWithoutCalendarKeys(): void
+    {
+        $settings = $this->calendarSettings([], Rite::AMBROSIAN, '/calendar/ambrosian');
+
+        self::assertArrayNotHasKey('national_calendar', $settings);
+        self::assertArrayNotHasKey('diocesan_calendar', $settings);
+        self::assertSame('ambrosian', $settings['rite']);
+    }
+
+    /**
+     * `Utilities::convertArray2XML()` maps `rite` to a `<Rite>` element, which the
+     * Settings sequence in LiturgicalCalendar.xsd declares between HolydaysOfObligation
+     * and the optional NationalCalendar/DiocesanCalendar elements.
+     */
+    public function testXmlResponseCarriesRiteElement(): void
+    {
+        $handler = new CalendarHandler([], Rite::AMBROSIAN);
+        $handler->setAllowedReturnTypes([ReturnTypeParam::JSON, ReturnTypeParam::XML]);
+        $response = $handler->handle(
+            $this->requestFor('GET', '/calendar/ambrosian', ['Accept' => 'application/xml'])
+        );
+
+        self::assertStringContainsString('<Rite>ambrosian</Rite>', (string) $response->getBody());
+    }
+
+    /**
+     * @return array<string,array{0:string[],1:Rite,2:string,3:string}>
+     */
+    public static function eventsRoutes(): array
+    {
+        return [
+            'roman catalog'     => [[], Rite::ROMAN, '/events', 'roman'],
+            'national catalog'  => [['nation', 'IT'], Rite::ROMAN, '/events/nation/IT', 'roman'],
+            'ambrosian comune'  => [[], Rite::AMBROSIAN, '/events/ambrosian', 'ambrosian'],
+            'ambrosian diocese' => [['diocese', 'milano_it'], Rite::AMBROSIAN, '/events/ambrosian/diocese/milano_it', 'ambrosian'],
+        ];
+    }
+
+    /**
+     * @param string[] $pathParts
+     */
+    #[DataProvider('eventsRoutes')]
+    public function testEventsSettingsEchoTheRite(array $pathParts, Rite $rite, string $uri, string $expected): void
+    {
+        $settings = $this->eventsSettings($pathParts, $rite, $uri);
+
+        self::assertArrayHasKey('rite', $settings, "$uri should echo settings.rite");
+        self::assertSame($expected, $settings['rite']);
+    }
+
+    public function testAmbrosianEventsComuneIsIdentifiableWithoutCalendarKeys(): void
+    {
+        $settings = $this->eventsSettings([], Rite::AMBROSIAN, '/events/ambrosian');
+
+        self::assertNull($settings['national_calendar']);
+        self::assertNull($settings['diocesan_calendar']);
+        self::assertSame('ambrosian', $settings['rite']);
+    }
+}

--- a/phpunit_tests/fixtures/golden-master/diocese-romamo-2023.json
+++ b/phpunit_tests/fixtures/golden-master/diocese-romamo-2023.json
@@ -17997,6 +17997,7 @@
             "StsPeterPaulAp": false,
             "AllSaints": true
         },
+        "rite": "roman",
         "national_calendar": "IT",
         "diocesan_calendar": "romamo_it"
     },

--- a/phpunit_tests/fixtures/golden-master/general-1997.json
+++ b/phpunit_tests/fixtures/golden-master/general-1997.json
@@ -16105,7 +16105,8 @@
             "StJoseph": true,
             "StsPeterPaulAp": true,
             "AllSaints": true
-        }
+        },
+        "rite": "roman"
     },
     "metadata": {
         "solemnities_lord_bvm": [

--- a/phpunit_tests/fixtures/golden-master/general-2001.json
+++ b/phpunit_tests/fixtures/golden-master/general-2001.json
@@ -16486,7 +16486,8 @@
             "StJoseph": true,
             "StsPeterPaulAp": true,
             "AllSaints": true
-        }
+        },
+        "rite": "roman"
     },
     "metadata": {
         "solemnities_lord_bvm": [

--- a/phpunit_tests/fixtures/golden-master/general-2005.json
+++ b/phpunit_tests/fixtures/golden-master/general-2005.json
@@ -17005,7 +17005,8 @@
             "StJoseph": true,
             "StsPeterPaulAp": true,
             "AllSaints": true
-        }
+        },
+        "rite": "roman"
     },
     "metadata": {
         "solemnities_lord_bvm": [

--- a/phpunit_tests/fixtures/golden-master/general-2020.json
+++ b/phpunit_tests/fixtures/golden-master/general-2020.json
@@ -16990,7 +16990,8 @@
             "StJoseph": true,
             "StsPeterPaulAp": true,
             "AllSaints": true
-        }
+        },
+        "rite": "roman"
     },
     "metadata": {
         "solemnities_lord_bvm": [

--- a/phpunit_tests/fixtures/golden-master/general-2024.json
+++ b/phpunit_tests/fixtures/golden-master/general-2024.json
@@ -17078,7 +17078,8 @@
             "StJoseph": true,
             "StsPeterPaulAp": true,
             "AllSaints": true
-        }
+        },
+        "rite": "roman"
     },
     "metadata": {
         "solemnities_lord_bvm": [

--- a/phpunit_tests/fixtures/golden-master/general-2025-litur.json
+++ b/phpunit_tests/fixtures/golden-master/general-2025-litur.json
@@ -16745,7 +16745,8 @@
             "StJoseph": true,
             "StsPeterPaulAp": true,
             "AllSaints": true
-        }
+        },
+        "rite": "roman"
     },
     "metadata": {
         "solemnities_lord_bvm": [

--- a/phpunit_tests/fixtures/golden-master/nation-IT-2023.json
+++ b/phpunit_tests/fixtures/golden-master/nation-IT-2023.json
@@ -17140,6 +17140,7 @@
             "StsPeterPaulAp": false,
             "AllSaints": true
         },
+        "rite": "roman",
         "national_calendar": "IT"
     },
     "metadata": {

--- a/phpunit_tests/fixtures/golden-master/nation-US-2023.json
+++ b/phpunit_tests/fixtures/golden-master/nation-US-2023.json
@@ -17508,6 +17508,7 @@
             "StsPeterPaulAp": false,
             "AllSaints": true
         },
+        "rite": "roman",
         "national_calendar": "US"
     },
     "metadata": {

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4945,6 +4945,10 @@ final class CalendarHandler extends AbstractHandler
         $SerializeableLitCal->settings->year_type              = $this->CalendarParams->YearType;
         $SerializeableLitCal->settings->eternal_high_priest    = $this->CalendarParams->EternalHighPriest;
         $SerializeableLitCal->settings->holydays_of_obligation = $this->CalendarParams->HolyDaysOfObligation;
+        // Echoed for every rite, `roman` included, so consumers can branch on it without a presence check.
+        // A rite-level Ambrosian calendar sets neither national_calendar nor diocesan_calendar, so this is
+        // the only thing that tells it apart from the General Roman Calendar by payload alone.
+        $SerializeableLitCal->settings->rite = $this->CalendarParams->Rite;
         if ($this->CalendarParams->NationalCalendar !== null) {
             $SerializeableLitCal->settings->national_calendar = $this->CalendarParams->NationalCalendar;
         }

--- a/src/Handlers/EventsHandler.php
+++ b/src/Handlers/EventsHandler.php
@@ -884,7 +884,11 @@ final class EventsHandler extends AbstractHandler
             'settings'      => [
                 'locale'            => $this->EventsParams->Locale,
                 'national_calendar' => $this->EventsParams->NationalCalendar,
-                'diocesan_calendar' => $this->EventsParams->DiocesanCalendar
+                'diocesan_calendar' => $this->EventsParams->DiocesanCalendar,
+                // Echoed for every rite, `roman` included, so consumers can branch on it without a
+                // presence check. A rite-level /events/ambrosian request sets neither national_calendar
+                // nor diocesan_calendar, so this is the only thing that distinguishes it from /events.
+                'rite'              => $this->EventsParams->Rite
             ]
         ];
         $responseBody = json_encode($responseObj, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
Closes #760.

## What

`settings.rite` is now echoed on both `/calendar` and `/events`, for **every** rite —
`roman` included — so consumers can read it without a presence check.

```console
$ curl -s 'http://localhost:8000/calendar/ambrosian' | jq '.settings.rite'
"ambrosian"

$ curl -s 'http://localhost:8000/calendar' | jq '.settings.rite'
"roman"

$ curl -s 'http://localhost:8000/events/ambrosian' | jq '.settings'
{ "locale": "la_VA", "national_calendar": null, "diocesan_calendar": null, "rite": "ambrosian" }
```

`Router::extractRiteSegment()` already accepts `roman` explicitly and defaults to it, so the
value is always known.

## Why `/events` too

The issue is scoped to `/calendar`, but `/events` echoes the same `settings` block and has the
identical blind spot: `/events/ambrosian` sets neither `national_calendar` nor
`diocesan_calendar`, so it was indistinguishable from `/events`. Covering both keeps the two
read endpoints consistent.

## Placement

`settings`, per the issue's reasoning — the rite is a request parameter (a path segment) that
the API resolves and applies, like `year_type` and `locale`, both already echoed there.

## Changes

| File | Change |
|------|--------|
| `src/Handlers/CalendarHandler.php`      | emit `settings->rite` from `CalendarParams->Rite` |
| `src/Handlers/EventsHandler.php`        | emit `settings['rite']` from `EventsParams->Rite`  |
| `jsondata/schemas/CommonDef.json`       | new shared `Rite` definition                       |
| `jsondata/schemas/LitCal.json`          | `rite` added + required in all three settings variants |
| `jsondata/schemas/LitCalEventsPath.json`| `rite` added + required in all three `oneOf` branches  |
| `jsondata/schemas/LiturgicalCalendar.xsd` | `<Rite>` in the Settings sequence                |

`openapi.json` needs no change — its `/calendar` and `/events` responses `$ref` the schema files,
which are authoritative.

### XML placement

`<Rite>` sits between `HolydaysOfObligation` and the optional
`NationalCalendar`/`DiocesanCalendar` elements, keeping the mandatory elements contiguous.
`Utilities::transformKey()` maps `rite` → `Rite` with no special-casing.

### Golden-master fixtures

Regenerated. The diff across all nine fixtures is exclusively the new field:

```console
$ git diff -U0 -- phpunit_tests/fixtures/golden-master/ | grep -E '^[+-]' | grep -v '^[+-][+-][+-]' | sort | uniq -c
      6 -        }
      6 +        },
      6 +        "rite": "roman"
      3 +        "rite": "roman",
```

I confirmed the regression check is meaningful rather than trivially green: with the fixtures
reset to `HEAD` and the handler change applied, `CalendarGoldenMasterTest` fails 9/9 on exactly
this field.

## Compatibility

Additive. Existing consumers ignore unknown fields, and the absence of a rite today is not
information anyone can rely on, since it is absent for every rite.

One caveat for XML consumers: the XSD `Settings` sequence is ordered and now requires `Rite`, so
a client validating against the **new** XSD will reject an **old** response. That only matters
during the window between deploying the schema and deploying the code.

## Verification

- `vendor/bin/phpunit --exclude-group slow` — 2068 tests green, against a server built from this
  branch. (Against the default `:8000` server, which runs the main checkout, `CalendarTest::testGetCalendarReturnsXML`
  fails on the old payload vs. the new XSD — expected. The one remaining failure when pointing the
  suite at a worktree port is `ExecuteValidationTest`, the documented worktree-port artifact where
  the Dockerised WebSocket server cannot reach the host port.)
- `composer analyse` (PHPStan level 10) — no errors
- `composer lint` — clean
- `composer lint:openapi` — valid
- New `phpunit_tests/Handlers/SettingsRiteEchoTest.php` — 14 tests covering both handlers across
  general/national/diocesan/ambrosian-comune/ambrosian-diocesan routes, plus the XML element and
  the "identifiable without calendar keys" case that motivated the issue.
- Ad-hoc check (not committed): the generated XML validates against the updated XSD for all three
  Roman routes.

## Two pre-existing issues found along the way

Neither is touched here; both predate this change and deserve their own issues if you agree.

1. **Ambrosian XML has never validated against the XSD.** The `LitColor` enumeration in
   `LiturgicalCalendar.xsd` lists only `green|red|white|purple|rose`, but Ambrosian events use
   `morello`, so `/calendar/ambrosian?return_type=XML` fails schema validation on the colour
   `<Option>` — independently of this PR.

2. **The golden-master generator can mask its own regression check.**
   `CalendarGoldenMasterGenerateTest` writes the fixtures and sorts before
   `CalendarGoldenMasterTest` in a default run, so a full-suite run rewrites the baseline before
   the check reads it. It is in group `golden-master-generate`, but that group is not excluded by
   default.

Also worth flagging at deploy time, not a code issue: `computeEngineCacheDataVersion()` hashes only
`jsondata/sourcedata` and `i18n/*.mo`, never the PHP source. This is a code-only change to the
serialiser, so a deployed instance will keep serving cached rite-less calendars until `engineCache/`
is cleared (or `API_VERSION` bumps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar and events configurations now require a liturgical rite: `roman` or `ambrosian`.
  * JSON responses include the selected rite in their settings.
  * XML responses now include the corresponding `<Rite>` element.
  * Ambrosian calendars can be identified correctly, including comune routes without additional calendar keys.

* **Documentation**
  * Configuration examples and supported calendar formats now document the required rite setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->