### PR TITLE
fix(schemas,ambrosian): make Ambrosian calendars validate as XML; AllSouls is morello

### DIFF
--- a/jsondata/schemas/LiturgicalCalendar.xsd
+++ b/jsondata/schemas/LiturgicalCalendar.xsd
@@ -102,6 +102,13 @@
                     <xs:element name="HasVesperII" minOccurs="0" type="xs:boolean" />
                     <xs:element name="HasVigilMass" minOccurs="0" type="xs:boolean" />
                     <xs:element name="HolyDayOfObligation" minOccurs="0" type="xs:boolean" />
+                    <!--
+                      Ambrosian temporale flags, serialized only when non-null by
+                      LiturgicalEvent::jsonSerialize(); already declared (optional)
+                      in the LitCal.json response schema.
+                    -->
+                    <xs:element name="IsAliturgical" minOccurs="0" type="xs:boolean" />
+                    <xs:element name="IsDominical" minOccurs="0" type="xs:boolean" />
                     <xs:element name="IsVigilFor" minOccurs="0" type="xs:string" />
                     <xs:element name="IsVigilMass" minOccurs="0" type="xs:boolean" />
                     <xs:element name="LiturgicalSeason" minOccurs="0" type="xs:string" />
@@ -371,6 +378,14 @@
       </xs:sequence>
     </xs:complexType>
   </xs:element>
+  <!--
+    Union of the liturgical colors across every rite the API serves, mirroring
+    the `color` enumeration in CommonDef.json and the LitColor PHP enum.
+    `green`/`red`/`white`/`purple`/`rose` are Roman; `morello`/`black` are
+    Ambrosian. XML Schema has no way to key a facet off a sibling element, so
+    the enumeration is deliberately the union rather than rite-scoped; scoping
+    color validity per rite is tracked separately in issue #771.
+  -->
   <xs:simpleType name="ColorEnumType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="green" />
@@ -378,6 +393,8 @@
       <xs:enumeration value="white" />
       <xs:enumeration value="purple" />
       <xs:enumeration value="rose" />
+      <xs:enumeration value="morello" />
+      <xs:enumeration value="black" />
     </xs:restriction>
   </xs:simpleType>
   <xs:complexType name="LitCalEventType">

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -7703,14 +7703,18 @@
                           "red",
                           "white",
                           "purple",
-                          "rose"
+                          "rose",
+                          "morello",
+                          "black"
                         ],
                         "examples": [
                           "green",
                           "red",
                           "white",
                           "purple",
-                          "rose"
+                          "rose",
+                          "morello",
+                          "black"
                         ]
                       },
                       "idx": {

--- a/jsondata/sourcedata/rite/ambrosian/missals/propriumdesanctis_2024/propriumdesanctis.json
+++ b/jsondata/sourcedata/rite/ambrosian/missals/propriumdesanctis_2024/propriumdesanctis.json
@@ -211,7 +211,7 @@
     { "month": 10, "day": 28, "event_key": "StsSimonJudeApostles", "grade": 4, "common": [ "Proper" ], "calendar": "AMBROSIAN", "color": [ "red" ] },
     { "month": 10, "day": 29, "event_key": "StHonoratusOfVercelli", "grade": 2, "common": [ "Pastors:For a Bishop" ], "calendar": "AMBROSIAN", "color": [ "white" ] },
     { "month": 11, "day": 1, "event_key": "AllSaints", "grade": 6, "common": [ "Proper" ], "calendar": "AMBROSIAN", "color": [ "white" ] },
-    { "month": 11, "day": 2, "event_key": "AllSouls", "grade": 6, "common": [ "Proper" ], "calendar": "AMBROSIAN", "color": [ "purple" ] },
+    { "month": 11, "day": 2, "event_key": "AllSouls", "grade": 6, "common": [ "Proper" ], "calendar": "AMBROSIAN", "color": [ "morello" ] },
     { "month": 11, "day": 3, "event_key": "StMartinDePorres", "grade": 2, "common": [ "Holy Men and Women:For Religious" ], "calendar": "AMBROSIAN", "color": [ "white" ] },
     { "month": 11, "day": 4, "event_key": "StCharlesBorromeo", "grade": 6, "common": [ "Pastors:For a Bishop" ], "calendar": "AMBROSIAN", "color": [ "white" ] },
     { "month": 11, "day": 9, "event_key": "DedicationLateran", "grade": 5, "common": [ "Proper" ], "calendar": "AMBROSIAN", "color": [ "white" ], "is_dominical": true },

--- a/phpunit_tests/Handlers/CalendarHandlerXmlSchemaTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerXmlSchemaTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Issue #772: the Ambrosian XML serialization had never been validated against
+ * `jsondata/schemas/LiturgicalCalendar.xsd`.
+ *
+ * `Routes/Readonly/CalendarTest::testGetCalendarReturnsXML()` covers the Roman
+ * `/calendar` only, and it does so over HTTP against a running server — which in
+ * this project is a Docker container bound to a *different* checkout, so it can
+ * never validate the working tree's XSD against the working tree's code.
+ *
+ * These cases run the handler in-process and validate the serialized body with
+ * `DOMDocument::schemaValidate()` against the repository's own XSD file, so both
+ * rites are covered by the same mechanism and the assertion is about *this*
+ * revision's schema.
+ */
+#[CoversClass(CalendarHandler::class)]
+final class CalendarHandlerXmlSchemaTest extends AbstractHandlerTestCase
+{
+    /**
+     * The Ambrosian calendars pin the process-global locale to `it_IT` (see
+     * {@see SettingsRiteEchoTest::tearDown()}); reset to `C` so later tests
+     * still see untranslated msgids.
+     */
+    protected function tearDown(): void
+    {
+        setlocale(LC_ALL, 'C');
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<string,array{0:string[],1:Rite,2:string}>
+     */
+    public static function xmlCalendarRoutes(): array
+    {
+        return [
+            'general roman calendar'  => [[], Rite::ROMAN, '/calendar'],
+            'roman national calendar' => [['nation', 'IT'], Rite::ROMAN, '/calendar/nation/IT'],
+            'ambrosian rite'          => [[], Rite::AMBROSIAN, '/calendar/ambrosian'],
+            'ambrosian diocese'       => [['diocese', 'milano_it'], Rite::AMBROSIAN, '/calendar/ambrosian/diocese/milano_it'],
+        ];
+    }
+
+    /**
+     * @param string[] $pathParts
+     */
+    #[DataProvider('xmlCalendarRoutes')]
+    public function testXmlResponseValidatesAgainstSchema(array $pathParts, Rite $rite, string $uri): void
+    {
+        $xsd = dirname(__DIR__, 2) . '/jsondata/schemas/LiturgicalCalendar.xsd';
+        self::assertFileExists($xsd, 'XSD not found: ' . $xsd);
+
+        $handler = new CalendarHandler($pathParts, $rite);
+        $handler->setAllowedReturnTypes([
+            ReturnTypeParam::JSON,
+            ReturnTypeParam::YAML,
+            ReturnTypeParam::XML,
+            ReturnTypeParam::ICS,
+        ]);
+        $response = $handler->handle($this->requestFor('GET', $uri, ['Accept' => 'application/xml']));
+
+        self::assertSame(200, $response->getStatusCode(), $uri . ' should return HTTP 200, got: ' . $response->getBody());
+        self::assertStringStartsWith(
+            'application/xml',
+            $response->getHeaderLine('Content-Type'),
+            $uri . ' should be served as application/xml'
+        );
+
+        $previous = libxml_use_internal_errors(true);
+        libxml_clear_errors();
+
+        try {
+            $dom    = new \DOMDocument();
+            $loaded = $dom->loadXML((string) $response->getBody());
+            self::assertTrue($loaded, $uri . ' did not produce well-formed XML: ' . self::formatLibxmlErrors());
+
+            libxml_clear_errors();
+            $valid = $dom->schemaValidate($xsd);
+            self::assertTrue(
+                $valid,
+                $uri . ' XML does not validate against LiturgicalCalendar.xsd:' . PHP_EOL . self::formatLibxmlErrors()
+            );
+        } finally {
+            libxml_clear_errors();
+            libxml_use_internal_errors($previous);
+        }
+    }
+
+    /**
+     * Report *every* schema violation, not just the first: this test exists to
+     * surface accumulated drift, and a one-error message would hide all but one
+     * defect per run.
+     */
+    private static function formatLibxmlErrors(): string
+    {
+        $messages = array_map(
+            static fn (\LibXMLError $error): string => sprintf('  line %d: %s', $error->line, trim($error->message)),
+            libxml_get_errors()
+        );
+
+        // Distinct messages only: a single drifted element can repeat hundreds of
+        // times across a full year of events.
+        $messages = array_values(array_unique($messages));
+
+        return $messages === [] ? '  (no libxml errors reported)' : implode(PHP_EOL, $messages);
+    }
+}

--- a/phpunit_tests/Models/AmbrosianSourceColorTest.php
+++ b/phpunit_tests/Models/AmbrosianSourceColorTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models;
+
+use LiturgicalCalendar\Api\Enum\LitColor;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #772 (part 2): the Ambrosian source tree must not carry Roman-only
+ * liturgical colors.
+ *
+ * `purple` and `rose` belong to the Roman rite; the Ambrosian violet-family
+ * color is `morello`, which is a proper denomination of the rite and is kept
+ * distinct from `purple` in {@see LitColor} even though the vestments are in
+ * practice interchangeable.
+ *
+ * The concrete defect this guards was the Commemoration of All the Faithful
+ * Departed (`AllSouls`, 2 November), authored as `purple` while all fifteen
+ * other violet-family Ambrosian rows already used `morello`.
+ *
+ * Note this asserts on the *shipped source data*, not on the JSON Schema: the
+ * schema's color enumeration is deliberately the union across rites (XML Schema
+ * and JSON Schema alike have no clean way to key a color facet off the rite of
+ * the containing file). Rite-scoping color validity in the validators themselves
+ * is tracked in issue #771; until that lands, this test is what keeps the
+ * Ambrosian tree honest.
+ */
+final class AmbrosianSourceColorTest extends TestCase
+{
+    /**
+     * Colors admissible in the Ambrosian rite. `black` is admitted by the
+     * Ordinamento Generale del Messale Ambrosiano n. 320 as an optional
+     * alternative to `morello` in offices and Masses for the dead (and on
+     * Lenten ferias), so it belongs in the admissible set even though no row
+     * currently uses it.
+     */
+    private const AMBROSIAN_COLORS = ['green', 'red', 'white', 'morello', 'black'];
+
+    private static function ambrosianRoot(): string
+    {
+        return dirname(__DIR__, 2) . '/jsondata/sourcedata/rite/ambrosian';
+    }
+
+    /**
+     * Every JSON file under the Ambrosian source tree, excluding the `i18n/`
+     * translation files (which carry no `color` keys).
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function ambrosianSourceFiles(): array
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator(self::ambrosianRoot(), \FilesystemIterator::SKIP_DOTS)
+        );
+
+        $cases = [];
+        foreach ($iterator as $file) {
+            if (!$file instanceof \SplFileInfo || $file->getExtension() !== 'json') {
+                continue;
+            }
+            $path = $file->getPathname();
+            if (str_contains($path, DIRECTORY_SEPARATOR . 'i18n' . DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+            $cases[substr($path, strlen(self::ambrosianRoot()) + 1)] = [$path];
+        }
+
+        ksort($cases);
+        self::assertNotEmpty($cases, 'No Ambrosian source files discovered under ' . self::ambrosianRoot());
+
+        return $cases;
+    }
+
+    #[DataProvider('ambrosianSourceFiles')]
+    public function testNoRomanOnlyColorsInAmbrosianSourceData(string $path): void
+    {
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $offenders = [];
+        self::collectColors($decoded, $offenders);
+
+        self::assertSame(
+            [],
+            $offenders,
+            'Ambrosian source data must not use Roman-only colors (use "morello" for the violet family): '
+            . implode(', ', array_unique($offenders))
+        );
+    }
+
+    /**
+     * Walk an arbitrarily nested decoded structure and record any `color`
+     * entry whose value is not admissible in the Ambrosian rite.
+     *
+     * @param mixed             $node
+     * @param array<int,string> $offenders
+     */
+    private static function collectColors(mixed $node, array &$offenders): void
+    {
+        if (!is_array($node)) {
+            return;
+        }
+
+        foreach ($node as $key => $value) {
+            if ($key === 'color' && is_array($value)) {
+                foreach ($value as $color) {
+                    if (is_string($color) && !in_array($color, self::AMBROSIAN_COLORS, true)) {
+                        $offenders[] = $color;
+                    }
+                }
+                continue;
+            }
+            self::collectColors($value, $offenders);
+        }
+    }
+
+    /**
+     * The specific row from issue #772: per OGMA n. 320 the proper color of the
+     * Ambrosian Commemoration of All the Faithful Departed is `morello`. (Black
+     * is admitted only as an optional alternative and is excluded on Sundays,
+     * which the scalar-per-event color field cannot yet express — see the
+     * follow-up tracked separately.)
+     */
+    public function testAllSoulsIsMorello(): void
+    {
+        $path = self::ambrosianRoot() . '/missals/propriumdesanctis_2024/propriumdesanctis.json';
+        $data = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($data);
+
+        $allSouls = array_find(
+            $data,
+            static fn (mixed $row): bool => is_array($row) && ( $row['event_key'] ?? null ) === 'AllSouls'
+        );
+
+        self::assertIsArray($allSouls, 'AllSouls row not found in the Ambrosian sanctorale');
+        self::assertSame([LitColor::MORELLO->value], $allSouls['color']);
+    }
+}

--- a/phpunit_tests/Schemas/ColorEnumParityTest.php
+++ b/phpunit_tests/Schemas/ColorEnumParityTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\LitColor;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Issue #772: the liturgical color vocabulary is spelled out in four independent
+ * places, and they had silently drifted apart.
+ *
+ * When `morello` and `black` were added to the PHP {@see LitColor} enum and to
+ * `CommonDef.json`, the XML Schema (`LiturgicalCalendar.xsd`) and the OpenAPI
+ * description of the XML response body were left behind — with the result that
+ * *every* Ambrosian calendar requested as XML failed schema validation, and
+ * nothing anywhere noticed because no test had ever validated Ambrosian XML.
+ *
+ * This test is the guard against a repeat: all four lists must carry the same
+ * set of colors. It deliberately compares sets, not order — the four files order
+ * their entries differently and that is not a defect.
+ *
+ * Note the enumerations are the *union* across rites: `purple`/`rose` are Roman,
+ * `morello`/`black` are Ambrosian. Neither JSON Schema nor XML Schema can key a
+ * color facet off the rite of the containing document, so rite-scoped color
+ * validation belongs in the validators rather than in these enums — tracked in
+ * issue #771.
+ */
+final class ColorEnumParityTest extends TestCase
+{
+    private static function schemasDir(): string
+    {
+        return dirname(__DIR__, 2) . '/jsondata/schemas';
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private static function sorted(array $values): array
+    {
+        $values = array_values(array_unique($values));
+        sort($values);
+        return $values;
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private static function phpEnumColors(): array
+    {
+        return self::sorted(array_map(static fn (LitColor $c): string => $c->value, LitColor::cases()));
+    }
+
+    public function testCommonDefJsonMatchesPhpEnum(): void
+    {
+        $path    = self::schemasDir() . '/CommonDef.json';
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        $enum = $decoded['definitions']['LitColor']['items']['enum'] ?? null;
+        self::assertIsArray($enum, 'CommonDef.json: could not locate definitions.LitColor.items.enum');
+
+        self::assertSame(
+            self::phpEnumColors(),
+            self::sorted($enum),
+            'CommonDef.json LitColor enum has drifted from the PHP LitColor enum'
+        );
+    }
+
+    public function testXsdColorEnumTypeMatchesPhpEnum(): void
+    {
+        $path = self::schemasDir() . '/LiturgicalCalendar.xsd';
+        $dom  = new \DOMDocument();
+        self::assertTrue($dom->load($path), 'Could not load ' . $path);
+
+        $xpath = new \DOMXPath($dom);
+        $xpath->registerNamespace('xs', 'http://www.w3.org/2001/XMLSchema');
+        $nodes = $xpath->query('//xs:simpleType[@name="ColorEnumType"]/xs:restriction/xs:enumeration/@value');
+        self::assertNotFalse($nodes);
+        self::assertGreaterThan(0, $nodes->length, 'LiturgicalCalendar.xsd: ColorEnumType not found');
+
+        $values = [];
+        foreach ($nodes as $node) {
+            $values[] = $node->nodeValue ?? '';
+        }
+
+        self::assertSame(
+            self::phpEnumColors(),
+            self::sorted($values),
+            'LiturgicalCalendar.xsd ColorEnumType has drifted from the PHP LitColor enum'
+        );
+    }
+
+    /**
+     * The OpenAPI description of the XML `Color/option` element mirrors the XSD
+     * facet; it drifted in lockstep with it.
+     */
+    public function testOpenApiColorEnumMatchesPhpEnum(): void
+    {
+        $path    = self::schemasDir() . '/openapi.json';
+        $raw     = (string) file_get_contents($path);
+        $decoded = json_decode($raw, true, 1024, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        $enums = [];
+        self::collectColorOptionEnums($decoded, $enums);
+        self::assertNotEmpty($enums, 'openapi.json: no Color.properties.option.enum found');
+
+        foreach ($enums as $enum) {
+            self::assertSame(
+                self::phpEnumColors(),
+                self::sorted($enum),
+                'openapi.json Color option enum has drifted from the PHP LitColor enum'
+            );
+        }
+    }
+
+    /**
+     * Recursively collect every `Color.properties.option.enum` array, so the test
+     * keeps working if the OpenAPI document grows further copies of the schema.
+     *
+     * @param array<int|string,mixed> $node
+     * @param array<int,array<int,mixed>> $found
+     */
+    private static function collectColorOptionEnums(array $node, array &$found): void
+    {
+        foreach ($node as $key => $value) {
+            if (!is_array($value)) {
+                continue;
+            }
+            if ($key === 'Color' && isset($value['properties']['option']['enum']) && is_array($value['properties']['option']['enum'])) {
+                $found[] = $value['properties']['option']['enum'];
+            }
+            self::collectColorOptionEnums($value, $found);
+        }
+    }
+}


### PR DESCRIPTION
## Ambrosian XML never validated, and `AllSouls` was the wrong colour

Fixes #772. Two independent colour defects, both surfaced from #770.

### 1. Ambrosian XML has never validated against the XSD

`/calendar/ambrosian` served as XML failed `LiturgicalCalendar.xsd` validation outright — and nothing noticed, because no test had ever validated Ambrosian XML. The pre-existing coverage (`Routes/Readonly/CalendarTest::testGetCalendarReturnsXML`) exercises only the Roman `/calendar`, and does it over HTTP against a running server, which in this project is bound to a different checkout.

Working TDD from a failing Ambrosian-XML test surfaced **three** pieces of accumulated drift, not one:

| Drift | Fix |
|-------|-----|
| `ColorEnumType` restricted to the five Roman colours, so every `morello` failed the enumeration facet | Added `morello` + `black` — `LitColor` and `CommonDef.json` already had them |
| `IsAliturgical` / `IsDominical` undeclared, rejected as unexpected elements | Declared as optional booleans — already optional in `LitCal.json` |
| `openapi.json`'s copy of the XML `Color/option` enum had drifted identically | Same two values added |

The XSD enumeration is deliberately the **union** across rites. XML Schema cannot key a facet off a sibling element, so rite-scoping colour validity belongs in the validators and is tracked separately in #771; the intent is documented inline.

### 2. Ambrosian `AllSouls` was `purple` rather than `morello`

The Commemoration of All the Faithful Departed (2 November) was authored with the Roman `purple`, while all fifteen other violet-family Ambrosian rows already used `morello`. Per *Ordinamento Generale del Messale Ambrosiano* n. 320 the proper colour of this celebration is `morello`; `black` is admitted only as an *optional* alternative on ferial days and is **excluded on Sundays** (and on vigil Masses that open a Sunday). `morello` is therefore the correct unconditional primary colour.

Modelling the conditional `black` alternative is **not** attempted here — the colour field is scalar-per-event, and expressing "primary `morello`, optional `black` when the day is neither a Sunday nor opens one" is a schema change. Filed as a follow-up.

`AllSouls` was the only Roman-only colour anywhere in the Ambrosian tree: the full census is `white` ×263, `red` ×86, `morello` ×15→16, `purple` ×1→0, `rose` ×0. That makes the rite-scoped assertion planned in #771 green.

### Test coverage added

- **`Handlers/CalendarHandlerXmlSchemaTest`** — validates the serialized XML body **in-process** via `DOMDocument::schemaValidate()` against the repository's own XSD, across General Roman, Italian national, Ambrosian rite and Ambrosian diocesan (Milan). Reports every distinct violation rather than only the first, since its job is surfacing accumulated drift.
- **`Schemas/ColorEnumParityTest`** — pins the four independent spellings of the colour vocabulary (PHP `LitColor`, `CommonDef.json`, `LiturgicalCalendar.xsd`, `openapi.json`) to the same set, so they cannot silently drift apart again. This guards the *class* of bug, not just this instance.
- **`Models/AmbrosianSourceColorTest`** — walks the whole Ambrosian source tree and fails on any Roman-only colour, plus an explicit `AllSouls is morello` case.

Every new test was confirmed red before the corresponding fix and green after. Reverting only the XSD on the final tree reproduces the failure on exactly the two Ambrosian routes:

```console
Tests: 4, Assertions: 20, Failures: 2.
  Element '...Option': [facet 'enumeration'] The value 'morello' is not an element of the set {'green', 'red', 'white', 'purple', 'rose'}.
  Element '...IsDominical': This element is not expected.
```

### Verification

| Check | Result |
|-------|--------|
| `composer test:quick` (baseline `development`) | 2067 tests, 171411 assertions, 11 skipped, **0 failures** |
| `composer test:quick` (this PR) | 2081 tests, 171450 assertions, 11 skipped, **0 failures** |
| `composer analyse` (PHPStan L10) | `[OK] No errors` |
| `composer lint` (phpcs) | clean |
| `composer lint:openapi` | valid |
| `composer parallel-lint` | 566 files, no syntax errors |

+14 tests, all new. Skipped set unchanged. No golden-master fixture churn — the golden masters are Roman-only, so the Ambrosian data change does not touch them.

### Follow-up

The conditional-`black` colour modelling need (OGMA n. 320, including the Sunday-vigil case documented by the Milan Curia for 2 November 2019) will be filed as its own issue; it interacts with #771.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Ambrosian liturgical colors “morello” and “black” across calendar schemas and API documentation.
  - Liturgical event data can now include optional indicators for aliturgical and dominical celebrations.

- **Updates**
  - Corrected the Ambrosian All Souls celebration color to “morello”.

- **Tests**
  - Added validation coverage for XML responses, supported color consistency, and Ambrosian source data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->