### PR TITLE
feat(tests): scope liturgical tests to a rite (#767)

### DIFF
--- a/authz/openfga-expectations.json
+++ b/authz/openfga-expectations.json
@@ -9,7 +9,8 @@
     "general_roman_calendar",
     "national_calendar_test",
     "diocesan_calendar_test",
-    "general_roman_calendar_test"
+    "general_roman_calendar_test",
+    "rite_calendar_test"
   ],
   "forbidden_types": [
     "test_definition"

--- a/docs/ops/test-scope-migration-runbook.md
+++ b/docs/ops/test-scope-migration-runbook.md
@@ -251,3 +251,66 @@ The migration writes the new tuple **before** deleting the old one, so:
   for this; manual OpenFGA tuple writes or a reverse migration script would be
   needed. Prefer rolling forward rather than rolling back once all environments
   are migrated.
+
+---
+
+## Follow-up migration — `general_roman_calendar_test` → `rite_calendar_test`
+
+Issue #767 made the rite a first-class scope for liturgical tests. The Ambrosian
+rite-level calendar (`GET /calendar/ambrosian`) is neither national nor diocesan,
+so `general_roman_calendar_test` — a type with exactly one id,
+`general_roman_calendar` — could not name it. `TestScopeResolver` now emits
+`rite_calendar_test:<rite>` for every rite-level test:
+
+| Type                          | Object id                                | Status                        |
+|-------------------------------|------------------------------------------|-------------------------------|
+| `general_roman_calendar_test` | Fixed id `general_roman_calendar`        | Deprecated; kept in the model |
+| `rite_calendar_test`          | A `Rite` value: `roman` / `ambrosian`    | Successor                     |
+
+The shape of this migration mirrors the one above, with one deliberate
+difference: it is **copy-only by default**. The legacy tuples are left in place
+so that rolling the API back to pre-#767 code keeps authorizing.
+
+### Step 1 — apply the model
+
+`rite_calendar_test` is added to `scripts/openfga-model.additive.json` alongside
+`general_roman_calendar_test`, with an identical relation set. As above, the
+authoritative model lives in `cdcf-infra`: land the equivalent change to
+`cdcf-infra/auth/models/LiturgicalCalendar.json`, then upload the new model
+version on the VPS.
+
+### Step 2 — copy the tuples
+
+```bash
+# Dry run first — prints every tuple that would be copied.
+php scripts/migrate-rite-test-tuples.php
+
+# Apply.
+php scripts/migrate-rite-test-tuples.php --apply
+```
+
+Each `general_roman_calendar_test:general_roman_calendar` tuple gains a
+counterpart on `rite_calendar_test:roman`, preserving user and relation.
+Re-running is a no-op. An id other than `general_roman_calendar` on the legacy
+type is reported and left untouched — the script never guesses a rite — and the
+run exits with status `2` so the anomaly is not lost in CI output.
+
+### Step 3 — prune (later)
+
+Only once **every** deployment runs post-#767 code:
+
+```bash
+php scripts/migrate-rite-test-tuples.php --apply --prune
+```
+
+Then drop `general_roman_calendar_test` from the model and from the PHP
+allow-lists that still name it:
+
+- `src/Services/TestScopeResolver.php` (docblock only — it no longer emits it)
+- `src/Services/ResourceExistenceChecker.php`
+- `src/Services/ResourceAdminService.php`
+- `src/Repositories/AccessRequestRepository.php`
+- `authz/openfga-expectations.json`
+- `jsondata/schemas/openapi.json`
+
+This step is **out of scope for the current change** and tracked as a follow-up.

--- a/docs/ops/test-scope-migration-runbook.md
+++ b/docs/ops/test-scope-migration-runbook.md
@@ -6,7 +6,7 @@ This branch (`feat/calendar-scoped-tests`) replaces the flat `test_definition`
 OpenFGA type with three calendar-scoped types:
 
 | New type                      | Scope                   | Object id                         |
-| ----------------------------- | ----------------------- | --------------------------------- |
+|-------------------------------|-------------------------|-----------------------------------|
 | `national_calendar_test`      | National-calendar tests | ISO nation code, e.g. `IT`        |
 | `diocesan_calendar_test`      | Diocesan-calendar tests | Diocese id, e.g. `ROMA`           |
 | `general_roman_calendar_test` | GRC / unscoped tests    | Fixed id `general_roman_calendar` |
@@ -254,22 +254,38 @@ The migration writes the new tuple **before** deleting the old one, so:
 
 ---
 
-## Follow-up migration — `general_roman_calendar_test` → `rite_calendar_test`
+## Follow-up migration — rite-qualified test scopes
 
-Issue #767 made the rite a first-class scope for liturgical tests. The Ambrosian
-rite-level calendar (`GET /calendar/ambrosian`) is neither national nor diocesan,
-so `general_roman_calendar_test` — a type with exactly one id,
-`general_roman_calendar` — could not name it. `TestScopeResolver` now emits
-`rite_calendar_test:<rite>` for every rite-level test:
+Issue #767 made the rite a first-class scope for liturgical tests. Two things
+follow, and one migration covers both.
 
-| Type                          | Object id                                | Status                        |
-|-------------------------------|------------------------------------------|-------------------------------|
-| `general_roman_calendar_test` | Fixed id `general_roman_calendar`        | Deprecated; kept in the model |
-| `rite_calendar_test`          | A `Rite` value: `roman` / `ambrosian`    | Successor                     |
+**The rite-level calendar needed a type.** The Ambrosian rite-level calendar
+(`GET /calendar/ambrosian`) is neither national nor diocesan, so
+`general_roman_calendar_test` — a type with exactly one id,
+`general_roman_calendar` — could not name it.
+
+**Scoped calendar ids needed a rite.** A bare calendar id does not identify a
+calendar: the source tree is partitioned as
+`jsondata/sourcedata/rite/{rite}/calendars/...`, so `lugano_ch` could name an
+Ambrosian calendar or a Roman one, and granting `diocesan_calendar_test` on a
+bare `lugano_ch` would be an ambiguous grant. National scopes are qualified too,
+for one uniform rule — even though only the Roman rite has a national tier.
+
+| Type                          | Object id before         | Object id after                       |
+|-------------------------------|--------------------------|---------------------------------------|
+| `general_roman_calendar_test` | `general_roman_calendar` | → `rite_calendar_test:roman`          |
+| `rite_calendar_test`          | *(new)*                  | A `Rite` value: `roman` / `ambrosian` |
+| `national_calendar_test`      | `US`                     | `roman/US`                            |
+| `diocesan_calendar_test`      | `lugano_ch`              | `ambrosian/lugano_ch`                 |
+
+The rite of an existing national or diocesan tuple is inferred from the
+rite-partitioned source tree, which is the authority on which rite a calendar is
+defined under. An id defined under two rites is reported and skipped — the script
+never guesses which grant was meant.
 
 The shape of this migration mirrors the one above, with one deliberate
-difference: it is **copy-only by default**. The legacy tuples are left in place
-so that rolling the API back to pre-#767 code keeps authorizing.
+difference: it is **copy-only by default**. The superseded tuples are left in
+place so that rolling the API back to pre-#767 code keeps authorizing.
 
 ### Step 1 — apply the model
 
@@ -289,11 +305,12 @@ php scripts/migrate-rite-test-tuples.php
 php scripts/migrate-rite-test-tuples.php --apply
 ```
 
-Each `general_roman_calendar_test:general_roman_calendar` tuple gains a
-counterpart on `rite_calendar_test:roman`, preserving user and relation.
-Re-running is a no-op. An id other than `general_roman_calendar` on the legacy
-type is reported and left untouched — the script never guesses a rite — and the
-run exits with status `2` so the anomaly is not lost in CI output.
+Each superseded tuple gains a counterpart on its rite-qualified successor,
+preserving user and relation. Re-running is a no-op: already-qualified ids are
+recognised and skipped. Anything the script cannot resolve — an unexpected id on
+the legacy type, or a calendar id defined under two rites or none — is reported
+and left untouched, and the run exits with status `2` so the anomaly is not lost
+in CI output.
 
 ### Step 3 — prune (later)
 
@@ -302,6 +319,9 @@ Only once **every** deployment runs post-#767 code:
 ```bash
 php scripts/migrate-rite-test-tuples.php --apply --prune
 ```
+
+This deletes both the legacy `general_roman_calendar_test` tuples and the
+unqualified `national_calendar_test` / `diocesan_calendar_test` ones.
 
 Then drop `general_roman_calendar_test` from the model and from the PHP
 allow-lists that still name it:

--- a/docs/superpowers/specs/2026-08-14-rite-scoped-liturgical-tests-design.md
+++ b/docs/superpowers/specs/2026-08-14-rite-scoped-liturgical-tests-design.md
@@ -1,0 +1,175 @@
+# Rite-scoped liturgical tests
+
+Design for [issue #767](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/767).
+
+## Problem
+
+`jsondata/tests/*.json` cannot be scoped to a rite. Two consequences:
+
+1. **Rite-level calendars are inexpressible.** `AppliesToOrExcludes` in `jsondata/schemas/LitCalTest.json`
+   sets `additionalProperties: false` and permits only `national_calendar(s)` / `diocesan_calendar(s)`.
+   `GET /calendar/ambrosian` is neither national nor diocesan, so no test can name it.
+   `TestScopeResolver::mapAppliesTo()` silently defaults an unscoped test to the General Roman Calendar,
+   so an Ambrosian test written without a scope runs against the GRC and fails every assertion.
+
+2. **Ambrosian dioceses are expressible but unrunnable.** `Health::buildCalendarRequestPath()` emits
+   `/diocese/{id}/{year}`, with no rite segment. The router requires one for the four Ambrosian dioceses
+   (`milano_it`, `bergam_it`, `novara_it`, `lugano_ch`), so such a test requests a URL that 400s.
+
+Verified against a running instance:
+
+| Path                                                         | Status |
+|--------------------------------------------------------------|--------|
+| `/calendar/roman/2026?year_type=CIVIL`                       | 200    |
+| `/calendar/roman/nation/US/2026?year_type=CIVIL`             | 200    |
+| `/calendar/roman/diocese/rotter_nl/2026?year_type=CIVIL`     | 200    |
+| `/calendar/ambrosian/2026?year_type=CIVIL`                   | 200    |
+| `/calendar/ambrosian/diocese/lugano_ch/2026?year_type=CIVIL` | 200    |
+| `/calendar/diocese/lugano_ch/2026?year_type=CIVIL`           | 400    |
+| `/calendar/ambrosian/nation/IT/2026?year_type=CIVIL`         | 400    |
+
+The last row matters: the Ambrosian rite has a rite-level calendar and diocesan calendars, but no
+national calendars.
+
+## Decisions
+
+The issue posed three design questions; the maintainer answered all three in the issue thread.
+
+1. **The rite is an independent axis, declared explicitly.** It is *not* inferred from the calendar id.
+   `/calendars` metadata does currently carry a `rite` per diocesan calendar, but that is incidental:
+   `lugano_ch` happens to have only an Ambrosian calendar today and could later have a Roman one too.
+
+2. **The rite-level calendar gets its own FGA object type**, `rite_calendar_test`, keyed by rite id
+   (`roman`, `ambrosian`). This generalises the existing `general_roman_calendar_test`, whose single
+   fixed id `general_roman_calendar` is exactly "the Roman rite-level calendar".
+
+3. **An unscoped test is no longer valid.** `applies_to` becomes required, and `rite` becomes required
+   inside it. Ten test files exist; scoping them all to `roman` is cheap and removes a whole class of
+   silent misconfiguration.
+
+## Scope shape
+
+`applies_to` gains a required `rite` and drops the "at least one calendar key" requirement:
+
+```json
+{ "applies_to": { "rite": "roman" } }
+{ "applies_to": { "rite": "roman", "national_calendar": "US" } }
+{ "applies_to": { "rite": "ambrosian" } }
+{ "applies_to": { "rite": "ambrosian", "diocesan_calendar": "lugano_ch" } }
+```
+
+`excludes` keeps its current shape and does **not** accept `rite`. `excludes` narrows the set of
+calendars a test applies to; the rite is already pinned by `applies_to`, so excluding a rite is
+meaningless. The two therefore stop sharing one schema definition: `AppliesToScope` (rite required) and
+`ExcludesScope` (the current definition, unchanged).
+
+## Authorization
+
+`TestScopeResolver::mapAppliesTo()` becomes:
+
+| `applies_to`                           | FGA scope                     |
+|----------------------------------------|-------------------------------|
+| `{"diocesan_calendar": "<id>"}`        | `diocesan_calendar_test:<id>` |
+| `{"national_calendar": "<id>"}`        | `national_calendar_test:<id>` |
+| `{"rite": "<rite>"}` (no calendar key) | `rite_calendar_test:<rite>`   |
+| absent / unrecognised                  | `rite_calendar_test:roman`    |
+
+The diocesan and national branches keep precedence and stay keyed by calendar id alone. Diocesan and
+national calendar ids are globally unique across rites today, and the *data* resource types
+(`diocesan_calendar`, `national_calendar`) are keyed the same way — rite-qualifying only the test scope
+would make the two halves of the model disagree. If a calendar id ever needs to be rite-qualified, that
+is a change to the whole resource model, not to tests, and is out of scope here.
+
+`general_roman_calendar_test` is **not removed**. It stays in the FGA model and in every PHP allow-list
+so existing tuples keep authorizing, following the additive-model pattern already used in this repo
+(`scripts/openfga-model.additive.json`, `docs/ops/test-scope-migration-runbook.md`). A migration script
+copies each `general_roman_calendar_test:general_roman_calendar` tuple onto `rite_calendar_test:roman`.
+Dropping the old type is a follow-up, once every deployment runs merged code.
+
+Touched surfaces:
+
+- `scripts/openfga-model.additive.json` — new `rite_calendar_test` type
+- `authz/openfga-expectations.json` — `required_types`
+- `src/Services/TestScopeResolver.php` — the mapping
+- `src/Services/ResourceExistenceChecker.php` — resource type; always exists
+- `src/Repositories/AccessRequestRepository.php` — `OBJECT_TYPES`, `ROLE_OBJECT_TYPES`, id validation
+  (a `rite_calendar_test` id must be a valid `Rite` value)
+- `src/Services/ResourceAdminService.php` — `TEST_OBJECT_TYPES`, `VIEWER_OBJECT_TYPES`
+- `scripts/migrate-rite-test-tuples.php` + runbook section
+
+## Runner
+
+`Health::buildCalendarRequestPath()` takes a `Rite` and always emits the canonical explicit segment
+(`/calendar/roman/...`), the form the `Rite` enum documents as canonical:
+
+| category           | path                                                |
+|--------------------|-----------------------------------------------------|
+| `ritecalendar`     | `/{rite}/{year}?year_type=CIVIL`                    |
+| `nationalcalendar` | `/{rite}/nation/{calendar}/{year}?year_type=CIVIL`  |
+| `diocesancalendar` | `/{rite}/diocese/{calendar}/{year}?year_type=CIVIL` |
+
+`ritecalendar` is a new category for the rite-level calendar. The existing `calendar === 'VA'` special
+case (which already means "the universal calendar", not `/nation/VA`) keeps working and resolves the
+same way as `ritecalendar`.
+
+The rite reaching that method is resolved by `Health::resolveRite()`:
+
+1. an explicit `rite` property on the WebSocket message, when present and a valid `Rite`;
+2. for `diocesancalendar`, the rite announced for that diocese in `/calendars` metadata
+   (`diocesan_calendars[].rite`);
+3. for `ritecalendar`, the calendar id itself read as a `Rite`;
+4. otherwise `Rite::default()`.
+
+National calendars are Roman-only — `/calendars` announces no `rite` for them and
+`/calendar/ambrosian/nation/IT` 400s — so `nationalcalendar` falls through to step 4.
+
+Step 2 keeps the existing UnitTestInterface client working unchanged — it fixes gap 2 without a client
+release — while step 1 is the forward path once clients are rite-aware, and is the authority when both
+are present. `rite` is optional on the message, so `ACTION_PROPERTIES` (which lists *required* props)
+is unchanged.
+
+## Failing loudly
+
+`/calendar` responses already echo `settings.rite` (issue #760). `LitTestRunner` uses it: if the
+response's rite differs from the test's declared `applies_to.rite`, it reports one clear error
+("test is scoped to rite X, calendar returned rite Y") instead of running assertions that would all
+fail for the wrong reason. This is the direct antidote to the failure mode that motivated the issue.
+
+`LitTestRunner::getCalendarName()` also learns to name the rite-level calendar
+("the General Roman Calendar" / "the Ambrosian Calendar") rather than hard-coding
+"the Universal Roman Calendar".
+
+## Data
+
+All ten existing test files get `"rite": "roman"`; the four with no `applies_to` at all gain
+`"applies_to": {"rite": "roman"}`.
+
+`StIgnatiusOfLoyolaTest.json` is restored, scoped `{"rite": "ambrosian"}`. The copy found on disk was
+itself wrong: it asserts the memorial on 31 July for every year 1999–2030, but in the Ambrosian
+calendar the memorial is suppressed when 31 July falls on a Sunday. Verified against a running
+instance — 2005, 2011, 2016 and 2022 return no `StIgnatiusOfLoyola` event at all. Those four
+assertions become `eventNotExists` / `expected_value: null`, matching the pattern already used in
+`StCamillusDeLellisTest.json`.
+
+## Out of scope
+
+- **Frontend `admin-tests.php` scope picker** (`LiturgicalCalendarFrontend`). Requiring `applies_to.rite`
+  is a breaking change for that editor's PUT/PATCH payloads, so it needs a companion change in that
+  repo. Tracked separately.
+- **Removing `general_roman_calendar_test`.** Additive now, removal once all deployments run merged code.
+- **Rite-qualifying diocesan/national calendar ids** in the resource model.
+
+## Testing
+
+- `phpunit_tests/Test/TestItemTest.php` — rite required, invalid rite rejected, `excludes` still rejects
+  `rite`, typed `Rite` exposed.
+- `phpunit_tests/Services/TestScopeResolverTest.php` — each mapping branch, including the legacy
+  no-`applies_to` fallback to `rite_calendar_test:roman`.
+- New `phpunit_tests/Health/BuildCalendarRequestPathTest.php` — path construction per category × rite,
+  via reflection on the private method (the class needs no server).
+- `phpunit_tests/Test/LitTestRunnerTest.php` — rite-mismatch guard.
+- `phpunit_tests/Schemas/SchemaValidationTest.php::testRealTestSourceValidation` validates only
+  `glob(...)[0]` — a single file, whichever sorts first. Widen it to a data provider over the whole
+  `jsondata/tests/` corpus, so a test file that never gained a rite fails loudly instead of hiding
+  behind its neighbours.
+- Live probe of every path form the runner can now emit.

--- a/docs/superpowers/specs/2026-08-14-rite-scoped-liturgical-tests-design.md
+++ b/docs/superpowers/specs/2026-08-14-rite-scoped-liturgical-tests-design.md
@@ -58,6 +58,12 @@ The issue posed three design questions; the maintainer answered all three in the
 { "applies_to": { "rite": "ambrosian", "diocesan_calendar": "lugano_ch" } }
 ```
 
+The Ambrosian rite is proper to the Archdiocese of Milan and a handful of neighbouring dioceses rather
+than to any nation, and `/calendar/ambrosian/nation/{id}` is a 400 — so `rite: ambrosian` combined with
+`national_calendar` / `national_calendars` is rejected, by a conditional in the schema and by the same
+rule in `TestItem`. Without that, a test could pass corpus validation and fail only when the runner
+issued its request: the same expressible-but-unrunnable trap as gap 2.
+
 `excludes` keeps its current shape and does **not** accept `rite`. `excludes` narrows the set of
 calendars a test applies to; the rite is already pinned by `applies_to`, so excluding a rite is
 meaningless. The two therefore stop sharing one schema definition: `AppliesToScope` (rite required) and
@@ -161,8 +167,8 @@ assertions become `eventNotExists` / `expected_value: null`, matching the patter
 
 ## Testing
 
-- `phpunit_tests/Test/TestItemTest.php` — rite required, invalid rite rejected, `excludes` still rejects
-  `rite`, typed `Rite` exposed.
+- `phpunit_tests/Test/TestItemTest.php` — rite required, invalid rite rejected, Ambrosian + national
+  calendar rejected, `excludes` still rejects `rite`, typed `Rite` exposed.
 - `phpunit_tests/Services/TestScopeResolverTest.php` — each mapping branch, including the legacy
   no-`applies_to` fallback to `rite_calendar_test:roman`.
 - New `phpunit_tests/Health/BuildCalendarRequestPathTest.php` — path construction per category × rite,

--- a/docs/superpowers/specs/2026-08-14-rite-scoped-liturgical-tests-design.md
+++ b/docs/superpowers/specs/2026-08-14-rite-scoped-liturgical-tests-design.md
@@ -73,24 +73,37 @@ meaningless. The two therefore stop sharing one schema definition: `AppliesToSco
 
 `TestScopeResolver::mapAppliesTo()` becomes:
 
-| `applies_to`                           | FGA scope                     |
-|----------------------------------------|-------------------------------|
-| `{"diocesan_calendar": "<id>"}`        | `diocesan_calendar_test:<id>` |
-| `{"national_calendar": "<id>"}`        | `national_calendar_test:<id>` |
-| `{"rite": "<rite>"}` (no calendar key) | `rite_calendar_test:<rite>`   |
-| absent / unrecognised                  | `rite_calendar_test:roman`    |
+| `applies_to`                                   | FGA scope                         |
+|------------------------------------------------|-----------------------------------|
+| `{"rite": "<r>", "diocesan_calendar": "<id>"}` | `diocesan_calendar_test:<r>/<id>` |
+| `{"rite": "<r>", "national_calendar": "<id>"}` | `national_calendar_test:<r>/<id>` |
+| `{"rite": "<r>"}` (no calendar key)            | `rite_calendar_test:<r>`          |
+| absent / unrecognised                          | `rite_calendar_test:roman`        |
 
-The diocesan and national branches keep precedence and stay keyed by calendar id alone. Diocesan and
-national calendar ids are globally unique across rites today, and the *data* resource types
-(`diocesan_calendar`, `national_calendar`) are keyed the same way — rite-qualifying only the test scope
-would make the two halves of the model disagree. If a calendar id ever needs to be rite-qualified, that
-is a change to the whole resource model, not to tests, and is out of scope here.
+**Every scope carries its rite**, including the national and diocesan ones. A calendar id alone does not
+identify a calendar: the source tree is already partitioned as
+`jsondata/sourcedata/rite/{rite}/calendars/...`, so nothing stops the same diocese being defined under
+both rites, and `lugano_ch` only happens to be Ambrosian-only today. Granting `diocesan_calendar_test` on
+a bare `lugano_ch` would therefore be an ambiguous grant — it would silently cover a Roman `lugano_ch`
+calendar the moment one existed. National scopes are qualified too, for one uniform rule, even though only
+the Roman rite has a national tier; `national_calendar_test:ambrosian/*` is rejected rather than merely
+unused.
+
+`/` separates the two: it is safe in an OpenFGA object id (only whitespace, `:`, `#` and `*` carry meaning)
+and reads as the hierarchy it is. `TestScopeResolver::qualify()` / `::parseQualifiedId()` are the single
+definition of the format; `AccessRequestRepository` validates incoming ids through the parser.
+
+This applies to the *test* scopes only. The data resource types (`national_calendar`, `diocesan_calendar`)
+keep bare ids in this change — rite-qualifying those touches `/data` authorization and production calendar
+grants, and belongs in its own change.
 
 `general_roman_calendar_test` is **not removed**. It stays in the FGA model and in every PHP allow-list
 so existing tuples keep authorizing, following the additive-model pattern already used in this repo
-(`scripts/openfga-model.additive.json`, `docs/ops/test-scope-migration-runbook.md`). A migration script
-copies each `general_roman_calendar_test:general_roman_calendar` tuple onto `rite_calendar_test:roman`.
-Dropping the old type is a follow-up, once every deployment runs merged code.
+(`scripts/openfga-model.additive.json`, `docs/ops/test-scope-migration-runbook.md`). The unqualified
+`national_calendar_test` / `diocesan_calendar_test` ids stay valid for the same reason. A migration script
+copies every superseded tuple onto its successor, inferring each calendar's rite from the rite-partitioned
+source tree and skipping anything it cannot resolve unambiguously. Dropping the old type and pruning the
+unqualified ids is a follow-up, once every deployment runs merged code.
 
 Touched surfaces:
 
@@ -99,7 +112,8 @@ Touched surfaces:
 - `src/Services/TestScopeResolver.php` — the mapping
 - `src/Services/ResourceExistenceChecker.php` — resource type; always exists
 - `src/Repositories/AccessRequestRepository.php` — `OBJECT_TYPES`, `ROLE_OBJECT_TYPES`, id validation
-  (a `rite_calendar_test` id must be a valid `Rite` value)
+  (`rite_calendar_test` takes a `Rite` value; the scoped test types require `<rite>/<calendarId>`), and a
+  type-aware `validIdsLabelForType()` so a rejection says what the type actually accepts
 - `src/Services/ResourceAdminService.php` — `TEST_OBJECT_TYPES`, `VIEWER_OBJECT_TYPES`
 - `scripts/migrate-rite-test-tuples.php` + runbook section
 

--- a/docs/superpowers/specs/2026-08-14-rite-scoped-liturgical-tests-design.md
+++ b/docs/superpowers/specs/2026-08-14-rite-scoped-liturgical-tests-design.md
@@ -177,7 +177,11 @@ assertions become `eventNotExists` / `expected_value: null`, matching the patter
   is a breaking change for that editor's PUT/PATCH payloads, so it needs a companion change in that
   repo. Tracked separately.
 - **Removing `general_roman_calendar_test`.** Additive now, removal once all deployments run merged code.
-- **Rite-qualifying diocesan/national calendar ids** in the resource model.
+- **Rite-qualifying the data resource types** (`national_calendar`, `diocesan_calendar`, `wider_region`) —
+  [#786](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/786). Same ambiguity, but the
+  blast radius is production calendar-editing grants plus `/data` rite-awareness. That issue also records a
+  live bug found while scoping it: `ResourceExistenceChecker` globs only the Roman partition, so all four
+  Ambrosian dioceses read as deleted and the reconciler would purge their grants.
 
 ## Testing
 

--- a/jsondata/schemas/LitCalTest.json
+++ b/jsondata/schemas/LitCalTest.json
@@ -35,6 +35,23 @@
                 }
             },
             "required": [ "rite" ],
+            "allOf": [
+                {
+                    "description": "national calendars exist only in the Roman rite: the Ambrosian rite is proper to the Archdiocese of Milan and a handful of neighbouring dioceses, not to any nation, and `/calendar/ambrosian/nation/{id}` is a 400. Rejecting the combination here stops a test that could never run from passing corpus validation.",
+                    "if": {
+                        "required": [ "rite" ],
+                        "properties": {
+                            "rite": { "const": "ambrosian" }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "national_calendar": false,
+                            "national_calendars": false
+                        }
+                    }
+                }
+            ],
             "additionalProperties": false
         },
         "ExcludesScope": {

--- a/jsondata/schemas/LitCalTest.json
+++ b/jsondata/schemas/LitCalTest.json
@@ -7,8 +7,40 @@
         { "$ref": "#/definitions/ExactCorrespondenceUntilType" }
     ],
     "definitions": {
-        "AppliesToOrExcludes": {
+        "AppliesToScope": {
             "type": "object",
+            "title": "AppliesToScope",
+            "description": "the calendar a test is scoped to. `rite` is required and names the rite the calendar is computed under: on its own it identifies the rite-level calendar (`/calendar/roman`, `/calendar/ambrosian`); paired with a calendar key it identifies a national or diocesan calendar within that rite (`/calendar/ambrosian/diocese/lugano_ch`). Without it a test would silently run against the General Roman Calendar and fail every assertion — see issue #767.",
+            "properties": {
+                "rite": {
+                    "$ref": "./CommonDef.json#/definitions/Rite"
+                },
+                "national_calendar": {
+                    "$ref": "./CommonDef.json#/definitions/NationalCalendarId"
+                },
+                "diocesan_calendar": {
+                    "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+                },
+                "national_calendars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "./CommonDef.json#/definitions/NationalCalendarId"
+                    }
+                },
+                "diocesan_calendars": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+                    }
+                }
+            },
+            "required": [ "rite" ],
+            "additionalProperties": false
+        },
+        "ExcludesScope": {
+            "type": "object",
+            "title": "ExcludesScope",
+            "description": "calendars removed from the set a test applies to. `rite` is deliberately absent: the rite is already pinned by `applies_to`, so excluding one would be meaningless.",
             "minProperties": 1,
             "properties": {
                 "national_calendar": {
@@ -56,16 +88,16 @@
                     "const": "exactCorrespondence"
                 },
                 "applies_to": {
-                    "$ref": "#/definitions/AppliesToOrExcludes"
+                    "$ref": "#/definitions/AppliesToScope"
                 },
                 "excludes": {
-                    "$ref": "#/definitions/AppliesToOrExcludes"
+                    "$ref": "#/definitions/ExcludesScope"
                 },
                 "assertions": {
                     "$ref": "#/definitions/Assertions"
                 }
             },
-            "required": [ "name", "event_key", "description", "test_type", "assertions" ],
+            "required": [ "name", "event_key", "description", "test_type", "applies_to", "assertions" ],
             "additionalProperties": false
         },
         "ExactCorrespondenceSinceType": {
@@ -89,16 +121,16 @@
                     "$ref": "./CommonDef.json#/definitions/Year"
                 },
                 "applies_to": {
-                    "$ref": "#/definitions/AppliesToOrExcludes"
+                    "$ref": "#/definitions/AppliesToScope"
                 },
                 "excludes": {
-                    "$ref": "#/definitions/AppliesToOrExcludes"
+                    "$ref": "#/definitions/ExcludesScope"
                 },
                 "assertions": {
                     "$ref": "#/definitions/Assertions"
                 }
             },
-            "required": [ "name", "event_key", "description", "test_type", "assertions", "year_since" ],
+            "required": [ "name", "event_key", "description", "test_type", "applies_to", "assertions", "year_since" ],
             "additionalProperties": false
         },
         "ExactCorrespondenceUntilType": {
@@ -122,16 +154,16 @@
                     "$ref": "./CommonDef.json#/definitions/Year"
                 },
                 "applies_to": {
-                    "$ref": "#/definitions/AppliesToOrExcludes"
+                    "$ref": "#/definitions/AppliesToScope"
                 },
                 "excludes": {
-                    "$ref": "#/definitions/AppliesToOrExcludes"
+                    "$ref": "#/definitions/ExcludesScope"
                 },
                 "assertions": {
                     "$ref": "#/definitions/Assertions"
                 }
             },
-            "required": [ "name", "event_key", "description", "test_type", "assertions", "year_until" ],
+            "required": [ "name", "event_key", "description", "test_type", "applies_to", "assertions", "year_until" ],
             "additionalProperties": false
         },
         "Assertions": {

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -3113,7 +3113,7 @@
                           "permissions": [
                             {
                               "object_type": "national_calendar_test",
-                              "object_id": "IT",
+                              "object_id": "roman/IT",
                               "relation": "viewer"
                             }
                           ],
@@ -10319,7 +10319,7 @@
           },
           "viewer_scopes": {
             "type": "object",
-            "description": "Object IDs the caller can view (viewer-or-above), keyed by OpenFGA object type. Keys cover general_roman_calendar, national_calendar_test, diocesan_calendar_test, general_roman_calendar_test and rite_calendar_test.",
+            "description": "Object IDs the caller can view (viewer-or-above), keyed by OpenFGA object type. Keys cover general_roman_calendar, national_calendar_test, diocesan_calendar_test, general_roman_calendar_test and rite_calendar_test. Scoped test ids are rite-qualified as `<rite>/<calendarId>` (e.g. `ambrosian/lugano_ch`), because a bare calendar id does not identify a calendar; `rite_calendar_test` ids are the rite itself.",
             "additionalProperties": {
               "type": "array",
               "items": {
@@ -10332,7 +10332,7 @@
                 "decrees"
               ],
               "national_calendar_test": [
-                "IT"
+                "roman/IT"
               ],
               "diocesan_calendar_test": [],
               "general_roman_calendar_test": [],

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -3538,7 +3538,8 @@
                 "wider_region",
                 "national_calendar_test",
                 "diocesan_calendar_test",
-                "general_roman_calendar_test"
+                "general_roman_calendar_test",
+                "rite_calendar_test"
               ]
             }
           },
@@ -3904,7 +3905,8 @@
                 "wider_region",
                 "national_calendar_test",
                 "diocesan_calendar_test",
-                "general_roman_calendar_test"
+                "general_roman_calendar_test",
+                "rite_calendar_test"
               ]
             }
           },
@@ -6741,6 +6743,9 @@
                       "description": "The memorial 'Mary Mother of the Church' was added in 2018 by Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments on the Monday after Pentecost",
                       "test_type": "exactCorrespondenceSince",
                       "year_since": 2018,
+                      "applies_to": {
+                        "rite": "roman"
+                      },
                       "assertions": [
                         {
                           "year": 2017,
@@ -6767,6 +6772,9 @@
                       "event_key": "NativityJohnBaptist",
                       "description": "When the Nativity of John the Baptist coincides with the Solemnity of the Sacred Heart, is it correctly moved to June 23?",
                       "test_type": "exactCorrespondence",
+                      "applies_to": {
+                        "rite": "roman"
+                      },
                       "assertions": [
                         {
                           "year": 2022,
@@ -6795,6 +6803,7 @@
                       "test_type": "exactCorrespondenceSince",
                       "year_since": 2011,
                       "applies_to": {
+                        "rite": "roman",
                         "national_calendar": "US"
                       },
                       "assertions": [
@@ -6831,6 +6840,9 @@
                       "event_key": "StJaneFrancesDeChantal",
                       "description": "Saint Jane Frances de Chantal was moved from December 12 to August 12 in the 2002 Latin Edition of the Roman Missal, to allow bishops conferences to insert Our Lady of Guadalupe as an optional memorial on December 12. DOES ST JANE FRANCES DE CHANTAL FALL ON THE RIGHT DAY BOTH BEFORE AND AFTER 2002, OR IT CORRECTLY OVERRIDEN BY GREATER FESTIVITIES?",
                       "test_type": "exactCorrespondence",
+                      "applies_to": {
+                        "rite": "roman"
+                      },
                       "assertions": [
                         {
                           "year": 2001,
@@ -6915,6 +6927,9 @@
                   "description": "The memorial 'Mary Mother of the Church' was added in 2018 by Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments on the Monday after Pentecost",
                   "test_type": "exactCorrespondenceSince",
                   "year_since": 2018,
+                  "applies_to": {
+                    "rite": "roman"
+                  },
                   "assertions": [
                     {
                       "year": 2017,
@@ -8371,10 +8386,10 @@
             }
           },
           "applies_to": {
-            "$ref": "./LitCalTest.json#/definitions/AppliesToOrExcludes"
+            "$ref": "./LitCalTest.json#/definitions/AppliesToScope"
           },
           "excludes": {
-            "$ref": "./LitCalTest.json#/definitions/AppliesToOrExcludes"
+            "$ref": "./LitCalTest.json#/definitions/ExcludesScope"
           }
         },
         "required": [
@@ -8382,6 +8397,7 @@
           "event_key",
           "description",
           "test_type",
+          "applies_to",
           "assertions"
         ]
       },
@@ -8431,10 +8447,10 @@
             }
           },
           "applies_to": {
-            "$ref": "./LitCalTest.json#/definitions/AppliesToOrExcludes"
+            "$ref": "./LitCalTest.json#/definitions/AppliesToScope"
           },
           "excludes": {
-            "$ref": "./LitCalTest.json#/definitions/AppliesToOrExcludes"
+            "$ref": "./LitCalTest.json#/definitions/ExcludesScope"
           }
         },
         "required": [
@@ -8442,6 +8458,7 @@
           "event_key",
           "description",
           "test_type",
+          "applies_to",
           "assertions",
           "year_since"
         ]
@@ -8492,10 +8509,10 @@
             }
           },
           "applies_to": {
-            "$ref": "./LitCalTest.json#/definitions/AppliesToOrExcludes"
+            "$ref": "./LitCalTest.json#/definitions/AppliesToScope"
           },
           "excludes": {
-            "$ref": "./LitCalTest.json#/definitions/AppliesToOrExcludes"
+            "$ref": "./LitCalTest.json#/definitions/ExcludesScope"
           }
         },
         "required": [
@@ -8503,6 +8520,7 @@
           "event_key",
           "description",
           "test_type",
+          "applies_to",
           "assertions",
           "year_until"
         ]
@@ -8720,7 +8738,8 @@
               "wider_region",
               "national_calendar_test",
               "diocesan_calendar_test",
-              "general_roman_calendar_test"
+              "general_roman_calendar_test",
+              "rite_calendar_test"
             ],
             "description": "OpenFGA object type"
           },
@@ -9172,7 +9191,8 @@
               "wider_region",
               "national_calendar_test",
               "diocesan_calendar_test",
-              "general_roman_calendar_test"
+              "general_roman_calendar_test",
+              "rite_calendar_test"
             ]
           },
           "object_id": {
@@ -10299,7 +10319,7 @@
           },
           "viewer_scopes": {
             "type": "object",
-            "description": "Object IDs the caller can view (viewer-or-above), keyed by OpenFGA object type. Keys cover general_roman_calendar, national_calendar_test, diocesan_calendar_test and general_roman_calendar_test.",
+            "description": "Object IDs the caller can view (viewer-or-above), keyed by OpenFGA object type. Keys cover general_roman_calendar, national_calendar_test, diocesan_calendar_test, general_roman_calendar_test and rite_calendar_test.",
             "additionalProperties": {
               "type": "array",
               "items": {
@@ -10315,7 +10335,10 @@
                 "IT"
               ],
               "diocesan_calendar_test": [],
-              "general_roman_calendar_test": []
+              "general_roman_calendar_test": [],
+              "rite_calendar_test": [
+                "roman"
+              ]
             }
           }
         },
@@ -10345,7 +10368,8 @@
                   "enum": [
                     "national_calendar_test",
                     "diocesan_calendar_test",
-                    "general_roman_calendar_test"
+                    "general_roman_calendar_test",
+                    "rite_calendar_test"
                   ],
                   "example": "national_calendar_test",
                   "description": "The OpenFGA object type."
@@ -10374,7 +10398,8 @@
                   "enum": [
                     "national_calendar_test",
                     "diocesan_calendar_test",
-                    "general_roman_calendar_test"
+                    "general_roman_calendar_test",
+                    "rite_calendar_test"
                   ],
                   "example": "national_calendar_test",
                   "description": "The OpenFGA object type."

--- a/jsondata/tests/MaryMotherChurchTest.json
+++ b/jsondata/tests/MaryMotherChurchTest.json
@@ -4,6 +4,9 @@
     "description": "The memorial 'Mary Mother of the Church' was added in 2018 by Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments on the Monday after Pentecost",
     "test_type": "exactCorrespondenceSince",
     "year_since": 2018,
+    "applies_to": {
+        "rite": "roman"
+    },
     "assertions": [
         {
             "year": 2015,

--- a/jsondata/tests/NativityJohnBaptistTest.json
+++ b/jsondata/tests/NativityJohnBaptistTest.json
@@ -3,6 +3,9 @@
     "event_key": "NativityJohnBaptist",
     "description": "When the Nativity of John the Baptist coincides with the Solemnity of the Sacred Heart, is it correctly moved to June 23?",
     "test_type": "exactCorrespondence",
+    "applies_to": {
+        "rite": "roman"
+    },
     "assertions": [
         {
             "year": 2022,

--- a/jsondata/tests/PrayerUnbornTest.json
+++ b/jsondata/tests/PrayerUnbornTest.json
@@ -5,6 +5,7 @@
     "test_type": "exactCorrespondenceSince",
     "year_since": 2011,
     "applies_to": {
+        "rite": "roman",
         "national_calendar": "US"
     },
     "assertions": [

--- a/jsondata/tests/StCamillusDeLellisTest.json
+++ b/jsondata/tests/StCamillusDeLellisTest.json
@@ -4,6 +4,7 @@
     "description": "The optional memorial of 'Saint Camillus de Lellis, Priest' should fall on July 18, moved from July 14 to make way for bl Kateri Tekakwitha",
     "test_type": "exactCorrespondence",
     "applies_to": {
+        "rite": "roman",
         "national_calendar": "US"
     },
     "assertions": [

--- a/jsondata/tests/StElizabethPortugalTest.json
+++ b/jsondata/tests/StElizabethPortugalTest.json
@@ -4,6 +4,7 @@
     "description": "The optional memorial of 'Saint Elizabeth of Portugal' should fall on July 5, moved from July 4 to make way for Independence Day",
     "test_type": "exactCorrespondence",
     "applies_to": {
+        "rite": "roman",
         "national_calendar": "US"
     },
     "assertions": [

--- a/jsondata/tests/StIgnatiusOfLoyolaTest.json
+++ b/jsondata/tests/StIgnatiusOfLoyolaTest.json
@@ -1,0 +1,203 @@
+{
+    "name": "StIgnatiusOfLoyolaTest",
+    "event_key": "StIgnatiusOfLoyola",
+    "description": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31 in the Ambrosian calendar, except when July 31 falls on a Sunday, when the memorial is suppressed",
+    "test_type": "exactCorrespondence",
+    "applies_to": {
+        "rite": "ambrosian"
+    },
+    "assertions": [
+        {
+            "year": 1999,
+            "expected_value": "1999-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2000,
+            "expected_value": "2000-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2001,
+            "expected_value": "2001-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2002,
+            "expected_value": "2002-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2003,
+            "expected_value": "2003-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2004,
+            "expected_value": "2004-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2005,
+            "expected_value": null,
+            "assert": "eventNotExists",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should not exist when July 31 falls on a Sunday"
+        },
+        {
+            "year": 2006,
+            "expected_value": "2006-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2007,
+            "expected_value": "2007-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2008,
+            "expected_value": "2008-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2009,
+            "expected_value": "2009-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2010,
+            "expected_value": "2010-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2011,
+            "expected_value": null,
+            "assert": "eventNotExists",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should not exist when July 31 falls on a Sunday"
+        },
+        {
+            "year": 2012,
+            "expected_value": "2012-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2013,
+            "expected_value": "2013-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2014,
+            "expected_value": "2014-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2015,
+            "expected_value": "2015-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2016,
+            "expected_value": null,
+            "assert": "eventNotExists",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should not exist when July 31 falls on a Sunday"
+        },
+        {
+            "year": 2017,
+            "expected_value": "2017-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2018,
+            "expected_value": "2018-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2019,
+            "expected_value": "2019-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2020,
+            "expected_value": "2020-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2021,
+            "expected_value": "2021-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2022,
+            "expected_value": null,
+            "assert": "eventNotExists",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should not exist when July 31 falls on a Sunday"
+        },
+        {
+            "year": 2023,
+            "expected_value": "2023-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2024,
+            "expected_value": "2024-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2025,
+            "expected_value": "2025-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2026,
+            "expected_value": "2026-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2027,
+            "expected_value": "2027-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2028,
+            "expected_value": "2028-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2029,
+            "expected_value": "2029-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        },
+        {
+            "year": 2030,
+            "expected_value": "2030-07-31T00:00:00+00:00",
+            "assert": "eventExists AND hasExpectedDate",
+            "assertion": "The Memorial of 'Saint Ignatius of Loyola' should fall on July 31"
+        }
+    ]
+}

--- a/jsondata/tests/StJaneFrancesDeChantalTest.json
+++ b/jsondata/tests/StJaneFrancesDeChantalTest.json
@@ -3,6 +3,9 @@
     "event_key": "StJaneFrancesDeChantal",
     "description": "Saint Jane Frances de Chantal was moved from December 12 to August 12 in the 2002 Latin Edition of the Roman Missal, to allow bishops conferences to insert Our Lady of Guadalupe as an optional memorial on December 12. DOES ST JANE FRANCES DE CHANTAL FALL ON THE RIGHT DAY BOTH BEFORE AND AFTER 2002, OR IT CORRECTLY OVERRIDEN BY GREATER FESTIVITIES?",
     "test_type": "exactCorrespondence",
+    "applies_to": {
+        "rite": "roman"
+    },
     "assertions": [
         {
             "year": 2001,

--- a/jsondata/tests/StPaulCrossTest.json
+++ b/jsondata/tests/StPaulCrossTest.json
@@ -4,6 +4,7 @@
     "description": "The optional memorial of 'Saint Paul of the Cross, Priest' should fall on October 20, moved from October 19 to make way for the North American Martyrs",
     "test_type": "exactCorrespondence",
     "applies_to": {
+        "rite": "roman",
         "national_calendar": "US"
     },
     "assertions": [

--- a/jsondata/tests/StVincentDeaconTest.json
+++ b/jsondata/tests/StVincentDeaconTest.json
@@ -4,6 +4,7 @@
     "description": "The optional memorial of 'Saint Vincent, Deacon and Martyr' should fall on January 23, moved from January 22 to make way for the National Day of Prayer for the Unborn",
     "test_type": "exactCorrespondence",
     "applies_to": {
+        "rite": "roman",
         "national_calendar": "US"
     },
     "assertions": [

--- a/jsondata/tests/ThanksgivingDayTest.json
+++ b/jsondata/tests/ThanksgivingDayTest.json
@@ -4,6 +4,7 @@
     "description": "The Memorial of '[ USA ] Thanksgiving' should fall on the fourth Thursday of November",
     "test_type": "exactCorrespondence",
     "applies_to": {
+        "rite": "roman",
         "national_calendar": "US"
     },
     "assertions": [

--- a/jsondata/tests/rotter_nl_HLaurentiusdiakenenmartelaarpatroonvanhetbisdomTest.json
+++ b/jsondata/tests/rotter_nl_HLaurentiusdiakenenmartelaarpatroonvanhetbisdomTest.json
@@ -4,6 +4,7 @@
     "description": "The FEAST of &#039;H. Laurentius, diaken en martelaar, patroon van het bisdom&#039; should fall on August 10",
     "test_type": "exactCorrespondence",
     "applies_to": {
+        "rite": "roman",
         "diocesan_calendar": "rotter_nl"
     },
     "assertions": [

--- a/phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php
@@ -177,7 +177,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [],
             [
                 'requested_role' => 'calendar_editor',
-                'permissions'    => [['object_type' => 'national_calendar_test', 'object_id' => 'IT', 'relation' => 'editor']],
+                'permissions'    => [['object_type' => 'national_calendar_test', 'object_id' => 'roman/IT', 'relation' => 'editor']],
             ]
         )->withAttribute('oidc_user', $this->oidcUser());
 
@@ -472,7 +472,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [],
             [
                 'requested_role' => 'test_editor',
-                'permissions'    => [['object_type' => 'national_calendar_test', 'object_id' => 'IT', 'relation' => 'editor']],
+                'permissions'    => [['object_type' => 'national_calendar_test', 'object_id' => 'roman/IT', 'relation' => 'editor']],
                 'justification'  => 'I help test the IT national calendar.',
             ]
         )->withAttribute('oidc_user', $this->oidcUser());

--- a/phpunit_tests/Handlers/Auth/DashboardScopesHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/DashboardScopesHandlerTest.php
@@ -40,9 +40,9 @@ final class DashboardScopesHandlerTest extends AbstractHandlerTestCase
 
     /**
      * Response queue order: 4 admin list-objects (ADMIN_OBJECT_TYPES: national_calendar,
-     * diocesan_calendar, wider_region, general_roman_calendar), then 4 viewer list-objects
+     * diocesan_calendar, wider_region, general_roman_calendar), then 5 viewer list-objects
      * (VIEWER_OBJECT_TYPES: general_roman_calendar, national_calendar_test,
-     * diocesan_calendar_test, general_roman_calendar_test).
+     * diocesan_calendar_test, general_roman_calendar_test, rite_calendar_test).
      *
      * @param array<int, GuzzleResponse> $viewerResponses
      * @return array<int, GuzzleResponse>
@@ -88,6 +88,7 @@ final class DashboardScopesHandlerTest extends AbstractHandlerTestCase
             new GuzzleResponse(200, [], '{"objects":["national_calendar_test:IT"]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":["rite_calendar_test:roman"]}'),
         ]));
 
         $request = $this->requestFor('GET', '/auth/dashboard-scopes')
@@ -104,6 +105,7 @@ final class DashboardScopesHandlerTest extends AbstractHandlerTestCase
                 'national_calendar_test'      => ['IT'],
                 'diocesan_calendar_test'      => [],
                 'general_roman_calendar_test' => [],
+                'rite_calendar_test'          => ['roman'],
             ],
             $body['viewer_scopes']
         );
@@ -142,6 +144,7 @@ final class DashboardScopesHandlerTest extends AbstractHandlerTestCase
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
         ]));
 
         $request = $this->requestFor('GET', '/auth/dashboard-scopes')
@@ -175,6 +178,7 @@ final class DashboardScopesHandlerTest extends AbstractHandlerTestCase
                 'national_calendar_test'      => [],
                 'diocesan_calendar_test'      => [],
                 'general_roman_calendar_test' => [],
+                'rite_calendar_test'          => [],
             ],
             $body['viewer_scopes']
         );

--- a/phpunit_tests/Handlers/Auth/DashboardScopesHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/DashboardScopesHandlerTest.php
@@ -85,7 +85,7 @@ final class DashboardScopesHandlerTest extends AbstractHandlerTestCase
     {
         $handler = $this->handlerWith(self::emptyAdminThenViewer([
             new GuzzleResponse(200, [], '{"objects":["general_roman_calendar:decrees"]}'),
-            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:roman/IT"]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":["rite_calendar_test:roman"]}'),
@@ -102,7 +102,7 @@ final class DashboardScopesHandlerTest extends AbstractHandlerTestCase
         self::assertSame(
             [
                 'general_roman_calendar'      => ['decrees'],
-                'national_calendar_test'      => ['IT'],
+                'national_calendar_test'      => ['roman/IT'],
                 'diocesan_calendar_test'      => [],
                 'general_roman_calendar_test' => [],
                 'rite_calendar_test'          => ['roman'],

--- a/phpunit_tests/Handlers/Auth/TestScopesHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/TestScopesHandlerTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use LiturgicalCalendar\Api\Handlers\Auth\TestScopesHandler;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
 use LiturgicalCalendar\Tests\Handlers\AbstractHandlerTestCase;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -39,13 +40,14 @@ final class TestScopesHandlerTest extends AbstractHandlerTestCase
     }
 
     /**
-     * Six list-objects: editor x3 types, then admin x3 types.
+     * One empty list-objects response per (relation × TEST_OBJECT_TYPES) probe:
+     * editor for each type, then admin for each type.
      *
      * @return array<int, GuzzleResponse>
      */
-    private function sixEmpty(): array
+    private function allEmpty(): array
     {
-        return array_fill(0, 6, new GuzzleResponse(200, [], '{"objects":[]}'));
+        return array_fill(0, 2 * count(ResourceAdminService::TEST_OBJECT_TYPES), new GuzzleResponse(200, [], '{"objects":[]}'));
     }
 
     public function testMissingOidcUserIsUnauthorized(): void
@@ -67,11 +69,7 @@ final class TestScopesHandlerTest extends AbstractHandlerTestCase
     {
         $handler = $this->handlerWith([
             new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}'),
-            new GuzzleResponse(200, [], '{"objects":[]}'),
-            new GuzzleResponse(200, [], '{"objects":[]}'),
-            new GuzzleResponse(200, [], '{"objects":[]}'),
-            new GuzzleResponse(200, [], '{"objects":[]}'),
-            new GuzzleResponse(200, [], '{"objects":[]}'),
+            ...$this->allEmpty(),
         ]);
 
         $request = $this->requestFor('GET', '/auth/test-scopes')
@@ -89,7 +87,7 @@ final class TestScopesHandlerTest extends AbstractHandlerTestCase
 
     public function testGlobalAdminFlaggedWithEmptyScopes(): void
     {
-        $handler = $this->handlerWith($this->sixEmpty());
+        $handler = $this->handlerWith($this->allEmpty());
 
         $request = $this->requestFor('GET', '/auth/test-scopes')
             ->withAttribute('oidc_user', ['sub' => 'root', 'roles' => ['admin']]);

--- a/phpunit_tests/Handlers/Auth/TestScopesHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/TestScopesHandlerTest.php
@@ -70,7 +70,7 @@ final class TestScopesHandlerTest extends AbstractHandlerTestCase
         // Exactly one response per (relation x TEST_OBJECT_TYPES) probe: the first
         // editor probe returns an object, the rest are empty.
         $responses    = $this->allEmpty();
-        $responses[0] = new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}');
+        $responses[0] = new GuzzleResponse(200, [], '{"objects":["national_calendar_test:roman/USA"]}');
         $handler      = $this->handlerWith($responses);
 
         $request = $this->requestFor('GET', '/auth/test-scopes')
@@ -80,7 +80,7 @@ final class TestScopesHandlerTest extends AbstractHandlerTestCase
 
         self::assertFalse($body['is_global_admin']);
         self::assertSame(
-            [['object_type' => 'national_calendar_test', 'object_id' => 'USA']],
+            [['object_type' => 'national_calendar_test', 'object_id' => 'roman/USA']],
             $body['editor']
         );
         self::assertSame([], $body['admin']);

--- a/phpunit_tests/Handlers/Auth/TestScopesHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/TestScopesHandlerTest.php
@@ -67,10 +67,11 @@ final class TestScopesHandlerTest extends AbstractHandlerTestCase
 
     public function testScopedEditorGetsEditorAndAdminLists(): void
     {
-        $handler = $this->handlerWith([
-            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}'),
-            ...$this->allEmpty(),
-        ]);
+        // Exactly one response per (relation x TEST_OBJECT_TYPES) probe: the first
+        // editor probe returns an object, the rest are empty.
+        $responses    = $this->allEmpty();
+        $responses[0] = new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}');
+        $handler      = $this->handlerWith($responses);
 
         $request = $this->requestFor('GET', '/auth/test-scopes')
             ->withAttribute('oidc_user', ['sub' => 'usa-editor', 'roles' => ['test_editor']]);

--- a/phpunit_tests/Handlers/TestsHandlerTest.php
+++ b/phpunit_tests/Handlers/TestsHandlerTest.php
@@ -263,7 +263,7 @@ final class TestsHandlerTest extends AbstractHandlerTestCase
      */
     public function testDeletePurgesScopedTestOperationalTuples(): void
     {
-        // --- Arrange: create a temp fixture that TestScopeResolver maps to national_calendar_test:US ---
+        // --- Arrange: create a temp fixture that TestScopeResolver maps to national_calendar_test:roman/US ---
         // Unique per-run name so the fixture cannot collide with a real or
         // shared test file (the handler reads from the real JsonData::TESTS_FOLDER,
         // so the fixture must live there). tearDown removes it via $testFixturePath.
@@ -283,7 +283,7 @@ final class TestsHandlerTest extends AbstractHandlerTestCase
         $purge = $this->createMock(ResourceTuplePurgeServiceInterface::class);
         $purge->expects($this->once())
             ->method('purgeForObject')
-            ->with('national_calendar_test:US');
+            ->with('national_calendar_test:roman/US');
         $handler->setPurgeService($purge);
 
         // --- Act: issue DELETE (bypasses JWT middleware — in-process) --------

--- a/phpunit_tests/HealthRiteRequestPathTest.php
+++ b/phpunit_tests/HealthRiteRequestPathTest.php
@@ -133,7 +133,13 @@ final class HealthRiteRequestPathTest extends TestCase
 
     /**
      * Populate Health::$metadata with a two-diocese stand-in for the duration of
-     * $fn, then restore whatever was (or was not) there before.
+     * $fn, then put back what was there before.
+     *
+     * `Health::$metadata` is a typed static with no default, so PHP offers no way
+     * to return it to the genuinely uninitialised state. When it started out
+     * uninitialised we therefore leave an *empty* MetadataCalendars behind rather
+     * than the fixture, so a later test in the same process cannot resolve
+     * `lugano_ch` or `rotter_nl` from data this helper invented.
      */
     private static function withMetadata(callable $fn): void
     {
@@ -176,7 +182,25 @@ final class HealthRiteRequestPathTest extends TestCase
         } finally {
             if ($wasSet && $previous !== null) {
                 $property->setValue(null, $previous);
+            } else {
+                $property->setValue(null, self::emptyMetadata());
             }
         }
+    }
+
+    private static function emptyMetadata(): MetadataCalendars
+    {
+        return MetadataCalendars::fromObject((object) [
+            'national_calendars'       => [],
+            'national_calendars_keys'  => [],
+            'diocesan_calendars'       => [],
+            'diocesan_calendars_keys'  => [],
+            'diocesan_groups'          => [],
+            'wider_regions'            => [],
+            'wider_regions_keys'       => [],
+            'ambrosian_calendars'      => [],
+            'ambrosian_calendars_keys' => [],
+            'locales'                  => ['en'],
+        ]);
     }
 }

--- a/phpunit_tests/HealthRiteRequestPathTest.php
+++ b/phpunit_tests/HealthRiteRequestPathTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for the rite-aware calendar request path the WebSocket runner builds
+ * (issue #767).
+ *
+ * Before this change `buildCalendarRequestPath()` emitted `/diocese/{id}/{year}`
+ * with no rite segment, which the router rejects with a 400 for the four
+ * Ambrosian dioceses — so a test scoped to one of them could never pass. The
+ * two methods under test are pure enough to drive directly by reflection,
+ * without standing up Ratchet or the HTTP API.
+ */
+#[CoversClass(Health::class)]
+final class HealthRiteRequestPathTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: int, 2: string, 3: Rite, 4: string}>
+     */
+    public static function requestPathProvider(): array
+    {
+        return [
+            'roman rite-level'     => ['roman', 2026, 'ritecalendar', Rite::ROMAN, '/roman/2026?year_type=CIVIL'],
+            'ambrosian rite-level' => ['ambrosian', 2026, 'ritecalendar', Rite::AMBROSIAN, '/ambrosian/2026?year_type=CIVIL'],
+            'legacy VA marker'     => ['VA', 2026, 'nationalcalendar', Rite::ROMAN, '/roman/2026?year_type=CIVIL'],
+            'roman national'       => ['US', 2026, 'nationalcalendar', Rite::ROMAN, '/roman/nation/US/2026?year_type=CIVIL'],
+            'roman diocesan'       => ['rotter_nl', 2026, 'diocesancalendar', Rite::ROMAN, '/roman/diocese/rotter_nl/2026?year_type=CIVIL'],
+            'ambrosian diocesan'   => ['lugano_ch', 2026, 'diocesancalendar', Rite::AMBROSIAN, '/ambrosian/diocese/lugano_ch/2026?year_type=CIVIL'],
+        ];
+    }
+
+    #[DataProvider('requestPathProvider')]
+    public function testBuildCalendarRequestPath(string $calendar, int $year, string $category, Rite $rite, string $expected): void
+    {
+        self::assertSame($expected, self::buildPath($calendar, $year, $category, $rite));
+    }
+
+    public function testUnknownCategoryThrows(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown calendar category: widerregioncalendar');
+        self::buildPath('europe', 2026, 'widerregioncalendar', Rite::ROMAN);
+    }
+
+    public function testExplicitRiteHintWins(): void
+    {
+        self::assertSame(Rite::AMBROSIAN, self::resolveRite('US', 'nationalcalendar', 'ambrosian'));
+    }
+
+    public function testUnknownRiteHintFallsBackToDefault(): void
+    {
+        self::assertSame(Rite::ROMAN, self::resolveRite('US', 'nationalcalendar', 'byzantine'));
+    }
+
+    public function testRiteCalendarCategoryReadsTheRiteFromTheCalendarId(): void
+    {
+        self::assertSame(Rite::AMBROSIAN, self::resolveRite('ambrosian', 'ritecalendar', null));
+        self::assertSame(Rite::ROMAN, self::resolveRite('roman', 'ritecalendar', null));
+    }
+
+    public function testUnknownRiteCalendarIdFallsBackToDefault(): void
+    {
+        self::assertSame(Rite::ROMAN, self::resolveRite('byzantine', 'ritecalendar', null));
+    }
+
+    public function testNationalCalendarAlwaysResolvesToTheDefaultRite(): void
+    {
+        // /calendars announces no rite for national calendars, and
+        // /calendar/ambrosian/nation/IT is a 400 — there are none.
+        self::assertSame(Rite::ROMAN, self::resolveRite('IT', 'nationalcalendar', null));
+    }
+
+    public function testDiocesanCalendarWithoutLoadedMetadataFallsBackToDefault(): void
+    {
+        // findDioceseMetadata() throws RuntimeException until the WS connection
+        // has fetched /calendars; the request itself will surface the real error.
+        self::assertSame(Rite::ROMAN, self::resolveRite('lugano_ch', 'diocesancalendar', null));
+    }
+
+    public function testDiocesanCalendarReadsTheRiteFromMetadata(): void
+    {
+        self::withMetadata(function (): void {
+            self::assertSame(Rite::AMBROSIAN, self::resolveRite('lugano_ch', 'diocesancalendar', null));
+            self::assertSame(Rite::ROMAN, self::resolveRite('rotter_nl', 'diocesancalendar', null));
+        });
+    }
+
+    public function testUnknownDioceseFallsBackToDefault(): void
+    {
+        self::withMetadata(function (): void {
+            self::assertSame(Rite::ROMAN, self::resolveRite('nowhere_zz', 'diocesancalendar', null));
+        });
+    }
+
+    public function testReadRiteHintIgnoresAbsentAndNonStringValues(): void
+    {
+        $method = new \ReflectionMethod(Health::class, 'readRiteHint');
+
+        self::assertNull($method->invoke(null, (object) ['action' => 'executeUnitTest']));
+        self::assertNull($method->invoke(null, (object) ['rite' => 42]));
+        self::assertSame('ambrosian', $method->invoke(null, (object) ['rite' => 'ambrosian']));
+    }
+
+    private static function buildPath(string $calendar, int $year, string $category, Rite $rite): string
+    {
+        $health = ( new \ReflectionClass(Health::class) )->newInstanceWithoutConstructor();
+        $method = new \ReflectionMethod(Health::class, 'buildCalendarRequestPath');
+
+        /** @var string $path */
+        $path = $method->invoke($health, $calendar, $year, $category, $rite);
+        return $path;
+    }
+
+    private static function resolveRite(string $calendar, string $category, ?string $riteHint): Rite
+    {
+        $health = ( new \ReflectionClass(Health::class) )->newInstanceWithoutConstructor();
+        $method = new \ReflectionMethod(Health::class, 'resolveRite');
+
+        /** @var Rite $rite */
+        $rite = $method->invoke($health, $calendar, $category, $riteHint);
+        return $rite;
+    }
+
+    /**
+     * Populate Health::$metadata with a two-diocese stand-in for the duration of
+     * $fn, then restore whatever was (or was not) there before.
+     */
+    private static function withMetadata(callable $fn): void
+    {
+        $property = new \ReflectionProperty(Health::class, 'metadata');
+        $wasSet   = $property->isInitialized();
+        $previous = $wasSet ? $property->getValue() : null;
+
+        $property->setValue(null, MetadataCalendars::fromObject((object) [
+            'national_calendars'       => [],
+            'national_calendars_keys'  => [],
+            'diocesan_calendars_keys'  => ['lugano_ch', 'rotter_nl'],
+            'diocesan_groups'          => [],
+            'wider_regions'            => [],
+            'wider_regions_keys'       => [],
+            'ambrosian_calendars'      => [],
+            'ambrosian_calendars_keys' => [],
+            'locales'                  => ['en'],
+            'diocesan_calendars'       => [
+                (object) [
+                    'calendar_id' => 'lugano_ch',
+                    'diocese'     => 'Lugano',
+                    'nation'      => 'CH',
+                    'locales'     => ['it_IT'],
+                    'timezone'    => 'Europe/Zurich',
+                    'rite'        => 'ambrosian',
+                ],
+                (object) [
+                    'calendar_id' => 'rotter_nl',
+                    'diocese'     => 'Rotterdam',
+                    'nation'      => 'NL',
+                    'locales'     => ['nl_NL'],
+                    'timezone'    => 'Europe/Amsterdam',
+                    'rite'        => 'roman',
+                ],
+            ],
+        ]));
+
+        try {
+            $fn();
+        } finally {
+            if ($wasSet && $previous !== null) {
+                $property->setValue(null, $previous);
+            }
+        }
+    }
+}

--- a/phpunit_tests/HealthRiteRequestPathTest.php
+++ b/phpunit_tests/HealthRiteRequestPathTest.php
@@ -111,6 +111,109 @@ final class HealthRiteRequestPathTest extends TestCase
         self::assertSame('ambrosian', $method->invoke(null, (object) ['rite' => 'ambrosian']));
     }
 
+    /**
+     * The WebSocket dispatch has to hand the message's `rite` to the path builder,
+     * or a rite-aware client's selection is silently dropped and every Ambrosian
+     * diocesan request 400s (issue #767).
+     *
+     * Driven with a category the builder rejects, so the assertion lands on the
+     * synchronous path-building step and no HTTP request is ever queued — this
+     * needs neither the WS server nor the API to be running.
+     *
+     * @return array<string, array{0: array<string, mixed>}>
+     */
+    public static function dispatchedActionProvider(): array
+    {
+        return [
+            'executeUnitTest'  => [
+                [
+                    'action'   => 'executeUnitTest',
+                    'category' => 'widerregioncalendar',
+                    'calendar' => 'europe',
+                    'year'     => 2026,
+                    'test'     => 'SomeTest',
+                    'rite'     => 'ambrosian',
+                ]
+            ],
+            'validateCalendar' => [
+                [
+                    'action'       => 'validateCalendar',
+                    'category'     => 'widerregioncalendar',
+                    'calendar'     => 'europe',
+                    'year'         => 2026,
+                    'responsetype' => 'JSON',
+                    'rite'         => 'ambrosian',
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('dispatchedActionProvider')]
+    public function testWebSocketDispatchReachesTheRiteAwarePathBuilder(array $payload): void
+    {
+        $health = new Health();
+        $conn   = self::stubConnection();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown calendar category: widerregioncalendar');
+
+        // onMessage() echoes progress; swallow it so the assertion output stays clean.
+        ob_start();
+        try {
+            $health->onMessage($conn, (string) json_encode($payload));
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    public function testDispatchAcceptsAMessageWithNoRiteProperty(): void
+    {
+        // A client that predates rite awareness must still dispatch; its rite is
+        // resolved from metadata instead of the message.
+        $health = new Health();
+        $conn   = self::stubConnection();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown calendar category: widerregioncalendar');
+
+        ob_start();
+        try {
+            $health->onMessage($conn, (string) json_encode([
+                'action'   => 'executeUnitTest',
+                'category' => 'widerregioncalendar',
+                'calendar' => 'europe',
+                'year'     => 2026,
+                'test'     => 'SomeTest',
+            ]));
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    /**
+     * A minimal Ratchet connection: onMessage() only needs somewhere to send.
+     */
+    private static function stubConnection(): \Ratchet\ConnectionInterface
+    {
+        return new class (1) implements \Ratchet\ConnectionInterface {
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
     private static function buildPath(string $calendar, int $year, string $category, Rite $rite): string
     {
         $health = ( new \ReflectionClass(Health::class) )->newInstanceWithoutConstructor();

--- a/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
+++ b/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
@@ -285,10 +285,10 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
         $client = $this->createMock(OpenFgaClient::class);
         $client->expects($this->once())
             ->method('check')
-            ->with('user:user-123', 'editor', 'national_calendar_test:US')
+            ->with('user:user-123', 'editor', 'national_calendar_test:roman/US')
             ->willReturn(true);
 
-        $resolver   = static fn () => ['national_calendar_test', 'US'];
+        $resolver   = static fn () => ['national_calendar_test', 'roman/US'];
         $middleware = new OpenFgaAuthorizationMiddleware(
             $client,
             'test_definition',
@@ -310,10 +310,10 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
         $client = $this->createMock(OpenFgaClient::class);
         $client->expects($this->once())
             ->method('check')
-            ->with('user:user-123', 'editor', 'national_calendar_test:US')
+            ->with('user:user-123', 'editor', 'national_calendar_test:roman/US')
             ->willReturn(false);
 
-        $resolver   = static fn () => ['national_calendar_test', 'US'];
+        $resolver   = static fn () => ['national_calendar_test', 'roman/US'];
         $middleware = new OpenFgaAuthorizationMiddleware(
             $client,
             'test_definition',
@@ -327,7 +327,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
             ->withAttribute('test_id', 'some-test');
 
         $this->expectException(ForbiddenException::class);
-        $this->expectExceptionMessage('national_calendar_test:US');
+        $this->expectExceptionMessage('national_calendar_test:roman/US');
         $middleware->process($request, $this->nextHandler);
     }
 
@@ -385,7 +385,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
         $client = $this->createMock(OpenFgaClient::class);
         $client->expects($this->once())
             ->method('check')
-            ->with('user:user-123', 'editor', 'national_calendar_test:US')
+            ->with('user:user-123', 'editor', 'national_calendar_test:roman/US')
             ->willReturn(true);
 
         // TestScopeResolver is final; use a real instance backed by a temp dir.
@@ -437,7 +437,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
         $client = $this->createMock(OpenFgaClient::class);
         $client->expects($this->once())
             ->method('check')
-            ->with('user:user-123', 'editor', 'national_calendar_test:US')
+            ->with('user:user-123', 'editor', 'national_calendar_test:roman/US')
             ->willReturn(true);
 
         // TestScopeResolver is final; use a real instance backed by a temp dir.
@@ -470,10 +470,10 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
         $client = $this->createMock(OpenFgaClient::class);
         $client->expects($this->once())
             ->method('check')
-            ->with('user:user-123', 'editor', 'national_calendar_test:US')
+            ->with('user:user-123', 'editor', 'national_calendar_test:roman/US')
             ->willReturn(true);
 
-        $resolver   = static fn () => ['national_calendar_test', 'US'];
+        $resolver   = static fn () => ['national_calendar_test', 'roman/US'];
         $middleware = new OpenFgaAuthorizationMiddleware(
             $client,
             'test_definition',
@@ -517,7 +517,7 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
         $client = $this->createMock(OpenFgaClient::class);
         $client->expects($this->once())
             ->method('check')
-            ->with('user:user-123', 'editor', 'national_calendar_test:NL')
+            ->with('user:user-123', 'editor', 'national_calendar_test:roman/NL')
             ->willReturn(true);
 
         // Empty temp dir: the test file does NOT exist (create flow).

--- a/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
@@ -91,12 +91,25 @@ final class AccessRequestRepositoryConstantsTest extends TestCase
         self::assertTrue(AccessRequestRepository::isValidObjectIdForType('diocesan_calendar_test', 'ambrosian/lugano_ch'));
     }
 
+    /**
+     * Every arm of the label map, because the label is the only thing a rejected
+     * caller sees: an arm that silently falls through to the General Roman
+     * Calendar's ids tells them nothing useful.
+     */
     public function testValidIdsLabelIsTypeAware(): void
     {
         self::assertStringContainsString('roman/US', AccessRequestRepository::validIdsLabelForType('national_calendar_test'));
         self::assertStringContainsString('ambrosian/lugano_ch', AccessRequestRepository::validIdsLabelForType('diocesan_calendar_test'));
         self::assertSame('roman, ambrosian', AccessRequestRepository::validIdsLabelForType('rite_calendar_test'));
         self::assertSame('general_roman_calendar', AccessRequestRepository::validIdsLabelForType('general_roman_calendar_test'));
+
+        self::assertSame(
+            implode(', ', AccessRequestRepository::GRC_OBJECT_IDS),
+            AccessRequestRepository::validIdsLabelForType('general_roman_calendar')
+        );
+        self::assertSame('a two-letter ISO nation code', AccessRequestRepository::validIdsLabelForType('national_calendar'));
+        self::assertSame('any non-empty id', AccessRequestRepository::validIdsLabelForType('wider_region'));
+        self::assertSame('any non-empty id', AccessRequestRepository::validIdsLabelForType('something_unknown'));
     }
 
     public function testValidRelationsHasNoDeleter(): void

--- a/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
@@ -68,12 +68,35 @@ final class AccessRequestRepositoryConstantsTest extends TestCase
         self::assertFalse(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar_test', ''));
     }
 
-    public function testNewCalendarTestTypesAcceptNonEmptyIds(): void
+    public function testScopedCalendarTestTypesRequireRiteQualifiedIds(): void
     {
-        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('national_calendar_test', 'IT'));
+        // A bare calendar id does not identify a calendar — `lugano_ch` could be
+        // Ambrosian or Roman — so a scoped test grant must name the rite.
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('national_calendar_test', 'roman/IT'));
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('diocesan_calendar_test', 'roman/romamo_it'));
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('diocesan_calendar_test', 'ambrosian/lugano_ch'));
+
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('national_calendar_test', 'IT'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('diocesan_calendar_test', 'romamo_it'));
         self::assertFalse(AccessRequestRepository::isValidObjectIdForType('national_calendar_test', ''));
-        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('diocesan_calendar_test', 'romamo_it'));
         self::assertFalse(AccessRequestRepository::isValidObjectIdForType('diocesan_calendar_test', ''));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('diocesan_calendar_test', 'byzantine/foo'));
+    }
+
+    public function testOnlyTheRomanRiteHasANationalTier(): void
+    {
+        // /calendar/ambrosian/nation/{id} is a 400 — there is no Ambrosian
+        // national calendar to grant against.
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('national_calendar_test', 'ambrosian/IT'));
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('diocesan_calendar_test', 'ambrosian/lugano_ch'));
+    }
+
+    public function testValidIdsLabelIsTypeAware(): void
+    {
+        self::assertStringContainsString('roman/US', AccessRequestRepository::validIdsLabelForType('national_calendar_test'));
+        self::assertStringContainsString('ambrosian/lugano_ch', AccessRequestRepository::validIdsLabelForType('diocesan_calendar_test'));
+        self::assertSame('roman, ambrosian', AccessRequestRepository::validIdsLabelForType('rite_calendar_test'));
+        self::assertSame('general_roman_calendar', AccessRequestRepository::validIdsLabelForType('general_roman_calendar_test'));
     }
 
     public function testValidRelationsHasNoDeleter(): void

--- a/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
@@ -42,14 +42,23 @@ final class AccessRequestRepositoryConstantsTest extends TestCase
 
     public function testNewTestTypesAreValid(): void
     {
-        foreach (['national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test'] as $t) {
+        foreach (['national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test', 'rite_calendar_test'] as $t) {
             self::assertContains($t, AccessRequestRepository::VALID_OBJECT_TYPES);
         }
         self::assertNotContains('test_definition', AccessRequestRepository::VALID_OBJECT_TYPES);
         self::assertSame(
-            ['national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test'],
+            ['national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test', 'rite_calendar_test'],
             AccessRequestRepository::ROLE_OBJECT_TYPES['test_editor']
         );
+    }
+
+    public function testRiteCalendarTestObjectIdMustBeAKnownRite(): void
+    {
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('rite_calendar_test', 'roman'));
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('rite_calendar_test', 'ambrosian'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('rite_calendar_test', 'byzantine'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('rite_calendar_test', 'general_roman_calendar'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('rite_calendar_test', ''));
     }
 
     public function testGrcTestObjectIdMustBeFixed(): void

--- a/phpunit_tests/Schemas/SchemaValidationTest.php
+++ b/phpunit_tests/Schemas/SchemaValidationTest.php
@@ -625,8 +625,12 @@ class SchemaValidationTest extends TestCase
      * test files, and checking only the alphabetically-first one lets the rest
      * drift unnoticed.
      *
-     * @group slow
+     * Uses the #[Group('slow')] attribute rather than a `@group slow` docblock,
+     * which PHPUnit 12 does not honour — see the sibling Ambrosian temporale test
+     * above. CI runs the whole suite (`composer test:coverage`, no exclusions), so
+     * the corpus is still checked on every run.
      */
+    #[Group('slow')]
     #[DataProvider('realTestSourceFileProvider')]
     public function testRealTestSourceValidation(string $testFile): void
     {

--- a/phpunit_tests/Schemas/SchemaValidationTest.php
+++ b/phpunit_tests/Schemas/SchemaValidationTest.php
@@ -617,25 +617,23 @@ class SchemaValidationTest extends TestCase
     }
 
     /**
-     * Test loading a real test source file against its schema.
+     * Every real test source file must validate against its schema.
+     *
+     * Deliberately data-driven over the whole `jsondata/tests/` corpus rather
+     * than a single `glob()[0]`: a requirement newly added to LitCalTest.json
+     * (e.g. `applies_to.rite`, issue #767) has to be satisfied by *all* the
+     * test files, and checking only the alphabetically-first one lets the rest
+     * drift unnoticed.
      *
      * @group slow
      */
-    public function testRealTestSourceValidation(): void
+    #[DataProvider('realTestSourceFileProvider')]
+    public function testRealTestSourceValidation(string $testFile): void
     {
         $schemaPath = LitSchema::TEST_SRC->path();
         $schema     = Schema::import($schemaPath);
 
-        // Try to find any test source file (in jsondata/tests/, not sourcedata)
-        $testsPath = JsonData::TESTS_FOLDER->path();
-        $files     = glob($testsPath . '/*.json');
-
-        if (empty($files) || $files === false) {
-            $this->markTestSkipped('No test source files found');
-        }
-
-        $testFile = $files[0];
-        $content  = file_get_contents($testFile);
+        $content = file_get_contents($testFile);
         $this->assertIsString($content);
 
         $data = json_decode($content);
@@ -644,5 +642,25 @@ class SchemaValidationTest extends TestCase
         // This should not throw
         $schema->in($data);
         $this->assertTrue(true, "Real test source file should pass validation: $testFile");
+    }
+
+    /**
+     * @return array<string,array{string}>
+     */
+    public static function realTestSourceFileProvider(): array
+    {
+        // Test source files live in jsondata/tests/, not sourcedata. Resolved
+        // from the repo root rather than via JsonData::TESTS_FOLDER, because a
+        // data provider runs before any test can initialise Router::$apiFilePath.
+        $files = glob(dirname(__DIR__, 2) . '/jsondata/tests/*.json');
+        if (empty($files) || $files === false) {
+            return [];
+        }
+
+        $cases = [];
+        foreach ($files as $file) {
+            $cases[basename($file)] = [$file];
+        }
+        return $cases;
     }
 }

--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -157,12 +157,14 @@ final class ResourceAdminServiceTest extends TestCase
 
     public function testResolveTestScopesGroupsEditorThenAdmin(): void
     {
-        // Order: editor for the 3 test types, then admin for the 3 test types.
+        // Order: editor for each TEST_OBJECT_TYPES entry, then admin for each.
         $service = $this->serviceWith([
             new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
         ]);
@@ -189,12 +191,14 @@ final class ResourceAdminServiceTest extends TestCase
     public function testResolveViewerScopesReturnsIdsKeyedByType(): void
     {
         // One list-objects response per VIEWER_OBJECT_TYPES entry, in order:
-        // general_roman_calendar, national_calendar_test, diocesan_calendar_test, general_roman_calendar_test
+        // general_roman_calendar, national_calendar_test, diocesan_calendar_test,
+        // general_roman_calendar_test, rite_calendar_test
         $service = $this->serviceWith([
             new GuzzleResponse(200, [], '{"objects":["general_roman_calendar:temporale","general_roman_calendar:decrees"]}'),
             new GuzzleResponse(200, [], '{"objects":["national_calendar_test:IT"]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":["rite_calendar_test:ambrosian"]}'),
         ]);
 
         self::assertSame(
@@ -203,6 +207,7 @@ final class ResourceAdminServiceTest extends TestCase
                 'national_calendar_test'      => ['IT'],
                 'diocesan_calendar_test'      => [],
                 'general_roman_calendar_test' => [],
+                'rite_calendar_test'          => ['ambrosian'],
             ],
             $service->resolveViewerScopes('grc-editor')
         );
@@ -220,6 +225,7 @@ final class ResourceAdminServiceTest extends TestCase
                 'national_calendar_test'      => [],
                 'diocesan_calendar_test'      => [],
                 'general_roman_calendar_test' => [],
+                'rite_calendar_test'          => [],
             ],
             $service->resolveViewerScopes('grc-editor')
         );

--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -162,11 +162,11 @@ final class ResourceAdminServiceTest extends TestCase
         // rite_calendar_test. The last of each group returns a rite object so the
         // new probe is observable rather than silently empty.
         $service = $this->serviceWith([
-            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}'),
+            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:roman/USA"]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":["rite_calendar_test:ambrosian"]}'),
-            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}'),
+            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:roman/USA"]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":["rite_calendar_test:ambrosian"]}'),
@@ -176,14 +176,14 @@ final class ResourceAdminServiceTest extends TestCase
 
         self::assertSame(
             [
-                ['object_type' => 'national_calendar_test', 'object_id' => 'USA'],
+                ['object_type' => 'national_calendar_test', 'object_id' => 'roman/USA'],
                 ['object_type' => 'rite_calendar_test', 'object_id' => 'ambrosian'],
             ],
             $scopes['editor']
         );
         self::assertSame(
             [
-                ['object_type' => 'national_calendar_test', 'object_id' => 'USA'],
+                ['object_type' => 'national_calendar_test', 'object_id' => 'roman/USA'],
                 ['object_type' => 'rite_calendar_test', 'object_id' => 'ambrosian'],
             ],
             $scopes['admin']
@@ -204,7 +204,7 @@ final class ResourceAdminServiceTest extends TestCase
         // general_roman_calendar_test, rite_calendar_test
         $service = $this->serviceWith([
             new GuzzleResponse(200, [], '{"objects":["general_roman_calendar:temporale","general_roman_calendar:decrees"]}'),
-            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:roman/IT"]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":["rite_calendar_test:ambrosian"]}'),
@@ -213,7 +213,7 @@ final class ResourceAdminServiceTest extends TestCase
         self::assertSame(
             [
                 'general_roman_calendar'      => ['temporale', 'decrees'],
-                'national_calendar_test'      => ['IT'],
+                'national_calendar_test'      => ['roman/IT'],
                 'diocesan_calendar_test'      => [],
                 'general_roman_calendar_test' => [],
                 'rite_calendar_test'          => ['ambrosian'],

--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -157,26 +157,35 @@ final class ResourceAdminServiceTest extends TestCase
 
     public function testResolveTestScopesGroupsEditorThenAdmin(): void
     {
-        // Order: editor for each TEST_OBJECT_TYPES entry, then admin for each.
+        // Order: editor for each TEST_OBJECT_TYPES entry, then admin for each —
+        // national_calendar_test, diocesan_calendar_test, general_roman_calendar_test,
+        // rite_calendar_test. The last of each group returns a rite object so the
+        // new probe is observable rather than silently empty.
         $service = $this->serviceWith([
             new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
-            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":["rite_calendar_test:ambrosian"]}'),
             new GuzzleResponse(200, [], '{"objects":["national_calendar_test:USA"]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
             new GuzzleResponse(200, [], '{"objects":[]}'),
-            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":["rite_calendar_test:ambrosian"]}'),
         ]);
 
         $scopes = $service->resolveTestScopes('cei-admin');
 
         self::assertSame(
-            [['object_type' => 'national_calendar_test', 'object_id' => 'USA']],
+            [
+                ['object_type' => 'national_calendar_test', 'object_id' => 'USA'],
+                ['object_type' => 'rite_calendar_test', 'object_id' => 'ambrosian'],
+            ],
             $scopes['editor']
         );
         self::assertSame(
-            [['object_type' => 'national_calendar_test', 'object_id' => 'USA']],
+            [
+                ['object_type' => 'national_calendar_test', 'object_id' => 'USA'],
+                ['object_type' => 'rite_calendar_test', 'object_id' => 'ambrosian'],
+            ],
             $scopes['admin']
         );
     }

--- a/phpunit_tests/Services/ResourceExistenceCheckerTest.php
+++ b/phpunit_tests/Services/ResourceExistenceCheckerTest.php
@@ -36,6 +36,16 @@ final class ResourceExistenceCheckerTest extends TestCase
         $this->assertTrue($checker->isResourceType('national_calendar_test'));
         $this->assertTrue($checker->isResourceType('diocesan_calendar_test'));
         $this->assertTrue($checker->isResourceType('general_roman_calendar_test'));
+        $this->assertTrue($checker->isResourceType('rite_calendar_test'));
+    }
+
+    public function testRiteCalendarTestExistsOnlyForKnownRites(): void
+    {
+        $checker = new ResourceExistenceChecker();
+        $this->assertTrue($checker->exists('rite_calendar_test', 'roman'));
+        $this->assertTrue($checker->exists('rite_calendar_test', 'ambrosian'));
+        $this->assertFalse($checker->exists('rite_calendar_test', 'byzantine'));
+        $this->assertFalse($checker->exists('rite_calendar_test', ''));
     }
 
     public function testMissingNationalCalendarDoesNotExist(): void

--- a/phpunit_tests/Services/RoleCascadeServiceTest.php
+++ b/phpunit_tests/Services/RoleCascadeServiceTest.php
@@ -38,7 +38,7 @@ final class RoleCascadeServiceTest extends TestCase
     {
         $fga = $this->createMock(OpenFgaClient::class);
         // 'test_editor' role: types=[national_calendar_test, diocesan_calendar_test,
-        // general_roman_calendar_test], relations=[admin,viewer,editor].
+        // general_roman_calendar_test, rite_calendar_test], relations=[admin,viewer,editor].
         // First listObjects call (type=national_calendar_test, relation=admin) returns
         // non-empty → method short-circuits and returns true.
         $fga->expects(self::once())
@@ -140,10 +140,11 @@ final class RoleCascadeServiceTest extends TestCase
     public function testCascadeTupleRevokeForRoleDeletesTuplesAndCascadesDb(): void
     {
         $fga = $this->createMock(OpenFgaClient::class);
-        // 'test_editor' role has 3 types: national_calendar_test, diocesan_calendar_test,
-        // general_roman_calendar_test. Only the first type's admin relation returns an object
-        // id; all other (type, relation) pairs return empty. cascadeTupleRevokeForRole does
-        // not short-circuit — it probes all 3 types × 3 relations = 9 listObjects calls.
+        // 'test_editor' role has 4 types: national_calendar_test, diocesan_calendar_test,
+        // general_roman_calendar_test, rite_calendar_test. Only the first type's admin relation
+        // returns an object id; all other (type, relation) pairs return empty.
+        // cascadeTupleRevokeForRole does not short-circuit — it probes all 4 types × 3
+        // relations = 12 listObjects calls.
         $listCalls = 0;
         $fga->method('listObjects')
             ->willReturnCallback(
@@ -168,7 +169,7 @@ final class RoleCascadeServiceTest extends TestCase
         self::assertSame('user:u1', $deleted[0]['user']);
         self::assertSame('admin', $deleted[0]['relation']);
         self::assertSame('national_calendar_test:t1', $deleted[0]['object']);
-        self::assertSame(9, $listCalls, 'listObjects should be probed for exactly every (type × relation) pair (3 types × 3 relations)');
+        self::assertSame(12, $listCalls, 'listObjects should be probed for exactly every (type × relation) pair (4 types × 3 relations)');
     }
 
     public function testCascadeTupleRevokeForRoleSwallowsDeleteFailures(): void

--- a/phpunit_tests/Services/TestScopeResolverTest.php
+++ b/phpunit_tests/Services/TestScopeResolverTest.php
@@ -30,11 +30,13 @@ final class TestScopeResolverTest extends TestCase
         $this->assertSame(['national_calendar_test', 'US'], $r->resolve('BarTest'));
     }
 
-    public function testResolvesGeneralWhenAppliestoAbsent(): void
+    public function testResolvesRomanRiteWhenAppliestoAbsent(): void
     {
+        // Legacy files written before applies_to.rite became required still
+        // have to resolve to *something*; the default rite is Roman.
         $r = new TestScopeResolver($this->fixturesDir);
         $this->assertSame(
-            ['general_roman_calendar_test', 'general_roman_calendar'],
+            ['rite_calendar_test', 'roman'],
             $r->resolve('BazTest')
         );
     }
@@ -101,12 +103,51 @@ final class TestScopeResolverTest extends TestCase
         );
     }
 
-    public function testResolveFromPayloadDefaultsToGeneralRoman(): void
+    public function testResolveFromPayloadDefaultsToRomanRite(): void
     {
         $r = new TestScopeResolver($this->fixturesDir);
         $this->assertSame(
-            ['general_roman_calendar_test', 'general_roman_calendar'],
+            ['rite_calendar_test', 'roman'],
             $r->resolveFromPayload(['name' => 'SomeTest'])
+        );
+    }
+
+    public function testResolveFromPayloadRomanRite(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['rite_calendar_test', 'roman'],
+            $r->resolveFromPayload(['applies_to' => ['rite' => 'roman']])
+        );
+    }
+
+    public function testResolveFromPayloadAmbrosianRite(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['rite_calendar_test', 'ambrosian'],
+            $r->resolveFromPayload(['applies_to' => ['rite' => 'ambrosian']])
+        );
+    }
+
+    public function testResolveFromPayloadUnknownRiteFallsBackToDefault(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['rite_calendar_test', 'roman'],
+            $r->resolveFromPayload(['applies_to' => ['rite' => 'byzantine']])
+        );
+    }
+
+    public function testCalendarScopeWinsOverRite(): void
+    {
+        // An Ambrosian diocesan test is scoped by its diocese, not its rite:
+        // diocesan and national calendar ids are unique across rites, and the
+        // matching data resource types are keyed the same way.
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['diocesan_calendar_test', 'lugano_ch'],
+            $r->resolveFromPayload(['applies_to' => ['rite' => 'ambrosian', 'diocesan_calendar' => 'lugano_ch']])
         );
     }
 

--- a/phpunit_tests/Services/TestScopeResolverTest.php
+++ b/phpunit_tests/Services/TestScopeResolverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Services;
 
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Services\TestScopeResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -21,13 +22,13 @@ final class TestScopeResolverTest extends TestCase
     public function testResolvesDiocesan(): void
     {
         $r = new TestScopeResolver($this->fixturesDir);
-        $this->assertSame(['diocesan_calendar_test', 'rotter_nl'], $r->resolve('FooTest'));
+        $this->assertSame(['diocesan_calendar_test', 'roman/rotter_nl'], $r->resolve('FooTest'));
     }
 
     public function testResolvesNational(): void
     {
         $r = new TestScopeResolver($this->fixturesDir);
-        $this->assertSame(['national_calendar_test', 'US'], $r->resolve('BarTest'));
+        $this->assertSame(['national_calendar_test', 'roman/US'], $r->resolve('BarTest'));
     }
 
     public function testResolvesRomanRiteWhenAppliestoAbsent(): void
@@ -74,8 +75,9 @@ final class TestScopeResolverTest extends TestCase
     public function testAcceptsValidAlphanumericDashUnderscoreName(): void
     {
         $r = new TestScopeResolver($this->fixturesDir);
-        // FooTest is a known fixture — must still resolve
-        $this->assertSame(['diocesan_calendar_test', 'rotter_nl'], $r->resolve('FooTest'));
+        // FooTest is a known fixture — must still resolve. It predates the required
+        // `rite`, so it falls back to the default rite and is qualified with it.
+        $this->assertSame(['diocesan_calendar_test', 'roman/rotter_nl'], $r->resolve('FooTest'));
     }
 
     public function testAcceptsNameWithDashAndUnderscore(): void
@@ -85,12 +87,21 @@ final class TestScopeResolverTest extends TestCase
         $this->assertNull($r->resolve('Valid-Test_Name-123'));
     }
 
+    public function testResolvesRiteQualifiedDiocesanScopeFromFile(): void
+    {
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['diocesan_calendar_test', 'ambrosian/lugano_ch'],
+            $r->resolve('AmbrosianDioceseTest')
+        );
+    }
+
     public function testResolveFromPayloadNational(): void
     {
         $r = new TestScopeResolver($this->fixturesDir);
         $this->assertSame(
-            ['national_calendar_test', 'NL'],
-            $r->resolveFromPayload(['applies_to' => ['national_calendar' => 'NL']])
+            ['national_calendar_test', 'roman/NL'],
+            $r->resolveFromPayload(['applies_to' => ['rite' => 'roman', 'national_calendar' => 'NL']])
         );
     }
 
@@ -98,7 +109,18 @@ final class TestScopeResolverTest extends TestCase
     {
         $r = new TestScopeResolver($this->fixturesDir);
         $this->assertSame(
-            ['diocesan_calendar_test', 'romamo_it'],
+            ['diocesan_calendar_test', 'roman/romamo_it'],
+            $r->resolveFromPayload(['applies_to' => ['rite' => 'roman', 'diocesan_calendar' => 'romamo_it']])
+        );
+    }
+
+    public function testUnqualifiedLegacyPayloadFallsBackToTheDefaultRite(): void
+    {
+        // A payload written before `rite` was required still has to resolve to a
+        // scope; it is qualified with the default rite rather than left bare.
+        $r = new TestScopeResolver($this->fixturesDir);
+        $this->assertSame(
+            ['diocesan_calendar_test', 'roman/romamo_it'],
             $r->resolveFromPayload(['applies_to' => ['diocesan_calendar' => 'romamo_it']])
         );
     }
@@ -139,16 +161,41 @@ final class TestScopeResolverTest extends TestCase
         );
     }
 
-    public function testCalendarScopeWinsOverRite(): void
+    public function testCalendarScopeSelectsTheTypeAndTheRiteQualifiesTheId(): void
     {
-        // An Ambrosian diocesan test is scoped by its diocese, not its rite:
-        // diocesan and national calendar ids are unique across rites, and the
-        // matching data resource types are keyed the same way.
+        // An Ambrosian diocesan test lands on diocesan_calendar_test, but its id
+        // carries the rite: `lugano_ch` on its own would be an ambiguous grant,
+        // since the source tree admits the same diocese under either rite.
         $r = new TestScopeResolver($this->fixturesDir);
         $this->assertSame(
-            ['diocesan_calendar_test', 'lugano_ch'],
+            ['diocesan_calendar_test', 'ambrosian/lugano_ch'],
             $r->resolveFromPayload(['applies_to' => ['rite' => 'ambrosian', 'diocesan_calendar' => 'lugano_ch']])
         );
+    }
+
+    public function testTheSameDioceseUnderTwoRitesGetsTwoDistinctScopes(): void
+    {
+        $r     = new TestScopeResolver($this->fixturesDir);
+        $ambro = $r->resolveFromPayload(['applies_to' => ['rite' => 'ambrosian', 'diocesan_calendar' => 'lugano_ch']]);
+        $roman = $r->resolveFromPayload(['applies_to' => ['rite' => 'roman', 'diocesan_calendar' => 'lugano_ch']]);
+
+        $this->assertNotSame($ambro, $roman);
+        $this->assertSame(['diocesan_calendar_test', 'ambrosian/lugano_ch'], $ambro);
+        $this->assertSame(['diocesan_calendar_test', 'roman/lugano_ch'], $roman);
+    }
+
+    public function testQualifyAndParseRoundTrip(): void
+    {
+        $qualified = TestScopeResolver::qualify(Rite::AMBROSIAN, 'lugano_ch');
+        $this->assertSame('ambrosian/lugano_ch', $qualified);
+        $this->assertSame([Rite::AMBROSIAN, 'lugano_ch'], TestScopeResolver::parseQualifiedId($qualified));
+    }
+
+    public function testParseQualifiedIdRejectsUnqualifiedAndUnknownRites(): void
+    {
+        $this->assertNull(TestScopeResolver::parseQualifiedId('rotter_nl'));
+        $this->assertNull(TestScopeResolver::parseQualifiedId('byzantine/foo'));
+        $this->assertNull(TestScopeResolver::parseQualifiedId('roman/'));
     }
 
     public function testResolveFromPayloadReturnsNullForNonArray(): void

--- a/phpunit_tests/Services/TestTupleMigrationTest.php
+++ b/phpunit_tests/Services/TestTupleMigrationTest.php
@@ -20,7 +20,7 @@ final class TestTupleMigrationTest extends TestCase
     }
 
     /**
-     * A `test_definition:FooTest` tuple must remap to `diocesan_calendar_test:rotter_nl`
+     * A `test_definition:FooTest` tuple must remap to `diocesan_calendar_test:roman/rotter_nl`
      * when FooTest.json carries `applies_to.diocesan_calendar = "rotter_nl"`.
      */
     public function testMapsTupleToDiocesanScope(): void
@@ -40,7 +40,7 @@ final class TestTupleMigrationTest extends TestCase
             [
                 'user'     => 'user:1',
                 'relation' => 'editor',
-                'object'   => 'diocesan_calendar_test:rotter_nl',
+                'object'   => 'diocesan_calendar_test:roman/rotter_nl',
             ],
             $result
         );

--- a/phpunit_tests/Test/LitTestRunnerTest.php
+++ b/phpunit_tests/Test/LitTestRunnerTest.php
@@ -51,9 +51,9 @@ final class LitTestRunnerTest extends TestCase
      * Build a minimal calendar response with the given litcal events and year.
      *
      * The LitTestRunner only reads `settings->year`, optional
-     * `settings->national_calendar` / `settings->diocesan_calendar`, and
-     * the `litcal` array. Anything else gets passed through into the
-     * `jsonData` attachment but isn't inspected.
+     * `settings->rite` / `settings->national_calendar` /
+     * `settings->diocesan_calendar`, and the `litcal` array. Anything else
+     * gets passed through into the `jsonData` attachment but isn't inspected.
      *
      * @param array<int,\stdClass> $litcal
      */
@@ -200,6 +200,66 @@ final class LitTestRunnerTest extends TestCase
         $msg = $runner->getMessage();
         $this->assertSame('success', $msg->type);
         $this->assertStringContainsString('Calendar US', $msg->text);
+    }
+
+    public function testRiteMismatchIsReportedAsASingleError(): void
+    {
+        // MaryMotherChurchTest is scoped to the Roman rite. Handing it an
+        // Ambrosian calendar must produce one clear diagnostic rather than a
+        // wall of failed assertions — the failure mode behind issue #767.
+        $data                 = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2019-06-10T00:00:00+00:00'],
+        ]);
+        $data->settings->rite = 'ambrosian';
+
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $msg = $runner->getMessage();
+        $this->assertSame('error', $msg->type);
+        $this->assertStringContainsString('is scoped to the roman rite', $msg->text);
+        $this->assertStringContainsString('computed under the ambrosian rite', $msg->text);
+    }
+
+    public function testMatchingRitePassesTheGuard(): void
+    {
+        $data                 = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2019-06-10T00:00:00+00:00'],
+        ]);
+        $data->settings->rite = 'roman';
+
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $this->assertSame('success', $runner->getMessage()->type);
+    }
+
+    public function testUnknownRiteInResponseIsIgnoredByTheGuard(): void
+    {
+        // A rite the API does not know is not a mismatch we can reason about;
+        // the assertions still run rather than being masked by a guard error.
+        $data                 = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2019-06-10T00:00:00+00:00'],
+        ]);
+        $data->settings->rite = 'byzantine';
+
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $this->assertSame('success', $runner->getMessage()->type);
+    }
+
+    public function testRiteLevelCalendarIsNamedByItsRite(): void
+    {
+        $data                 = $this->calendarPayload(2019, [
+            (object) ['event_key' => 'MaryMotherChurch', 'date' => '2019-06-10T00:00:00+00:00'],
+        ]);
+        $data->settings->rite = 'roman';
+
+        $runner = new LitTestRunner('MaryMotherChurchTest', $data);
+        $runner->runTest();
+
+        $this->assertStringContainsString('the General Roman Calendar', $runner->getMessage()->text);
     }
 
     public function testDiocesanCalendarSettingsAppearInMessageText(): void

--- a/phpunit_tests/Test/TestItemTest.php
+++ b/phpunit_tests/Test/TestItemTest.php
@@ -207,6 +207,29 @@ final class TestItemTest extends TestCase
         new TestItem($obj);
     }
 
+    public function testRejectsAmbrosianNationalCalendarScope(): void
+    {
+        // /calendar/ambrosian/nation/{id} is a 400 — the Ambrosian rite has no
+        // national calendars — so this scope must be rejected at validation time
+        // rather than at request time.
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['rite' => 'ambrosian', 'national_calendar' => 'IT'];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`national_calendar` is not valid for the ambrosian rite');
+        new TestItem($obj);
+    }
+
+    public function testRejectsAmbrosianNationalCalendarsScope(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['rite' => 'ambrosian', 'national_calendars' => ['IT']];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`national_calendars` is not valid for the ambrosian rite');
+        new TestItem($obj);
+    }
+
     public function testStoresAmbrosianRite(): void
     {
         $obj             = $this->baseObject();

--- a/phpunit_tests/Test/TestItemTest.php
+++ b/phpunit_tests/Test/TestItemTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Test;
 
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Test\TestItem;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,7 @@ final class TestItemTest extends TestCase
             'event_key'   => 'sample_event',
             'description' => 'sample',
             'test_type'   => 'exactCorrespondenceSince',
+            'applies_to'  => (object) ['rite' => 'roman'],
             'assertions'  => [
                 (object) [
                     'year'           => 2020,
@@ -51,7 +53,9 @@ final class TestItemTest extends TestCase
         $this->assertSame('exactCorrespondenceSince', $item->test_type);
         $this->assertNull($item->year_since);
         $this->assertNull($item->year_until);
-        $this->assertNull($item->applies_to);
+        $this->assertSame(Rite::ROMAN, $item->rite);
+        $this->assertIsObject($item->applies_to);
+        $this->assertSame('roman', $item->applies_to->rite);
         $this->assertNull($item->excludes);
     }
 
@@ -70,7 +74,7 @@ final class TestItemTest extends TestCase
     public function testStoresAppliesToAndExcludesObjects(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['national_calendar' => 'US'];
+        $obj->applies_to = (object) ['rite' => 'roman', 'national_calendar' => 'US'];
         $obj->excludes   = (object) ['diocesan_calendar' => 'rotter_nl'];
 
         $item = new TestItem($obj);
@@ -84,7 +88,7 @@ final class TestItemTest extends TestCase
     public function testAcceptsArrayFormNationalCalendars(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['national_calendars' => ['US', 'IT']];
+        $obj->applies_to = (object) ['rite' => 'roman', 'national_calendars' => ['US', 'IT']];
 
         $item = new TestItem($obj);
 
@@ -95,7 +99,7 @@ final class TestItemTest extends TestCase
     public function testAcceptsArrayFormDiocesanCalendars(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['diocesan_calendars' => ['rotter_nl', 'romamo_it']];
+        $obj->applies_to = (object) ['rite' => 'roman', 'diocesan_calendars' => ['rotter_nl', 'romamo_it']];
 
         $item = new TestItem($obj);
 
@@ -163,20 +167,84 @@ final class TestItemTest extends TestCase
         new TestItem($obj);
     }
 
-    public function testThrowsWhenAppliesToHasNoRecognisedKey(): void
+    public function testThrowsWhenAppliesToHasNoRite(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['unrelated_key' => 'whatever'];
+        $obj->applies_to = (object) ['national_calendar' => 'US'];
 
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('`applies_to` must have at least one of the properties');
+        $this->expectExceptionMessage('`applies_to` must have a `rite` property');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenAppliesToIsMissingEntirely(): void
+    {
+        $obj = $this->baseObject();
+        unset($obj->applies_to);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Missing required property: applies_to');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenRiteIsNotAString(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['rite' => 1];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`rite` must have a string value');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenRiteIsUnknown(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['rite' => 'byzantine'];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`rite` has an unknown value `byzantine`');
+        new TestItem($obj);
+    }
+
+    public function testStoresAmbrosianRite(): void
+    {
+        $obj             = $this->baseObject();
+        $obj->applies_to = (object) ['rite' => 'ambrosian', 'diocesan_calendar' => 'lugano_ch'];
+
+        $item = new TestItem($obj);
+
+        $this->assertSame(Rite::AMBROSIAN, $item->rite);
+        $this->assertIsObject($item->applies_to);
+        $this->assertSame('lugano_ch', $item->applies_to->diocesan_calendar);
+    }
+
+    public function testThrowsWhenExcludesCarriesARite(): void
+    {
+        // The rite is pinned by applies_to; excluding one is meaningless and
+        // would leave the test with nothing to run against.
+        $obj           = $this->baseObject();
+        $obj->excludes = (object) ['rite' => 'ambrosian'];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`excludes` must not have a `rite` property');
+        new TestItem($obj);
+    }
+
+    public function testThrowsWhenExcludesHasNoRecognisedKey(): void
+    {
+        $obj           = $this->baseObject();
+        $obj->excludes = (object) ['unrelated_key' => 'whatever'];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('`excludes` must have at least one of the properties');
         new TestItem($obj);
     }
 
     public function testThrowsWhenNationalCalendarIsNotString(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['national_calendar' => 123];
+        $obj->applies_to = (object) ['rite' => 'roman', 'national_calendar' => 123];
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('`national_calendar` must have a string value');
@@ -186,7 +254,7 @@ final class TestItemTest extends TestCase
     public function testThrowsWhenDiocesanCalendarIsNotString(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['diocesan_calendar' => 123];
+        $obj->applies_to = (object) ['rite' => 'roman', 'diocesan_calendar' => 123];
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('`diocesan_calendar` must have a string value');
@@ -196,7 +264,7 @@ final class TestItemTest extends TestCase
     public function testThrowsWhenNationalCalendarsIsNotArray(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['national_calendars' => 'US'];
+        $obj->applies_to = (object) ['rite' => 'roman', 'national_calendars' => 'US'];
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('`national_calendars` must have an array value');
@@ -206,7 +274,7 @@ final class TestItemTest extends TestCase
     public function testThrowsWhenNationalCalendarsContainsNonString(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['national_calendars' => ['US', 123]];
+        $obj->applies_to = (object) ['rite' => 'roman', 'national_calendars' => ['US', 123]];
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('`national_calendars` must have an array of strings');
@@ -216,7 +284,7 @@ final class TestItemTest extends TestCase
     public function testThrowsWhenDiocesanCalendarsIsNotArray(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['diocesan_calendars' => 'rotter_nl'];
+        $obj->applies_to = (object) ['rite' => 'roman', 'diocesan_calendars' => 'rotter_nl'];
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('`diocesan_calendars` must have an array value');
@@ -226,7 +294,7 @@ final class TestItemTest extends TestCase
     public function testThrowsWhenDiocesanCalendarsContainsNonString(): void
     {
         $obj             = $this->baseObject();
-        $obj->applies_to = (object) ['diocesan_calendars' => ['rotter_nl', 0]];
+        $obj->applies_to = (object) ['rite' => 'roman', 'diocesan_calendars' => ['rotter_nl', 0]];
 
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('`diocesan_calendars` must have an array of strings');

--- a/phpunit_tests/Test/TestsMapTest.php
+++ b/phpunit_tests/Test/TestsMapTest.php
@@ -38,6 +38,7 @@ final class TestsMapTest extends TestCase
             'event_key'   => 'evt',
             'description' => 'd',
             'test_type'   => 'exactCorrespondenceSince',
+            'applies_to'  => (object) ['rite' => 'roman'],
             'assertions'  => $assertions,
         ];
     }

--- a/phpunit_tests/fixtures/tests/AmbrosianDioceseTest.json
+++ b/phpunit_tests/fixtures/tests/AmbrosianDioceseTest.json
@@ -1,0 +1,9 @@
+{
+    "name": "AmbrosianDioceseTest",
+    "event_key": "AmbrosianDioceseEvent",
+    "applies_to": {
+        "rite": "ambrosian",
+        "diocesan_calendar": "lugano_ch"
+    },
+    "assertions": []
+}

--- a/scripts/migrate-rite-test-tuples.php
+++ b/scripts/migrate-rite-test-tuples.php
@@ -1,0 +1,188 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Idempotent migration: copy every `general_roman_calendar_test` OpenFGA tuple
+ * onto the generalised `rite_calendar_test:roman` object (issue #767).
+ *
+ * `general_roman_calendar_test` had exactly one id, `general_roman_calendar`,
+ * denoting the Roman rite-level calendar. Once rites became a first-class scope
+ * that type could no longer name the Ambrosian rite-level calendar, so
+ * `TestScopeResolver` now emits `rite_calendar_test:<rite>` instead. Existing
+ * grants have to follow, or every current test editor silently loses access.
+ *
+ * Usage:
+ *   php scripts/migrate-rite-test-tuples.php [--dry-run|--apply] [--prune]
+ *
+ * Flags:
+ *   --dry-run  (default) Print what WOULD be done without touching the store.
+ *   --apply             Write the new tuples in OpenFGA.
+ *   --prune             Additionally DELETE the old general_roman_calendar_test
+ *                       tuples. Off by default: the old type stays in the model
+ *                       and in every PHP allow-list so a rollback to pre-#767
+ *                       code keeps authorizing. Only prune once every
+ *                       deployment runs merged code.
+ *
+ * Safety guarantees:
+ *   - Copy-then-prune ordering: a tuple is never deleted before its replacement
+ *     is confirmed written.
+ *   - Writing a tuple that already exists is benign (TupleAlreadyExistsException
+ *     is caught and treated as a no-op).
+ *   - Deleting a tuple that no longer exists is benign (TupleNotFoundException
+ *     is caught and treated as a no-op).
+ *   - The script is safe to re-run after a partial migration.
+ *
+ * Required environment variables (loaded from .env* files if present):
+ *   OPENFGA_API_URL, OPENFGA_STORE_ID, OPENFGA_MODEL_ID
+ *
+ * Optional:
+ *   OPENFGA_API_TOKEN
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+use Dotenv\Dotenv;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+
+const LEGACY_OBJECT = 'general_roman_calendar_test:general_roman_calendar';
+const LEGACY_PREFIX = 'general_roman_calendar_test:';
+
+// ---------------------------------------------------------------------------
+// Bootstrap: load environment from .env* files if present
+// ---------------------------------------------------------------------------
+$projectRoot = dirname(__DIR__);
+$dotenv      = Dotenv::createImmutable(
+    $projectRoot,
+    ['.env', '.env.local', '.env.development', '.env.test', '.env.staging', '.env.production'],
+    false
+);
+$dotenv->safeLoad();
+
+// ---------------------------------------------------------------------------
+// Argument parsing: --apply enables writes; default is --dry-run
+// ---------------------------------------------------------------------------
+$apply  = in_array('--apply', $argv, true);
+$prune  = in_array('--prune', $argv, true);
+$dryRun = !$apply;
+
+$modeName = $dryRun ? 'DRY RUN' : 'APPLY';
+$modeHint = $dryRun ? ' (pass --apply to apply changes)' : '';
+echo "Mode: {$modeName}{$modeHint}" . PHP_EOL;
+echo 'Prune legacy tuples: ' . ( $prune ? 'YES' : 'no (copy only)' ) . PHP_EOL;
+echo PHP_EOL;
+
+// ---------------------------------------------------------------------------
+// Dependency setup
+// ---------------------------------------------------------------------------
+if (!OpenFgaClient::isConfigured()) {
+    fwrite(STDERR, "Error: OpenFGA is not configured. Set OPENFGA_API_URL, OPENFGA_STORE_ID, and OPENFGA_MODEL_ID.\n");
+    exit(1);
+}
+
+$client = OpenFgaClient::fromEnv();
+
+// ---------------------------------------------------------------------------
+// Enumerate all general_roman_calendar_test tuples (paginated)
+//
+// Read ALL tuples (empty user + empty object = no filter) and filter in app
+// code, mirroring scripts/migrate-test-tuples.php: the type-only object filter
+// is not reliably valid per the OpenFGA Read API spec.
+// ---------------------------------------------------------------------------
+/** @var list<array{user: string, relation: string, object: string}> $allTuples */
+$allTuples         = [];
+$continuationToken = null;
+
+do {
+    $page              = $client->readTuples('', '', null, null, $continuationToken);
+    $allTuples         = array_merge($allTuples, $page['tuples']);
+    $continuationToken = $page['next_continuation_token'] !== '' ? $page['next_continuation_token'] : null;
+} while ($continuationToken !== null);
+
+$legacyTuples = array_values(
+    array_filter($allTuples, static fn (array $t): bool => str_starts_with($t['object'], LEGACY_PREFIX))
+);
+
+$totalCount   = count($legacyTuples);
+$copiedCount  = 0;
+$prunedCount  = 0;
+$skippedCount = 0;
+
+/** @var list<string> $unexpectedObjects */
+$unexpectedObjects = [];
+
+$newObject = 'rite_calendar_test:' . Rite::ROMAN->value;
+
+// ---------------------------------------------------------------------------
+// Process each tuple
+// ---------------------------------------------------------------------------
+foreach ($legacyTuples as $tuple) {
+    // The legacy type only ever had one id. Anything else is unexpected data we
+    // must not guess a rite for, so report it and leave it alone.
+    if ($tuple['object'] !== LEGACY_OBJECT) {
+        ++$skippedCount;
+        $unexpectedObjects[] = $tuple['object'];
+        echo "[SKIPPED] {$tuple['object']} (unexpected id for the legacy type — leaving untouched)" . PHP_EOL;
+        continue;
+    }
+
+    if ($dryRun) {
+        ++$copiedCount;
+        echo "[DRY RUN] {$tuple['user']} {$tuple['relation']} {$tuple['object']} → {$newObject}" . PHP_EOL;
+        if ($prune) {
+            echo "[DRY RUN] would then delete {$tuple['user']} {$tuple['relation']} {$tuple['object']}" . PHP_EOL;
+        }
+        continue;
+    }
+
+    // --- APPLY: write the new tuple first; only then optionally prune the old ---
+
+    try {
+        $client->writeTuple($tuple['user'], $tuple['relation'], $newObject);
+        echo "[COPIED] {$tuple['user']} {$tuple['relation']} {$tuple['object']} → {$newObject}" . PHP_EOL;
+    } catch (TupleAlreadyExistsException) {
+        echo "[ALREADY EXISTS] {$tuple['user']} {$tuple['relation']} {$newObject} — write skipped" . PHP_EOL;
+    }
+    ++$copiedCount;
+
+    if (!$prune) {
+        continue;
+    }
+
+    try {
+        $client->deleteTuple($tuple['user'], $tuple['relation'], $tuple['object']);
+        ++$prunedCount;
+        echo "[PRUNED] {$tuple['user']} {$tuple['relation']} {$tuple['object']}" . PHP_EOL;
+    } catch (TupleNotFoundException) {
+        // Old tuple was already removed in a previous run — benign.
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+$copiedLabel = $dryRun ? 'Would copy' : 'Copied';
+
+echo PHP_EOL;
+echo 'Summary:' . PHP_EOL;
+echo sprintf("  Total legacy tuples : %d\n", $totalCount);
+echo sprintf("  %-20s: %d\n", $copiedLabel, $copiedCount);
+if ($prune) {
+    echo sprintf("  %-20s: %d\n", $dryRun ? 'Would prune' : 'Pruned', $prunedCount);
+}
+echo sprintf("  %-20s: %d\n", 'Skipped', $skippedCount);
+
+if ($unexpectedObjects !== []) {
+    echo PHP_EOL;
+    echo 'Unexpected legacy object ids (left untouched):' . PHP_EOL;
+    foreach (array_unique($unexpectedObjects) as $object) {
+        echo "  - {$object}" . PHP_EOL;
+    }
+}
+
+echo PHP_EOL;
+exit($skippedCount > 0 ? 2 : 0);

--- a/scripts/migrate-rite-test-tuples.php
+++ b/scripts/migrate-rite-test-tuples.php
@@ -2,14 +2,27 @@
 <?php
 
 /**
- * Idempotent migration: copy every `general_roman_calendar_test` OpenFGA tuple
- * onto the generalised `rite_calendar_test:roman` object (issue #767).
+ * Idempotent migration: bring every scoped-test OpenFGA tuple onto its
+ * rite-qualified successor (issue #767).
  *
- * `general_roman_calendar_test` had exactly one id, `general_roman_calendar`,
- * denoting the Roman rite-level calendar. Once rites became a first-class scope
- * that type could no longer name the Ambrosian rite-level calendar, so
- * `TestScopeResolver` now emits `rite_calendar_test:<rite>` instead. Existing
- * grants have to follow, or every current test editor silently loses access.
+ * Three remappings, all of them because a scope has to name a rite:
+ *
+ *   general_roman_calendar_test:general_roman_calendar → rite_calendar_test:roman
+ *   national_calendar_test:<id>                        → national_calendar_test:<rite>/<id>
+ *   diocesan_calendar_test:<id>                        → diocesan_calendar_test:<rite>/<id>
+ *
+ * `general_roman_calendar_test` had exactly one id, denoting the Roman rite-level
+ * calendar; it cannot name the Ambrosian one, so `rite_calendar_test` replaces it.
+ * The national and diocesan types keep their names but gain a rite-qualified id,
+ * because a bare calendar id is ambiguous: the source tree is partitioned as
+ * `jsondata/sourcedata/rite/{rite}/calendars/...`, so `lugano_ch` could name an
+ * Ambrosian calendar or a Roman one. Existing grants have to follow, or every
+ * current test editor silently loses access.
+ *
+ * The rite of an existing national/diocesan tuple is inferred from that same
+ * source tree, which is the authority on which rite a calendar is defined under.
+ * A calendar id that is defined under two rites is reported and skipped — the
+ * script never guesses which grant was meant.
  *
  * Usage:
  *   php scripts/migrate-rite-test-tuples.php [--dry-run|--apply] [--prune]
@@ -17,11 +30,10 @@
  * Flags:
  *   --dry-run  (default) Print what WOULD be done without touching the store.
  *   --apply             Write the new tuples in OpenFGA.
- *   --prune             Additionally DELETE the old general_roman_calendar_test
- *                       tuples. Off by default: the old type stays in the model
- *                       and in every PHP allow-list so a rollback to pre-#767
- *                       code keeps authorizing. Only prune once every
- *                       deployment runs merged code.
+ *   --prune             Additionally DELETE the superseded tuples. Off by
+ *                       default: the legacy type and the unqualified ids stay
+ *                       valid so a rollback to pre-#767 code keeps authorizing.
+ *                       Only prune once every deployment runs merged code.
  *
  * Safety guarantees:
  *   - Copy-then-prune ordering: a tuple is never deleted before its replacement
@@ -30,6 +42,7 @@
  *     is caught and treated as a no-op).
  *   - Deleting a tuple that no longer exists is benign (TupleNotFoundException
  *     is caught and treated as a no-op).
+ *   - Already-migrated tuples are recognised and left alone.
  *   - The script is safe to re-run after a partial migration.
  *
  * Required environment variables (loaded from .env* files if present):
@@ -48,15 +61,19 @@ use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
 use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\TestScopeResolver;
 
-const LEGACY_OBJECT = 'general_roman_calendar_test:general_roman_calendar';
-const LEGACY_PREFIX = 'general_roman_calendar_test:';
+const LEGACY_GRC_OBJECT = 'general_roman_calendar_test:general_roman_calendar';
+const LEGACY_GRC_PREFIX = 'general_roman_calendar_test:';
+const NATIONAL_PREFIX   = 'national_calendar_test:';
+const DIOCESAN_PREFIX   = 'diocesan_calendar_test:';
+
+$projectRoot = dirname(__DIR__);
 
 // ---------------------------------------------------------------------------
 // Bootstrap: load environment from .env* files if present
 // ---------------------------------------------------------------------------
-$projectRoot = dirname(__DIR__);
-$dotenv      = Dotenv::createImmutable(
+$dotenv = Dotenv::createImmutable(
     $projectRoot,
     ['.env', '.env.local', '.env.development', '.env.test', '.env.staging', '.env.production'],
     false
@@ -70,11 +87,58 @@ $apply  = in_array('--apply', $argv, true);
 $prune  = in_array('--prune', $argv, true);
 $dryRun = !$apply;
 
-$modeName = $dryRun ? 'DRY RUN' : 'APPLY';
-$modeHint = $dryRun ? ' (pass --apply to apply changes)' : '';
-echo "Mode: {$modeName}{$modeHint}" . PHP_EOL;
-echo 'Prune legacy tuples: ' . ( $prune ? 'YES' : 'no (copy only)' ) . PHP_EOL;
+echo 'Mode: ' . ( $dryRun ? 'DRY RUN (pass --apply to apply changes)' : 'APPLY' ) . PHP_EOL;
+echo 'Prune superseded tuples: ' . ( $prune ? 'YES' : 'no (copy only)' ) . PHP_EOL;
 echo PHP_EOL;
+
+/**
+ * Rites under which a diocesan calendar of the given id is defined on disk.
+ *
+ * Closures rather than named functions: this file is a script whose job is side
+ * effects, and PSR-1 asks a file to declare symbols or execute logic, not both.
+ *
+ * @var callable(string): list<Rite> $ritesDefiningDiocese
+ */
+$ritesDefiningDiocese = static function (string $calendarId) use ($projectRoot): array {
+    $found = [];
+    foreach (Rite::cases() as $rite) {
+        $matches = glob(
+            sprintf(
+                '%s/jsondata/sourcedata/rite/%s/calendars/dioceses/*/%s',
+                $projectRoot,
+                $rite->value,
+                $calendarId
+            ),
+            GLOB_ONLYDIR
+        );
+        if ($matches !== false && $matches !== []) {
+            $found[] = $rite;
+        }
+    }
+    return $found;
+};
+
+/**
+ * Rites under which a national calendar of the given id is defined on disk.
+ *
+ * @var callable(string): list<Rite> $ritesDefiningNation
+ */
+$ritesDefiningNation = static function (string $calendarId) use ($projectRoot): array {
+    $found = [];
+    foreach (Rite::cases() as $rite) {
+        $file = sprintf(
+            '%s/jsondata/sourcedata/rite/%s/calendars/nations/%s/%s.json',
+            $projectRoot,
+            $rite->value,
+            $calendarId,
+            $calendarId
+        );
+        if (is_file($file)) {
+            $found[] = $rite;
+        }
+    }
+    return $found;
+};
 
 // ---------------------------------------------------------------------------
 // Dependency setup
@@ -87,7 +151,7 @@ if (!OpenFgaClient::isConfigured()) {
 $client = OpenFgaClient::fromEnv();
 
 // ---------------------------------------------------------------------------
-// Enumerate all general_roman_calendar_test tuples (paginated)
+// Enumerate every tuple (paginated)
 //
 // Read ALL tuples (empty user + empty object = no filter) and filter in app
 // code, mirroring scripts/migrate-test-tuples.php: the type-only object filter
@@ -103,38 +167,70 @@ do {
     $continuationToken = $page['next_continuation_token'] !== '' ? $page['next_continuation_token'] : null;
 } while ($continuationToken !== null);
 
-$legacyTuples = array_values(
-    array_filter($allTuples, static fn (array $t): bool => str_starts_with($t['object'], LEGACY_PREFIX))
-);
+$candidates = array_values(array_filter($allTuples, static function (array $t): bool {
+    return str_starts_with($t['object'], LEGACY_GRC_PREFIX)
+        || str_starts_with($t['object'], NATIONAL_PREFIX)
+        || str_starts_with($t['object'], DIOCESAN_PREFIX);
+}));
 
-$totalCount   = count($legacyTuples);
 $copiedCount  = 0;
 $prunedCount  = 0;
 $skippedCount = 0;
+$alreadyCount = 0;
 
-/** @var list<string> $unexpectedObjects */
-$unexpectedObjects = [];
-
-$newObject = 'rite_calendar_test:' . Rite::ROMAN->value;
+/** @var list<string> $unresolved */
+$unresolved = [];
 
 // ---------------------------------------------------------------------------
 // Process each tuple
 // ---------------------------------------------------------------------------
-foreach ($legacyTuples as $tuple) {
-    // The legacy type only ever had one id. Anything else is unexpected data we
-    // must not guess a rite for, so report it and leave it alone.
-    if ($tuple['object'] !== LEGACY_OBJECT) {
-        ++$skippedCount;
-        $unexpectedObjects[] = $tuple['object'];
-        echo "[SKIPPED] {$tuple['object']} (unexpected id for the legacy type — leaving untouched)" . PHP_EOL;
-        continue;
+foreach ($candidates as $tuple) {
+    $object   = $tuple['object'];
+    $colonPos = (int) strpos($object, ':');
+    $type     = substr($object, 0, $colonPos);
+    $objectId = substr($object, $colonPos + 1);
+
+    $newObject = null;
+
+    if ($type === 'general_roman_calendar_test') {
+        // The legacy type only ever had one id. Anything else is unexpected data
+        // we must not guess a rite for.
+        if ($object !== LEGACY_GRC_OBJECT) {
+            ++$skippedCount;
+            $unresolved[] = "{$object} (unexpected id for the legacy type)";
+            echo "[SKIPPED] {$object} — unexpected id for the legacy type, leaving untouched" . PHP_EOL;
+            continue;
+        }
+        $newObject = 'rite_calendar_test:' . Rite::ROMAN->value;
+    } else {
+        if (null !== TestScopeResolver::parseQualifiedId($objectId)) {
+            ++$alreadyCount;
+            echo "[ALREADY QUALIFIED] {$object}" . PHP_EOL;
+            continue;
+        }
+
+        $rites = $type === 'diocesan_calendar_test'
+            ? $ritesDefiningDiocese($objectId)
+            : $ritesDefiningNation($objectId);
+
+        if (count($rites) !== 1) {
+            ++$skippedCount;
+            $reason       = $rites === []
+                ? 'no calendar of that id is defined under any rite'
+                : 'defined under more than one rite: ' . implode(', ', array_column($rites, 'value'));
+            $unresolved[] = "{$object} ({$reason})";
+            echo "[SKIPPED] {$object} — {$reason}, leaving untouched" . PHP_EOL;
+            continue;
+        }
+
+        $newObject = $type . ':' . TestScopeResolver::qualify($rites[0], $objectId);
     }
 
     if ($dryRun) {
         ++$copiedCount;
-        echo "[DRY RUN] {$tuple['user']} {$tuple['relation']} {$tuple['object']} → {$newObject}" . PHP_EOL;
+        echo "[DRY RUN] {$tuple['user']} {$tuple['relation']} {$object} → {$newObject}" . PHP_EOL;
         if ($prune) {
-            echo "[DRY RUN] would then delete {$tuple['user']} {$tuple['relation']} {$tuple['object']}" . PHP_EOL;
+            echo "[DRY RUN] would then delete {$tuple['user']} {$tuple['relation']} {$object}" . PHP_EOL;
         }
         continue;
     }
@@ -143,7 +239,7 @@ foreach ($legacyTuples as $tuple) {
 
     try {
         $client->writeTuple($tuple['user'], $tuple['relation'], $newObject);
-        echo "[COPIED] {$tuple['user']} {$tuple['relation']} {$tuple['object']} → {$newObject}" . PHP_EOL;
+        echo "[COPIED] {$tuple['user']} {$tuple['relation']} {$object} → {$newObject}" . PHP_EOL;
     } catch (TupleAlreadyExistsException) {
         echo "[ALREADY EXISTS] {$tuple['user']} {$tuple['relation']} {$newObject} — write skipped" . PHP_EOL;
     }
@@ -154,9 +250,9 @@ foreach ($legacyTuples as $tuple) {
     }
 
     try {
-        $client->deleteTuple($tuple['user'], $tuple['relation'], $tuple['object']);
+        $client->deleteTuple($tuple['user'], $tuple['relation'], $object);
         ++$prunedCount;
-        echo "[PRUNED] {$tuple['user']} {$tuple['relation']} {$tuple['object']}" . PHP_EOL;
+        echo "[PRUNED] {$tuple['user']} {$tuple['relation']} {$object}" . PHP_EOL;
     } catch (TupleNotFoundException) {
         // Old tuple was already removed in a previous run — benign.
     }
@@ -165,22 +261,21 @@ foreach ($legacyTuples as $tuple) {
 // ---------------------------------------------------------------------------
 // Summary
 // ---------------------------------------------------------------------------
-$copiedLabel = $dryRun ? 'Would copy' : 'Copied';
-
 echo PHP_EOL;
 echo 'Summary:' . PHP_EOL;
-echo sprintf("  Total legacy tuples : %d\n", $totalCount);
-echo sprintf("  %-20s: %d\n", $copiedLabel, $copiedCount);
+echo sprintf("  Candidate tuples    : %d\n", count($candidates));
+echo sprintf("  %-20s: %d\n", $dryRun ? 'Would copy' : 'Copied', $copiedCount);
 if ($prune) {
     echo sprintf("  %-20s: %d\n", $dryRun ? 'Would prune' : 'Pruned', $prunedCount);
 }
+echo sprintf("  %-20s: %d\n", 'Already qualified', $alreadyCount);
 echo sprintf("  %-20s: %d\n", 'Skipped', $skippedCount);
 
-if ($unexpectedObjects !== []) {
+if ($unresolved !== []) {
     echo PHP_EOL;
-    echo 'Unexpected legacy object ids (left untouched):' . PHP_EOL;
-    foreach (array_unique($unexpectedObjects) as $object) {
-        echo "  - {$object}" . PHP_EOL;
+    echo 'Left untouched (resolve by hand):' . PHP_EOL;
+    foreach (array_unique($unresolved) as $entry) {
+        echo "  - {$entry}" . PHP_EOL;
     }
 }
 

--- a/scripts/openfga-model.additive.json
+++ b/scripts/openfga-model.additive.json
@@ -273,6 +273,38 @@
           "deleter": { "directly_related_user_types": [{ "type": "user" }] }
         }
       }
+    },
+    {
+      "type": "rite_calendar_test",
+      "relations": {
+        "admin": { "this": {} },
+        "editor": {
+          "union": {
+            "child": [
+              { "this": {} },
+              { "computedUserset": { "relation": "admin" } }
+            ]
+          }
+        },
+        "viewer": {
+          "union": {
+            "child": [
+              { "this": {} },
+              { "computedUserset": { "relation": "editor" } },
+              { "computedUserset": { "relation": "admin" } }
+            ]
+          }
+        },
+        "deleter": { "this": {} }
+      },
+      "metadata": {
+        "relations": {
+          "admin":   { "directly_related_user_types": [{ "type": "user" }] },
+          "editor":  { "directly_related_user_types": [{ "type": "user" }] },
+          "viewer":  { "directly_related_user_types": [{ "type": "user" }] },
+          "deleter": { "directly_related_user_types": [{ "type": "user" }] }
+        }
+      }
     }
   ]
 }

--- a/src/Handlers/Auth/AccessRequestHandler.php
+++ b/src/Handlers/Auth/AccessRequestHandler.php
@@ -224,12 +224,7 @@ final class AccessRequestHandler extends AbstractHandler
             }
 
             if (!AccessRequestRepository::isValidObjectIdForType($objectType, $objectId)) {
-                // general_roman_calendar_test accepts only the literal id
-                // 'general_roman_calendar'. All other types that reach this branch
-                // are general_roman_calendar itself, whose valid ids are the GRC set.
-                $validIdsLabel = $objectType === 'general_roman_calendar_test'
-                    ? 'general_roman_calendar'
-                    : implode(', ', AccessRequestRepository::GRC_OBJECT_IDS);
+                $validIdsLabel = AccessRequestRepository::validIdsLabelForType($objectType);
                 throw new ValidationException(
                     sprintf(
                         'permissions[%d].object_id "%s" is invalid for object_type "%s". Valid ids: %s',
@@ -395,12 +390,7 @@ final class AccessRequestHandler extends AbstractHandler
             }
 
             if (!AccessRequestRepository::isValidObjectIdForType($objType, $objId)) {
-                // general_roman_calendar_test accepts only the literal id
-                // 'general_roman_calendar'. All other types that reach this branch
-                // are general_roman_calendar itself, whose valid ids are the GRC set.
-                $validIdsLabel = $objType === 'general_roman_calendar_test'
-                    ? 'general_roman_calendar'
-                    : implode(', ', AccessRequestRepository::GRC_OBJECT_IDS);
+                $validIdsLabel = AccessRequestRepository::validIdsLabelForType($objType);
                 throw new ValidationException(sprintf(
                     'permissions[%d].object_id "%s" is invalid for object_type "%s". Valid ids: %s',
                     $index,

--- a/src/Handlers/TestsHandler.php
+++ b/src/Handlers/TestsHandler.php
@@ -34,6 +34,7 @@ final class TestsHandler extends AbstractHandler
         'applies_to',
         'excludes',
         'assertions',
+        'rite',
         'national_calendar',
         'diocesan_calendar',
         'national_calendars',

--- a/src/Health.php
+++ b/src/Health.php
@@ -19,6 +19,7 @@ use LiturgicalCalendar\Api\Enum\ICSErrorLevel;
 use LiturgicalCalendar\Api\Enum\LitSchema;
 use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
@@ -46,8 +47,8 @@ use Psr\Http\Message\ResponseInterface;
  * @phpstan-type ExecuteValidationSourceFolder \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFolder:string}
  * @phpstan-type ExecuteValidationSourceFile \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFile:string}
  * @phpstan-type ExecuteValidationResource \stdClass&object{action:'executeValidation',category:'resourceDataCheck',validate:string,sourceFile:string}
- * @phpstan-type ValidateCalendar \stdClass&object{action:'validateCalendar',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar',responsetype:'JSON'|'XML'|'ICS'|'YML'}
- * @phpstan-type ExecuteUnitTest \stdClass&object{action:'executeUnitTest',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar',test:string}
+ * @phpstan-type ValidateCalendar \stdClass&object{action:'validateCalendar',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',responsetype:'JSON'|'XML'|'ICS'|'YML',rite?:string}
+ * @phpstan-type ExecuteUnitTest \stdClass&object{action:'executeUnitTest',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',test:string,rite?:string}
  *
  * @phpstan-import-type LiturgicalEvent from \LiturgicalCalendar\Api\Test\LitTestRunner
  */
@@ -374,7 +375,8 @@ class Health implements MessageComponentInterface
                         $messageReceived->year,
                         $messageReceived->category,
                         $messageReceived->responsetype,
-                        $from
+                        $from,
+                        self::readRiteHint($messageReceived)
                     );
                     break;
                 case 'executeUnitTest':
@@ -384,7 +386,8 @@ class Health implements MessageComponentInterface
                         $messageReceived->calendar,
                         $messageReceived->year,
                         $messageReceived->category,
-                        $from
+                        $from,
+                        self::readRiteHint($messageReceived)
                     );
                     break;
                 default:
@@ -973,21 +976,93 @@ class Health implements MessageComponentInterface
     }
 
     /**
-     * Build the calendar API request path based on calendar ID, year, and category.
+     * Read the optional `rite` property off an incoming WebSocket message.
+     *
+     * `rite` is optional — it is deliberately absent from `ACTION_PROPERTIES`,
+     * which lists only required properties — so clients that predate rite
+     * awareness keep working and get their rite resolved from metadata instead.
+     * A non-string value is treated as absent rather than as an error; the
+     * resolver validates the string against {@see Rite} in any case.
+     */
+    private static function readRiteHint(\stdClass $message): ?string
+    {
+        if (property_exists($message, 'rite') && is_string($message->rite)) {
+            return $message->rite;
+        }
+        return null;
+    }
+
+    /**
+     * Determine the rite a calendar request should be computed under.
+     *
+     * Resolution order:
+     *   1. an explicit `rite` on the WebSocket message, when it names a known {@see Rite};
+     *   2. for `diocesancalendar`, the rite `/calendars` announces for that diocese;
+     *   3. for `ritecalendar`, the calendar id itself read as a rite;
+     *   4. otherwise the default rite.
+     *
+     * Step 2 is what lets an existing, rite-unaware client keep working: the four
+     * Ambrosian dioceses need `/calendar/ambrosian/diocese/{id}` and 400 without
+     * the segment (issue #767). National calendars are Roman-only — `/calendars`
+     * announces no rite for them — so they fall through to step 4.
+     *
+     * @param string  $calendar The calendar identifier.
+     * @param string  $category The type of calendar ('nationalcalendar', 'diocesancalendar' or 'ritecalendar').
+     * @param ?string $riteHint The `rite` property of the incoming message, if any.
+     */
+    private function resolveRite(string $calendar, string $category, ?string $riteHint = null): Rite
+    {
+        if (null !== $riteHint) {
+            $rite = Rite::tryFrom($riteHint);
+            if (null !== $rite) {
+                return $rite;
+            }
+        }
+
+        if ($category === 'diocesancalendar') {
+            try {
+                return $this->findDioceseMetadata($calendar)->rite;
+            } catch (\RuntimeException | NotFoundException) {
+                // Metadata not loaded yet, or an unknown diocese: fall through to
+                // the default. The request itself will report the real problem.
+                return Rite::default();
+            }
+        }
+
+        if ($category === 'ritecalendar') {
+            return Rite::tryFrom($calendar) ?? Rite::default();
+        }
+
+        return Rite::default();
+    }
+
+    /**
+     * Build the calendar API request path based on calendar ID, year, category and rite.
+     *
+     * The rite segment is always emitted explicitly (`/roman/...`, `/ambrosian/...`),
+     * which is the canonical URL form {@see Rite} documents. It is required — not
+     * merely canonical — for Ambrosian diocesan calendars, which 400 without it.
      *
      * @param string $calendar The calendar identifier (e.g., 'VA' for Vatican, 'USA' for national).
      * @param int $year The year for the calendar request.
-     * @param string $category The type of calendar ('nationalcalendar' or 'diocesancalendar').
+     * @param string $category The type of calendar ('nationalcalendar', 'diocesancalendar' or 'ritecalendar').
+     * @param Rite $rite The rite the calendar is computed under.
      * @return string The constructed request path.
      */
-    private function buildCalendarRequestPath(string $calendar, int $year, string $category): string
+    private function buildCalendarRequestPath(string $calendar, int $year, string $category, Rite $rite): string
     {
-        if ($calendar === 'VA') {
-            return "/$year?year_type=CIVIL";
+        $ritePath = '/' . $rite->value;
+
+        // 'VA' is the historical marker for "the rite-level calendar", not a
+        // request for /nation/VA; it predates the `ritecalendar` category and
+        // resolves the same way.
+        if ($calendar === 'VA' || $category === 'ritecalendar') {
+            return "$ritePath/$year?year_type=CIVIL";
         }
+
         return match ($category) {
-            'nationalcalendar'  => "/nation/$calendar/$year?year_type=CIVIL",
-            'diocesancalendar'  => "/diocese/$calendar/$year?year_type=CIVIL",
+            'nationalcalendar'  => "$ritePath/nation/$calendar/$year?year_type=CIVIL",
+            'diocesancalendar'  => "$ritePath/diocese/$calendar/$year?year_type=CIVIL",
             default             => throw new \InvalidArgumentException("Unknown calendar category: {$category}")
         };
     }
@@ -998,15 +1073,16 @@ class Health implements MessageComponentInterface
      *
      * @param string $calendar The calendar identifier (e.g., 'VA' for Vatican).
      * @param int $year The year for which the calendar is to be validated.
-     * @param string $category The type of calendar (e.g., 'nationalcalendar', 'diocesancalendar').
+     * @param string $category The type of calendar (e.g., 'nationalcalendar', 'diocesancalendar', 'ritecalendar').
      * @param string $responseType The response format type (e.g., 'JSON', 'XML', 'ICS', 'YML').
      * @param ConnectionInterface $to The connection to which messages about the validation process are sent.
+     * @param ?string $riteHint The `rite` property of the incoming message, if any.
      *
      * This function retrieves the calendar data from a remote source based on the given parameters
      * and validates it against the appropriate schema. It supports multiple response types, including
      * XML, ICS, YML, and JSON. Validation results are sent as messages to the provided connection interface.
      */
-    private function validateCalendar(string $calendar, int $year, string $category, string $responseType, ConnectionInterface $to): void
+    private function validateCalendar(string $calendar, int $year, string $category, string $responseType, ConnectionInterface $to, ?string $riteHint = null): void
     {
         $runToken        = $this->resolveRunToken($to);
         $returnTypeParam = ReturnTypeParam::from($responseType);
@@ -1018,7 +1094,7 @@ class Health implements MessageComponentInterface
             'stream'  => true
         ];
 
-        $req     = $this->buildCalendarRequestPath($calendar, $year, $category);
+        $req     = $this->buildCalendarRequestPath($calendar, $year, $category, $this->resolveRite($calendar, $category, $riteHint));
         $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
         $promise->then(
             function (array $result) use ($to, $calendar, $year, $category, $req, $responseType, $runToken) {
@@ -1265,10 +1341,11 @@ class Health implements MessageComponentInterface
      * @param string $test The name of the unit test to be executed.
      * @param string $calendar The name of the calendar to be tested.
      * @param int $year The year for which the test should be executed.
-     * @param string $category The type of calendar to be tested: nationalcalendar or diocesancalendar.
+     * @param string $category The type of calendar to be tested: nationalcalendar, diocesancalendar or ritecalendar.
      * @param ConnectionInterface $to The connection to which the test result should be sent.
+     * @param ?string $riteHint The `rite` property of the incoming message, if any.
      */
-    private function executeUnitTest(string $test, string $calendar, int $year, string $category, ConnectionInterface $to): void
+    private function executeUnitTest(string $test, string $calendar, int $year, string $category, ConnectionInterface $to, ?string $riteHint = null): void
     {
         $runToken        = $this->resolveRunToken($to);
         $returnTypeParam = ReturnTypeParam::JSON;
@@ -1280,7 +1357,7 @@ class Health implements MessageComponentInterface
             'stream'  => true
         ];
 
-        $req     = $this->buildCalendarRequestPath($calendar, $year, $category);
+        $req     = $this->buildCalendarRequestPath($calendar, $year, $category, $this->resolveRite($calendar, $category, $riteHint));
         $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
         $promise->then(
             function (array $result) use ($to, $test, $year, $runToken) {

--- a/src/Repositories/AccessRequestRepository.php
+++ b/src/Repositories/AccessRequestRepository.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Api\Repositories;
 
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Services\TestScopeResolver;
 use PDO;
 
 /**
@@ -103,9 +104,31 @@ class AccessRequestRepository
      *
      * general_roman_calendar uses a fixed enumerated id set; general_roman_calendar_test
      * accepts only the literal id 'general_roman_calendar'; rite_calendar_test accepts
-     * only a known Rite value; all other types accept any non-empty id (the resource
-     * itself is validated downstream by the handler).
+     * only a known Rite value; the scoped test types require a rite-qualified
+     * `<rite>/<calendarId>` id, because a bare calendar id does not identify a
+     * calendar (see TestScopeResolver); all other types accept any non-empty id (the
+     * resource itself is validated downstream by the handler).
      */
+    /**
+     * Human-readable description of the ids `isValidObjectIdForType()` accepts.
+     *
+     * Kept next to the rule it describes so the two cannot drift: an error that
+     * lists the General Roman Calendar's ids while rejecting a diocesan test
+     * scope tells the caller nothing useful.
+     */
+    public static function validIdsLabelForType(string $objectType): string
+    {
+        return match ($objectType) {
+            'general_roman_calendar'      => implode(', ', self::GRC_OBJECT_IDS),
+            'general_roman_calendar_test' => 'general_roman_calendar',
+            'rite_calendar_test'          => implode(', ', array_column(Rite::cases(), 'value')),
+            'national_calendar_test'      => 'a rite-qualified nation code, e.g. ' . TestScopeResolver::qualify(Rite::ROMAN, 'US'),
+            'diocesan_calendar_test'      => 'a rite-qualified diocese id, e.g. ' . TestScopeResolver::qualify(Rite::AMBROSIAN, 'lugano_ch'),
+            'national_calendar'           => 'a two-letter ISO nation code',
+            default                       => 'any non-empty id',
+        };
+    }
+
     public static function isValidObjectIdForType(string $objectType, string $objectId): bool
     {
         if ($objectType === 'general_roman_calendar') {
@@ -118,6 +141,15 @@ class AccessRequestRepository
 
         if ($objectType === 'rite_calendar_test') {
             return null !== Rite::tryFrom($objectId);
+        }
+
+        if ($objectType === 'national_calendar_test' || $objectType === 'diocesan_calendar_test') {
+            $parsed = TestScopeResolver::parseQualifiedId($objectId);
+            if (null === $parsed) {
+                return false;
+            }
+            // Only the Roman rite has a national tier.
+            return $objectType !== 'national_calendar_test' || Rite::ROMAN === $parsed[0];
         }
 
         if ($objectType === 'national_calendar') {

--- a/src/Repositories/AccessRequestRepository.php
+++ b/src/Repositories/AccessRequestRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Api\Repositories;
 
 use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Enum\Rite;
 use PDO;
 
 /**
@@ -66,6 +67,7 @@ class AccessRequestRepository
         'national_calendar_test',
         'diocesan_calendar_test',
         'general_roman_calendar_test',
+        'rite_calendar_test',
         'general_roman_calendar',
     ];
 
@@ -84,10 +86,11 @@ class AccessRequestRepository
             'national_calendar_test',
             'diocesan_calendar_test',
             'general_roman_calendar_test',
+            'rite_calendar_test',
             'general_roman_calendar',
         ],
         'calendar_editor' => ['national_calendar', 'diocesan_calendar', 'wider_region', 'general_roman_calendar'],
-        'test_editor'     => ['national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test'],
+        'test_editor'     => ['national_calendar_test', 'diocesan_calendar_test', 'general_roman_calendar_test', 'rite_calendar_test'],
     ];
 
     public function __construct(?PDO $db = null)
@@ -99,8 +102,9 @@ class AccessRequestRepository
      * Validate an object_id for a given object_type.
      *
      * general_roman_calendar uses a fixed enumerated id set; general_roman_calendar_test
-     * accepts only the literal id 'general_roman_calendar'; all other types accept any
-     * non-empty id (the resource itself is validated downstream by the handler).
+     * accepts only the literal id 'general_roman_calendar'; rite_calendar_test accepts
+     * only a known Rite value; all other types accept any non-empty id (the resource
+     * itself is validated downstream by the handler).
      */
     public static function isValidObjectIdForType(string $objectType, string $objectId): bool
     {
@@ -110,6 +114,10 @@ class AccessRequestRepository
 
         if ($objectType === 'general_roman_calendar_test') {
             return $objectId === 'general_roman_calendar';
+        }
+
+        if ($objectType === 'rite_calendar_test') {
+            return null !== Rite::tryFrom($objectId);
         }
 
         if ($objectType === 'national_calendar') {

--- a/src/Services/ResourceAdminService.php
+++ b/src/Services/ResourceAdminService.php
@@ -34,6 +34,7 @@ final class ResourceAdminService
         'national_calendar_test',
         'diocesan_calendar_test',
         'general_roman_calendar_test',
+        'rite_calendar_test',
     ];
 
     /**
@@ -47,6 +48,7 @@ final class ResourceAdminService
         'national_calendar_test',
         'diocesan_calendar_test',
         'general_roman_calendar_test',
+        'rite_calendar_test',
     ];
 
     public function __construct(private readonly OpenFgaClient $fgaClient)

--- a/src/Services/ResourceExistenceChecker.php
+++ b/src/Services/ResourceExistenceChecker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Api\Services;
 
 use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Rite;
 
 /**
  * Decides whether the backing data for an OpenFGA object still exists on disk.
@@ -15,6 +16,7 @@ use LiturgicalCalendar\Api\Enum\JsonData;
  * Resource types and their backing-data locations:
  *   general_roman_calendar       — fixed; always exists
  *   general_roman_calendar_test  — fixed; always exists
+ *   rite_calendar_test           — fixed catalog; exists iff the id is a known Rite
  *   national_calendar            — jsondata/sourcedata/rite/roman/calendars/nations/{id}/{id}.json
  *   wider_region                 — jsondata/sourcedata/rite/roman/calendars/wider_regions/{id}/ (directory)
  *   diocesan_calendar            — jsondata/sourcedata/rite/roman/calendars/dioceses/{nation}/{id}/ (directory, glob)
@@ -32,6 +34,7 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
         'national_calendar_test',
         'diocesan_calendar_test',
         'general_roman_calendar_test',
+        'rite_calendar_test',
     ];
 
     public function isResourceType(string $objectType): bool
@@ -46,6 +49,10 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
             case 'general_roman_calendar_test':
                 // Fixed catalog ids — always present.
                 return true;
+
+            case 'rite_calendar_test':
+                // Fixed catalog, one entry per rite the API can compute.
+                return null !== Rite::tryFrom($objectId);
 
             case 'national_calendar':
                 return is_file(

--- a/src/Services/ResourceExistenceChecker.php
+++ b/src/Services/ResourceExistenceChecker.php
@@ -20,8 +20,8 @@ use LiturgicalCalendar\Api\Enum\Rite;
  *   national_calendar            — jsondata/sourcedata/rite/roman/calendars/nations/{id}/{id}.json
  *   wider_region                 — jsondata/sourcedata/rite/roman/calendars/wider_regions/{id}/ (directory)
  *   diocesan_calendar            — jsondata/sourcedata/rite/roman/calendars/dioceses/{nation}/{id}/ (directory, glob)
- *   national_calendar_test       — governance scope; always treated as existing
- *   diocesan_calendar_test       — governance scope; always treated as existing
+ *   national_calendar_test       — governance scope (id `<rite>/<calendarId>`); always treated as existing
+ *   diocesan_calendar_test       — governance scope (id `<rite>/<calendarId>`); always treated as existing
  */
 final class ResourceExistenceChecker implements ResourceExistenceCheckerInterface
 {
@@ -76,7 +76,10 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
             case 'national_calendar_test':
             case 'diocesan_calendar_test':
                 // Scoped test objects are governance scopes, not file-backed resources.
-                // Treat as always existing to avoid false purges.
+                // Treat as always existing to avoid false purges. Deliberately not
+                // validating the `<rite>/<calendarId>` shape here: during the migration
+                // window legacy unqualified ids are still in the store, and this method
+                // decides what the reconciler *purges*.
                 return true;
 
             default:

--- a/src/Services/TestScopeResolver.php
+++ b/src/Services/TestScopeResolver.php
@@ -14,10 +14,19 @@ use LiturgicalCalendar\Api\Enum\Rite;
  * Reads `{testsDir}/{testName}.json` and inspects the top-level `applies_to`
  * key:
  *
- *   - `{"diocesan_calendar": "<id>"}` → `['diocesan_calendar_test', '<id>']`
- *   - `{"national_calendar": "<id>"}` → `['national_calendar_test', '<id>']`
- *   - `{"rite": "<rite>"}`            → `['rite_calendar_test', '<rite>']`
- *   - absent / empty / other          → `['rite_calendar_test', 'roman']`
+ *   - `{"rite": "<r>", "diocesan_calendar": "<id>"}` → `['diocesan_calendar_test', '<r>/<id>']`
+ *   - `{"rite": "<r>", "national_calendar": "<id>"}` → `['national_calendar_test', '<r>/<id>']`
+ *   - `{"rite": "<r>"}`                              → `['rite_calendar_test', '<r>']`
+ *   - absent / empty / other                         → `['rite_calendar_test', 'roman']`
+ *
+ * **Every scope carries its rite.** A calendar id alone does not identify a
+ * calendar: `lugano_ch` could name an Ambrosian calendar or a Roman one, and the
+ * source tree is already partitioned that way
+ * (`jsondata/sourcedata/rite/{rite}/calendars/...`), so nothing stops the same
+ * diocese from being defined under both. Granting `diocesan_calendar_test` on a
+ * bare `lugano_ch` would therefore be an ambiguous grant. National scopes are
+ * qualified too, for one uniform rule — even though only the Roman rite has a
+ * national tier today.
  *
  * `rite_calendar_test` generalises the older `general_roman_calendar_test`,
  * whose single fixed id `general_roman_calendar` denoted exactly the Roman
@@ -35,6 +44,51 @@ final class TestScopeResolver
     public function __construct(?string $testsDir = null)
     {
         $this->testsDir = $testsDir ?? JsonData::TESTS_FOLDER->path();
+    }
+
+    /**
+     * Separates the rite from the calendar id inside a scoped-test object id.
+     *
+     * `/` is safe in an OpenFGA object id (only whitespace, `:`, `#` and `*` carry
+     * meaning) and reads as the hierarchy it is: rite over calendar.
+     */
+    public const RITE_SEPARATOR = '/';
+
+    /**
+     * Compose the rite-qualified object id for a national or diocesan test scope.
+     *
+     * The single definition of the qualified-id format; parseQualifiedId() is its
+     * inverse. Everything that writes or reads one of these ids goes through here
+     * rather than re-implementing the concatenation.
+     */
+    public static function qualify(Rite $rite, string $calendarId): string
+    {
+        return $rite->value . self::RITE_SEPARATOR . $calendarId;
+    }
+
+    /**
+     * Split a rite-qualified object id back into its rite and calendar id.
+     *
+     * Returns null when the id is not rite-qualified — an unmigrated legacy id
+     * such as a bare `rotter_nl`, or a prefix that names no known rite.
+     *
+     * @return array{0: Rite, 1: string}|null
+     */
+    public static function parseQualifiedId(string $objectId): ?array
+    {
+        $pos = strpos($objectId, self::RITE_SEPARATOR);
+        if (false === $pos) {
+            return null;
+        }
+
+        $rite       = Rite::tryFrom(substr($objectId, 0, $pos));
+        $calendarId = substr($objectId, $pos + strlen(self::RITE_SEPARATOR));
+
+        if (null === $rite || '' === $calendarId) {
+            return null;
+        }
+
+        return [$rite, $calendarId];
     }
 
     /**
@@ -61,26 +115,28 @@ final class TestScopeResolver
      */
     private static function mapAppliesTo(mixed $appliesTo): array
     {
-        if (is_array($appliesTo) && isset($appliesTo['diocesan_calendar']) && is_string($appliesTo['diocesan_calendar'])) {
-            return ['diocesan_calendar_test', $appliesTo['diocesan_calendar']];
-        }
-
-        if (is_array($appliesTo) && isset($appliesTo['national_calendar']) && is_string($appliesTo['national_calendar'])) {
-            return ['national_calendar_test', $appliesTo['national_calendar']];
-        }
-
-        // No national or diocesan calendar named: the test is scoped to a
-        // rite-level calendar. `applies_to.rite` is required by the schema, but
-        // resolve() also runs over files written before that requirement and
-        // resolveFromPayload() over payloads the handler has not yet validated,
-        // so an absent or unknown rite falls back to the default (Roman) rather
-        // than failing to resolve a scope at all.
+        // `applies_to.rite` is required by the schema, but resolve() also runs
+        // over files written before that requirement and resolveFromPayload()
+        // over payloads the handler has not yet validated, so an absent or
+        // unknown rite falls back to the default (Roman) rather than failing to
+        // resolve a scope at all.
         $rite = null;
         if (is_array($appliesTo) && isset($appliesTo['rite']) && is_string($appliesTo['rite'])) {
             $rite = Rite::tryFrom($appliesTo['rite']);
         }
+        $rite ??= Rite::default();
 
-        return ['rite_calendar_test', ( $rite ?? Rite::default() )->value];
+        if (is_array($appliesTo) && isset($appliesTo['diocesan_calendar']) && is_string($appliesTo['diocesan_calendar'])) {
+            return ['diocesan_calendar_test', self::qualify($rite, $appliesTo['diocesan_calendar'])];
+        }
+
+        if (is_array($appliesTo) && isset($appliesTo['national_calendar']) && is_string($appliesTo['national_calendar'])) {
+            return ['national_calendar_test', self::qualify($rite, $appliesTo['national_calendar'])];
+        }
+
+        // No national or diocesan calendar named: the test is scoped to the
+        // rite-level calendar, whose id is the rite itself.
+        return ['rite_calendar_test', $rite->value];
     }
 
     /**

--- a/src/Services/TestScopeResolver.php
+++ b/src/Services/TestScopeResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Api\Services;
 
 use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Rite;
 
 /**
  * Maps a test file name to the OpenFGA (object type, object id) pair that
@@ -15,7 +16,15 @@ use LiturgicalCalendar\Api\Enum\JsonData;
  *
  *   - `{"diocesan_calendar": "<id>"}` → `['diocesan_calendar_test', '<id>']`
  *   - `{"national_calendar": "<id>"}` → `['national_calendar_test', '<id>']`
- *   - absent / empty / other          → `['general_roman_calendar_test', 'general_roman_calendar']`
+ *   - `{"rite": "<rite>"}`            → `['rite_calendar_test', '<rite>']`
+ *   - absent / empty / other          → `['rite_calendar_test', 'roman']`
+ *
+ * `rite_calendar_test` generalises the older `general_roman_calendar_test`,
+ * whose single fixed id `general_roman_calendar` denoted exactly the Roman
+ * rite-level calendar; `rite_calendar_test:roman` is its successor and
+ * `rite_calendar_test:ambrosian` the scope this generalisation unlocks
+ * (issue #767). The old type is still accepted everywhere so pre-migration
+ * tuples keep authorizing — see `scripts/migrate-rite-test-tuples.php`.
  *
  * Returns `null` when the test file is missing or unreadable.
  */
@@ -60,7 +69,18 @@ final class TestScopeResolver
             return ['national_calendar_test', $appliesTo['national_calendar']];
         }
 
-        return ['general_roman_calendar_test', 'general_roman_calendar'];
+        // No national or diocesan calendar named: the test is scoped to a
+        // rite-level calendar. `applies_to.rite` is required by the schema, but
+        // resolve() also runs over files written before that requirement and
+        // resolveFromPayload() over payloads the handler has not yet validated,
+        // so an absent or unknown rite falls back to the default (Roman) rather
+        // than failing to resolve a scope at all.
+        $rite = null;
+        if (is_array($appliesTo) && isset($appliesTo['rite']) && is_string($appliesTo['rite'])) {
+            $rite = Rite::tryFrom($appliesTo['rite']);
+        }
+
+        return ['rite_calendar_test', ( $rite ?? Rite::default() )->value];
     }
 
     /**

--- a/src/Test/LitTestRunner.php
+++ b/src/Test/LitTestRunner.php
@@ -170,7 +170,7 @@ class LitTestRunner
                 $this->setError('Test name is not set');
                 return;
             }
-            $riteMismatch = $this->detectRiteMismatch();
+            $riteMismatch = $this->detectRiteMismatch(self::$testCache, $this->Test);
             if (null !== $riteMismatch) {
                 $this->setError($riteMismatch);
                 return;
@@ -278,26 +278,26 @@ class LitTestRunner
      * reads as 32 broken assertions rather than one misrouted run. That is the
      * failure mode that motivated issue #767.
      *
+     * The cache and test name are passed in already narrowed by runTest(), which
+     * has just checked both — re-checking here would add a branch no caller can
+     * reach.
+     *
      * Returns the error text on mismatch, or null when the rites agree or the
      * response does not state one.
      */
-    private function detectRiteMismatch(): ?string
+    private function detectRiteMismatch(TestsMap $testCache, string $testName): ?string
     {
-        if (null === self::$testCache || null === $this->Test) {
-            return null;
-        }
-
         $responseRite = $this->responseRite();
         if (null === $responseRite) {
             return null;
         }
 
-        $declaredRite = self::$testCache->get($this->Test)->rite;
+        $declaredRite = $testCache->get($testName)->rite;
         if ($declaredRite === $responseRite) {
             return null;
         }
 
-        return "{$this->Test} is scoped to the {$declaredRite->value} rite, but the calendar under test was computed under the {$responseRite->value} rite";
+        return "{$testName} is scoped to the {$declaredRite->value} rite, but the calendar under test was computed under the {$responseRite->value} rite";
     }
 
     /**

--- a/src/Test/LitTestRunner.php
+++ b/src/Test/LitTestRunner.php
@@ -5,6 +5,7 @@ namespace LiturgicalCalendar\Api\Test;
 use Swaggest\JsonSchema\Schema;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitEventTestAssertion;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Test\TestsMap;
 
 /**
@@ -53,7 +54,7 @@ class LitTestRunner
     private bool $readyState = false;
 
     /**
-     * @var object{settings:object{year:int,national_calendar?:string,diocesan_calendar?:string},litcal:array<LiturgicalEvent>} The data to be tested
+     * @var object{settings:object{year:int,rite?:string,national_calendar?:string,diocesan_calendar?:string},litcal:array<LiturgicalEvent>} The data to be tested
      */
     private object $dataToTest;
 
@@ -82,7 +83,7 @@ class LitTestRunner
      * Updates the ready state based on successful initialization.
      *
      * @param string $Test The name of the test.
-     * @param \stdClass&object{settings:object{year:int,national_calendar?:string,diocesan_calendar?:string},litcal:LiturgicalEvent[]} $testData The test data object.
+     * @param \stdClass&object{settings:object{year:int,rite?:string,national_calendar?:string,diocesan_calendar?:string},litcal:LiturgicalEvent[]} $testData The test data object.
      */
     public function __construct(string $Test, \stdClass $testData)
     {
@@ -169,6 +170,12 @@ class LitTestRunner
                 $this->setError('Test name is not set');
                 return;
             }
+            $riteMismatch = $this->detectRiteMismatch();
+            if (null !== $riteMismatch) {
+                $this->setError($riteMismatch);
+                return;
+            }
+
             $assertion = self::$testCache->retrieveAssertionForYear($this->Test, $this->dataToTest->settings->year);
             if (is_null($assertion)) {
                 $this->setError("Out of bounds error: {$this->Test} only supports calendar years [ " . implode(', ', self::$testCache->getYearsSupported($this->Test)) . ' ]');
@@ -232,9 +239,65 @@ class LitTestRunner
      */
     private function getCalendarName(): string
     {
-        return property_exists($this->dataToTest->settings, 'diocesan_calendar') ? $this->dataToTest->settings->diocesan_calendar : (
-            property_exists($this->dataToTest->settings, 'national_calendar') ? $this->dataToTest->settings->national_calendar : 'the Universal Roman Calendar'
-        );
+        if (property_exists($this->dataToTest->settings, 'diocesan_calendar')) {
+            return $this->dataToTest->settings->diocesan_calendar;
+        }
+
+        if (property_exists($this->dataToTest->settings, 'national_calendar')) {
+            return $this->dataToTest->settings->national_calendar;
+        }
+
+        return match ($this->responseRite()) {
+            Rite::AMBROSIAN => 'the Ambrosian Calendar',
+            default         => 'the General Roman Calendar'
+        };
+    }
+
+    /**
+     * The rite the calendar under test was computed under, as echoed back in
+     * `settings.rite` (issue #760), or null when the response predates that
+     * field or carries an unknown value.
+     */
+    private function responseRite(): ?Rite
+    {
+        if (
+            false === property_exists($this->dataToTest->settings, 'rite')
+            || false === is_string($this->dataToTest->settings->rite)
+        ) {
+            return null;
+        }
+
+        return Rite::tryFrom($this->dataToTest->settings->rite);
+    }
+
+    /**
+     * Guard against a test being run against a calendar of the wrong rite.
+     *
+     * Without it, an Ambrosian test pointed at the General Roman Calendar fails
+     * every single assertion — the event key simply does not exist there — and
+     * reads as 32 broken assertions rather than one misrouted run. That is the
+     * failure mode that motivated issue #767.
+     *
+     * Returns the error text on mismatch, or null when the rites agree or the
+     * response does not state one.
+     */
+    private function detectRiteMismatch(): ?string
+    {
+        if (null === self::$testCache || null === $this->Test) {
+            return null;
+        }
+
+        $responseRite = $this->responseRite();
+        if (null === $responseRite) {
+            return null;
+        }
+
+        $declaredRite = self::$testCache->get($this->Test)->rite;
+        if ($declaredRite === $responseRite) {
+            return null;
+        }
+
+        return "{$this->Test} is scoped to the {$declaredRite->value} rite, but the calendar under test was computed under the {$responseRite->value} rite";
     }
 
     /**

--- a/src/Test/TestItem.php
+++ b/src/Test/TestItem.php
@@ -2,10 +2,18 @@
 
 namespace LiturgicalCalendar\Api\Test;
 
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Test\AssertionCollection;
 
 /**
- * @phpstan-type AppliesToOrExcludes object{
+ * @phpstan-type AppliesToScope object{
+ *      rite: string,
+ *      national_calendars?: string[],
+ *      diocesan_calendars?: string[],
+ *      national_calendar?: string,
+ *      diocesan_calendar?: string
+ * }
+ * @phpstan-type ExcludesScope object{
  *      national_calendars?: string[],
  *      diocesan_calendars?: string[],
  *      national_calendar?: string,
@@ -21,8 +29,18 @@ class TestItem
     public ?int $year_since = null;
     public ?int $year_until = null;
 
-    /** @phpstan-var AppliesToOrExcludes|null */ public ?object $applies_to = null;
-    /** @phpstan-var AppliesToOrExcludes|null */ public ?object $excludes   = null;
+    /** @phpstan-var AppliesToScope */ public object $applies_to;
+
+    /**
+     * The rite the test is scoped to, decoded from `applies_to.rite`.
+     *
+     * Kept alongside the raw `applies_to` object (which stays verbatim so the
+     * item round-trips back to JSON unchanged) so consumers can branch on a
+     * typed value rather than re-parsing the string.
+     */
+    public Rite $rite;
+
+    /** @phpstan-var ExcludesScope|null */ public ?object $excludes = null;
     public AssertionCollection $assertions;
 
     private const REQUIRED_PROPERTIES = [
@@ -30,6 +48,7 @@ class TestItem
         'event_key',
         'description',
         'test_type',
+        'applies_to',
         'assertions'
     ];
 
@@ -40,7 +59,11 @@ class TestItem
         'test_type'
     ];
 
-    private const APPLIES_TO_OR_EXCLUDES_PROPERTIES = [
+    /**
+     * Calendar keys permitted in `applies_to` alongside the required `rite`,
+     * and the only keys permitted in `excludes`.
+     */
+    private const CALENDAR_SCOPE_PROPERTIES = [
         'national_calendars',
         'diocesan_calendars',
         'national_calendar',
@@ -50,14 +73,15 @@ class TestItem
     /**
      * Constructs a new TestItem instance from the given test object.
      *
-     * @param \stdClass&object{name:string,description:string,test_type:string,event_key:string,assertions:array<object{year:int,expected_value:string|null,assert:string,assertion:string,comment:string}>} $testObject An object representing a test, which must contain
+     * @param \stdClass&object{name:string,description:string,test_type:string,event_key:string,applies_to:object,assertions:array<object{year:int,expected_value:string|null,assert:string,assertion:string,comment:string}>} $testObject An object representing a test, which must contain
      *                              the required properties: 'name', 'event_key',
-     *                              'description', 'test_type', and 'assertions'.
+     *                              'description', 'test_type', 'applies_to', and 'assertions'.
      *
      * @throws \InvalidArgumentException If any of the required properties are missing,
      *                                   if any of the string properties are not strings,
      *                                   if 'year_since' or 'year_until' are not integers,
-     *                                   or if 'applies_to' or 'excludes' are not objects.
+     *                                   if 'applies_to' or 'excludes' are not objects,
+     *                                   or if 'applies_to' carries no valid `rite`.
      */
     public function __construct(\stdClass $testObject)
     {
@@ -93,68 +117,122 @@ class TestItem
             $this->year_until = $testObject->year_until;
         }
 
-        if (property_exists($testObject, 'applies_to')) {
-            if (false === is_object($testObject->applies_to)) {
-                throw new \InvalidArgumentException(__METHOD__ . ': Property `applies_to` must be an object');
-            }
-            self::checkAppliesToExcludesConditions($testObject->applies_to);
-            $this->applies_to = $testObject->applies_to;
+        if (false === is_object($testObject->applies_to)) {
+            throw new \InvalidArgumentException(__METHOD__ . ': Property `applies_to` must be an object');
         }
+        $this->rite = self::checkAppliesToConditions($testObject->applies_to);
+        /** @phpstan-var AppliesToScope $appliesTo */
+        $appliesTo        = $testObject->applies_to;
+        $this->applies_to = $appliesTo;
 
         if (property_exists($testObject, 'excludes')) {
             if (false === is_object($testObject->excludes)) {
                 throw new \InvalidArgumentException(__METHOD__ . ': Property `excludes` must be an object');
             }
-            self::checkAppliesToExcludesConditions($testObject->excludes);
+            self::checkExcludesConditions($testObject->excludes);
             $this->excludes = $testObject->excludes;
         }
     }
 
     /**
-     * @param object $appliedsToOrExcludes
+     * Validate an `applies_to` object and decode its required `rite`.
+     *
+     * A test with no rite cannot be run: the runner would fall back to the
+     * General Roman Calendar and every assertion of an Ambrosian test would
+     * fail for the wrong reason (issue #767). The rite is therefore mandatory,
+     * and the calendar keys remain optional — `{"rite": "ambrosian"}` alone
+     * names the rite-level calendar.
      *
      * @throws \InvalidArgumentException
      */
-    private static function checkAppliesToExcludesConditions(object $appliedsToOrExcludes): void
+    private static function checkAppliesToConditions(object $appliesTo): Rite
     {
-        $appliesToOrExcludesArr = (array) $appliedsToOrExcludes;
+        $appliesToArr = (array) $appliesTo;
 
-        if (false === count(array_intersect_key($appliesToOrExcludesArr, array_flip(self::APPLIES_TO_OR_EXCLUDES_PROPERTIES))) > 0) {
-            throw new \InvalidArgumentException(__METHOD__ . ': Property `applies_to` must have at least one of the properties: ' . implode(', ', self::APPLIES_TO_OR_EXCLUDES_PROPERTIES));
+        if (false === array_key_exists('rite', $appliesToArr)) {
+            throw new \InvalidArgumentException(__METHOD__ . ': Property `applies_to` must have a `rite` property, one of: ' . implode(', ', array_column(Rite::cases(), 'value')));
         }
 
+        if (false === is_string($appliesToArr['rite'])) {
+            throw new \InvalidArgumentException(__METHOD__ . ': Property `rite` must have a string value');
+        }
+
+        $rite = Rite::tryFrom($appliesToArr['rite']);
+        if (null === $rite) {
+            throw new \InvalidArgumentException(__METHOD__ . ": Property `rite` has an unknown value `{$appliesToArr['rite']}`, expected one of: " . implode(', ', array_column(Rite::cases(), 'value')));
+        }
+
+        self::checkCalendarScopeConditions($appliesToArr, 'applies_to');
+
+        return $rite;
+    }
+
+    /**
+     * Validate an `excludes` object.
+     *
+     * `excludes` narrows the set of calendars a test applies to, so it needs at
+     * least one calendar key. It does NOT accept a `rite`: the rite is already
+     * pinned by `applies_to`, and excluding it would leave nothing to test.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private static function checkExcludesConditions(object $excludes): void
+    {
+        $excludesArr = (array) $excludes;
+
+        if (array_key_exists('rite', $excludesArr)) {
+            throw new \InvalidArgumentException(__METHOD__ . ': Property `excludes` must not have a `rite` property; the rite is pinned by `applies_to`');
+        }
+
+        if (false === count(array_intersect_key($excludesArr, array_flip(self::CALENDAR_SCOPE_PROPERTIES))) > 0) {
+            throw new \InvalidArgumentException(__METHOD__ . ': Property `excludes` must have at least one of the properties: ' . implode(', ', self::CALENDAR_SCOPE_PROPERTIES));
+        }
+
+        self::checkCalendarScopeConditions($excludesArr, 'excludes');
+    }
+
+    /**
+     * Type-check the calendar keys shared by `applies_to` and `excludes`.
+     *
+     * @param array<array-key,mixed> $appliesToOrExcludesArr
+     * @param string                 $context The owning property name, for error messages.
+     *
+     * @throws \InvalidArgumentException
+     */
+    private static function checkCalendarScopeConditions(array $appliesToOrExcludesArr, string $context): void
+    {
         if (array_key_exists('national_calendar', $appliesToOrExcludesArr)) {
             if (false === is_string($appliesToOrExcludesArr['national_calendar'])) {
-                throw new \InvalidArgumentException(__METHOD__ . ': Property `national_calendar` must have a string value');
+                throw new \InvalidArgumentException(__METHOD__ . ": Property `{$context}`.`national_calendar` must have a string value");
             }
         }
 
         if (array_key_exists('diocesan_calendar', $appliesToOrExcludesArr)) {
             if (false === is_string($appliesToOrExcludesArr['diocesan_calendar'])) {
-                throw new \InvalidArgumentException(__METHOD__ . ': Property `diocesan_calendar` must have a string value');
+                throw new \InvalidArgumentException(__METHOD__ . ": Property `{$context}`.`diocesan_calendar` must have a string value");
             }
         }
 
         if (array_key_exists('national_calendars', $appliesToOrExcludesArr)) {
             if (false === is_array($appliesToOrExcludesArr['national_calendars'])) {
-                throw new \InvalidArgumentException(__METHOD__ . ': Property `national_calendars` must have an array value');
+                throw new \InvalidArgumentException(__METHOD__ . ": Property `{$context}`.`national_calendars` must have an array value");
             }
 
             foreach ($appliesToOrExcludesArr['national_calendars'] as $calendar) {
                 if (false === is_string($calendar)) {
-                    throw new \InvalidArgumentException(__METHOD__ . ': Property `national_calendars` must have an array of strings value');
+                    throw new \InvalidArgumentException(__METHOD__ . ": Property `{$context}`.`national_calendars` must have an array of strings value");
                 }
             }
         }
 
         if (array_key_exists('diocesan_calendars', $appliesToOrExcludesArr)) {
             if (false === is_array($appliesToOrExcludesArr['diocesan_calendars'])) {
-                throw new \InvalidArgumentException(__METHOD__ . ': Property `diocesan_calendars` must have an array value');
+                throw new \InvalidArgumentException(__METHOD__ . ": Property `{$context}`.`diocesan_calendars` must have an array value");
             }
 
             foreach ($appliesToOrExcludesArr['diocesan_calendars'] as $calendar) {
                 if (false === is_string($calendar)) {
-                    throw new \InvalidArgumentException(__METHOD__ . ': Property `diocesan_calendars` must have an array of strings value');
+                    throw new \InvalidArgumentException(__METHOD__ . ": Property `{$context}`.`diocesan_calendars` must have an array of strings value");
                 }
             }
         }

--- a/src/Test/TestItem.php
+++ b/src/Test/TestItem.php
@@ -164,6 +164,20 @@ class TestItem
 
         self::checkCalendarScopeConditions($appliesToArr, 'applies_to');
 
+        // National calendars exist only in the Roman rite. The Ambrosian rite is
+        // proper to the Archdiocese of Milan and a handful of neighbouring
+        // dioceses rather than to any nation, and `/calendar/ambrosian/nation/{id}`
+        // is a 400 — so a test with that scope could pass validation and then fail
+        // only when the runner issues its request, which is exactly the
+        // expressible-but-unrunnable trap issue #767 set out to close.
+        if (Rite::ROMAN !== $rite) {
+            foreach (['national_calendar', 'national_calendars'] as $nationalKey) {
+                if (array_key_exists($nationalKey, $appliesToArr)) {
+                    throw new \InvalidArgumentException(__METHOD__ . ": Property `applies_to`.`{$nationalKey}` is not valid for the {$rite->value} rite; national calendars exist only in the " . Rite::ROMAN->value . ' rite');
+                }
+            }
+        }
+
         return $rite;
     }
 

--- a/src/Test/TestsMap.php
+++ b/src/Test/TestsMap.php
@@ -5,7 +5,7 @@ namespace LiturgicalCalendar\Api\Test;
 use LiturgicalCalendar\Api\Test\TestItem;
 
 /**
- * @phpstan-type TestDataObject \stdClass&object{name:string,description:string,test_type:string,event_key:string,assertions:array<object{year:int,expected_value:string|null,assert:string,assertion:string,comment:string}>}
+ * @phpstan-type TestDataObject \stdClass&object{name:string,description:string,test_type:string,event_key:string,applies_to:object,assertions:array<object{year:int,expected_value:string|null,assert:string,assertion:string,comment:string}>}
  */
 class TestsMap
 {


### PR DESCRIPTION
Closes #767.

Liturgical tests could not be scoped to a rite, with two consequences: the Ambrosian rite-level calendar
(`GET /calendar/ambrosian`) was untestable at all, and a test scoped to one of the four Ambrosian dioceses —
a scope the schema already accepted — produced a URL the router rejects with a 400.

The three design questions in the issue were answered in its comments; this implements those answers.

## Scope shape

`applies_to` is now **required** on every test, with a **required `rite`**:

```json
{ "applies_to": { "rite": "roman" } }
{ "applies_to": { "rite": "roman", "national_calendar": "US" } }
{ "applies_to": { "rite": "ambrosian" } }
{ "applies_to": { "rite": "ambrosian", "diocesan_calendar": "lugano_ch" } }
```

`AppliesToOrExcludes` splits into `AppliesToScope` (rite required, calendar keys optional) and `ExcludesScope`
(unchanged, and it rejects `rite` — the rite is already pinned by `applies_to`, so excluding one would leave
nothing to test).

Making the rite mandatory is the point rather than a side effect: `TestScopeResolver` previously defaulted an
unscoped test to the General Roman Calendar, which is exactly how the deleted `StIgnatiusOfLoyolaTest` came to
fail all 32 of its assertions silently.

## Authorization

New `rite_calendar_test` OpenFGA object type, keyed by rite id (`roman`, `ambrosian`). It generalises
`general_roman_calendar_test`, whose single fixed id `general_roman_calendar` denoted exactly the Roman
rite-level calendar.

| `applies_to`                           | FGA scope                     |
|----------------------------------------|-------------------------------|
| `{"diocesan_calendar": "<id>"}`         | `diocesan_calendar_test:<id>`  |
| `{"national_calendar": "<id>"}`         | `national_calendar_test:<id>`  |
| `{"rite": "<rite>"}` (no calendar key)  | `rite_calendar_test:<rite>`    |
| absent / unrecognised                   | `rite_calendar_test:roman`     |

The diocesan and national branches keep precedence and stay keyed by calendar id alone — those ids are unique
across rites today, and the matching *data* resource types (`diocesan_calendar`, `national_calendar`) are keyed
the same way, so rite-qualifying only the test scope would make the two halves of the model disagree.

**The migration is additive.** `general_roman_calendar_test` stays in the model and in every PHP allow-list, so
existing tuples keep authorizing and a rollback to pre-#767 code is safe. `scripts/migrate-rite-test-tuples.php`
copies each grant onto `rite_calendar_test:roman`; it is copy-only by default and `--prune` is gated behind full
rollout. Runbook section added to `docs/ops/test-scope-migration-runbook.md`.

## Runner

`Health::buildCalendarRequestPath()` now takes a `Rite` and always emits the canonical explicit segment:

| category           | path                                                |
|--------------------|-----------------------------------------------------|
| `ritecalendar`     | `/{rite}/{year}?year_type=CIVIL`                     |
| `nationalcalendar` | `/{rite}/nation/{calendar}/{year}?year_type=CIVIL`   |
| `diocesancalendar` | `/{rite}/diocese/{calendar}/{year}?year_type=CIVIL`  |

`ritecalendar` is a new category for the rite-level calendar; the historical `calendar === 'VA'` marker (which
already meant "the universal calendar", not `/nation/VA`) resolves the same way.

`Health::resolveRite()` prefers an explicit `rite` on the WebSocket message, and otherwise reads it from
`/calendars` metadata for diocesan calendars. That second step fixes gap 2 for the **existing** UnitTestInterface
client with no client release required; `rite` is optional on the message, so `ACTION_PROPERTIES` is unchanged.

## Failing loudly

`/calendar` responses already echo `settings.rite` (#760). `LitTestRunner` now compares it against the test's
declared rite and reports one clear error on mismatch instead of running assertions that would all fail for the
wrong reason:

```text
StIgnatiusOfLoyolaTest is scoped to the ambrosian rite, but the calendar under test was computed under the roman rite
```

`getCalendarName()` also learns to name the rite-level calendar ("the General Roman Calendar" / "the Ambrosian
Calendar") instead of hard-coding "the Universal Roman Calendar".

## Data

All ten existing tests are scoped `rite: roman` — no behaviour change for any of them.

`StIgnatiusOfLoyolaTest.json` is restored, scoped `rite: ambrosian`. **The copy found on disk was itself wrong:**
it asserted the memorial on 31 July for every year 1999–2030, but in the Ambrosian calendar the memorial is
suppressed when 31 July falls on a Sunday. Verified against a running instance — 2005, 2011, 2016 and 2022 return
no `StIgnatiusOfLoyola` event at all — so those four assertions are now `eventNotExists`, matching the pattern
already used in `StCamillusDeLellisTest.json`.

`SchemaValidationTest::testRealTestSourceValidation` was validating only `glob(...)[0]` — one file, whichever
sorts first. Widened to a data provider over the whole corpus, so a test file that never gained a rite fails
loudly instead of hiding behind its neighbours.

## Verification

Full suite green: **2463 tests, 478878 assertions, 14 skipped, 0 failures**. PHPStan level 10 clean, phpcs clean,
`composer lint:openapi` back to zero warnings (matching the pre-change baseline), markdownlint clean.

Acceptance criteria checked end-to-end against a running instance, driving the real `Health` path builder and the
real `LitTestRunner`:

```text
=== 1. StIgnatiusOfLoyolaTest (rite: ambrosian) against the Ambrosian rite-level calendar ===
  32 passed / 0 failed across 32 years
  path used: /ambrosian/2026?year_type=CIVIL

=== 2. Ambrosian diocesan request path ===
  milano_it   /ambrosian/diocese/milano_it/2026?year_type=CIVIL   OK
  bergam_it   /ambrosian/diocese/bergam_it/2026?year_type=CIVIL   OK
  novara_it   /ambrosian/diocese/novara_it/2026?year_type=CIVIL   OK
  lugano_ch   /ambrosian/diocese/lugano_ch/2026?year_type=CIVIL   OK

=== 3. Rite-mismatch guard ===
  Ambrosian test vs Roman calendar -> OK: error: StIgnatiusOfLoyolaTest is scoped to the ambrosian rite,
  but the calendar under test was computed under the roman rite

=== 4. Existing Roman tests still pass ===
  MaryMotherChurchTest       /roman/2019?year_type=CIVIL                   SUCCESS
  NativityJohnBaptistTest    /roman/2022?year_type=CIVIL                   SUCCESS
  ThanksgivingDayTest        /roman/nation/US/2024?year_type=CIVIL         SUCCESS
  rotter_nl_HLaurentius...   /roman/diocese/rotter_nl/2024?year_type=CIVIL SUCCESS
```

## Follow-ups (deliberately out of scope)

- **Frontend `admin-tests.php` scope picker.** Requiring `applies_to.rite` is a breaking change for that editor's
  PUT/PATCH payloads, so `LiturgicalCalendarFrontend` needs a companion change before this lands anywhere the two
  are deployed together.
- **Removing `general_roman_calendar_test`**, once every deployment runs merged code — steps listed in the runbook.
- **Rite-qualifying diocesan/national calendar ids** in the resource model, if a calendar id ever needs to exist
  under two rites. That is a change to the whole resource model, not to tests.

Design spec: `docs/superpowers/specs/2026-08-14-rite-scoped-liturgical-tests-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added rite-aware calendar requests and unit-test execution for Roman and Ambrosian rites.
  - Added rite-specific authorization scopes, dashboard visibility, and qualified calendar test identifiers.
  - Added validation for rite-scoped applicability and response-rite mismatches.
  - Added Ambrosian liturgical test coverage and updated existing tests with explicit Roman scope.

- **Documentation**
  - Added design guidance and an operational migration runbook for rite-scoped tests.

- **Refactor**
  - Separated applicability and exclusion rules, requiring a declared rite.
  - Added migration support for existing calendar-test permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->