### PR TITLE
feat(authz): rite-qualify the data resource scopes and make /data rite-aware (#786)

### DIFF
--- a/docs/ops/test-scope-migration-runbook.md
+++ b/docs/ops/test-scope-migration-runbook.md
@@ -389,7 +389,9 @@ Editors should retain access. Spot-check a diocesan grant of each rite:
 # Mirrors what OpenFgaClient sends: the bearer token when OPENFGA_API_TOKEN is set,
 # and the pinned model id — omitting authorization_model_id checks against the store's
 # latest model rather than the one the API is running.
-curl -s "$OPENFGA_API_URL/stores/$OPENFGA_STORE_ID/check" \
+# -fsS so an HTTP 4xx/5xx fails the command: plain `curl -s` exits 0 on an error
+# response, which would read as a successful verification.
+curl -fsS "$OPENFGA_API_URL/stores/$OPENFGA_STORE_ID/check" \
   -H 'Content-Type: application/json' \
   ${OPENFGA_API_TOKEN:+-H "Authorization: Bearer $OPENFGA_API_TOKEN"} \
   -d '{
@@ -399,8 +401,11 @@ curl -s "$OPENFGA_API_URL/stores/$OPENFGA_STORE_ID/check" \
           "relation": "editor",
           "object": "diocesan_calendar:ambrosian/lugano_ch"
         }
-      }'
+      }' | jq -e '.allowed'
 ```
+
+`jq -e` exits non-zero when `allowed` is false or absent, so a denied check fails the
+command too rather than printing `{"allowed":false}` and exiting 0.
 
 ### Step 3 — prune (later)
 

--- a/docs/ops/test-scope-migration-runbook.md
+++ b/docs/ops/test-scope-migration-runbook.md
@@ -334,3 +334,70 @@ allow-lists that still name it:
 - `jsondata/schemas/openapi.json`
 
 This step is **out of scope for the current change** and tracked as a follow-up.
+
+---
+
+## Follow-up migration — rite-qualified *data* resource scopes
+
+Issue #786 applied the same reasoning to the calendar **data** resource types that #767
+applied to the test scopes. A bare calendar id does not identify a calendar: the source
+tree is partitioned as `jsondata/sourcedata/rite/{rite}/calendars/...`, so `lugano_ch`
+could name an Ambrosian calendar or a Roman one, and a grant on the bare id would
+silently widen to cover whichever was added later.
+
+| Type                     | Object id before | Object id after       |
+|--------------------------|------------------|-----------------------|
+| `diocesan_calendar`      | `lugano_ch`      | `ambrosian/lugano_ch` |
+| `national_calendar`      | `US`             | `roman/US`            |
+| `wider_region`           | `Europe`         | `roman/Europe`        |
+| `general_roman_calendar` | `temporale`      | *(unchanged)*         |
+
+`general_roman_calendar` is untouched: its ids are `temporale`, `decrees` and missal
+editions, which are not calendars and are Roman by construction.
+
+**No model change is needed.** Unlike the test-scope migration above, the object *types*
+are unchanged — only their ids move — so there is no new type to add and no model version
+to upload.
+
+These are **production calendar-editing grants**, not test-authoring scopes. Treat the
+rollback story accordingly: the unqualified ids stay valid in every PHP allow-list until
+the prune step, so a rollback to pre-#786 code keeps authorizing.
+
+### Step 1 — copy the tuples
+
+```bash
+# Dry run first — prints every tuple that would be rewritten.
+php scripts/migrate-rite-data-tuples.php
+
+# Apply.
+php scripts/migrate-rite-data-tuples.php --apply
+```
+
+National calendars and wider regions exist only in the Roman rite, so their rite is a
+constant. A diocese's rite is inferred from the rite-partitioned source tree. A diocese id
+defined under two rites, or under none, is reported and left untouched, and the run exits
+with status `2` so the anomaly is not lost in CI output.
+
+`member_nation` tuples are rewritten on **both** sides: their user side is a
+`national_calendar:` object rather than a `user:`, so it needs qualifying too.
+
+### Step 2 — verify
+
+Editors should retain access. Spot-check a diocesan grant of each rite:
+
+```bash
+curl -s "$OPENFGA_API_URL/stores/$OPENFGA_STORE_ID/check" \
+  -H 'Content-Type: application/json' \
+  -d '{"tuple_key":{"user":"user:<sub>","relation":"editor","object":"diocesan_calendar:ambrosian/lugano_ch"}}'
+```
+
+### Step 3 — prune (later)
+
+Only once **every** deployment runs post-#786 code:
+
+```bash
+php scripts/migrate-rite-data-tuples.php --apply --prune
+```
+
+Then the unqualified ids can be rejected outright rather than merely superseded. The same
+step for the #785 test scopes is described above; the two can be pruned independently.

--- a/docs/ops/test-scope-migration-runbook.md
+++ b/docs/ops/test-scope-migration-runbook.md
@@ -386,9 +386,20 @@ with status `2` so the anomaly is not lost in CI output.
 Editors should retain access. Spot-check a diocesan grant of each rite:
 
 ```bash
+# Mirrors what OpenFgaClient sends: the bearer token when OPENFGA_API_TOKEN is set,
+# and the pinned model id — omitting authorization_model_id checks against the store's
+# latest model rather than the one the API is running.
 curl -s "$OPENFGA_API_URL/stores/$OPENFGA_STORE_ID/check" \
   -H 'Content-Type: application/json' \
-  -d '{"tuple_key":{"user":"user:<sub>","relation":"editor","object":"diocesan_calendar:ambrosian/lugano_ch"}}'
+  ${OPENFGA_API_TOKEN:+-H "Authorization: Bearer $OPENFGA_API_TOKEN"} \
+  -d '{
+        "authorization_model_id": "'"$OPENFGA_MODEL_ID"'",
+        "tuple_key": {
+          "user": "user:<sub>",
+          "relation": "editor",
+          "object": "diocesan_calendar:ambrosian/lugano_ch"
+        }
+      }'
 ```
 
 ### Step 3 — prune (later)

--- a/docs/superpowers/specs/2026-08-14-rite-qualified-data-scopes-design.md
+++ b/docs/superpowers/specs/2026-08-14-rite-qualified-data-scopes-design.md
@@ -54,6 +54,13 @@ of this id exist under any rite", and only returns false when none does.
 `national_calendar` and `wider_region` remain Roman-only lookups (no Ambrosian tier exists), tolerating an
 optional `roman/` prefix once step 3 lands.
 
+**A second false negative, found while writing the migration.** The Vatican is announced as a national
+calendar but is still served by the General Roman Calendar and has no `nations/VA/VA.json` of its own yet,
+so `exists('national_calendar', 'VA')` returned false and the reconciler would purge any
+`national_calendar:VA` grant — the same silent revocation, and the id is accepted as valid when the grant is
+requested. `exists()` special-cases VA, with a comment marking the case for removal once the Vatican gains
+its folder.
+
 ## 2. `/data` rite-awareness
 
 `Router::extractRiteSegment()` already strips a leading rite segment for `calendar`, `events` and the root
@@ -121,8 +128,13 @@ no new type to add and no model version to ship.
 `scripts/migrate-rite-data-tuples.php`, mirroring `migrate-rite-test-tuples.php`: copy-only by default,
 `--prune` gated behind full rollout, idempotent, already-qualified ids recognised and skipped.
 
-Each calendar's rite is inferred from the rite-partitioned source tree, which is the authority. An id defined
-under two rites, or under none, is reported and skipped — never guessed — and the run exits `2`.
+Only a **diocese's** rite is inferred from the source tree. National calendars and wider regions exist
+exclusively in the Roman rite, so their rite is a constant — and using the filesystem for them would have
+been fragile as well as redundant, since the Vatican has no folder yet and would have been skipped. A diocese
+id defined under two rites, or under none, is reported and skipped — never guessed — and the run exits `2`.
+
+`member_nation` tuples are rewritten on both sides: their user side is a `national_calendar:` object rather
+than a `user:`.
 
 These are **production calendar-editing grants**, not test-authoring scopes, so the rollback story matters
 more than it did in #785: the unqualified ids stay valid in every allow-list until the prune step.

--- a/docs/superpowers/specs/2026-08-14-rite-qualified-data-scopes-design.md
+++ b/docs/superpowers/specs/2026-08-14-rite-qualified-data-scopes-design.md
@@ -1,0 +1,148 @@
+# Rite-qualified data resource scopes and a rite-aware `/data`
+
+Design for [issue #786](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/786).
+
+Follows [#785](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/785), which did the same
+for the *test* scopes and deferred the data resource types to this change.
+
+## Problem
+
+Three related defects, one of them live.
+
+**1. Ambrosian dioceses read as deleted.** `ResourceExistenceChecker::exists()` resolves a diocesan calendar
+by globbing `JsonData::DIOCESAN_CALENDARS_FOLDER`, which derives from `ROMAN_RITE_FOLDER`. The Ambrosian
+partition has its own constant, `AMBROSIAN_DIOCESAN_CALENDARS_FOLDER`, that the checker never consults:
+
+```text
+ResourceExistenceChecker::exists('diocesan_calendar', ...)
+  rotter_nl  (roman)     => true
+  lugano_ch  (ambrosian) => false
+  milano_it  (ambrosian) => false
+  bergam_it  (ambrosian) => false
+  novara_it  (ambrosian) => false
+```
+
+`ResourceTuplePurgeReconciler` purges on exactly that predicate, so a legitimate
+`diocesan_calendar:milano_it` grant looks orphaned and is revoked on any sweep. This is silent permission
+loss, live today.
+
+**2. `/data` cannot address Ambrosian calendars.** `/data/diocese/lugano_ch` is a 404 (`/data/diocese/rotter_nl`
+reaches the handler and 422s on validation). `RegionalDataHandler` resolves every path through Roman-only
+`JsonData` constants, in ~20 call sites across read/create/update/delete.
+
+**3. Data resource object ids are ambiguous.** `diocesan_calendar:lugano_ch` does not identify a calendar.
+The source tree is partitioned by rite, so nothing prevents the same diocese existing under both; a grant on
+the bare id would silently widen to cover a Roman `lugano_ch` the moment one was added.
+
+## Sequencing
+
+The issue proposes, and this follows, four ordered commits:
+
+1. The existence-checker fix — self-contained, stops live permission loss, depends on nothing else.
+2. `/data` rite-awareness — there is little point authorizing `diocesan_calendar:ambrosian/lugano_ch` while
+   no route can address that calendar.
+3. The object-id change.
+4. Tuple migration + runbook.
+
+## 1. Existence checker
+
+`diocesan_calendar` globs both rite partitions. Once ids are rite-qualified (step 3) the rite could select a
+single partition, but the checker must keep accepting unqualified legacy ids for the whole migration window —
+and this method decides what gets *purged*, so it stays deliberately permissive: it answers "does a calendar
+of this id exist under any rite", and only returns false when none does.
+
+`national_calendar` and `wider_region` remain Roman-only lookups (no Ambrosian tier exists), tolerating an
+optional `roman/` prefix once step 3 lands.
+
+## 2. `/data` rite-awareness
+
+`Router::extractRiteSegment()` already strips a leading rite segment for `calendar`, `events` and the root
+route. `data` joins that list, so `/data/ambrosian/diocese/lugano_ch` parses to the same 0/1/2-part shape the
+handler already expects and every downstream count-based branch is untouched.
+
+`canonicalRiteUrl()` deliberately does **not** gain `data`. It advertises the explicit form for cacheable
+read routes; `/data` is an admin write surface where a `Link: rel="canonical"` header on a `PUT` is noise.
+
+Path resolution follows the pattern the Ambrosian rollout established in `CalendarHandler` and
+`EventsHandler`: an explicit branch on `Rite::AMBROSIAN` selecting the `AMBROSIAN_*` constant, paired with a
+`validateRiteCompatibility()` on the params object. `RegionalDataParams` gains the rite and rejects, mirroring
+`EventsParams::validateRiteCompatibility()`:
+
+- `nation` or `widerregion` under a non-Roman rite — the Ambrosian rite has neither tier, and there are no
+  `AMBROSIAN_NATIONAL_*` / `AMBROSIAN_WIDER_REGION_*` constants because the data does not exist;
+- a diocese whose metadata rite differs from the requested rite.
+
+To avoid an `if (rite)` at each of ~20 call sites, the rite-partitioned constants are selected once through
+small static resolvers on `JsonData` (`diocesanCalendarFileFor(Rite)`, `diocesanCalendarI18nFolderFor(Rite)`,
+…), so a call site becomes `JsonData::diocesanCalendarFileFor($rite)->path()`.
+
+## 3. Rite-qualified object ids
+
+| Object type              | Id before   | Id after              |
+|--------------------------|-------------|-----------------------|
+| `diocesan_calendar`      | `lugano_ch` | `ambrosian/lugano_ch` |
+| `national_calendar`      | `US`        | `roman/US`            |
+| `wider_region`           | `Europe`    | `roman/Europe`        |
+| `general_roman_calendar` | `temporale` | *(unchanged)*         |
+
+Same `<rite>/<id>` format as the test scopes, same separator, same rationale.
+
+`wider_region` **is** qualified. The issue left this open (design question 2) and the instruction that
+prompted the change named only diocesan and national calendars. Qualifying it anyway is the choice here
+because wider regions live in the same rite-partitioned tree (`rite/roman/calendars/wider_regions`) as the
+other two, so exempting them would mean the model qualifies two of the three calendar-data types that sit
+side by side in the same directory — a carve-out that has to be remembered rather than a rule that can be
+stated. **Flagged for review**: it costs extra migration surface for no present benefit, and reverting it is
+a one-line change to the mapping plus its migration branch.
+
+`general_roman_calendar` stays bare. Its ids are not calendars — they are `temporale`, `decrees` and missal
+editions — and they are Roman by construction.
+
+`TestScopeResolver::qualify()` / `::parseQualifiedId()` move to a neutral home, since the data types now use
+them too and a repository depending on a *test* service for its id format would be backwards. New home:
+`src/Services/RiteScopedObjectId.php` — a tiny final class holding the separator, `qualify()` and `parse()`.
+`TestScopeResolver` keeps thin delegating wrappers so #785's public surface does not break.
+
+Touched surfaces:
+
+- `src/Http/Middleware/OpenFgaAuthorizationMiddleware.php` — `forCalendarData()` and `forMissals()` compose
+  qualified ids; `OBJECT_TYPE_MAP` unchanged
+- `src/Handlers/RegionalDataHandler.php` — `fgaObjectTypeForCategory()` and the delete-path outbox rows
+- `src/Repositories/AccessRequestRepository.php` — `isValidObjectIdForType()`, `validIdsLabelForType()`
+- `src/Services/ResourceExistenceChecker.php` — parse the prefix
+- `scripts/reconcile-resource-tuples.php` — unchanged, but its behaviour changes with the checker
+- `jsondata/schemas/openapi.json`, `docs/ops/`
+
+No OpenFGA **model** change: the object types are unchanged and only their ids move, so unlike #785 there is
+no new type to add and no model version to ship.
+
+## 4. Migration
+
+`scripts/migrate-rite-data-tuples.php`, mirroring `migrate-rite-test-tuples.php`: copy-only by default,
+`--prune` gated behind full rollout, idempotent, already-qualified ids recognised and skipped.
+
+Each calendar's rite is inferred from the rite-partitioned source tree, which is the authority. An id defined
+under two rites, or under none, is reported and skipped — never guessed — and the run exits `2`.
+
+These are **production calendar-editing grants**, not test-authoring scopes, so the rollback story matters
+more than it did in #785: the unqualified ids stay valid in every allow-list until the prune step.
+
+## Out of scope
+
+- `/tests` rite-awareness — [#787](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/787),
+  which defers its path-segment decision to whatever this change settles.
+- Frontend admin calendar pages, which construct these object ids —
+  [LiturgicalCalendarFrontend#459](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/issues/459)
+  covers the test editor; the calendar pages need the same treatment.
+- Pruning the legacy unqualified tuples, and the #785 test-scope ones, once every deployment runs merged code.
+
+## Testing
+
+- `ResourceExistenceCheckerTest` — all four Ambrosian dioceses exist; unknown ids still do not; qualified and
+  unqualified ids both resolve.
+- A reconciler test proving an Ambrosian diocesan tuple is no longer purged — the regression that motivated
+  the issue.
+- `RouterRiteSegmentTest` — `/data` strips the rite segment; `/data/ambrosian/nation/IT` is rejected.
+- `RegionalDataParams` rite-compatibility tests mirroring the `EventsParams` ones.
+- Middleware tests for the qualified ids on `forCalendarData()` / `forMissals()`.
+- Live probes of every `/data` path shape the router can now emit.

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -2723,7 +2723,7 @@
                           "permissions": [
                             {
                               "object_type": "national_calendar",
-                              "object_id": "IT",
+                              "object_id": "roman/IT",
                               "relation": "editor"
                             }
                           ],
@@ -2764,7 +2764,7 @@
                           "permissions": [
                             {
                               "object_type": "national_calendar",
-                              "object_id": "IT",
+                              "object_id": "roman/IT",
                               "relation": "editor"
                             }
                           ],
@@ -8745,7 +8745,7 @@
           },
           "object_id": {
             "type": "string",
-            "description": "Resource identifier (e.g., 'IT', 'BOSTON', 'Americas')"
+            "description": "Resource identifier. Ids that name a calendar are rite-qualified as `<rite>/<calendarId>` (e.g. `roman/IT`, `ambrosian/lugano_ch`, `roman/Americas`), because a bare calendar id does not identify a calendar; general_roman_calendar ids stay bare (e.g. `temporale`)."
           },
           "relation": {
             "type": "string",
@@ -9197,7 +9197,7 @@
           },
           "object_id": {
             "type": "string",
-            "description": "Resource identifier (e.g., 'IT', 'BOSTON')"
+            "description": "Resource identifier. Ids that name a calendar are rite-qualified as `<rite>/<calendarId>` (e.g. `roman/IT`, `ambrosian/lugano_ch`); general_roman_calendar ids stay bare (e.g. `temporale`)."
           },
           "relation": {
             "type": "string",
@@ -10263,8 +10263,8 @@
                 },
                 "object_id": {
                   "type": "string",
-                  "example": "IT",
-                  "description": "The OpenFGA object ID."
+                  "example": "roman/IT",
+                  "description": "The OpenFGA object ID. Ids that name a calendar are rite-qualified as `<rite>/<calendarId>`."
                 }
               },
               "required": [
@@ -10306,8 +10306,8 @@
                 },
                 "object_id": {
                   "type": "string",
-                  "example": "IT",
-                  "description": "The OpenFGA object ID."
+                  "example": "roman/IT",
+                  "description": "The OpenFGA object ID. Ids that name a calendar are rite-qualified as `<rite>/<calendarId>`."
                 }
               },
               "required": [
@@ -10376,8 +10376,8 @@
                 },
                 "object_id": {
                   "type": "string",
-                  "example": "IT",
-                  "description": "The OpenFGA object ID."
+                  "example": "roman/IT",
+                  "description": "The OpenFGA object ID. Ids that name a calendar are rite-qualified as `<rite>/<calendarId>`."
                 }
               },
               "required": [
@@ -10406,8 +10406,8 @@
                 },
                 "object_id": {
                   "type": "string",
-                  "example": "IT",
-                  "description": "The OpenFGA object ID."
+                  "example": "roman/IT",
+                  "description": "The OpenFGA object ID. Ids that name a calendar are rite-qualified as `<rite>/<calendarId>`."
                 }
               },
               "required": [

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -3539,7 +3539,8 @@
                 "national_calendar_test",
                 "diocesan_calendar_test",
                 "general_roman_calendar_test",
-                "rite_calendar_test"
+                "rite_calendar_test",
+                "general_roman_calendar"
               ]
             }
           },
@@ -3906,7 +3907,8 @@
                 "national_calendar_test",
                 "diocesan_calendar_test",
                 "general_roman_calendar_test",
-                "rite_calendar_test"
+                "rite_calendar_test",
+                "general_roman_calendar"
               ]
             }
           },
@@ -8739,7 +8741,8 @@
               "national_calendar_test",
               "diocesan_calendar_test",
               "general_roman_calendar_test",
-              "rite_calendar_test"
+              "rite_calendar_test",
+              "general_roman_calendar"
             ],
             "description": "OpenFGA object type"
           },
@@ -9192,7 +9195,8 @@
               "national_calendar_test",
               "diocesan_calendar_test",
               "general_roman_calendar_test",
-              "rite_calendar_test"
+              "rite_calendar_test",
+              "general_roman_calendar"
             ]
           },
           "object_id": {

--- a/phpunit_tests/Enum/JsonDataRiteResolversTest.php
+++ b/phpunit_tests/Enum/JsonDataRiteResolversTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Rite;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The rite resolvers decide which partition of the source tree `/data` reads and
+ * writes (issue #786). Getting one wrong would silently send an Ambrosian write into
+ * the Roman tree, so each is pinned to the case it must return.
+ *
+ * Only the diocesan tier has resolvers: there are no `AMBROSIAN_NATIONAL_*` or
+ * `AMBROSIAN_WIDER_REGION_*` constants, because the Ambrosian rite has neither tier.
+ */
+#[CoversClass(JsonData::class)]
+final class JsonDataRiteResolversTest extends TestCase
+{
+    /**
+     * @return array<string, array{0: string, 1: Rite, 2: JsonData}>
+     */
+    public static function resolverProvider(): array
+    {
+        return [
+            'file / roman'            => ['diocesanCalendarFileFor', Rite::ROMAN, JsonData::DIOCESAN_CALENDAR_FILE],
+            'file / ambrosian'        => ['diocesanCalendarFileFor', Rite::AMBROSIAN, JsonData::AMBROSIAN_DIOCESAN_CALENDAR_FILE],
+            'folder / roman'          => ['diocesanCalendarsFolderFor', Rite::ROMAN, JsonData::DIOCESAN_CALENDARS_FOLDER],
+            'folder / ambrosian'      => ['diocesanCalendarsFolderFor', Rite::AMBROSIAN, JsonData::AMBROSIAN_DIOCESAN_CALENDARS_FOLDER],
+            'i18n folder / roman'     => ['diocesanCalendarI18nFolderFor', Rite::ROMAN, JsonData::DIOCESAN_CALENDAR_I18N_FOLDER],
+            'i18n folder / ambrosian' => ['diocesanCalendarI18nFolderFor', Rite::AMBROSIAN, JsonData::AMBROSIAN_DIOCESAN_CALENDAR_I18N_FOLDER],
+            'i18n file / roman'       => ['diocesanCalendarI18nFileFor', Rite::ROMAN, JsonData::DIOCESAN_CALENDAR_I18N_FILE],
+            'i18n file / ambrosian'   => ['diocesanCalendarI18nFileFor', Rite::AMBROSIAN, JsonData::AMBROSIAN_DIOCESAN_CALENDAR_I18N_FILE],
+        ];
+    }
+
+    #[DataProvider('resolverProvider')]
+    public function testResolverReturnsTheRitesOwnCase(string $resolver, Rite $rite, JsonData $expected): void
+    {
+        self::assertSame($expected, JsonData::{$resolver}($rite));
+    }
+
+    public function testTheTwoRitesNeverResolveToTheSameCase(): void
+    {
+        foreach (
+            [
+                'diocesanCalendarFileFor',
+                'diocesanCalendarsFolderFor',
+                'diocesanCalendarI18nFolderFor',
+                'diocesanCalendarI18nFileFor',
+            ] as $resolver
+        ) {
+            self::assertNotSame(
+                JsonData::{$resolver}(Rite::ROMAN),
+                JsonData::{$resolver}(Rite::AMBROSIAN),
+                "{$resolver}() must send each rite to its own partition"
+            );
+        }
+    }
+
+    public function testAmbrosianPathsLiveUnderTheAmbrosianRiteFolder(): void
+    {
+        self::assertStringContainsString('/rite/ambrosian/', JsonData::diocesanCalendarFileFor(Rite::AMBROSIAN)->value);
+        self::assertStringContainsString('/rite/roman/', JsonData::diocesanCalendarFileFor(Rite::ROMAN)->value);
+    }
+}

--- a/phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/Admin/PermissionAdminHandlerTest.php
@@ -408,8 +408,8 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
             // readTuples: 3 tuples on national_calendar
             new Response(200, [], (string) json_encode([
                 'tuples'             => [
-                    ['key' => ['user' => 'user:alice', 'relation' => 'editor', 'object' => 'national_calendar:IT']],
-                    ['key' => ['user' => 'user:bob',   'relation' => 'viewer', 'object' => 'national_calendar:US']],
+                    ['key' => ['user' => 'user:alice', 'relation' => 'editor', 'object' => 'national_calendar:roman/IT']],
+                    ['key' => ['user' => 'user:bob',   'relation' => 'viewer', 'object' => 'national_calendar:roman/US']],
                     ['key' => ['user' => 'user:carol', 'relation' => 'editor', 'object' => 'national_calendar:FR']],
                 ],
                 'continuation_token' => '',
@@ -417,8 +417,8 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
             // listObjects: admin allowed on IT + US (NOT FR)
             new Response(200, [], (string) json_encode([
                 'objects' => [
-                    'national_calendar:IT',
-                    'national_calendar:US',
+                    'national_calendar:roman/IT',
+                    'national_calendar:roman/US',
                 ],
             ])),
         ]);
@@ -448,7 +448,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
         self::assertCount(2, $body['permissions']);
         $allowedObjects = array_column($body['permissions'], 'object');
         sort($allowedObjects);
-        self::assertSame(['national_calendar:IT', 'national_calendar:US'], $allowedObjects);
+        self::assertSame(['national_calendar:roman/IT', 'national_calendar:roman/US'], $allowedObjects);
 
         // Exactly two HTTP calls: readTuples + listObjects. Never N+1.
         self::assertCount(2, $requestHistory);
@@ -491,7 +491,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
                         [
                             'user'        => 'user-alice',
                             'object_type' => 'national_calendar',
-                            'object_id'   => 'IT',
+                            'object_id'   => 'roman/IT',
                             'relation'    => 'editor',
                         ]
                     ))
@@ -524,7 +524,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
         $requestBody = [
             'user'        => 'user-alice',
             'object_type' => 'national_calendar',
-            'object_id'   => 'IT',
+            'object_id'   => 'roman/IT',
             'relation'    => 'editor',
         ];
 
@@ -589,7 +589,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
                         [
                             'user'        => 'user-alice',
                             'object_type' => 'national_calendar',
-                            'object_id'   => 'IT',
+                            'object_id'   => 'roman/IT',
                             'relation'    => 'editor',
                         ]
                     ))
@@ -637,7 +637,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
                         [
                             'user'        => 'user-alice',
                             'object_type' => 'national_calendar',
-                            'object_id'   => 'IT',
+                            'object_id'   => 'roman/IT',
                             'relation'    => 'editor',
                         ]
                     ))
@@ -681,7 +681,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
                             [
                                 'user'        => 'user-alice',
                                 'object_type' => 'national_calendar',
-                                'object_id'   => 'IT',
+                                'object_id'   => 'roman/IT',
                                 'relation'    => 'editor',
                             ]
                         ))
@@ -735,7 +735,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
                             [
                                 'user'        => 'user-alice',
                                 'object_type' => 'national_calendar',
-                                'object_id'   => 'IT',
+                                'object_id'   => 'roman/IT',
                                 'relation'    => 'editor',
                             ]
                         ))
@@ -787,7 +787,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
                             [
                                 'user'        => 'user-alice',
                                 'object_type' => 'national_calendar',
-                                'object_id'   => 'IT',
+                                'object_id'   => 'roman/IT',
                                 'relation'    => 'editor',
                             ]
                         ))
@@ -815,7 +815,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
         $requestBody = [
             'user'        => 'user-alice',
             'object_type' => 'national_calendar',
-            'object_id'   => 'IT',
+            'object_id'   => 'roman/IT',
             'relation'    => 'editor',
         ];
 
@@ -877,7 +877,7 @@ final class PermissionAdminHandlerTest extends AbstractHandlerTestCase
             fn(OpenFgaClient $client) => $this->dispatchRevokePermission(
                 user: 'user:user-d9-12345',
                 objectType: 'national_calendar',
-                objectId: 'IT',
+                objectId: 'roman/IT',
                 relation: 'editor',
                 outboxRepo: $outboxRepo,
                 notifier: $notifier,

--- a/phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php
+++ b/phpunit_tests/Handlers/Auth/AccessRequestHandlerTest.php
@@ -107,7 +107,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             'POST',
             '/auth/access-requests',
             [],
-            ['permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]]
+            ['permissions' => [['object_type' => 'national_calendar', 'object_id' => 'roman/IT', 'relation' => 'editor']]]
         )->withAttribute('oidc_user', $this->oidcUser());
 
         $this->expectException(ValidationException::class);
@@ -124,7 +124,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [],
             [
                 'requested_role' => 'galactic_overlord',
-                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']],
+                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'roman/IT', 'relation' => 'editor']],
             ]
         )->withAttribute('oidc_user', $this->oidcUser());
 
@@ -157,7 +157,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [],
             [
                 'requested_role' => 'developer',
-                'permissions'    => [['object_type' => 'not_a_type', 'object_id' => 'IT', 'relation' => 'editor']],
+                'permissions'    => [['object_type' => 'not_a_type', 'object_id' => 'roman/IT', 'relation' => 'editor']],
             ]
         )->withAttribute('oidc_user', $this->oidcUser());
 
@@ -195,7 +195,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [],
             [
                 'requested_role' => 'test_editor',
-                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']],
+                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'roman/IT', 'relation' => 'editor']],
             ]
         )->withAttribute('oidc_user', $this->oidcUser());
 
@@ -214,7 +214,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [
                 'requested_role' => 'developer',
                 'permissions'    => [
-                    ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+                    ['object_type' => 'national_calendar', 'object_id' => 'roman/IT', 'relation' => 'editor'],
                 ],
                 'justification'  => 'I help maintain the IT calendar.',
             ]
@@ -240,7 +240,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [],
             [
                 'requested_role' => 'developer',
-                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']],
+                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'roman/IT', 'relation' => 'editor']],
             ]
         )->withAttribute('oidc_user', $this->oidcUser());
 
@@ -252,7 +252,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [],
             [
                 'requested_role' => 'developer',
-                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'US', 'relation' => 'editor']],
+                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'roman/US', 'relation' => 'editor']],
             ]
         )->withAttribute('oidc_user', $this->oidcUser());
 
@@ -267,7 +267,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             'POST',
             '/auth/access-requests/not-a-uuid/resubmit',
             [],
-            ['permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]]
+            ['permissions' => [['object_type' => 'national_calendar', 'object_id' => 'roman/IT', 'relation' => 'editor']]]
         )->withAttribute('oidc_user', $this->oidcUser());
 
         $this->expectException(ValidationException::class);
@@ -286,7 +286,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             'POST',
             '/auth/access-requests/' . $reqId . '/resubmit',
             [],
-            ['permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]]
+            ['permissions' => [['object_type' => 'national_calendar', 'object_id' => 'roman/IT', 'relation' => 'editor']]]
         )->withAttribute('oidc_user', $this->oidcUser('user-alice'));
 
         $this->expectException(ForbiddenException::class);
@@ -305,7 +305,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [],
             [
                 'permissions' => [
-                    ['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor'],
+                    ['object_type' => 'national_calendar', 'object_id' => 'roman/IT', 'relation' => 'editor'],
                 ],
             ]
         )->withAttribute('oidc_user', $this->oidcUser());
@@ -490,7 +490,7 @@ final class AccessRequestHandlerTest extends AbstractHandlerTestCase
             [],
             [
                 'requested_role' => 'test_editor',
-                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']],
+                'permissions'    => [['object_type' => 'national_calendar', 'object_id' => 'roman/IT', 'relation' => 'editor']],
             ]
         )->withAttribute('oidc_user', $this->oidcUser());
 

--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Handlers;
 
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
 use LiturgicalCalendar\Api\Http\Exception\UnprocessableContentException;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
@@ -135,6 +136,63 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
         $this->mtJsonPath  = '';
         $this->mtI18nDir   = '';
         $this->mtI18nPath  = '';
+    }
+
+    /**
+     * Issue #786: /data reads the rite's own partition of the source tree. Before the
+     * rite segment existed, the Ambrosian diocesan calendars were unreachable — the
+     * handler could only resolve Roman-only JsonData constants, so this was a 404.
+     */
+    public function testGetAmbrosianDiocesanCalendarReadsTheAmbrosianTree(): void
+    {
+        $response = ( new RegionalDataHandler(['diocese', 'lugano_ch'], Rite::AMBROSIAN) )
+            ->handle($this->requestFor('GET', '/data/ambrosian/diocese/lugano_ch', ['Accept-Language' => 'it-IT']));
+
+        self::assertSame(200, $response->getStatusCode());
+
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal', $body);
+        self::assertNotEmpty($body['litcal']);
+    }
+
+    public function testGetRomanDiocesanCalendarStillReadsTheRomanTree(): void
+    {
+        $response = ( new RegionalDataHandler(['diocese', 'rotter_nl'], Rite::ROMAN) )
+            ->handle($this->requestFor('GET', '/data/roman/diocese/rotter_nl', ['Accept-Language' => 'nl-NL']));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertArrayHasKey('litcal', $this->decodeJsonBody($response));
+    }
+
+    public function testGetAmbrosianDiocesanI18nReadsTheAmbrosianTree(): void
+    {
+        // The i18n file for an Ambrosian diocese lives beside its calendar, under
+        // rite/ambrosian/, not in the Roman tree.
+        $response = ( new RegionalDataHandler(['diocese', 'lugano_ch', 'it_IT'], Rite::AMBROSIAN) )
+            ->handle($this->requestFor('GET', '/data/ambrosian/diocese/lugano_ch/it_IT', ['Accept-Language' => 'it-IT']));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertNotEmpty($this->decodeJsonBody($response));
+    }
+
+    public function testDiocesanCalendarOfAnotherRiteIsRejected(): void
+    {
+        // Requesting an Ambrosian diocese under the Roman rite would otherwise read
+        // and write the wrong partition of the source tree.
+        $this->expectException(UnprocessableContentException::class);
+        $this->expectExceptionMessage('belongs to the ambrosian rite, not the requested roman rite');
+
+        ( new RegionalDataHandler(['diocese', 'lugano_ch'], Rite::ROMAN) )
+            ->handle($this->requestFor('GET', '/data/diocese/lugano_ch', ['Accept-Language' => 'it-IT']));
+    }
+
+    public function testRomanDioceseUnderTheAmbrosianRiteIsRejected(): void
+    {
+        $this->expectException(UnprocessableContentException::class);
+        $this->expectExceptionMessage('belongs to the roman rite, not the requested ambrosian rite');
+
+        ( new RegionalDataHandler(['diocese', 'rotter_nl'], Rite::AMBROSIAN) )
+            ->handle($this->requestFor('GET', '/data/ambrosian/diocese/rotter_nl', ['Accept-Language' => 'nl-NL']));
     }
 
     public function testOptionsPreflightSucceeds(): void

--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -357,7 +357,7 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
         $purge = $this->createMock(ResourceTuplePurgeServiceInterface::class);
         $purge->expects($this->once())
             ->method('purgeForObject')
-            ->with('national_calendar:HR');
+            ->with('national_calendar:roman/HR');
         $handler->setPurgeService($purge);
 
         // --- Act: issue DELETE (bypasses JWT middleware — in-process) --------
@@ -495,9 +495,9 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
             ->with($this->callback(function (array $rows): bool {
                 foreach ($rows as $r) {
                     if (
-                        $r['fga_user'] === 'national_calendar:MT'
+                        $r['fga_user'] === 'national_calendar:roman/MT'
                         && $r['fga_relation'] === 'member_nation'
-                        && $r['fga_object'] === 'wider_region:Europe'
+                        && $r['fga_object'] === 'wider_region:roman/Europe'
                     ) {
                         return true;
                     }

--- a/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
+++ b/phpunit_tests/Http/OpenFgaAuthorizationMiddlewareTest.php
@@ -4,6 +4,7 @@ namespace LiturgicalCalendar\Tests\Http;
 
 use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Middleware\OpenFgaAuthorizationMiddleware;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\TestScopeResolver;
@@ -260,12 +261,67 @@ class OpenFgaAuthorizationMiddlewareTest extends TestCase
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    /**
+     * Issue #786: the /data object id carries the route's rite, so a grant on an
+     * Ambrosian diocese cannot be satisfied by a Roman one of the same id.
+     */
+    public function testForCalendarDataQualifiesTheObjectIdWithTheRite(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->once())
+            ->method('check')
+            ->with('user:abc', 'editor', 'diocesan_calendar:ambrosian/lugano_ch')
+            ->willReturn(true);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forCalendarData($client, 'diocese', Rite::AMBROSIAN);
+        self::assertNotNull($middleware);
+
+        $request = ( new ServerRequest('PATCH', '/data/ambrosian/diocese/lugano_ch') )
+            ->withAttribute('oidc_user', ['sub' => 'abc', 'roles' => ['calendar_editor']])
+            ->withAttribute('calendar_id', 'lugano_ch');
+
+        $this->assertEquals(200, $middleware->process($request, $this->nextHandler)->getStatusCode());
+    }
+
+    public function testForCalendarDataDefaultsToTheRomanRite(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->once())
+            ->method('check')
+            ->with('user:abc', 'editor', 'diocesan_calendar:roman/rotter_nl')
+            ->willReturn(true);
+
+        $middleware = OpenFgaAuthorizationMiddleware::forCalendarData($client, 'diocese');
+        self::assertNotNull($middleware);
+
+        $request = ( new ServerRequest('PATCH', '/data/diocese/rotter_nl') )
+            ->withAttribute('oidc_user', ['sub' => 'abc', 'roles' => ['calendar_editor']])
+            ->withAttribute('calendar_id', 'rotter_nl');
+
+        $this->assertEquals(200, $middleware->process($request, $this->nextHandler)->getStatusCode());
+    }
+
+    public function testForCalendarDataFailsClosedWithoutACalendarId(): void
+    {
+        $client = $this->createMock(OpenFgaClient::class);
+        $client->expects($this->never())->method('check');
+
+        $middleware = OpenFgaAuthorizationMiddleware::forCalendarData($client, 'diocese', Rite::ROMAN);
+        self::assertNotNull($middleware);
+
+        $request = ( new ServerRequest('PATCH', '/data/diocese/') )
+            ->withAttribute('oidc_user', ['sub' => 'abc', 'roles' => ['calendar_editor']]);
+
+        $this->expectException(ForbiddenException::class);
+        $middleware->process($request, $this->nextHandler);
+    }
+
     public function testForMissalsNationalChecksNationalCalendarByPrefix(): void
     {
         $client = $this->createMock(OpenFgaClient::class);
         $client->expects($this->once())
             ->method('check')
-            ->with('user:abc', 'admin', 'national_calendar:IT')
+            ->with('user:abc', 'admin', 'national_calendar:roman/IT')
             ->willReturn(true);
 
         $middleware = OpenFgaAuthorizationMiddleware::forMissals($client, 'IT_1983');

--- a/phpunit_tests/Params/RegionalDataParamsTest.php
+++ b/phpunit_tests/Params/RegionalDataParamsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Params;
 
 use LiturgicalCalendar\Api\Enum\PathCategory;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanData;
 use LiturgicalCalendar\Api\Params\RegionalDataParams;
@@ -27,6 +28,66 @@ final class RegionalDataParamsTest extends TestCase
         $this->expectException(ValidationException::class);
 
         new RegionalDataParams(['category' => PathCategory::NATION]); // @phpstan-ignore-line
+    }
+
+    public function testRiteDefaultsToRomanWhenAbsent(): void
+    {
+        $params = new RegionalDataParams([
+            'category' => PathCategory::NATION,
+            'key'      => 'IT',
+        ]);
+
+        self::assertSame(Rite::ROMAN, $params->rite);
+    }
+
+    public function testDiocesanCategoryAcceptsTheAmbrosianRite(): void
+    {
+        // The diocesan tier is the only one that exists under more than one rite.
+        $params = new RegionalDataParams([
+            'category' => PathCategory::DIOCESE,
+            'key'      => 'lugano_ch',
+            'rite'     => Rite::AMBROSIAN,
+        ]);
+
+        self::assertSame(Rite::AMBROSIAN, $params->rite);
+        self::assertSame(PathCategory::DIOCESE, $params->category);
+    }
+
+    public function testAmbrosianNationalCalendarIsRejected(): void
+    {
+        // There is no rite/ambrosian/calendars/nations tree to read or write.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('has no national calendars');
+
+        new RegionalDataParams([
+            'category' => PathCategory::NATION,
+            'key'      => 'IT',
+            'rite'     => Rite::AMBROSIAN,
+        ]);
+    }
+
+    public function testAmbrosianWiderRegionIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('has no wider regions');
+
+        new RegionalDataParams([
+            'category' => PathCategory::WIDERREGION,
+            'key'      => 'Europe',
+            'rite'     => Rite::AMBROSIAN,
+        ]);
+    }
+
+    public function testRomanRiteAcceptsEveryCategory(): void
+    {
+        foreach ([PathCategory::NATION, PathCategory::DIOCESE, PathCategory::WIDERREGION] as $category) {
+            $params = new RegionalDataParams([
+                'category' => $category,
+                'key'      => 'whatever',
+                'rite'     => Rite::ROMAN,
+            ]);
+            self::assertSame(Rite::ROMAN, $params->rite);
+        }
     }
 
     public function testCategoryAndKeyAreAssigned(): void

--- a/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryConstantsTest.php
@@ -35,8 +35,9 @@ final class AccessRequestRepositoryConstantsTest extends TestCase
         }
         self::assertFalse(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', 'EDITIO_TYPICA_1971'));
         self::assertFalse(AccessRequestRepository::isValidObjectIdForType('general_roman_calendar', ''));
-        // Other types keep free-form ids (non-empty)
-        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('national_calendar', 'IT'));
+        // Calendar-naming types require a rite-qualified id (issue #786).
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('national_calendar', 'roman/IT'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('national_calendar', 'IT'));
         self::assertFalse(AccessRequestRepository::isValidObjectIdForType('national_calendar', ''));
     }
 
@@ -107,8 +108,9 @@ final class AccessRequestRepositoryConstantsTest extends TestCase
             implode(', ', AccessRequestRepository::GRC_OBJECT_IDS),
             AccessRequestRepository::validIdsLabelForType('general_roman_calendar')
         );
-        self::assertSame('a two-letter ISO nation code', AccessRequestRepository::validIdsLabelForType('national_calendar'));
-        self::assertSame('any non-empty id', AccessRequestRepository::validIdsLabelForType('wider_region'));
+        self::assertStringContainsString('roman/US', AccessRequestRepository::validIdsLabelForType('national_calendar'));
+        self::assertStringContainsString('ambrosian/lugano_ch', AccessRequestRepository::validIdsLabelForType('diocesan_calendar'));
+        self::assertStringContainsString('roman/Europe', AccessRequestRepository::validIdsLabelForType('wider_region'));
         self::assertSame('any non-empty id', AccessRequestRepository::validIdsLabelForType('something_unknown'));
     }
 

--- a/phpunit_tests/Repositories/AccessRequestRepositoryTest.php
+++ b/phpunit_tests/Repositories/AccessRequestRepositoryTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Repositories;
 
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Repositories\AccessRequestRepository;
+use LiturgicalCalendar\Api\Services\RiteScopedObjectId;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -407,7 +409,7 @@ final class AccessRequestRepositoryTest extends RepositoryTestCase
                 $code = $a . $b;
                 self::assertSame(
                     isset($enumSet[$code]),
-                    AccessRequestRepository::isValidObjectIdForType('national_calendar', $code),
+                    AccessRequestRepository::isValidObjectIdForType('national_calendar', RiteScopedObjectId::qualify(Rite::ROMAN, $code)),
                     "Validation of '{$code}' differs between CommonDef.json and the access-request validator"
                 );
             }
@@ -417,7 +419,26 @@ final class AccessRequestRepositoryTest extends RepositoryTestCase
     #[DataProvider('provideNationCodes')]
     public function testNationalCalendarObjectIdValidation(string $code, bool $expected): void
     {
-        self::assertSame($expected, AccessRequestRepository::isValidObjectIdForType('national_calendar', $code));
+        // The nation code is carried inside a rite-qualified id (issue #786).
+        self::assertSame(
+            $expected,
+            AccessRequestRepository::isValidObjectIdForType('national_calendar', RiteScopedObjectId::qualify(Rite::ROMAN, $code))
+        );
+    }
+
+    public function testNationalCalendarRequiresARiteQualifiedId(): void
+    {
+        // A bare nation code no longer identifies a calendar.
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('national_calendar', 'IT'));
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('national_calendar', 'roman/IT'));
+    }
+
+    public function testOnlyTheDiocesanTierExistsUnderANonRomanRite(): void
+    {
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('diocesan_calendar', 'ambrosian/lugano_ch'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('national_calendar', 'ambrosian/IT'));
+        self::assertFalse(AccessRequestRepository::isValidObjectIdForType('wider_region', 'ambrosian/Europe'));
+        self::assertTrue(AccessRequestRepository::isValidObjectIdForType('wider_region', 'roman/Europe'));
     }
 
     /** @return array<string, array{0: string, 1: bool}> */

--- a/phpunit_tests/RouterRiteSegmentTest.php
+++ b/phpunit_tests/RouterRiteSegmentTest.php
@@ -61,9 +61,9 @@ final class RouterRiteSegmentTest extends TestCase
         self::assertSame(['nation', 'US'], $parts);
     }
 
-    public function testRiteSegmentOnlyAppliesToTheCalendarAndEventsRoutes(): void
+    public function testRiteSegmentOnlyAppliesToTheRiteCarryingRoutes(): void
     {
-        // A route that is neither calendar nor events must never treat a leading
+        // A route that carries no rite segment must never treat a leading
         // 'ambrosian'/'roman' as a rite.
         $parts = ['ambrosian'];
         self::assertSame(Rite::ROMAN, Router::extractRiteSegment('metadata', $parts));
@@ -84,5 +84,36 @@ final class RouterRiteSegmentTest extends TestCase
         $parts = ['nation', 'US'];
         self::assertSame(Rite::ROMAN, Router::extractRiteSegment('events', $parts));
         self::assertSame(['nation', 'US'], $parts);
+    }
+
+    /**
+     * Issue #786: `/data` gained the same optional leading rite segment, so the
+     * Ambrosian diocesan calendars became addressable — `/data/diocese/lugano_ch`
+     * was a 404 before, because the handler could only read the Roman partition.
+     */
+    public function testDataRouteSupportsAnAmbrosianRiteSegment(): void
+    {
+        $parts = ['ambrosian', 'diocese', 'lugano_ch'];
+        self::assertSame(Rite::AMBROSIAN, Router::extractRiteSegment('data', $parts));
+        self::assertSame(['diocese', 'lugano_ch'], $parts);
+    }
+
+    public function testDataRouteExplicitRomanIsEquivalentToBare(): void
+    {
+        $explicit = ['roman', 'diocese', 'rotter_nl'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('data', $explicit));
+
+        $bare = ['diocese', 'rotter_nl'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('data', $bare));
+
+        // Both forms leave the handler the same 2-part shape to parse.
+        self::assertSame($bare, $explicit);
+    }
+
+    public function testDataRouteWithNoRiteSegmentLeavesTheCategoryIntact(): void
+    {
+        $parts = ['widerregion', 'Europe'];
+        self::assertSame(Rite::ROMAN, Router::extractRiteSegment('data', $parts));
+        self::assertSame(['widerregion', 'Europe'], $parts);
     }
 }

--- a/phpunit_tests/Services/Outbox/ResourceTuplePurgeReconcilerTest.php
+++ b/phpunit_tests/Services/Outbox/ResourceTuplePurgeReconcilerTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Services\Outbox;
 
+use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceExistenceChecker;
 use LiturgicalCalendar\Api\Services\ResourceExistenceCheckerInterface;
 use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
 use LiturgicalCalendar\Api\Services\Outbox\ResourceTuplePurgeReconciler;
@@ -45,6 +47,43 @@ final class ResourceTuplePurgeReconcilerTest extends TestCase
         $result     = $reconciler->sweep();
 
         $this->assertSame(1, $result['purgedObjects']);
+    }
+
+    /**
+     * Regression guard for issue #786, wired to the REAL ResourceExistenceChecker.
+     *
+     * Every other test here stubs the checker, so none of them could catch the bug:
+     * the checker globbed only the Roman partition, every Ambrosian diocese answered
+     * "deleted", and a sweep silently revoked live editor grants on all four of them.
+     * A Roman diocese and a genuinely absent one are swept alongside to show the
+     * predicate still discriminates.
+     */
+    public function testSweepDoesNotPurgeGrantsOnAmbrosianDiocesanCalendars(): void
+    {
+        Router::getApiPaths();
+
+        $client = $this->createStub(OpenFgaClient::class);
+        $client->method('readTuples')->willReturn([
+            'tuples'                  => [
+                ['user' => 'user:a', 'relation' => 'editor', 'object' => 'diocesan_calendar:milano_it'],
+                ['user' => 'user:b', 'relation' => 'editor', 'object' => 'diocesan_calendar:lugano_ch'],
+                ['user' => 'user:c', 'relation' => 'editor', 'object' => 'diocesan_calendar:rotter_nl'],
+                // genuinely absent under either rite -> this one SHOULD be purged
+                ['user' => 'user:d', 'relation' => 'editor', 'object' => 'diocesan_calendar:nowhere_zz'],
+            ],
+            'next_continuation_token' => '',
+        ]);
+
+        $purge = $this->createMock(ResourceTuplePurgeServiceInterface::class);
+        $purge->expects($this->once())
+            ->method('purgeForObject')
+            ->with('diocesan_calendar:nowhere_zz')
+            ->willReturn(1);
+
+        $reconciler = new ResourceTuplePurgeReconciler($client, new ResourceExistenceChecker(), $purge);
+        $result     = $reconciler->sweep();
+
+        $this->assertSame(1, $result['purgedObjects'], 'Only the absent diocese may be purged.');
     }
 
     public function testNoOperationalTuplesYieldsZeroPurgedObjects(): void

--- a/phpunit_tests/Services/ResourceExistenceCheckerTest.php
+++ b/phpunit_tests/Services/ResourceExistenceCheckerTest.php
@@ -59,6 +59,40 @@ final class ResourceExistenceCheckerTest extends TestCase
         $this->assertFalse($checker->exists('diocesan_calendar', ''));
     }
 
+    /**
+     * The Vatican is announced as a national calendar but is still served by the
+     * General Roman Calendar, so it has no `nations/VA/VA.json` yet. Without the
+     * special case a live `national_calendar:VA` grant reads as orphaned and the
+     * reconciler purges it. Delete this test's VA assertions once the Vatican gains
+     * its own folder — the ordinary is_file() path will cover it then.
+     */
+    public function testVaticanNationalCalendarExistsWithoutItsOwnFolder(): void
+    {
+        $checker = new ResourceExistenceChecker();
+        $this->assertTrue($checker->exists('national_calendar', 'VA'));
+        $this->assertTrue($checker->exists('national_calendar', 'roman/VA'));
+    }
+
+    public function testNationalCalendarsWithFoldersExistAndUnknownOnesDoNot(): void
+    {
+        $checker = new ResourceExistenceChecker();
+        $this->assertTrue($checker->exists('national_calendar', 'roman/US'));
+        $this->assertTrue($checker->exists('national_calendar', 'roman/IT'));
+        $this->assertFalse($checker->exists('national_calendar', 'roman/ZZ'));
+        $this->assertFalse($checker->exists('national_calendar', 'ZZ'));
+    }
+
+    public function testQualifiedAndUnqualifiedIdsResolveAlike(): void
+    {
+        // Unqualified ids stay in the store for the whole migration window, and this
+        // predicate decides what gets purged, so both forms must resolve.
+        $checker = new ResourceExistenceChecker();
+        $this->assertTrue($checker->exists('diocesan_calendar', 'ambrosian/lugano_ch'));
+        $this->assertTrue($checker->exists('diocesan_calendar', 'lugano_ch'));
+        $this->assertTrue($checker->exists('wider_region', 'roman/Europe'));
+        $this->assertTrue($checker->exists('wider_region', 'Europe'));
+    }
+
     public function testNonResourceTypeIsNotAResourceType(): void
     {
         $checker = new ResourceExistenceChecker();

--- a/phpunit_tests/Services/ResourceExistenceCheckerTest.php
+++ b/phpunit_tests/Services/ResourceExistenceCheckerTest.php
@@ -25,6 +25,40 @@ final class ResourceExistenceCheckerTest extends TestCase
         $this->assertTrue($checker->exists('general_roman_calendar_test', 'temporale'));
     }
 
+    /**
+     * Regression guard for issue #786.
+     *
+     * exists() used to glob only JsonData::DIOCESAN_CALENDARS_FOLDER, which derives
+     * from ROMAN_RITE_FOLDER, so every Ambrosian diocese reported as gone. Because
+     * ResourceTuplePurgeReconciler purges on exactly this predicate, a legitimate
+     * editor grant on an Ambrosian diocesan calendar was revoked on any sweep.
+     */
+    public function testAmbrosianDiocesanCalendarsExist(): void
+    {
+        $checker = new ResourceExistenceChecker();
+        foreach (['lugano_ch', 'milano_it', 'bergam_it', 'novara_it'] as $diocese) {
+            $this->assertTrue(
+                $checker->exists('diocesan_calendar', $diocese),
+                "Ambrosian diocese {$diocese} must not read as deleted — the reconciler purges on this."
+            );
+        }
+    }
+
+    public function testRomanDiocesanCalendarsStillExist(): void
+    {
+        $checker = new ResourceExistenceChecker();
+        foreach (['rotter_nl', 'romamo_it', 'boston_us'] as $diocese) {
+            $this->assertTrue($checker->exists('diocesan_calendar', $diocese));
+        }
+    }
+
+    public function testUnknownDiocesanCalendarDoesNotExistUnderEitherRite(): void
+    {
+        $checker = new ResourceExistenceChecker();
+        $this->assertFalse($checker->exists('diocesan_calendar', 'nowhere_zz'));
+        $this->assertFalse($checker->exists('diocesan_calendar', ''));
+    }
+
     public function testNonResourceTypeIsNotAResourceType(): void
     {
         $checker = new ResourceExistenceChecker();

--- a/phpunit_tests/Services/RiteScopedObjectIdTest.php
+++ b/phpunit_tests/Services/RiteScopedObjectIdTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Services\RiteScopedObjectId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The `<rite>/<calendarId>` OpenFGA object id format shared by the test scopes
+ * (issue #767) and the data resource types (#786).
+ */
+#[CoversClass(RiteScopedObjectId::class)]
+final class RiteScopedObjectIdTest extends TestCase
+{
+    public function testQualifyComposesRiteAndCalendarId(): void
+    {
+        self::assertSame('ambrosian/lugano_ch', RiteScopedObjectId::qualify(Rite::AMBROSIAN, 'lugano_ch'));
+        self::assertSame('roman/US', RiteScopedObjectId::qualify(Rite::ROMAN, 'US'));
+    }
+
+    public function testParseIsTheInverseOfQualify(): void
+    {
+        foreach (Rite::cases() as $rite) {
+            $qualified = RiteScopedObjectId::qualify($rite, 'some_calendar');
+            self::assertSame([$rite, 'some_calendar'], RiteScopedObjectId::parse($qualified));
+        }
+    }
+
+    /**
+     * @return array<string, array{0: string}>
+     */
+    public static function unparseableIdProvider(): array
+    {
+        return [
+            'unqualified legacy id' => ['rotter_nl'],
+            'unknown rite'          => ['byzantine/foo'],
+            'empty calendar id'     => ['roman/'],
+            'empty string'          => [''],
+            'separator only'        => ['/'],
+        ];
+    }
+
+    #[DataProvider('unparseableIdProvider')]
+    public function testParseReturnsNullForAnythingNotRiteQualified(string $objectId): void
+    {
+        self::assertNull(RiteScopedObjectId::parse($objectId));
+    }
+
+    public function testTheSameCalendarIdUnderTwoRitesYieldsDistinctObjectIds(): void
+    {
+        // The whole point: a bare `lugano_ch` grant would be ambiguous.
+        self::assertNotSame(
+            RiteScopedObjectId::qualify(Rite::ROMAN, 'lugano_ch'),
+            RiteScopedObjectId::qualify(Rite::AMBROSIAN, 'lugano_ch')
+        );
+    }
+
+    public function testCalendarIdStripsTheQualifierWhenPresent(): void
+    {
+        self::assertSame('lugano_ch', RiteScopedObjectId::calendarId('ambrosian/lugano_ch'));
+        self::assertSame('US', RiteScopedObjectId::calendarId('roman/US'));
+    }
+
+    public function testCalendarIdPassesThroughAnUnqualifiedId(): void
+    {
+        // Legacy ids are still in the store for the whole migration window, so the
+        // filesystem lookups that use this must keep working on both forms.
+        self::assertSame('rotter_nl', RiteScopedObjectId::calendarId('rotter_nl'));
+        self::assertSame('', RiteScopedObjectId::calendarId(''));
+        self::assertSame('byzantine/foo', RiteScopedObjectId::calendarId('byzantine/foo'));
+    }
+}

--- a/scripts/migrate-rite-data-tuples.php
+++ b/scripts/migrate-rite-data-tuples.php
@@ -1,0 +1,278 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Idempotent migration: rite-qualify the OpenFGA object ids of the calendar *data*
+ * resource types (issue #786).
+ *
+ *   national_calendar:<id>  → national_calendar:<rite>/<id>
+ *   diocesan_calendar:<id>  → diocesan_calendar:<rite>/<id>
+ *   wider_region:<id>       → wider_region:<rite>/<id>
+ *
+ * A bare calendar id does not identify a calendar: the source tree is partitioned as
+ * `jsondata/sourcedata/rite/{rite}/calendars/...`, so `lugano_ch` could name an
+ * Ambrosian calendar or a Roman one, and a grant on the bare id would silently widen
+ * to cover whichever was added later. Existing grants have to follow, or every current
+ * calendar editor loses access.
+ *
+ * The companion of `migrate-rite-test-tuples.php`, which did the same for the *test*
+ * scope types in #785. These are **production calendar-editing grants**, so the default
+ * is copy-only and nothing is deleted until `--prune`.
+ *
+ * National calendars and wider regions exist only in the Roman rite, so their rite is a
+ * constant. Only a diocese needs inferring, from the rite-partitioned source tree, which
+ * is the authority on which rite a calendar is defined under. A diocese id defined under
+ * two rites — or under none — is reported and skipped: the script never guesses which
+ * grant was meant.
+ *
+ * `general_roman_calendar` is deliberately untouched: its ids are `temporale`, `decrees`
+ * and missal editions, which are not calendars and are Roman by construction.
+ *
+ * Usage:
+ *   php scripts/migrate-rite-data-tuples.php [--dry-run|--apply] [--prune]
+ *
+ * Flags:
+ *   --dry-run  (default) Print what WOULD be done without touching the store.
+ *   --apply             Write the rite-qualified tuples in OpenFGA.
+ *   --prune             Additionally DELETE the superseded unqualified tuples. Off by
+ *                       default: the unqualified ids stay valid in every allow-list so a
+ *                       rollback to pre-#786 code keeps authorizing. Only prune once
+ *                       every deployment runs merged code.
+ *
+ * Safety guarantees:
+ *   - Copy-then-prune ordering: a tuple is never deleted before its replacement is
+ *     confirmed written.
+ *   - Writing a tuple that already exists is benign (TupleAlreadyExistsException).
+ *   - Deleting a tuple that no longer exists is benign (TupleNotFoundException).
+ *   - Already-qualified ids are recognised and skipped.
+ *   - `member_nation` tuples are migrated on BOTH sides: the user side is a
+ *     `national_calendar:` object, not a `user:`, so it needs qualifying too.
+ *   - Safe to re-run after a partial migration.
+ *
+ * Required environment variables (loaded from .env* files if present):
+ *   OPENFGA_API_URL, OPENFGA_STORE_ID, OPENFGA_MODEL_ID
+ *
+ * Optional:
+ *   OPENFGA_API_TOKEN
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+use Dotenv\Dotenv;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Services\Exception\TupleAlreadyExistsException;
+use LiturgicalCalendar\Api\Services\Exception\TupleNotFoundException;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\RiteScopedObjectId;
+
+/** Object types whose ids name a calendar and therefore gain a rite. */
+const QUALIFIED_TYPES = ['national_calendar', 'diocesan_calendar', 'wider_region'];
+
+$projectRoot = dirname(__DIR__);
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+$dotenv = Dotenv::createImmutable(
+    $projectRoot,
+    ['.env', '.env.local', '.env.development', '.env.test', '.env.staging', '.env.production'],
+    false
+);
+$dotenv->safeLoad();
+
+$apply  = in_array('--apply', $argv, true);
+$prune  = in_array('--prune', $argv, true);
+$dryRun = !$apply;
+
+echo 'Mode: ' . ( $dryRun ? 'DRY RUN (pass --apply to apply changes)' : 'APPLY' ) . PHP_EOL;
+echo 'Prune superseded tuples: ' . ( $prune ? 'YES' : 'no (copy only)' ) . PHP_EOL;
+echo PHP_EOL;
+
+/**
+ * Rites under which a diocesan calendar of the given id is defined on disk.
+ *
+ * Only the diocesan tier needs inferring. National calendars and wider regions exist
+ * exclusively in the Roman rite — there is no `rite/ambrosian/calendars/nations` or
+ * `.../wider_regions` — so their rite is a constant, not a lookup, and stays constant
+ * however the Roman tree grows.
+ *
+ * Using the filesystem for them would also have been fragile rather than merely
+ * redundant: the Vatican is announced as a national calendar but is still served by the
+ * General Roman Calendar and has no `nations/VA/VA.json` of its own yet, so a filesystem
+ * probe would report `national_calendar:VA` unresolvable and skip a live grant.
+ *
+ * Closures rather than named functions: this file is a script whose job is side
+ * effects, and PSR-1 asks a file to declare symbols or execute logic, not both.
+ *
+ * @var callable(string): list<Rite> $ritesDefiningDiocese
+ */
+$ritesDefiningDiocese = static function (string $calendarId) use ($projectRoot): array {
+    $found = [];
+    foreach (Rite::cases() as $rite) {
+        $matches = glob(
+            sprintf('%s/jsondata/sourcedata/rite/%s/calendars/dioceses/*/%s', $projectRoot, $rite->value, $calendarId),
+            GLOB_ONLYDIR
+        );
+        if ($matches !== false && $matches !== []) {
+            $found[] = $rite;
+        }
+    }
+    return $found;
+};
+
+// ---------------------------------------------------------------------------
+// Dependency setup
+// ---------------------------------------------------------------------------
+if (!OpenFgaClient::isConfigured()) {
+    fwrite(STDERR, "Error: OpenFGA is not configured. Set OPENFGA_API_URL, OPENFGA_STORE_ID, and OPENFGA_MODEL_ID.\n");
+    exit(1);
+}
+
+$client = OpenFgaClient::fromEnv();
+
+// ---------------------------------------------------------------------------
+// Enumerate every tuple (paginated). Read with no filter and select in app code,
+// mirroring the sibling migration scripts: the type-only object filter is not
+// reliably valid per the OpenFGA Read API spec.
+// ---------------------------------------------------------------------------
+/** @var list<array{user: string, relation: string, object: string}> $allTuples */
+$allTuples         = [];
+$continuationToken = null;
+
+do {
+    $page              = $client->readTuples('', '', null, null, $continuationToken);
+    $allTuples         = array_merge($allTuples, $page['tuples']);
+    $continuationToken = $page['next_continuation_token'] !== '' ? $page['next_continuation_token'] : null;
+} while ($continuationToken !== null);
+
+/**
+ * Rite-qualify one `<type>:<id>` reference, or return it unchanged.
+ *
+ * Returns [newReference, status] where status is one of 'qualified', 'unchanged'
+ * (not a calendar-naming type, or already qualified) or a reason string.
+ *
+ * @var callable(string): array{0: string, 1: string} $qualifyReference
+ */
+$qualifyReference = static function (string $reference) use ($ritesDefiningDiocese): array {
+    $colon = strpos($reference, ':');
+    if ($colon === false) {
+        return [$reference, 'unchanged'];
+    }
+
+    $type = substr($reference, 0, $colon);
+    $id   = substr($reference, $colon + 1);
+
+    if (!in_array($type, QUALIFIED_TYPES, true)) {
+        return [$reference, 'unchanged'];
+    }
+
+    if (null !== RiteScopedObjectId::parse($id)) {
+        return [$reference, 'already'];
+    }
+
+    // National calendars and wider regions exist only in the Roman rite.
+    if ($type !== 'diocesan_calendar') {
+        return [$type . ':' . RiteScopedObjectId::qualify(Rite::ROMAN, $id), 'qualified'];
+    }
+
+    $rites = $ritesDefiningDiocese($id);
+    if (count($rites) !== 1) {
+        $reason = $rites === []
+            ? "no diocesan calendar of id `{$id}` is defined under any rite"
+            : "`{$id}` is defined under more than one rite: " . implode(', ', array_column($rites, 'value'));
+        return [$reference, $reason];
+    }
+
+    return [$type . ':' . RiteScopedObjectId::qualify($rites[0], $id), 'qualified'];
+};
+
+$copiedCount  = 0;
+$prunedCount  = 0;
+$skippedCount = 0;
+$alreadyCount = 0;
+
+/** @var list<string> $unresolved */
+$unresolved = [];
+
+foreach ($allTuples as $tuple) {
+    // Both sides can carry a calendar reference: `member_nation` tuples have a
+    // national_calendar on the USER side, not a user:.
+    [$newUser, $userStatus]     = $qualifyReference($tuple['user']);
+    [$newObject, $objectStatus] = $qualifyReference($tuple['object']);
+
+    $statuses = [$userStatus, $objectStatus];
+
+    $problems = array_values(array_filter($statuses, static fn (string $s): bool => !in_array($s, ['unchanged', 'already', 'qualified'], true)));
+    if ($problems !== []) {
+        ++$skippedCount;
+        $detail       = "{$tuple['user']} {$tuple['relation']} {$tuple['object']} — " . implode('; ', $problems);
+        $unresolved[] = $detail;
+        echo "[SKIPPED] {$detail}" . PHP_EOL;
+        continue;
+    }
+
+    if (!in_array('qualified', $statuses, true)) {
+        if (in_array('already', $statuses, true)) {
+            ++$alreadyCount;
+        }
+        continue;
+    }
+
+    $before = "{$tuple['user']} {$tuple['relation']} {$tuple['object']}";
+    $after  = "{$newUser} {$tuple['relation']} {$newObject}";
+
+    if ($dryRun) {
+        ++$copiedCount;
+        echo "[DRY RUN] {$before} → {$after}" . PHP_EOL;
+        if ($prune) {
+            echo "[DRY RUN] would then delete {$before}" . PHP_EOL;
+        }
+        continue;
+    }
+
+    try {
+        $client->writeTuple($newUser, $tuple['relation'], $newObject);
+        echo "[COPIED] {$before} → {$after}" . PHP_EOL;
+    } catch (TupleAlreadyExistsException) {
+        echo "[ALREADY EXISTS] {$after} — write skipped" . PHP_EOL;
+    }
+    ++$copiedCount;
+
+    if (!$prune) {
+        continue;
+    }
+
+    try {
+        $client->deleteTuple($tuple['user'], $tuple['relation'], $tuple['object']);
+        ++$prunedCount;
+        echo "[PRUNED] {$before}" . PHP_EOL;
+    } catch (TupleNotFoundException) {
+        // Already removed by a previous run — benign.
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+echo PHP_EOL;
+echo 'Summary:' . PHP_EOL;
+echo sprintf("  Tuples read         : %d\n", count($allTuples));
+echo sprintf("  %-20s: %d\n", $dryRun ? 'Would copy' : 'Copied', $copiedCount);
+if ($prune) {
+    echo sprintf("  %-20s: %d\n", $dryRun ? 'Would prune' : 'Pruned', $prunedCount);
+}
+echo sprintf("  %-20s: %d\n", 'Already qualified', $alreadyCount);
+echo sprintf("  %-20s: %d\n", 'Skipped', $skippedCount);
+
+if ($unresolved !== []) {
+    echo PHP_EOL;
+    echo 'Left untouched (resolve by hand):' . PHP_EOL;
+    foreach (array_unique($unresolved) as $entry) {
+        echo "  - {$entry}" . PHP_EOL;
+    }
+}
+
+echo PHP_EOL;
+exit($skippedCount > 0 ? 2 : 0);

--- a/src/Enum/JsonData.php
+++ b/src/Enum/JsonData.php
@@ -472,4 +472,40 @@ enum JsonData: string
     {
         return Router::$apiFilePath . $this->value;
     }
+
+    /**
+     * The diocesan-calendar data file template for the given rite.
+     *
+     * The source tree is partitioned by rite, and only the diocesan tier exists under
+     * more than one: there are no `AMBROSIAN_NATIONAL_*` or `AMBROSIAN_WIDER_REGION_*`
+     * constants because the Ambrosian rite has neither tier. These resolvers let a call
+     * site ask for "the diocesan file for this rite" instead of repeating the branch.
+     */
+    public static function diocesanCalendarFileFor(Rite $rite): self
+    {
+        return $rite === Rite::AMBROSIAN
+            ? self::AMBROSIAN_DIOCESAN_CALENDAR_FILE
+            : self::DIOCESAN_CALENDAR_FILE;
+    }
+
+    public static function diocesanCalendarsFolderFor(Rite $rite): self
+    {
+        return $rite === Rite::AMBROSIAN
+            ? self::AMBROSIAN_DIOCESAN_CALENDARS_FOLDER
+            : self::DIOCESAN_CALENDARS_FOLDER;
+    }
+
+    public static function diocesanCalendarI18nFolderFor(Rite $rite): self
+    {
+        return $rite === Rite::AMBROSIAN
+            ? self::AMBROSIAN_DIOCESAN_CALENDAR_I18N_FOLDER
+            : self::DIOCESAN_CALENDAR_I18N_FOLDER;
+    }
+
+    public static function diocesanCalendarI18nFileFor(Rite $rite): self
+    {
+        return $rite === Rite::AMBROSIAN
+            ? self::AMBROSIAN_DIOCESAN_CALENDAR_I18N_FILE
+            : self::DIOCESAN_CALENDAR_I18N_FILE;
+    }
 }

--- a/src/Handlers/Admin/PermissionAdminHandler.php
+++ b/src/Handlers/Admin/PermissionAdminHandler.php
@@ -838,7 +838,7 @@ final class PermissionAdminHandler extends AbstractHandler
                     'Invalid object_id "%s" for object_type "%s". Valid ids: %s',
                     $objectId,
                     $objectType,
-                    implode(', ', AccessRequestRepository::GRC_OBJECT_IDS)
+                    AccessRequestRepository::validIdsLabelForType($objectType)
                 )
             );
         }

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -66,14 +66,27 @@ final class RegionalDataHandler extends AbstractHandler
     use ResolvesOutboxTooling;
 
     private readonly MetadataCalendars $CalendarsMetadata;
+
+    /**
+     * The rite selected by the optional leading rite segment on `/data`.
+     *
+     * Only the diocesan tier exists under more than one rite; `RegionalDataParams::validateRiteCompatibility()`
+     * rejects a national or wider-region request under a non-Roman rite before any path is built.
+     */
+    private readonly Rite $rite;
     private RegionalDataParams $params;
     private Logger $auditLogger;
     private string $clientIp = 'unknown';
 
     /** @param string[] $requestPathParams */
-    public function __construct(array $requestPathParams = [])
+    /**
+     * @param string[] $requestPathParams
+     * @param Rite     $rite The rite selected by the optional leading `/data` rite segment.
+     */
+    public function __construct(array $requestPathParams = [], Rite $rite = Rite::ROMAN)
     {
         parent::__construct($requestPathParams);
+        $this->rite = $rite;
         // Allow credentials for cross-origin cookie requests (required for authenticated PUT/PATCH/DELETE)
         $this->allowCredentials = true;
         // Build the calendars metadata index in-process from local source data
@@ -142,7 +155,7 @@ final class RegionalDataHandler extends AbstractHandler
                     $description = "The requested resource {$this->params->key} was not found in the index";
                     throw new NotFoundException($description);
                 }
-                $i18nDataFile = strtr(JsonData::DIOCESAN_CALENDAR_I18N_FILE->path(), [
+                $i18nDataFile = strtr(JsonData::diocesanCalendarI18nFileFor($this->rite)->path(), [
                     '{nation}'  => $dioceseEntry->nation,
                     '{diocese}' => $this->params->key,
                     '{locale}'  => $this->params->i18nRequest
@@ -209,7 +222,7 @@ final class RegionalDataHandler extends AbstractHandler
                     throw new NotFoundException($description);
                 }
 
-                $calendarDataFile = strtr(JsonData::DIOCESAN_CALENDAR_FILE->path(), [
+                $calendarDataFile = strtr(JsonData::diocesanCalendarFileFor($this->rite)->path(), [
                     '{nation}'       => $dioceseEntry->nation,
                     '{diocese}'      => $this->params->key,
                     '{diocese_name}' => $dioceseEntry->diocese
@@ -245,7 +258,7 @@ final class RegionalDataHandler extends AbstractHandler
             switch ($this->params->category) {
                 case PathCategory::DIOCESE:
                     /** @var MetadataDiocesanCalendarItem $dioceseEntry */
-                    $CalendarDataI18nFile = strtr(JsonData::DIOCESAN_CALENDAR_I18N_FILE->path(), [
+                    $CalendarDataI18nFile = strtr(JsonData::diocesanCalendarI18nFileFor($this->rite)->path(), [
                         '{nation}'  => $dioceseEntry->nation,
                         '{diocese}' => $this->params->key,
                         '{locale}'  => $this->params->locale
@@ -297,7 +310,8 @@ final class RegionalDataHandler extends AbstractHandler
      *
      * This is a private method and should only be called from {@see \LiturgicalCalendar\Api\Handlers\RegionalDataHandler::createCalendar()}.
      *
-     * The diocesan calendar data resource is created in the `JsonData::DIOCESAN_CALENDARS_FOLDER` directory.
+     * The diocesan calendar data resource is created in the rite's diocesan tree
+     * ({@see \LiturgicalCalendar\Api\Enum\JsonData::diocesanCalendarsFolderFor()}).
      *
      * This method ensures the necessary directories for storing diocesan calendar data are created.
      * It processes the internationalization (i18n) data provided in the payload, saving it to the appropriate
@@ -343,7 +357,7 @@ final class RegionalDataHandler extends AbstractHandler
         // Ensure we have all the necessary folders in place
         // Since we are passing `true` to the `i18n` mkdir, all missing parent folders will also be created,
         // so we don't have to worry about manually checking and creating each one individually
-        $diocesanCalendarI18nFolder = strtr(JsonData::DIOCESAN_CALENDAR_I18N_FOLDER->path(), [
+        $diocesanCalendarI18nFolder = strtr(JsonData::diocesanCalendarI18nFolderFor($this->rite)->path(), [
             '{nation}'  => $nation,
             '{diocese}' => $diocese_id
         ]);
@@ -357,12 +371,12 @@ final class RegionalDataHandler extends AbstractHandler
         // Write i18n files and capture locales for audit logging
         $i18nLocales = $this->writeI18nFiles(
             $rawPayload,
-            JsonData::DIOCESAN_CALENDAR_I18N_FILE,
+            JsonData::diocesanCalendarI18nFileFor($this->rite),
             ['{nation}' => $nation, '{diocese}' => $diocese_id]
         );
 
         $diocesanCalendarFile = strtr(
-            JsonData::DIOCESAN_CALENDAR_FILE->path(),
+            JsonData::diocesanCalendarFileFor($this->rite)->path(),
             [
                 '{nation}'       => $nation,
                 '{diocese}'      => $diocese_id,
@@ -835,7 +849,8 @@ final class RegionalDataHandler extends AbstractHandler
      *
      * It is private as it is called from {@see \LiturgicalCalendar\Api\Handlers\RegionalDataHandler::updateCalendar()}.
      *
-     * The resource is updated in the {@see \LiturgicalCalendar\Api\Enum\JsonData::DIOCESAN_CALENDARS_FOLDER} folder.
+     * The resource is updated in the rite's diocesan tree
+     * ({@see \LiturgicalCalendar\Api\Enum\JsonData::diocesanCalendarsFolderFor()}).
      *
      * If the resource to update is not found in the diocesan calendars index, the response will be a JSON error response with a status code of 404 Not Found.
      * If the resource to update is not writable or the write was not successful, the response will be a JSON error response with a status code of 503 Service Unavailable.
@@ -865,15 +880,15 @@ final class RegionalDataHandler extends AbstractHandler
         $key         = $this->params->key;
         $i18nLocales = $this->updateI18nFiles(
             $rawPayload,
-            JsonData::DIOCESAN_CALENDAR_I18N_FILE,
-            JsonData::DIOCESAN_CALENDAR_I18N_FOLDER,
+            JsonData::diocesanCalendarI18nFileFor($this->rite),
+            JsonData::diocesanCalendarI18nFolderFor($this->rite),
             ['{nation}' => $dioceseEntry->nation, '{diocese}' => $key],
             $payload->metadata->locales,
             "diocesan calendar {$key}"
         );
 
         $DiocesanCalendarFile = strtr(
-            JsonData::DIOCESAN_CALENDAR_FILE->path(),
+            JsonData::diocesanCalendarFileFor($this->rite)->path(),
             [
                 '{nation}'       => $dioceseEntry->nation,
                 '{diocese}'      => $this->params->key,
@@ -991,7 +1006,7 @@ final class RegionalDataHandler extends AbstractHandler
                     throw new NotFoundException($description);
                 }
                 $calendarDataFile   = strtr(
-                    JsonData::DIOCESAN_CALENDAR_FILE->path(),
+                    JsonData::diocesanCalendarFileFor($this->rite)->path(),
                     [
                         '{nation}'       => $dioceseEntry->nation,
                         '{diocese}'      => $dioceseEntry->calendar_id,
@@ -999,7 +1014,7 @@ final class RegionalDataHandler extends AbstractHandler
                     ]
                 );
                 $calendarI18nFolder = strtr(
-                    JsonData::DIOCESAN_CALENDAR_I18N_FOLDER->path(),
+                    JsonData::diocesanCalendarI18nFolderFor($this->rite)->path(),
                     [
                         '{nation}'  => $dioceseEntry->nation,
                         '{diocese}' => $dioceseEntry->calendar_id
@@ -1526,6 +1541,15 @@ final class RegionalDataHandler extends AbstractHandler
                         . implode(', ', $this->CalendarsMetadata->diocesan_calendars_keys);
                     throw new UnprocessableContentException($description);
                 }
+
+                // The rite segment must agree with the rite the diocese is actually defined
+                // under, or the handler would read and write the wrong partition of the source
+                // tree. Mirrors EventsParams::validateRiteCompatibility(); done here rather than
+                // in the params object because it needs the /calendars metadata lookup above.
+                if ($currentDiocese->rite !== $params->rite) {
+                    $description = "Diocesan calendar `{$params->key}` belongs to the {$currentDiocese->rite->value} rite, not the requested {$params->rite->value} rite.";
+                    throw new UnprocessableContentException($description);
+                }
             }
         }
 
@@ -1682,6 +1706,7 @@ final class RegionalDataHandler extends AbstractHandler
         $this->validateRequestPath($request);
 
         $params['category'] = PathCategory::from($this->requestPathParams[0]);
+        $params['rite']     = $this->rite;
         if (in_array($method, [RequestMethod::GET, RequestMethod::POST, RequestMethod::PUT, RequestMethod::PATCH, RequestMethod::DELETE], true)) {
             $params['key'] = $this->requestPathParams[1];
         }

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -11,6 +11,7 @@ use LiturgicalCalendar\Api\Handlers\Auth\ClientIpTrait;
 use LiturgicalCalendar\Api\Handlers\Concerns\ResolvesOutboxTooling;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\RiteScopedObjectId;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxOperation;
 use LiturgicalCalendar\Api\Services\Outbox\OutboxProcessor;
 use LiturgicalCalendar\Api\JsonFormatter;
@@ -495,9 +496,11 @@ final class RegionalDataHandler extends AbstractHandler
             $repo = $this->getOutboxRepository();
             $row  = [
                 'operation'       => OutboxOperation::WRITE_TUPLE,
-                'fga_user'        => "national_calendar:{$nation}",
+                // Both sides are rite-qualified: wider regions layer over national
+                // calendars, and both exist only in the Roman rite (issue #786).
+                'fga_user'        => 'national_calendar:' . RiteScopedObjectId::qualify(Rite::ROMAN, $nation),
                 'fga_relation'    => 'member_nation',
-                'fga_object'      => "wider_region:{$widerRegion}",
+                'fga_object'      => 'wider_region:' . RiteScopedObjectId::qualify(Rite::ROMAN, $widerRegion),
                 'idempotency_key' => "member_nation:wider_region:{$widerRegion}:national_calendar:{$nation}",
                 'metadata'        => ['member_nation_seed' => true],
             ];
@@ -980,6 +983,19 @@ final class RegionalDataHandler extends AbstractHandler
     }
 
     /**
+     * The full rite-qualified FGA object (`<type>:<rite>/<key>`) for this request.
+     *
+     * A bare calendar id does not identify a calendar — the source tree is partitioned
+     * by rite — so every object that names one carries its rite (issue #786).
+     */
+    private function fgaObjectForRequest(): string
+    {
+        return $this->fgaObjectTypeForCategory()
+            . ':'
+            . RiteScopedObjectId::qualify($this->params->rite, (string) $this->params->key);
+    }
+
+    /**
      * Get the paths for deleting a regional calendar data resource.
      *
      * The return value is an array with two elements:
@@ -1135,19 +1151,19 @@ final class RegionalDataHandler extends AbstractHandler
         // Purge operational (editor/viewer) FGA tuples orphaned by the file
         // deletion. The admin (governance) tuple is intentionally retained so
         // the resource can be recreated without losing ownership.
-        $objectType = $this->fgaObjectTypeForCategory();
-        $purge      = $this->getPurgeService();
+        $fgaObject = $this->fgaObjectForRequest();
+        $purge     = $this->getPurgeService();
         if ($purge !== null) {
             // Best-effort: the calendar files are already deleted, so an
             // OpenFGA/outbox error must NOT fail the completed deletion —
             // the reconciler sweep cleans up any stragglers.
             try {
-                $purge->purgeForObject("{$objectType}:{$this->params->key}");
+                $purge->purgeForObject($fgaObject);
             } catch (\Throwable $e) {
                 try {
                     $this->auditLogger->warning(
                         'Post-delete tuple purge failed; reconciler will retry',
-                        ['object' => "{$objectType}:{$this->params->key}", 'error' => $e->getMessage()]
+                        ['object' => $fgaObject, 'error' => $e->getMessage()]
                     );
                 } catch (\Throwable) {
                     // Logging is best-effort too; never fail a completed deletion.

--- a/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
+++ b/src/Http/Middleware/OpenFgaAuthorizationMiddleware.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Http\Middleware;
 
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\RiteScopedObjectId;
 use LiturgicalCalendar\Api\Services\TestScopeResolver;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -26,13 +28,17 @@ use Psr\Http\Server\RequestHandlerInterface;
  *   Calendar tests override PUT → "editor" (creating a test is an editing act).
  *
  * Object types:
- *   /data/nation/{id}       → national_calendar:{id}
- *   /data/diocese/{id}      → diocesan_calendar:{id}
- *   /data/widerregion/{id}  → wider_region:{id}
- *   /tests/{id}             → {national,diocesan,general_roman}_calendar_test:{scopeId} (via TestScopeResolver)
+ *   /data/nation/{id}       → national_calendar:{rite}/{id}
+ *   /data/diocese/{id}      → diocesan_calendar:{rite}/{id}
+ *   /data/widerregion/{id}  → wider_region:{rite}/{id}
+ *   /tests/{id}             → {national,diocesan}_calendar_test:{rite}/{id} | rite_calendar_test:{rite} (via TestScopeResolver)
  *   /temporale, /decrees    → general_roman_calendar:{fixedId}
  *   /missals/{editio_typica}→ general_roman_calendar:{missalId}
- *   /missals/{national}     → national_calendar:{nation}
+ *   /missals/{national}     → national_calendar:roman/{nation}
+ *
+ * Object ids that name a calendar are rite-qualified: a bare calendar id does not
+ * identify a calendar, since the source tree is partitioned by rite and the same
+ * diocese could be defined under both (issue #786). See {@see RiteScopedObjectId}.
  */
 final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
 {
@@ -214,18 +220,33 @@ final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
      * Maps the path category (nation/diocese/widerregion) to the OpenFGA
      * object type and creates the appropriate middleware instance.
      *
+     * The object id is rite-qualified from the route's rite segment, so a grant on an
+     * Ambrosian diocese cannot be satisfied by a Roman one of the same id, or vice
+     * versa (issue #786). Resolved per-request rather than fixed at construction so an
+     * absent or blank `calendar_id` attribute fails closed.
+     *
      * @param OpenFgaClient $client       The OpenFGA client
      * @param string        $pathCategory Path category from the URL (e.g., "nation")
+     * @param Rite          $rite         The rite selected by the route's rite segment
      * @return self|null Configured middleware, or null if the path category is unknown
      */
-    public static function forCalendarData(OpenFgaClient $client, string $pathCategory): ?self
+    public static function forCalendarData(OpenFgaClient $client, string $pathCategory, Rite $rite = Rite::ROMAN): ?self
     {
         $objectType = self::OBJECT_TYPE_MAP[$pathCategory] ?? null;
         if ($objectType === null) {
             return null;
         }
 
-        return new self($client, $objectType, 'calendar_id');
+        $objectResolver = static function (ServerRequestInterface $request) use ($objectType, $rite): ?array {
+            $calendarId = $request->getAttribute('calendar_id');
+            if (!is_string($calendarId) || trim($calendarId) === '') {
+                return null;
+            }
+
+            return [$objectType, RiteScopedObjectId::qualify($rite, $calendarId)];
+        };
+
+        return new self($client, $objectType, 'calendar_id', null, $objectResolver);
     }
 
     /**
@@ -309,7 +330,9 @@ final class OpenFgaAuthorizationMiddleware implements MiddlewareInterface
             return new self($client, 'general_roman_calendar', 'calendar_id', $missalId);
         }
 
+        // Missals live only under the Roman source tree, so the owning national
+        // calendar's grant is always the Roman-rite one.
         $nation = explode('_', $missalId)[0];
-        return new self($client, 'national_calendar', 'calendar_id', $nation);
+        return new self($client, 'national_calendar', 'calendar_id', RiteScopedObjectId::qualify(Rite::ROMAN, $nation));
     }
 }

--- a/src/Params/RegionalDataParams.php
+++ b/src/Params/RegionalDataParams.php
@@ -4,6 +4,7 @@ namespace LiturgicalCalendar\Api\Params;
 
 use LiturgicalCalendar\Api\Enum\LitLocale;
 use LiturgicalCalendar\Api\Enum\PathCategory;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanData;
 use LiturgicalCalendar\Api\Models\RegionalData\NationalData\NationalData;
@@ -20,6 +21,12 @@ use LiturgicalCalendar\Api\Models\RegionalData\WiderRegionData\WiderRegionData;
 class RegionalDataParams implements ParamsInterface
 {
     public PathCategory $category;
+
+    /**
+     * The rite the addressed calendar belongs to, from the optional leading rite
+     * segment on `/data` (Roman when absent).
+     */
+    public Rite $rite           = Rite::ROMAN;
     public ?string $key         = null;
     public ?string $locale      = null;
     public ?string $i18nRequest = null;
@@ -46,7 +53,7 @@ class RegionalDataParams implements ParamsInterface
      * is set to null.
      *
      * Additionally, it initializes the list of available system locales.
-     * @param array{category:PathCategory,key:string,i18n?:string,i18nRequest?:string,locale?:string,payload?:DiocesanData|NationalData|WiderRegionData,rawPayload?:\stdClass} $params
+     * @param array{category:PathCategory,key:string,rite?:Rite,i18n?:string,i18nRequest?:string,locale?:string,payload?:DiocesanData|NationalData|WiderRegionData,rawPayload?:\stdClass} $params
      */
     public function __construct(array $params)
     {
@@ -94,6 +101,12 @@ class RegionalDataParams implements ParamsInterface
         $this->category = $params['category'];
         $this->key      = $params['key'];
 
+        if (array_key_exists('rite', $params) && $params['rite'] instanceof Rite) {
+            $this->rite = $params['rite'];
+        }
+
+        $this->validateRiteCompatibility();
+
         if (array_key_exists('payload', $params)) {
             $this->payload = $params['payload'];
 
@@ -116,6 +129,39 @@ class RegionalDataParams implements ParamsInterface
                 $description = "Invalid value {$params['locale']} for param `locale`, valid values are: la, la_VA, " . implode(', ', LitLocale::$AllAvailableLocales);
                 throw new ValidationException($description);
             }
+        }
+    }
+
+    /**
+     * Reject a category that the requested rite has no tier for.
+     *
+     * Mirrors {@see \LiturgicalCalendar\Api\Params\EventsParams::validateRiteCompatibility()}.
+     * Only the diocesan tier exists under more than one rite: the Ambrosian rite is proper
+     * to the Archdiocese of Milan and a handful of neighbouring dioceses rather than to any
+     * nation or region, and the source tree has no `rite/ambrosian/calendars/nations` or
+     * `.../wider_regions` to read or write.
+     *
+     * The diocese-belongs-to-this-rite check needs `/calendars` metadata and therefore lives
+     * in the handler, alongside the lookup it shares.
+     *
+     * @throws ValidationException
+     */
+    public function validateRiteCompatibility(): void
+    {
+        if ($this->rite === Rite::ROMAN) {
+            return;
+        }
+
+        if ($this->category === PathCategory::NATION) {
+            throw new ValidationException(
+                "The {$this->rite->value} rite has no national calendars; request a diocesan calendar of that rite instead."
+            );
+        }
+
+        if ($this->category === PathCategory::WIDERREGION) {
+            throw new ValidationException(
+                "The {$this->rite->value} rite has no wider regions; wider regions are a layer over national calendars, which exist only in the Roman rite."
+            );
         }
     }
 }

--- a/src/Repositories/AccessRequestRepository.php
+++ b/src/Repositories/AccessRequestRepository.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Api\Repositories;
 
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Services\RiteScopedObjectId;
 use LiturgicalCalendar\Api\Services\TestScopeResolver;
 use PDO;
 
@@ -124,7 +125,9 @@ class AccessRequestRepository
             'rite_calendar_test'          => implode(', ', array_column(Rite::cases(), 'value')),
             'national_calendar_test'      => 'a rite-qualified nation code, e.g. ' . TestScopeResolver::qualify(Rite::ROMAN, 'US'),
             'diocesan_calendar_test'      => 'a rite-qualified diocese id, e.g. ' . TestScopeResolver::qualify(Rite::AMBROSIAN, 'lugano_ch'),
-            'national_calendar'           => 'a two-letter ISO nation code',
+            'national_calendar'           => 'a rite-qualified nation code, e.g. ' . RiteScopedObjectId::qualify(Rite::ROMAN, 'US'),
+            'diocesan_calendar'           => 'a rite-qualified diocese id, e.g. ' . RiteScopedObjectId::qualify(Rite::AMBROSIAN, 'lugano_ch'),
+            'wider_region'                => 'a rite-qualified wider region, e.g. ' . RiteScopedObjectId::qualify(Rite::ROMAN, 'Europe'),
             default                       => 'any non-empty id',
         };
     }
@@ -152,8 +155,25 @@ class AccessRequestRepository
             return $objectType !== 'national_calendar_test' || Rite::ROMAN === $parsed[0];
         }
 
-        if ($objectType === 'national_calendar') {
-            return self::isValidNationCode($objectId);
+        // Data resource types that name a calendar are rite-qualified for the same
+        // reason the scoped test types are: a bare calendar id does not identify a
+        // calendar, since the source tree is partitioned by rite (issue #786).
+        if (in_array($objectType, ['national_calendar', 'diocesan_calendar', 'wider_region'], true)) {
+            $parsed = RiteScopedObjectId::parse($objectId);
+            if (null === $parsed) {
+                return false;
+            }
+
+            [$rite, $calendarId] = $parsed;
+
+            // Only the diocesan tier exists under more than one rite.
+            if ($rite !== Rite::ROMAN && $objectType !== 'diocesan_calendar') {
+                return false;
+            }
+
+            return $objectType === 'national_calendar'
+                ? self::isValidNationCode($calendarId)
+                : $calendarId !== '';
         }
 
         return $objectId !== '';

--- a/src/Router.php
+++ b/src/Router.php
@@ -108,14 +108,19 @@ class Router
      * calendar or events route, stripping that segment from the request-path parts
      * when present.
      *
-     * Only the calendar route (`calendar`, or the empty root route) and the events
-     * route (`events`) carry a rite segment. A leading segment whose value is a valid
+     * The calendar route (`calendar`, or the empty root route), the events route
+     * (`events`) and the regional-data route (`data`) carry a rite segment. A leading
+     * segment whose value is a valid
      * {@see Rite} case (`roman`, `ambrosian`) selects that rite and is removed from
      * `$requestPathParts` so the remaining 0/1/2/3-part shape parsing runs identically
      * to an un-prefixed request; `/calendar` and `/calendar/roman` are therefore
      * equivalent, symmetric with `/calendar/ambrosian` (and likewise for `/events`).
-     * Absence of a rite segment defaults to Roman. No nation or diocese identifier
-     * collides with a rite value, so this is unambiguous.
+     * Absence of a rite segment defaults to Roman. No nation, diocese or path-category
+     * identifier collides with a rite value, so this is unambiguous.
+     *
+     * `data` takes the segment but is deliberately absent from {@see self::canonicalRiteUrl()}:
+     * that header advertises the explicit form for cacheable read routes, and `/data` is an
+     * admin write surface where a `Link: rel="canonical"` on a PUT is noise.
      *
      * Of the two equivalent forms, the explicit one is canonical: a request that omits the
      * rite segment is answered with a `Link: rel="canonical"` header naming the explicit URL
@@ -126,7 +131,7 @@ class Router
      */
     public static function extractRiteSegment(string $route, array &$requestPathParts): Rite
     {
-        if ($route === 'calendar' || $route === '' || $route === 'events') {
+        if ($route === 'calendar' || $route === '' || $route === 'events' || $route === 'data') {
             $maybeRite = Rite::tryFrom((string) ( $requestPathParts[0] ?? '' ));
             if ($maybeRite !== null) {
                 array_shift($requestPathParts);
@@ -538,7 +543,7 @@ class Router
                 $this->handler       = $applicationsHandler;
                 break;
             case 'data':
-                $regionalDataHandler = new RegionalDataHandler($requestPathParts);
+                $regionalDataHandler = new RegionalDataHandler($requestPathParts, $rite);
                 $pathCount           = count($requestPathParts);
                 $firstInCategory     = $pathCount > 0 && in_array($requestPathParts[0], PathCategory::values(), true);
                 $allowedMethods      = match (true) {

--- a/src/Router.php
+++ b/src/Router.php
@@ -739,7 +739,7 @@ class Router
 
             // Apply authorization middleware with role-based access control
             // (shared between OIDC and JWT paths)
-            $this->configureAuthorizationPipeline($pipeline, $route, $requestPathParts);
+            $this->configureAuthorizationPipeline($pipeline, $route, $requestPathParts, $rite);
         }
 
         $this->response = $pipeline->handle($this->request)
@@ -792,11 +792,14 @@ class Router
      * @param MiddlewarePipeline $pipeline The middleware pipeline to configure
      * @param string $route The current route being handled
      * @param array<int, string> $requestPathParts The parsed path parts after the route
+     * @param Rite $rite The rite selected by the route's optional rite segment; qualifies the
+     *                   calendar object ids the FGA middleware checks against (issue #786)
      */
     private function configureAuthorizationPipeline(
         MiddlewarePipeline $pipeline,
         string $route,
-        array $requestPathParts
+        array $requestPathParts,
+        Rite $rite = Rite::ROMAN
     ): void {
         // Cache a single OpenFGA client for the pipeline (avoid multiple fromEnv calls)
         $fgaClient = OpenFgaClient::isConfigured() ? OpenFgaClient::fromEnv() : null;
@@ -820,7 +823,8 @@ class Router
             if ($oidcAvailable && $fgaClient !== null && count($requestPathParts) >= 2) {
                 $fgaMiddleware = OpenFgaAuthorizationMiddleware::forCalendarData(
                     $fgaClient,
-                    $requestPathParts[0]
+                    $requestPathParts[0],
+                    $rite
                 );
                 if ($fgaMiddleware !== null) {
                     $pipeline->pipe($fgaMiddleware);

--- a/src/Services/ResourceExistenceChecker.php
+++ b/src/Services/ResourceExistenceChecker.php
@@ -31,6 +31,12 @@ use LiturgicalCalendar\Api\Enum\Rite;
  */
 final class ResourceExistenceChecker implements ResourceExistenceCheckerInterface
 {
+    /**
+     * The Vatican is announced as a national calendar but is still served by the
+     * General Roman Calendar, so it has no source folder of its own yet.
+     */
+    private const VATICAN_NATIONAL_CALENDAR_ID = 'VA';
+
     /** @var list<string> */
     private const RESOURCE_TYPES = [
         'national_calendar',
@@ -61,10 +67,7 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
                 return null !== Rite::tryFrom($objectId);
 
             case 'national_calendar':
-                $calendarId = RiteScopedObjectId::calendarId($objectId);
-                return is_file(
-                    JsonData::NATIONAL_CALENDARS_FOLDER->path() . "/{$calendarId}/{$calendarId}.json"
-                );
+                return self::nationalCalendarExists(RiteScopedObjectId::calendarId($objectId));
 
             case 'wider_region':
                 return is_dir(
@@ -119,5 +122,28 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
         }
 
         return false;
+    }
+
+    /**
+     * True when a national calendar of this id is announced by the API.
+     *
+     * Normally that means a source folder, but the Vatican is announced as a national
+     * calendar while still being served by the General Roman Calendar — it has no
+     * `nations/VA/VA.json` of its own yet. Without the special case a live
+     * `national_calendar:VA` grant reads as orphaned and the reconciler purges it, the
+     * same silent revocation the Ambrosian dioceses suffered (issue #786).
+     *
+     * Remove the special case once the Vatican gains its own folder; the `is_file()`
+     * check below will cover it from then on.
+     */
+    private static function nationalCalendarExists(string $calendarId): bool
+    {
+        if ($calendarId === self::VATICAN_NATIONAL_CALENDAR_ID) {
+            return true;
+        }
+
+        return is_file(
+            JsonData::NATIONAL_CALENDARS_FOLDER->path() . "/{$calendarId}/{$calendarId}.json"
+        );
     }
 }

--- a/src/Services/ResourceExistenceChecker.php
+++ b/src/Services/ResourceExistenceChecker.php
@@ -19,7 +19,7 @@ use LiturgicalCalendar\Api\Enum\Rite;
  *   rite_calendar_test           — fixed catalog; exists iff the id is a known Rite
  *   national_calendar            — jsondata/sourcedata/rite/roman/calendars/nations/{id}/{id}.json
  *   wider_region                 — jsondata/sourcedata/rite/roman/calendars/wider_regions/{id}/ (directory)
- *   diocesan_calendar            — jsondata/sourcedata/rite/roman/calendars/dioceses/{nation}/{id}/ (directory, glob)
+ *   diocesan_calendar            — jsondata/sourcedata/rite/{rite}/calendars/dioceses/{nation}/{id}/ (directory, glob across rites)
  *   national_calendar_test       — governance scope (id `<rite>/<calendarId>`); always treated as existing
  *   diocesan_calendar_test       — governance scope (id `<rite>/<calendarId>`); always treated as existing
  */
@@ -65,13 +65,7 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
                 );
 
             case 'diocesan_calendar':
-                // Diocesan files live at dioceses/<NATION>/<dioceseId>/; check for the folder
-                // across all nation sub-directories via glob.
-                $matches = glob(
-                    JsonData::DIOCESAN_CALENDARS_FOLDER->path() . "/*/{$objectId}",
-                    GLOB_ONLYDIR
-                );
-                return $matches !== false && $matches !== [];
+                return self::diocesanCalendarExists($objectId);
 
             case 'national_calendar_test':
             case 'diocesan_calendar_test':
@@ -85,5 +79,36 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
             default:
                 return false;
         }
+    }
+
+    /**
+     * True when a diocesan calendar of this id is defined under any rite.
+     *
+     * Diocesan files live at `dioceses/<NATION>/<dioceseId>/`, and the source tree is
+     * partitioned by rite. Globbing only the Roman partition reported every Ambrosian
+     * diocese as gone, and because the reconciler purges on this predicate that
+     * silently revoked live editor grants on the four Ambrosian dioceses (issue #786).
+     *
+     * Deliberately answers "under ANY rite" rather than a specific one: this decides
+     * what gets purged, so a false negative destroys a grant while a false positive
+     * merely keeps a stale tuple around for the next sweep.
+     */
+    private static function diocesanCalendarExists(string $objectId): bool
+    {
+        // A glob pattern is being built from this value, so anything outside the
+        // diocese-id character set is rejected rather than escaped. This also stops an
+        // empty id from matching every nation directory and reporting as existing.
+        if (1 !== preg_match('/\A[A-Za-z0-9_-]+\z/', $objectId)) {
+            return false;
+        }
+
+        foreach ([JsonData::DIOCESAN_CALENDARS_FOLDER, JsonData::AMBROSIAN_DIOCESAN_CALENDARS_FOLDER] as $folder) {
+            $matches = glob($folder->path() . "/*/{$objectId}", GLOB_ONLYDIR);
+            if ($matches !== false && $matches !== []) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Services/ResourceExistenceChecker.php
+++ b/src/Services/ResourceExistenceChecker.php
@@ -19,6 +19,12 @@ use LiturgicalCalendar\Api\Enum\Rite;
  *   rite_calendar_test           — fixed catalog; exists iff the id is a known Rite
  *   national_calendar            — jsondata/sourcedata/rite/roman/calendars/nations/{id}/{id}.json
  *   wider_region                 — jsondata/sourcedata/rite/roman/calendars/wider_regions/{id}/ (directory)
+ *
+ * Ids that name a calendar are rite-qualified as `<rite>/<calendarId>` (issue #786).
+ * The qualifier is stripped before the filesystem lookup rather than used to select a
+ * partition: this method decides what the reconciler PURGES, and unqualified legacy ids
+ * are still in the store for the whole migration window, so it answers "does a calendar
+ * of this id exist at all" and never destroys a grant over a format mismatch.
  *   diocesan_calendar            — jsondata/sourcedata/rite/{rite}/calendars/dioceses/{nation}/{id}/ (directory, glob across rites)
  *   national_calendar_test       — governance scope (id `<rite>/<calendarId>`); always treated as existing
  *   diocesan_calendar_test       — governance scope (id `<rite>/<calendarId>`); always treated as existing
@@ -55,13 +61,14 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
                 return null !== Rite::tryFrom($objectId);
 
             case 'national_calendar':
+                $calendarId = RiteScopedObjectId::calendarId($objectId);
                 return is_file(
-                    JsonData::NATIONAL_CALENDARS_FOLDER->path() . "/{$objectId}/{$objectId}.json"
+                    JsonData::NATIONAL_CALENDARS_FOLDER->path() . "/{$calendarId}/{$calendarId}.json"
                 );
 
             case 'wider_region':
                 return is_dir(
-                    JsonData::WIDER_REGIONS_FOLDER->path() . "/{$objectId}"
+                    JsonData::WIDER_REGIONS_FOLDER->path() . '/' . RiteScopedObjectId::calendarId($objectId)
                 );
 
             case 'diocesan_calendar':
@@ -95,6 +102,8 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
      */
     private static function diocesanCalendarExists(string $objectId): bool
     {
+        $objectId = RiteScopedObjectId::calendarId($objectId);
+
         // A glob pattern is being built from this value, so anything outside the
         // diocese-id character set is rejected rather than escaped. This also stops an
         // empty id from matching every nation directory and reporting as existing.

--- a/src/Services/RiteScopedObjectId.php
+++ b/src/Services/RiteScopedObjectId.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+
+/**
+ * The `<rite>/<calendarId>` form of an OpenFGA object id.
+ *
+ * A calendar id alone does not identify a calendar. The source tree is partitioned
+ * by rite (`jsondata/sourcedata/rite/{rite}/calendars/...`), so nothing stops the
+ * same diocese being defined under both; `lugano_ch` only happens to be
+ * Ambrosian-only today. A grant on the bare id would therefore be ambiguous, and
+ * would silently widen to cover a Roman `lugano_ch` the moment one existed.
+ *
+ * Every object type that names a *calendar* carries its rite this way:
+ *
+ *   diocesan_calendar:ambrosian/lugano_ch      diocesan_calendar_test:ambrosian/lugano_ch
+ *   national_calendar:roman/US                 national_calendar_test:roman/US
+ *   wider_region:roman/Europe
+ *
+ * `rite_calendar_test` is the exception that proves the rule: its id *is* the rite.
+ * `general_roman_calendar` keeps bare ids because they are not calendars — they are
+ * `temporale`, `decrees` and missal editions, Roman by construction.
+ *
+ * Introduced for the test scopes in issue #767 and extended to the data resource
+ * types in #786; this class is the single definition of the format for both, which
+ * is why it lives here rather than on {@see TestScopeResolver}.
+ */
+final class RiteScopedObjectId
+{
+    /**
+     * Separates the rite from the calendar id.
+     *
+     * `/` is safe in an OpenFGA object id — only whitespace, `:`, `#` and `*` carry
+     * meaning there — and reads as the hierarchy it is: rite over calendar.
+     */
+    public const SEPARATOR = '/';
+
+    /**
+     * Compose the rite-qualified object id for a calendar.
+     */
+    public static function qualify(Rite $rite, string $calendarId): string
+    {
+        return $rite->value . self::SEPARATOR . $calendarId;
+    }
+
+    /**
+     * Split a rite-qualified object id back into its rite and calendar id.
+     *
+     * Returns null when the id is not rite-qualified — an unmigrated legacy id such
+     * as a bare `rotter_nl`, or a prefix that names no known rite. Callers decide
+     * what an unqualified id means for them: input validation rejects it, while the
+     * reconciler's existence check tolerates it for the whole migration window.
+     *
+     * @return array{0: Rite, 1: string}|null
+     */
+    public static function parse(string $objectId): ?array
+    {
+        $pos = strpos($objectId, self::SEPARATOR);
+        if (false === $pos) {
+            return null;
+        }
+
+        $rite       = Rite::tryFrom(substr($objectId, 0, $pos));
+        $calendarId = substr($objectId, $pos + strlen(self::SEPARATOR));
+
+        if (null === $rite || '' === $calendarId) {
+            return null;
+        }
+
+        return [$rite, $calendarId];
+    }
+
+    /**
+     * The calendar id with any rite qualifier stripped.
+     *
+     * For code that needs the bare id regardless of whether the caller supplied a
+     * migrated or a legacy one — filesystem lookups, mostly.
+     */
+    public static function calendarId(string $objectId): string
+    {
+        $parsed = self::parse($objectId);
+
+        return null === $parsed ? $objectId : $parsed[1];
+    }
+}

--- a/src/Services/TestScopeResolver.php
+++ b/src/Services/TestScopeResolver.php
@@ -49,46 +49,30 @@ final class TestScopeResolver
     /**
      * Separates the rite from the calendar id inside a scoped-test object id.
      *
-     * `/` is safe in an OpenFGA object id (only whitespace, `:`, `#` and `*` carry
-     * meaning) and reads as the hierarchy it is: rite over calendar.
+     * @deprecated Use {@see RiteScopedObjectId::SEPARATOR}. Retained so #767's public
+     *             surface keeps working now that the data resource types share the format.
      */
-    public const RITE_SEPARATOR = '/';
+    public const RITE_SEPARATOR = RiteScopedObjectId::SEPARATOR;
 
     /**
      * Compose the rite-qualified object id for a national or diocesan test scope.
      *
-     * The single definition of the qualified-id format; parseQualifiedId() is its
-     * inverse. Everything that writes or reads one of these ids goes through here
-     * rather than re-implementing the concatenation.
+     * Delegates to {@see RiteScopedObjectId::qualify()}, which is the single definition
+     * of the format now that the data resource types use it too (#786).
      */
     public static function qualify(Rite $rite, string $calendarId): string
     {
-        return $rite->value . self::RITE_SEPARATOR . $calendarId;
+        return RiteScopedObjectId::qualify($rite, $calendarId);
     }
 
     /**
      * Split a rite-qualified object id back into its rite and calendar id.
      *
-     * Returns null when the id is not rite-qualified — an unmigrated legacy id
-     * such as a bare `rotter_nl`, or a prefix that names no known rite.
-     *
      * @return array{0: Rite, 1: string}|null
      */
     public static function parseQualifiedId(string $objectId): ?array
     {
-        $pos = strpos($objectId, self::RITE_SEPARATOR);
-        if (false === $pos) {
-            return null;
-        }
-
-        $rite       = Rite::tryFrom(substr($objectId, 0, $pos));
-        $calendarId = substr($objectId, $pos + strlen(self::RITE_SEPARATOR));
-
-        if (null === $rite || '' === $calendarId) {
-            return null;
-        }
-
-        return [$rite, $calendarId];
+        return RiteScopedObjectId::parse($objectId);
     }
 
     /**


### PR DESCRIPTION
Closes #786.

Completes the OpenFGA tuple alignment started in #785, which did the *test* scopes and deferred the data
resource types here. Four ordered commits, in the sequence the issue proposes — the standalone bug fix first,
so it can ship or be cherry-picked on its own.

## 1. The live purge bug (`ff6ce656`)

`ResourceExistenceChecker::exists()` globbed only `JsonData::DIOCESAN_CALENDARS_FOLDER`, which derives from
`ROMAN_RITE_FOLDER`. The Ambrosian partition has its own constant the checker never consulted, so every
Ambrosian diocese answered "does not exist" — and `ResourceTuplePurgeReconciler` purges on exactly that
predicate. A legitimate editor grant on any of the four was revoked on any sweep.

The lookup now spans both rite partitions. It deliberately answers *"is this diocese defined under **any**
rite"* rather than a specific one: this decides what gets purged, so a false negative destroys a grant while
a false positive merely keeps a stale tuple around for the next sweep.

**A second bug, found by the same test:** `exists('diocesan_calendar', '')` returned `true`, because the
empty id made the glob match every nation directory. Ids are now validated against the diocese-id character
set before being interpolated into a glob pattern — which also stops a metacharacter in a tuple id matching
unintended directories.

Regression cover at both levels: the checker directly, and a reconciler sweep wired to the **real** checker.
Every existing reconciler test stubs it, which is exactly why none of them caught this.

## 2. `/data` rite-awareness (`aed9c8ef`)

`/data` could not address the Ambrosian calendars at all. `data` joins `calendar`, `events` and the root
route in `Router::extractRiteSegment()`, so the handler still sees the same 2-part shape and every
downstream count-based branch is untouched.

`JsonData` gains rite resolvers (`diocesanCalendarFileFor()` and friends) so the ~9 diocesan path sites ask
for "the diocesan file for this rite" rather than repeating an `if`. Only the diocesan tier needs them —
there are no `AMBROSIAN_NATIONAL_*` or `AMBROSIAN_WIDER_REGION_*` constants, because the Ambrosian rite has
neither tier. `RegionalDataParams` rejects a category the rite has no tier for, mirroring
`EventsParams::validateRiteCompatibility()`.

Verified against a server running this branch:

```text
/data/ambrosian/diocese/lugano_ch    200  (was 404)
/data/ambrosian/diocese/milano_it    200  (was 404)
/data/roman/diocese/lugano_ch        422  rite disagreement
/data/ambrosian/diocese/rotter_nl    422  rite disagreement
/data/ambrosian/nation/US            400  no such tier
/data/ambrosian/widerregion/Europe   400  no such tier
/data/diocese/rotter_nl              200  unchanged
/data/roman/diocese/rotter_nl        200  equivalent to bare
```

`data` is deliberately **not** added to `canonicalRiteUrl()`: that header advertises the explicit form for
cacheable read routes, and a `Link: rel="canonical"` on a `PUT` is noise. Easy to add if you'd rather have
the symmetry.

## 3. Rite-qualified object ids (`d25a2e6e`)

| Object type              | Id before   | Id after              |
|--------------------------|-------------|-----------------------|
| `diocesan_calendar`      | `lugano_ch` | `ambrosian/lugano_ch` |
| `national_calendar`      | `US`        | `roman/US`            |
| `wider_region`           | `Europe`    | `roman/Europe`        |
| `general_roman_calendar` | `temporale` | *(unchanged)*         |

`general_roman_calendar` keeps bare ids: they are `temporale`, `decrees` and missal editions — not calendars,
and Roman by construction.

**`wider_region` is qualified**, which the issue left open as a design question. The Ambrosian rite has no
wider regions, but they live in the same rite-partitioned tree as the other two, so exempting them would
qualify two of three sibling types and leave a carve-out to remember rather than a rule to state. Reverting
is a one-line change to the mapping plus its migration branch.

New `RiteScopedObjectId` holds the format; `TestScopeResolver`'s #785 helpers delegate to it, so a repository
no longer depends on a *test* service for its id format.

**No OpenFGA model change** — the object types are unchanged and only their ids move.

Also fixes a third instance of the stale valid-ids message, this time in `PermissionAdminHandler`: rejecting
`national_calendar:IT` reported `Valid ids: temporale, EDITIO_TYPICA_1970, …`.

## 4. Migration, runbook, and a Vatican purge bug (`e532fd10`)

`scripts/migrate-rite-data-tuples.php` rewrites live grants onto their qualified ids — copy-only by default,
`--prune` gated behind full rollout, idempotent. `member_nation` tuples are rewritten on **both** sides:
their user side is a `national_calendar:` object, not a `user:`.

Only a *diocese's* rite is inferred from the source tree; national calendars and wider regions are Roman by
definition. Writing that inference surfaced **a third live purge bug of the same shape**: the Vatican is
announced as a national calendar but is still served by the General Roman Calendar and has no
`nations/VA/VA.json` of its own yet, so

```text
ResourceExistenceChecker::exists('national_calendar', 'VA') => false
```

and the reconciler would purge any `national_calendar:VA` grant — even though the id is accepted as valid
when the grant is requested. `exists()` now treats VA as present, with a comment marking the special case for
removal once the Vatican gains its folder.

## Verification

Full suite **2495 green**, PHPStan level 10 clean, phpcs clean, markdownlint clean, `lint:openapi` valid with
zero warnings, plus the live `/data` probe above.

One note on the run: two `Routes/Auth/LoginRateLimitTest` cases failed once mid-session and passed on re-run
and in isolation — my own repeated probing had filled the live API's rate-limit bucket. Not a regression, but
worth knowing they are order- and traffic-sensitive.

## Follow-ups

- **Prune the superseded tuples** — this PR's and #785's — once every deployment runs merged code. Both
  runbook sections describe the step; they can be pruned independently.
- **#787** — `/tests` rite-awareness, which deferred its path-segment decision to whatever this change
  settled. `/data` now takes the segment, so that question has an answer to follow.
- **LiturgicalCalendarFrontend#459** covers the test editor; the **admin calendar pages** construct these
  data object ids and need the same treatment before the prune step.
- **Remove the Vatican special case** in `ResourceExistenceChecker` once `nations/VA/VA.json` exists.

Design spec: `docs/superpowers/specs/2026-08-14-rite-qualified-data-scopes-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rite-aware calendar data access, including Ambrosian diocesan calendars and explicit Roman routing.
  * Calendar resource identifiers now support formats such as `roman/IT` and `ambrosian/lugano_ch`.
  * Added validation restricting national and wider-region resources to the Roman rite.
  * Improved resource detection, including Vatican national-calendar handling.

* **Documentation**
  * Added design guidance and an operational runbook for migrating existing calendar permissions.

* **Chores**
  * Added a dry-run migration utility with optional application and cleanup of legacy permission identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->