### PR TITLE
fix(data): report an i18n/locales mismatch as 422, not 500

### DIFF
--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -696,6 +696,52 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
     }
 
     /**
+     * A payload whose `i18n` covers fewer locales than `metadata.locales` announces must be
+     * rejected as unprocessable content, NOT crash with an uncaught \ValueError (issue #462).
+     *
+     * JSON Schema cannot express "the keys of this object equal the values of that array", so
+     * the invariant is enforced in the RegionalData model layer, which signals a breach with a
+     * plain \ValueError. Nothing on the write path caught it, so a client that submitted a
+     * short `i18n` — which the diocesan editor did whenever a save beat its secondary-locale
+     * translation fetch — got a 500 blaming the server for its own bad request.
+     *
+     * Covered here for the diocesan and national categories; wider-region reaches the same
+     * model check through the identical `fromObject()` write path.
+     */
+    public function testPutDiocesanCalendarRejectsI18nNarrowerThanDeclaredLocales(): void
+    {
+        $payload                        = self::diocesanPayloadWithColor('ambrosian', 'morello', 'novara_it', 'Diocesi di Novara');
+        $payload['metadata']['locales'] = ['it_IT', 'la_VA'];
+        // `i18n` still carries it_IT alone — exactly the mismatch the model rejects.
+
+        $this->expectException(UnprocessableContentException::class);
+        // Assert on the message, not merely the type: many unrelated conditions on this path
+        // also raise UnprocessableContentException, so a bare type assertion could pass for
+        // the wrong reason.
+        $this->expectExceptionMessage('keys of i18n parameter must be the same as the values of metadata.locales');
+
+        ( new RegionalDataHandler(['diocese', 'novara_it']) )
+            ->handle($this->requestFor('PUT', '/data/diocese/novara_it', [], $payload));
+    }
+
+    /**
+     * The national category has its own `fromObject()` call, so it needs its own guard — the
+     * defect was never diocese-specific.
+     */
+    public function testPutNationalCalendarRejectsI18nNarrowerThanDeclaredLocales(): void
+    {
+        $payload                        = self::mtNationalCalendarPayload();
+        $payload['metadata']['locales'] = ['en_MT', 'it_IT'];
+        // `i18n` still carries en_MT alone.
+
+        $this->expectException(UnprocessableContentException::class);
+        $this->expectExceptionMessage('keys of i18n parameter must be the same as the values of metadata.locales');
+
+        ( new RegionalDataHandler(['nation', 'MT']) )
+            ->handle($this->requestFor('PUT', '/data/nation/MT', [], $payload));
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private static function diocesanPayloadWithColor(string $rite, string $color, string $dioceseId, string $dioceseName): array

--- a/phpunit_tests/Handlers/RegionalDataHandlerTest.php
+++ b/phpunit_tests/Handlers/RegionalDataHandlerTest.php
@@ -742,6 +742,58 @@ final class RegionalDataHandlerTest extends AbstractHandlerTestCase
     }
 
     /**
+     * And the third `fromObject()` call. Wider-region had no write-path coverage of this
+     * check at all before, which is what left the branch unexercised.
+     */
+    public function testPutWiderRegionCalendarRejectsI18nNarrowerThanDeclaredLocales(): void
+    {
+        $payload = self::europeWiderRegionPayload();
+        // Two locales declared, `i18n` carries it_IT alone.
+        $payload['metadata']['locales'] = ['it_IT', 'fr_FR'];
+
+        $this->expectException(UnprocessableContentException::class);
+        $this->expectExceptionMessage('keys of i18n parameter must be the same as the values of metadata.locales');
+
+        ( new RegionalDataHandler(['widerregion', 'Europe']) )
+            ->handle($this->requestFor('PUT', '/data/widerregion/Europe', [], $payload));
+    }
+
+    /**
+     * A schema-valid wider-region PUT/PATCH payload for Europe.
+     *
+     * Modelled on the shipped `wider_regions/Europe/Europe.json`: `national_calendars` is a
+     * name => ISO code map and is required by the schema, and `makePatron` is one of the two
+     * actions a wider region admits. The i18n section is required by the PUT/PATCH handlers.
+     *
+     * @return array<string,mixed>
+     */
+    private static function europeWiderRegionPayload(): array
+    {
+        return [
+            'litcal'             => [
+                [
+                    'liturgical_event' => ['event_key' => 'StBenedict', 'grade' => 4],
+                    'metadata'         => [
+                        'action'       => 'makePatron',
+                        'since_year'   => 1964,
+                        'url'          => 'https://www.vatican.va/',
+                        // Required alongside `url` for makePatron, per MetadataMakePatron.
+                        'url_lang_map' => ['it' => 'it', 'la' => 'la'],
+                    ],
+                ],
+            ],
+            'national_calendars' => ['Italy' => 'IT', 'France' => 'FR'],
+            'metadata'           => [
+                'wider_region' => 'Europe',
+                'locales'      => ['it_IT'],
+            ],
+            'i18n'               => [
+                'it_IT' => ['StBenedict' => 'San Benedetto'],
+            ],
+        ];
+    }
+
+    /**
      * @return array<string,mixed>
      */
     private static function diocesanPayloadWithColor(string $rite, string $color, string $dioceseId, string $dioceseName): array

--- a/src/Handlers/RegionalDataHandler.php
+++ b/src/Handlers/RegionalDataHandler.php
@@ -1314,6 +1314,27 @@ final class RegionalDataHandler extends AbstractHandler
     }
 
     /**
+     * Translate a payload \ValueError from the RegionalData model layer into a 422.
+     *
+     * The models validate invariants the JSON schema cannot express — chiefly that
+     * `i18n` keys exactly the locales `metadata.locales` announces — and signal a
+     * breach with a plain \ValueError. Uncaught that is a 500, which misreports a
+     * client-data problem as a server fault (issue #462).
+     *
+     * The translation lives here rather than in the models because the very same
+     * DTOs load calendars from disk. There, a mismatch is OUR bug in stored data,
+     * not the caller's, and must stay a server error — so only the request path may
+     * reinterpret it as unprocessable content.
+     *
+     * @param \ValueError $e The error raised while building the DTO
+     * @return UnprocessableContentException Ready to throw at the call site
+     */
+    private static function payloadValueError(\ValueError $e): UnprocessableContentException
+    {
+        return new UnprocessableContentException($e->getMessage());
+    }
+
+    /**
      * Validate payload data against a schema
      *
      * @param \stdClass $data Data to validate
@@ -1762,8 +1783,14 @@ final class RegionalDataHandler extends AbstractHandler
                             throw new UnprocessableContentException('The litcal array must contain at least one liturgical event');
                         }
                         $params['rawPayload'] = $payload;  // Store raw for writing to disk
-                        $params['payload']    = DiocesanData::fromObject($payload);  // DTO for property access
-                        $key                  = $params['payload']->metadata->diocese_id;
+                        // DTO for property access. See payloadValueError() for why the
+                        // model layer's \ValueError has to be translated here.
+                        try {
+                            $params['payload'] = DiocesanData::fromObject($payload);
+                        } catch (\ValueError $e) {
+                            throw self::payloadValueError($e);
+                        }
+                        $key = $params['payload']->metadata->diocese_id;
                     }
                     break;
                 case PathCategory::NATION:
@@ -1777,8 +1804,12 @@ final class RegionalDataHandler extends AbstractHandler
                             throw new UnprocessableContentException('The litcal array must contain at least one liturgical event');
                         }
                         $params['rawPayload'] = $payload;  // Store raw for writing to disk
-                        $params['payload']    = NationalData::fromObject($payload);  // DTO for property access
-                        $key                  = $params['payload']->metadata->nation;
+                        try {
+                            $params['payload'] = NationalData::fromObject($payload);
+                        } catch (\ValueError $e) {
+                            throw self::payloadValueError($e);
+                        }
+                        $key = $params['payload']->metadata->nation;
                     }
                     break;
                 case PathCategory::WIDERREGION:
@@ -1792,8 +1823,12 @@ final class RegionalDataHandler extends AbstractHandler
                             throw new UnprocessableContentException('The litcal array must contain at least one liturgical event');
                         }
                         $params['rawPayload'] = $payload;  // Store raw for writing to disk
-                        $params['payload']    = WiderRegionData::fromObject($payload);  // DTO for property access
-                        $key                  = $params['payload']->metadata->wider_region;
+                        try {
+                            $params['payload'] = WiderRegionData::fromObject($payload);
+                        } catch (\ValueError $e) {
+                            throw self::payloadValueError($e);
+                        }
+                        $key = $params['payload']->metadata->wider_region;
                     }
                     break;
                 default:


### PR DESCRIPTION
Fixes the API half of [LiturgicalCalendarFrontend#462](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/issues/462). The frontend half is [LiturgicalCalendarFrontend#464](https://github.com/Liturgical-Calendar/LiturgicalCalendarFrontend/pull/464) — independent of this, either can land first.

## The bug

`i18n` must key exactly the locales `metadata.locales` announces. JSON Schema cannot express "the keys of this object equal the values of that array", so the RegionalData models enforce it and signal a breach with a plain `\ValueError`:

```php
if (implode(',', $i18nProps) !== implode(',', $this->metadata->locales)) {
    throw new \ValueError('keys of i18n parameter must be the same as the values of metadata.locales');
}
```

Nothing on the write path caught it. `RegionalDataHandler`'s three `fromObject()` calls sat bare, so the error escaped and became a 500 — blaming the server for what is squarely a client-data problem. The two sibling checks immediately above each of those calls already throw `UnprocessableContentException` (missing `i18n`, empty `litcal`), so 422 is plainly the intended shape for this family.

It was reachable in practice: the frontend's diocesan editor submitted exactly that payload whenever a save beat its secondary-locale translation fetch.

## What changed

`\ValueError` → `UnprocessableContentException` at all three write sites, via a small `payloadValueError()` helper carrying the rationale.

**Why in the handler and not in the models:** the same DTOs load calendars from disk. There a locales/i18n mismatch is *our* bug in stored source data, not the caller's, and must stay a server error. Only the request path may reinterpret it as unprocessable content. Moving the exception type into `validateTranslations()` would have conflated the two.

**All three categories**, not just diocesan: `DiocesanData`, `NationalData` and `WiderRegionData` each have their own `fromObject()` call and the identical model-side check. The defect was never diocese-specific — only its discovery was.

`loadTranslations()` (the other `validateTranslations()` caller) has no callers anywhere in `src/`, so the constructor path is the whole surface.

## Test plan

- [x] Two new tests in `RegionalDataHandlerTest`, diocesan and national, each declaring two locales with `i18n` covering one. They assert the **message**, not merely the exception type: several unrelated conditions on this path also raise `UnprocessableContentException`, so a bare type assertion could pass for the wrong reason.
- [x] **Confirmed to fail against the unpatched handler** with `Failed asserting that exception of type "ValueError" matches expected exception ...UnprocessableContentException` — so these are genuine regression tests, not tautologies.
- [x] `composer test:quick` — 2354 tests, 172818 assertions, **no failures**. 5 errors, all in `phpunit_tests/WebSocket/ExecuteUnitTestTest.php`, which needs `composer ws:start`; unrelated to this path.
- [x] `composer lint` (phpcs) and `composer analyse` (PHPStan level 10) — clean.

Wider-region has no payload fixture in the test class, so it is covered by inspection rather than by a test; the docblock says so explicitly rather than implying coverage it does not have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation for regional data updates to ensure internationalization keys match all declared locales.
  - Invalid diocesan, national, and wider-region payloads now return clear, actionable validation errors instead of server errors.
  - Added coverage for invalid locale configurations across supported regional data update scenarios.
  - Standardized validation responses for malformed regional data submissions, providing more consistent feedback when updates cannot be processed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->