### PR TITLE
chore(jsondata): normalise decrees source files and guard against drift

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,29 @@ jobs:
       - name: PHP Code Sniffer
         run: composer lint
 
+  jsondata_lint:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
+        with:
+          php-version: ${{ env.PHP_VERSION }}
+
+      - name: Download vendor folder from build job
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: vendor-folder
+          path: vendor
+
+      - name: Fix permissions on vendor binaries
+        run: test -d vendor/bin && chmod +x vendor/bin/* || true
+
+      - name: JSON source data canonical-encoding check
+        run: composer lint:jsondata
+
   static_analysis:
     runs-on: ubuntu-latest
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,8 +73,16 @@ jobs:
   jsondata_lint:
     runs-on: ubuntu-latest
     needs: build
+    # Least privilege: this job only reads the tree and re-encodes JSON. It needs no
+    # write scope, and `actions: read` is deliberately NOT granted — download-artifact
+    # resolves same-run artifacts through the runtime token, not GITHUB_TOKEN.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here pushes; don't leave the token in .git/config for later steps.
+          persist-credentials: false
 
       - name: Set up PHP
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,7 @@
         "lint:md": "npx --yes markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#vendor\" \"#.worktrees\" \"#.aider*\" \"#.superpowers\"",
         "lint:md:fix": "npx --yes markdownlint-cli2 --fix \"**/*.md\" \"#node_modules\" \"#vendor\" \"#.worktrees\" \"#.aider*\" \"#.superpowers\"",
         "lint:openapi": "npx --yes @redocly/cli lint",
+        "lint:jsondata": "@php scripts/lint-jsondata.php",
         "analyse": "phpstan analyse",
         "parallel-lint": "parallel-lint --exclude .git --exclude vendor .",
         "test": "phpunit --testdox --display-warnings --exclude-group golden-master-generate",

--- a/jsondata/sourcedata/rite/roman/decrees/decrees.json
+++ b/jsondata/sourcedata/rite/roman/decrees/decrees.json
@@ -7,7 +7,7 @@
         "liturgical_event": {
             "event_key": "StMaryMagdalene",
             "grade": 4,
-            "calendar":"GENERAL ROMAN"
+            "calendar": "GENERAL ROMAN"
         },
         "metadata": {
             "action": "setProperty",
@@ -44,9 +44,9 @@
         "liturgical_event": {
             "event_key": "MaryMotherChurch",
             "grade": 3,
-            "common": ["Proper"],
+            "common": [ "Proper" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "mobile",
             "strtotime": {
                 "day_of_the_week": "Monday",
@@ -85,7 +85,7 @@
         "description": "The Supreme Pontiff Pope FRANCIS, considering the important evangelical witness offered by Martha, Mary and Lazarus in welcoming the Lord Jesus into their home, in listening to him attentively, in believing that he is the resurrection and the life, and accepting the proposal of this Dicastery, has decreed that 29 July be designated in the General Roman Calendar as the Memorial of Saints Martha, Mary and Lazarus.",
         "liturgical_event": {
             "event_key": "StMartha",
-            "calendar":"GENERAL ROMAN"
+            "calendar": "GENERAL ROMAN"
         },
         "metadata": {
             "action": "setProperty",
@@ -122,9 +122,9 @@
             "grade": 2,
             "month": 10,
             "day": 11,
-            "common": ["Pastors:For a Pope"],
+            "common": [ "Pastors:For a Pope" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "fixed"
         },
         "metadata": {
@@ -159,9 +159,9 @@
             "grade": 2,
             "month": 10,
             "day": 22,
-            "common": ["Pastors:For a Pope"],
+            "common": [ "Pastors:For a Pope" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "fixed"
         },
         "metadata": {
@@ -196,9 +196,9 @@
             "grade": 2,
             "month": 12,
             "day": 10,
-            "common": ["Blessed Virgin Mary"],
+            "common": [ "Blessed Virgin Mary" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "fixed"
         },
         "metadata": {
@@ -233,9 +233,9 @@
             "grade": 2,
             "month": 5,
             "day": 29,
-            "common": ["Pastors:For a Pope"],
+            "common": [ "Pastors:For a Pope" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "fixed"
         },
         "metadata": {
@@ -272,9 +272,9 @@
             "grade": 2,
             "month": 10,
             "day": 5,
-            "common": ["Holy Men and Women:For Religious"],
+            "common": [ "Holy Men and Women:For Religious" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "fixed"
         },
         "metadata": {
@@ -309,9 +309,9 @@
             "grade": 2,
             "month": 2,
             "day": 27,
-            "common": ["Holy Men and Women:For an Abbot", "Doctors"],
+            "common": [ "Holy Men and Women:For an Abbot", "Doctors" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "fixed"
         },
         "metadata": {
@@ -348,9 +348,9 @@
             "grade": 2,
             "month": 5,
             "day": 10,
-            "common": ["Pastors:For One Pastor", "Doctors"],
+            "common": [ "Pastors:For One Pastor", "Doctors" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "fixed"
         },
         "metadata": {
@@ -387,9 +387,9 @@
             "grade": 2,
             "month": 9,
             "day": 17,
-            "common": ["Virgins:For One Virgin", "Doctors"],
+            "common": [ "Virgins:For One Virgin", "Doctors" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "fixed"
         },
         "metadata": {
@@ -423,7 +423,7 @@
         "description": "Fulfilling the wishes of many Brothers in the Episcopate and of a great number of the faithful throughout the world, after consulting the Dicastery for the Causes of Saints and hearing the opinion of the Dicastery for the Doctrine of the Faith regarding her eminent doctrine, with certain knowledge and after lengthy reflection, with the fullness of Our apostolic authority We declare Saint Thérèse of the Child Jesus and the Holy Face, virgin, to be a Doctor of the Universal Church.",
         "liturgical_event": {
             "event_key": "StThereseChildJesus",
-            "common": ["Proper"],
+            "common": [ "Proper" ],
             "calendar": "GENERAL ROMAN"
         },
         "metadata": {
@@ -457,7 +457,7 @@
         "description": "Dopo aver avuto il parere della Congregazione delle Cause dei Santi, con la mia Autorità Apostolica lo DICHIARO Sant'Ireneo di Lione Dottore della Chiesa con il titolo di Doctor unitatis.",
         "liturgical_event": {
             "event_key": "StIrenaeus",
-            "common": ["Proper"],
+            "common": [ "Proper" ],
             "calendar": "GENERAL ROMAN"
         },
         "metadata": {
@@ -476,9 +476,9 @@
             "grade": 2,
             "month": 9,
             "day": 5,
-            "common": ["Virgins:For One Virgin", "Holy Men and Women:For Those Who Practiced Works of Mercy"],
+            "common": [ "Virgins:For One Virgin", "Holy Men and Women:For Those Who Practiced Works of Mercy" ],
             "calendar": "GENERAL ROMAN",
-            "color": ["white"],
+            "color": [ "white" ],
             "type": "fixed"
         },
         "metadata": {

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/de.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/de.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "",
-    "StMartha": "",
-    "StJohnXXIII": "",
-    "StJohnPaulII": "",
     "OurLadyOfLoreto": "",
-    "StPaulVI": "",
     "StFaustinaKowalska": "",
     "StGregoryNarek": "",
-    "StJohnAvila": "",
     "StHildegardBingen": "",
-    "StThereseChildJesus": "",
     "StIrenaeus": "",
-    "StMotherTeresa": "Heilige Teresa von Kolkata, Jungfrau"
+    "StJohnAvila": "",
+    "StJohnPaulII": "",
+    "StJohnXXIII": "",
+    "StMartha": "",
+    "StMotherTeresa": "Heilige Teresa von Kolkata, Jungfrau",
+    "StPaulVI": "",
+    "StThereseChildJesus": ""
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/en.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/en.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "Blessed Virgin Mary, Mother of the Church",
-    "StMartha": "Saints Martha, Mary and Lazarus",
-    "StJohnXXIII": "Saint John XXIII, Pope",
-    "StJohnPaulII": "Saint John Paul II, Pope",
     "OurLadyOfLoreto": "Blessed Virgin Mary of Loreto",
-    "StPaulVI": "Saint Paul VI, Pope",
     "StFaustinaKowalska": "Saint Faustina Kowalska",
     "StGregoryNarek": "Saint Gregory of Narek, Abbot and Doctor of the Church",
-    "StJohnAvila": "Saint John of Avila, Priest and Doctor of the Church",
     "StHildegardBingen": "Saint Hildegard of Bingen, Virgin and Doctor of the Church",
-    "StThereseChildJesus": "Saint Thérèse of the Child Jesus, Virgin and Doctor of the Church",
     "StIrenaeus": "Saint Irenaeus, Bishop and Martyr and Doctor of the Church",
-    "StMotherTeresa": "Saint Teresa of Calcutta, Virgin"
+    "StJohnAvila": "Saint John of Avila, Priest and Doctor of the Church",
+    "StJohnPaulII": "Saint John Paul II, Pope",
+    "StJohnXXIII": "Saint John XXIII, Pope",
+    "StMartha": "Saints Martha, Mary and Lazarus",
+    "StMotherTeresa": "Saint Teresa of Calcutta, Virgin",
+    "StPaulVI": "Saint Paul VI, Pope",
+    "StThereseChildJesus": "Saint Thérèse of the Child Jesus, Virgin and Doctor of the Church"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/es.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/es.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "Santa Virgen María, Madre de la Iglesia",
-    "StMartha": "Santa Marta, María y Lázaro",
-    "StJohnXXIII": "San Juan XXIII, Papa",
-    "StJohnPaulII": "San Juan Pablo II, Papa",
     "OurLadyOfLoreto": "Santa Virgen María de Loreto",
-    "StPaulVI": "San Pablo VI, Papa",
     "StFaustinaKowalska": "Santa Faustina Kowalska",
     "StGregoryNarek": "San Gregorio de Narek, Abad y Doctor de la Iglesia",
-    "StJohnAvila": "San Juan de Ávila, Sacerdote y Doctor de la Iglesia",
     "StHildegardBingen": "Santa Hildegarda de Bingen, Virgen y Doctora de la Iglesia",
-    "StThereseChildJesus": "Santa Teresa del Niño Jesús, Virgen y Doctora de la Iglesia",
     "StIrenaeus": "San Ireneo, Obispo, Mártir y Doctor de la Iglesia",
-    "StMotherTeresa": "Santa Teresa de Calcuta, Virgen"
+    "StJohnAvila": "San Juan de Ávila, Sacerdote y Doctor de la Iglesia",
+    "StJohnPaulII": "San Juan Pablo II, Papa",
+    "StJohnXXIII": "San Juan XXIII, Papa",
+    "StMartha": "Santa Marta, María y Lázaro",
+    "StMotherTeresa": "Santa Teresa de Calcuta, Virgen",
+    "StPaulVI": "San Pablo VI, Papa",
+    "StThereseChildJesus": "Santa Teresa del Niño Jesús, Virgen y Doctora de la Iglesia"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/fr.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/fr.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "Sainte Marie Mère de Dieu",
-    "StMartha": "Saintes Marthe, Marie et saint Lazare",
-    "StJohnXXIII": "Saint Jean XXIII, pape",
-    "StJohnPaulII": "Saint Jean-Paul II, pape",
     "OurLadyOfLoreto": "Bienheureuse Vierge Marie de Lorette",
-    "StPaulVI": "Saint Paul VI, pape",
     "StFaustinaKowalska": "Sainte Faustine Kowalska",
     "StGregoryNarek": "Saint Grégoire de Narek, abbé et docteur de l'Église",
-    "StJohnAvila": "Saint Jean d'Avila, prêtre et docteur de l'Église",
     "StHildegardBingen": "Sainte Hildegarde de Bingen, vierge et docteur de l'Église",
-    "StThereseChildJesus": "Sainte Thérèse de l'Enfant Jésus, vierge et docteur de l'Église",
     "StIrenaeus": "Saint Irénée, évêque, martyr et docteur de l'Église",
-    "StMotherTeresa": "Sainte Teresa de Calcutta, vierge"
+    "StJohnAvila": "Saint Jean d'Avila, prêtre et docteur de l'Église",
+    "StJohnPaulII": "Saint Jean-Paul II, pape",
+    "StJohnXXIII": "Saint Jean XXIII, pape",
+    "StMartha": "Saintes Marthe, Marie et saint Lazare",
+    "StMotherTeresa": "Sainte Teresa de Calcutta, vierge",
+    "StPaulVI": "Saint Paul VI, pape",
+    "StThereseChildJesus": "Sainte Thérèse de l'Enfant Jésus, vierge et docteur de l'Église"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/hr.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/hr.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "Blažena Djevica Marija Majka Crkve",
-    "StMartha": "Sveta Marta, Marija i Lazar",
-    "StJohnXXIII": "Sveti Ivan XXIII., papa",
-    "StJohnPaulII": "Sveti Ivan Pavao II., papa",
     "OurLadyOfLoreto": "Blažena Djevica Marija Loretska",
-    "StPaulVI": "Sveti Pavao VI., papa",
     "StFaustinaKowalska": "Sveta Faustina Kowalska, djevica",
     "StGregoryNarek": "Sveti Grgur iz Nareka, opat i crkveni naučitelj",
-    "StJohnAvila": "Sveti Ivan Avilski, prezbiter i crkveni naučitelj",
     "StHildegardBingen": "Sveta Hildegarda iz Bingena, djevica i crkvena naučiteljica",
-    "StThereseChildJesus": "Sveta Terezija od Djeteta Isusa, djevica i crkvena naučiteljica",
     "StIrenaeus": "Sveti Irenej, biskup i mučenik i crkveni naučitelj",
-    "StMotherTeresa": "Sveta Terezija od Calcuta, djevica"
+    "StJohnAvila": "Sveti Ivan Avilski, prezbiter i crkveni naučitelj",
+    "StJohnPaulII": "Sveti Ivan Pavao II., papa",
+    "StJohnXXIII": "Sveti Ivan XXIII., papa",
+    "StMartha": "Sveta Marta, Marija i Lazar",
+    "StMotherTeresa": "Sveta Terezija od Calcuta, djevica",
+    "StPaulVI": "Sveti Pavao VI., papa",
+    "StThereseChildJesus": "Sveta Terezija od Djeteta Isusa, djevica i crkvena naučiteljica"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/hu.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/hu.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "",
-    "StMartha": "",
-    "StJohnXXIII": "",
-    "StJohnPaulII": "",
     "OurLadyOfLoreto": "",
-    "StPaulVI": "",
     "StFaustinaKowalska": "",
     "StGregoryNarek": "",
-    "StJohnAvila": "",
     "StHildegardBingen": "",
-    "StThereseChildJesus": "",
     "StIrenaeus": "",
-    "StMotherTeresa": ""
+    "StJohnAvila": "",
+    "StJohnPaulII": "",
+    "StJohnXXIII": "",
+    "StMartha": "",
+    "StMotherTeresa": "",
+    "StPaulVI": "",
+    "StThereseChildJesus": ""
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/id.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/id.json
@@ -1,15 +1,15 @@
 {
-    "StMartha": "Santa Marta, Maria, dan Lazarus",
-    "StJohnPaulII": "Santo Yohanes Paulus II, Paus",
+    "MaryMotherChurch": "Santa Perawan Maria Bunda Gereja",
     "OurLadyOfLoreto": "Santa Perawan Maria dari Loreto",
-    "StPaulVI": "Santo Paulus VI, Paus",
     "StFaustinaKowalska": "Santa Faustina Kowalska",
     "StGregoryNarek": "Santo Gregorius dari Narek, Abas dan Pujangga Gereja",
-    "StJohnXXIII": "Santo Yohanes XXIII, Paus",
-    "MaryMotherChurch": "Santa Perawan Maria Bunda Gereja",
-    "StJohnAvila": "Santo Yohanes dari Avila, Imam dan Pujangga Gereja",
     "StHildegardBingen": "Santa Hildegard dari Bingen, Perawan dan Pujangga Gereja",
-    "StThereseChildJesus": "Santa Teresia dari Kanak-kanak Yesus, Perawan dan Pujangga Gereja",
     "StIrenaeus": "Santo Ireneus, Uskup, Martir, dan Pujangga Gereja",
-    "StMotherTeresa": "Santa Teresa dari Kalkuta, Perawan"
+    "StJohnAvila": "Santo Yohanes dari Avila, Imam dan Pujangga Gereja",
+    "StJohnPaulII": "Santo Yohanes Paulus II, Paus",
+    "StJohnXXIII": "Santo Yohanes XXIII, Paus",
+    "StMartha": "Santa Marta, Maria, dan Lazarus",
+    "StMotherTeresa": "Santa Teresa dari Kalkuta, Perawan",
+    "StPaulVI": "Santo Paulus VI, Paus",
+    "StThereseChildJesus": "Santa Teresia dari Kanak-kanak Yesus, Perawan dan Pujangga Gereja"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/it.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/it.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "Beata Vergine Maria, Madre della Chiesa",
-    "StMartha": "Santi Marta, Maria e Lazzaro",
-    "StJohnXXIII": "San Giovanni XXIII, papa",
-    "StJohnPaulII": "San Giovanni Paolo II, papa",
     "OurLadyOfLoreto": "Beata Maria Vergine di Loreto",
-    "StPaulVI": "San Paolo VI, Papa",
     "StFaustinaKowalska": "Santa Faustina Kowalska",
     "StGregoryNarek": "San Gregorio di Narek, abate e dottore della Chiesa",
-    "StJohnAvila": "San Giovanni d'Avila, sacerdote e dottore della Chiesa",
     "StHildegardBingen": "Santa Ildegarda de Bingen, vergine e dottore della Chiesa",
-    "StThereseChildJesus": "Santa Teresa di Gesù Bambino, vergine e dottore della Chiesa",
     "StIrenaeus": "Sant'Ireneo, vescovo e martire e dottore della Chiesa",
-    "StMotherTeresa": "Santa Teresa di Calcutta, vergine"
+    "StJohnAvila": "San Giovanni d'Avila, sacerdote e dottore della Chiesa",
+    "StJohnPaulII": "San Giovanni Paolo II, papa",
+    "StJohnXXIII": "San Giovanni XXIII, papa",
+    "StMartha": "Santi Marta, Maria e Lazzaro",
+    "StMotherTeresa": "Santa Teresa di Calcutta, vergine",
+    "StPaulVI": "San Paolo VI, Papa",
+    "StThereseChildJesus": "Santa Teresa di Gesù Bambino, vergine e dottore della Chiesa"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/la.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/la.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "Beatæ Mariæ Virginis, Ecclesiæ Matris",
-    "StMartha": "Sanctorum Marthæ, Mariæ et Lazari",
-    "StJohnXXIII": "S. Ioannis XXIII, papæ",
-    "StJohnPaulII": "S. Ioannis Pauli II, papæ",
     "OurLadyOfLoreto": "Beatæ Mariæ Virginis de Loreto",
-    "StPaulVI": "Sancti Pauli VI, Papæ",
     "StFaustinaKowalska": "Sanctæ Faustinæ Kowalska",
     "StGregoryNarek": "Sancti Gregorii Narecensis, abbatis et Ecclesiæ doctoris",
-    "StJohnAvila": "Sancti Ioannis De Avila, presbyteri et Ecclesiæ doctoris",
     "StHildegardBingen": "Sanctæ Hildegardis Bingensis, virginis et Ecclesiæ doctoris",
-    "StThereseChildJesus": "Sanctæ Teresiæ a Iesu Infante, virginis et Ecclesiæ doctoris",
     "StIrenaeus": "Sancti Irenæi, episcopi et martyris et Ecclesiæ doctoris",
-    "StMotherTeresa": "Sanctæ Teresiæ de Calcutta, virginis"
+    "StJohnAvila": "Sancti Ioannis De Avila, presbyteri et Ecclesiæ doctoris",
+    "StJohnPaulII": "S. Ioannis Pauli II, papæ",
+    "StJohnXXIII": "S. Ioannis XXIII, papæ",
+    "StMartha": "Sanctorum Marthæ, Mariæ et Lazari",
+    "StMotherTeresa": "Sanctæ Teresiæ de Calcutta, virginis",
+    "StPaulVI": "Sancti Pauli VI, Papæ",
+    "StThereseChildJesus": "Sanctæ Teresiæ a Iesu Infante, virginis et Ecclesiæ doctoris"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/nl.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/nl.json
@@ -1,15 +1,15 @@
 {
-    "StMartha": "HH. Marta, Maria en Lazarus",
-    "StJohnXXIII": "H. Johannes XXIII, paus",
+    "MaryMotherChurch": "H. Maagd Maria, Moeder van de Kerk",
     "OurLadyOfLoreto": "H. Maagd Maria van Loreto",
-    "StPaulVI": "H. Paulus VI, paus",
     "StFaustinaKowalska": "H. Faustina Kowalska",
     "StGregoryNarek": "H. Gregorius van Narek, abt en kerkleraar",
     "StHildegardBingen": "H. Hildegard van Bingen, maagd en kerklerares",
-    "StThereseChildJesus": "H. Teresia van het Kind Jezus (Teresia van Lisieux), maagd en kerklerares",
     "StIrenaeus": "H. Ireneüs, bisschop, martelaar en kerkleraar",
-    "MaryMotherChurch": "H. Maagd Maria, Moeder van de Kerk",
-    "StJohnPaulII": "H. Johannes Paulus II, paus",
     "StJohnAvila": "H. Johannes van Avila, priester en kerkleraar",
-    "StMotherTeresa": "H. Teresa van Calcuta, maagd"
+    "StJohnPaulII": "H. Johannes Paulus II, paus",
+    "StJohnXXIII": "H. Johannes XXIII, paus",
+    "StMartha": "HH. Marta, Maria en Lazarus",
+    "StMotherTeresa": "H. Teresa van Calcuta, maagd",
+    "StPaulVI": "H. Paulus VI, paus",
+    "StThereseChildJesus": "H. Teresia van het Kind Jezus (Teresia van Lisieux), maagd en kerklerares"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/pl.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/pl.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "Najświętsza Maryja Panna, Matka Kościoła",
-    "StMartha": "Święci Marta, Maria i Łazarz z Betanii",
-    "StJohnXXIII": "Święty Jan XXIII, papież",
-    "StJohnPaulII": "Święty Jan Paweł II, papież",
     "OurLadyOfLoreto": "Najświętsza Maryja Panna Loretańska",
-    "StPaulVI": "Święty Paweł VI, papież",
     "StFaustinaKowalska": "Święta Faustyna Kowalska",
     "StGregoryNarek": "Święty Grzegorz z Nareku, opat i doktor Kościoła",
-    "StJohnAvila": "Święty Jan z Avili, prezbiter i doktor Kościoła",
     "StHildegardBingen": "Święta Hildegarda z Bingen, dziewica i doktor Kościoła",
-    "StThereseChildJesus": "Święta Teresa od Dzieciątka Jezus, dziewica i doktor Kościoła",
     "StIrenaeus": "Święty Ireneusz, biskup i męczennik, doktor Kościoła",
-    "StMotherTeresa": "Święta Teresa z Kalkuty, dziewica"
+    "StJohnAvila": "Święty Jan z Avili, prezbiter i doktor Kościoła",
+    "StJohnPaulII": "Święty Jan Paweł II, papież",
+    "StJohnXXIII": "Święty Jan XXIII, papież",
+    "StMartha": "Święci Marta, Maria i Łazarz z Betanii",
+    "StMotherTeresa": "Święta Teresa z Kalkuty, dziewica",
+    "StPaulVI": "Święty Paweł VI, papież",
+    "StThereseChildJesus": "Święta Teresa od Dzieciątka Jezus, dziewica i doktor Kościoła"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/pt.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/pt.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "Abençoada Virgem Maria, Mãe da Igreja",
-    "StMartha": "Santos Marta, Maria e Lázaro",
-    "StJohnXXIII": "Santo João XXIII, Papa",
-    "StJohnPaulII": "Santo João Paulo II, Papa",
     "OurLadyOfLoreto": "Abençoada Virgem Maria de Loreto",
-    "StPaulVI": "Santo Paulo VI, Papa",
     "StFaustinaKowalska": "Santa Faustina Kowalska",
     "StGregoryNarek": "São Gregório de Narek, Abade e Doutor da Igreja",
-    "StJohnAvila": "São João de Ávila, Padre e Doutor da Igreja",
     "StHildegardBingen": "Santa Hildegarda de Bingen, Virgem e Doutora da Igreja",
-    "StThereseChildJesus": "Santa Teresa do Menino Jesus, Virgem e Doutora da Igreja",
     "StIrenaeus": "São Ireneu, Bispo e Mártir e Doutor da Igreja",
-    "StMotherTeresa": "Santa Teresa de Calcuta, Virgem"
+    "StJohnAvila": "São João de Ávila, Padre e Doutor da Igreja",
+    "StJohnPaulII": "Santo João Paulo II, Papa",
+    "StJohnXXIII": "Santo João XXIII, Papa",
+    "StMartha": "Santos Marta, Maria e Lázaro",
+    "StMotherTeresa": "Santa Teresa de Calcuta, Virgem",
+    "StPaulVI": "Santo Paulo VI, Papa",
+    "StThereseChildJesus": "Santa Teresa do Menino Jesus, Virgem e Doutora da Igreja"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/sk.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/sk.json
@@ -1,15 +1,15 @@
 {
-    "StMartha": "Svätí Marta, Mária a Lazár",
     "MaryMotherChurch": "Blahoslavená Panna Mária, Matka Cirkvi",
-    "StJohnXXIII": "Svätý Ján XXIII., pápež",
-    "StJohnPaulII": "Svätý Ján Pavol II., pápež",
     "OurLadyOfLoreto": "Blahoslavená Panna Mária z Loreta",
-    "StPaulVI": "Svätý Pavol VI., pápež",
     "StFaustinaKowalska": "Svätá Faustína Kowalská",
     "StGregoryNarek": "Svätý Gregor z Nareku, opát a učiteľ Cirkvi",
-    "StJohnAvila": "Svätý Ján z Avily, kňaz a učiteľ Cirkvi",
     "StHildegardBingen": "Sv. Hildegarda z Bingenu, panna a učiteľka Cirkvi",
-    "StThereseChildJesus": "Svätá Terézia od Dieťaťa Ježiša, panna a učiteľka Cirkvi",
     "StIrenaeus": "Svätý Irenej, biskup a mučeník a učiteľ Cirkvi",
-    "StMotherTeresa": "Svätá Terézia z Kalkaty, panna"
+    "StJohnAvila": "Svätý Ján z Avily, kňaz a učiteľ Cirkvi",
+    "StJohnPaulII": "Svätý Ján Pavol II., pápež",
+    "StJohnXXIII": "Svätý Ján XXIII., pápež",
+    "StMartha": "Svätí Marta, Mária a Lazár",
+    "StMotherTeresa": "Svätá Terézia z Kalkaty, panna",
+    "StPaulVI": "Svätý Pavol VI., pápež",
+    "StThereseChildJesus": "Svätá Terézia od Dieťaťa Ježiša, panna a učiteľka Cirkvi"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/i18n/vi.json
+++ b/jsondata/sourcedata/rite/roman/decrees/i18n/vi.json
@@ -1,15 +1,15 @@
 {
     "MaryMotherChurch": "Đức Trinh Nữ Maria, Mẹ Hội Thánh",
-    "StMartha": "Thánh Martha, Maria và Ladarô",
-    "StJohnXXIII": "Thánh Gioan XXIII, Giáo hoàng",
-    "StJohnPaulII": "Thánh Gioan Phaolô II, Giáo hoàng",
     "OurLadyOfLoreto": "Đức Mẹ Loreto",
-    "StPaulVI": "Thánh Phaolô VI, Giáo hoàng",
     "StFaustinaKowalska": "Thánh Maria Faustina Kowalska, Trinh nữ",
     "StGregoryNarek": "Thánh Grêgôriô thành Narek, Viện phụ, Tiến sĩ Hội Thánh",
-    "StJohnAvila": "Thánh Gioan thành Ávila, Linh mục, Tiến sĩ Hội Thánh",
     "StHildegardBingen": "Thánh Hildegard thành Bingen, Trinh nữ, Tiến sĩ Hội Thánh",
-    "StThereseChildJesus": "Thánh Têrêsa Hài Đồng Giêsu, Trinh nữ, Tiến sĩ Hội Thánh",
     "StIrenaeus": "Thánh Irênê, Giám mục, Tử đạo, Tiến sĩ Hội Thánh",
-    "StMotherTeresa": "Thánh Têrêsa thành Calcutta, Trinh nữ"
+    "StJohnAvila": "Thánh Gioan thành Ávila, Linh mục, Tiến sĩ Hội Thánh",
+    "StJohnPaulII": "Thánh Gioan Phaolô II, Giáo hoàng",
+    "StJohnXXIII": "Thánh Gioan XXIII, Giáo hoàng",
+    "StMartha": "Thánh Martha, Maria và Ladarô",
+    "StMotherTeresa": "Thánh Têrêsa thành Calcutta, Trinh nữ",
+    "StPaulVI": "Thánh Phaolô VI, Giáo hoàng",
+    "StThereseChildJesus": "Thánh Têrêsa Hài Đồng Giêsu, Trinh nữ, Tiến sĩ Hội Thánh"
 }

--- a/jsondata/sourcedata/rite/roman/decrees/lectionary/en.json
+++ b/jsondata/sourcedata/rite/roman/decrees/lectionary/en.json
@@ -5,29 +5,11 @@
         "gospel_acclamation": "",
         "gospel": "John 19: 25-34"
     },
-    "StJohnXXIII": {
-        "first_reading": "Ezekiel 34: 11-16",
-        "responsorial_psalm": "Psalm 23: 1-3a, 4, 5, 6",
-        "gospel_acclamation": "John 10: 14",
-        "gospel": "John 21: 15-17"
-    },
-    "StJohnPaulII": {
-        "first_reading": "Isaiah 52: 7-10",
-        "responsorial_psalm": "Psalm 96: 1-2a, 2b-3, 7-8a, 10",
-        "gospel_acclamation": "John 10: 14",
-        "gospel": "John 21: 15-17"
-    },
     "OurLadyOfLoreto": {
         "first_reading": "Isaiah 7: 10-14; 8: 10",
         "responsorial_psalm": "Luke 1: 46-47, 48-49, 50-51, 52-53, 54-55",
         "gospel_acclamation": "Luke 1: 28",
         "gospel": "Luke 1: 26-38"
-    },
-    "StPaulVI": {
-        "first_reading": "1 Corinthians 9: 16-19, 22-23",
-        "responsorial_psalm": "Psalm 96: 1-2a, 2b-3, 7-8a, 10",
-        "gospel_acclamation": "Mark 1: 17",
-        "gospel": "Matthew 16: 13-19"
     },
     "StFaustinaKowalska": {
         "first_reading": "Ephesians 3: 14-19",
@@ -41,22 +23,40 @@
         "gospel_acclamation": "John 6: 63c, 68c",
         "gospel": "Matthew 7: 21-29"
     },
-    "StJohnAvila": {
-        "first_reading": "Acts 13: 46-49",
-        "responsorial_psalm": "Psalm 23: 1-3a, 4, 5, 6",
-        "gospel_acclamation": "Matthew 5: 16",
-        "gospel": "Matthew 5: 13-19"
-    },
     "StHildegardBingen": {
         "first_reading": "Song of Songs 8: 6-7",
         "responsorial_psalm": "Psalm 45: 11-12, 14-15, 16-17",
         "gospel_acclamation": "Matthew 5: 8",
         "gospel": "Matthew 25: 1-13"
     },
+    "StJohnAvila": {
+        "first_reading": "Acts 13: 46-49",
+        "responsorial_psalm": "Psalm 23: 1-3a, 4, 5, 6",
+        "gospel_acclamation": "Matthew 5: 16",
+        "gospel": "Matthew 5: 13-19"
+    },
+    "StJohnPaulII": {
+        "first_reading": "Isaiah 52: 7-10",
+        "responsorial_psalm": "Psalm 96: 1-2a, 2b-3, 7-8a, 10",
+        "gospel_acclamation": "John 10: 14",
+        "gospel": "John 21: 15-17"
+    },
+    "StJohnXXIII": {
+        "first_reading": "Ezekiel 34: 11-16",
+        "responsorial_psalm": "Psalm 23: 1-3a, 4, 5, 6",
+        "gospel_acclamation": "John 10: 14",
+        "gospel": "John 21: 15-17"
+    },
     "StMotherTeresa": {
         "first_reading": "Isaiah 58: 6-11",
         "responsorial_psalm": "Psalm 33: 2-3, 4-5, 6-7, 8-9, 10-11",
         "gospel_acclamation": "Matthew 11: 25",
         "gospel": "Matthew 25: 31-46|Matthew 25: 31-40"
+    },
+    "StPaulVI": {
+        "first_reading": "1 Corinthians 9: 16-19, 22-23",
+        "responsorial_psalm": "Psalm 96: 1-2a, 2b-3, 7-8a, 10",
+        "gospel_acclamation": "Mark 1: 17",
+        "gospel": "Matthew 16: 13-19"
     }
 }

--- a/jsondata/sourcedata/rite/roman/decrees/lectionary/es.json
+++ b/jsondata/sourcedata/rite/roman/decrees/lectionary/es.json
@@ -5,25 +5,7 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StJohnXXIII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StJohnPaulII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
     "OurLadyOfLoreto": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StPaulVI": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -41,13 +23,25 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
+    "StHildegardBingen": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
     "StJohnAvila": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StHildegardBingen": {
+    "StJohnPaulII": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
+    "StJohnXXIII": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -58,5 +52,11 @@
         "responsorial_psalm": "Salmo 33, 2-3. 4-5. 6-7. 8-9. 10-11",
         "gospel_acclamation": "Mateo 11, 25",
         "gospel": "Mateo 25, 31-46|Mateo 25, 31-40"
+    },
+    "StPaulVI": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
     }
 }

--- a/jsondata/sourcedata/rite/roman/decrees/lectionary/fr.json
+++ b/jsondata/sourcedata/rite/roman/decrees/lectionary/fr.json
@@ -5,25 +5,7 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StJohnXXIII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StJohnPaulII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
     "OurLadyOfLoreto": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StPaulVI": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -41,13 +23,25 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
+    "StHildegardBingen": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
     "StJohnAvila": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StHildegardBingen": {
+    "StJohnPaulII": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
+    "StJohnXXIII": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -58,5 +52,11 @@
         "responsorial_psalm": "Psaume 33, 2-3. 4-5. 6-7. 8-9. 10-11",
         "gospel_acclamation": "Matthieu 11, 25",
         "gospel": "Matthieu 25, 31-46|Matthieu 25, 31-40"
+    },
+    "StPaulVI": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
     }
 }

--- a/jsondata/sourcedata/rite/roman/decrees/lectionary/hr.json
+++ b/jsondata/sourcedata/rite/roman/decrees/lectionary/hr.json
@@ -5,25 +5,7 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StJohnXXIII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StJohnPaulII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
     "OurLadyOfLoreto": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StPaulVI": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -41,13 +23,25 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
+    "StHildegardBingen": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
     "StJohnAvila": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StHildegardBingen": {
+    "StJohnPaulII": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
+    "StJohnXXIII": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -58,5 +52,11 @@
         "responsorial_psalm": "Ps 33,2-3.4-5.6-7.8-9.10-11",
         "gospel_acclamation": "Mt 11,25",
         "gospel": "Mt 25,31-46|Mt 25,31-40"
+    },
+    "StPaulVI": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
     }
 }

--- a/jsondata/sourcedata/rite/roman/decrees/lectionary/it.json
+++ b/jsondata/sourcedata/rite/roman/decrees/lectionary/it.json
@@ -5,25 +5,7 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StJohnXXIII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StJohnPaulII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
     "OurLadyOfLoreto": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StPaulVI": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -41,13 +23,25 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
+    "StHildegardBingen": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
     "StJohnAvila": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StHildegardBingen": {
+    "StJohnPaulII": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
+    "StJohnXXIII": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -58,5 +52,11 @@
         "responsorial_psalm": "Salmo 33, 2-3. 4-5. 6-7. 8-9. 10-11",
         "gospel_acclamation": "Matteo 11, 25",
         "gospel": "Matteo 25, 31-46|Matteo 25, 31-40"
+    },
+    "StPaulVI": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
     }
 }

--- a/jsondata/sourcedata/rite/roman/decrees/lectionary/la.json
+++ b/jsondata/sourcedata/rite/roman/decrees/lectionary/la.json
@@ -5,25 +5,7 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StJohnXXIII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StJohnPaulII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
     "OurLadyOfLoreto": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StPaulVI": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -41,13 +23,25 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
+    "StHildegardBingen": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
     "StJohnAvila": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StHildegardBingen": {
+    "StJohnPaulII": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
+    "StJohnXXIII": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -58,5 +52,11 @@
         "responsorial_psalm": "Psalmo 33, 2-3. 4-5. 6-7. 8-9. 10-11",
         "gospel_acclamation": "Matthæum 11, 25",
         "gospel": "Matthæum 25, 31-46|Matthæum 25, 31-40"
+    },
+    "StPaulVI": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
     }
 }

--- a/jsondata/sourcedata/rite/roman/decrees/lectionary/nl.json
+++ b/jsondata/sourcedata/rite/roman/decrees/lectionary/nl.json
@@ -5,25 +5,7 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StJohnXXIII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StJohnPaulII": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
     "OurLadyOfLoreto": {
-        "first_reading": "",
-        "responsorial_psalm": "",
-        "gospel_acclamation": "",
-        "gospel": ""
-    },
-    "StPaulVI": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -41,13 +23,25 @@
         "gospel_acclamation": "",
         "gospel": ""
     },
+    "StHildegardBingen": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
     "StJohnAvila": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
         "gospel": ""
     },
-    "StHildegardBingen": {
+    "StJohnPaulII": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
+    },
+    "StJohnXXIII": {
         "first_reading": "",
         "responsorial_psalm": "",
         "gospel_acclamation": "",
@@ -58,5 +52,11 @@
         "responsorial_psalm": "Psalm 33, 2-3. 4-5. 6-7. 8-9. 10-11",
         "gospel_acclamation": "Mattheüs 11, 25",
         "gospel": "Mattheüs 25, 31-46|Mattheüs 25, 31-40"
+    },
+    "StPaulVI": {
+        "first_reading": "",
+        "responsorial_psalm": "",
+        "gospel_acclamation": "",
+        "gospel": ""
     }
 }

--- a/scripts/lint-jsondata.php
+++ b/scripts/lint-jsondata.php
@@ -1,0 +1,126 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Guard against source-data churn: re-encode every decrees source file
+ * through the exact canonicalizer its write-path handler uses, and fail if
+ * the committed file differs from that canonical form.
+ *
+ * Background: DecreesHandler's write path always re-encodes what it writes
+ * (JsonFormatter::encode(), plus ksort() for the i18n/lectionary sidecars).
+ * If a committed source file isn't already in that canonical form, every
+ * write-path request that happens to touch it produces a spurious diff —
+ * for months this was misdiagnosed as "whitespace churn". This script
+ * catches that class of drift in CI before it lands, and points at the fix.
+ *
+ * Usage:
+ *   php scripts/lint-jsondata.php
+ *
+ * Exit codes:
+ *   0  every checked file already matches its canonical encoding.
+ *   1  at least one file has drifted; drifting files are named on stdout.
+ *
+ * IMPORTANT — scope:
+ *   This script currently covers ONLY the decrees family
+ *   (jsondata/sourcedata/rite/roman/decrees/**), whose canonical form is
+ *   verified against DecreesHandler::saveDecreesDatabase(), ::distributeI18n(),
+ *   and ::distributeReadings(). A survey found the canonical form is NOT
+ *   uniform across jsondata (e.g. TestsHandler writes tests with
+ *   JsonFormatter::encode($payload, false) — escaped unicode, no trailing
+ *   newline — a different rule entirely). Do NOT widen the glob below to
+ *   "all of jsondata" without first verifying the canonical form file-family
+ *   by file-family; a single global rule would just create the same churn
+ *   somewhere new.
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\JsonFormatter;
+use LiturgicalCalendar\Api\Router;
+
+// Initialize the file-path prefix that JsonData::path() requires.
+// Router sets this during HTTP boot; CLI scripts must set it manually.
+Router::$apiFilePath = dirname(__DIR__) . DIRECTORY_SEPARATOR;
+
+// Canonical encoding for decrees.json: a re-indexed JSON list, no key sorting
+// (it's a list, not a map). Mirrors DecreesHandler::saveDecreesDatabase().
+$canonicalDecreesFile = static function (string $raw): string {
+    /** @var mixed $decoded */
+    $decoded = json_decode($raw, false, 512, JSON_THROW_ON_ERROR);
+    if (!is_array($decoded)) {
+        throw new \RuntimeException('decrees.json did not decode to a JSON array');
+    }
+    return JsonFormatter::encode(array_values($decoded)) . PHP_EOL;
+};
+
+// Canonical encoding for decrees i18n/lectionary sidecars: key-sorted map.
+// Mirrors DecreesHandler::distributeI18n() and ::distributeReadings().
+$canonicalDecreesSidecar = static function (string $raw): string {
+    /** @var array<string,mixed> $decoded */
+    $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+    if (!is_array($decoded)) {
+        throw new \RuntimeException('sidecar file did not decode to a JSON object');
+    }
+    ksort($decoded);
+    return JsonFormatter::encode($decoded) . PHP_EOL;
+};
+
+$decreesFile     = JsonData::DECREES_FILE->path();
+$i18nFiles       = glob(JsonData::DECREES_I18N_FOLDER->path() . '/*.json') ?: [];
+$lectionaryFiles = glob(JsonData::LECTIONARY_DECREES_FOLDER->path() . '/*.json') ?: [];
+
+/** @var array<int,array{path:string,canonicalize:\Closure(string):string}> $checks */
+$checks = [
+    ['path' => $decreesFile, 'canonicalize' => $canonicalDecreesFile],
+];
+foreach ($i18nFiles as $f) {
+    $checks[] = ['path' => $f, 'canonicalize' => $canonicalDecreesSidecar];
+}
+foreach ($lectionaryFiles as $f) {
+    $checks[] = ['path' => $f, 'canonicalize' => $canonicalDecreesSidecar];
+}
+
+/** @var string[] $drifted paths whose on-disk content differs from its canonical encoding */
+$drifted = [];
+foreach ($checks as $check) {
+    $path = $check['path'];
+    $raw  = file_get_contents($path);
+    if ($raw === false) {
+        fwrite(STDERR, "Could not read {$path}\n");
+        $drifted[] = $path;
+        continue;
+    }
+    try {
+        $canonical = ( $check['canonicalize'] )($raw);
+    } catch (\Throwable $e) {
+        fwrite(STDERR, "Could not canonicalize {$path}: {$e->getMessage()}\n");
+        $drifted[] = $path;
+        continue;
+    }
+    if ($raw !== $canonical) {
+        $drifted[] = $path;
+    }
+}
+
+if ($drifted === []) {
+    echo 'lint:jsondata OK — ' . count($checks) . " decrees source file(s) match their write-path canonical encoding.\n";
+    exit(0);
+}
+
+fwrite(STDERR, "lint:jsondata FAILED — the following file(s) are not in their write-path canonical encoding:\n");
+foreach ($drifted as $path) {
+    $rel = str_starts_with($path, Router::$apiFilePath) ? substr($path, strlen(Router::$apiFilePath)) : $path;
+    fwrite(STDERR, "  - {$rel}\n");
+}
+fwrite(
+    STDERR,
+    "\nThis means a future write through the decrees admin API (DecreesHandler) would rewrite these files even\n"
+    . "though no data changed, appearing as spurious diffs. Fix by re-running the normalizer that produced these\n"
+    . "exact rules: re-encode decrees.json via JsonFormatter::encode(array_values(\$decoded)) . PHP_EOL, and each\n"
+    . "i18n/*.json / lectionary/*.json sidecar via ksort(\$decoded); JsonFormatter::encode(\$decoded) . PHP_EOL,\n"
+    . "then commit the result. Do not hand-edit formatting — let the canonicalizer produce the bytes.\n"
+);
+exit(1);


### PR DESCRIPTION
Stops the recurring "decrees churn" — the 16-file dirty working tree that appears in the shared checkout after any
decrees write-path test run, and which has been rediscovered and re-dismissed repeatedly.

## It was never whitespace

Two distinct causes, both verified against live evidence:

**1. The sidecars (`i18n/*.json`, `lectionary/*.json`) — key ORDER.**
`DecreesHandler::distributeI18n()` (`:572`) and `distributeReadings()` (`:592`) `ksort($arr)` before every write.
The committed files were never sorted, so the first write reordered them. For every affected file the decoded data
was identical and `written == sorted(committed)`.

**2. `decrees.json` — formatting.**
Committed style was `"calendar":"GENERAL ROMAN"` and `["Proper"]`. `JsonFormatter::encode()` emits
`JSON_PRETTY_PRINT` plus a short-array collapse to `[ "Proper" ]` — so the file had last been written by something
other than the API's own formatter. Re-encoding the committed file reproduced the churned file **byte-for-byte**
(30328 bytes).

**Why it went unnoticed for so long:** the standing advice was "verify with `jq -S`, then discard". `jq -S` *sorts
keys*, so it is structurally blind to cause 1 — it reports "identical" for exactly the change taking place. It was
proving data equivalence while appearing to characterise the diff.

## What this does

**Normalisation (`3d4d4cf9`)** — rewrites all 22 decrees source files in the exact canonical form their writers
produce, so subsequent API writes are byte-identical:

- `decrees.json` → `JsonFormatter::encode(array_values($decoded)) . PHP_EOL` (`DecreesHandler.php:528`)
- each `i18n/*.json` and `lectionary/*.json` → `ksort($decoded)` then `JsonFormatter::encode($decoded) . PHP_EOL`

22 files, **232 insertions / 232 deletions** — pure reordering and reformatting. Data identity was proved twice,
independently: at write time by the normaliser, and afterwards by comparing each file's decoded value against
`git show <merge-base>:<path>` with order-insensitive comparison. All 22 identical.

Note this covers 22 files, not the 16 that happen to be dirty at any moment — 6 further lectionary sidecars were
also encode-unstable and would have tripped the guard on their first write.

**Guard (`176c09d3`)** — `scripts/lint-jsondata.php`, a `lint:jsondata` composer script, and a `jsondata_lint` CI
job following the existing `codesniffer` / `static_analysis` pattern. It re-encodes each decrees source file and
fails if any differs, naming the file and the exact rule to re-apply.

## Verification

Independently re-checked, not taken on report:

- Clean tree → guard exits **0**: `22 decrees source file(s) match their write-path canonical encoding`.
- Perturbed `i18n/en.json` by swapping two keys (data unchanged, order changed — the exact failure `jq -S` cannot
  see) → guard exits **1** and names `jsondata/sourcedata/rite/roman/decrees/i18n/en.json`.
- Restored byte-for-byte → exits **0** again, tree clean.
- `composer lint` and `composer analyse` clean.

## Deliberately NOT in scope

A survey found **70 of 301** `jsondata` files are not encode-stable. This PR touches only the decrees family,
because the canonical form is **not uniform**: `TestsHandler.php:437` writes tests with
`JsonFormatter::encode($payload, false)` — escaped unicode and **no trailing newline** — while decrees sidecars use
`encode($arr) . PHP_EOL`. A single global normaliser or guard would be wrong and would plant the same churn
somewhere new. The remaining families need rules derived from their own writers; worth filing separately.

No live-server proof that the churn is gone: `localhost:8000` serves a different checkout, and running the decrees
write-path tests against it would dirty *that* tree. The proof here is offline canonicalisation plus the guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Data Updates**
  - Standardized the ordering and formatting of liturgical decree, lectionary, and translation data across supported languages.
  - No translations, readings, or other displayed content were changed.

- **Quality Improvements**
  - Added automated validation to detect invalid, unreadable, or inconsistently formatted liturgical data before release.
  - Future data updates can be checked for consistency more reliably.
  - Improved consistency of data presentation without changing the information shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->