### PR TITLE
chore(vscode): repoint stale json.schemas fileMatch globs at real paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,53 +11,53 @@
     "json.schemas": [
         {
             "fileMatch": [
-                "/sourcedata/missals/propriumdesanctis_*.json"
+                "/jsondata/sourcedata/rite/*/missals/propriumdesanctis_*/propriumdesanctis*.json"
             ],
             "url": "./jsondata/schemas/PropriumDeSanctis.json"
         },
         {
             "fileMatch": [
-                "/sourcedata/missals/propriumdetempore.json"
+                "/jsondata/sourcedata/rite/*/missals/propriumdetempore/propriumdetempore.json"
             ],
             "url": "./jsondata/schemas/PropriumDeTempore.json"
         },
         {
             "fileMatch": [
-                "/sourcedata/decrees/decrees.json"
+                "/jsondata/sourcedata/rite/*/decrees/decrees.json"
             ],
             "url": "./jsondata/schemas/LitCalDecreesSource.json"
         },
         {
             "fileMatch": [
-                "/sourcedata/calendars/wider_regions/*/*.json"
+                "/jsondata/sourcedata/rite/*/calendars/wider_regions/*/*.json"
             ],
             "url": "./jsondata/schemas/WiderRegionCalendar.json"
         },
         {
             "fileMatch": [
-                "/sourcedata/calendars/nations/*/*.json"
+                "/jsondata/sourcedata/rite/*/calendars/nations/*/*.json"
             ],
             "url": "./jsondata/schemas/NationalCalendar.json"
         },
         {
             "fileMatch": [
-                "/sourcedata/calendars/dioceses/*/*/*.json"
+                "/jsondata/sourcedata/rite/*/calendars/dioceses/*/*/*.json"
             ],
             "url": "./jsondata/schemas/DiocesanCalendar.json"
         },
         {
             "fileMatch": [
-                "/sourcedata/tests/*.json"
+                "/jsondata/tests/*/*.json"
             ],
             "url": "./jsondata/schemas/LitCalTest.json"
         },
         {
             "fileMatch": [
-                "/sourcedata/calendars/dioceses/*/*/i18n/*.json",
-                "/sourcedata/calendars/nations/*/i18n/*.json",
-                "/sourcedata/calendars/wider_regions/*/i18n/*.json",
-                "/sourcedata/decrees/i18n/*.json",
-                "/sourcedata/missals/*/i18n/*.json"
+                "/jsondata/sourcedata/rite/*/calendars/dioceses/*/*/i18n/*.json",
+                "/jsondata/sourcedata/rite/*/calendars/nations/*/i18n/*.json",
+                "/jsondata/sourcedata/rite/*/calendars/wider_regions/*/i18n/*.json",
+                "/jsondata/sourcedata/rite/*/decrees/i18n/*.json",
+                "/jsondata/sourcedata/rite/*/missals/*/i18n/*.json"
             ],
             "url": "./jsondata/schemas/LitCalTranslation.json"
         }


### PR DESCRIPTION
## Summary

Every `fileMatch` in `.vscode/settings.json` was rooted at `/sourcedata/...`, but **there is no top-level `sourcedata/` directory** — the data lives under `jsondata/sourcedata/`, and most of it moved again under `jsondata/sourcedata/rite/{rite}/` during the Ambrosian rollout. With a leading `/` anchoring each pattern to the workspace root, **not one mapping matched anything**, so contributors editing source data got no validation, no completion, and no inline errors from the very schemas this repo maintains.

## What changed

| Schema | Was (matched nothing) | Now |
| ------ | --------------------- | --- |
| `PropriumDeSanctis.json`   | `/sourcedata/missals/propriumdesanctis_*.json`      | `/jsondata/sourcedata/rite/*/missals/propriumdesanctis_*/propriumdesanctis*.json` |
| `PropriumDeTempore.json`   | `/sourcedata/missals/propriumdetempore.json`        | `/jsondata/sourcedata/rite/*/missals/propriumdetempore/propriumdetempore.json`    |
| `LitCalDecreesSource.json` | `/sourcedata/decrees/decrees.json`                  | `/jsondata/sourcedata/rite/*/decrees/decrees.json`                                |
| `WiderRegionCalendar.json` | `/sourcedata/calendars/wider_regions/*/*.json`      | `/jsondata/sourcedata/rite/*/calendars/wider_regions/*/*.json`                    |
| `NationalCalendar.json`    | `/sourcedata/calendars/nations/*/*.json`            | `/jsondata/sourcedata/rite/*/calendars/nations/*/*.json`                          |
| `DiocesanCalendar.json`    | `/sourcedata/calendars/dioceses/*/*/*.json`         | `/jsondata/sourcedata/rite/*/calendars/dioceses/*/*/*.json`                       |
| `LitCalTest.json`          | `/sourcedata/tests/*.json`                          | `/jsondata/tests/*/*.json`                                                        |
| `LitCalTranslation.json`   | five `/sourcedata/...i18n/*.json` patterns          | same five, rooted at `/jsondata/sourcedata/rite/*/...`                            |

The rite-partitioned entries use a `rite/*/` segment so both rites are covered by one pattern rather than enumerating them.

### Two notes on specific patterns

- **The tests entry was wrong twice over.** `/sourcedata/tests/*.json` never existed — the corpus has always been under `jsondata/` — *and* the single-level `*` glob cannot match the rite-partitioned `jsondata/tests/{rite}/{name}.json` layout introduced by #787.
- **PropriumDeSanctis has two filename conventions in the corpus.** Roman missals use `propriumdesanctis_{edition}.json`; the Ambrosian 2024 missal uses a bare `propriumdesanctis.json`. The pattern accommodates both.

## Verification

The failure mode here is entirely silent, which is how a whole file's worth of mappings could rot unnoticed — so every pattern was checked against the real tree rather than eyeballed. Each of the 12 patterns now resolves to at least one file (previously: all zero):

```text
PropriumDeSanctis    ->  6 files      DiocesanCalendar   -> 16 files
PropriumDeTempore    ->  2 files      LitCalTest         -> 11 files
LitCalDecreesSource  ->  1 file       LitCalTranslation  -> 21 + 6 + 57 + 14 + 62 files
WiderRegionCalendar  ->  3 files
NationalCalendar     ->  5 files
```

Spot-checked that the globs stay tight: the lectionary payloads nested one level deeper (`.../nations/US/lectionary/en_US.json`, `.../dioceses/NL/bredad_nl/lectionary/nl_NL.json`) are correctly *not* claimed by the calendar patterns, since `*` does not cross a path separator.

## Scope

Developer experience only; no runtime behaviour changes. No schema currently exists for the lectionary source files, so no mapping was added for them.

Closes #795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated editor schema matching for JSON files in the repository’s current directory structure.
  * Improved validation support for missal, decree, calendar, test, and internationalization data files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->