### PR TITLE
fix(tests): report a rite mismatch instead of an unreadable-file error

### DIFF
--- a/phpunit_tests/Test/LitTestRunnerTest.php
+++ b/phpunit_tests/Test/LitTestRunnerTest.php
@@ -166,6 +166,10 @@ final class LitTestRunnerTest extends TestCase
         $this->assertSame('error', $msg->type);
         $this->assertStringContainsString('could not read Test instructions', $msg->text);
         $this->assertObjectNotHasProperty('jsonData', $msg);
+
+        // Regression guard for #794: a name that exists under NO rite must keep the
+        // missing-file message. The rite-mismatch branch added there must not swallow it.
+        $this->assertStringNotContainsString('is scoped to', $msg->text);
     }
 
     public function testGetMessageWithoutRunningProducesFallbackError(): void
@@ -295,5 +299,29 @@ final class LitTestRunnerTest extends TestCase
         // The same name under roman/ does not exist, so the runner is not ready.
         $roman = new LitTestRunner('StIgnatiusOfLoyolaTest', $data, Rite::ROMAN);
         self::assertFalse($roman->isReady());
+    }
+
+    public function testTestMissingFromRequestedRiteButPresentInAnotherReportsARiteMismatch(): void
+    {
+        // #794: after #787 partitioned the corpus by rite, Health resolves the rite from
+        // the calendar under test and hands it to LitTestRunner as the test's partition.
+        // An Ambrosian-scoped test run against a Roman calendar therefore misses the file
+        // and used to report "could not read Test instructions" — pointing the operator at
+        // the filesystem when the file is fine and the requested rite is wrong.
+        // StIgnatiusOfLoyolaTest exists only under jsondata/tests/ambrosian/.
+        $data   = $this->calendarPayload(2024, []);
+        $runner = new LitTestRunner('StIgnatiusOfLoyolaTest', $data, Rite::ROMAN);
+
+        $this->assertFalse($runner->isReady());
+
+        $msg = $runner->getMessage();
+        $this->assertSame('error', $msg->type);
+        $this->assertSame(
+            'StIgnatiusOfLoyolaTest is scoped to the ambrosian rite, but the calendar under test was computed under the roman rite',
+            $msg->text,
+            'The wording must match detectRiteMismatch() exactly: one condition, one phrasing.'
+        );
+        $this->assertStringNotContainsString('could not read Test instructions', $msg->text);
+        $this->assertObjectNotHasProperty('jsonData', $msg, 'Setup errors should not carry the full calendar payload');
     }
 }

--- a/src/Test/LitTestRunner.php
+++ b/src/Test/LitTestRunner.php
@@ -106,7 +106,7 @@ class LitTestRunner
         $cacheKey       = $rite->value . '/' . $Test;
         $this->cacheKey = $cacheKey;
         if (false === self::$testCache->has($cacheKey)) {
-            $testPath = rtrim(JsonData::testsFolderFor($rite)->path(), '/\\') . DIRECTORY_SEPARATOR . basename($Test) . '.json';
+            $testPath = self::testPathFor($Test, $rite);
             if (file_exists($testPath)) {
                 $testInstructionsRaw = file_get_contents($testPath);
                 if ($testInstructionsRaw) {
@@ -130,11 +130,83 @@ class LitTestRunner
                     }
                 }
             } else {
-                $this->setError("Test server could not read Test instructions for {$Test}");
+                // The file is absent from the requested rite's partition. Before blaming
+                // the filesystem, look for the same test name under the other rites: if it
+                // lives there, the file is fine and the *request* is wrong, and the operator
+                // needs to hear about the rite rather than go hunting for a missing file.
+                // See issue #794 — after #787 partitioned the corpus by rite, Health resolves
+                // the rite from the calendar under test and passes it as the test's partition,
+                // so a mismatch lands here instead of in detectRiteMismatch().
+                $declaredRites = self::ritesDefiningTest($Test, $rite);
+                if ([] === $declaredRites) {
+                    $this->setError("Test server could not read Test instructions for {$Test}");
+                } else {
+                    $this->setError($this->riteMismatchMessage($declaredRites, $rite));
+                }
             }
         } else {
             $this->readyState = self::$testCache->isReady($cacheKey);
         }
+    }
+
+    /**
+     * The path the test instructions for `$Test` would occupy in `$rite`'s partition of the corpus.
+     */
+    private static function testPathFor(string $Test, Rite $rite): string
+    {
+        return rtrim(JsonData::testsFolderFor($rite)->path(), '/\\') . DIRECTORY_SEPARATOR . basename($Test) . '.json';
+    }
+
+    /**
+     * The rites — other than `$requested` — whose partition actually defines a test named `$Test`.
+     *
+     * Iterates {@see \LiturgicalCalendar\Api\Enum\Rite::cases()} rather than naming the two
+     * current rites, so a third rite is covered the day it is added. One `file_exists()` per
+     * rite; deliberately uncached, since this only runs on the error path where the requested
+     * partition has already come up empty.
+     *
+     * @return list<Rite>
+     */
+    private static function ritesDefiningTest(string $Test, Rite $requested): array
+    {
+        $found = [];
+        foreach (Rite::cases() as $candidate) {
+            if ($candidate === $requested) {
+                continue;
+            }
+            if (file_exists(self::testPathFor($Test, $candidate))) {
+                $found[] = $candidate;
+            }
+        }
+
+        return $found;
+    }
+
+    /**
+     * The single operator-facing sentence for "this test and this calendar are of different rites".
+     *
+     * Shared by the two paths that can detect the condition — the constructor, when the test
+     * is absent from the requested partition but present in another, and
+     * {@see \LiturgicalCalendar\Api\Test\LitTestRunner::detectRiteMismatch()}, when the response
+     * echoes back a rite that disagrees with the loaded test's. One condition, one phrasing.
+     *
+     * A test name can legitimately be defined under more than one other rite; all of them are
+     * named, since which one the operator meant is exactly what is in question.
+     *
+     * @param non-empty-list<Rite> $declaredRites The rite(s) the test is actually scoped to.
+     * @param Rite                 $responseRite  The rite the calendar under test was computed under.
+     */
+    private function riteMismatchMessage(array $declaredRites, Rite $responseRite): string
+    {
+        $names = array_map(static fn (Rite $rite): string => $rite->value, $declaredRites);
+        if (1 === count($names)) {
+            $scope = "the {$names[0]} rite";
+        } else {
+            $last  = array_pop($names);
+            $scope = 'the ' . implode(', ', $names) . " and {$last} rites";
+        }
+
+        return "{$this->Test} is scoped to {$scope}, but the calendar under test was computed under the {$responseRite->value} rite";
     }
 
     /**
@@ -315,7 +387,7 @@ class LitTestRunner
             return null;
         }
 
-        return "{$this->Test} is scoped to the {$declaredRite->value} rite, but the calendar under test was computed under the {$responseRite->value} rite";
+        return $this->riteMismatchMessage([$declaredRite], $responseRite);
     }
 
     /**


### PR DESCRIPTION
## The problem

`LitTestRunner::detectRiteMismatch()` (added by #767) produces a precise, operator-facing message when a test is run against a calendar computed under a different rite:

```text
X is scoped to the ambrosian rite, but the calendar under test was computed under the roman rite
```

After #787 partitioned the test corpus by rite, that guard became close to unreachable, and what an operator actually saw in the same situation was far less useful:

```text
Test server could not read Test instructions for X
```

**Why the guard stopped firing:** `src/Health.php` (`executeUnitTest()`) resolves the rite from the **calendar under test** and passes it as the **test's partition**. When the two disagree, `LitTestRunner::__construct()` looks for the test file under the *calendar's* rite partition, does not find it, and hits the missing-file `else` branch — reporting the error before `detectRiteMismatch()` is ever consulted.

The replacement message is actively misleading: it says the file is unreadable when the file is fine and the **request** is wrong, sending an operator to the filesystem instead of to the rite they selected.

Impact is diagnostics-only, on the WebSocket test-runner surface used by UnitTestInterface. No calendar output, data, or authorization is affected.

Closes #794

## The fix (option 1 from the issue)

Distinguish the two cases inside `LitTestRunner`. When the test file is absent from the requested rite's partition, check the other rite partitions for a test of the same name:

- **Exists under another rite** → report the rite mismatch explicitly.
- **Exists nowhere** → the original "could not read Test instructions" message stands.

Details:

- The sentence is factored into a private `riteMismatchMessage()` helper, shared by the constructor's new branch and by `detectRiteMismatch()`. One condition, one phrasing — the wording an operator sees is now identical whichever path detects it.
- Rites are enumerated from `Rite::cases()` rather than hardcoding roman/ambrosian, so a third rite is covered the day it is added.
- **Multi-rite case:** if the same test name is defined under more than one *other* rite, all of them are named (`"... is scoped to the roman and ambrosian rites, but ..."`), since which one the operator meant is exactly what is in question. Naming only the first would be guessing.
- `detectRiteMismatch()` is kept in place — it still guards the distinct case where the response echoes back a `settings.rite` that disagrees with the loaded test's declared rite (a test present in the requested partition, so the constructor branch never sees it).
- The lookup is one `file_exists()` per rite, on an already-failing path, and runs only when the static `self::$testCache` lacks the key. It is deliberately uncached and cannot poison the cache (nothing is added on the missing-file path).

## Alternatives rejected

- **Option 2 — make `Health` resolve the two rites separately** and pass the test's own partition alongside the calendar's. This touches the caller and threads a second rite through the call chain: a larger change for the same diagnostic, with no benefit the in-runner fix does not already deliver.
- **Option 3 — delete `detectRiteMismatch()` as dead code.** This discards the more useful of the two messages and leaves the misleading one as the only thing an operator ever sees. Exactly backwards.

## The two messages now distinguished

| Situation | Message |
|-----------|---------|
| Test exists under a different rite than requested | `X is scoped to the <other> rite, but the calendar under test was computed under the <requested> rite` |
| Test exists under no rite at all | `Test server could not read Test instructions for X` |

## Tests

`phpunit_tests/Test/LitTestRunnerTest.php` extended, following the file's existing conventions:

- **New** `testTestMissingFromRequestedRiteButPresentInAnotherReportsARiteMismatch` — `StIgnatiusOfLoyolaTest` (real corpus, ambrosian-only) requested with `Rite::ROMAN`. Asserts `isReady()` is false and the full message text matches `detectRiteMismatch()`'s wording exactly.
- **Strengthened** `testUnknownTestNameProducesErrorWithoutJsonData` — the regression guard that one message was not simply swapped for the other: a name existing under no rite must still say "could not read Test instructions", and must *not* say "is scoped to".
- Existing behaviour for a test present in the requested partition (`testRunnerResolvesTestsFromTheRitePartition`, plus the nine happy/assertion-failure cases) is unchanged.

Cache contamination is a non-issue here: `self::$testCache` is keyed `{rite}/{Test}`, and the missing-file path never adds an entry, so the ambrosian-cached entry from the sibling test cannot leak into the roman lookup.

## Verification

```text
composer lint            → Time: 10.21 secs; Memory: 48MB  (clean)
composer analyse         → 314/314 [OK] No errors  (PHPStan level 10)
composer parallel-lint   → Checked 581 files in 0.6 seconds. No syntax error found
composer test:quick      → Tests: 2269, Assertions: 23105, Errors: 18, Skipped: 339
```

The 18 errors are environmental and **pre-existing**, verified against a stashed baseline on the same worktree:

```text
baseline (changes stashed): Tests: 2268, Assertions: 23099, Errors: 18, Skipped: 339
with this change:           Tests: 2269, Assertions: 23105, Errors: 18, Skipped: 339
```

Identical error count; +1 test, +6 assertions. 17 of the 18 are `Routes/*` suites failing `setUpBeforeClass` with `Could not detect API binding on http://localhost:8000` (no API server running locally); the 18th is `RegionalDataHandlerTest::testUpdateNationalCalendarSucceeds` failing on `SQLSTATE[08006]` — no Postgres on :5432. Neither surface is touched by this change.

Targeted suite:

```text
vendor/bin/phpunit --testdox phpunit_tests/Test/LitTestRunnerTest.php
OK (15 tests, 45 assertions)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test resolution across rite partitions.
  * Missing tests now retain the correct “could not read Test instructions” error.
  * Tests found only in another rite now report a clear rite-mismatch error.
  * Standardized rite-mismatch messages across validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->