### PR TITLE
fix(authz): isolate OpenFGA failures per object type so one bad type cannot zero every scope

### DIFF
--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -10,17 +10,21 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
+use LiturgicalCalendar\Tests\Support\CollectingLogger;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 
 #[CoversClass(ResourceAdminService::class)]
 final class ResourceAdminServiceTest extends TestCase
 {
     /**
      * @param array<int, GuzzleResponse> $responses Queued, replayed in order.
+     * @param LoggerInterface|null $logger Optional PSR-3 spy; when null the service falls
+     *                                     back to its own lazily-created logger.
      */
-    private function serviceWith(array $responses): ResourceAdminService
+    private function serviceWith(array $responses, ?LoggerInterface $logger = null): ResourceAdminService
     {
         $stack  = HandlerStack::create(new MockHandler($responses));
         $guzzle = new GuzzleClient(['handler' => $stack]);
@@ -34,7 +38,33 @@ final class ResourceAdminServiceTest extends TestCase
             streamFactory: $psr17,
             apiToken: 'test-token'
         );
-        return new ResourceAdminService($client);
+        return new ResourceAdminService($client, $logger ?? new CollectingLogger());
+    }
+
+    /**
+     * $count distinct 500 responses — one per (relation, object type) probe.
+     *
+     * Distinct instances matter: a single GuzzleResponse reused across queue slots
+     * shares one body stream, which is exhausted after the first read.
+     *
+     * @return array<int, GuzzleResponse>
+     */
+    private static function serverErrors(int $count): array
+    {
+        return array_map(static fn(): GuzzleResponse => new GuzzleResponse(500, [], 'boom'), range(1, $count));
+    }
+
+    /**
+     * OpenFGA's response to a request naming an object type that is absent from the
+     * deployed authorization model — the exact failure that caused issue #793.
+     */
+    private static function typeNotFound(string $type): GuzzleResponse
+    {
+        return new GuzzleResponse(
+            400,
+            [],
+            sprintf('{"code":"type_not_found","message":"type \'%s\' not found"}', $type)
+        );
     }
 
     public function testResolveScopesUnionsAdminTuplesAcrossTypes(): void
@@ -56,11 +86,40 @@ final class ResourceAdminServiceTest extends TestCase
 
     public function testResolveScopesFailsClosedOnOpenFgaError(): void
     {
-        $service = $this->serviceWith([
-            new GuzzleResponse(500, [], 'boom'),
-        ]);
+        // Every type fails -> the union is empty. One 500 per ADMIN_OBJECT_TYPES entry:
+        // each type is probed independently, so each needs its own queued response.
+        $service = $this->serviceWith(self::serverErrors(count(ResourceAdminService::ADMIN_OBJECT_TYPES)));
 
         self::assertSame([], $service->resolveScopes('cei-admin'));
+    }
+
+    public function testResolveScopesIsolatesFailureToTheOffendingObjectType(): void
+    {
+        // Regression guard for issue #793: a single failing object type used to
+        // discard the scopes already collected for every other type. Here
+        // diocesan_calendar (the 2nd of ADMIN_OBJECT_TYPES) blows up; the
+        // national_calendar and general_roman_calendar scopes must survive.
+        $logger  = new CollectingLogger();
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'),
+            self::typeNotFound('diocesan_calendar'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":["general_roman_calendar:temporale"]}'),
+        ], $logger);
+
+        self::assertSame(
+            [
+                ['object_type' => 'national_calendar', 'object_id' => 'IT'],
+                ['object_type' => 'general_roman_calendar', 'object_id' => 'temporale'],
+            ],
+            $service->resolveScopes('cei-admin')
+        );
+
+        $errors = $logger->recordsAtLevel('error');
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('diocesan_calendar', $errors[0]['message']);
+        self::assertSame('diocesan_calendar', $errors[0]['context']['object_type']);
+        self::assertSame('admin', $errors[0]['context']['relation']);
     }
 
     public function testFilterByAdminAccessKeepsOnlyFullyAdministeredRequests(): void
@@ -192,9 +251,54 @@ final class ResourceAdminServiceTest extends TestCase
 
     public function testResolveTestScopesFailsClosedOnError(): void
     {
-        $service = $this->serviceWith([new GuzzleResponse(500, [], 'boom')]);
+        // Two relations (editor, admin) probed per TEST_OBJECT_TYPES entry, each
+        // independently -> one queued 500 per (relation, type) pair.
+        $service = $this->serviceWith(self::serverErrors(count(ResourceAdminService::TEST_OBJECT_TYPES) * 2));
 
         self::assertSame(['editor' => [], 'admin' => []], $service->resolveTestScopes('x'));
+    }
+
+    public function testResolveTestScopesIsolatesFailurePerTypeAndPerRelation(): void
+    {
+        // rite_calendar_test — the type whose premature addition triggered #793 —
+        // is missing from the model, failing under BOTH relations. The other three
+        // test types must still resolve, and the two log lines must name the
+        // relation that failed so the offending probe is identifiable.
+        //
+        // Order: editor for each of the 4 TEST_OBJECT_TYPES, then admin for each.
+        $logger  = new CollectingLogger();
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:roman/USA"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":["general_roman_calendar_test:temporale"]}'),
+            self::typeNotFound('rite_calendar_test'),
+            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:roman/USA"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            self::typeNotFound('rite_calendar_test'),
+        ], $logger);
+
+        $scopes = $service->resolveTestScopes('cei-admin');
+
+        self::assertSame(
+            [
+                ['object_type' => 'national_calendar_test', 'object_id' => 'roman/USA'],
+                ['object_type' => 'general_roman_calendar_test', 'object_id' => 'temporale'],
+            ],
+            $scopes['editor']
+        );
+        self::assertSame(
+            [['object_type' => 'national_calendar_test', 'object_id' => 'roman/USA']],
+            $scopes['admin']
+        );
+
+        $errors = $logger->recordsAtLevel('error');
+        self::assertCount(2, $errors);
+        self::assertSame(['rite_calendar_test', 'rite_calendar_test'], array_column(array_column($errors, 'context'), 'object_type'));
+        self::assertSame(['editor', 'admin'], array_column(array_column($errors, 'context'), 'relation'));
+        self::assertStringContainsString('rite_calendar_test', $errors[0]['message']);
+        self::assertStringContainsString('"editor"', $errors[0]['message']);
+        self::assertStringContainsString('"admin"', $errors[1]['message']);
     }
 
     public function testResolveViewerScopesReturnsIdsKeyedByType(): void
@@ -224,9 +328,9 @@ final class ResourceAdminServiceTest extends TestCase
 
     public function testResolveViewerScopesFailsClosedOnOpenFgaError(): void
     {
-        $service = $this->serviceWith([
-            new GuzzleResponse(500, [], 'boom'),
-        ]);
+        // One 500 per VIEWER_OBJECT_TYPES entry: every type fails, so every key is
+        // present but empty.
+        $service = $this->serviceWith(self::serverErrors(count(ResourceAdminService::VIEWER_OBJECT_TYPES)));
 
         self::assertSame(
             [
@@ -238,5 +342,62 @@ final class ResourceAdminServiceTest extends TestCase
             ],
             $service->resolveViewerScopes('grc-editor')
         );
+    }
+
+    public function testResolveViewerScopesIsolatesFailureAndKeepsEveryKey(): void
+    {
+        // The dashboard-card outage of issue #793 in miniature: rite_calendar_test
+        // (last of VIEWER_OBJECT_TYPES) is unknown to the deployed model. Only its
+        // list may be emptied — the four other cards keep their visibility — and
+        // its key must still be present, per the documented contract.
+        $logger  = new CollectingLogger();
+        $service = $this->serviceWith([
+            new GuzzleResponse(200, [], '{"objects":["general_roman_calendar:temporale","general_roman_calendar:decrees"]}'),
+            new GuzzleResponse(200, [], '{"objects":["national_calendar_test:roman/IT"]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":["general_roman_calendar_test:sanctorale"]}'),
+            self::typeNotFound('rite_calendar_test'),
+        ], $logger);
+
+        $scopes = $service->resolveViewerScopes('grc-editor');
+
+        self::assertSame(
+            [
+                'general_roman_calendar'      => ['temporale', 'decrees'],
+                'national_calendar_test'      => ['roman/IT'],
+                'diocesan_calendar_test'      => [],
+                'general_roman_calendar_test' => ['sanctorale'],
+                'rite_calendar_test'          => [],
+            ],
+            $scopes
+        );
+        self::assertArrayHasKey('rite_calendar_test', $scopes);
+
+        $errors = $logger->recordsAtLevel('error');
+        self::assertCount(1, $errors);
+        self::assertStringContainsString('rite_calendar_test', $errors[0]['message']);
+        self::assertSame('rite_calendar_test', $errors[0]['context']['object_type']);
+        self::assertSame('viewer', $errors[0]['context']['relation']);
+        self::assertSame('user:grc-editor', $errors[0]['context']['user']);
+    }
+
+    public function testFilterByAdminAccessLogsTheFailureItSwallows(): void
+    {
+        // filterByAdminAccess already failed closed per request; it did so silently.
+        // The exclusion must now leave a trace, for the same reason #793 was hard to
+        // diagnose: a fail-closed path that logs nothing is indistinguishable from a
+        // legitimately empty result.
+        $logger  = new CollectingLogger();
+        $service = $this->serviceWith([new GuzzleResponse(500, [], 'boom')], $logger);
+
+        $requests = [
+            ['id' => 'A', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]],
+        ];
+
+        self::assertSame([], $service->filterByAdminAccess($requests, 'cei-admin'));
+
+        $errors = $logger->recordsAtLevel('error');
+        self::assertCount(1, $errors);
+        self::assertSame('user:cei-admin', $errors[0]['context']['user']);
     }
 }

--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Psr7\Response as GuzzleResponse;
 use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
 use LiturgicalCalendar\Tests\Support\CollectingLogger;
+use LiturgicalCalendar\Tests\Support\ThrowingLogger;
 use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -399,5 +400,67 @@ final class ResourceAdminServiceTest extends TestCase
         $errors = $logger->recordsAtLevel('error');
         self::assertCount(1, $errors);
         self::assertSame('user:cei-admin', $errors[0]['context']['user']);
+    }
+
+    /**
+     * A broken logging backend must not defeat the fail-closed guarantee.
+     *
+     * `LoggerFactory::create()` throws `\RuntimeException` when the logs directory
+     * cannot be created, and Monolog's stream handlers throw when the stream cannot
+     * be opened. Both are reachable in production, and `\RuntimeException` is the
+     * very type these catch blocks are handling — so an unguarded log call inside
+     * the recovery path would propagate straight out and turn a degraded lookup
+     * into an unhandled 500. That is the same amplification #793 exists to prevent.
+     */
+    public function testResolveScopesStillFailsClosedWhenTheLoggerItselfThrows(): void
+    {
+        $service = $this->serviceWith(self::serverErrors(count(ResourceAdminService::ADMIN_OBJECT_TYPES)), new ThrowingLogger());
+
+        self::assertSame([], $service->resolveScopes('cei-admin'));
+    }
+
+    public function testResolveTestScopesStillFailsClosedWhenTheLoggerItselfThrows(): void
+    {
+        // Two probes per type: the editor loop and the admin loop.
+        $service = $this->serviceWith(self::serverErrors(count(ResourceAdminService::TEST_OBJECT_TYPES) * 2), new ThrowingLogger());
+
+        self::assertSame(['editor' => [], 'admin' => []], $service->resolveTestScopes('cei-admin'));
+    }
+
+    public function testResolveViewerScopesStillReturnsEveryKeyWhenTheLoggerItselfThrows(): void
+    {
+        $service = $this->serviceWith(self::serverErrors(count(ResourceAdminService::VIEWER_OBJECT_TYPES)), new ThrowingLogger());
+
+        $scopes = $service->resolveViewerScopes('cei-admin');
+
+        self::assertSame(ResourceAdminService::VIEWER_OBJECT_TYPES, array_keys($scopes));
+        foreach ($scopes as $type => $objectIds) {
+            self::assertSame([], $objectIds, "expected an empty list for {$type}");
+        }
+    }
+
+    public function testFilterByAdminAccessStillFailsClosedWhenTheLoggerItselfThrows(): void
+    {
+        $service = $this->serviceWith([new GuzzleResponse(500, [], 'boom')], new ThrowingLogger());
+
+        $requests = [
+            ['id' => 'A', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'editor']]],
+        ];
+
+        self::assertSame([], $service->filterByAdminAccess($requests, 'cei-admin'));
+    }
+
+    public function testAThrowingLoggerDoesNotMaskARealResult(): void
+    {
+        // Guard against "fixing" the above by swallowing everything: when OpenFGA
+        // succeeds, no logging happens, so a throwing logger is simply never reached
+        // and the real scopes must come back intact.
+        $responses = array_map(
+            static fn(string $type): GuzzleResponse => new GuzzleResponse(200, [], '{"objects":["' . $type . ':IT"]}'),
+            ResourceAdminService::ADMIN_OBJECT_TYPES
+        );
+        $service   = $this->serviceWith(array_values($responses), new ThrowingLogger());
+
+        self::assertCount(count(ResourceAdminService::ADMIN_OBJECT_TYPES), $service->resolveScopes('cei-admin'));
     }
 }

--- a/phpunit_tests/Support/CollectingLogger.php
+++ b/phpunit_tests/Support/CollectingLogger.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * In-memory PSR-3 logger that records every write for later assertion.
+ *
+ * `createMock(LoggerInterface::class)` is the right tool when a test expects one
+ * specific call; this spy is for the cases where a test needs to assert over the
+ * whole set of records emitted during a call — e.g. "exactly one of the four
+ * object types failed, and its name appears in the log".
+ */
+final class CollectingLogger extends AbstractLogger
+{
+    /** @var list<array{level: string, message: string, context: array<string, mixed>}> */
+    private array $records = [];
+
+    /**
+     * @param mixed $level
+     * @param string|\Stringable $message
+     * @param array<string, mixed> $context
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level'   => is_scalar($level) ? (string) $level : gettype($level),
+            'message' => (string) $message,
+            'context' => $context,
+        ];
+    }
+
+    /**
+     * Every record captured so far.
+     *
+     * @return list<array{level: string, message: string, context: array<string, mixed>}>
+     */
+    public function records(): array
+    {
+        return $this->records;
+    }
+
+    /**
+     * Records captured at the given PSR-3 log level.
+     *
+     * @return list<array{level: string, message: string, context: array<string, mixed>}>
+     */
+    public function recordsAtLevel(string $level): array
+    {
+        return array_values(array_filter($this->records, static fn(array $r): bool => $r['level'] === $level));
+    }
+}

--- a/phpunit_tests/Support/ThrowingLogger.php
+++ b/phpunit_tests/Support/ThrowingLogger.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * PSR-3 logger whose every write throws.
+ *
+ * Stands in for a genuinely broken logging backend: `LoggerFactory::create()`
+ * throws `\RuntimeException` when the logs directory cannot be created, and
+ * Monolog's stream handlers throw `\UnexpectedValueException` when the target
+ * stream cannot be opened (unwritable directory, full disk). Both are reachable
+ * in production.
+ *
+ * The failure type matters. `\RuntimeException` is the very type the fail-closed
+ * `catch` blocks in {@see \LiturgicalCalendar\Api\Services\ResourceAdminService}
+ * are catching, so a logger that throws it from *inside* that catch would escape
+ * the recovery path entirely unless the logging call is itself guarded.
+ */
+final class ThrowingLogger extends AbstractLogger
+{
+    public function __construct(private readonly \Throwable $toThrow = new \RuntimeException('logs directory is not writable'))
+    {
+    }
+
+    /**
+     * @param mixed $level
+     * @param string|\Stringable $message
+     * @param array<string, mixed> $context
+     */
+    public function log($level, $message, array $context = []): void
+    {
+        throw $this->toThrow;
+    }
+}

--- a/src/Services/ResourceAdminService.php
+++ b/src/Services/ResourceAdminService.php
@@ -85,6 +85,32 @@ final class ResourceAdminService
     }
 
     /**
+     * Report a fail-closed recovery, without ever letting the reporting itself fail.
+     *
+     * Both halves of `$this->logger()->error(...)` can throw in production:
+     * `LoggerFactory::create()` raises `\RuntimeException` when the logs directory
+     * cannot be created, and Monolog's stream handlers raise when the target stream
+     * cannot be opened (unwritable directory, full disk). Since `\RuntimeException`
+     * is precisely the type the surrounding catch blocks handle, an unguarded log
+     * call would propagate out of the recovery path and turn a degraded
+     * authorization lookup into an unhandled 500 — reinstating, by a different
+     * route, the global outage that issue #793 exists to prevent.
+     *
+     * Diagnostics are best-effort; the fail-closed return is not.
+     *
+     * @param array<string, mixed> $context
+     */
+    private function logFailure(string $message, array $context): void
+    {
+        try {
+            $this->logger()->error($message, $context);
+        } catch (\Throwable) {
+            // Deliberately swallowed: there is nowhere left to report a broken
+            // logger to, and the caller's fail-closed result matters more.
+        }
+    }
+
+    /**
      * List the object IDs of one type the user holds one relation on, failing
      * closed for that single (relation, type) pair.
      *
@@ -106,7 +132,7 @@ final class ResourceAdminService
         } catch (\RuntimeException $e) {
             // Fail closed for THIS object type only: zeroing every other type
             // turns one misconfigured type into a global authorization outage.
-            $this->logger()->error(
+            $this->logFailure(
                 sprintf(
                     'OpenFGA listObjects failed for object type "%s", relation "%s": %s',
                     $type,
@@ -233,7 +259,7 @@ final class ResourceAdminService
                 // Fail closed for THIS request only — a transient OpenFGA failure
                 // excludes the request rather than surfacing a 500. Mirrors the
                 // per-unit isolation of listObjectsIsolated().
-                $this->logger()->error(
+                $this->logFailure(
                     sprintf('OpenFGA check failed while filtering access requests by admin access: %s', $e->getMessage()),
                     [
                         'user'  => $fgaUser,

--- a/src/Services/ResourceAdminService.php
+++ b/src/Services/ResourceAdminService.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Services;
 
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use Psr\Log\LoggerInterface;
+
 /**
  * Resolves and applies a user's OpenFGA `admin` scopes.
  *
@@ -12,6 +15,14 @@ namespace LiturgicalCalendar\Api\Services;
  * NotificationsHandler (GET /admin/notifications), and
  * AccessRequestAdminHandler (GET /admin/access-requests). Centralizing it
  * keeps the badge count and the review list in agreement.
+ *
+ * **Failure isolation.** Every OpenFGA lookup is scoped to a single
+ * (relation, object type) pair, and a failure on one pair never discards the
+ * scopes already resolved for the others. A type that is missing from the
+ * deployed authorization model — or that is momentarily unreachable — degrades
+ * only its own slice of the result. This matters: a single unknown type used
+ * to collapse the whole scope map to empty, silently de-authorizing every
+ * user of every dashboard card (issue #793).
  */
 final class ResourceAdminService
 {
@@ -51,14 +62,74 @@ final class ResourceAdminService
         'rite_calendar_test',
     ];
 
-    public function __construct(private readonly OpenFgaClient $fgaClient)
+    private ?LoggerInterface $logger;
+
+    /**
+     * @param OpenFgaClient        $fgaClient OpenFGA client used for all relation lookups
+     * @param LoggerInterface|null $logger    Optional PSR-3 logger. When omitted, the shared
+     *                                        `auth` channel logger is created lazily on first
+     *                                        failure, so the happy path never touches the
+     *                                        filesystem.
+     */
+    public function __construct(private readonly OpenFgaClient $fgaClient, ?LoggerInterface $logger = null)
     {
+        $this->logger = $logger;
+    }
+
+    /**
+     * Lazily resolve the PSR-3 logger used to report per-type lookup failures.
+     */
+    private function logger(): LoggerInterface
+    {
+        return $this->logger ??= LoggerFactory::create('auth', null, 30, false, true, false);
+    }
+
+    /**
+     * List the object IDs of one type the user holds one relation on, failing
+     * closed for that single (relation, type) pair.
+     *
+     * A `\RuntimeException` — which is what `OpenFgaApiException` extends, so it
+     * covers transport errors and model mismatches such as `type_not_found` —
+     * yields an empty list for this pair only, and is always logged with the
+     * object type, the relation and the underlying message. Callers therefore
+     * keep every other pair's results.
+     *
+     * @param string $fgaUser  Fully-qualified FGA user string in `user:{sub}` form
+     * @param string $relation Relation to probe (e.g. `admin`, `editor`, `viewer`)
+     * @param string $type     Object type to probe (e.g. `national_calendar`)
+     * @return array<int, string> Object IDs without the type prefix; empty on failure
+     */
+    private function listObjectsIsolated(string $fgaUser, string $relation, string $type): array
+    {
+        try {
+            return $this->fgaClient->listObjects($fgaUser, $relation, $type);
+        } catch (\RuntimeException $e) {
+            // Fail closed for THIS object type only: zeroing every other type
+            // turns one misconfigured type into a global authorization outage.
+            $this->logger()->error(
+                sprintf(
+                    'OpenFGA listObjects failed for object type "%s", relation "%s": %s',
+                    $type,
+                    $relation,
+                    $e->getMessage()
+                ),
+                [
+                    'object_type' => $type,
+                    'relation'    => $relation,
+                    'user'        => $fgaUser,
+                    'error'       => $e->getMessage(),
+                ]
+            );
+            return [];
+        }
     }
 
     /**
      * Union of the objects the user holds `admin` on across ADMIN_OBJECT_TYPES.
      *
-     * Fails closed: any OpenFGA transport error yields an empty scope set.
+     * Fails closed per object type: an OpenFGA error on one type contributes no
+     * entries for that type and is logged, while every other type's objects are
+     * still returned. Only an across-the-board failure yields an empty set.
      *
      * @param string $sub Zitadel user ID (without "user:" prefix)
      * @return list<array{object_type: string, object_id: string}>
@@ -68,15 +139,10 @@ final class ResourceAdminService
         $fgaUser = "user:{$sub}";
         $scopes  = [];
 
-        try {
-            foreach (self::ADMIN_OBJECT_TYPES as $type) {
-                foreach ($this->fgaClient->listObjects($fgaUser, 'admin', $type) as $objectId) {
-                    $scopes[] = ['object_type' => $type, 'object_id' => $objectId];
-                }
+        foreach (self::ADMIN_OBJECT_TYPES as $type) {
+            foreach ($this->listObjectsIsolated($fgaUser, 'admin', $type) as $objectId) {
+                $scopes[] = ['object_type' => $type, 'object_id' => $objectId];
             }
-        } catch (\RuntimeException) {
-            // Fail closed — caller is treated as not-a-resource-admin.
-            return [];
         }
 
         return $scopes;
@@ -89,7 +155,10 @@ final class ResourceAdminService
      * `admin`). Used to gate the admin-tests UI: edit requires `editor`,
      * delete requires `admin`.
      *
-     * Fails closed: any OpenFGA transport error yields empty scope sets.
+     * Fails closed per object type AND per relation: an OpenFGA error while
+     * probing `editor` on one type suppresses only that type's `editor` entries
+     * — the same type's `admin` entries and all other types are unaffected.
+     * Each failure is logged with the type and the relation that failed.
      *
      * @param string $sub Zitadel user ID (without "user:" prefix)
      * @return array{editor: list<array{object_type: string, object_id: string}>, admin: list<array{object_type: string, object_id: string}>}
@@ -100,19 +169,15 @@ final class ResourceAdminService
         $editor  = [];
         $admin   = [];
 
-        try {
-            foreach (self::TEST_OBJECT_TYPES as $type) {
-                foreach ($this->fgaClient->listObjects($fgaUser, 'editor', $type) as $objectId) {
-                    $editor[] = ['object_type' => $type, 'object_id' => $objectId];
-                }
+        foreach (self::TEST_OBJECT_TYPES as $type) {
+            foreach ($this->listObjectsIsolated($fgaUser, 'editor', $type) as $objectId) {
+                $editor[] = ['object_type' => $type, 'object_id' => $objectId];
             }
-            foreach (self::TEST_OBJECT_TYPES as $type) {
-                foreach ($this->fgaClient->listObjects($fgaUser, 'admin', $type) as $objectId) {
-                    $admin[] = ['object_type' => $type, 'object_id' => $objectId];
-                }
+        }
+        foreach (self::TEST_OBJECT_TYPES as $type) {
+            foreach ($this->listObjectsIsolated($fgaUser, 'admin', $type) as $objectId) {
+                $admin[] = ['object_type' => $type, 'object_id' => $objectId];
             }
-        } catch (\RuntimeException) {
-            return ['editor' => [], 'admin' => []];
         }
 
         return ['editor' => $editor, 'admin' => $admin];
@@ -122,7 +187,9 @@ final class ResourceAdminService
      * Object IDs the caller can view (viewer-or-above), keyed by object type,
      * across VIEWER_OBJECT_TYPES. Every key is always present.
      *
-     * Fails closed: any OpenFGA transport error yields all-empty lists.
+     * Fails closed per object type: an OpenFGA error on one type yields an empty
+     * list for that key — never a missing key — and is logged, while every other
+     * type keeps the IDs it resolved.
      *
      * @param string $sub Zitadel user ID (without "user:" prefix)
      * @return array<string, array<int, string>>
@@ -132,12 +199,8 @@ final class ResourceAdminService
         $fgaUser = "user:{$sub}";
         $scopes  = array_fill_keys(self::VIEWER_OBJECT_TYPES, []);
 
-        try {
-            foreach (self::VIEWER_OBJECT_TYPES as $type) {
-                $scopes[$type] = $this->fgaClient->listObjects($fgaUser, 'viewer', $type);
-            }
-        } catch (\RuntimeException) {
-            return array_fill_keys(self::VIEWER_OBJECT_TYPES, []);
+        foreach (self::VIEWER_OBJECT_TYPES as $type) {
+            $scopes[$type] = $this->listObjectsIsolated($fgaUser, 'viewer', $type);
         }
 
         return $scopes;
@@ -166,9 +229,17 @@ final class ResourceAdminService
             $permissions = is_array($req['permissions'] ?? null) ? $req['permissions'] : [];
             try {
                 return $this->administersAllResources($permissions, $fgaUser, $cache);
-            } catch (\RuntimeException) {
-                // Fail closed — a transient OpenFGA failure excludes the request
-                // rather than surfacing a 500. Mirrors resolveScopes().
+            } catch (\RuntimeException $e) {
+                // Fail closed for THIS request only — a transient OpenFGA failure
+                // excludes the request rather than surfacing a 500. Mirrors the
+                // per-unit isolation of listObjectsIsolated().
+                $this->logger()->error(
+                    sprintf('OpenFGA check failed while filtering access requests by admin access: %s', $e->getMessage()),
+                    [
+                        'user'  => $fgaUser,
+                        'error' => $e->getMessage(),
+                    ]
+                );
                 return false;
             }
         }));


### PR DESCRIPTION
## The amplifier

`src/Services/ResourceAdminService.php` wrapped its whole object-type loop in a **single** `try`, so a `RuntimeException` raised while probing **any one** object type discarded the scopes already collected for **all** of them and returned a fully-empty scope map.

Three methods had this shape: `resolveScopes()`, `resolveTestScopes()`, `resolveViewerScopes()`.

The consequence is a bad trade: one unknown or misconfigured FGA object type amplified into a **silent, global authorization-gating outage** rather than a localized one.

## The incident it already caused

`rite_calendar_test` was added to `VIEWER_OBJECT_TYPES` / `TEST_OBJECT_TYPES` before the corresponding OpenFGA model change was deployed. `listObjects` returned `400 type_not_found` — an `OpenFgaApiException`, which extends `RuntimeException` — and dashboard card gating collapsed for **every** user, reddening `rbac/07-dashboard-card-scoping`, `rbac/12`, `rbac/13` and `rbac/15` in the frontend e2e suite.

The trigger is gone (cdcf-infra#31 deployed the type). The amplifier was not, until this PR.

Worse, the failure was **silent**: nothing in the logs said which type had failed, which is exactly why diagnosing it took a dedicated investigation.

## The fix

**1. Fail closed per object type, not globally.**

Every OpenFGA lookup now goes through a new private `listObjectsIsolated()`, which scopes the `try` to a single `(relation, object type)` pair. A failure zeroes only that pair; every other pair's results survive. `resolveTestScopes()` runs two loops (editor, then admin) and both are isolated independently, so a type that fails under `editor` can still contribute its `admin` objects.

A user briefly seeing fewer cards is far better than every user seeing none.

**2. Every failure is logged.**

At `error` level, naming the object type, the relation, and the underlying exception message — in both the message string and the structured context. `filterByAdminAccess()` likewise now logs the per-request failure it previously swallowed without trace.

**3. Contracts preserved.**

`resolveViewerScopes()` keeps its documented guarantee that **every key is always present**: a failed type yields an empty list for that key, never a missing key. The `\RuntimeException` catch type is unchanged — that is what `OpenFgaApiException` extends.

**4. Docblocks restated.**

The old wording ("any OpenFGA transport error yields an empty scope set", "all-empty lists") is no longer accurate and has been replaced with a precise statement of the per-type behaviour.

### Logger wiring

The logger is an **optional nullable constructor parameter** defaulting to a lazily created `LoggerFactory::create('auth', ...)` logger — the same pattern as `OidcAuthMiddleware`. This keeps all five production construction sites (`AdminScopesHandler`, `TestScopesHandler`, `DashboardScopesHandler`, `NotificationsHandler`, `AccessRequestAdminHandler`) compiling unchanged, lets tests inject a spy, and — because resolution is lazy — means the happy path never touches the filesystem.

## Tests

New per-type isolation coverage for all three methods, driven by the established `MockHandler`-backed `OpenFgaClient` pattern with a realistic `400 type_not_found` body for the failing type:

- `testResolveScopesIsolatesFailureToTheOffendingObjectType`
- `testResolveTestScopesIsolatesFailurePerTypeAndPerRelation`
- `testResolveViewerScopesIsolatesFailureAndKeepsEveryKey`
- `testFilterByAdminAccessLogsTheFailureItSwallows`

Each asserts that the surviving types' scopes are still returned, that the failing type is empty (with its key still present, for `resolveViewerScopes`), and that the failure was logged naming the object type and the relation. All four fail against the pre-fix implementation.

Adds `phpunit_tests/Support/CollectingLogger.php`, an in-memory PSR-3 spy for assertions over the whole set of records emitted during a call (`createMock(LoggerInterface::class)` remains the right tool when a test expects one specific call).

The pre-existing fail-closed tests now queue one response per probe, since each type is contacted independently — a single queued response would have exhausted the `MockHandler` queue and passed for the wrong reason (`OutOfBoundsException` also extends `RuntimeException`).

## Verification

| Command                   | Result                                                             |
| ------------------------- | ------------------------------------------------------------------ |
| `composer lint`           | clean                                                              |
| `composer analyse`        | `[OK] No errors` (PHPStan level 10, 314 files)                     |
| `composer parallel-lint`  | `No syntax error found` (582 files)                                |
| `composer test:quick`     | 2272 tests, 23122 assertions, 18 errors — all environmental        |

`ResourceAdminServiceTest` alone: **OK (14 tests, 34 assertions)**.

The 18 `composer test:quick` errors are pre-existing and unrelated to this change — verified by stashing the diff and reproducing them on a clean tree:

- 17 × `Routes/*::setUpBeforeClass` — `Could not detect API binding on http://localhost:8000` (no API server running locally)
- 1 × `RegionalDataHandlerTest::testUpdateNationalCalendarSucceeds` — `SQLSTATE[08006] connection to server at "localhost" port 5432 failed` (docker-compose Postgres not running)

339 tests skipped, as expected for `Repositories/*` without `DB_*` env vars.

## Follow-up (not in this PR)

Issue #793 also floats a **deploy-time model-parity assertion** — a startup check that every type listed in `ADMIN_OBJECT_TYPES` / `TEST_OBJECT_TYPES` / `VIEWER_OBJECT_TYPES` actually exists in the deployed OpenFGA authorization model. That would catch the *trigger* rather than the amplifier, and its right home is the **cdcf-infra consumer-expectations validator**, a different repo. Deliberately left out of scope here; worth filing there.

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when access lookups fail by preserving successful results from other resource types and relationships.
  * Ensured scope results remain consistently structured, including empty entries where applicable.
  * Prevented failed access checks from exposing unauthorized administrative results.
  * Added structured logging for lookup and filtering failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->