### PR TITLE
fix(health): register the Ambrosian temporale in getPathToSchemaFile()

### DIFF
--- a/phpunit_tests/HealthSchemaMappingTest.php
+++ b/phpunit_tests/HealthSchemaMappingTest.php
@@ -56,6 +56,37 @@ final class HealthSchemaMappingTest extends TestCase
         $this->assertSame(LitSchema::PROPRIUMDESANCTIS->path(), $result);
     }
 
+    public function testAmbrosianTemporaleFileMapsToPropriumDeTemporeSchema(): void
+    {
+        // The sanctorale arm was registered on its own, leaving the Ambrosian temporale as the
+        // one shipped missal file no client could schema-validate (issue #800). Every Roman
+        // missal registers both halves; the Ambrosian rite must too.
+        $result = self::getPathToSchemaFile(JsonData::AMBROSIAN_TEMPORALE_FILE->value);
+
+        $this->assertSame(LitSchema::PROPRIUMDETEMPORE->path(), $result);
+    }
+
+    public function testRomanTemporaleFileStillMapsToPropriumDeTemporeSchema(): void
+    {
+        // Guards against the new Ambrosian temporale arm shadowing the pre-existing Roman one,
+        // which lives in the same match expression.
+        $result = self::getPathToSchemaFile(
+            JsonData::MISSALS_FOLDER->value . '/propriumdetempore/propriumdetempore.json'
+        );
+
+        $this->assertSame(LitSchema::PROPRIUMDETEMPORE->path(), $result);
+    }
+
+    public function testAmbrosianTemporaleAndSanctoraleMapToDistinctSchemas(): void
+    {
+        // The two Ambrosian files sit next to each other under the same missals folder and differ
+        // only by leaf name, so a copy-paste slip would silently point both at one schema.
+        $temporale  = self::getPathToSchemaFile(JsonData::AMBROSIAN_TEMPORALE_FILE->value);
+        $sanctorale = self::getPathToSchemaFile(JsonData::AMBROSIAN_SANCTORALE_FILE->value);
+
+        $this->assertNotSame($temporale, $sanctorale);
+    }
+
     public function testUnknownFileMapsToNull(): void
     {
         $result = self::getPathToSchemaFile('/some/unregistered/path.json');

--- a/src/Health.php
+++ b/src/Health.php
@@ -1948,6 +1948,7 @@ class Health implements MessageComponentInterface
             JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_2008/propriumdesanctis_2008.json'       => LitSchema::PROPRIUMDESANCTIS->path(),
             JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_IT_1983/propriumdesanctis_IT_1983.json' => LitSchema::PROPRIUMDESANCTIS->path(),
             JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_US_2011/propriumdesanctis_US_2011.json' => LitSchema::PROPRIUMDESANCTIS->path(),
+            JsonData::AMBROSIAN_TEMPORALE_FILE->value                                                     => LitSchema::PROPRIUMDETEMPORE->path(),
             JsonData::AMBROSIAN_SANCTORALE_FILE->value                                                    => LitSchema::PROPRIUMDESANCTIS->path(),
             Route::CALENDARS->path()                                                                      => LitSchema::METADATA->path(),
             Route::DECREES->path()                                                                        => LitSchema::DECREES->path(),


### PR DESCRIPTION
## Summary

`Health::getPathToSchemaFile()` maps known source-data file paths to the schema they must validate against. It registered the Ambrosian **sanctorale** but not the Ambrosian **temporale**, so `JsonData::AMBROSIAN_TEMPORALE_FILE` fell through to `default => null`.

```diff
+            JsonData::AMBROSIAN_TEMPORALE_FILE->value  => LitSchema::PROPRIUMDETEMPORE->path(),
             JsonData::AMBROSIAN_SANCTORALE_FILE->value => LitSchema::PROPRIUMDESANCTIS->path(),
```

The asymmetry reads as an oversight rather than a decision — the sanctorale arm was added on its own (`HealthSchemaMappingTest` records it as "Plan 5 / Task 6"), while every Roman missal registers both its temporale and its sanctorale in the same match expression.

## Effect

A WebSocket `executeValidation` message naming the Ambrosian temporale received a `null` schema, so `processValidationData()` took the else branch:

```text
executeValidation validation->sourceFile (JSON): Unable to detect schema for dataPath … and category …
```

The file-exists and json-valid assertions still passed; only schema validation reported an error. That made the Ambrosian temporale the one shipped missal file no client could schema-validate.

## Why now

Found while implementing UnitTestInterface#39 (rite-awareness). Once UTI can select the Ambrosian rite-level calendar, its universal source-data checks point at the Ambrosian missal pair — the sanctorale check goes green, the temporale check could not, purely because of this missing arm. This unblocks a clean Ambrosian run from that UI.

## Tests

Three cases added to `phpunit_tests/HealthSchemaMappingTest.php`, beside the existing sanctorale one:

- the new Ambrosian temporale mapping;
- the **Roman** temporale arm it sits next to, guarding against the new arm shadowing it in the same match expression;
- an assertion that the two Ambrosian files resolve to **distinct** schemas — they differ only by leaf name under the same missals folder, so a copy-paste slip would silently point both at one schema, and that is exactly the kind of mistake this PR is fixing.

I confirmed the new mapping test is not vacuous by reverting only the `src/Health.php` line and re-running:

```text
✘ Ambrosian temporale file maps to proprium de tempore schema
  Failed asserting that null is identical to '…/jsondata/schemas/PropriumDeTempore.json'.
```

## Verification

```text
composer lint            → clean (Time: 10.53 secs)
composer parallel-lint   → Checked 581 files, no syntax error found
composer analyse         → [OK] No errors           (PHPStan level 10)
vendor/bin/phpunit phpunit_tests/HealthSchemaMappingTest.php
                         → OK (6 tests, 6 assertions)
composer test:quick      → Tests: 2271, Assertions: 23102, Errors: 18, Skipped: 339
```

The 18 errors are pre-existing and environmental, not from this change: 17 are `Routes/*` `setUpBeforeClass` failing with `Could not detect API binding on http://localhost:8000`, and the 18th is `RegionalDataHandlerTest::testUpdateNationalCalendarSucceeds` with `SQLSTATE[08006]` (no Postgres on :5432). Neither the local API server nor the Docker infra stack was running. The same count of 18 was independently observed on an untouched checkout of this base commit; the test count rises from 2268 to 2271, which is exactly the three tests added here.

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected schema recognition for Ambrosian temporale data.
  * Preserved existing schema mapping for Roman temporale data.
  * Ensured Ambrosian temporale and sanctorale data resolve to distinct schemas.

* **Tests**
  * Added coverage validating the updated schema mappings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->