### PR TITLE
fix(schemas): constrain source-data url fields to https and escape href interpolation

### DIFF
--- a/jsondata/schemas/DiocesanCalendar.json
+++ b/jsondata/schemas/DiocesanCalendar.json
@@ -89,7 +89,9 @@
                             },
                             "url": {
                                 "type": "string",
-                                "format": "uri"
+                                "format": "uri",
+                                "pattern": "^https://",
+                                "description": "Must be an absolute https:// URL. Other URI schemes (javascript:, data:, ...) are rejected, since this value is interpolated into an href attribute in the calendar messages output. A %s sprintf placeholder may appear later in the URL."
                             }
                         },
                         "required": [

--- a/jsondata/schemas/NationalCalendar.json
+++ b/jsondata/schemas/NationalCalendar.json
@@ -223,7 +223,9 @@
                         },
                         "url": {
                             "type": "string",
-                            "format": "uri"
+                            "format": "uri",
+                            "pattern": "^https://",
+                            "description": "Must be an absolute https:// URL. Other URI schemes (javascript:, data:, ...) are rejected, since this value is interpolated into an href attribute in the calendar messages output. A %s sprintf placeholder may appear later in the URL."
                         }
                     },
                     "required": [
@@ -279,7 +281,9 @@
                         },
                         "url": {
                             "type": "string",
-                            "format": "uri"
+                            "format": "uri",
+                            "pattern": "^https://",
+                            "description": "Must be an absolute https:// URL. Other URI schemes (javascript:, data:, ...) are rejected, since this value is interpolated into an href attribute in the calendar messages output. A %s sprintf placeholder may appear later in the URL."
                         }
                     },
                     "required": [
@@ -397,7 +401,9 @@
                         },
                         "url": {
                             "type": "string",
-                            "format": "uri"
+                            "format": "uri",
+                            "pattern": "^https://",
+                            "description": "Must be an absolute https:// URL. Other URI schemes (javascript:, data:, ...) are rejected, since this value is interpolated into an href attribute in the calendar messages output. A %s sprintf placeholder may appear later in the URL."
                         }
                     },
                     "required": [

--- a/jsondata/schemas/WiderRegionCalendar.json
+++ b/jsondata/schemas/WiderRegionCalendar.json
@@ -142,7 +142,9 @@
                 },
                 "url": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "pattern": "^https://",
+                    "description": "Must be an absolute https:// URL. Other URI schemes (javascript:, data:, ...) are rejected, since this value is interpolated into an href attribute in the calendar messages output. A %s sprintf placeholder may appear later in the URL."
                 },
                 "url_lang_map": {
                     "$ref": "#/definitions/UrlLangMap"
@@ -176,7 +178,9 @@
                 },
                 "url": {
                     "type": "string",
-                    "format": "uri"
+                    "format": "uri",
+                    "pattern": "^https://",
+                    "description": "Must be an absolute https:// URL. Other URI schemes (javascript:, data:, ...) are rejected, since this value is interpolated into an href attribute in the calendar messages output. A %s sprintf placeholder may appear later in the URL."
                 },
                 "url_lang_map": {
                     "$ref": "#/definitions/UrlLangMap"

--- a/phpunit_tests/Schemas/SourceDataUrlSchemeTest.php
+++ b/phpunit_tests/Schemas/SourceDataUrlSchemeTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * Regression tests for issue #789: `format: uri` does not constrain the URI scheme.
+ *
+ * `javascript:alert(1)` is a perfectly well-formed RFC 3986 URI, so a `format: uri`
+ * assertion accepts it. The source-data `url` values are interpolated into `href`
+ * attributes in the calendar `messages[]` output, so the schemas additionally pin
+ * them to `^https://`.
+ *
+ * Two complementary guarantees are covered here:
+ *
+ * 1. every `url` actually shipped in `jsondata/sourcedata/` satisfies `^https://`,
+ *    so the tightened schemas do not reject the existing corpus;
+ * 2. each of the six schema declarations really does reject a `javascript:` URL
+ *    while still accepting an `https://` URL containing a `%s` sprintf placeholder
+ *    (several Vatican URLs carry a language placeholder).
+ */
+final class SourceDataUrlSchemeTest extends TestCase
+{
+    private const DANGEROUS_URL = 'javascript:alert(1)';
+
+    private const BENIGN_URL = 'https://www.vatican.va/content/paul-vi/%s/apost_letters/documents/hf_p-vi_apl_19641024_pacis-nuntius.html';
+
+    private static bool $routerInitialized = false;
+
+    /**
+     * Router::getApiPaths() is idempotent, but a flag keeps repeated calls cheap.
+     * It is invoked from the data providers too, which run before setUpBeforeClass().
+     */
+    private static function initRouter(): void
+    {
+        if (false === self::$routerInitialized) {
+            Router::getApiPaths();
+            self::$routerInitialized = true;
+        }
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        self::initRouter();
+    }
+
+    /**
+     * The six source-data declarations that govern a `url` value which ends up inside an `href`.
+     *
+     * @return array<string, array{LitSchema, string}>
+     */
+    private static function urlSchemaPointers(): array
+    {
+        return [
+            'DiocesanCalendar litcal[].metadata.url'      => [LitSchema::DIOCESAN, '/definitions/LitCal/items/properties/metadata/properties/url'],
+            'NationalCalendar setProperty/grade url'      => [LitSchema::NATIONAL, '/definitions/LitCalSetPropertyGrade/properties/metadata/properties/url'],
+            'NationalCalendar setProperty/name url'       => [LitSchema::NATIONAL, '/definitions/LitCalSetPropertyName/properties/metadata/properties/url'],
+            'NationalCalendar makePatron url'             => [LitSchema::NATIONAL, '/definitions/LitCalMakePatron/properties/metadata/properties/url'],
+            'WiderRegionCalendar createNew metadata url'  => [LitSchema::WIDERREGION, '/definitions/MetadataCreateNew/properties/url'],
+            'WiderRegionCalendar makePatron metadata url' => [LitSchema::WIDERREGION, '/definitions/MetadataMakePatron/properties/url'],
+        ];
+    }
+
+    /**
+     * @return \Generator<string, array{LitSchema, string}>
+     */
+    public static function urlSchemaPointerProvider(): \Generator
+    {
+        foreach (self::urlSchemaPointers() as $label => $pointer) {
+            yield $label => $pointer;
+        }
+    }
+
+    /**
+     * Every `url` string value found anywhere under `jsondata/sourcedata/`, one case per value,
+     * keyed by `<relative file path>#<json pointer>` so a failure names the offending location.
+     *
+     * @return \Generator<string, array{string, string, string}>
+     */
+    public static function shippedSourceDataUrlProvider(): \Generator
+    {
+        self::initRouter();
+
+        $sourceDataFolder = JsonData::SOURCEDATA_FOLDER->path();
+        $iterator         = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($sourceDataFolder, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        /** @var string[] $files */
+        $files = [];
+        foreach ($iterator as $fileInfo) {
+            if ($fileInfo instanceof \SplFileInfo && $fileInfo->isFile() && 'json' === $fileInfo->getExtension()) {
+                $files[] = $fileInfo->getPathname();
+            }
+        }
+        sort($files);
+
+        foreach ($files as $file) {
+            $contents = file_get_contents($file);
+            if (false === $contents) {
+                continue;
+            }
+
+            $decoded  = json_decode($contents);
+            $relative = str_replace($sourceDataFolder . DIRECTORY_SEPARATOR, '', $file);
+
+            $urls = [];
+            self::collectUrls($decoded, '', $urls);
+            foreach ($urls as $pointer => $url) {
+                yield $relative . '#' . $pointer => [$relative, $pointer, $url];
+            }
+        }
+    }
+
+    /**
+     * Recursively collect every `url` property whose value is a string, indexed by JSON pointer.
+     *
+     * @param array<string, string> $collected
+     * @param-out array<string, string> $collected
+     */
+    private static function collectUrls(mixed $node, string $pointer, array &$collected): void
+    {
+        if ($node instanceof \stdClass) {
+            foreach (get_object_vars($node) as $key => $value) {
+                $childPointer = $pointer . '/' . str_replace(['~', '/'], ['~0', '~1'], $key);
+                if ('url' === $key && is_string($value)) {
+                    $collected[$childPointer] = $value;
+                }
+                self::collectUrls($value, $childPointer, $collected);
+            }
+        } elseif (is_array($node)) {
+            foreach ($node as $index => $value) {
+                self::collectUrls($value, $pointer . '/' . (string) $index, $collected);
+            }
+        }
+    }
+
+    /**
+     * Guard against the shipped-data provider silently degenerating to a handful of cases
+     * (or to none at all) if the source-data tree is ever moved or restructured.
+     */
+    public function testShippedSourceDataProviderIsNotVacuous(): void
+    {
+        $count = iterator_count(self::shippedSourceDataUrlProvider());
+        $this->assertGreaterThanOrEqual(20, $count, 'Expected the shipped source data to contain a meaningful number of `url` values');
+    }
+
+    #[DataProvider('shippedSourceDataUrlProvider')]
+    public function testShippedSourceDataUrlUsesHttpsScheme(string $relativePath, string $pointer, string $url): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/^https:\/\//',
+            $url,
+            sprintf('`%s` at JSON pointer `%s` must use the https:// scheme, got: %s', $relativePath, $pointer, $url)
+        );
+    }
+
+    #[DataProvider('urlSchemaPointerProvider')]
+    public function testSchemaRejectsDangerousUrlScheme(LitSchema $litSchema, string $pointer): void
+    {
+        $schema = self::importSubSchema($litSchema, $pointer);
+
+        $this->expectException(\Swaggest\JsonSchema\Exception::class);
+        $schema->in(self::DANGEROUS_URL);
+    }
+
+    #[DataProvider('urlSchemaPointerProvider')]
+    public function testSchemaAcceptsHttpsUrlWithSprintfPlaceholder(LitSchema $litSchema, string $pointer): void
+    {
+        $schema = self::importSubSchema($litSchema, $pointer);
+
+        $this->assertSame(self::BENIGN_URL, $schema->in(self::BENIGN_URL));
+    }
+
+    /**
+     * Validating a whole document (rather than the isolated `url` sub-schema) proves that the
+     * constraint is actually reached along the real validation path used for national calendars.
+     */
+    public function testNationalCalendarDocumentRejectsDangerousUrlScheme(): void
+    {
+        $document = self::decodeSourceFile('rite/roman/calendars/nations/IT/IT.json');
+        $schema   = Schema::import(LitSchema::NATIONAL->path());
+
+        // The shipped document must still validate as-is.
+        $schema->in($document);
+
+        $mutated = self::decodeSourceFile('rite/roman/calendars/nations/IT/IT.json');
+        $this->assertIsArray($mutated->litcal);
+
+        $mutatedCount = 0;
+        foreach ($mutated->litcal as $litCalItem) {
+            if ($litCalItem instanceof \stdClass && isset($litCalItem->metadata->url)) {
+                $litCalItem->metadata->url = self::DANGEROUS_URL;
+                ++$mutatedCount;
+            }
+        }
+        $this->assertGreaterThan(0, $mutatedCount, 'Expected the Italian national calendar to declare at least one metadata.url');
+
+        $this->expectException(\Swaggest\JsonSchema\Exception::class);
+        $schema->in($mutated);
+    }
+
+    private static function decodeSourceFile(string $relativePath): \stdClass
+    {
+        $path     = JsonData::SOURCEDATA_FOLDER->path() . '/' . $relativePath;
+        $contents = file_get_contents($path);
+        self::assertNotFalse($contents, "Unable to read source file: $relativePath");
+
+        $decoded = json_decode($contents);
+        self::assertInstanceOf(\stdClass::class, $decoded, "Unable to decode source file: $relativePath");
+
+        return $decoded;
+    }
+
+    /**
+     * Import a single sub-schema of a source-data schema file, addressed by JSON pointer.
+     */
+    private static function importSubSchema(LitSchema $litSchema, string $pointer): Schema
+    {
+        self::initRouter();
+
+        $path = realpath($litSchema->path());
+        self::assertNotFalse($path, 'Unable to resolve schema path for ' . $litSchema->name);
+
+        $schema = Schema::import('file://' . $path . '#' . $pointer);
+        self::assertInstanceOf(Schema::class, $schema);
+
+        return $schema;
+    }
+}

--- a/phpunit_tests/Schemas/SourceDataUrlSchemeTest.php
+++ b/phpunit_tests/Schemas/SourceDataUrlSchemeTest.php
@@ -31,6 +31,14 @@ final class SourceDataUrlSchemeTest extends TestCase
 {
     private const DANGEROUS_URL = 'javascript:alert(1)';
 
+    /**
+     * An `https://` URL that satisfies the `^https://` pattern but is not a well-formed URI —
+     * an unescaped backslash is not permitted in RFC 3986. Only `format: uri` can reject this,
+     * so it is the value that proves the two constraints are complementary rather than
+     * redundant, and that `format` assertion is still live on every pointer.
+     */
+    private const MALFORMED_URL = 'https://www.vatican.va/invalid\url';
+
     private const BENIGN_URL = 'https://www.vatican.va/content/paul-vi/%s/apost_letters/documents/hf_p-vi_apl_19641024_pacis-nuntius.html';
 
     private static bool $routerInitialized = false;
@@ -170,6 +178,27 @@ final class SourceDataUrlSchemeTest extends TestCase
 
         $this->expectException(\Swaggest\JsonSchema\Exception::class);
         $schema->in(self::DANGEROUS_URL);
+    }
+
+    /**
+     * `pattern` and `format` guard different things, and both must stay in place.
+     *
+     * `^https://` rejects the dangerous schemes but happily accepts a malformed URI, while
+     * `format: uri` rejects the malformed URI but happily accepts `javascript:`. Dropping
+     * either constraint on the theory that the other supersedes it would silently widen what
+     * the source data may carry, so this asserts the `format` half independently, per pointer.
+     */
+    #[DataProvider('urlSchemaPointerProvider')]
+    public function testSchemaRejectsMalformedHttpsUrl(LitSchema $litSchema, string $pointer): void
+    {
+        $schema = self::importSubSchema($litSchema, $pointer);
+
+        // Guard the premise: the pattern alone would let this through, so a failure below is
+        // attributable to `format: uri` and to nothing else.
+        self::assertMatchesRegularExpression('/^https:\/\//', self::MALFORMED_URL);
+
+        $this->expectException(\Swaggest\JsonSchema\Exception::class);
+        $schema->in(self::MALFORMED_URL);
     }
 
     #[DataProvider('urlSchemaPointerProvider')]

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -3966,7 +3966,10 @@ final class CalendarHandler extends AbstractHandler
                                 /** @var LitCalItemSetPropertyGradeMetadata $metadata */
                                 $metadata                = $litEventItem->metadata;
                                 $existingLiturgicalEvent = $this->Cal->getLiturgicalEvent($liturgicalEvent->event_key);
-                                $url                     = $metadata->url !== null ? '<a href="' . $metadata->url . '" target="_blank">' . $metadata->url . '</a>' : 'source unknown #handleNationalCalendarEvents';
+                                // The URL is escaped again at the point of interpolation as defence in depth:
+                                // `double_encode: false` keeps the value idempotent with the escaping already applied when the model was hydrated.
+                                $escapedUrl = $metadata->url !== null ? htmlspecialchars($metadata->url, ENT_QUOTES, 'UTF-8', false) : null;
+                                $url        = $escapedUrl !== null ? '<a href="' . $escapedUrl . '" target="_blank">' . $escapedUrl . '</a>' : 'source unknown #handleNationalCalendarEvents';
                                 if (null !== $existingLiturgicalEvent) {
                                     $this->Messages[] = sprintf(
                                         /**translators:

--- a/src/Models/Decrees/DecreeEventMetadata.php
+++ b/src/Models/Decrees/DecreeEventMetadata.php
@@ -51,6 +51,11 @@ abstract class DecreeEventMetadata extends AbstractJsonRepresentation
             $vaticanLangCode = $this->url_lang_map->getBestLangFromMap(LitLocale::$PRIMARY_LANGUAGE);
             $url             = sprintf($this->url, $vaticanLangCode);
         }
+
+        // Escape the final value (i.e. after any sprintf interpolation) at the point where it becomes markup.
+        // `double_encode: false` keeps this idempotent with the escaping already applied in the constructor.
+        $url = htmlspecialchars($url, ENT_QUOTES, 'UTF-8', false);
+
         return '<a href="' . $url . '" target="_blank">' . _('Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments') . '</a>';
     }
 

--- a/src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php
+++ b/src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php
@@ -46,6 +46,11 @@ final class LitCalItemMakePatronMetadata extends LiturgicalEventMetadata
         } else {
             $url = $this->url;
         }
+
+        // Escape the final value (i.e. after any sprintf interpolation) at the point where it becomes markup.
+        // `double_encode: false` keeps this idempotent with the escaping already applied when the model was hydrated.
+        $url = htmlspecialchars($url ?? '', ENT_QUOTES, 'UTF-8', false);
+
         return '<a href="' . $url . '" target="_blank">' . _('Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments') . '</a>';
     }
 


### PR DESCRIPTION
## The problem

`format: uri` on the source-data `url` fields does **not** constrain the URI scheme. `javascript:alert(1)` is a perfectly well-formed RFC 3986 URI, so it validated cleanly.

This is not a case of an inert assertion: format assertion **is** enabled in this repo's validator (`swaggest/json-schema`). Confirmed empirically against the shipped schemas:

| value                    | before this PR |
|--------------------------|----------------|
| `"not a uri at all"`     | REJECTED       |
| `'" onmouseover=x'`      | REJECTED       |
| `javascript:alert(1)`    | **ACCEPTED**   |

So the constraint was real but wrong — it kept out malformed strings while letting a script-scheme URI straight through. Those values are concatenated **unescaped** into `href` attributes in the calendar `messages[]` output.

## The fix

### 1. Scheme allowlist — six source-data `url` declarations

`"pattern": "^https://"` (plus a `description` stating the requirement) added alongside the existing `"type": "string", "format": "uri"`:

| file                        | JSON pointer                                                            |
|-----------------------------|-------------------------------------------------------------------------|
| `DiocesanCalendar.json`     | `/definitions/LitCal/items/properties/metadata/properties/url`           |
| `NationalCalendar.json`     | `/definitions/LitCalSetPropertyGrade/properties/metadata/properties/url` |
| `NationalCalendar.json`     | `/definitions/LitCalSetPropertyName/properties/metadata/properties/url`  |
| `NationalCalendar.json`     | `/definitions/LitCalMakePatron/properties/metadata/properties/url`       |
| `WiderRegionCalendar.json`  | `/definitions/MetadataCreateNew/properties/url`                          |
| `WiderRegionCalendar.json`  | `/definitions/MetadataMakePatron/properties/url`                         |

The pattern is anchored only at the start, so the `%s` sprintf language placeholder carried by many Vatican URLs still validates (21 of the 26 shipped values contain one).

**No shipped data breaks.** All 26 `url` values under `jsondata/sourcedata/` are already `https://` (vatican.va, press.vatican.va, cultodivino.va, liturgico.chiesacattolica.it, hfranciskanci.com) — zero non-https, zero relative.

Deliberately left alone, because they already carry a stricter pattern or are unrelated to `href` output: `LitCalDecreesSource.json` `DecreeURL`/`DecreeURLS` (already vatican.va-pinned), `LitCalMissalsPath.json` `api_path`, `LitCal.json` `Origin`.

### 2. Escaping at the interpolation sites (defence in depth)

The three data-driven `<a href=` sites (every other `<a href=` in `src/` is a hardcoded literal and was left alone):

- `src/Handlers/CalendarHandler.php` — the setProperty/grade message; both the href value **and** the link text are escaped.
- `src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php::getUrl()`
- `src/Models/Decrees/DecreeEventMetadata.php::getUrl()`

In the latter two the escape is applied to the **final** value, after the `sprintf($this->url, $vaticanLangCode)`, not before.

One deviation worth flagging: these models already call `htmlspecialchars($url, ENT_QUOTES)` when they are hydrated, so the interpolation-site escape passes `double_encode: false`. Without it, a URL containing `&` would render as a literal `&amp;`. No shipped URL contains `&` today, so output is byte-identical either way — this just keeps it that way if one is ever added.

### 3. Regression test

New `phpunit_tests/Schemas/SourceDataUrlSchemeTest.php` (pure filesystem/logic, extends `PHPUnit\Framework\TestCase`), 40 tests / 71 assertions:

- walks `jsondata/sourcedata/` recursively for every `.json` file and asserts each `url` matches `^https://`, one data-provider case per value keyed by `<relative path>#<json pointer>` so a failure names the offending location rather than "false is not true";
- a not-vacuous guard so the walk can't silently degenerate to zero cases if the tree moves;
- per-pointer unit tests proving each of the six declarations now rejects `javascript:alert(1)` and still accepts an `https://…%s…` value, validated against the **actual** schema file via `Swaggest\JsonSchema\Schema::import()` — this is the test that would have caught the original gap;
- one end-to-end check that validates the real `nations/IT/IT.json` document against `NationalCalendar.json`, then re-validates it with the `metadata.url` values swapped for `javascript:alert(1)` and asserts it is rejected, proving the constraint is reached along the real validation path and not only in isolation.

## openapi.json

**Unrelated — left alone.** The three `format: uri` occurrences in `jsondata/schemas/openapi.json` (~9808, ~10070, ~10107) are the `website` property on the `Application`, `CreateApplicationBody`, and `UpdateApplicationBody` component schemas — nothing to do with calendar source data, and not rendered into an `href`. There is no inlined duplication to keep in sync: openapi.json reaches the source-data schemas through external `$ref`s (`"$ref": "./NationalCalendar.json"`, `./DiocesanCalendar.json`, `./WiderRegionCalendar.json`), so it picks up the tightened constraint automatically. `composer lint:openapi` was run anyway and passes.

## Verification

| command                  | result |
|--------------------------|--------|
| `composer lint`          | pass (exit 0) |
| `composer analyse`       | PHPStan level 10 — `[OK] No errors`, 314 files |
| `composer parallel-lint` | 582 files, no syntax error |
| `composer lint:jsondata` | `OK — 22 decrees source file(s) match their write-path canonical encoding` |
| `composer lint:openapi`  | `Your API description is valid` |
| `composer test:quick`    | Tests: 2308, Assertions: 23170, Errors: 18, Skipped: 339 |

All 18 errors are environmental and pre-existing, none attributable to this change: 17 are `Routes/*` suites failing `setUpBeforeClass` with `Could not detect API binding on http://localhost:8000` (no API server was running), and 1 is `Handlers/RegionalDataHandlerTest::testUpdateNationalCalendarSucceeds` failing with `SQLSTATE[08006] connection to server at "localhost" port 5432 failed` (Postgres not up). Every non-Routes, non-DB test passes, including the new suite.

Closes #789

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted calendar metadata and source-data links to absolute HTTPS URLs.
  - Rejected unsafe URL schemes while supporting optional language placeholders.
  - Escaped generated links to prevent unsafe HTML content and preserve existing entities.

- **Bug Fixes**
  - Improved safety when displaying URLs in national, regional, and decree-related calendar data.

- **Tests**
  - Added comprehensive validation covering shipped calendar data, schema rules, unsafe schemes, and valid HTTPS URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->