### PR TITLE
fix(health): describe the executeValidation categories accurately, drop the dead ones

### DIFF
--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -28,10 +29,24 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Health::class)]
 final class HealthSchemaCategoryTest extends TestCase
 {
+    private static bool $routerInitialized = false;
+
+    /**
+     * `LitSchema::path()` and `Route::path()` both need `Router`'s static paths resolved.
+     * Data providers run *before* `setUpBeforeClass()`, so any provider that builds a
+     * `Route::path()` must initialise them itself; the flag keeps repeat calls cheap.
+     */
+    private static function initRouter(): void
+    {
+        if (false === self::$routerInitialized) {
+            Router::getApiPaths();
+            self::$routerInitialized = true;
+        }
+    }
+
     public static function setUpBeforeClass(): void
     {
-        // LitSchema::path()/JsonData::path() both depend on Router::$apiFilePath.
-        Router::getApiPaths();
+        self::initRouter();
     }
 
     private static function retrieveSchemaForCategory(string $category, string $dataPath): ?string
@@ -97,6 +112,45 @@ final class HealthSchemaCategoryTest extends TestCase
     public function testSourceDataCheckRejectsAnUnrecognisedSlug(): void
     {
         self::assertNull(self::retrieveSchemaForCategory('sourceDataCheck', 'not-a-known-slug'));
+    }
+
+    // ---------------------------------------------------------------- resourceDataCheck
+
+    /**
+     * `resourceDataCheck` resolves from the API endpoint URL, either by matching a route shape
+     * or — for the bare routes — by falling through to {@see Health::getPathToSchemaFile()}.
+     *
+     * @return array<string, array{string, LitSchema}>
+     */
+    public static function resourceDataCheckUrlProvider(): array
+    {
+        self::initRouter();
+
+        return [
+            'missal by id'      => [Route::MISSALS->path() . '/EDITIO_TYPICA_1970', LitSchema::PROPRIUMDESANCTIS],
+            'events for nation' => [Route::EVENTS->path() . '/nation/US', LitSchema::EVENTS],
+            'data for nation'   => [Route::DATA->path() . '/nation/US', LitSchema::NATIONAL],
+            'data for diocese'  => [Route::DATA->path() . '/diocese/romamo_it', LitSchema::DIOCESAN],
+            'data for region'   => [Route::DATA->path() . '/widerregion/Europe', LitSchema::WIDERREGION],
+            'bare route'        => [Route::CALENDARS->path(), LitSchema::METADATA],
+        ];
+    }
+
+    #[DataProvider('resourceDataCheckUrlProvider')]
+    public function testResourceDataCheckResolvesFromTheEndpointUrl(string $url, LitSchema $expected): void
+    {
+        self::assertSame($expected->path(), self::retrieveSchemaForCategory('resourceDataCheck', $url));
+    }
+
+    public function testResourceDataCheckRejectsAnUnrecognisedUrl(): void
+    {
+        self::assertNull(self::retrieveSchemaForCategory('resourceDataCheck', 'https://example.test/not/a/route'));
+    }
+
+    public function testResourceDataCheckDoesNotResolveASourceDataCheckSlug(): void
+    {
+        // Completes the mismatch matrix: each category rejects the others' input.
+        self::assertNull(self::retrieveSchemaForCategory('resourceDataCheck', 'national-calendar-US'));
     }
 
     // ---------------------------------------------------------------- the two are not interchangeable

--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for `Health::retrieveSchemaForCategory()` — the `executeValidation` schema-resolution
+ * strategy selector, which had none before issue #805.
+ *
+ * The three supported categories are NOT interchangeable: each resolves from a different input.
+ * That is easy to miss, because the property is a bare string and choosing wrong does not fail
+ * loudly — it yields a null schema, which the client renders as "Unable to detect schema for
+ * dataPath …" long after the mistake. An automated reviewer proposed swapping two of them on
+ * UnitTestInterface#41 for exactly this reason. These tests pin the distinction down.
+ *
+ * Note the argument is the caller's `$pathForSchema`, not the raw `sourceFile`: for
+ * `sourceDataCheck` that is the `validate` slug; for the other two it is the `sourceFile`.
+ */
+#[CoversClass(Health::class)]
+final class HealthSchemaCategoryTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // LitSchema::path()/JsonData::path() both depend on Router::$apiFilePath.
+        Router::getApiPaths();
+    }
+
+    private static function retrieveSchemaForCategory(string $category, string $dataPath): ?string
+    {
+        $method = new \ReflectionMethod(Health::class, 'retrieveSchemaForCategory');
+        /** @var string|null $result */
+        $result = $method->invoke(null, $category, $dataPath);
+
+        return $result;
+    }
+
+    // ---------------------------------------------------------------- universalcalendar
+
+    /**
+     * `universalcalendar` resolves from the source-data PATH.
+     *
+     * @return array<string, array{string, LitSchema}>
+     */
+    public static function universalCalendarPathProvider(): array
+    {
+        return [
+            'roman temporale'      => [JsonData::MISSALS_FOLDER->value . '/propriumdetempore/propriumdetempore.json', LitSchema::PROPRIUMDETEMPORE],
+            'roman sanctorale'     => [JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_2002/propriumdesanctis_2002.json', LitSchema::PROPRIUMDESANCTIS],
+            'ambrosian temporale'  => [JsonData::AMBROSIAN_TEMPORALE_FILE->value, LitSchema::PROPRIUMDETEMPORE],
+            'ambrosian sanctorale' => [JsonData::AMBROSIAN_SANCTORALE_FILE->value, LitSchema::PROPRIUMDESANCTIS],
+        ];
+    }
+
+    #[DataProvider('universalCalendarPathProvider')]
+    public function testUniversalCalendarResolvesFromTheSourceFilePath(string $path, LitSchema $expected): void
+    {
+        self::assertSame($expected->path(), self::retrieveSchemaForCategory('universalcalendar', $path));
+    }
+
+    // ---------------------------------------------------------------- sourceDataCheck
+
+    /**
+     * `sourceDataCheck` resolves from the `validate` SLUG.
+     *
+     * @return array<string, array{string, LitSchema}>
+     */
+    public static function sourceDataCheckSlugProvider(): array
+    {
+        return [
+            'temporale'            => ['proprium-de-tempore', LitSchema::PROPRIUMDETEMPORE],
+            'editio typica missal' => ['proprium-de-sanctis-2002', LitSchema::PROPRIUMDESANCTIS],
+            'regional missal'      => ['proprium-de-sanctis-IT-1983', LitSchema::PROPRIUMDESANCTIS],
+            'wider region'         => ['wider-region-Europe', LitSchema::WIDERREGION],
+            'national calendar'    => ['national-calendar-US', LitSchema::NATIONAL],
+            'diocesan calendar'    => ['diocesan-calendar-romamo_it', LitSchema::DIOCESAN],
+            'decrees'              => ['memorials-from-decrees', LitSchema::DECREES_SRC],
+            'test definition'      => ['tests-StIgnatiusOfLoyolaTest', LitSchema::TEST_SRC],
+            'i18n folder suffix'   => ['national-calendar-US-i18n', LitSchema::I18N],
+        ];
+    }
+
+    #[DataProvider('sourceDataCheckSlugProvider')]
+    public function testSourceDataCheckResolvesFromTheValidateSlug(string $slug, LitSchema $expected): void
+    {
+        self::assertSame($expected->path(), self::retrieveSchemaForCategory('sourceDataCheck', $slug));
+    }
+
+    public function testSourceDataCheckRejectsAnUnrecognisedSlug(): void
+    {
+        self::assertNull(self::retrieveSchemaForCategory('sourceDataCheck', 'not-a-known-slug'));
+    }
+
+    // ---------------------------------------------------------------- the two are not interchangeable
+
+    /**
+     * The heart of #805 / UnitTestInterface#41: feeding one category the other's input
+     * silently yields no schema. Both directions are asserted so neither can regress.
+     */
+    public function testSourceDataCheckDoesNotResolveAUniversalCalendarPath(): void
+    {
+        $path = JsonData::MISSALS_FOLDER->value . '/propriumdetempore/propriumdetempore.json';
+
+        // Sanity: the value really does resolve under its own category.
+        self::assertSame(LitSchema::PROPRIUMDETEMPORE->path(), self::retrieveSchemaForCategory('universalcalendar', $path));
+
+        self::assertNull(self::retrieveSchemaForCategory('sourceDataCheck', $path));
+    }
+
+    public function testUniversalCalendarDoesNotResolveASourceDataCheckSlug(): void
+    {
+        // Sanity: the slug really does resolve under its own category.
+        self::assertSame(LitSchema::PROPRIUMDETEMPORE->path(), self::retrieveSchemaForCategory('sourceDataCheck', 'proprium-de-tempore'));
+
+        self::assertNull(self::retrieveSchemaForCategory('universalcalendar', 'proprium-de-tempore'));
+    }
+
+    /**
+     * The PascalCase labels the universal checks actually send. These are display/CSS labels,
+     * never schema keys — which is precisely what the rejected UnitTestInterface#41 suggestion
+     * would have fed to the slug matcher.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function universalValidateLabelProvider(): array
+    {
+        return [
+            'PropriumDeTempore'     => ['PropriumDeTempore'],
+            'PropriumDeSanctis2002' => ['PropriumDeSanctis2002'],
+            'PropriumDeSanctis2024' => ['PropriumDeSanctis2024'],
+            'LitCalMetadata'        => ['LitCalMetadata'],
+            'MemorialsFromDecrees'  => ['MemorialsFromDecrees'],
+        ];
+    }
+
+    #[DataProvider('universalValidateLabelProvider')]
+    public function testUniversalValidateLabelsAreNotSourceDataCheckSlugs(string $label): void
+    {
+        self::assertNull(self::retrieveSchemaForCategory('sourceDataCheck', $label));
+    }
+
+    // ---------------------------------------------------------------- removed legacy categories
+
+    /**
+     * Categories removed by #805. They were never sent by any client and had no coverage, but
+     * they did resolve a schema — after which the caller left the raw `sourceFile` as the data
+     * path, so the read failed anyway. They now return null, which reports the real problem.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function removedCategoryProvider(): array
+    {
+        return [
+            'nationalcalendar'    => ['nationalcalendar'],
+            'diocesancalendar'    => ['diocesancalendar'],
+            'widerregioncalendar' => ['widerregioncalendar'],
+            'propriumdesanctis'   => ['propriumdesanctis'],
+        ];
+    }
+
+    #[DataProvider('removedCategoryProvider')]
+    public function testRemovedLegacyCategoriesResolveToNull(string $category): void
+    {
+        self::assertNull(self::retrieveSchemaForCategory($category, 'US'));
+    }
+
+    public function testUnknownCategoryResolvesToNull(): void
+    {
+        self::assertNull(self::retrieveSchemaForCategory('definitelyNotACategory', 'US'));
+    }
+}

--- a/src/Health.php
+++ b/src/Health.php
@@ -50,7 +50,10 @@ use Psr\Http\Message\ResponseInterface;
  *   - `universalcalendar`  — the schema is resolved from the `sourceFile` **path**, via {@see Health::getPathToSchemaFile()}.
  *                            `validate` is a display/CSS label only (PascalCase), never a schema key.
  *   - `sourceDataCheck`    — the schema is resolved from the `validate` **slug** (anchored lowercase patterns such as
- *                            `national-calendar-IT`), and `sourceFile`/`sourceFolder` carry a bare id the server expands into a path.
+ *                            `national-calendar-IT`). The data path is `sourceFile`/`sourceFolder` **as supplied**, except for the
+ *                            `wider-region-…`, `national-calendar-…`, `diocesan-calendar-…` and `proprium-de-sanctis-…-i18n` slugs,
+ *                            where the server reconstructs the path from the slug — which is why messages carrying those send a bare
+ *                            id (`IT`, `Europe`) while the rest send a real path (`jsondata/tests/roman/…`).
  *   - `resourceDataCheck`  — the schema is resolved from the `sourceFile` **URL** of an API endpoint.
  *
  * Do not confuse these with the *calendar type* named by `category` on `validateCalendar` and `executeUnitTest` below;

--- a/src/Health.php
+++ b/src/Health.php
@@ -44,9 +44,22 @@ use Psr\Http\Message\ResponseInterface;
  *      group?: string
  * }
  *
- * @phpstan-type ExecuteValidationSourceFolder \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFolder:string}
- * @phpstan-type ExecuteValidationSourceFile \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFile:string}
- * @phpstan-type ExecuteValidationResource \stdClass&object{action:'executeValidation',category:'resourceDataCheck',validate:string,sourceFile:string}
+ * `executeValidation` accepts exactly three categories, and they are NOT interchangeable — each names a different
+ * schema-resolution strategy, and the wrong one yields a null schema rather than a loud failure:
+ *
+ *   - `universalcalendar`  — the schema is resolved from the `sourceFile` **path**, via {@see Health::getPathToSchemaFile()}.
+ *                            `validate` is a display/CSS label only (PascalCase), never a schema key.
+ *   - `sourceDataCheck`    — the schema is resolved from the `validate` **slug** (anchored lowercase patterns such as
+ *                            `national-calendar-IT`), and `sourceFile`/`sourceFolder` carry a bare id the server expands into a path.
+ *   - `resourceDataCheck`  — the schema is resolved from the `sourceFile` **URL** of an API endpoint.
+ *
+ * Do not confuse these with the *calendar type* named by `category` on `validateCalendar` and `executeUnitTest` below;
+ * that is an unrelated vocabulary that merely shares the property name. See issue #806.
+ *
+ * @phpstan-type ExecuteValidationCategory 'universalcalendar'|'sourceDataCheck'|'resourceDataCheck'
+ * @phpstan-type ExecuteValidationSourceFolder \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFolder:string,responsetype?:string}
+ * @phpstan-type ExecuteValidationSourceFile \stdClass&object{action:'executeValidation',category:'universalcalendar'|'sourceDataCheck',validate:string,sourceFile:string,responsetype?:string}
+ * @phpstan-type ExecuteValidationResource \stdClass&object{action:'executeValidation',category:'resourceDataCheck',validate:string,sourceFile:string,responsetype?:string}
  * @phpstan-type ValidateCalendar \stdClass&object{action:'validateCalendar',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',responsetype:'JSON'|'XML'|'ICS'|'YML',rite?:string}
  * @phpstan-type ExecuteUnitTest \stdClass&object{action:'executeUnitTest',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',test:string,rite?:string}
  *
@@ -1988,19 +2001,25 @@ class Health implements MessageComponentInterface
     }
 
     /**
-     * Returns the appropriate schema for the given category and dataPath.
-     * If dataPath is null, it will return the schema for the category.
-     * If dataPath is not null, it will return the schema for the dataPath.
-     * If the category is 'universalcalendar', it will return the schema from the DATA_PATH_TO_SCHEMA array.
-     * If the category is 'nationalcalendar', 'diocesancalendar', 'widerregioncalendar', or 'propriumdesanctis',
-     * it will return the corresponding schema constant.
-     * If the category is 'resourceDataCheck', it will return the schema for the dataPath if it matches one of the patterns,
-     * otherwise it will return the schema from the DATA_PATH_TO_SCHEMA array.
-     * If the category is not recognized, it will return null.
+     * Resolve the JSON Schema an `executeValidation` message should validate against.
      *
-     * @param string $category The category of the data.
-     * @param string $dataPath The path to the data.
-     * @return string|null The schema for the given category and dataPath, or null if the category is not recognized.
+     * Three categories are supported, each resolving from a different input — see the
+     * `ExecuteValidationCategory` note in the class docblock:
+     *
+     *   - `universalcalendar`: `$dataPath` is a source-data path or API URL, looked up in
+     *     {@see Health::getPathToSchemaFile()};
+     *   - `sourceDataCheck`: `$dataPath` is the `validate` slug, matched against anchored patterns;
+     *   - `resourceDataCheck`: `$dataPath` is an API endpoint URL.
+     *
+     * Any other category returns null, which surfaces to the client as
+     * "Unable to detect schema for dataPath …".
+     *
+     * Note the caller passes `$pathForSchema`, not the raw `sourceFile`: for `sourceDataCheck`
+     * that is the `validate` slug, and for the other two it is the `sourceFile` itself.
+     *
+     * @param string $category The schema-resolution strategy; one of ExecuteValidationCategory.
+     * @param string $dataPath The value to resolve from — a path, a URL, or a `validate` slug, per the category.
+     * @return string|null The schema path, or null when the category is not one of the three supported values.
      */
     private static function retrieveSchemaForCategory(string $category, string $dataPath): ?string
     {
@@ -2021,14 +2040,6 @@ class Health implements MessageComponentInterface
                     }
                 }
                 return Health::getPathToSchemaFile($dataPath);
-            case 'nationalcalendar':
-                return $isVersionedDataPath ? preg_replace($versionedPattern, $versionedReplacement, LitSchema::NATIONAL->path()) : LitSchema::NATIONAL->path();
-            case 'diocesancalendar':
-                return $isVersionedDataPath ? preg_replace($versionedPattern, $versionedReplacement, LitSchema::DIOCESAN->path()) : LitSchema::DIOCESAN->path();
-            case 'widerregioncalendar':
-                return $isVersionedDataPath ? preg_replace($versionedPattern, $versionedReplacement, LitSchema::WIDERREGION->path()) : LitSchema::WIDERREGION->path();
-            case 'propriumdesanctis':
-                return $isVersionedDataPath ? preg_replace($versionedPattern, $versionedReplacement, LitSchema::PROPRIUMDESANCTIS->path()) : LitSchema::PROPRIUMDESANCTIS->path();
             case 'resourceDataCheck':
                 if (
                     preg_match('/\/missals\/[_A-Z0-9]+$/', $dataPath)


### PR DESCRIPTION
## Summary

The `@phpstan-type` block in `src/Health.php` is the only machine-readable description of the WebSocket protocol, and it was wrong: it declared `category` on `executeValidation` as exactly `'sourceDataCheck'` or `'resourceDataCheck'`, omitting **`universalcalendar`** — the category UnitTestInterface has sent for the six universal source-data checks for as long as they have existed, and the only arm that resolves a schema from a source-data *path*.

That inaccuracy already cost real time. An automated reviewer cited these annotations on UnitTestInterface#41 and proposed switching every universal check to `sourceDataCheck`, which would have broken all six Roman checks and both Ambrosian ones.

## Changes

### 1. The annotations now describe reality

`ExecuteValidationSourceFile` declares `'universalcalendar'|'sourceDataCheck'`; all three variants document the optional `responsetype`. A new `ExecuteValidationCategory` alias names the supported set once, and the class docblock spells out what each category resolves from:

| category            | resolves the schema from | `validate` is                      |
|---------------------|--------------------------|------------------------------------|
| `universalcalendar` | the `sourceFile` **path** | a display/CSS label (PascalCase)   |
| `sourceDataCheck`   | the `validate` **slug**   | the schema key (lowercase-hyphen)  |
| `resourceDataCheck` | the `sourceFile` **URL**  | a display/CSS label                |

It also warns that the identically-named `category` on `validateCalendar`/`executeUnitTest` is an unrelated vocabulary — the collision #806 proposes to disentangle.

### 2. Four dead arms removed

`nationalcalendar`, `diocesancalendar`, `widerregioncalendar` and `propriumdesanctis` are gone from `retrieveSchemaForCategory()`. Evidence they are dead:

- they date to the original composer-packaging commit;
- `retrieveSchemaForCategory()` had **no test coverage at all**;
- **no client sends them.** The only WebSocket clients in the workspace are `assets/js/index.js` and `assets/js/resources.js`, and between them they send exactly three categories:

  ```text
  13  "category": "resourceDataCheck"
  17  "category": "sourceDataCheck"
   9  "category": "universalcalendar"
  ```

  (The `widerregioncalendar` hits in `phpunit_tests/HealthRiteRequestPathTest.php` are the *other* vocabulary — they assert it is rejected as a calendar type by `buildCalendarRequestPath()`, and are untouched.)

**This is a strict improvement, not a behaviour loss.** On `executeValidation` those arms resolved a schema and then fell through to the branch that leaves the raw `sourceFile` as `$dataPath` — so the file read failed immediately afterwards with a misleading error. That is exactly what the pre-existing UnitTestInterface docs described: *"causes the server to use the raw `sourceFile` value as the path, which fails."* They now return `null`, which reports the real problem: *"Unable to detect schema for dataPath …"*.

All four `LitSchema` constants involved (`NATIONAL`, `DIOCESAN`, `WIDERREGION`, `PROPRIUMDESANCTIS`) remain in use by the surviving `sourceDataCheck` / `resourceDataCheck` arms, so nothing is orphaned.

### 3. First tests for `retrieveSchemaForCategory()`

It had none. `phpunit_tests/HealthSchemaCategoryTest.php` adds 26, covering:

- each category's happy path, including both Ambrosian missal files;
- **both directions of the confusion that motivated this** — a source path under `sourceDataCheck`, and a slug under `universalcalendar` — each with a sanity assertion first, so the test cannot pass because the value was junk;
- the PascalCase `validate` labels the universal checks really send (`PropriumDeTempore`, `LitCalMetadata`, …), which is precisely what the rejected #41 suggestion would have fed to the slug matcher;
- the four removed categories, and an unknown one.

Confirmed the removal tests are not vacuous by reverting only `src/Health.php`:

```text
✘ Removed legacy categories resolve to null with nationalcalendar
✘ Removed legacy categories resolve to null with diocesancalendar
✘ Removed legacy categories resolve to null with widerregioncalendar
✘ Removed legacy categories resolve to null with propriumdesanctis
Tests: 4, Assertions: 4, Failures: 4.
```

## Verification

```text
composer lint            → clean
composer parallel-lint   → Checked 585 files, no syntax error found
composer analyse         → [OK] No errors        (PHPStan level 10)
vendor/bin/phpunit phpunit_tests/HealthSchemaCategoryTest.php
                         → OK (26 tests, 28 assertions)
composer test:quick      → Tests: 2353, Assertions: 25182, Errors: 17, Skipped: 27
```

All 17 errors are `Routes/*` suites erroring in `setUpBeforeClass` with `Could not detect API binding on http://localhost:8000` — no local API server running. Verified that is the entire set (17 of 17).

## Follow-ups, deliberately not in this PR

- **UnitTestInterface docs mention the removed arms.** UnitTestInterface#44 (merged) tells contributors those legacy names exist in this switch and must not be used, citing this issue as "their removal". Once this lands, that sentence should be simplified to "only three categories exist". Small doc-only PR.
- **`universalcalendar` has no integration coverage.** `phpunit_tests/WebSocket/ExecuteValidationTest.php` exercises only `sourceDataCheck` and `resourceDataCheck` — the category with the most client usage is the one its integration tests skip. The unit tests here are the stronger guard, but a fourth scenario there would close the gap.

Closes #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updated Behavior**
  * Schema resolution supports the `universalcalendar`, `resourceDataCheck`, and `sourceDataCheck` categories.
  * Recognized slug formats are routed appropriately, while supplied paths continue to be respected when applicable.
  * Legacy, invalid, unknown, or mismatched categories and endpoints no longer resolve to a schema.

* **Documentation**
  * Clarified supported schema-resolution categories and path-handling behavior.

* **Tests**
  * Added coverage for valid routes, invalid inputs, legacy categories, unsupported labels, and cross-category mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->