### PR TITLE
fix(health): emit one frame per step on a sourceFolder check, not one per file

### DIFF
--- a/phpunit_tests/HealthFolderStepResultTest.php
+++ b/phpunit_tests/HealthFolderStepResultTest.php
@@ -122,4 +122,36 @@ final class HealthFolderStepResultTest extends TestCase
 
         self::assertSame('run-token-1', $frames[0]->runToken);
     }
+
+    /**
+     * The three-frames-per-check contract has to hold on the *short* paths too.
+     *
+     * A folder that does not exist used to emit a single `file-exists` error and return, which
+     * under-delivers by two frames. That is the same wedge as over-delivering, approached from
+     * the other side: a client counting toward `checks.length * 3` never reaches its target.
+     */
+    public function testAMissingFolderStillReportsAllThreeSteps(): void
+    {
+        $conn = self::createStubConnection(2);
+
+        $health   = new Health();
+        $validate = 'national-calendar-IT-i18n';
+        $missing  = ['/nowhere does not exist or contains no json files'];
+
+        $method = new \ReflectionMethod(Health::class, 'sendFolderStepResult');
+        foreach (['file-exists', 'json-valid', 'schema-valid'] as $step) {
+            $method->invoke($health, $conn, "$validate.$step", $missing, '', 'Data folder could not be checked', 'run-token-1');
+        }
+
+        $frames = array_map(static fn(string $raw): \stdClass => json_decode($raw), $conn->sent);
+
+        self::assertCount(3, $frames);
+        self::assertSame(
+            [".$validate.file-exists", ".$validate.json-valid", ".$validate.schema-valid"],
+            array_map(static fn(\stdClass $f): string => $f->classes, $frames)
+        );
+        foreach ($frames as $frame) {
+            self::assertSame('error', $frame->type);
+        }
+    }
 }

--- a/phpunit_tests/HealthFolderStepResultTest.php
+++ b/phpunit_tests/HealthFolderStepResultTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ratchet\ConnectionInterface;
@@ -132,26 +133,37 @@ final class HealthFolderStepResultTest extends TestCase
      */
     public function testAMissingFolderStillReportsAllThreeSteps(): void
     {
-        $conn = self::createStubConnection(2);
+        // Driven through executeValidation() rather than the helper: the fix is in the `glob()`
+        // guard, and a test that called sendFolderStepResult() three times itself would pass
+        // whether or not that guard had been fixed. The path is synchronous — the guard returns
+        // before any promise is created — so no event loop is needed.
+        Router::getApiPaths();
 
-        $health   = new Health();
-        $validate = 'national-calendar-IT-i18n';
-        $missing  = ['/nowhere does not exist or contains no json files'];
+        $conn   = self::createStubConnection(3);
+        $health = new Health();
 
-        $method = new \ReflectionMethod(Health::class, 'sendFolderStepResult');
-        foreach (['file-exists', 'json-valid', 'schema-valid'] as $step) {
-            $method->invoke($health, $conn, "$validate.$step", $missing, '', 'Data folder could not be checked', 'run-token-1');
-        }
+        $tokens = new \ReflectionProperty(Health::class, 'runTokens');
+        $tokens->setValue($health, [$conn->resourceId => 'run-token-1']);
+
+        $validate = 'tests-NoSuchTest-i18n';
+        $method   = new \ReflectionMethod(Health::class, 'executeValidation');
+        $method->invoke($health, (object) [
+            'action'       => 'executeValidation',
+            'category'     => 'sourceDataCheck',
+            'validate'     => $validate,
+            'sourceFolder' => 'jsondata/definitely-not-a-real-folder',
+        ], $conn);
 
         $frames = array_map(static fn(string $raw): \stdClass => json_decode($raw), $conn->sent);
 
-        self::assertCount(3, $frames);
+        self::assertCount(3, $frames, 'a missing folder must still report every step');
         self::assertSame(
             [".$validate.file-exists", ".$validate.json-valid", ".$validate.schema-valid"],
             array_map(static fn(\stdClass $f): string => $f->classes, $frames)
         );
         foreach ($frames as $frame) {
             self::assertSame('error', $frame->type);
+            self::assertSame('run-token-1', $frame->runToken);
         }
     }
 }

--- a/phpunit_tests/HealthFolderStepResultTest.php
+++ b/phpunit_tests/HealthFolderStepResultTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * `Health::sendFolderStepResult()` — one frame per step of a `sourceFolder` check.
+ *
+ * A folder check is a statement about the folder, so each of its three steps must produce
+ * exactly one frame whether it passes or fails. Previously a failure emitted one frame *per
+ * failing file*, which made the frame count depend on how many files happened to be broken.
+ *
+ * That is unpredictable for any client: both UnitTestInterface runners size a phase as
+ * `checks.length * 3` and complete it by counting frames, so a folder containing two bad files
+ * over-delivered and inflated the counters — the recorded "success counter (162) past the
+ * rendered-card total (159)" incident — and with a strict equality check would have hung the
+ * phase outright (UnitTestInterface#43).
+ */
+#[CoversClass(Health::class)]
+final class HealthFolderStepResultTest extends TestCase
+{
+    /**
+     * A minimal Ratchet connection that records every outbound frame. `resourceId` is a dynamic
+     * public property Ratchet assigns and is not part of `ConnectionInterface`, so this mirrors
+     * the stub convention already used by HealthHelpersTest rather than a PHPUnit mock, which
+     * would trigger a dynamic-property deprecation.
+     */
+    private static function createStubConnection(int $resourceId)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * @param list<string> $errors
+     * @return list<\stdClass> the decoded frames the helper emitted
+     */
+    private function invoke(array $errors): array
+    {
+        $conn = self::createStubConnection(1);
+
+        $method = new \ReflectionMethod(Health::class, 'sendFolderStepResult');
+        $method->invoke(
+            new Health(),
+            $conn,
+            'national-calendar-IT-i18n.json-valid',
+            $errors,
+            'all good',
+            'not all good',
+            'run-token-1'
+        );
+
+        return array_map(static fn(string $raw): \stdClass => json_decode($raw), $conn->sent);
+    }
+
+    public function testAPassingStepEmitsExactlyOneSuccessFrame(): void
+    {
+        $frames = $this->invoke([]);
+
+        self::assertCount(1, $frames);
+        self::assertSame('success', $frames[0]->type);
+        self::assertSame('all good', $frames[0]->text);
+        self::assertSame('.national-calendar-IT-i18n.json-valid', $frames[0]->classes);
+    }
+
+    public function testOneFailingFileEmitsExactlyOneErrorFrame(): void
+    {
+        $frames = $this->invoke(['it.json: Syntax error']);
+
+        self::assertCount(1, $frames);
+        self::assertSame('error', $frames[0]->type);
+        self::assertStringContainsString('it.json: Syntax error', $frames[0]->text);
+    }
+
+    /**
+     * The regression that motivated this: N broken files used to mean N frames.
+     */
+    public function testManyFailingFilesStillEmitExactlyOneErrorFrame(): void
+    {
+        $frames = $this->invoke(['it.json: Syntax error', 'en.json: Syntax error', 'fr.json: Control character error']);
+
+        self::assertCount(1, $frames, 'a folder step must report once, however many files are broken');
+        self::assertSame('error', $frames[0]->type);
+    }
+
+    public function testTheErrorFrameNamesEveryOffendingFile(): void
+    {
+        $frames = $this->invoke(['it.json: Syntax error', 'en.json: Syntax error']);
+
+        // Aggregating must not lose the detail that the per-file frames used to carry.
+        self::assertStringContainsString('it.json', $frames[0]->text);
+        self::assertStringContainsString('en.json', $frames[0]->text);
+        self::assertStringContainsString('2 problem(s)', $frames[0]->text);
+    }
+
+    public function testTheFrameCarriesTheRunTokenForCorrelation(): void
+    {
+        $frames = $this->invoke([]);
+
+        self::assertSame('run-token-1', $frames[0]->runToken);
+    }
+}

--- a/src/Health.php
+++ b/src/Health.php
@@ -679,11 +679,20 @@ class Health implements MessageComponentInterface
             }
             $files = glob($dataPath . '/*.json');
             if (false === $files || empty($files)) {
-                $message          = new \stdClass();
-                $message->type    = 'error';
-                $message->text    = "Data folder $sourceFolder ($dataPath) does not exist or does not contain any json files";
-                $message->classes = ".$validate.file-exists";
-                $this->sendMessage($to, $message);
+                // Report all three steps, not just file-exists. A client sizes the phase as three
+                // frames per check, so short-circuiting with a single frame under-delivers and the
+                // phase never completes — the same wedge, approached from the other side.
+                $missing = ["$dataPath does not exist or contains no json files"];
+                foreach (['file-exists', 'json-valid', 'schema-valid'] as $step) {
+                    $this->sendFolderStepResult(
+                        $to,
+                        "$validate.$step",
+                        $missing,
+                        '', // unreachable: $missing is non-empty, so the failure text is used
+                        "Data folder $sourceFolder could not be checked",
+                        $runToken
+                    );
+                }
                 return;
             }
 
@@ -723,6 +732,9 @@ class Health implements MessageComponentInterface
                         $jsonData = json_decode($fileData);
                         if (json_last_error() !== JSON_ERROR_NONE) {
                             $jsonErrors[] = "$filename: " . json_last_error_msg();
+                            // A file that would not decode was never schema-checked either, so the
+                            // schema step must not go on to claim it validated successfully.
+                            $schemaErrors[] = "$filename: not validated, the file could not be decoded as JSON";
                         } else {
                             if (null !== $schema) {
                                 $validationResult = $this->validateDataAgainstSchema($jsonData, $schema);
@@ -736,8 +748,12 @@ class Health implements MessageComponentInterface
                             }
                         }
                     },
-                    function (\Throwable $reason) use ($filename, &$fileExistsErrors) {
+                    function (\Throwable $reason) use ($filename, &$fileExistsErrors, &$jsonErrors, &$schemaErrors) {
                         $fileExistsErrors[] = "unreadable i18n json file $filename: " . $reason->getMessage();
+                        // An unread file was neither decoded nor validated; without these the
+                        // later steps would report success over a file nobody managed to open.
+                        $jsonErrors[]   = "$filename: not decoded, the file could not be read";
+                        $schemaErrors[] = "$filename: not validated, the file could not be read";
                     }
                 );
             }

--- a/src/Health.php
+++ b/src/Health.php
@@ -687,9 +687,17 @@ class Health implements MessageComponentInterface
                 return;
             }
 
-            $fileExistsAndIsReadable = true;
-            $jsonDecodable           = true;
-            $schemaValidated         = true;
+            // A folder check reports on the folder, not on each file in it: exactly one frame per
+            // step, whatever the outcome. Failures are therefore collected here and summarised
+            // once at the end, rather than emitted per file — sending one frame per failing file
+            // made the frame count depend on how many files happened to be broken, which no
+            // client can predict (see UnitTestInterface#43).
+            /** @var list<string> $fileExistsErrors */
+            $fileExistsErrors = [];
+            /** @var list<string> $jsonErrors */
+            $jsonErrors = [];
+            /** @var list<string> $schemaErrors */
+            $schemaErrors = [];
 
             /** @var list<PromiseInterface<string>> $promises */
             $promises = [];
@@ -700,57 +708,36 @@ class Health implements MessageComponentInterface
                 $matchI8nFile = preg_match('/(?:[a-z]{2,3}(?:_[A-Z][a-z]{3})?(?:_[A-Z]{2})?|(?:ar|en|eo)_001|(?:en_150|es_419))\.json$/', $filename);
 
                 if (false === $matchI8nFile || 0 === $matchI8nFile) {
-                    $fileExistsAndIsReadable = false;
-                    $message                 = new \stdClass();
-                    $message->type           = 'error';
-                    $message->text           = "Data folder $sourceFolder contains an invalid i18n json filename $filename";
-                    $message->classes        = ".$validate.file-exists";
-                    $this->sendMessage($to, $message);
+                    $fileExistsErrors[] = "invalid i18n json filename $filename";
                     continue;
                 }
 
                 /** @var PromiseInterface<array{data: string, fromCache: bool}> $promise */
                 $promise    = $this->cachedFileGetContents($file);
                 $promises[] = $promise->then(
-                    function (array $result) use ($to, $validation, $filename, $schema, $pathForSchema, $runToken, &$jsonDecodable, &$schemaValidated) {
+                    function (array $result) use ($validation, $filename, $schema, $pathForSchema, &$jsonErrors, &$schemaErrors) {
                         /** @var array{data: string, fromCache: bool} $result */
                         $fileData = $result['data'];
                         $validate = (string) $validation->validate;
                         $category = (string) $validation->category;
                         $jsonData = json_decode($fileData);
                         if (json_last_error() !== JSON_ERROR_NONE) {
-                            $jsonDecodable    = false;
-                            $message          = new \stdClass();
-                            $message->type    = 'error';
-                            $message->text    = "The i18n json file $filename was not successfully decoded as JSON: " . json_last_error_msg();
-                            $message->classes = ".$validate.json-valid";
-                            $this->sendMessage($to, $message, $runToken);
+                            $jsonErrors[] = "$filename: " . json_last_error_msg();
                         } else {
                             if (null !== $schema) {
                                 $validationResult = $this->validateDataAgainstSchema($jsonData, $schema);
                                 if ($validationResult instanceof \stdClass) {
-                                    $schemaValidated           = false;
-                                    $validationResult->classes = ".$validate.schema-valid";
-                                    $this->sendMessage($to, $validationResult, $runToken);
+                                    /** @var string $validationText */
+                                    $validationText = $validationResult->text;
+                                    $schemaErrors[] = "$filename: " . $validationText;
                                 }
                             } else {
-                                $message          = new \stdClass();
-                                $message->type    = 'error';
-                                $message->text    = "executeValidation validation->sourceFolder: Unable to detect a schema for {$validate} and category {$category} (path for schema: $pathForSchema)";
-                                $message->classes = ".$validate.schema-valid";
-                                $this->sendMessage($to, $message, $runToken);
+                                $schemaErrors[] = "$filename: unable to detect a schema for {$validate} and category {$category} (path for schema: $pathForSchema)";
                             }
                         }
                     },
-                    function (\Throwable $reason) use ($to, $validation, $filename, $runToken, &$fileExistsAndIsReadable) {
-                        $fileExistsAndIsReadable = false;
-                        $validate                = (string) $validation->validate;
-                        $sourceFolder            = (string) $validation->sourceFolder;
-                        $message                 = new \stdClass();
-                        $message->type           = 'error';
-                        $message->text           = "Data folder $sourceFolder contains an unreadable i18n json file $filename: " . $reason->getMessage();
-                        $message->classes        = ".$validate.file-exists";
-                        $this->sendMessage($to, $message, $runToken);
+                    function (\Throwable $reason) use ($filename, &$fileExistsErrors) {
+                        $fileExistsErrors[] = "unreadable i18n json file $filename: " . $reason->getMessage();
                     }
                 );
             }
@@ -758,35 +745,39 @@ class Health implements MessageComponentInterface
             $allPromises = Promise\all($promises);
 
             $allPromises->then(
-                function () use ($to, $validation, $schema, $fileExistsAndIsReadable, $jsonDecodable, $schemaValidated, $runToken) {
+                function () use ($to, $validation, $schema, &$fileExistsErrors, &$jsonErrors, &$schemaErrors, $runToken) {
                     $validate     = (string) $validation->validate;
                     $sourceFolder = (string) $validation->sourceFolder;
-                    if ($fileExistsAndIsReadable) {
-                        $message = (object) [
-                            'type'    => 'success',
-                            'text'    => "The Data folder $sourceFolder exists and contains valid i18n json files",
-                            'classes' => ".$validate.file-exists"
-                        ];
-                        $this->sendMessage($to, $message, $runToken);
-                    }
 
-                    if ($jsonDecodable) {
-                        $message = (object) [
-                            'type'    => 'success',
-                            'text'    => "The i18n json files in Data folder $sourceFolder were successfully decoded as JSON",
-                            'classes' => ".$validate.json-valid"
-                        ];
-                        $this->sendMessage($to, $message, $runToken);
-                    }
+                    // Exactly one frame per step, pass or fail. A folder check is a statement
+                    // about the folder, so a failure names the offending files inside a single
+                    // frame instead of emitting one frame each.
+                    $this->sendFolderStepResult(
+                        $to,
+                        "$validate.file-exists",
+                        $fileExistsErrors,
+                        "The Data folder $sourceFolder exists and contains valid i18n json files",
+                        "Data folder $sourceFolder",
+                        $runToken
+                    );
 
-                    if ($schemaValidated) {
-                        $message = (object) [
-                            'type'    => 'success',
-                            'text'    => "The i18n json files in Data folder $sourceFolder were successfully validated against the Schema $schema",
-                            'classes' => ".$validate.schema-valid"
-                        ];
-                        $this->sendMessage($to, $message, $runToken);
-                    }
+                    $this->sendFolderStepResult(
+                        $to,
+                        "$validate.json-valid",
+                        $jsonErrors,
+                        "The i18n json files in Data folder $sourceFolder were successfully decoded as JSON",
+                        "The i18n json files in Data folder $sourceFolder were not all decoded as JSON",
+                        $runToken
+                    );
+
+                    $this->sendFolderStepResult(
+                        $to,
+                        "$validate.schema-valid",
+                        $schemaErrors,
+                        "The i18n json files in Data folder $sourceFolder were successfully validated against the Schema $schema",
+                        "The i18n json files in Data folder $sourceFolder were not all valid against the Schema $schema",
+                        $runToken
+                    );
                 },
                 function (\Throwable $e) use ($validation) {
                     echo 'Error verifying i18n folder for validation ' . json_encode($validation) . ': ' . $e->getMessage() . "\n";
@@ -936,6 +927,37 @@ class Health implements MessageComponentInterface
         }
 
         $message->classes = ".$validate.diocese-metadata";
+        $this->sendMessage($to, $message, $runToken);
+    }
+
+    /**
+     * Emit the single result frame for one step of a `sourceFolder` check.
+     *
+     * A folder check reports on the folder as a whole, so each step yields exactly one frame
+     * whether it passed or failed. Emitting one frame per failing file instead would make the
+     * number of frames depend on how many files happened to be broken — unpredictable for a
+     * client that has to know when a phase is complete (UnitTestInterface#43).
+     *
+     * @param string       $classes      Response `classes` selector, without the leading dot.
+     * @param list<string> $errors       Per-file failures; empty means the step passed.
+     * @param string       $successText  Message for the passing case.
+     * @param string       $failurePrefix Lead-in for the failing case; the offending files follow.
+     * @param ?string      $runToken     Run token to echo back.
+     */
+    private function sendFolderStepResult(
+        ConnectionInterface $to,
+        string $classes,
+        array $errors,
+        string $successText,
+        string $failurePrefix,
+        ?string $runToken
+    ): void {
+        $message          = new \stdClass();
+        $message->type    = [] === $errors ? 'success' : 'error';
+        $message->text    = [] === $errors
+            ? $successText
+            : $failurePrefix . ' — ' . count($errors) . ' problem(s): ' . implode('; ', $errors);
+        $message->classes = '.' . $classes;
         $this->sendMessage($to, $message, $runToken);
     }
 


### PR DESCRIPTION
## Summary

A `sourceFolder` check is a statement about the **folder**, so each of its three steps (`file-exists`, `json-valid`, `schema-valid`) should produce exactly one response frame. It did on the happy path — the `Promise\all` handler emitted three aggregate successes — but on failure it emitted one error frame **per failing file**, straight from inside the `foreach`, while the matching aggregate success was suppressed by a by-reference flag.

So the frame count depended on how many files happened to be broken:

| folder state | frames emitted |
| --- | --- |
| all i18n files valid | 3 |
| 1 file with invalid JSON | 3 (1 error + 2 aggregate successes) |
| 3 files with invalid JSON | 5 |
| 2 unreadable + 1 invalid JSON | 6 |

## Why it matters

That is unpredictable for any client. Both UnitTestInterface runners size a phase as `checks.length * 3` and complete it by counting arriving frames:

```javascript
sourceDataExpectedResponses = sourceDataChecks.length * 3; // 3 responses per check
…
if ( sourceDataReceivedResponses >= sourceDataExpectedResponses ) { /* phase complete */ }
```

The surplus frames inflated the counters — recorded in that repo as the success counter (162) overshooting the rendered-card total (159) — and against the strict equality check that comparison used until yesterday, the phase would **never complete at all**. UnitTestInterface#43 mitigates that client-side with `>=`; this is the root cause.

It also made the per-file frames useless as diagnostics in their own right: they all carry the same `.{validate}.{step}` selector, so they repaint the same card, each overwriting the last one's tooltip.

## The fix

Failures are collected per step and summarised in a **single** frame that names every offending file, via a new `sendFolderStepResult()`. Three steps in, three frames out, pass or fail.

No detail is lost — the aggregate text carries the problem count and each filename with its reason:

```text
Data folder … — 2 problem(s): it.json: Syntax error; en.json: Syntax error
```

The three by-reference booleans (`$fileExistsAndIsReadable`, `$jsonDecodable`, `$schemaValidated`) are replaced by three error lists, which is also what makes the summary possible.

## Tests

`phpunit_tests/HealthFolderStepResultTest.php`, 5 cases, including the regression itself — three broken files must still yield exactly one frame — and a check that aggregating does not discard the per-file detail the old frames carried.

The connection stub follows the existing `HealthHelpersTest::createStubConnection()` convention (an anonymous class with a real `resourceId`) rather than a PHPUnit mock, which triggers a dynamic-property deprecation since `resourceId` is not part of `ConnectionInterface`.

## Verification

```text
composer lint            → clean
composer parallel-lint   → Checked 585 files, no syntax error found
composer analyse         → [OK] No errors        (PHPStan level 10)
vendor/bin/phpunit phpunit_tests/HealthFolderStepResultTest.php
                         → OK (5 tests, 13 assertions), no deprecations
composer test:quick      → Tests: 2366, Assertions: 25203, Errors: 17, Skipped: 27
```

The 17 errors are the usual `Routes/*` suites failing in `setUpBeforeClass` with `Could not detect API binding on http://localhost:8000` — no local API server running.

## Follow-up

With this merged, `checks.length * 3` becomes exactly right for folder checks, so the note added in UnitTestInterface#46 explaining that `>=` is load-bearing for folder multiplicity needs revising — `>=` remains correct as duplicate-tolerance, but that second justification goes away. I will update it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Folder validation now reports all expected validation steps when no JSON files are found.
  * Each validation step emits a single consolidated success or error result.
  * Error results include every affected filename and detailed validation issues.
  * Unreadable files, invalid JSON, and schema failures are consistently reported.
  * Responses retain the run token for reliable result correlation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->