### PR TITLE
feat(health): let a client abandon a run with cancelRun

### DIFF
--- a/docs/superpowers/plans/2026-08-19-cancel-run.md
+++ b/docs/superpowers/plans/2026-08-19-cancel-run.md
@@ -46,12 +46,13 @@ Playwright 1.57 on the client.
 
 **UnitTestInterface (checkout `UnitTestInterface`):**
 
-| File                     | Responsibility                                                    |
-|--------------------------|-------------------------------------------------------------------|
-| `e2e/websocket-stub.ts`  | Reusable `window.WebSocket` recorder that opens and never replies |
-| `e2e/cancel-run.spec.ts` | Asserts both runners emit the cancel frame when a run is stopped  |
-| `assets/js/index.js`     | Sends the frame from the Calendars runner's stop branch           |
-| `assets/js/resources.js` | Sends the frame from the Resources runner's stop branch           |
+| File                      | Responsibility                                                    |
+|---------------------------|-------------------------------------------------------------------|
+| `assets/js/wsProtocol.js` | Shared protocol helpers; today just the cancel frame              |
+| `e2e/websocket-stub.ts`   | Reusable `window.WebSocket` recorder that opens and never replies |
+| `e2e/cancel-run.spec.ts`  | Asserts both runners emit the cancel frame when a run is stopped  |
+| `assets/js/index.js`      | Sends the frame from the Calendars runner's stop branch           |
+| `assets/js/resources.js`  | Sends the frame from the Resources runner's stop branch           |
 
 ---
 
@@ -489,16 +490,24 @@ Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
 
 **Files:**
 
+- Create: `assets/js/wsProtocol.js`
 - Create: `e2e/websocket-stub.ts`
 - Create: `e2e/cancel-run.spec.ts`
-- Modify: `assets/js/index.js` (stop branch, ~line 1640-1644)
-- Modify: `assets/js/resources.js` (stop branch, ~line 1209-1213)
+- Modify: `assets/js/index.js` (import block at the top; stop branch ~line 1640-1644)
+- Modify: `assets/js/resources.js` (import block at the top; stop branch ~line 1209-1213)
 
 **Interfaces:**
 
 - Consumes: the wire action `{"action": "cancelRun", "runToken": "<token>"}` produced by Task 1.
-- Produces: `installWebSocketStub(page: Page): Promise<void>` from `e2e/websocket-stub.ts`, which sets
-  `window.__wsSent: string[]` in the page — reusable by later protocol work (#42).
+- Produces: `sendCancelRun(conn: WebSocket, runToken: string|null): boolean` from `assets/js/wsProtocol.js`, returning
+  `true` only when a frame was sent; `installWebSocketStub(page: Page): Promise<void>` and
+  `sentFrames(page: Page): Promise<string[]>` from `e2e/websocket-stub.ts`, which set and read `window.__wsSent`.
+
+Both runners are already ES modules importing from `./common.js` and `./testResults.js`, so a third shared module needs
+no change to how either page loads its script. `wsProtocol.js` is deliberately the seed of the shared protocol client
+that #42 will grow: `index.js` and `resources.js` are two independent implementations of the same protocol that have
+already drifted (they each carry their own identical `sendMessage()` today), so new protocol behaviour lands in one
+place rather than becoming a fourth thing to keep in lockstep.
 
 - [ ] **Step 1: Create the branch and start the servers this task needs**
 
@@ -603,7 +612,9 @@ export const sentFrames = (page: Page): Promise<string[]> =>
 
 - [ ] **Step 3: Write the failing spec**
 
-Create `e2e/cancel-run.spec.ts`:
+Create `e2e/cancel-run.spec.ts`. The first three tests call the shared helper directly in the page context — the same
+dynamic-import technique `e2e/result-painting.spec.ts` uses — because the guard branches (closed socket, absent token)
+are not reachable by clicking. The last two prove both runners are actually wired to it.
 
 ```typescript
 import { test, expect, Page } from '@playwright/test';
@@ -616,9 +627,58 @@ import { installWebSocketStub, sentFrames } from './websocket-stub';
  * fetching calendars for a run nobody was watching. Both runners must now send `cancelRun` naming the
  * run being abandoned.
  *
- * The WebSocket is stubbed, so these specs need no WebSocket server — only the API on :8000, whose
- * /calendars, /missals and /tests responses gate the start button.
+ * No WebSocket server is needed: the helper specs import the module directly, and the wiring specs stub
+ * `window.WebSocket`. Only the API on :8000 is required, whose responses gate the start button.
  */
+
+/**
+ * Call the real `sendCancelRun()` in the page context against a recording fake connection.
+ *
+ * The module specifier is held in a variable so TypeScript treats the `import()` as dynamic and does not
+ * try to resolve a browser-served path against the e2e tsconfig.
+ */
+const callHelper = async (page: Page, readyState: number, runToken: string | null) =>
+    page.evaluate(async ({ readyState, runToken }) => {
+        const specifier = '/assets/js/wsProtocol.js';
+        const { sendCancelRun } = (await import(specifier)) as {
+            sendCancelRun: (conn: unknown, token: string | null) => boolean;
+        };
+        const sent: string[] = [];
+        const conn = { readyState, send: (data: string) => sent.push(data) };
+        return { returned: sendCancelRun(conn, runToken), sent };
+    }, { readyState, runToken });
+
+test.describe('the sendCancelRun helper', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/');
+    });
+
+    test('sends the cancel frame when the socket is open and the run has a token', async ({ page }) => {
+        const { returned, sent } = await callHelper(page, 1, 'run-a');
+
+        expect(returned).toBe(true);
+        expect(sent).toHaveLength(1);
+        expect(JSON.parse(sent[0])).toEqual({ action: 'cancelRun', runToken: 'run-a' });
+    });
+
+    test('sends nothing when the socket is not open', async ({ page }) => {
+        // Stop is also reachable while the socket is reconnecting. A closed socket needs no cancel:
+        // the server drops the run's queued work when the connection closes.
+        const { returned, sent } = await callHelper(page, 3, 'run-a');
+
+        expect(returned).toBe(false);
+        expect(sent).toEqual([]);
+    });
+
+    test('sends nothing when there is no run to cancel', async ({ page }) => {
+        // A cancel carrying no token is a protocol error the server rejects, which the UI would then
+        // paint as a failure. Better never to send one.
+        const { returned, sent } = await callHelper(page, 1, null);
+
+        expect(returned).toBe(false);
+        expect(sent).toEqual([]);
+    });
+});
 
 /** Start a run, then stop it, returning every frame the page sent. */
 const startThenStop = async (page: Page, path: string): Promise<string[]> => {
@@ -642,11 +702,9 @@ test('the Calendars runner tells the server when a run is stopped', async ({ pag
 
     const cancel = JSON.parse(frames[frames.length - 1]);
     expect(cancel.action).toBe('cancelRun');
-    expect(typeof cancel.runToken).toBe('string');
 
     // The cancel must name the run it is abandoning, not some fresh value.
-    const firstRequest = JSON.parse(frames[0]);
-    expect(cancel.runToken).toBe(firstRequest.runToken);
+    expect(cancel.runToken).toBe(JSON.parse(frames[0]).runToken);
 });
 
 test('the Resources runner tells the server when a run is stopped', async ({ page }) => {
@@ -654,10 +712,8 @@ test('the Resources runner tells the server when a run is stopped', async ({ pag
 
     const cancel = JSON.parse(frames[frames.length - 1]);
     expect(cancel.action).toBe('cancelRun');
-    expect(typeof cancel.runToken).toBe('string');
 
-    const firstRequest = JSON.parse(frames[0]);
-    expect(cancel.runToken).toBe(firstRequest.runToken);
+    expect(cancel.runToken).toBe(JSON.parse(frames[0]).runToken);
 });
 ```
 
@@ -671,66 +727,112 @@ npx playwright test e2e/cancel-run.spec.ts --project=chromium --no-deps
 `--no-deps` skips the `setup` project, which authenticates against Zitadel and is unrelated here; the stored
 `e2e/.auth/user.json` is reused.
 
-Expected: **2 failures**. The last recorded frame is still the run's final validation request, so
-`expect(cancel.action).toBe('cancelRun')` fails with the action of whatever the runner sent last
+Expected: **5 failures**. The three helper specs fail on the dynamic import — `/assets/js/wsProtocol.js` is served as a
+404 HTML page, so the `import()` rejects. The two wiring specs fail because the last recorded frame is still the run's
+final validation request, so `expect(cancel.action).toBe('cancelRun')` reports whatever the runner sent last
 (`executeValidation` or `validateCalendar`).
 
-- [ ] **Step 5: Send the cancel from the Calendars runner**
+- [ ] **Step 5: Write the shared helper**
 
-In `assets/js/index.js`, in the stop branch of the `#startTestRunnerBtn` click handler, insert immediately after
+Create `assets/js/wsProtocol.js`:
+
+```javascript
+/**
+ * Shared helpers for the Health WebSocket protocol.
+ *
+ * `index.js` and `resources.js` are two independent implementations of the same protocol and have already
+ * drifted apart in ways that cost debugging sessions — different state names, different runToken guards,
+ * two vocabularies for the same file (see #42). New protocol behaviour lands here so both runners share one
+ * definition rather than acquiring a fourth thing to keep in lockstep.
+ * @module wsProtocol
+ */
+
+/**
+ * Tell the server a run is abandoned, so it stops draining a backlog nobody is watching.
+ *
+ * Silent on the wire: the server acknowledges by dropping the run's queued requests and sends nothing back
+ * (LiturgicalCalendarAPI#806 section H).
+ *
+ * Call this *before* clearing the run token — the cancel has to name the run it is stopping, and the server
+ * ignores a cancel that names a run the connection is no longer on.
+ *
+ * @param {WebSocket} conn - The connection the run was started on.
+ * @param {?string} runToken - The run being abandoned; the same token its requests carried.
+ * @returns {boolean} true when a cancel was sent, false when there was nothing to send it on or about.
+ */
+export const sendCancelRun = ( conn, runToken ) => {
+    if ( !conn || conn.readyState !== WebSocket.OPEN ) {
+        return false;
+    }
+    if ( typeof runToken !== 'string' || runToken === '' ) {
+        return false;
+    }
+    conn.send( JSON.stringify( { action: 'cancelRun', runToken } ) );
+    return true;
+};
+```
+
+- [ ] **Step 6: Wire the Calendars runner**
+
+In `assets/js/index.js`, add to the imports at the top of the file, after the existing `./common.js` and
+`./testResults.js` import blocks:
+
+```javascript
+import { sendCancelRun } from './wsProtocol.js';
+```
+
+Then in the stop branch of the `#startTestRunnerBtn` click handler, insert immediately after
 `console.log( 'Stopping test run...' );` and before `currentState = TestState.Stopped;`:
 
 ```javascript
         // Tell the server the run is abandoned, so it stops draining a backlog nobody is watching.
-        // Must happen before currentRunToken is cleared: sendMessage() attaches the token, and the
-        // cancel has to name the run it is stopping. The explicit null test matters because
-        // sendMessage() omits the token when there is none, and a cancel without one is a protocol
-        // error the server rejects.
-        if ( conn.readyState === WebSocket.OPEN && currentRunToken !== null ) {
-            sendMessage( { action: 'cancelRun' } );
-        }
+        // Must precede clearing currentRunToken: the cancel has to name the run it is stopping.
+        sendCancelRun( conn, currentRunToken );
 ```
 
-- [ ] **Step 6: Send the cancel from the Resources runner**
+- [ ] **Step 7: Wire the Resources runner**
 
-In `assets/js/resources.js`, in the stop branch of the `#startTestRunnerBtn` click handler, insert immediately after
+In `assets/js/resources.js`, add to the imports at the top of the file, after the existing `./common.js` and
+`./testResults.js` import blocks:
+
+```javascript
+import { sendCancelRun } from './wsProtocol.js';
+```
+
+Then in the stop branch of the `#startTestRunnerBtn` click handler, insert immediately after
 `console.log( 'Stopping test run...' );` and before `currentState = TestState.Stopped;`:
 
 ```javascript
         // Tell the server the run is abandoned, so it stops draining a backlog nobody is watching.
-        // Must happen before currentRunToken is cleared: sendMessage() attaches the token, and the
-        // cancel has to name the run it is stopping. The explicit null test matters because
-        // sendMessage() omits the token when there is none, and a cancel without one is a protocol
-        // error the server rejects.
-        if ( conn.readyState === WebSocket.OPEN && currentRunToken !== null ) {
-            sendMessage( { action: 'cancelRun' } );
-        }
+        // Must precede clearing currentRunToken: the cancel has to name the run it is stopping.
+        sendCancelRun( conn, currentRunToken );
 ```
 
-- [ ] **Step 7: Run the spec to verify it passes**
+- [ ] **Step 8: Run the spec to verify it passes**
 
 ```bash
 cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
 npx playwright test e2e/cancel-run.spec.ts --project=chromium --no-deps
 ```
 
-Expected: `2 passed`.
+Expected: `5 passed`.
 
-If instead the start button never enables, the API on `:8000` is not up — fix that rather than relaxing the assertion.
-If the run does not park after its first frame, report it; do not replace the poll with a fixed `waitForTimeout`.
+If the start button never enables, the API on `:8000` is not up — fix that rather than relaxing the assertion. If the
+run does not park after its first frame, report it; do not replace the poll with a fixed `waitForTimeout`.
 
-- [ ] **Step 8: Typecheck and syntax-check**
+- [ ] **Step 9: Typecheck and syntax-check**
 
 ```bash
 cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
 npm run typecheck
+node --check assets/js/wsProtocol.js
 node --check assets/js/index.js
 node --check assets/js/resources.js
 ```
 
 Expected: all clean.
 
-- [ ] **Step 9: Check for regressions in the specs that share this surface**
+- [ ] **Step 10: Check for regressions in the specs that share this surface**
 
 ```bash
 cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
@@ -739,11 +841,11 @@ npx playwright test e2e/result-painting.spec.ts e2e/results-replay.spec.ts e2e/r
 
 Expected: all pass. These are the specs that touch the runners and the painter.
 
-- [ ] **Step 10: Commit**
+- [ ] **Step 11: Commit**
 
 ```bash
 cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
-git add e2e/websocket-stub.ts e2e/cancel-run.spec.ts assets/js/index.js assets/js/resources.js
+git add assets/js/wsProtocol.js e2e/websocket-stub.ts e2e/cancel-run.spec.ts assets/js/index.js assets/js/resources.js
 git commit -m "fix(runner): tell the server when a run is stopped
 
 Stopping a run was purely local: state was reset, incoming frames were
@@ -752,19 +854,26 @@ run nobody was watching. On a wide year range that is 81 calendar requests
 plus all their downstream validation, wasted on every stopped run.
 
 Both runners now send {action: 'cancelRun', runToken} before clearing the
-token — the cancel has to name the run it is abandoning. The readyState
-guard matters because stop is also reachable while the socket is
-reconnecting; a closed socket needs no cancel, since the server drops the
-run's queued work when the connection closes.
+token — the cancel has to name the run it is abandoning. It goes through a
+new shared wsProtocol.js rather than being pasted into both files: index.js
+and resources.js are already two independent implementations of the same
+protocol that have drifted apart in ways that cost debugging sessions, and
+this is the seed of the shared client #42 will grow.
 
-The server side is LiturgicalCalendarAPI#806 section H. It answers with
+The helper stays silent when the socket is not open — stop is reachable
+while reconnecting, and a closed connection already drops the run's queued
+work server-side — and when there is no token, since a tokenless cancel is
+a protocol error the UI would paint as a failure.
+
+The server side is LiturgicalCalendarAPI#806 section H, which answers with
 silence: PR #46 made an unrecognised response type paint a visible failure,
 so an ack frame would have needed handling here first.
 
-Verified with a new e2e spec that stubs window.WebSocket with a recorder
-that opens and never replies, parking the run after its first request. The
-stub needs no WebSocket server — playwright.config.ts starts none — and is
-written for reuse by the protocol work in #42.
+Verified with a new e2e spec: three cases call the helper directly for the
+guard branches, two drive each runner end to end against a stubbed
+window.WebSocket that opens and never replies, parking the run after its
+first request. Neither needs a WebSocket server — playwright.config.ts
+starts none.
 
 Closes #43
 

--- a/docs/superpowers/plans/2026-08-19-cancel-run.md
+++ b/docs/superpowers/plans/2026-08-19-cancel-run.md
@@ -91,6 +91,12 @@ Four test methods cover the spec's six cases: case 1 (matching cancel drops the 
 emitted) are the first method; cases 2 and 3 (untagged and other-connection entries survive) are the second; case 4
 (stale cancel) is the third; case 5 (missing `runToken`) is the fourth.
 
+> **Landed with six, not four.** The final whole-branch review added two the plan did not foresee: one covering a
+> `runToken` that is present but not a string (which reaches the handler and must not throw), and one asserting that an
+> *ordinary* message still stores its token — that second one guards the exemption clause in Step 6, since inverting
+> its comparison would break response correlation for every normal run with a green suite. The spec's testing section
+> lists all eight cases; this step is left as it was planned.
+
 Create `phpunit_tests/HealthCancelRunTest.php`:
 
 ```php

--- a/docs/superpowers/plans/2026-08-19-cancel-run.md
+++ b/docs/superpowers/plans/2026-08-19-cancel-run.md
@@ -507,22 +507,28 @@ cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
 git checkout main && git pull && git checkout -b feat/43-cancel-run
 ```
 
-The spec stubs the WebSocket, so **no WebSocket server is needed**. Two things are:
+The spec stubs the WebSocket, so **no WebSocket server is needed**. Two things are: the API on `:8000`, whose
+`/calendars`, `/missals` and `/tests` responses gate the start button, and the UnitTestInterface pages on `:3003`.
+
+Both come from the docker stack in the frontend repo. Bringing up `litcal-tests` pulls in `litcal-api` as a dependency:
 
 ```bash
-# 1. The API on :8000 — the page's /calendars, /missals and /tests fetches gate the start button.
-#    Start it however this machine normally does (docker compose up -d in the API checkout, or
-#    `composer start` there). Verify:
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarFrontend
+docker compose up -d litcal-tests
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8000/calendars   # expect 200
-
-# 2. The UnitTestInterface pages on :3003, served from THIS checkout:
-cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
-php -S localhost:3003 &
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:3003/            # expect 200
 ```
 
-Serving from this checkout matters: `playwright.config.ts` has no `webServer` block, so the specs test whatever is
-already on `:3003`. Point it at the wrong directory and the run silently exercises unmodified files.
+`docker-compose.override.yml` bind-mounts `../UnitTestInterface/assets:ro` into the `litcal-tests` container, so the
+edits in Steps 5 and 6 are served live with no rebuild. It bind-mounts `../UnitTestInterface/index.php`,
+`resources.php` and friends as **single files**, which pin their inodes — if a git operation ever replaces one of those
+files the container keeps serving the old content until `docker compose up -d --force-recreate litcal-tests`. This task
+only edits `assets/`, a directory mount, so that trap does not apply here.
+
+**The `:8000` API container mounts the *main* API checkout's `src`, not the `feat/cancel-run` worktree.** The server-side
+`cancelRun` from Task 1 is therefore *not* running behind `:8000` or `:8082`. That is fine — this task stubs the
+WebSocket and never reaches a real server — but do not attempt a live end-to-end check here and do not read anything
+into `:8082`'s behaviour. Task 1's coverage is the in-process PHPUnit test.
 
 - [ ] **Step 2: Write the WebSocket stub**
 

--- a/docs/superpowers/plans/2026-08-19-cancel-run.md
+++ b/docs/superpowers/plans/2026-08-19-cancel-run.md
@@ -1,0 +1,808 @@
+# `cancelRun` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a stopped test run tell the Health WebSocket server it was abandoned, so the server stops fetching
+calendars and validating files for nobody.
+
+**Architecture:** The server already discards queued requests whose `runToken` no longer matches the connection's stored
+token (`Health::dropSupersededQueuedRequests()`), and `cachedGet()` already tags every queue entry with its `resourceId`
+and `runToken`. A new `cancelRun` action clears the stored token and reuses that existing filter; it introduces no
+cancellation machinery of its own and sends nothing back. The client sends the frame from the stop branch of both
+runners.
+
+**Tech Stack:** PHP 8.4 (Ratchet WebSocket, ReactPHP event loop, Guzzle), PHPUnit 12; vanilla ES modules and
+Playwright 1.57 on the client.
+
+## Global Constraints
+
+- **Two repositories, two branches.** Server work happens in the API worktree at
+  `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-cancelrun` on branch `feat/cancel-run`
+  (PR base: `development`). Client work happens in place at
+  `/home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface` on branch `feat/43-cancel-run`
+  (PR base: `main` — note UnitTestInterface's default branch is `main`, not `development`).
+- **Never commit in the API main checkout** (`.../LiturgicalCalendarAPI`). It is shared with other concurrent agents.
+  Only the worktree above. `git push` from the worktree is safe.
+- **Never use `--no-verify`.** CaptainHook pre-commit runs phpcs and markdownlint; fix and re-commit instead.
+- Commits are GPG-signed. If signing fails headlessly, stop and ask the user to unlock the key — do not disable signing.
+- PHP style: PSR-12 per `phpcs.xml`, short array syntax, 4-space indent, single quotes unless interpolating.
+- PHPStan runs at level 10 but scans `src` only, so `phpunit_tests/` is not analysed.
+- The client field keeps the name `runToken`. API#806's proposed `runId` rename is explicitly out of scope.
+- The server sends **no** response to `cancelRun`. UnitTestInterface PR #46 made an unrecognised response `type` paint a
+  visible failure, so any new type would need matching handling in both runners.
+- Spec: `docs/superpowers/specs/2026-08-19-cancel-run-design.md`.
+
+---
+
+## File Structure
+
+**API (worktree `LiturgicalCalendarAPI-cancelrun`):**
+
+| File                                    | Responsibility                                                                   |
+|-----------------------------------------|----------------------------------------------------------------------------------|
+| `src/Health.php`                        | Declares the action, exempts it from the ambient token store, handles it         |
+| `phpunit_tests/HealthCancelRunTest.php` | In-process coverage: queue filtering, the stale-cancel guard, protocol rejection |
+
+**UnitTestInterface (checkout `UnitTestInterface`):**
+
+| File                     | Responsibility                                                    |
+|--------------------------|-------------------------------------------------------------------|
+| `e2e/websocket-stub.ts`  | Reusable `window.WebSocket` recorder that opens and never replies |
+| `e2e/cancel-run.spec.ts` | Asserts both runners emit the cancel frame when a run is stopped  |
+| `assets/js/index.js`     | Sends the frame from the Calendars runner's stop branch           |
+| `assets/js/resources.js` | Sends the frame from the Resources runner's stop branch           |
+
+---
+
+## Task 1: Server-side `cancelRun`
+
+**Files:**
+
+- Modify: `src/Health.php` (class docblock ~line 67; `ACTION_PROPERTIES` ~line 87; `onMessage()` ~lines 365-374 and
+  the switch ~line 408; a new method after `resolveRunToken()` ~line 512; `dropSupersededQueuedRequests()` docblock
+  ~line 1878)
+- Create: `phpunit_tests/HealthCancelRunTest.php`
+
+**Interfaces:**
+
+- Consumes: `Health::dropSupersededQueuedRequests()` (private, existing, unchanged behaviour);
+  `Health::$runTokens` (`array<int, string>`, keyed by `resourceId`); `Health::$queue` entries shaped
+  `array{url: string, options: array, resolve: \Closure, reject: \Closure, resourceId: int|null, runToken: string|null}`.
+- Produces: `Health::cancelRun(string $runToken, ConnectionInterface $from): void` (private); the wire action
+  `{"action": "cancelRun", "runToken": "<token>"}`; the phpstan-type `CancelRun`.
+
+- [ ] **Step 1: Create the branch and confirm the worktree is usable**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-cancelrun
+git status --short
+git branch --show-current   # expect: feat/cancel-run
+ls vendor/bin/phpunit       # must exist; if not, run `composer install` first
+```
+
+The `vendor/` directory must be a real install, never a symlink to the main checkout's — a symlinked vendor makes
+PHPUnit silently test the main checkout's `src`.
+
+- [ ] **Step 2: Write the failing test**
+
+Four test methods cover the spec's six cases: case 1 (matching cancel drops the run's entries) and case 6 (no frame
+emitted) are the first method; cases 2 and 3 (untagged and other-connection entries survive) are the second; case 4
+(stale cancel) is the third; case 5 (missing `runToken`) is the fourth.
+
+Create `phpunit_tests/HealthCancelRunTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * `cancelRun` — the client telling the server a run was abandoned.
+ *
+ * Stopping a run used to be purely client-side: the runner dropped incoming frames while the server
+ * kept working through the abandoned run's backlog. The server already knew how to discard such
+ * requests — `dropSupersededQueuedRequests()` filters queue entries whose `runToken` no longer matches
+ * the connection's stored token — but only a *restart* ever advanced that token. `cancelRun` clears it
+ * on demand, which is why these tests assert on the queue rather than on any response frame: the
+ * action is deliberately silent.
+ *
+ * See UnitTestInterface#43 and #806 section H.
+ */
+#[CoversClass(Health::class)]
+final class HealthCancelRunTest extends TestCase
+{
+    /**
+     * A minimal Ratchet connection that records every outbound frame. `resourceId` is a dynamic public
+     * property Ratchet assigns and is not part of `ConnectionInterface`, so this mirrors the stub
+     * convention already used by HealthFolderStepResultTest rather than a PHPUnit mock, which would
+     * trigger a dynamic-property deprecation.
+     */
+    private static function createStubConnection(int $resourceId)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * A queue entry shaped like the ones `cachedGet()` enqueues. The promise callbacks are never
+     * invoked here — these tests only ever inspect which entries survive the filter.
+     *
+     * @return array<string, mixed>
+     */
+    private static function queueEntry(string $url, ?int $resourceId, ?string $runToken): array
+    {
+        return [
+            'url'        => $url,
+            'options'    => [],
+            'resolve'    => static function (): void {
+            },
+            'reject'     => static function (): void {
+            },
+            'resourceId' => $resourceId,
+            'runToken'   => $runToken
+        ];
+    }
+
+    /** @param list<array<string, mixed>> $queue */
+    private static function setQueue(Health $health, array $queue): void
+    {
+        ( new \ReflectionProperty(Health::class, 'queue') )->setValue($health, $queue);
+    }
+
+    /** @return list<array<string, mixed>> */
+    private static function getQueue(Health $health): array
+    {
+        /** @var list<array<string, mixed>> */
+        return ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+    }
+
+    /** @param array<int, string> $tokens */
+    private static function setRunTokens(Health $health, array $tokens): void
+    {
+        ( new \ReflectionProperty(Health::class, 'runTokens') )->setValue($health, $tokens);
+    }
+
+    /** @return array<int, string> */
+    private static function getRunTokens(Health $health): array
+    {
+        /** @var array<int, string> */
+        return ( new \ReflectionProperty(Health::class, 'runTokens') )->getValue($health);
+    }
+
+    /** @param array<string, string> $payload */
+    private static function cancel(Health $health, ConnectionInterface $conn, array $payload): void
+    {
+        $health->onMessage($conn, (string) json_encode($payload));
+    }
+
+    public function testCancellingTheCurrentRunDropsItsQueuedRequestsAndSaysNothing(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        self::setRunTokens($health, [1 => 'run-a']);
+        self::setQueue($health, [
+            self::queueEntry('https://example.test/a', 1, 'run-a'),
+            self::queueEntry('https://example.test/b', 1, 'run-a')
+        ]);
+
+        self::cancel($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertSame([], self::getQueue($health), 'the cancelled run keeps no queued work');
+        self::assertSame([], self::getRunTokens($health), 'the connection is no longer on any run');
+        self::assertSame([], $conn->sent, 'cancelRun is acknowledged by silence, not by a frame');
+    }
+
+    public function testUntaggedAndOtherConnectionsRequestsSurvive(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        self::setRunTokens($health, [1 => 'run-a', 2 => 'run-b']);
+        self::setQueue($health, [
+            // The connect-time metadata fetch carries no run token and belongs to no run.
+            self::queueEntry('https://example.test/metadata', null, null),
+            self::queueEntry('https://example.test/mine', 1, 'run-a'),
+            self::queueEntry('https://example.test/theirs', 2, 'run-b')
+        ]);
+
+        self::cancel($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertSame(
+            ['https://example.test/metadata', 'https://example.test/theirs'],
+            array_column(self::getQueue($health), 'url')
+        );
+        self::assertSame([2 => 'run-b'], self::getRunTokens($health), 'the other connection keeps its run');
+    }
+
+    public function testAStaleCancelDoesNotTouchTheRunThatReplacedIt(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        // The user stopped and restarted faster than the cancel frame travelled: the connection is
+        // already on run-b when the cancel naming run-a arrives.
+        self::setRunTokens($health, [1 => 'run-b']);
+        self::setQueue($health, [self::queueEntry('https://example.test/new-run', 1, 'run-b')]);
+
+        self::cancel($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertCount(1, self::getQueue($health), 'the new run keeps its queued work');
+        self::assertSame([1 => 'run-b'], self::getRunTokens($health), 'the new run keeps its token');
+        self::assertSame([], $conn->sent);
+    }
+
+    public function testACancelWithoutARunTokenIsRejectedAndChangesNothing(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        self::setRunTokens($health, [1 => 'run-a']);
+        self::setQueue($health, [self::queueEntry('https://example.test/a', 1, 'run-a')]);
+
+        self::cancel($health, $conn, ['action' => 'cancelRun']);
+
+        self::assertCount(1, self::getQueue($health));
+        self::assertSame([1 => 'run-a'], self::getRunTokens($health));
+
+        self::assertCount(1, $conn->sent, 'a malformed cancel is a protocol error, and those are visible');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('Invalid message properties', $frame->errorMsg);
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-cancelrun
+vendor/bin/phpunit phpunit_tests/HealthCancelRunTest.php
+```
+
+Expected: **4 failures**, roughly —
+
+- `testCancellingTheCurrentRunDropsItsQueuedRequestsAndSaysNothing`: the queue still holds 2 entries and `$conn->sent`
+  holds one `echobot` frame, because `cancelRun` reaches the switch's `default:` branch.
+- `testUntaggedAndOtherConnectionsRequestsSurvive`: all three URLs still present.
+- `testAStaleCancelDoesNotTouchTheRunThatReplacedIt`: passes on the queue assertion but the ambient token store has
+  overwritten `run-b` with `run-a`, so the `runTokens` assertion fails.
+- `testACancelWithoutARunTokenIsRejectedAndChangesNothing`: the emitted frame has no `errorMsg` property (the `default:`
+  branch sets only `type` and `text`), so the last assertion fails.
+
+A PHP warning about `foreach()` on `null` may also appear: `validateMessageProperties()` indexes
+`ACTION_PROPERTIES['cancelRun']`, which does not exist yet. That warning disappears in Step 4.
+
+- [ ] **Step 4: Declare the action's required properties**
+
+In `src/Health.php`, extend `ACTION_PROPERTIES`:
+
+```php
+    private const ACTION_PROPERTIES = [
+        'executeValidation' => ['category', 'validate', 'sourceFile'],
+        'validateCalendar'  => ['category', 'calendar', 'year', 'responsetype'],
+        'executeUnitTest'   => ['category', 'calendar', 'year', 'test'],
+        'cancelRun'         => ['runToken']
+    ];
+```
+
+`runToken` is optional on every other action. Requiring it here means a cancel that omits it is rejected by the existing
+`validateMessageProperties()` path instead of reaching a handler with nothing to match on.
+
+- [ ] **Step 5: Add the `CancelRun` phpstan-type**
+
+In the class docblock, after the `ExecuteUnitTest` line:
+
+```php
+ * @phpstan-type CancelRun \stdClass&object{action:'cancelRun',runToken:string}
+```
+
+and widen the `@var` union inside `onMessage()`:
+
+```php
+        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest|CancelRun $messageReceived */
+```
+
+- [ ] **Step 6: Exempt `cancelRun` from the ambient token store**
+
+Replace the token-store block near the top of `onMessage()`:
+
+```php
+        // Store optional run token for response correlation. `cancelRun` is exempt: it names the run it
+        // wants abandoned rather than the run this connection is on, and storing it here would install
+        // the very token cancelRun() is about to clear — making even a stale cancel match, and dropping
+        // the queue of the run that replaced it.
+        if (
+            $messageReceived instanceof \stdClass
+            && property_exists($messageReceived, 'action')
+            && $messageReceived->action !== 'cancelRun'
+            && property_exists($messageReceived, 'runToken')
+            && is_string($messageReceived->runToken)
+            && preg_match('/^[A-Za-z0-9_\-]{1,64}$/', $messageReceived->runToken)
+        ) {
+            $this->runTokens[$resourceId] = $messageReceived->runToken;
+        }
+```
+
+- [ ] **Step 7: Dispatch the action**
+
+In the `switch ($messageReceived->action)` block, immediately before `default:`:
+
+```php
+                case 'cancelRun':
+                    /** @var CancelRun $messageReceived */
+                    $this->cancelRun($messageReceived->runToken, $from);
+                    break;
+```
+
+- [ ] **Step 8: Implement the handler**
+
+Insert immediately after `resolveRunToken()`:
+
+```php
+    /**
+     * Abandon a run: forget its token, so its queued requests stop being work worth doing.
+     *
+     * Sent by the client when the user stops a run, so the server does not keep fetching calendars and
+     * validating files for a run nobody is watching. Only the queued backlog is dropped — requests
+     * already in flight are capped at maxConcurrency and their frames are discarded client-side, so
+     * chasing them would buy little for a great deal of plumbing.
+     *
+     * The token must match what this connection is currently running. A cancel naming a run the
+     * connection has already left — the user stopped and restarted faster than the frame travelled —
+     * is a no-op: acting on it would clear the token of the run that *replaced* it and drop that run's
+     * queue instead, which is a worse bug than the one this fixes.
+     *
+     * Nothing is sent back; see #806 section H.
+     *
+     * @param string $runToken The run the client wants abandoned.
+     * @param ConnectionInterface $from The connection that asked.
+     */
+    private function cancelRun(string $runToken, ConnectionInterface $from): void
+    {
+        $resourceId = $from->resourceId;
+        if (false === is_int($resourceId) || ( $this->runTokens[$resourceId] ?? null ) !== $runToken) {
+            return;
+        }
+        unset($this->runTokens[$resourceId]);
+        $this->dropSupersededQueuedRequests();
+    }
+```
+
+`dropSupersededQueuedRequests()` is called rather than `processQueue()` on purpose: dropping is the whole point of a
+cancel, whereas `processQueue()` would additionally dispatch the surviving requests and re-arm the tick timer as a side
+effect. The tick loop already running picks up the shortened queue by itself.
+
+The `is_int($resourceId)` test is not only defensive: `resourceId` is a dynamic property Ratchet assigns and is not
+declared on `ConnectionInterface`, so PHPStan level 10 sees it as `mixed`. Without the test, using it as an array key
+fails `composer analyse`.
+
+- [ ] **Step 9: Update the filter's docblock to name its second trigger**
+
+In `dropSupersededQueuedRequests()`, replace the opening sentence:
+
+```php
+    /**
+     * Drop queued requests whose run this connection is no longer on. Two things cause that: the client
+     * stopped and started a new run, so the connection's stored token advanced; or the client sent
+     * `cancelRun` and {@see Health::cancelRun()} cleared the stored token outright. Their responses would
+     * be discarded by the client anyway, so skipping the work lets a restarted run dispatch immediately
+     * instead of first draining the abandoned run's backlog. Untagged requests (e.g. the metadata fetch
+     * on connect) carry no token and are always kept. In-flight requests are not affected (they are few —
+     * capped at maxConcurrency — and their responses are discarded client-side).
+     */
+```
+
+- [ ] **Step 10: Run the test to verify it passes**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-cancelrun
+vendor/bin/phpunit phpunit_tests/HealthCancelRunTest.php
+```
+
+Expected: `OK (4 tests, ...)`.
+
+- [ ] **Step 11: Run lint and static analysis**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-cancelrun
+composer lint
+composer analyse
+```
+
+Expected: both clean. If `composer analyse` fails with a path "is not a file" error, the PHPStan result cache is shared
+across worktrees and stale: run `rm -rf /tmp/phpstan` and retry (`--clear-result-cache` alone is not enough).
+
+- [ ] **Step 12: Run the wider suite**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-cancelrun
+composer test:quick
+```
+
+Use the composer script, never a bare `phpunit --exclude-group` — a CLI `--exclude-group` overrides the XML config and
+un-fences the golden-master-generate group, which silently rewrites the fixtures it is checked against.
+
+Expected: no new failures. `phpunit_tests/WebSocket/ExecuteValidationTest.php` self-skips because no WebSocket server is
+running, and `Routes/*` tests self-skip or hit the main checkout's server on `:8000` — a green result there says nothing
+about this branch, so judge only on `HealthCancelRunTest` plus the absence of *new* failures elsewhere.
+
+- [ ] **Step 13: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-cancelrun
+git add src/Health.php phpunit_tests/HealthCancelRunTest.php
+git commit -m "feat(health): let a client abandon a run with cancelRun
+
+Stopping a run was purely client-side: the runner dropped incoming frames
+while the server worked through the whole abandoned backlog — 81 calendar
+requests plus their validation on a wide year range.
+
+The server already knew how to discard that work. dropSupersededQueuedRequests()
+filters queue entries whose runToken no longer matches the connection's stored
+token, and cachedGet() tags every entry with both. Only a restart ever advanced
+the token, so stop-and-walk-away leaked. cancelRun clears it on demand and
+reuses the same filter.
+
+The token must match the connection's current run. A cancel naming a run the
+connection has already left would otherwise clear the token of the run that
+replaced it and drop *its* queue. Same reason cancelRun is exempt from the
+ambient token store at the top of onMessage: storing the token would make every
+stale cancel match.
+
+Silent by design. UnitTestInterface#46 made an unrecognised response type paint
+a visible failure, so an ack frame would need handling in both runners first.
+
+Refs UnitTestInterface#43, #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Client-side cancel frame
+
+**Files:**
+
+- Create: `e2e/websocket-stub.ts`
+- Create: `e2e/cancel-run.spec.ts`
+- Modify: `assets/js/index.js` (stop branch, ~line 1640-1644)
+- Modify: `assets/js/resources.js` (stop branch, ~line 1209-1213)
+
+**Interfaces:**
+
+- Consumes: the wire action `{"action": "cancelRun", "runToken": "<token>"}` produced by Task 1.
+- Produces: `installWebSocketStub(page: Page): Promise<void>` from `e2e/websocket-stub.ts`, which sets
+  `window.__wsSent: string[]` in the page — reusable by later protocol work (#42).
+
+- [ ] **Step 1: Create the branch and start the servers this task needs**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
+git checkout main && git pull && git checkout -b feat/43-cancel-run
+```
+
+The spec stubs the WebSocket, so **no WebSocket server is needed**. Two things are:
+
+```bash
+# 1. The API on :8000 — the page's /calendars, /missals and /tests fetches gate the start button.
+#    Start it however this machine normally does (docker compose up -d in the API checkout, or
+#    `composer start` there). Verify:
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8000/calendars   # expect 200
+
+# 2. The UnitTestInterface pages on :3003, served from THIS checkout:
+cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
+php -S localhost:3003 &
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:3003/            # expect 200
+```
+
+Serving from this checkout matters: `playwright.config.ts` has no `webServer` block, so the specs test whatever is
+already on `:3003`. Point it at the wrong directory and the run silently exercises unmodified files.
+
+- [ ] **Step 2: Write the WebSocket stub**
+
+Create `e2e/websocket-stub.ts`:
+
+```typescript
+import { Page } from '@playwright/test';
+
+/**
+ * Replaces `window.WebSocket` with a recorder that reports itself open and never replies.
+ *
+ * Both runners drive themselves from `conn.onmessage` — the next request is only sent once the previous
+ * response has been handled — so a stub that never answers parks a started run after its first outbound
+ * frame. That is exactly the state the stop button exists for, and it is reachable without a WebSocket
+ * server, which `playwright.config.ts` does not start.
+ *
+ * Every outbound frame is recorded on `window.__wsSent` for assertions.
+ *
+ * Must be installed before navigation: the runners construct their WebSocket at module scope.
+ */
+export const installWebSocketStub = async (page: Page): Promise<void> => {
+    await page.addInitScript(() => {
+        const sent: string[] = [];
+        (window as unknown as { __wsSent: string[] }).__wsSent = sent;
+
+        class StubWebSocket {
+            static readonly CONNECTING = 0;
+            static readonly OPEN = 1;
+            static readonly CLOSING = 2;
+            static readonly CLOSED = 3;
+
+            readonly CONNECTING = 0;
+            readonly OPEN = 1;
+            readonly CLOSING = 2;
+            readonly CLOSED = 3;
+
+            readyState = 0;
+            onopen: ((event: unknown) => void) | null = null;
+            onmessage: ((event: unknown) => void) | null = null;
+            onclose: ((event: unknown) => void) | null = null;
+            onerror: ((event: unknown) => void) | null = null;
+
+            constructor(public readonly url: string) {
+                // `onopen` is assigned after the constructor returns, so open on the next tick.
+                setTimeout(() => {
+                    this.readyState = 1;
+                    this.onopen?.({});
+                }, 0);
+            }
+
+            send(data: string): void {
+                sent.push(data);
+            }
+
+            close(): void {
+                this.readyState = 3;
+            }
+
+            addEventListener(): void {}
+
+            removeEventListener(): void {}
+        }
+
+        (window as unknown as { WebSocket: unknown }).WebSocket = StubWebSocket;
+    });
+};
+
+/** Every frame the page has sent, oldest first. */
+export const sentFrames = (page: Page): Promise<string[]> =>
+    page.evaluate(() => (window as unknown as { __wsSent: string[] }).__wsSent ?? []);
+```
+
+- [ ] **Step 3: Write the failing spec**
+
+Create `e2e/cancel-run.spec.ts`:
+
+```typescript
+import { test, expect, Page } from '@playwright/test';
+import { installWebSocketStub, sentFrames } from './websocket-stub';
+
+/**
+ * Stopping a run tells the server (UnitTestInterface#43, LiturgicalCalendarAPI#806 section H).
+ *
+ * Stopping used to be purely local: state was reset, incoming frames were dropped, and the server kept
+ * fetching calendars for a run nobody was watching. Both runners must now send `cancelRun` naming the
+ * run being abandoned.
+ *
+ * The WebSocket is stubbed, so these specs need no WebSocket server — only the API on :8000, whose
+ * /calendars, /missals and /tests responses gate the start button.
+ */
+
+/** Start a run, then stop it, returning every frame the page sent. */
+const startThenStop = async (page: Page, path: string): Promise<string[]> => {
+    await installWebSocketStub(page);
+    await page.goto(path);
+
+    const startBtn = page.locator('#startTestRunnerBtn');
+    await expect(startBtn).toBeEnabled({ timeout: 20000 });
+
+    await startBtn.click();
+    // The stub never replies, so the run parks after its first request. Wait for that request rather
+    // than for a fixed delay, so the cancel is provably the *second* thing sent.
+    await expect.poll(async () => (await sentFrames(page)).length, { timeout: 10000 }).toBeGreaterThan(0);
+
+    await startBtn.click(); // same button, now in its stop role
+    return sentFrames(page);
+};
+
+test('the Calendars runner tells the server when a run is stopped', async ({ page }) => {
+    const frames = await startThenStop(page, '/');
+
+    const cancel = JSON.parse(frames[frames.length - 1]);
+    expect(cancel.action).toBe('cancelRun');
+    expect(typeof cancel.runToken).toBe('string');
+
+    // The cancel must name the run it is abandoning, not some fresh value.
+    const firstRequest = JSON.parse(frames[0]);
+    expect(cancel.runToken).toBe(firstRequest.runToken);
+});
+
+test('the Resources runner tells the server when a run is stopped', async ({ page }) => {
+    const frames = await startThenStop(page, '/resources.php');
+
+    const cancel = JSON.parse(frames[frames.length - 1]);
+    expect(cancel.action).toBe('cancelRun');
+    expect(typeof cancel.runToken).toBe('string');
+
+    const firstRequest = JSON.parse(frames[0]);
+    expect(cancel.runToken).toBe(firstRequest.runToken);
+});
+```
+
+- [ ] **Step 4: Run the spec to verify it fails**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
+npx playwright test e2e/cancel-run.spec.ts --project=chromium --no-deps
+```
+
+`--no-deps` skips the `setup` project, which authenticates against Zitadel and is unrelated here; the stored
+`e2e/.auth/user.json` is reused.
+
+Expected: **2 failures**. The last recorded frame is still the run's final validation request, so
+`expect(cancel.action).toBe('cancelRun')` fails with the action of whatever the runner sent last
+(`executeValidation` or `validateCalendar`).
+
+- [ ] **Step 5: Send the cancel from the Calendars runner**
+
+In `assets/js/index.js`, in the stop branch of the `#startTestRunnerBtn` click handler, insert immediately after
+`console.log( 'Stopping test run...' );` and before `currentState = TestState.Stopped;`:
+
+```javascript
+        // Tell the server the run is abandoned, so it stops draining a backlog nobody is watching.
+        // Must happen before currentRunToken is cleared: sendMessage() attaches the token, and the
+        // cancel has to name the run it is stopping. The explicit null test matters because
+        // sendMessage() omits the token when there is none, and a cancel without one is a protocol
+        // error the server rejects.
+        if ( conn.readyState === WebSocket.OPEN && currentRunToken !== null ) {
+            sendMessage( { action: 'cancelRun' } );
+        }
+```
+
+- [ ] **Step 6: Send the cancel from the Resources runner**
+
+In `assets/js/resources.js`, in the stop branch of the `#startTestRunnerBtn` click handler, insert immediately after
+`console.log( 'Stopping test run...' );` and before `currentState = TestState.Stopped;`:
+
+```javascript
+        // Tell the server the run is abandoned, so it stops draining a backlog nobody is watching.
+        // Must happen before currentRunToken is cleared: sendMessage() attaches the token, and the
+        // cancel has to name the run it is stopping. The explicit null test matters because
+        // sendMessage() omits the token when there is none, and a cancel without one is a protocol
+        // error the server rejects.
+        if ( conn.readyState === WebSocket.OPEN && currentRunToken !== null ) {
+            sendMessage( { action: 'cancelRun' } );
+        }
+```
+
+- [ ] **Step 7: Run the spec to verify it passes**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
+npx playwright test e2e/cancel-run.spec.ts --project=chromium --no-deps
+```
+
+Expected: `2 passed`.
+
+If instead the start button never enables, the API on `:8000` is not up — fix that rather than relaxing the assertion.
+If the run does not park after its first frame, report it; do not replace the poll with a fixed `waitForTimeout`.
+
+- [ ] **Step 8: Typecheck and syntax-check**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
+npm run typecheck
+node --check assets/js/index.js
+node --check assets/js/resources.js
+```
+
+Expected: all clean.
+
+- [ ] **Step 9: Check for regressions in the specs that share this surface**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
+npx playwright test e2e/result-painting.spec.ts e2e/results-replay.spec.ts e2e/results-replay-resources.spec.ts e2e/rite-selection.spec.ts --project=chromium --no-deps
+```
+
+Expected: all pass. These are the specs that touch the runners and the painter.
+
+- [ ] **Step 10: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
+git add e2e/websocket-stub.ts e2e/cancel-run.spec.ts assets/js/index.js assets/js/resources.js
+git commit -m "fix(runner): tell the server when a run is stopped
+
+Stopping a run was purely local: state was reset, incoming frames were
+dropped, and the server kept fetching calendars and validating files for a
+run nobody was watching. On a wide year range that is 81 calendar requests
+plus all their downstream validation, wasted on every stopped run.
+
+Both runners now send {action: 'cancelRun', runToken} before clearing the
+token — the cancel has to name the run it is abandoning. The readyState
+guard matters because stop is also reachable while the socket is
+reconnecting; a closed socket needs no cancel, since the server drops the
+run's queued work when the connection closes.
+
+The server side is LiturgicalCalendarAPI#806 section H. It answers with
+silence: PR #46 made an unrecognised response type paint a visible failure,
+so an ack frame would have needed handling here first.
+
+Verified with a new e2e spec that stubs window.WebSocket with a recorder
+that opens and never replies, parking the run after its first request. The
+stub needs no WebSocket server — playwright.config.ts starts none — and is
+written for reuse by the protocol work in #42.
+
+Closes #43
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Publish and cross-link
+
+**Files:** none — repository and issue metadata only.
+
+**Interfaces:**
+
+- Consumes: the branches produced by Tasks 1 and 2.
+
+- [ ] **Step 1: Push both branches**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-cancelrun
+git push -u origin feat/cancel-run
+
+cd /home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface
+git push -u origin feat/43-cancel-run
+```
+
+- [ ] **Step 2: Open the server PR**
+
+Base `development`. Body must state: what leaked (stop-and-walk-away), that
+`dropSupersededQueuedRequests()` already existed and is reused unchanged, why the token-match guard is load-bearing, why
+the action is silent, and the verification output from Task 1 Steps 10-12.
+
+- [ ] **Step 3: Open the client PR**
+
+Base `main` (not `development`). Body must state the same wire contract, link the server PR, and carry the verification
+output from Task 2 Steps 7-9. Note explicitly that the WebSocket stub is groundwork for #42.
+
+- [ ] **Step 4: Comment on UnitTestInterface#43**
+
+Record which of its items this closes (item 3, the missing cancel message) and which it does not: the mid-run reconnect
+inconsistency, which is a resume-vs-abort design decision overlapping #28 rather than a bug fix. State that #43 closes on
+the client PR and that the reconnect item should move to #28.
+
+- [ ] **Step 5: Comment on API#806**
+
+Record that section H is implemented ahead of the rest of the proposal, using today's `runToken` field name rather than
+the proposed `runId`, so the rename is one line when the contract lands.

--- a/docs/superpowers/specs/2026-08-19-cancel-run-design.md
+++ b/docs/superpowers/specs/2026-08-19-cancel-run-design.md
@@ -1,0 +1,187 @@
+# `cancelRun`: telling the Health server a run was abandoned
+
+Design for the last open item in [UnitTestInterface#43](https://github.com/Liturgical-Calendar/UnitTestInterface/issues/43),
+implementing section H of [API#806](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/806).
+
+## Problem
+
+Stopping a test run in UnitTestInterface is currently a purely client-side act. The stop branch of both runners sets
+`currentState = TestState.Stopped` and `currentRunToken = null`, after which `conn.onmessage` drops every arriving frame.
+**No message is sent to the server.** The server keeps fetching calendars and validating files for a run nobody is watching.
+
+On a wide year range that is 81 calendar requests plus all their downstream validation, every one of them wasted.
+
+### What already exists
+
+The server is closer to solving this than #43 assumed. `Health::dropSupersededQueuedRequests()` already discards queued
+requests whose `runToken` no longer matches the connection's stored token, and queue entries are already tagged with both
+`resourceId` and `runToken` at enqueue time in `cachedGet()`.
+
+That covers **stop-then-restart**: a new run overwrites the connection's stored token, and the abandoned run's backlog is
+filtered on the next `processQueue()` pass.
+
+The gap is **stop-and-walk-away**. Nothing advances the stored token, so nothing is ever filtered, and the server drains
+the entire abandoned backlog.
+
+So this design is not "add cancellation to the server". It is "give the client a way to trigger the drop the server can
+already do".
+
+## Scope
+
+| In scope                                                    | Out of scope                                                        |
+|-------------------------------------------------------------|---------------------------------------------------------------------|
+| A `cancelRun` action that drops a run's **queued** requests | Aborting in-flight HTTP requests                                    |
+| The client-side send in both runners' stop branches         | Aborting local file reads and schema validation for a cancelled run |
+| A `CancelRun` phpstan-type alongside the existing five      | The rest of API#805's stale annotations                             |
+| Server-side unit coverage, client-side e2e coverage         | Any part of the v2 contract (API#806 sections A-G)                  |
+| —                                                           | The `runToken` → `runId` rename API#806 proposes                    |
+
+In-flight requests are deliberately left alone. They are capped at `maxConcurrency` — 4 in development, 10 in production —
+and the client already discards their result frames because `currentRunToken` is `null`. Chasing them would mean threading
+a cancellation check through roughly fifteen call sites in `Health.php` that currently thread only `$runToken`, for a
+bounded and small saving.
+
+The field keeps the name `runToken` rather than adopting API#806's proposed `runId`. Shipping a real fix today is worth
+more than pre-aligning with a contract that is still a proposal; the rename, when it lands, is one line here.
+
+## Server design — `src/Health.php`
+
+### 1. Declare the action's required properties
+
+`ACTION_PROPERTIES` gains:
+
+```php
+'cancelRun' => ['runToken']
+```
+
+`runToken` is optional on every other action. Making it **required** here means a cancel that omits it is rejected by the
+existing `validateMessageProperties()` path — surfacing as the standard protocol error — rather than reaching a handler
+that would have to decide what to clear. It also gives the unguarded `ACTION_PROPERTIES[$message->action]` lookup a
+defined entry for this action.
+
+### 2. Exempt `cancelRun` from the ambient token store
+
+`onMessage()` stores `runToken` from *any* inbound message before the switch runs. Left alone, a cancel would install the
+very token it is about to clear, and the match test in step 3 would always succeed — including for a stale cancel. The
+store is therefore gated on `$messageReceived->action !== 'cancelRun'`.
+
+### 3. The handler
+
+```php
+private function cancelRun(string $runToken, ConnectionInterface $from): void
+{
+    $resourceId = $from->resourceId;
+    if (false === is_int($resourceId) || ( $this->runTokens[$resourceId] ?? null ) !== $runToken) {
+        return;
+    }
+    unset($this->runTokens[$resourceId]);
+    $this->dropSupersededQueuedRequests();
+}
+```
+
+The match test is the load-bearing line. A cancel that names a run the connection is no longer on — the user stopped and
+restarted faster than the frame travelled — must be a no-op. Without the test it would clear the **new** run's token and
+drop the new run's queue, which is a worse bug than the one being fixed.
+
+`dropSupersededQueuedRequests()` is called directly rather than `processQueue()`. Dropping is the entire point of a
+cancel; `processQueue()` would additionally dispatch the surviving requests and re-arm the tick timer as a side effect.
+The tick loop that is already running picks up the shortened queue on its own.
+
+### 4. No new response vocabulary
+
+The server sends nothing back. This matches API#806 section H, and it matters more than it looks: UnitTestInterface PR #46
+just made an unrecognised response `type` paint a **visible failure**, so any acknowledgement frame would need matching
+handling in both runners or it would surface in the UI as a spurious failed check. A silent action adds nothing to a
+protocol that is about to be redesigned.
+
+### 5. Why `dropSupersededQueuedRequests()` needs no code change
+
+Its predicate keeps an entry when any of these holds:
+
+```php
+null === $item['resourceId']                                   // untagged, e.g. the connect-time metadata fetch
+| null === $item['runToken']                                  // enqueued before any run token was set |
+|------------------------------------------------------------------------------------------------------|
+```
+
+With the stored token unset, the third clause evaluates `null === 'run-a'` for the cancelled run's entries, so they are
+filtered. Untagged entries and other connections' entries are already protected by the first two clauses. Only the
+docblock changes, to name the second trigger — it currently describes supersession alone.
+
+## Client design — UnitTestInterface
+
+The stop branches of `assets/js/index.js` and `assets/js/resources.js` are identical in shape. Both gain the same insert,
+immediately before `currentRunToken = null`:
+
+```javascript
+if ( conn.readyState === WebSocket.OPEN ) {
+    conn.send( JSON.stringify( { action: 'cancelRun', runToken: currentRunToken } ) );
+}
+```
+
+The `readyState` guard matters because the stop button is also reachable while the socket is reconnecting. A closed socket
+needs no cancel: `Health::onClose()` already unsets the connection's stored token, and the queue drains on the next pass.
+
+Nothing else in the stop branch changes, and no response handling is added.
+
+The stop button is the **only** trigger. Navigating away or closing the tab needs no cancel: the socket closes, and
+`Health::onClose()` already unsets the connection's stored token, which produces the same drop on the next queue pass.
+
+## Data flow
+
+1. User clicks stop while a run is in flight.
+2. Client sends `{action: 'cancelRun', runToken: <the run's own token>}`, then performs its existing teardown.
+3. Server matches the token against the connection's stored token; on a match, clears it.
+4. `dropSupersededQueuedRequests()` filters every queued request tagged with that token.
+5. Requests already in flight complete and emit their frames; the client discards them, as it does today.
+
+## Error handling
+
+| Condition                              | Behaviour                                                                                 |
+|----------------------------------------|-------------------------------------------------------------------------------------------|
+| `runToken` missing from the message    | Rejected by `validateMessageProperties()`; existing protocol-error path, no state touched |
+| `runToken` does not match stored token | No-op. No frame, no state change, no queue filtering                                      |
+| `resourceId` is not an int             | No-op, same as above                                                                      |
+| Socket not `OPEN` when stop is clicked | Client skips the send; `onClose()` handles the cleanup                                    |
+| Cancel arrives with no queued requests | `dropSupersededQueuedRequests()` returns early on an empty queue                          |
+
+Only the first row produces anything visible. Since UnitTestInterface PR #46, the protocol-error frame is painted as a
+failure rather than silently consumed — which is the wanted behaviour for a client that sent a malformed cancel, and is
+the reason the success path stays silent.
+
+## Testing
+
+### Server
+
+New `phpunit_tests/HealthCancelRunTest.php`, following the stub-connection and reflection pattern established by
+`HealthFolderStepResultTest` — an anonymous `ConnectionInterface` that records outbound frames, driven in-process with no
+live socket. Reflection seeds `$runTokens` and `$queue`, then `onMessage()` is driven with a real JSON payload so the
+`ACTION_PROPERTIES` and token-store changes are exercised rather than bypassed.
+
+Cases:
+
+1. A matching cancel drops exactly that run's queued entries.
+2. Untagged entries survive.
+3. Another connection's entries survive.
+4. A stale cancel — the connection has already moved to a new token — changes nothing.
+5. A cancel missing `runToken` is rejected and changes nothing.
+6. No frame is emitted in the success case.
+
+### Client
+
+A Playwright spec using `page.addInitScript` to replace `window.WebSocket` with a recorder that reports itself open
+immediately and never replies. Start the run, stop it, and assert the last recorded outbound frame is the `cancelRun`
+carrying the token the run started with.
+
+The stub is written to be reusable: #42 will need exactly this to test protocol behaviour without a live server, and
+`playwright.config.ts` starts no WebSocket server today.
+
+If the stub proves flaky against the real start path, that will be reported rather than the client test being quietly
+dropped.
+
+## What this does not fix
+
+The mid-run reconnect inconsistency also recorded in #43 — `onclose` reconnects and `onopen` resets `currentState`
+underneath an in-flight run while `currentRunToken` stays set — is untouched. Resolving it means choosing between
+resuming and aborting the run, which is a design decision overlapping UnitTestInterface#28, not a bug fix. #43 can close
+on this work; the reconnect item belongs with #28.

--- a/docs/superpowers/specs/2026-08-19-cancel-run-design.md
+++ b/docs/superpowers/specs/2026-08-19-cancel-run-design.md
@@ -100,8 +100,8 @@ Its predicate keeps an entry when any of these holds:
 
 ```php
 null === $item['resourceId']                                   // untagged, e.g. the connect-time metadata fetch
-| null === $item['runToken']                                  // enqueued before any run token was set |
-|------------------------------------------------------------------------------------------------------|
+|| null === $item['runToken']                                  // enqueued before any run token was set
+|| ( $this->runTokens[$item['resourceId']] ?? null ) === $item['runToken']
 ```
 
 With the stored token unset, the third clause evaluates `null === 'run-a'` for the cancelled run's entries, so they are

--- a/docs/superpowers/specs/2026-08-19-cancel-run-design.md
+++ b/docs/superpowers/specs/2026-08-19-cancel-run-design.md
@@ -114,13 +114,19 @@ The stop branches of `assets/js/index.js` and `assets/js/resources.js` are ident
 immediately before `currentRunToken = null`:
 
 ```javascript
-if ( conn.readyState === WebSocket.OPEN ) {
-    conn.send( JSON.stringify( { action: 'cancelRun', runToken: currentRunToken } ) );
+if ( conn.readyState === WebSocket.OPEN && currentRunToken !== null ) {
+    sendMessage( { action: 'cancelRun' } );
 }
 ```
 
+Both runners already carry an identical `sendMessage()` helper that attaches `currentRunToken` to any outbound payload,
+so the cancel is guaranteed to name the same run its sibling frames named. That is also why the insert must precede
+`currentRunToken = null`.
+
 The `readyState` guard matters because the stop button is also reachable while the socket is reconnecting. A closed socket
 needs no cancel: `Health::onClose()` already unsets the connection's stored token, and the queue drains on the next pass.
+The explicit null test is the second half of the same care: `sendMessage()` omits the token when there is none, and a
+cancel carrying no token is a protocol error the server rejects.
 
 Nothing else in the stop branch changes, and no response handling is added.
 

--- a/docs/superpowers/specs/2026-08-19-cancel-run-design.md
+++ b/docs/superpowers/specs/2026-08-19-cancel-run-design.md
@@ -68,8 +68,11 @@ store is therefore gated on `$messageReceived->action !== 'cancelRun'`.
 ### 3. The handler
 
 ```php
-private function cancelRun(string $runToken, ConnectionInterface $from): void
+private function cancelRun(mixed $runToken, ConnectionInterface $from): void
 {
+    if (false === is_string($runToken)) {
+        return;
+    }
     $resourceId = $from->resourceId;
     if (false === is_int($resourceId) || ( $this->runTokens[$resourceId] ?? null ) !== $runToken) {
         return;
@@ -78,6 +81,12 @@ private function cancelRun(string $runToken, ConnectionInterface $from): void
     $this->dropSupersededQueuedRequests();
 }
 ```
+
+The parameter is `mixed`, not `string`, because `validateMessageProperties()` checks that a property *exists* and
+nothing more. A `runToken` of `null`, `[]` or `{}` therefore passes validation and reaches this handler, and none of
+those coerce in weak mode — they raise `TypeError`, which is an `\Error`, and Ratchet's `IoServer::handleData` catches
+only `\Exception`. An unguarded typed parameter here would let any client kill the WebSocket process with one frame.
+The three pre-existing actions carry the same exposure and are deliberately left alone; see the scope table.
 
 The match test is the load-bearing line. A cancel that names a run the connection is no longer on — the user stopped and
 restarted faster than the frame travelled — must be a no-op. Without the test it would clear the **new** run's token and
@@ -157,17 +166,25 @@ The stop button is the **only** trigger. Navigating away or closing the tab need
 
 ## Error handling
 
-| Condition                              | Behaviour                                                                                 |
-|----------------------------------------|-------------------------------------------------------------------------------------------|
-| `runToken` missing from the message    | Rejected by `validateMessageProperties()`; existing protocol-error path, no state touched |
-| `runToken` does not match stored token | No-op. No frame, no state change, no queue filtering                                      |
-| `resourceId` is not an int             | No-op, same as above                                                                      |
-| Socket not `OPEN` when stop is clicked | Client skips the send; `onClose()` handles the cleanup                                    |
-| Cancel arrives with no queued requests | `dropSupersededQueuedRequests()` returns early on an empty queue                          |
+| Condition                                                | Behaviour                                                                                 |
+|----------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| `runToken` missing from the message                      | Rejected by `validateMessageProperties()`; existing protocol-error path, no state touched |
+| `runToken` present but not a string                      | No-op inside the handler. No frame, no state change, no queue filtering                   |
+| `runToken` a string that does not match the stored token | No-op, same as above                                                                      |
+| `resourceId` is not an int                               | No-op, same as above                                                                      |
+| Socket not `OPEN` when stop is clicked                   | Client skips the send; `onClose()` handles the cleanup                                    |
+| Cancel arrives with no queued requests                   | `dropSupersededQueuedRequests()` returns early on an empty queue                          |
 
-Only the first row produces anything visible. Since UnitTestInterface PR #46, the protocol-error frame is painted as a
-failure rather than silently consumed — which is the wanted behaviour for a client that sent a malformed cancel, and is
-the reason the success path stays silent.
+**Only the first row produces anything visible.** The asymmetry is deliberate, and worth stating because it can read as
+inconsistent: a *missing* `runToken` is caught by the generic presence validator every action shares, so it comes back
+as the standard protocol error — and since UnitTestInterface PR #46 that error is painted as a failed check, which is
+the right outcome for a client that sent a malformed frame. A `runToken` that is present but unusable instead reaches
+the handler, whose contract is already that a cancel it cannot act on changes nothing and says nothing. Making it
+shout would mean a stale cancel — an ordinary race, not a client bug — shouting too.
+
+The third row covers more than a stale token. Because `cancelRun` is exempt from the ambient token store, a token whose
+format could never have been stored in the first place (the store requires `^[A-Za-z0-9_\-]{1,64}$`) simply fails the
+match like any other non-matching string. There is no separate code path for it.
 
 ## Testing
 
@@ -186,6 +203,12 @@ Cases:
 4. A stale cancel — the connection has already moved to a new token — changes nothing.
 5. A cancel missing `runToken` is rejected and changes nothing.
 6. No frame is emitted in the success case.
+7. A cancel whose `runToken` is present but not a string is a silent no-op, and above all does not throw.
+8. An *ordinary* message still stores its `runToken`. This one guards the exemption clause rather than the cancel:
+   invert that comparison and every normal run loses response correlation silently, with a green suite.
+
+Cases 7 and 8 were added in response to the final whole-branch review, not foreseen when this document was first
+written.
 
 ### Client
 

--- a/docs/superpowers/specs/2026-08-19-cancel-run-design.md
+++ b/docs/superpowers/specs/2026-08-19-cancel-run-design.md
@@ -110,23 +110,37 @@ docblock changes, to name the second trigger — it currently describes superses
 
 ## Client design — UnitTestInterface
 
-The stop branches of `assets/js/index.js` and `assets/js/resources.js` are identical in shape. Both gain the same insert,
-immediately before `currentRunToken = null`:
+The stop branches of `assets/js/index.js` and `assets/js/resources.js` are identical in shape. Rather than pasting the
+same block into both, the behaviour goes into a new shared module, `assets/js/wsProtocol.js`:
 
 ```javascript
-if ( conn.readyState === WebSocket.OPEN && currentRunToken !== null ) {
-    sendMessage( { action: 'cancelRun' } );
-}
+export const sendCancelRun = ( conn, runToken ) => {
+    if ( !conn || conn.readyState !== WebSocket.OPEN ) {
+        return false;
+    }
+    if ( typeof runToken !== 'string' || runToken === '' ) {
+        return false;
+    }
+    conn.send( JSON.stringify( { action: 'cancelRun', runToken } ) );
+    return true;
+};
 ```
 
-Both runners already carry an identical `sendMessage()` helper that attaches `currentRunToken` to any outbound payload,
-so the cancel is guaranteed to name the same run its sibling frames named. That is also why the insert must precede
-`currentRunToken = null`.
+Both runners import it and call `sendCancelRun( conn, currentRunToken )` immediately before `currentRunToken = null` —
+the cancel has to name the run it is stopping.
+
+The two runners are already independent implementations of the same protocol that have drifted apart in ways that cost
+debugging sessions — different state names, different `runToken` guards, two vocabularies for the same file. Adding a
+fourth thing to keep in lockstep would be the wrong direction, and both files are already ES modules importing from
+`./common.js`, so a shared module costs nothing in page wiring. `wsProtocol.js` is the seed of the shared protocol
+client #42 will grow.
 
 The `readyState` guard matters because the stop button is also reachable while the socket is reconnecting. A closed socket
 needs no cancel: `Health::onClose()` already unsets the connection's stored token, and the queue drains on the next pass.
-The explicit null test is the second half of the same care: `sendMessage()` omits the token when there is none, and a
-cancel carrying no token is a protocol error the server rejects.
+The token test is the second half of the same care — a cancel carrying no token is a protocol error the server rejects,
+and since PR #46 the UI would paint that rejection as a failed check.
+
+Returning a boolean is what makes the two guard branches testable at all: neither is reachable by clicking.
 
 Nothing else in the stop branch changes, and no response handling is added.
 
@@ -175,9 +189,11 @@ Cases:
 
 ### Client
 
-A Playwright spec using `page.addInitScript` to replace `window.WebSocket` with a recorder that reports itself open
-immediately and never replies. Start the run, stop it, and assert the last recorded outbound frame is the `cancelRun`
-carrying the token the run started with.
+A Playwright spec in two halves. Three cases import `wsProtocol.js` directly in the page context — the technique
+`e2e/result-painting.spec.ts` already uses — and call `sendCancelRun()` against a recording fake connection, covering
+the frame it emits and the two guard branches that no amount of clicking can reach. Two more cases stub
+`window.WebSocket` with a recorder that reports itself open and never replies, then start and stop a run on each page
+and assert the last recorded frame is the `cancelRun` carrying the token the run started with.
 
 The stub is written to be reusable: #42 will need exactly this to test protocol behaviour without a live server, and
 `playwright.config.ts` starts no WebSocket server today.

--- a/phpunit_tests/HealthCancelRunTest.php
+++ b/phpunit_tests/HealthCancelRunTest.php
@@ -180,4 +180,57 @@ final class HealthCancelRunTest extends TestCase
         self::assertSame('echobot', $frame->type);
         self::assertSame('Invalid message properties', $frame->errorMsg);
     }
+
+    /**
+     * Regression test for the `$messageReceived->action !== 'cancelRun'` exemption on the ambient
+     * run-token store at the top of `onMessage()`. If that comparison were ever accidentally inverted
+     * to `===`, every *non*-cancelRun message would stop storing its token — `cancelRun` would keep
+     * working, but every ordinary run would silently lose response correlation, and a green suite
+     * would not notice, because all the other `runToken` coverage in this file seeds `$runTokens` by
+     * reflection and calls private handlers directly rather than driving them through `onMessage()`.
+     *
+     * `validateCalendar` is used as the "ordinary message" here because, sent with only `runToken`, it
+     * is missing every other required property (`category`, `calendar`, `year`, `responsetype`), so
+     * `validateMessageProperties()` rejects it and `onMessage()` falls straight to the protocol-error
+     * path — confirmed by the asserted echoed frame below — without dispatching an HTTP request or file
+     * read. That is what makes it safe to drive through the real entry point in a unit test.
+     */
+    public function testAnOrdinaryMessageStillStoresItsRunToken(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        $health->onMessage($conn, (string) json_encode(['action' => 'validateCalendar', 'runToken' => 'run-a']));
+
+        self::assertSame([1 => 'run-a'], self::getRunTokens($health), 'an ordinary message still stores its run token');
+
+        self::assertCount(1, $conn->sent, 'confirms the message short-circuited on the protocol-error path, not real work');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('Invalid message properties', $frame->errorMsg, 'confirms it never reached the validateCalendar dispatch');
+    }
+
+    /**
+     * `validateMessageProperties()` checks only that `runToken` is *present*, not that it is a string —
+     * `{"action":"cancelRun","runToken":null}` (same for an array or object) passes validation and
+     * reaches `cancelRun()`. Before its `is_string()` guard, PHP's weak-mode parameter coercion throws
+     * `TypeError` for a non-string argument against a `string` parameter; Ratchet's `IoServer::handleData`
+     * only catches `\Exception`, so that `\Error` would escape uncaught and take the whole WebSocket
+     * process down over one malformed cancel. A cancel the server cannot act on is already a documented
+     * no-op for a stale token (see `cancelRun()`'s docblock); this asserts a non-string token folds into
+     * that same no-op instead of crashing.
+     */
+    public function testACancelWithANonStringRunTokenIsASilentNoOp(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        self::setRunTokens($health, [1 => 'run-a']);
+        self::setQueue($health, [self::queueEntry('https://example.test/a', 1, 'run-a')]);
+
+        $health->onMessage($conn, (string) json_encode(['action' => 'cancelRun', 'runToken' => null]));
+
+        self::assertCount(1, self::getQueue($health), 'the queued request survives an unusable cancel');
+        self::assertSame([1 => 'run-a'], self::getRunTokens($health), 'the stored token is untouched');
+        self::assertSame([], $conn->sent, 'a cancel the server cannot act on stays silent, same as a stale token');
+    }
 }

--- a/phpunit_tests/HealthCancelRunTest.php
+++ b/phpunit_tests/HealthCancelRunTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * `cancelRun` — the client telling the server a run was abandoned.
+ *
+ * Stopping a run used to be purely client-side: the runner dropped incoming frames while the server
+ * kept working through the abandoned run's backlog. The server already knew how to discard such
+ * requests — `dropSupersededQueuedRequests()` filters queue entries whose `runToken` no longer matches
+ * the connection's stored token — but only a *restart* ever advanced that token. `cancelRun` clears it
+ * on demand, which is why these tests assert on the queue rather than on any response frame: the
+ * action is deliberately silent.
+ *
+ * See UnitTestInterface#43 and #806 section H.
+ */
+#[CoversClass(Health::class)]
+final class HealthCancelRunTest extends TestCase
+{
+    /**
+     * A minimal Ratchet connection that records every outbound frame. `resourceId` is a dynamic public
+     * property Ratchet assigns and is not part of `ConnectionInterface`, so this mirrors the stub
+     * convention already used by HealthFolderStepResultTest rather than a PHPUnit mock, which would
+     * trigger a dynamic-property deprecation.
+     */
+    private static function createStubConnection(int $resourceId)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * A queue entry shaped like the ones `cachedGet()` enqueues. The promise callbacks are never
+     * invoked here — these tests only ever inspect which entries survive the filter.
+     *
+     * @return array<string, mixed>
+     */
+    private static function queueEntry(string $url, ?int $resourceId, ?string $runToken): array
+    {
+        return [
+            'url'        => $url,
+            'options'    => [],
+            'resolve'    => static function (): void {
+            },
+            'reject'     => static function (): void {
+            },
+            'resourceId' => $resourceId,
+            'runToken'   => $runToken
+        ];
+    }
+
+    /** @param list<array<string, mixed>> $queue */
+    private static function setQueue(Health $health, array $queue): void
+    {
+        ( new \ReflectionProperty(Health::class, 'queue') )->setValue($health, $queue);
+    }
+
+    /** @return list<array<string, mixed>> */
+    private static function getQueue(Health $health): array
+    {
+        /** @var list<array<string, mixed>> */
+        return ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+    }
+
+    /** @param array<int, string> $tokens */
+    private static function setRunTokens(Health $health, array $tokens): void
+    {
+        ( new \ReflectionProperty(Health::class, 'runTokens') )->setValue($health, $tokens);
+    }
+
+    /** @return array<int, string> */
+    private static function getRunTokens(Health $health): array
+    {
+        /** @var array<int, string> */
+        return ( new \ReflectionProperty(Health::class, 'runTokens') )->getValue($health);
+    }
+
+    /** @param array<string, string> $payload */
+    private static function cancel(Health $health, ConnectionInterface $conn, array $payload): void
+    {
+        $health->onMessage($conn, (string) json_encode($payload));
+    }
+
+    public function testCancellingTheCurrentRunDropsItsQueuedRequestsAndSaysNothing(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        self::setRunTokens($health, [1 => 'run-a']);
+        self::setQueue($health, [
+            self::queueEntry('https://example.test/a', 1, 'run-a'),
+            self::queueEntry('https://example.test/b', 1, 'run-a')
+        ]);
+
+        self::cancel($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertSame([], self::getQueue($health), 'the cancelled run keeps no queued work');
+        self::assertSame([], self::getRunTokens($health), 'the connection is no longer on any run');
+        self::assertSame([], $conn->sent, 'cancelRun is acknowledged by silence, not by a frame');
+    }
+
+    public function testUntaggedAndOtherConnectionsRequestsSurvive(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        self::setRunTokens($health, [1 => 'run-a', 2 => 'run-b']);
+        self::setQueue($health, [
+            // The connect-time metadata fetch carries no run token and belongs to no run.
+            self::queueEntry('https://example.test/metadata', null, null),
+            self::queueEntry('https://example.test/mine', 1, 'run-a'),
+            self::queueEntry('https://example.test/theirs', 2, 'run-b')
+        ]);
+
+        self::cancel($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertSame(
+            ['https://example.test/metadata', 'https://example.test/theirs'],
+            array_column(self::getQueue($health), 'url')
+        );
+        self::assertSame([2 => 'run-b'], self::getRunTokens($health), 'the other connection keeps its run');
+    }
+
+    public function testAStaleCancelDoesNotTouchTheRunThatReplacedIt(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        // The user stopped and restarted faster than the cancel frame travelled: the connection is
+        // already on run-b when the cancel naming run-a arrives.
+        self::setRunTokens($health, [1 => 'run-b']);
+        self::setQueue($health, [self::queueEntry('https://example.test/new-run', 1, 'run-b')]);
+
+        self::cancel($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertCount(1, self::getQueue($health), 'the new run keeps its queued work');
+        self::assertSame([1 => 'run-b'], self::getRunTokens($health), 'the new run keeps its token');
+        self::assertSame([], $conn->sent);
+    }
+
+    public function testACancelWithoutARunTokenIsRejectedAndChangesNothing(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection(1);
+
+        self::setRunTokens($health, [1 => 'run-a']);
+        self::setQueue($health, [self::queueEntry('https://example.test/a', 1, 'run-a')]);
+
+        self::cancel($health, $conn, ['action' => 'cancelRun']);
+
+        self::assertCount(1, self::getQueue($health));
+        self::assertSame([1 => 'run-a'], self::getRunTokens($health));
+
+        self::assertCount(1, $conn->sent, 'a malformed cancel is a protocol error, and those are visible');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('Invalid message properties', $frame->errorMsg);
+    }
+}

--- a/src/Health.php
+++ b/src/Health.php
@@ -529,11 +529,22 @@ class Health implements MessageComponentInterface
      *
      * Nothing is sent back; see #806 section H.
      *
-     * @param string $runToken The run the client wants abandoned.
+     * `validateMessageProperties()` only checks that `runToken` is *present*, not that it is a string —
+     * `{"action":"cancelRun","runToken":null}` (or an array, or an object) passes validation and reaches
+     * here. In weak mode PHP does not coerce those into a `string` parameter; it throws `TypeError`, and
+     * Ratchet's `IoServer::handleData` only catches `\Exception`, so an `\Error` escapes and kills the
+     * whole WebSocket process over one malformed cancel. A cancel the server cannot act on is already a
+     * documented no-op (see above), so a non-string token folds into that same no-op path instead.
+     *
+     * @param mixed $runToken The run the client wants abandoned. Expected to be a string, but the caller
+     *                        only guarantees the property exists, not its type — see above.
      * @param ConnectionInterface $from The connection that asked.
      */
-    private function cancelRun(string $runToken, ConnectionInterface $from): void
+    private function cancelRun(mixed $runToken, ConnectionInterface $from): void
     {
+        if (false === is_string($runToken)) {
+            return;
+        }
         $resourceId = $from->resourceId;
         if (false === is_int($resourceId) || ( $this->runTokens[$resourceId] ?? null ) !== $runToken) {
             return;

--- a/src/Health.php
+++ b/src/Health.php
@@ -65,6 +65,7 @@ use Psr\Http\Message\ResponseInterface;
  * @phpstan-type ExecuteValidationResource \stdClass&object{action:'executeValidation',category:'resourceDataCheck',validate:string,sourceFile:string,responsetype?:string}
  * @phpstan-type ValidateCalendar \stdClass&object{action:'validateCalendar',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',responsetype:'JSON'|'XML'|'ICS'|'YML',rite?:string}
  * @phpstan-type ExecuteUnitTest \stdClass&object{action:'executeUnitTest',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',test:string,rite?:string}
+ * @phpstan-type CancelRun \stdClass&object{action:'cancelRun',runToken:string}
  *
  * @phpstan-import-type LiturgicalEvent from \LiturgicalCalendar\Api\Test\LitTestRunner
  */
@@ -87,7 +88,8 @@ class Health implements MessageComponentInterface
     private const ACTION_PROPERTIES = [
         'executeValidation' => ['category', 'validate', 'sourceFile'],
         'validateCalendar'  => ['category', 'calendar', 'year', 'responsetype'],
-        'executeUnitTest'   => ['category', 'calendar', 'year', 'test']
+        'executeUnitTest'   => ['category', 'calendar', 'year', 'test'],
+        'cancelRun'         => ['runToken']
     ];
 
     private const RED    = "\033[0;31m";
@@ -362,11 +364,16 @@ class Health implements MessageComponentInterface
         // Reset per-connection cache hit counter for each new message (test run)
         $this->cacheHitCounters[$resourceId] = 0;
         echo sprintf('Receiving message from connection %d: %s', $resourceId, $msg . "\n");
-        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest $messageReceived */
+        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest|CancelRun $messageReceived */
         $messageReceived = json_decode($msg);
-        // Store optional run token for response correlation
+        // Store optional run token for response correlation. `cancelRun` is exempt: it names the run it
+        // wants abandoned rather than the run this connection is on, and storing it here would install
+        // the very token cancelRun() is about to clear — making even a stale cancel match, and dropping
+        // the queue of the run that replaced it.
         if (
             $messageReceived instanceof \stdClass
+            && property_exists($messageReceived, 'action')
+            && $messageReceived->action !== 'cancelRun'
             && property_exists($messageReceived, 'runToken')
             && is_string($messageReceived->runToken)
             && preg_match('/^[A-Za-z0-9_\-]{1,64}$/', $messageReceived->runToken)
@@ -405,6 +412,10 @@ class Health implements MessageComponentInterface
                         $from,
                         self::readRiteHint($messageReceived)
                     );
+                    break;
+                case 'cancelRun':
+                    /** @var CancelRun $messageReceived */
+                    $this->cancelRun($messageReceived->runToken, $from);
                     break;
                 default:
                     $message       = new \stdClass();
@@ -501,6 +512,34 @@ class Health implements MessageComponentInterface
     private function resolveRunToken(ConnectionInterface $conn): ?string
     {
         return is_int($conn->resourceId) ? ( $this->runTokens[$conn->resourceId] ?? null ) : null;
+    }
+
+    /**
+     * Abandon a run: forget its token, so its queued requests stop being work worth doing.
+     *
+     * Sent by the client when the user stops a run, so the server does not keep fetching calendars and
+     * validating files for a run nobody is watching. Only the queued backlog is dropped — requests
+     * already in flight are capped at maxConcurrency and their frames are discarded client-side, so
+     * chasing them would buy little for a great deal of plumbing.
+     *
+     * The token must match what this connection is currently running. A cancel naming a run the
+     * connection has already left — the user stopped and restarted faster than the frame travelled —
+     * is a no-op: acting on it would clear the token of the run that *replaced* it and drop that run's
+     * queue instead, which is a worse bug than the one this fixes.
+     *
+     * Nothing is sent back; see #806 section H.
+     *
+     * @param string $runToken The run the client wants abandoned.
+     * @param ConnectionInterface $from The connection that asked.
+     */
+    private function cancelRun(string $runToken, ConnectionInterface $from): void
+    {
+        $resourceId = $from->resourceId;
+        if (false === is_int($resourceId) || ( $this->runTokens[$resourceId] ?? null ) !== $runToken) {
+            return;
+        }
+        unset($this->runTokens[$resourceId]);
+        $this->dropSupersededQueuedRequests();
     }
 
     /**
@@ -1877,12 +1916,13 @@ class Health implements MessageComponentInterface
     }
 
     /**
-     * Drop queued requests whose run has been superseded: the client stopped and started a new run,
-     * so the connection's stored token has advanced. Their responses would be discarded by the
-     * client anyway, so skipping the work lets a restarted run dispatch immediately instead of first
-     * draining the abandoned run's backlog. Untagged requests (e.g. the metadata fetch on connect)
-     * carry no token and are always kept. In-flight requests are not affected (they are few — capped
-     * at maxConcurrency — and their responses are discarded client-side).
+     * Drop queued requests whose run this connection is no longer on. Two things cause that: the client
+     * stopped and started a new run, so the connection's stored token advanced; or the client sent
+     * `cancelRun` and {@see Health::cancelRun()} cleared the stored token outright. Their responses would
+     * be discarded by the client anyway, so skipping the work lets a restarted run dispatch immediately
+     * instead of first draining the abandoned run's backlog. Untagged requests (e.g. the metadata fetch
+     * on connect) carry no token and are always kept. In-flight requests are not affected (they are few —
+     * capped at maxConcurrency — and their responses are discarded client-side).
      */
     private function dropSupersededQueuedRequests(): void
     {
@@ -2024,7 +2064,7 @@ class Health implements MessageComponentInterface
      * specified action. If any expected property is missing from the message
      * object, the function returns false, indicating the message is invalid.
      *
-     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest $message The message object to validate.
+     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest|CancelRun $message The message object to validate.
      * @return bool True if all required properties are present, false otherwise.
      */
     private static function validateMessageProperties(\stdClass $message): bool


### PR DESCRIPTION
## What leaked

Stopping a test run in UnitTestInterface was purely client-side: the runner reset its state and dropped incoming frames, while this server kept fetching calendars and validating files for a run nobody was watching. On a wide year range that is 81 calendar requests plus all their downstream validation, wasted on every stopped run.

## Why the fix is this small

The server already knew how to discard that work. `dropSupersededQueuedRequests()` filters queued requests whose `runToken` no longer matches the connection's stored token, and `cachedGet()` already tags every queue entry with its `resourceId` and `runToken`.

That covers **stop-then-restart**: a new run overwrites the stored token and the abandoned backlog is filtered on the next pass. The gap was **stop-and-walk-away** — nothing advanced the stored token, so nothing was ever filtered.

So `cancelRun` clears the stored token on demand and reuses that filter. `dropSupersededQueuedRequests()` gains no behavioural change, only a docblock naming its second trigger.

Implements section H of #806, ahead of the rest of that proposal. Client half: Liturgical-Calendar/UnitTestInterface#47.

## The load-bearing part

Two changes cooperate, and the fix is wrong without either:

- `cancelRun` is exempt from the ambient run-token store at the top of `onMessage()`. That block stores `runToken` from *any* inbound message before the switch runs, so without the exemption a cancel would install the very token it is about to clear.
- The handler acts only when the token matches what the connection is currently running.

Together they make a stale cancel — the user stopped and restarted faster than the frame travelled — a complete no-op. Without either, it would clear the token of the run that *replaced* it and drop that run's queued work, which is a worse bug than the one being fixed. `testAStaleCancelDoesNotTouchTheRunThatReplacedIt` fails against the removal of either half.

## Deliberately not done

- **In-flight requests are not aborted.** They are capped at `maxConcurrency` (4 dev / 10 prod) and the client already discards their frames. Chasing them would mean threading a cancellation check through roughly fifteen call sites that currently thread only `$runToken`.
- **No acknowledgement frame.** UnitTestInterface#46 made an unrecognised response `type` paint a visible failure, so any new type would need matching handling in both runners first. `cancelRun` is silent by design.
- **The field stays `runToken`.** #806 proposes renaming it to `runId`; that rename is one line here when the contract lands.
- **`dropSupersededQueuedRequests()` is called, not `processQueue()`.** Dropping is the whole point of a cancel; `processQueue()` would additionally dispatch surviving requests and re-arm the tick timer as a side effect. The already-running tick loop picks up the shortened queue itself.

## Review findings addressed before opening

A whole-branch review raised two Important issues on top of the original work, both now fixed:

- **A non-string `runToken` was an uncaught `TypeError`.** `validateMessageProperties()` checks presence only, so `{"action":"cancelRun","runToken":null}` reached `cancelRun(string $runToken, …)`; `null`/array/object do not coerce, and Ratchet's `IoServer::handleData` catches only `\Exception`, so an `\Error` would escape and take the WS process down. Now guarded. This is exact parity with the three pre-existing actions, which are left alone as out of scope — worth a follow-up.
- **Nothing tested that a *non-cancel* message still stores its token.** Inverting the new exemption comparison would have silently broken response correlation for every ordinary run with a green suite. Now covered.

## Verification

```
vendor/bin/phpunit phpunit_tests/HealthCancelRunTest.php   OK (6 tests, 19 assertions)
composer lint                                              clean
composer analyse            (PHPStan level 10)             [OK] No errors
composer test:quick                                        no new failures
```

Both new tests were verified to fail before their fix by mutating the actual guarded lines, not by approximation.

The `composer test:quick` errors that do appear were checked against the base commit rather than assumed pre-existing: 23 typed-property errors in unrelated handler tests, and 17 `Routes/*` "could not detect API binding" errors from those tests targeting the main checkout's server rather than this worktree.

Design and plan are committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for cancelling active runs through the WebSocket connection.
  - Cancelled runs clear their queued requests while preserving unrelated and in-progress work.
  - Added safeguards for stale, invalid, or malformed cancellation requests.
  - Cancellation completes silently without sending an unnecessary response.
  - Both run interfaces now notify the server before clearing a cancelled run.

- **Documentation**
  - Added implementation and design documentation for run cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->