### PR TITLE
feat(validations): advertise the source data the API can check

### DIFF
--- a/docs/superpowers/plans/2026-08-19-checkable-inventory.md
+++ b/docs/superpowers/plans/2026-08-19-checkable-inventory.md
@@ -1,0 +1,1395 @@
+# `/validations` Checkable Inventory Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the API advertise the source data it can validate, so clients stop hardcoding this repo's on-disk layout.
+
+**Architecture:** A typed inventory of checkable items — half derived from `RomanMissal`, half explicit — is served by a
+new `GET /validations` endpoint and then reused inside `Health` so the same list resolves schemas for WebSocket checks.
+`Health` gains nothing and sheds two hand-maintained lookups.
+
+**Tech Stack:** PHP 8.4, PSR-7/15 handlers, PHPUnit 12, `swaggest/json-schema` for response validation.
+
+## Global Constraints
+
+- Work in the API worktree `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory` on branch
+  `feat/806-checkable-inventory` (PR base: `development`). **Never commit in the main checkout**
+  `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI` — it is shared with other agents.
+- Never use `git commit --no-verify`. Commits are GPG-signed; if signing fails, stop and ask rather than disabling it.
+- PSR-12 per `phpcs.xml`; short array syntax; 4-space indent; single quotes unless interpolating.
+- PHPStan level 10 over `src` only — `phpunit_tests/` is not analysed.
+- **Paths come from `JsonData` enum cases, never string literals.**
+- **`CheckableItem` must never serialize its `path`.** Keeping filesystem paths off the wire is the entire feature.
+- **The endpoint must not touch the filesystem.** Advertising is not verification; `exists` is the first check, not a
+  precondition for being listed.
+- Response envelope is `litcal_validations`, matching the house `litcal_*` convention.
+- No `protocol` field and no query parameters. Versioning is #806 section F; filtering is client-side by decision.
+- Spec: `docs/superpowers/specs/2026-08-19-checkable-inventory-design.md`.
+
+---
+
+## File Structure
+
+| File                                                              | Responsibility                                                   |
+|-------------------------------------------------------------------|------------------------------------------------------------------|
+| `src/Models/ValidationsPath/CheckableItem.php`                    | One item; owns the rule that `path` never crosses the wire       |
+| `src/Models/ValidationsPath/CheckableInventory.php`               | Builds the list (derived + explicit); lookup by id and by path   |
+| `src/Handlers/ValidationsHandler.php`                             | `GET /validations`; serialization only                           |
+| `src/Enum/Route.php`                                              | `case VALIDATIONS = '/validations'`                              |
+| `src/Enum/LitSchema.php`                                          | `case VALIDATIONS = '/LitCalValidationsPath.json'`               |
+| `src/Router.php`                                                  | `case 'validations'` dispatch                                    |
+| `jsondata/schemas/LitCalValidationsPath.json`                     | Response schema, refd by `openapi.json`                          |
+| `jsondata/schemas/openapi.json`                                   | `/validations` path entry                                        |
+| `src/Health.php`                                                  | Sheds the kind-1 arms of two lookups; delegates to the inventory |
+| `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php` | Equivalence with today's table, region mapping, scope predicate  |
+| `phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php`     | Fails when data exists on disk with no inventory entry           |
+| `phpunit_tests/Handlers/ValidationsHandlerTest.php`               | HTTP shape, no-path-leak, method and param handling              |
+| `phpunit_tests/Handlers/ReadonlyPathsResponseSchemaTest.php`      | One more case: `/validations` against its schema                 |
+
+### The 18 items
+
+Nine files and their nine `i18n` folders.
+
+**Derived from `RomanMissal`** (5 files + 5 folders). `RomanMissal::getMissalIds()` returns eleven ids;
+`getSanctoraleFileName($id)` returns a path for `EDITIO_TYPICA_1970`, `EDITIO_TYPICA_2002`, `EDITIO_TYPICA_2008`,
+`US_2011`, `IT_1983` and `false` for the other six. Labels come from `getName()`, i18n folders from
+`getSanctoraleI18nFilePath()`, and `region` from the same rule `produceMetadata()` uses — except that this inventory
+emits `null` where that method emits `'VA'` (see the spec's "`region` semantics").
+
+**Explicit** (4 files + 4 folders): Roman temporale, Roman decrees, Ambrosian temporale, Ambrosian sanctorale.
+
+The Ambrosian sanctorale's id is `sanctorale:ambrosian`, not the `sanctorale:ambrosian:2024` the spec's illustrative
+example shows. There is one Ambrosian sanctorale and no registry to derive an edition from, so baking a year into the
+id would promise a dimension that does not exist. The Roman sanctorale ids do carry their missal id, because there
+`RomanMissal` genuinely distinguishes five of them.
+
+---
+
+## Task 1: The inventory
+
+**Files:**
+
+- Create: `src/Models/ValidationsPath/CheckableItem.php`
+- Create: `src/Models/ValidationsPath/CheckableInventory.php`
+- Test: `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php`
+
+**Interfaces:**
+
+- Consumes: `LiturgicalCalendar\Api\Enum\Rite` (`Rite::ROMAN`, `Rite::AMBROSIAN`, string-backed);
+  `LiturgicalCalendar\Api\Enum\LitSchema` (string-backed, values start with `/`, `path()` returns a filesystem path);
+  `LiturgicalCalendar\Api\Enum\JsonData` (cases expose `path()`); `LiturgicalCalendar\Api\Enum\RomanMissal`
+  (`getMissalIds(): array`, `getSanctoraleFileName(string): string|false`, `getSanctoraleI18nFilePath(string): string|false`,
+  `getName(string): string`).
+- Produces: `CheckableItem` with public readonly `id`, `kind`, `rite` (`Rite`), `region` (`?string`), `label`,
+  `schema` (`LitSchema`), `steps` (`list<string>`), `path` (`string`); and
+  `CheckableInventory::all(): list<CheckableItem>`, `::byId(string $id): ?CheckableItem`,
+  `::byPath(string $path): ?CheckableItem`.
+
+- [ ] **Step 1: Confirm the worktree**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+git rev-parse --show-toplevel   # must end in -inventory
+git branch --show-current       # expect: feat/806-checkable-inventory
+ls vendor/bin/phpunit           # must exist
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\ValidationsPath;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The inventory of source data the API can validate (#806 step A).
+ *
+ * Its reason for existing is that the layout was written down in several places that had to be
+ * edited in lockstep — the client's path constants, `Health`'s schema table, the `.vscode` globs —
+ * and nothing failed loudly when they diverged. These tests pin the two properties that make one
+ * list safe to rely on: it resolves everything the old table resolved, and its `region` mapping is
+ * exactly what the client's scope predicate assumes.
+ */
+#[CoversClass(CheckableInventory::class)]
+#[CoversClass(CheckableItem::class)]
+final class CheckableInventoryTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // JsonData cases build filesystem paths from this prefix.
+        Router::$apiFilePath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR;
+    }
+
+    /**
+     * The arms of `Health::getPathToSchemaFile()` that name source-data FILES, pasted here as the
+     * oracle. The refactor in a later task is proved equivalent against this rather than assumed.
+     * The route arms of that table are not source data and stay where they are.
+     *
+     * @return array<string, LitSchema>
+     */
+    private static function legacyFileTable(): array
+    {
+        return [
+            JsonData::MISSALS_FOLDER->value . '/propriumdetempore/propriumdetempore.json'                 => LitSchema::PROPRIUMDETEMPORE,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_1970/propriumdesanctis_1970.json'       => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_2002/propriumdesanctis_2002.json'       => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_2008/propriumdesanctis_2008.json'       => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_IT_1983/propriumdesanctis_IT_1983.json' => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_US_2011/propriumdesanctis_US_2011.json' => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::AMBROSIAN_TEMPORALE_FILE->value                                                    => LitSchema::PROPRIUMDETEMPORE,
+            JsonData::AMBROSIAN_SANCTORALE_FILE->value                                                   => LitSchema::PROPRIUMDESANCTIS,
+        ];
+    }
+
+    public function testItResolvesEverythingTheOldFileTableResolved(): void
+    {
+        foreach (self::legacyFileTable() as $path => $schema) {
+            $item = CheckableInventory::byPath($path);
+            self::assertNotNull($item, "no inventory entry for {$path}");
+            self::assertSame($schema, $item->schema, "wrong schema for {$path}");
+        }
+    }
+
+    public function testEveryItemIsFullyPopulatedAndIdsAreUnique(): void
+    {
+        $ids = [];
+        foreach (CheckableInventory::all() as $item) {
+            self::assertNotSame('', $item->id);
+            self::assertContains($item->kind, ['file', 'folder']);
+            self::assertNotSame('', $item->label);
+            self::assertNotSame('', $item->path);
+            self::assertSame(['exists', 'parses', 'validates'], $item->steps);
+            $ids[] = $item->id;
+        }
+        self::assertSame(array_unique($ids), $ids, 'inventory ids must be unique');
+    }
+
+    public function testItHoldsNineFilesAndNineFolders(): void
+    {
+        $kinds = array_count_values(array_map(
+            static fn (CheckableItem $i): string => $i->kind,
+            CheckableInventory::all()
+        ));
+
+        self::assertSame(9, $kinds['file']);
+        self::assertSame(9, $kinds['folder']);
+    }
+
+    public function testTheFiveMissalsWithASanctoraleArePresentAndTheOthersAbsent(): void
+    {
+        $ids = array_map(static fn (CheckableItem $i): string => $i->id, CheckableInventory::all());
+
+        foreach (['EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'US_2011', 'IT_1983'] as $missalId) {
+            self::assertContains("sanctorale:roman:{$missalId}", $ids);
+        }
+        foreach (['EDITIO_TYPICA_1971', 'EDITIO_TYPICA_1975', 'IT_2020', 'NL_1978', 'CA_2011', 'CA_2016'] as $missalId) {
+            self::assertNotContains("sanctorale:roman:{$missalId}", $ids);
+        }
+    }
+
+    /**
+     * The mapping the client's scope predicate depends on: `null` means "applies to the whole rite",
+     * a nation code means "only that nation's calendar". Deliberately NOT produceMetadata()'s 'VA',
+     * which is a nation code and would be simply false on the Ambrosian items.
+     */
+    public function testRegionIsNullForUniversalItemsAndANationCodeForNationalEditions(): void
+    {
+        self::assertNull(CheckableInventory::byId('temporale:roman')?->region);
+        self::assertNull(CheckableInventory::byId('sanctorale:roman:EDITIO_TYPICA_1970')?->region);
+        self::assertNull(CheckableInventory::byId('temporale:ambrosian')?->region);
+        self::assertNull(CheckableInventory::byId('sanctorale:ambrosian')?->region);
+
+        self::assertSame('US', CheckableInventory::byId('sanctorale:roman:US_2011')?->region);
+        self::assertSame('IT', CheckableInventory::byId('sanctorale:roman:IT_1983')?->region);
+    }
+
+    /**
+     * The client's predicate, applied here so the data is proved fit for it:
+     *   item.rite === rite && (item.region === null || item.region === nation)
+     */
+    public function testTheClientScopePredicateSelectsTheRightItems(): void
+    {
+        $inScope = static fn (CheckableItem $i, Rite $rite, ?string $nation): bool
+            => $i->rite === $rite && ( $i->region === null || $i->region === $nation );
+
+        $usa = array_map(
+            static fn (CheckableItem $i): string => $i->id,
+            array_values(array_filter(
+                CheckableInventory::all(),
+                static fn (CheckableItem $i): bool => $inScope($i, Rite::ROMAN, 'US')
+            ))
+        );
+        self::assertContains('sanctorale:roman:US_2011', $usa);
+        self::assertNotContains('sanctorale:roman:IT_1983', $usa);
+        self::assertContains('temporale:roman', $usa);
+
+        $ambrosian = array_map(
+            static fn (CheckableItem $i): string => $i->id,
+            array_values(array_filter(
+                CheckableInventory::all(),
+                static fn (CheckableItem $i): bool => $inScope($i, Rite::AMBROSIAN, null)
+            ))
+        );
+        sort($ambrosian);
+        self::assertSame(
+            ['sanctorale:ambrosian', 'sanctorale:ambrosian:i18n', 'temporale:ambrosian', 'temporale:ambrosian:i18n'],
+            $ambrosian
+        );
+    }
+
+    public function testTheSerializedFormNeverCarriesAPath(): void
+    {
+        foreach (CheckableInventory::all() as $item) {
+            $encoded = json_encode($item, JSON_THROW_ON_ERROR);
+            self::assertStringNotContainsString('jsondata', $encoded, "item {$item->id} leaked a path");
+            self::assertArrayNotHasKey('path', (array) json_decode($encoded, true, 512, JSON_THROW_ON_ERROR));
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+```
+
+Expected: an error, not failures — `Class "LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory" not found`.
+
+- [ ] **Step 4: Write `CheckableItem`**
+
+Create `src/Models/ValidationsPath/CheckableItem.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\ValidationsPath;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+
+/**
+ * One thing the API can be asked to validate: a source-data file, or a folder of i18n files.
+ *
+ * `$path` is the server-side location a check resolves against, and is deliberately absent from
+ * the serialized form. Keeping filesystem paths off the wire is the whole point of `/validations`
+ * (#806 step A): clients that hardcoded them had to be edited in lockstep with every layout
+ * change, which is #737/UnitTestInterface#38, #795 and #800. The omission lives in this class
+ * rather than in the handler so that a second caller cannot forget it.
+ *
+ * `$region` is `null` when the item applies to its whole rite, and an ISO nation code when it
+ * applies only to that nation's calendar. This differs on purpose from
+ * {@see \LiturgicalCalendar\Api\Enum\RomanMissal::produceMetadata()}, which reports `'VA'` for the
+ * editiones typicae: `'VA'` is a nation code that only reads as "universal" because the General
+ * Roman Calendar happens to be served under nation VA, and it would be false on Ambrosian items.
+ */
+final readonly class CheckableItem implements \JsonSerializable
+{
+    /**
+     * @param 'file'|'folder' $kind
+     * @param list<string> $steps
+     */
+    public function __construct(
+        public string $id,
+        public string $kind,
+        public Rite $rite,
+        public ?string $region,
+        public string $label,
+        public LitSchema $schema,
+        public array $steps,
+        public string $path
+    ) {
+    }
+
+    /**
+     * @return array{id:string,kind:string,rite:string,region:string|null,label:string,schema:string,steps:list<string>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'     => $this->id,
+            'kind'   => $this->kind,
+            'rite'   => $this->rite->value,
+            'region' => $this->region,
+            'label'  => $this->label,
+            // LitSchema values are '/Foo.json'; the wire carries the bare filename.
+            'schema' => ltrim($this->schema->value, '/'),
+            'steps'  => $this->steps
+        ];
+    }
+}
+```
+
+- [ ] **Step 5: Write `CheckableInventory`**
+
+Create `src/Models/ValidationsPath/CheckableInventory.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\ValidationsPath;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Enum\RomanMissal;
+use LiturgicalCalendar\Api\Router;
+
+/**
+ * The source data this API can validate, in one place.
+ *
+ * Previously the same knowledge lived in `Health`'s path-to-schema table, in a parallel branch
+ * that matched on slugs instead of paths, and in each client's hardcoded copy of the layout —
+ * with nothing detecting divergence. See #806.
+ *
+ * Half of it need not be written down at all: `RomanMissal` already registers every missal edition
+ * and already knows which have a sanctorale file, so those items are derived. The rest have
+ * dedicated `JsonData` constants and are listed explicitly.
+ *
+ * Paths always come from `JsonData` cases. `JsonData` is where this repo's layout is written down;
+ * this class must not become a second copy of it.
+ */
+final class CheckableInventory
+{
+    /** @var list<string> Every item is checked the same three ways today. */
+    private const STEPS = ['exists', 'parses', 'validates'];
+
+    /** @var list<CheckableItem>|null */
+    private static ?array $items = null;
+
+    /** @return list<CheckableItem> */
+    public static function all(): array
+    {
+        if (null === self::$items) {
+            self::$items = array_merge(self::derivedRomanSanctorale(), self::explicitItems());
+        }
+
+        return self::$items;
+    }
+
+    public static function byId(string $id): ?CheckableItem
+    {
+        return array_find(self::all(), static fn (CheckableItem $i): bool => $i->id === $id);
+    }
+
+    /**
+     * `Health` compares against `JsonData::*->value`, i.e. repo-relative paths, while this
+     * inventory stores the absolute form the `JsonData` and `RomanMissal` accessors return.
+     * Normalise here so neither caller has to know which representation it is holding.
+     */
+    public static function byPath(string $path): ?CheckableItem
+    {
+        $needle = str_starts_with($path, Router::$apiFilePath)
+            ? $path
+            : Router::$apiFilePath . ltrim($path, '/');
+        $needle = rtrim($needle, '/');
+
+        return array_find(
+            self::all(),
+            static fn (CheckableItem $i): bool => rtrim($i->path, '/') === $needle
+        );
+    }
+
+    /**
+     * The Roman sanctorale, derived from the missal registry rather than restated.
+     *
+     * `getSanctoraleFileName()` returns false for the editions that have no sanctorale file on
+     * disk, which is exactly how the five that do were picked in the old hand-written table. A new
+     * edition with a sanctorale file joins the inventory with no edit here.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function derivedRomanSanctorale(): array
+    {
+        $items = [];
+        foreach (RomanMissal::getMissalIds() as $missalId) {
+            $file = RomanMissal::getSanctoraleFileName($missalId);
+            if (false === $file) {
+                continue;
+            }
+
+            $name = RomanMissal::getName($missalId);
+            // 'VA' in produceMetadata() means "not nation-specific"; this inventory says so with null.
+            $region = str_starts_with($missalId, 'EDITIO_TYPICA_') ? null : explode('_', $missalId)[0];
+
+            $items[] = new CheckableItem(
+                "sanctorale:roman:{$missalId}",
+                'file',
+                Rite::ROMAN,
+                $region,
+                $name,
+                LitSchema::PROPRIUMDESANCTIS,
+                self::STEPS,
+                $file
+            );
+
+            $i18n = RomanMissal::getSanctoraleI18nFilePath($missalId);
+            if (false !== $i18n) {
+                $items[] = new CheckableItem(
+                    "sanctorale:roman:{$missalId}:i18n",
+                    'folder',
+                    Rite::ROMAN,
+                    $region,
+                    "{$name} translations",
+                    LitSchema::I18N,
+                    self::STEPS,
+                    rtrim($i18n, '/')
+                );
+            }
+        }
+
+        return $items;
+    }
+
+    /** @return list<CheckableItem> */
+    private static function explicitItems(): array
+    {
+        return [
+            new CheckableItem(
+                'temporale:roman',
+                'file',
+                Rite::ROMAN,
+                null,
+                'Roman Proprium de Tempore',
+                LitSchema::PROPRIUMDETEMPORE,
+                self::STEPS,
+                JsonData::TEMPORALE_FILE->path()
+            ),
+            new CheckableItem(
+                'temporale:roman:i18n',
+                'folder',
+                Rite::ROMAN,
+                null,
+                'Roman Proprium de Tempore translations',
+                LitSchema::I18N,
+                self::STEPS,
+                JsonData::TEMPORALE_I18N_FOLDER->path()
+            ),
+            new CheckableItem(
+                'decrees:roman',
+                'file',
+                Rite::ROMAN,
+                null,
+                'Memorials from Decrees',
+                LitSchema::DECREES_SRC,
+                self::STEPS,
+                JsonData::DECREES_FILE->path()
+            ),
+            new CheckableItem(
+                'decrees:roman:i18n',
+                'folder',
+                Rite::ROMAN,
+                null,
+                'Memorials from Decrees translations',
+                LitSchema::I18N,
+                self::STEPS,
+                JsonData::DECREES_I18N_FOLDER->path()
+            ),
+            new CheckableItem(
+                'temporale:ambrosian',
+                'file',
+                Rite::AMBROSIAN,
+                null,
+                'Ambrosian Proprium de Tempore',
+                LitSchema::PROPRIUMDETEMPORE,
+                self::STEPS,
+                JsonData::AMBROSIAN_TEMPORALE_FILE->path()
+            ),
+            new CheckableItem(
+                'temporale:ambrosian:i18n',
+                'folder',
+                Rite::AMBROSIAN,
+                null,
+                'Ambrosian Proprium de Tempore translations',
+                LitSchema::I18N,
+                self::STEPS,
+                JsonData::AMBROSIAN_TEMPORALE_I18N_FOLDER->path()
+            ),
+            new CheckableItem(
+                'sanctorale:ambrosian',
+                'file',
+                Rite::AMBROSIAN,
+                null,
+                'Ambrosian Proprium de Sanctis',
+                LitSchema::PROPRIUMDESANCTIS,
+                self::STEPS,
+                JsonData::AMBROSIAN_SANCTORALE_FILE->path()
+            ),
+            new CheckableItem(
+                'sanctorale:ambrosian:i18n',
+                'folder',
+                Rite::AMBROSIAN,
+                null,
+                'Ambrosian Proprium de Sanctis translations',
+                LitSchema::I18N,
+                self::STEPS,
+                JsonData::AMBROSIAN_SANCTORALE_I18N_FOLDER->path()
+            )
+        ];
+    }
+}
+```
+
+- [ ] **Step 6: Know which path representation each side holds**
+
+This is settled, not something to discover: `RomanMissal::getSanctoraleFileName()` and every `JsonData::*->path()`
+return **absolute** paths prefixed with `Router::$apiFilePath`, so that is what the inventory stores.
+`Health::getPathToSchemaFile()` compares against `JsonData::*->value`, which is **repo-relative and unprefixed**. That
+is why `byPath()` normalises its argument rather than either side converting.
+
+The test's `legacyFileTable()` therefore quotes the old table verbatim, in the unprefixed form `Health` actually uses,
+and `byPath()` is expected to resolve it. If that assertion fails, the bug is in `byPath()`'s normalisation — do not
+"fix" it by prefixing the oracle, which would stop the test proving that `Health`'s own inputs still resolve.
+
+Note also that `getSanctoraleI18nFilePath()` returns a path with a **trailing slash**, which is why the item stores
+`rtrim($i18n, '/')` — the drift test compares against `<dir>/i18n` with no trailing slash.
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+```
+
+Expected: OK, 7 tests.
+
+- [ ] **Step 8: Lint and analyse**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+composer lint
+composer analyse
+```
+
+Expected: clean. If `composer analyse` complains that some path "is not a file", the PHPStan result cache is shared
+across worktrees and stale: `rm -rf /tmp/phpstan` and retry.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+git add src/Models/ValidationsPath phpunit_tests/Models/ValidationsPath
+git commit -m "feat(validations): one inventory of the source data we can check
+
+The layout was written down in several places that had to be edited in
+lockstep — each client's path constants, Health's schema table, the .vscode
+globs — and nothing failed loudly when they diverged. That is #737/UTI#38,
+#795 and #800.
+
+This is the one list. Half of it is not written down at all: RomanMissal
+already registers every edition and already knows which have a sanctorale
+file, so those ten items derive, and a new edition joins with no edit here.
+The other eight have dedicated JsonData constants.
+
+CheckableItem drops its path in jsonSerialize() rather than leaving that to
+the handler. Keeping filesystem paths off the wire is the feature, so it
+belongs in the type where a second caller cannot forget it.
+
+region is null for not-nation-specific rather than produceMetadata()'s
+'VA': that is a nation code which only reads as universal because the
+General Roman calendar is served under nation VA, and it would be false on
+the Ambrosian items.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: The drift test
+
+**Files:**
+
+- Create: `phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php`
+
+**Interfaces:**
+
+- Consumes: `CheckableInventory::all()` returning `list<CheckableItem>`, each with a `path` property.
+
+- [ ] **Step 1: Write the test**
+
+This is the test that earns the whole feature: it fails when source data exists on disk that no inventory entry
+covers. It would have failed the moment the Ambrosian data landed without a match-table entry, which is #800.
+
+Create `phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\ValidationsPath;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source data that exists on disk but appears in no inventory entry.
+ *
+ * This is the failure #800 was: the Ambrosian temporale was present and unvalidatable, because
+ * nothing listed it. Divergence between the data and the list that describes it was silent, and
+ * stayed silent until someone went looking. Here it is a red test.
+ *
+ * Only this direction is asserted. An inventory entry with nothing on disk is deliberately NOT a
+ * failure here: that is what the `exists` step reports at check time, and asserting it would stop
+ * the inventory from advertising data a given deployment is missing — reintroducing the same
+ * blindness from the other side.
+ */
+#[CoversClass(CheckableInventory::class)]
+final class InventoryDriftTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        Router::$apiFilePath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR;
+    }
+
+    /** @return list<string> every path the inventory claims to cover */
+    private static function coveredPaths(): array
+    {
+        return array_map(
+            static fn (CheckableItem $i): string => rtrim($i->path, '/'),
+            CheckableInventory::all()
+        );
+    }
+
+    public function testEveryMissalDataFileAndI18nFolderIsCovered(): void
+    {
+        $covered = self::coveredPaths();
+        $root    = rtrim(JsonData::SOURCEDATA_FOLDER->path(), '/');
+
+        $missalDirs = glob($root . '/rite/*/missals/*', GLOB_ONLYDIR);
+        self::assertNotEmpty($missalDirs, 'no missal directories found — is the glob root right?');
+
+        foreach ($missalDirs as $dir) {
+            foreach (glob($dir . '/*.json') ?: [] as $file) {
+                self::assertContains(
+                    $file,
+                    $covered,
+                    "source data with no inventory entry: {$file} — add it to CheckableInventory"
+                );
+            }
+            if (is_dir($dir . '/i18n')) {
+                self::assertContains(
+                    $dir . '/i18n',
+                    $covered,
+                    "i18n folder with no inventory entry: {$dir}/i18n — add it to CheckableInventory"
+                );
+            }
+        }
+    }
+
+    public function testEveryDecreesDataFileAndI18nFolderIsCovered(): void
+    {
+        $covered = self::coveredPaths();
+        $root    = rtrim(JsonData::SOURCEDATA_FOLDER->path(), '/');
+
+        $decreeDirs = glob($root . '/rite/*/decrees', GLOB_ONLYDIR);
+        self::assertNotEmpty($decreeDirs, 'no decrees directories found — is the glob root right?');
+
+        foreach ($decreeDirs as $dir) {
+            foreach (glob($dir . '/*.json') ?: [] as $file) {
+                self::assertContains($file, $covered, "source data with no inventory entry: {$file}");
+            }
+            if (is_dir($dir . '/i18n')) {
+                self::assertContains($dir . '/i18n', $covered, "i18n folder with no inventory entry: {$dir}/i18n");
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
+```
+
+Expected: OK, 2 tests. If it fails, the inventory is genuinely missing something the repo ships — **add the entry to
+`CheckableInventory`**, do not weaken the glob. If it fails because a lectionary or other subdirectory is being picked
+up that is not a checkable propriumdesanctis/propriumdetempore file, narrow the `*.json` glob to exclude it and say so
+in your report, naming the file you excluded and why.
+
+- [ ] **Step 3: Prove the test can fail**
+
+Temporarily delete the `'sanctorale:ambrosian'` entry from `CheckableInventory::explicitItems()`, re-run, and confirm
+`testEveryMissalDataFileAndI18nFolderIsCovered` fails naming the Ambrosian sanctorale file. Restore the entry. Record
+the observed failure message. A drift test that cannot fail is worse than no drift test, because it reads like cover.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+git add phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
+git commit -m "test(validations): fail when source data has no inventory entry
+
+#800 was data on disk that no client could validate, because nothing listed
+it, and the divergence was silent until someone went looking. This makes
+that a red test.
+
+Only one direction is asserted. An entry with nothing on disk is not a
+failure here — that is what the exists step reports at check time, and
+asserting it would stop the inventory from advertising data a deployment is
+missing, which is the same blindness from the other side.
+
+Refs #806, #800
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: The `GET /validations` endpoint
+
+**Files:**
+
+- Create: `src/Handlers/ValidationsHandler.php`
+- Create: `jsondata/schemas/LitCalValidationsPath.json`
+- Modify: `src/Enum/Route.php` (add a case after `MISSALS`)
+- Modify: `src/Enum/LitSchema.php` (add a case after `SCHEMAS`)
+- Modify: `src/Router.php` (add a `case 'validations'` beside `case 'schemas'`)
+- Modify: `jsondata/schemas/openapi.json` (a `/validations` path entry)
+- Test: `phpunit_tests/Handlers/ValidationsHandlerTest.php`
+- Test: `phpunit_tests/Handlers/ReadonlyPathsResponseSchemaTest.php` (one added case)
+
+**Interfaces:**
+
+- Consumes: `CheckableInventory::all(): list<CheckableItem>` from Task 1; `CheckableItem::jsonSerialize()` which emits
+  `id`, `kind`, `rite`, `region`, `label`, `schema`, `steps` and never `path`.
+- Produces: `Route::VALIDATIONS` (`'/validations'`), `LitSchema::VALIDATIONS` (`'/LitCalValidationsPath.json'`),
+  and the `litcal_validations` response envelope.
+
+- [ ] **Step 1: Write the failing handler test**
+
+Create `phpunit_tests/Handlers/ValidationsHandlerTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\ValidationsHandler;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\NotAcceptableException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * `GET /validations` — what this API can be asked to check (#806 step A).
+ *
+ * The endpoint exists so clients stop hardcoding this repo's on-disk layout, so the assertion that
+ * matters most is the negative one: no response may contain a filesystem path.
+ */
+#[CoversClass(ValidationsHandler::class)]
+final class ValidationsHandlerTest extends AbstractHandlerTestCase
+{
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new ValidationsHandler() )->handle(
+            $this->requestFor('OPTIONS', '/validations', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetReturnsTheInventoryEnvelope(): void
+    {
+        $response = ( new ValidationsHandler() )->handle($this->requestFor('GET', '/validations'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/json', $response->getHeaderLine('Content-Type'));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_validations', $body);
+        self::assertCount(18, $body['litcal_validations']);
+    }
+
+    public function testEveryItemCarriesTheAdvertisedFields(): void
+    {
+        $body = $this->decodeJsonBody(
+            ( new ValidationsHandler() )->handle($this->requestFor('GET', '/validations'))
+        );
+
+        foreach ($body['litcal_validations'] as $item) {
+            foreach (['id', 'kind', 'rite', 'region', 'label', 'schema', 'steps'] as $key) {
+                self::assertArrayHasKey($key, $item);
+            }
+            self::assertContains($item['kind'], ['file', 'folder']);
+            self::assertContains($item['rite'], ['roman', 'ambrosian']);
+            self::assertTrue($item['region'] === null || preg_match('/^[A-Z]{2}$/', $item['region']) === 1);
+            self::assertStringEndsWith('.json', $item['schema']);
+            self::assertSame(['exists', 'parses', 'validates'], $item['steps']);
+        }
+    }
+
+    /** The reason the endpoint exists: no client should ever see a path again. */
+    public function testTheResponseLeaksNoFilesystemPath(): void
+    {
+        $raw = (string) ( new ValidationsHandler() )->handle($this->requestFor('GET', '/validations'))->getBody();
+
+        self::assertStringNotContainsString('jsondata', $raw);
+        self::assertStringNotContainsString('sourcedata', $raw);
+        self::assertStringNotContainsString('"path"', $raw);
+    }
+
+    public function testAnUnacceptableAcceptHeaderIsRejected(): void
+    {
+        $this->expectException(NotAcceptableException::class);
+        ( new ValidationsHandler() )->handle(
+            $this->requestFor('GET', '/validations', ['Accept' => 'image/png'])
+        );
+    }
+
+    public function testANonGetVerbIsRejected(): void
+    {
+        $this->expectException(MethodNotAllowedException::class);
+        ( new ValidationsHandler() )->handle($this->requestFor('DELETE', '/validations'));
+    }
+
+    public function testAPathParameterIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new ValidationsHandler(['roman']) )->handle($this->requestFor('GET', '/validations/roman'));
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+vendor/bin/phpunit phpunit_tests/Handlers/ValidationsHandlerTest.php
+```
+
+Expected: error — `Class "LiturgicalCalendar\Api\Handlers\ValidationsHandler" not found`.
+
+If instead every test is *skipped*, the base class needs `JWT_SECRET` (32+ chars) in the environment; set it in
+`.env.local` per CLAUDE.md before continuing, because skipped tests are not evidence.
+
+- [ ] **Step 3: Add the Route and LitSchema cases**
+
+In `src/Enum/Route.php`, after `case MISSALS = '/missals';`:
+
+```php
+    case VALIDATIONS        = '/validations';
+```
+
+In `src/Enum/LitSchema.php`, after `case SCHEMAS = '/LitCalSchemasPath.json';`:
+
+```php
+    case VALIDATIONS       = '/LitCalValidationsPath.json';
+```
+
+- [ ] **Step 4: Write the handler**
+
+Create `src/Handlers/ValidationsHandler.php`:
+
+```php
+<?php
+
+/**
+ * Advertise the source data this API can validate.
+ *
+ * Clients used to hardcode this repo's on-disk layout and had to be edited in lockstep with every
+ * change to it — see #806. They now read this list and send back an opaque id, so no filesystem
+ * path crosses the wire.
+ *
+ * This endpoint deliberately does not touch the filesystem. Advertising is not verification:
+ * `exists` is the first check, not a precondition for being listed, so a missing file surfaces as
+ * a failed check rather than as a silent absence from the list.
+ *
+ * @author    John Romano D'Orazio <priest@johnromanodorazio.com>
+ * @license   https://www.apache.org/licenses/LICENSE-2.0.txt Apache License 2.0
+ * @link      https://litcal.johnromanodorazio.com
+ */
+
+namespace LiturgicalCalendar\Api\Handlers;
+
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ValidationsHandler extends AbstractHandler
+{
+    /** @param string[] $requestPathParams */
+    public function __construct(array $requestPathParams = [])
+    {
+        parent::__construct($requestPathParams);
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+
+        $method = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime);
+
+        $pathParamCount = count($this->requestPathParams);
+        if ($pathParamCount > 0) {
+            throw new ValidationException(
+                'Invalid number of path parameters, expected 0, received ' . $pathParamCount
+            );
+        }
+
+        $payload                      = new \stdClass();
+        $payload->litcal_validations  = CheckableInventory::all();
+
+        return $this->encodeResponseBody($response, $payload);
+    }
+}
+```
+
+- [ ] **Step 5: Wire the route**
+
+In `src/Router.php`, beside `case 'schemas':`, add:
+
+```php
+            case 'validations':
+                $validationsHandler = new ValidationsHandler($requestPathParts);
+                $validationsHandler->setAllowedRequestMethods([RequestMethod::GET]);
+                $this->handler = $validationsHandler;
+                break;
+```
+
+Add `use LiturgicalCalendar\Api\Handlers\ValidationsHandler;` to the file's imports, keeping them alphabetical with
+the neighbouring handler imports.
+
+- [ ] **Step 6: Run the handler test to verify it passes**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+vendor/bin/phpunit phpunit_tests/Handlers/ValidationsHandlerTest.php
+```
+
+Expected: OK, 7 tests.
+
+- [ ] **Step 7: Write the response schema**
+
+Create `jsondata/schemas/LitCalValidationsPath.json`:
+
+```json
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://litcal.johnromanodorazio.com/api/dev/schemas/LitCalValidationsPath.json",
+    "title": "Liturgical Calendar Validations Path",
+    "description": "The source data this API can be asked to validate. Clients iterate this list and send back an item's opaque id, so no filesystem path crosses the wire.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["litcal_validations"],
+    "properties": {
+        "litcal_validations": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["id", "kind", "rite", "region", "label", "schema", "steps"],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Opaque identifier a client sends back to request this check."
+                    },
+                    "kind": {
+                        "type": "string",
+                        "enum": ["file", "folder"]
+                    },
+                    "rite": {
+                        "type": "string",
+                        "enum": ["roman", "ambrosian"]
+                    },
+                    "region": {
+                        "type": ["string", "null"],
+                        "pattern": "^[A-Z]{2}$",
+                        "description": "Null when the item applies to its whole rite; an ISO nation code when it applies only to that nation's calendar."
+                    },
+                    "label": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9]+\\.json$",
+                        "description": "Bare filename of the JSON schema this item validates against, resolvable under /schemas."
+                    },
+                    "steps": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "string",
+                            "enum": ["exists", "parses", "validates"]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 8: Add the response-schema test case**
+
+In `phpunit_tests/Handlers/ReadonlyPathsResponseSchemaTest.php`, add the import
+`use LiturgicalCalendar\Api\Handlers\ValidationsHandler;` and this method:
+
+```php
+    public function testValidationsResponseValidatesAgainstValidationsPathSchema(): void
+    {
+        $this->validateHandlerResponse(new ValidationsHandler(), '/validations', LitSchema::VALIDATIONS);
+    }
+```
+
+Run it:
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+vendor/bin/phpunit phpunit_tests/Handlers/ReadonlyPathsResponseSchemaTest.php
+```
+
+Expected: OK, with the new case passing.
+
+- [ ] **Step 9: Add the OpenAPI path entry**
+
+In `jsondata/schemas/openapi.json`, add this entry to `paths`, placed after the `/schemas` entries so the file keeps
+its existing grouping:
+
+```json
+    "/validations": {
+      "get": {
+        "tags": [
+          "Validations"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the source data this API can be asked to validate",
+        "description": "Clients iterate this list and send back an item's opaque id, so no filesystem path crosses the wire. Advertising is not verification: an item appearing here does not assert that the underlying data is present, only that it is checkable. Filtering by rite and region is done by the client.",
+        "operationId": "validationsGET",
+        "responses": {
+          "200": {
+            "description": "the source data this API can validate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./LitCalValidationsPath.json"
+                },
+                "example": {
+                  "litcal_validations": [
+                    {
+                      "id": "temporale:roman",
+                      "kind": "file",
+                      "rite": "roman",
+                      "region": null,
+                      "label": "Roman Proprium de Tempore",
+                      "schema": "PropriumDeTempore.json",
+                      "steps": [
+                        "exists",
+                        "parses",
+                        "validates"
+                      ]
+                    },
+                    {
+                      "id": "sanctorale:roman:US_2011:i18n",
+                      "kind": "folder",
+                      "rite": "roman",
+                      "region": "US",
+                      "label": "Roman Missal, USA edition (2011) translations",
+                      "schema": "LitCalTranslation.json",
+                      "steps": [
+                        "exists",
+                        "parses",
+                        "validates"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "the requested Accept header is not supported by this endpoint"
+          }
+        }
+      }
+    },
+```
+
+The `label` in that second example must match what `RomanMissal::getName('US_2011')` actually returns — check it and
+correct the example if it differs, rather than leaving the schema documenting a label the API does not emit:
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+php -r 'require "vendor/autoload.php"; echo LiturgicalCalendar\Api\Enum\RomanMissal::getName("US_2011"), "\n";'
+```
+
+Then lint the schema:
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+composer lint:openapi
+```
+
+Expected: clean. Redocly may report errors resolving `$ref`s to external schema files; that is pre-existing on this
+document and not introduced here — confirm the same output appears on the unmodified file (`git stash`, re-run,
+`git stash pop`) before treating any of it as yours.
+
+- [ ] **Step 10: Lint, analyse, and run the wider suite**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+composer lint
+composer analyse
+composer test:quick
+```
+
+Use the composer script for the suite, never a bare `phpunit --exclude-group` — a CLI `--exclude-group` overrides the
+XML config and un-fences the golden-master-generate group, which silently rewrites the fixtures it is checked against.
+
+Expected: no new failures. `Routes/*` tests target the main checkout's server on `:8000` and their result says nothing
+about this branch; judge on the new tests plus the absence of *new* failures elsewhere, checking anything ambiguous
+against the base commit rather than assuming.
+
+- [ ] **Step 11: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+git add src/Handlers/ValidationsHandler.php src/Enum/Route.php src/Enum/LitSchema.php src/Router.php \
+        jsondata/schemas/LitCalValidationsPath.json jsondata/schemas/openapi.json \
+        phpunit_tests/Handlers/ValidationsHandlerTest.php phpunit_tests/Handlers/ReadonlyPathsResponseSchemaTest.php
+git commit -m "feat(validations): serve the checkable inventory at GET /validations
+
+Clients hardcoded this repo's on-disk layout and had to be edited in
+lockstep with every change to it. They can now read the list and send back
+an opaque id.
+
+The endpoint does not stat the filesystem. Advertising is not verification:
+exists is the first check, not a precondition for being listed, so a
+missing file surfaces as a failed check rather than as a silent absence
+from the list — which is how #800 stayed invisible.
+
+No query parameters. Both consumers fetch once at load and filter in the
+browser, so changing rite or calendar re-filters an array instead of making
+another request.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `Health` delegates to the inventory
+
+**Files:**
+
+- Modify: `src/Health.php` — `getPathToSchemaFile()` and the `sourceDataCheck` branch of `retrieveSchemaForCategory()`
+- Test: `phpunit_tests/HealthSchemaMappingTest.php` and `phpunit_tests/HealthSchemaCategoryTest.php` (existing; must
+  keep passing unchanged)
+
+**Interfaces:**
+
+- Consumes: `CheckableInventory::byPath(string $path): ?CheckableItem` and `::byId(string $id): ?CheckableItem` from
+  Task 1; `CheckableItem::$schema` is a `LitSchema`, so callers need `->schema->path()` to get the filesystem path
+  these two methods have always returned.
+
+- [ ] **Step 1: Read the existing tests first**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+vendor/bin/phpunit phpunit_tests/HealthSchemaMappingTest.php phpunit_tests/HealthSchemaCategoryTest.php
+```
+
+Record the passing output. These two suites are the safety net for this refactor: they must pass **unchanged**
+afterwards. Do not edit them to accommodate the new code — if one fails, the refactor is wrong.
+
+- [ ] **Step 2: Delegate `getPathToSchemaFile()` for source-data files only**
+
+`getPathToSchemaFile()` currently mixes two unrelated kinds in one `match`: source-data **file** paths, and API
+**route** paths (`Route::CALENDARS->path()`, `Route::DECREES->path()` and so on). Only the first kind is in the
+inventory. Replace the eight source-data arms with an inventory lookup and keep the route arms exactly as they are:
+
+```php
+    private static function getPathToSchemaFile(string $dataFile): ?string
+    {
+        // Source-data files come from the one inventory (#806 step A); the arms below are API
+        // routes, which are a different kind of thing and stay here.
+        $item = CheckableInventory::byPath($dataFile);
+        if (null !== $item) {
+            return $item->schema->path();
+        }
+
+        return match ($dataFile) {
+            Route::CALENDARS->path() => LitSchema::METADATA->path(),
+            Route::DECREES->path()   => LitSchema::DECREES->path(),
+            Route::EVENTS->path()    => LitSchema::EVENTS->path(),
+            Route::TESTS->path()     => LitSchema::TESTS->path(),
+            Route::EASTER->path()    => LitSchema::EASTER->path(),
+            Route::MISSALS->path()   => LitSchema::MISSALS->path(),
+            Route::DATA->path()      => LitSchema::DATA->path(),
+            Route::SCHEMAS->path()   => LitSchema::SCHEMAS->path(),
+            default                  => null
+        };
+    }
+```
+
+Add `use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;` to `Health.php`'s imports.
+
+The inventory stores whatever representation Task 1 established — note its report before writing this. If `Health`
+passes an unprefixed repo-relative path while the inventory stores a prefixed one, normalise **at the lookup here**,
+not by changing what the inventory stores, and say so in a comment.
+
+- [ ] **Step 3: Run the mapping tests**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+vendor/bin/phpunit phpunit_tests/HealthSchemaMappingTest.php
+```
+
+Expected: the same passing output as Step 1, unchanged.
+
+- [ ] **Step 4: Delegate the `sourceDataCheck` slug branch for inventory-owned slugs**
+
+In `retrieveSchemaForCategory()`, the `sourceDataCheck` case resolves a `validate` slug through eight anchored
+`preg_match` calls. Four of those name things the inventory owns — `memorials-from-decrees`, `-i18n$`,
+`proprium-de-sanctis-…`, `proprium-de-tempore`. The other four (`wider-region-…`, `national-calendar-…`,
+`diocesan-calendar-…`, `tests-…`) are per-calendar data, which is out of scope and stays.
+
+Add an inventory lookup **before** the pattern list, mapping the client's legacy slugs onto inventory ids:
+
+```php
+            case 'sourceDataCheck':
+                // Legacy slugs from the runner pages, mapped onto inventory ids. #806 step A gives
+                // every item an id; until the clients send those ids (UnitTestInterface#42), the
+                // old vocabulary keeps working through this table.
+                $legacySlugToId = [
+                    'memorials-from-decrees'      => 'decrees:roman',
+                    'memorials-from-decrees-i18n' => 'decrees:roman:i18n',
+                    'proprium-de-tempore'         => 'temporale:roman',
+                    'proprium-de-tempore-i18n'    => 'temporale:roman:i18n'
+                ];
+                $item = CheckableInventory::byId($legacySlugToId[$dataPath] ?? $dataPath);
+                if (null !== $item) {
+                    return $item->schema->path();
+                }
+
+                // …the existing preg_match list continues here, unchanged…
+```
+
+Leave every existing `preg_match` in place beneath it. This is deliberately additive: the inventory answers what it
+owns, the patterns answer the rest, and no client changes behaviour. Removing the now-shadowed patterns is
+UnitTestInterface#42's business, once clients send ids.
+
+- [ ] **Step 5: Run the category tests**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+vendor/bin/phpunit phpunit_tests/HealthSchemaCategoryTest.php phpunit_tests/HealthSchemaMappingTest.php
+```
+
+Expected: the same passing output as Step 1, unchanged. If a slug now resolves to a *different* schema than before,
+stop — that is a behaviour change, not a refactor, and it means a legacy slug is mapped to the wrong inventory id.
+
+- [ ] **Step 6: Run the full local suite**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+composer lint
+composer analyse
+composer test:quick
+```
+
+Expected: clean lint and analysis, no new failures.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+git add src/Health.php
+git commit -m "refactor(health): resolve source-data schemas from the one inventory
+
+Health resolved the same files two ways: getPathToSchemaFile() matched on a
+path, and a separate branch matched the same files on a slug, with two
+different vocabularies depending on which runner page asked. That is
+ambiguity 4 in #806.
+
+Both now consult CheckableInventory first. Neither loses a capability: the
+route arms of the path table are API endpoints rather than source data and
+stay put, and the per-calendar patterns in the slug branch — wider region,
+national, diocesan, tests — are out of this scope and stay too.
+
+Additive on purpose. The legacy slugs keep working through a small mapping
+table, so no client changes behaviour today; retiring them belongs with
+UnitTestInterface#42, once clients send inventory ids.
+
+HealthSchemaMappingTest and HealthSchemaCategoryTest pass unchanged, which
+is the point: this is meant to be a refactor, and they are the proof.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Publish
+
+**Files:** none — repository metadata only.
+
+- [ ] **Step 1: Push**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-inventory
+git push -u origin feat/806-checkable-inventory
+```
+
+- [ ] **Step 2: Open the PR**
+
+Base `development`. The body must state: what the endpoint advertises and what it deliberately omits (per-calendar
+items and the API's own endpoints, with the reason); that half the inventory derives from `RomanMissal` rather than
+being restated; that the endpoint never stats the filesystem, and why that is deliberate rather than an oversight; that
+`Health` sheds two lookups and its existing tests pass unchanged; what the drift test guards and which direction it
+deliberately does not assert; and the verification output from each task.
+
+Note explicitly that this ships useful with no client change, and that the client half — filtering by rite and region —
+is gated on UnitTestInterface#48 and #42, not on this PR.

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -44,6 +44,34 @@ The runners check three different kinds of thing, and only one of them is the pr
 Only kind 1 caused #737/#38, #795 and #800. Advertising kinds 2 and 3 would add surface without removing duplication,
 so this endpoint covers kind 1 only.
 
+## Who consumes it, and how they differ
+
+The two UnitTestInterface pages check overlapping sets for different reasons, and the inventory has to serve both.
+
+**`resources.php` is exhaustive.** It checks every API path — `/calendars`, `/decrees`, `/tests`, `/events`,
+`/easter`, `/schemas`, `/missals`, `/data`, plus the per-nation and per-diocese combinations — and the calendar source
+files for *every* calendar the API supports. It cares about the whole surface, filtered only by the selected rite.
+
+**`index.php` is calendar-scoped.** It checks the source files for the *selected* calendar, and runs the liturgical
+accuracy tests. With no calendar selected it falls back to the General Roman Calendar, or to the Ambrosian calendar when
+the Ambrosian rite is selected with no specific calendar.
+
+Two consequences for this design:
+
+1. **`rite` alone is not enough.** Two of the nine files are national missal editions — `propriumdesanctis_US_2011` and
+   `propriumdesanctis_IT_1983` — and they are in scope for the USA and Italy calendars respectively, and nowhere else.
+   A flat, rite-tagged list cannot express that, so items carry a `region` as well.
+2. **Accuracy tests are filtered too**, by rite and by calendar: a test naming a calendar appears only for that calendar
+   and rite; a test naming no calendar appears for any calendar, still filtered by rite. Those tests are kind 2 (they
+   come from `/tests`), so they are outside this endpoint — but they are the reason the client's filtering predicate
+   has to exist regardless of what this endpoint returns.
+
+### A client-side prerequisite, not in this scope
+
+Neither page has a RiteSelect dropdown yet, so today nothing selects a rite to filter by. That control, and the
+filtering it drives, is client work belonging with UnitTestInterface#42 and the rite-awareness thread in #39. This
+endpoint supplies the data those filters need; it does not depend on them, and it ships useful without them.
+
 ## The inventory
 
 18 items: 9 files and their 9 `i18n` folders.
@@ -58,8 +86,8 @@ Half of them need not be written down at all.
 
 Those five are **exactly** the five Roman sanctorale arms in today's hand-written `Health::getPathToSchemaFile()` table.
 So the inventory derives them instead of restating them, together with their `i18n` folders via
-`getSanctoraleI18nFilePath()` and their labels via `getName()`. A new missal edition with a sanctorale file joins the
-inventory with no edit here.
+`getSanctoraleI18nFilePath()`, their labels via `getName()`, and their `region` the same way `produceMetadata()` already
+computes it. A new missal edition with a sanctorale file joins the inventory with no edit here.
 
 ### Explicit — four pairs (8 items)
 
@@ -84,7 +112,7 @@ is written down; this design stops *duplicating* it, it does not add a rival.
 Three units, each with one responsibility.
 
 **`src/Models/ValidationsPath/CheckableItem.php`** — one item. Readonly properties: `id`, `kind` (`file` or `folder`),
-`rite`, `label`, `schema`, `steps`, and `path`. Implements `JsonSerializable` and **omits `path`** from its serialized
+`rite`, `region`, `label`, `schema`, `steps`, and `path`. Implements `JsonSerializable` and **omits `path`** from its serialized
 form: the server needs it to resolve a check, and no client may ever see it. That omission is the whole point of the
 feature, so it belongs in the type rather than in the handler.
 
@@ -123,16 +151,18 @@ The house envelope is a `litcal_*` key — `/schemas` returns `litcal_schemas`, 
       "id": "temporale:roman",
       "kind": "file",
       "rite": "roman",
+      "region": null,
       "label": "Roman Proprium de Tempore",
       "schema": "PropriumDeTempore.json",
       "steps": ["exists", "parses", "validates"]
     },
     {
-      "id": "temporale:roman:i18n",
-      "kind": "folder",
+      "id": "sanctorale:roman:US_2011",
+      "kind": "file",
       "rite": "roman",
-      "label": "Roman Proprium de Tempore translations",
-      "schema": "LitCalTranslation.json",
+      "region": "US",
+      "label": "Roman Missal, USA edition (2011)",
+      "schema": "PropriumDeSanctis.json",
       "steps": ["exists", "parses", "validates"]
     }
   ]
@@ -145,6 +175,33 @@ another shared constant.
 
 **No `protocol` field.** #806's sketch has one, but versioning and capability negotiation are section F. Stamping a
 version on one endpoint before that contract is designed is a guess, and a wrong guess would have to be supported.
+
+### `region` semantics
+
+`null` means the item applies to its whole rite. A two-letter nation code means it applies only to that nation's
+calendar. So a client's scope test is one expression:
+
+```javascript
+const inScope = ( item, rite, nation ) =>
+    item.rite === rite && ( item.region === null || item.region === nation );
+```
+
+This deliberately diverges from `RomanMissal::produceMetadata()`, which reports `'VA'` rather than `null` for the
+*editiones typicae*. `'VA'` is a nation code, and using it as a scope marker only works because the General Roman
+Calendar happens to be served under nation `VA`; applied to the Ambrosian items it would be simply false. `null` says
+"not nation-specific" without borrowing a nation to say it.
+
+### No query parameters
+
+The endpoint takes none, and always returns the whole inventory. Both pages fetch it once at load and filter in the
+browser, so changing the rite or calendar selection re-filters an array rather than making another request. That keeps
+the two dropdowns instant and the response cacheable.
+
+The obvious objection is that "is this item in scope" is server knowledge, and two runners implementing it
+independently would recreate the drift #806 exists to end — in the two files that have already drifted apart from each
+other. The answer is not to move the rule to the server but to write it **once** on the client: the predicate above
+belongs in the shared `assets/js/wsProtocol.js` module, which both runners already import. One implementation, no extra
+request.
 
 ## Deliberately not doing
 

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -14,11 +14,18 @@ Every incident #806 cites is that one fault:
 | Incident         | What broke                                                                                         |
 |------------------|----------------------------------------------------------------------------------------------------|
 | API#737 → UTI#38 | source data moved under `rite/roman/`; the client's copy of the layout had to follow "in lockstep" |
-| API#795          | all twelve `.vscode` schema globs matched nothing — a third copy of the layout, never chased       |
+| API#795          | all twelve `.vscode` schema globs matched nothing — a third copy of the layout, fixed by hand      |
 | API#800          | Ambrosian temporale unvalidatable by any client: the data existed, no client listed it             |
 
-Under this design the server advertises its inventory and the client sends an opaque id. No path crosses the wire, so
-the whole class of breakage disappears.
+Under this design the server advertises its inventory and the client sends an opaque id. For the API clients that adopt
+it, no path crosses the wire, so that class of breakage disappears for them.
+
+That does not reach #795. #799 fixed it by hand, by re-copying the current layout into `.vscode/settings.json` — the
+same lockstep edit this design exists to stop needing, not a cure for having to make it. `.vscode/settings.json` is
+editor tooling, not an API client, so it neither sends nor receives anything from `/validations`; the drift test walks
+the source tree against the inventory, not against `.vscode`. The globs are correct today, but nothing here would
+notice if they went stale again. The same inventory could plausibly back a test asserting the `.vscode` globs still
+match real paths, which would close that class too — worth noting, not this design's job to do.
 
 ## Scope
 
@@ -170,7 +177,7 @@ The house envelope is a `litcal_*` key — `/schemas` returns `litcal_schemas`, 
       "kind": "file",
       "rite": "roman",
       "region": "US",
-      "label": "Roman Missal, USA edition (2011)",
+      "label": "2011 Roman Missal issued by the USCCB",
       "schema": "PropriumDeSanctis.json",
       "steps": ["exists", "parses", "validates"]
     }
@@ -248,11 +255,14 @@ via direct `handle()`, no running server):
 
 1. `byPath()` returns the same schema for every path that today's `getPathToSchemaFile()` table maps — the table is
    pasted into the test as the oracle, so the refactor is proved equivalent rather than assumed.
-2. `byId()` resolves the slugs the `sourceDataCheck` branch handles for inventory-owned entries.
+2. That `byId()` resolves the legacy `sourceDataCheck` slugs to the schema each is supposed to resolve to is not
+   covered here — it lives in `phpunit_tests/HealthSchemaCategoryTest.php`'s `sourceDataCheckSlugProvider()`, which
+   exercises `$legacySlugToId` (in `Health.php`) end to end through `retrieveSchemaForCategory()`, rather than calling
+   `CheckableInventory::byId()` directly.
 3. The five Roman sanctorale editions are present and the six without a sanctorale file are absent.
 4. `region` is `null` for the *editiones typicae* and for both Ambrosian items, `'US'` for `US_2011`, `'IT'` for
    `IT_1983` — the mapping the client's scope predicate depends on.
-5. Applying that predicate to the inventory yields, for `('roman', 'USA')`, the universal Roman items plus `US_2011`
+5. Applying that predicate to the inventory yields, for `('roman', 'US')`, the universal Roman items plus `US_2011`
    and not `IT_1983`; and for `('ambrosian', null)`, exactly the four Ambrosian items.
 
 **The drift test** — the one that earns its keep:

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -136,7 +136,9 @@ Plus `Route::VALIDATIONS = '/validations'` and a `case 'validations'` in `Router
 
 `Health` gains nothing. It *sheds*:
 
-- `getPathToSchemaFile()` becomes `CheckableInventory::byPath($path)?->schema`.
+- `getPathToSchemaFile()` consults `CheckableInventory::byPath($path)` first. Only its *source-data* arms move; the
+  same `match` also maps API **route** paths (`Route::CALENDARS->path()` and friends), which are a different kind of
+  thing and stay where they are.
 - The `sourceDataCheck` slug branch — eight anchored `preg_match` calls — becomes `byId($id)?->schema` for the entries
   the inventory owns.
 

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -100,8 +100,13 @@ Half of them need not be written down at all.
 
 Those five are **exactly** the five Roman sanctorale arms in today's hand-written `Health::getPathToSchemaFile()` table.
 So the inventory derives them instead of restating them, together with their `i18n` folders via
-`getSanctoraleI18nFilePath()`, their labels via `getName()`, and their `region` the same way `produceMetadata()` already
-computes it. A new missal edition with a sanctorale file joins the inventory with no edit here.
+`getSanctoraleI18nFilePath()` and their labels via `getName()`. A new missal edition with a sanctorale file joins the
+inventory with no edit here.
+
+`region` is derived by the same *rule* `produceMetadata()` uses — the id prefix for a national edition — but not to the
+same *value* for the universal ones: the **editiones typicae get `null` here, where `produceMetadata()` reports `'VA'`**.
+The reason is in "`region` semantics" below, and the distinction matters enough to state in both places rather than
+leave a reader to infer that "the same way" means identical output.
 
 ### Explicit — four pairs (8 items)
 

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -1,0 +1,202 @@
+# `/validations`: advertising what the API can check
+
+Design for step A of [API#806](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/806) — the discovery
+endpoint. Client counterpart: [UnitTestInterface#42](https://github.com/Liturgical-Calendar/UnitTestInterface/issues/42).
+
+## Problem
+
+Clients hardcode this API's on-disk layout. `UnitTestInterface/assets/js/index.js` and `resources.js` both embed
+repo-relative paths into `jsondata/sourcedata/`, and those paths must match what the server's schema-resolution table
+expects. Nothing detects divergence.
+
+Every incident #806 cites is that one fault:
+
+| Incident         | What broke                                                                                         |
+|------------------|----------------------------------------------------------------------------------------------------|
+| API#737 → UTI#38 | source data moved under `rite/roman/`; the client's copy of the layout had to follow "in lockstep" |
+| API#795          | all twelve `.vscode` schema globs matched nothing — a third copy of the layout, never chased       |
+| API#800          | Ambrosian temporale unvalidatable by any client: the data existed, no client listed it             |
+
+Under this design the server advertises its inventory and the client sends an opaque id. No path crosses the wire, so
+the whole class of breakage disappears.
+
+## Scope
+
+| In scope                                                                   | Out of scope                                                 |
+|----------------------------------------------------------------------------|--------------------------------------------------------------|
+| A `GET /validations` endpoint advertising static source-data files/folders | Per-calendar items — wider regions, nations, dioceses, tests |
+| Collapsing the server's two schema-resolution vocabularies into one        | The API's own endpoints (`resourceDataChecks`)               |
+| A drift test that fails when data exists with no inventory entry           | Any change to the WebSocket protocol itself                  |
+| —                                                                          | The `hello` frame and `protocol` versioning (#806 section F) |
+| —                                                                          | Client adoption (UnitTestInterface#42)                       |
+
+### Why only static files
+
+The runners check three different kinds of thing, and only one of them is the problem:
+
+1. **Static source files and folders** — missal propriums for both rites, decrees, and their `i18n` directories. These
+   are hardcoded in the clients *as filesystem paths*.
+2. **Per-calendar source data** — wider regions, nations, dioceses, tests. The client already derives these at runtime
+   from `/calendars` metadata. No path is embedded.
+3. **The API's own endpoints** — `/calendars`, `/decrees`, `/tests`, `/events`, `/easter`, `/schemas`, `/missals`. The
+   client builds these from its `ENDPOINTS` map. No path is embedded.
+
+Only kind 1 caused #737/#38, #795 and #800. Advertising kinds 2 and 3 would add surface without removing duplication,
+so this endpoint covers kind 1 only.
+
+## The inventory
+
+18 items: 9 files and their 9 `i18n` folders.
+
+Half of them need not be written down at all.
+
+### Derived — the Roman sanctorale (10 items)
+
+`RomanMissal` already registers every missal edition and already knows which have a sanctorale file:
+`getMissalIds()` returns eleven ids, and `getSanctoraleFileName()` returns a path for five of them
+(`EDITIO_TYPICA_1970`, `EDITIO_TYPICA_2002`, `EDITIO_TYPICA_2008`, `US_2011`, `IT_1983`) and `false` for the other six.
+
+Those five are **exactly** the five Roman sanctorale arms in today's hand-written `Health::getPathToSchemaFile()` table.
+So the inventory derives them instead of restating them, together with their `i18n` folders via
+`getSanctoraleI18nFilePath()` and their labels via `getName()`. A new missal edition with a sanctorale file joins the
+inventory with no edit here.
+
+### Explicit — four pairs (8 items)
+
+These have dedicated `JsonData` constants rather than a registry to derive from:
+
+| Item                      | Path constant                                | Schema                     |
+|---------------------------|----------------------------------------------|----------------------------|
+| Roman temporale           | `JsonData::TEMPORALE_FILE`                   | `PropriumDeTempore.json`   |
+| Roman temporale i18n      | `JsonData::TEMPORALE_I18N_FOLDER`            | `LitCalTranslation.json`   |
+| Roman decrees             | `JsonData::DECREES_FILE`                     | `LitCalDecreesSource.json` |
+| Roman decrees i18n        | `JsonData::DECREES_I18N_FOLDER`              | `LitCalTranslation.json`   |
+| Ambrosian temporale       | `JsonData::AMBROSIAN_TEMPORALE_FILE`         | `PropriumDeTempore.json`   |
+| Ambrosian temporale i18n  | `JsonData::AMBROSIAN_TEMPORALE_I18N_FOLDER`  | `LitCalTranslation.json`   |
+| Ambrosian sanctorale      | `JsonData::AMBROSIAN_SANCTORALE_FILE`        | `PropriumDeSanctis.json`   |
+| Ambrosian sanctorale i18n | `JsonData::AMBROSIAN_SANCTORALE_I18N_FOLDER` | `LitCalTranslation.json`   |
+
+Paths always come from `JsonData` cases, never from string literals. `JsonData` is already the single place the layout
+is written down; this design stops *duplicating* it, it does not add a rival.
+
+## Components
+
+Three units, each with one responsibility.
+
+**`src/Models/ValidationsPath/CheckableItem.php`** — one item. Readonly properties: `id`, `kind` (`file` or `folder`),
+`rite`, `label`, `schema`, `steps`, and `path`. Implements `JsonSerializable` and **omits `path`** from its serialized
+form: the server needs it to resolve a check, and no client may ever see it. That omission is the whole point of the
+feature, so it belongs in the type rather than in the handler.
+
+**`src/Models/ValidationsPath/CheckableInventory.php`** — assembles the list, derived plus explicit, and exposes
+`all()`, `byId(string $id): ?CheckableItem`, and `byPath(string $path): ?CheckableItem`.
+
+**`src/Handlers/ValidationsHandler.php`** — `GET /validations`, modelled on `SchemasHandler`, which is the smallest
+handler in the codebase and already has the shape: preflight, `setAccessControlAllowOriginHeader()`,
+`validateRequestMethod()`, `validateAcceptHeader()`, `encodeResponseBody()`. Serialization only.
+
+Plus `Route::VALIDATIONS = '/validations'` and a `case 'validations'` in `Router::route()`.
+
+### What `Health` loses
+
+`Health` gains nothing. It *sheds*:
+
+- `getPathToSchemaFile()` becomes `CheckableInventory::byPath($path)?->schema`.
+- The `sourceDataCheck` slug branch — eight anchored `preg_match` calls — becomes `byId($id)?->schema` for the entries
+  the inventory owns.
+
+That collapses #806's ambiguity 4, where the same file resolves under two different vocabularies depending on which
+page asks: `PropriumDeTempore` with `category: universalcalendar` from one runner, `proprium-de-tempore` with
+`category: sourceDataCheck` from the other. One id, one lookup.
+
+The slug branch's *calendar* patterns (`wider-region-…`, `national-calendar-…`, `diocesan-calendar-…`, `tests-…`) stay
+where they are. They are kind 2, out of scope.
+
+## Response
+
+The house envelope is a `litcal_*` key — `/schemas` returns `litcal_schemas`, `/calendars` returns `litcal_metadata`:
+
+```jsonc
+{
+  "litcal_validations": [
+    {
+      "id": "temporale:roman",
+      "kind": "file",
+      "rite": "roman",
+      "label": "Roman Proprium de Tempore",
+      "schema": "PropriumDeTempore.json",
+      "steps": ["exists", "parses", "validates"]
+    },
+    {
+      "id": "temporale:roman:i18n",
+      "kind": "folder",
+      "rite": "roman",
+      "label": "Roman Proprium de Tempore translations",
+      "schema": "LitCalTranslation.json",
+      "steps": ["exists", "parses", "validates"]
+    }
+  ]
+}
+```
+
+`steps` is `["exists", "parses", "validates"]` for every item today. It is carried per-item anyway because #806 section D
+exists to delete the clients' four hardcoded `* 3` constants, and a per-item list is what lets them do that without
+another shared constant.
+
+**No `protocol` field.** #806's sketch has one, but versioning and capability negotiation are section F. Stamping a
+version on one endpoint before that contract is designed is a guess, and a wrong guess would have to be supported.
+
+## Deliberately not doing
+
+**The endpoint does not touch the filesystem.** Advertising is not verification. `exists` is the first *check*, not a
+precondition for being listed, so a missing file appears as a failed check in the UI rather than as a silent absence
+from the list. That distinction is exactly how #800 stayed invisible: the Ambrosian data was present and no client
+listed it. A list that quietly drops what it cannot stat reintroduces the same blindness from the other direction.
+
+It also keeps the endpoint cheap and its output identical across environments.
+
+## Error handling
+
+| Condition                                  | Behaviour                                                                       |
+|--------------------------------------------|---------------------------------------------------------------------------------|
+| Non-GET request                            | 405 from `validateRequestMethod()`, as every read handler does                  |
+| `OPTIONS`                                  | CORS preflight, handled before method validation                                |
+| Unacceptable `Accept` header               | 406 from `validateAcceptHeader()` at `LAX` for GET                              |
+| Any path parameter                         | 400 — `/validations` takes none                                                 |
+| A registered missal has no sanctorale file | Not an error; `getSanctoraleFileName()` returns `false` and no item is produced |
+
+The endpoint has no failure mode of its own: it serves a static structure and never reads a file.
+
+## Testing
+
+**Handler tests** (`phpunit_tests/Handlers/ValidationsHandlerTest.php`, extending `AbstractHandlerTestCase` — in-process
+via direct `handle()`, no running server):
+
+1. `GET` returns 200 with the `litcal_validations` envelope.
+2. Every item carries `id`, `kind`, `rite`, `label`, `schema`, `steps`.
+3. **No item exposes `path`** — the serialized payload must not contain a `jsondata/` substring anywhere.
+4. Ids are unique.
+5. A non-GET verb is 405; a path parameter is 400.
+
+**Inventory tests** (`phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php`):
+
+1. `byPath()` returns the same schema for every path that today's `getPathToSchemaFile()` table maps — the table is
+   pasted into the test as the oracle, so the refactor is proved equivalent rather than assumed.
+2. `byId()` resolves the slugs the `sourceDataCheck` branch handles for inventory-owned entries.
+3. The five Roman sanctorale editions are present and the six without a sanctorale file are absent.
+
+**The drift test** — the one that earns its keep:
+
+Walk `jsondata/sourcedata/rite/*/missals/*/` and `jsondata/sourcedata/rite/*/decrees/`, and assert every data file and
+`i18n` directory found has an inventory entry. This converts silent divergence into a red test. It would have failed
+the moment the Ambrosian data landed without a match-table entry, which is #800.
+
+The inverse — an inventory entry with nothing on disk — is deliberately **not** asserted, for the reason given above:
+that is the `exists` check's job, and a test asserting it would make the inventory unable to advertise data a
+deployment is missing.
+
+## Migration
+
+Purely additive. No existing route changes, no client change is required to ship it, and the `Health` refactor is
+behaviour-preserving with the old table as the test oracle. UnitTestInterface#42 adopts it separately, and can do so one
+page at a time.

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -69,15 +69,15 @@ Two consequences for this design:
 
 ### A client-side prerequisite, not in this scope
 
-Neither page has a RiteSelect dropdown yet, so today nothing selects a rite to filter by. That control, and the
-filtering it drives, is client work tracked as **UnitTestInterface#48**, alongside #42 and the rite-awareness
-thread in #39. This endpoint supplies the data those filters need; it does not depend on them, and it ships useful
-without them.
+Neither page has a RiteSelect dropdown yet, so today nothing selects a rite to filter by. UnitTestInterface#39
+brought the calendar dropdown's options as far as carrying `data-rite`; the control itself, and the filtering it
+drives, is client work tracked as **UnitTestInterface#48**, alongside #42. This endpoint supplies the data those
+filters need; it does not depend on them, and it ships useful without them.
 
-Worth knowing when reading #48: the control already exists as `RiteSelect` in `liturgy-components-php`, but
-UnitTestInterface pins `liturgical-calendar/components: ^3.1` (locked v3.3.1) and `RiteSelect` shipped in v4.0.0 — a
-major bump that also raises the package's PHP floor to 8.2. So the client half of rite filtering is gated on a
-dependency upgrade, not on this endpoint.
+Worth knowing when reading #48: the client half is gated on adopting `@liturgical-calendar/components-js`, whose
+`CalendarSelect` is rite-aware and whose `MetaComponents/CalendarControls` already wires a rite select to a calendar
+select. The PHP components UnitTestInterface currently depends on render server-side, so they can supply the control
+but not the wiring. Either way the gate is a client-side dependency decision, not this endpoint.
 
 ## The inventory
 

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -70,8 +70,14 @@ Two consequences for this design:
 ### A client-side prerequisite, not in this scope
 
 Neither page has a RiteSelect dropdown yet, so today nothing selects a rite to filter by. That control, and the
-filtering it drives, is client work belonging with UnitTestInterface#42 and the rite-awareness thread in #39. This
-endpoint supplies the data those filters need; it does not depend on them, and it ships useful without them.
+filtering it drives, is client work tracked as **UnitTestInterface#48**, alongside #42 and the rite-awareness
+thread in #39. This endpoint supplies the data those filters need; it does not depend on them, and it ships useful
+without them.
+
+Worth knowing when reading #48: the control already exists as `RiteSelect` in `liturgy-components-php`, but
+UnitTestInterface pins `liturgical-calendar/components: ^3.1` (locked v3.3.1) and `RiteSelect` shipped in v4.0.0 — a
+major bump that also raises the package's PHP floor to 8.2. So the client half of rite filtering is gated on a
+dependency upgrade, not on this endpoint.
 
 ## The inventory
 

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -22,13 +22,14 @@ the whole class of breakage disappears.
 
 ## Scope
 
-| In scope                                                                   | Out of scope                                                 |
-|----------------------------------------------------------------------------|--------------------------------------------------------------|
-| A `GET /validations` endpoint advertising static source-data files/folders | Per-calendar items — wider regions, nations, dioceses, tests |
-| Collapsing the server's two schema-resolution vocabularies into one        | The API's own endpoints (`resourceDataChecks`)               |
-| A drift test that fails when data exists with no inventory entry           | Any change to the WebSocket protocol itself                  |
-| —                                                                          | The `hello` frame and `protocol` versioning (#806 section F) |
-| —                                                                          | Client adoption (UnitTestInterface#42)                       |
+| In scope                                                                   | Out of scope                                                                  |
+|----------------------------------------------------------------------------|-------------------------------------------------------------------------------|
+| A `GET /validations` endpoint advertising static source-data files/folders | Per-calendar items — wider regions, nations, dioceses, tests                  |
+| Collapsing the server's two schema-resolution vocabularies into one        | The API's own endpoints (`resourceDataChecks`)                                |
+| A drift test that fails when data exists with no inventory entry           | Any change to the WebSocket protocol itself                                   |
+| —                                                                          | The `hello` frame and `protocol` versioning (#806 section F)                  |
+| —                                                                          | Client adoption, and the client-side scope predicate (UnitTestInterface#42)   |
+| —                                                                          | A RiteSelect control on either page (client work; UnitTestInterface#42 / #39) |
 
 ### Why only static files
 
@@ -230,7 +231,7 @@ The endpoint has no failure mode of its own: it serves a static structure and ne
 via direct `handle()`, no running server):
 
 1. `GET` returns 200 with the `litcal_validations` envelope.
-2. Every item carries `id`, `kind`, `rite`, `label`, `schema`, `steps`.
+2. Every item carries `id`, `kind`, `rite`, `region`, `label`, `schema`, `steps`; `region` is `null` or a two-letter code.
 3. **No item exposes `path`** — the serialized payload must not contain a `jsondata/` substring anywhere.
 4. Ids are unique.
 5. A non-GET verb is 405; a path parameter is 400.
@@ -241,6 +242,10 @@ via direct `handle()`, no running server):
    pasted into the test as the oracle, so the refactor is proved equivalent rather than assumed.
 2. `byId()` resolves the slugs the `sourceDataCheck` branch handles for inventory-owned entries.
 3. The five Roman sanctorale editions are present and the six without a sanctorale file are absent.
+4. `region` is `null` for the *editiones typicae* and for both Ambrosian items, `'US'` for `US_2011`, `'IT'` for
+   `IT_1983` — the mapping the client's scope predicate depends on.
+5. Applying that predicate to the inventory yields, for `('roman', 'USA')`, the universal Roman items plus `US_2011`
+   and not `IT_1983`; and for `('ambrosian', null)`, exactly the four Ambrosian items.
 
 **The drift test** — the one that earns its keep:
 

--- a/jsondata/schemas/LitCalValidationsPath.json
+++ b/jsondata/schemas/LitCalValidationsPath.json
@@ -1,11 +1,12 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://litcal.johnromanodorazio.com/api/dev/schemas/LitCalValidationsPath.json",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Liturgical Calendar Validations Path",
     "description": "The source data this API can be asked to validate. Clients iterate this list and send back an item's opaque id, so no filesystem path crosses the wire.",
     "type": "object",
     "additionalProperties": false,
-    "required": ["litcal_validations"],
+    "required": [
+        "litcal_validations"
+    ],
     "properties": {
         "litcal_validations": {
             "type": "array",
@@ -13,7 +14,15 @@
             "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["id", "kind", "rite", "region", "label", "schema", "steps"],
+                "required": [
+                    "id",
+                    "kind",
+                    "rite",
+                    "region",
+                    "label",
+                    "schema",
+                    "steps"
+                ],
                 "properties": {
                     "id": {
                         "type": "string",
@@ -22,14 +31,23 @@
                     },
                     "kind": {
                         "type": "string",
-                        "enum": ["file", "folder"]
+                        "enum": [
+                            "file",
+                            "folder"
+                        ]
                     },
                     "rite": {
                         "type": "string",
-                        "enum": ["roman", "ambrosian"]
+                        "enum": [
+                            "roman",
+                            "ambrosian"
+                        ]
                     },
                     "region": {
-                        "type": ["string", "null"],
+                        "type": [
+                            "string",
+                            "null"
+                        ],
                         "pattern": "^[A-Z]{2}$",
                         "description": "Null when the item applies to its whole rite; an ISO nation code when it applies only to that nation's calendar."
                     },
@@ -47,7 +65,11 @@
                         "minItems": 1,
                         "items": {
                             "type": "string",
-                            "enum": ["exists", "parses", "validates"]
+                            "enum": [
+                                "exists",
+                                "parses",
+                                "validates"
+                            ]
                         }
                     }
                 }

--- a/jsondata/schemas/LitCalValidationsPath.json
+++ b/jsondata/schemas/LitCalValidationsPath.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://litcal.johnromanodorazio.com/api/dev/schemas/LitCalValidationsPath.json",
+    "title": "Liturgical Calendar Validations Path",
+    "description": "The source data this API can be asked to validate. Clients iterate this list and send back an item's opaque id, so no filesystem path crosses the wire.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["litcal_validations"],
+    "properties": {
+        "litcal_validations": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["id", "kind", "rite", "region", "label", "schema", "steps"],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Opaque identifier a client sends back to request this check."
+                    },
+                    "kind": {
+                        "type": "string",
+                        "enum": ["file", "folder"]
+                    },
+                    "rite": {
+                        "type": "string",
+                        "enum": ["roman", "ambrosian"]
+                    },
+                    "region": {
+                        "type": ["string", "null"],
+                        "pattern": "^[A-Z]{2}$",
+                        "description": "Null when the item applies to its whole rite; an ISO nation code when it applies only to that nation's calendar."
+                    },
+                    "label": {
+                        "type": "string",
+                        "minLength": 1
+                    },
+                    "schema": {
+                        "type": "string",
+                        "pattern": "^[A-Za-z0-9]+\\.json$",
+                        "description": "Bare filename of the JSON schema this item validates against, resolvable under /schemas."
+                    },
+                    "steps": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                            "type": "string",
+                            "enum": ["exists", "parses", "validates"]
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -65,6 +65,10 @@
       "description": "Retrieve the JSON schemas that define API request and response shapes and source data files"
     },
     {
+      "name": "Validations",
+      "description": "Retrieve the source data this API can be asked to validate"
+    },
+    {
       "name": "Temporale",
       "description": "Retrieve / create / update / delete Proprium de Tempore (temporale) events"
     },
@@ -7307,6 +7311,64 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      }
+    },
+    "/validations": {
+      "get": {
+        "tags": [
+          "Validations"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the source data this API can be asked to validate",
+        "description": "Clients iterate this list and send back an item's opaque id, so no filesystem path crosses the wire. Advertising is not verification: an item appearing here does not assert that the underlying data is present, only that it is checkable. Filtering by rite and region is done by the client.",
+        "operationId": "validationsGET",
+        "responses": {
+          "200": {
+            "description": "the source data this API can validate",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./LitCalValidationsPath.json"
+                },
+                "example": {
+                  "litcal_validations": [
+                    {
+                      "id": "temporale:roman",
+                      "kind": "file",
+                      "rite": "roman",
+                      "region": null,
+                      "label": "Roman Proprium de Tempore",
+                      "schema": "PropriumDeTempore.json",
+                      "steps": [
+                        "exists",
+                        "parses",
+                        "validates"
+                      ]
+                    },
+                    {
+                      "id": "sanctorale:roman:US_2011:i18n",
+                      "kind": "folder",
+                      "rite": "roman",
+                      "region": "US",
+                      "label": "2011 Roman Missal issued by the USCCB translations",
+                      "schema": "LitCalTranslation.json",
+                      "steps": [
+                        "exists",
+                        "parses",
+                        "validates"
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "the requested Accept header is not supported by this endpoint"
           }
         }
       }

--- a/phpunit_tests/Handlers/ReadonlyPathsResponseSchemaTest.php
+++ b/phpunit_tests/Handlers/ReadonlyPathsResponseSchemaTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Handlers\EasterHandler;
 use LiturgicalCalendar\Api\Handlers\MetadataHandler;
 use LiturgicalCalendar\Api\Handlers\SchemasHandler;
 use LiturgicalCalendar\Api\Handlers\TestsHandler;
+use LiturgicalCalendar\Api\Handlers\ValidationsHandler;
 use LiturgicalCalendar\Api\Router;
 use Psr\Http\Server\RequestHandlerInterface;
 use Swaggest\JsonSchema\Schema;
@@ -60,5 +61,10 @@ final class ReadonlyPathsResponseSchemaTest extends AbstractHandlerTestCase
     public function testSchemasResponseValidatesAgainstSchemasPathSchema(): void
     {
         $this->validateHandlerResponse(new SchemasHandler(), '/schemas', LitSchema::SCHEMAS);
+    }
+
+    public function testValidationsResponseValidatesAgainstValidationsPathSchema(): void
+    {
+        $this->validateHandlerResponse(new ValidationsHandler(), '/validations', LitSchema::VALIDATIONS);
     }
 }

--- a/phpunit_tests/Handlers/ValidationsHandlerTest.php
+++ b/phpunit_tests/Handlers/ValidationsHandlerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\ValidationsHandler;
+use LiturgicalCalendar\Api\Http\Exception\MethodNotAllowedException;
+use LiturgicalCalendar\Api\Http\Exception\NotAcceptableException;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * `GET /validations` — what this API can be asked to check (#806 step A).
+ *
+ * The endpoint exists so clients stop hardcoding this repo's on-disk layout, so the assertion that
+ * matters most is the negative one: no response may contain a filesystem path.
+ */
+#[CoversClass(ValidationsHandler::class)]
+final class ValidationsHandlerTest extends AbstractHandlerTestCase
+{
+    public function testOptionsPreflightSucceeds(): void
+    {
+        $response = ( new ValidationsHandler() )->handle(
+            $this->requestFor('OPTIONS', '/validations', [
+                'Origin'                        => 'https://app.example.test',
+                'Access-Control-Request-Method' => 'GET',
+            ])
+        );
+
+        self::assertSame(204, $response->getStatusCode());
+    }
+
+    public function testGetReturnsTheInventoryEnvelope(): void
+    {
+        $response = ( new ValidationsHandler() )->handle($this->requestFor('GET', '/validations'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('application/json', $response->getHeaderLine('Content-Type'));
+
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_validations', $body);
+        self::assertCount(18, $body['litcal_validations']);
+    }
+
+    public function testEveryItemCarriesTheAdvertisedFields(): void
+    {
+        $body = $this->decodeJsonBody(
+            ( new ValidationsHandler() )->handle($this->requestFor('GET', '/validations'))
+        );
+
+        foreach ($body['litcal_validations'] as $item) {
+            foreach (['id', 'kind', 'rite', 'region', 'label', 'schema', 'steps'] as $key) {
+                self::assertArrayHasKey($key, $item);
+            }
+            self::assertContains($item['kind'], ['file', 'folder']);
+            self::assertContains($item['rite'], ['roman', 'ambrosian']);
+            self::assertTrue($item['region'] === null || preg_match('/^[A-Z]{2}$/', $item['region']) === 1);
+            self::assertStringEndsWith('.json', $item['schema']);
+            self::assertSame(['exists', 'parses', 'validates'], $item['steps']);
+        }
+    }
+
+    /** The reason the endpoint exists: no client should ever see a path again. */
+    public function testTheResponseLeaksNoFilesystemPath(): void
+    {
+        $raw = (string) ( new ValidationsHandler() )->handle($this->requestFor('GET', '/validations'))->getBody();
+
+        self::assertStringNotContainsString('jsondata', $raw);
+        self::assertStringNotContainsString('sourcedata', $raw);
+        self::assertStringNotContainsString('"path"', $raw);
+    }
+
+    public function testAnUnacceptableAcceptHeaderIsRejected(): void
+    {
+        $this->expectException(NotAcceptableException::class);
+        ( new ValidationsHandler() )->handle(
+            $this->requestFor('GET', '/validations', ['Accept' => 'image/png'])
+        );
+    }
+
+    public function testANonGetVerbIsRejected(): void
+    {
+        $this->expectException(MethodNotAllowedException::class);
+        ( new ValidationsHandler() )->handle($this->requestFor('DELETE', '/validations'));
+    }
+
+    public function testAPathParameterIsRejected(): void
+    {
+        $this->expectException(ValidationException::class);
+        ( new ValidationsHandler(['roman']) )->handle($this->requestFor('GET', '/validations/roman'));
+    }
+}

--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -100,6 +100,8 @@ final class HealthSchemaCategoryTest extends TestCase
             'decrees'              => ['memorials-from-decrees', LitSchema::DECREES_SRC],
             'test definition'      => ['tests-StIgnatiusOfLoyolaTest', LitSchema::TEST_SRC],
             'i18n folder suffix'   => ['national-calendar-US-i18n', LitSchema::I18N],
+            'decrees i18n'         => ['memorials-from-decrees-i18n', LitSchema::I18N],
+            'temporale i18n'       => ['proprium-de-tempore-i18n', LitSchema::I18N],
         ];
     }
 

--- a/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+++ b/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\ValidationsPath;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The inventory of source data the API can validate (#806 step A).
+ *
+ * Its reason for existing is that the layout was written down in several places that had to be
+ * edited in lockstep — the client's path constants, `Health`'s schema table, the `.vscode` globs —
+ * and nothing failed loudly when they diverged. These tests pin the two properties that make one
+ * list safe to rely on: it resolves everything the old table resolved, and its `region` mapping is
+ * exactly what the client's scope predicate assumes.
+ */
+#[CoversClass(CheckableInventory::class)]
+#[CoversClass(CheckableItem::class)]
+final class CheckableInventoryTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // JsonData cases build filesystem paths from this prefix.
+        Router::$apiFilePath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR;
+    }
+
+    /**
+     * The arms of `Health::getPathToSchemaFile()` that name source-data FILES, pasted here as the
+     * oracle. The refactor in a later task is proved equivalent against this rather than assumed.
+     * The route arms of that table are not source data and stay where they are.
+     *
+     * @return array<string, LitSchema>
+     */
+    private static function legacyFileTable(): array
+    {
+        return [
+            JsonData::MISSALS_FOLDER->value . '/propriumdetempore/propriumdetempore.json'                 => LitSchema::PROPRIUMDETEMPORE,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_1970/propriumdesanctis_1970.json'       => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_2002/propriumdesanctis_2002.json'       => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_2008/propriumdesanctis_2008.json'       => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_IT_1983/propriumdesanctis_IT_1983.json' => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_US_2011/propriumdesanctis_US_2011.json' => LitSchema::PROPRIUMDESANCTIS,
+            JsonData::AMBROSIAN_TEMPORALE_FILE->value                                                     => LitSchema::PROPRIUMDETEMPORE,
+            JsonData::AMBROSIAN_SANCTORALE_FILE->value                                                    => LitSchema::PROPRIUMDESANCTIS,
+        ];
+    }
+
+    public function testItResolvesEverythingTheOldFileTableResolved(): void
+    {
+        foreach (self::legacyFileTable() as $path => $schema) {
+            $item = CheckableInventory::byPath($path);
+            self::assertNotNull($item, "no inventory entry for {$path}");
+            self::assertSame($schema, $item->schema, "wrong schema for {$path}");
+        }
+    }
+
+    public function testEveryItemIsFullyPopulatedAndIdsAreUnique(): void
+    {
+        $ids = [];
+        foreach (CheckableInventory::all() as $item) {
+            self::assertNotSame('', $item->id);
+            self::assertContains($item->kind, ['file', 'folder']);
+            self::assertNotSame('', $item->label);
+            self::assertNotSame('', $item->path);
+            self::assertSame(['exists', 'parses', 'validates'], $item->steps);
+            $ids[] = $item->id;
+        }
+        self::assertSame(array_unique($ids), $ids, 'inventory ids must be unique');
+    }
+
+    public function testItHoldsNineFilesAndNineFolders(): void
+    {
+        $kinds = array_count_values(array_map(
+            static fn (CheckableItem $i): string => $i->kind,
+            CheckableInventory::all()
+        ));
+
+        self::assertSame(9, $kinds['file']);
+        self::assertSame(9, $kinds['folder']);
+    }
+
+    public function testTheFiveMissalsWithASanctoraleArePresentAndTheOthersAbsent(): void
+    {
+        $ids = array_map(static fn (CheckableItem $i): string => $i->id, CheckableInventory::all());
+
+        foreach (['EDITIO_TYPICA_1970', 'EDITIO_TYPICA_2002', 'EDITIO_TYPICA_2008', 'US_2011', 'IT_1983'] as $missalId) {
+            self::assertContains("sanctorale:roman:{$missalId}", $ids);
+        }
+        foreach (['EDITIO_TYPICA_1971', 'EDITIO_TYPICA_1975', 'IT_2020', 'NL_1978', 'CA_2011', 'CA_2016'] as $missalId) {
+            self::assertNotContains("sanctorale:roman:{$missalId}", $ids);
+        }
+    }
+
+    /**
+     * The mapping the client's scope predicate depends on: `null` means "applies to the whole rite",
+     * a nation code means "only that nation's calendar". Deliberately NOT produceMetadata()'s 'VA',
+     * which is a nation code and would be simply false on the Ambrosian items.
+     */
+    public function testRegionIsNullForUniversalItemsAndANationCodeForNationalEditions(): void
+    {
+        self::assertNull(CheckableInventory::byId('temporale:roman')?->region);
+        self::assertNull(CheckableInventory::byId('sanctorale:roman:EDITIO_TYPICA_1970')?->region);
+        self::assertNull(CheckableInventory::byId('temporale:ambrosian')?->region);
+        self::assertNull(CheckableInventory::byId('sanctorale:ambrosian')?->region);
+
+        self::assertSame('US', CheckableInventory::byId('sanctorale:roman:US_2011')?->region);
+        self::assertSame('IT', CheckableInventory::byId('sanctorale:roman:IT_1983')?->region);
+    }
+
+    /**
+     * The client's predicate, applied here so the data is proved fit for it:
+     *   item.rite === rite && (item.region === null || item.region === nation)
+     */
+    public function testTheClientScopePredicateSelectsTheRightItems(): void
+    {
+        $inScope = static fn (CheckableItem $i, Rite $rite, ?string $nation): bool
+            => $i->rite === $rite && ( $i->region === null || $i->region === $nation );
+
+        $usa = array_map(
+            static fn (CheckableItem $i): string => $i->id,
+            array_values(array_filter(
+                CheckableInventory::all(),
+                static fn (CheckableItem $i): bool => $inScope($i, Rite::ROMAN, 'US')
+            ))
+        );
+        self::assertContains('sanctorale:roman:US_2011', $usa);
+        self::assertNotContains('sanctorale:roman:IT_1983', $usa);
+        self::assertContains('temporale:roman', $usa);
+
+        $ambrosian = array_map(
+            static fn (CheckableItem $i): string => $i->id,
+            array_values(array_filter(
+                CheckableInventory::all(),
+                static fn (CheckableItem $i): bool => $inScope($i, Rite::AMBROSIAN, null)
+            ))
+        );
+        sort($ambrosian);
+        self::assertSame(
+            ['sanctorale:ambrosian', 'sanctorale:ambrosian:i18n', 'temporale:ambrosian', 'temporale:ambrosian:i18n'],
+            $ambrosian
+        );
+    }
+
+    public function testTheSerializedFormNeverCarriesAPath(): void
+    {
+        foreach (CheckableInventory::all() as $item) {
+            $encoded = json_encode($item, JSON_THROW_ON_ERROR);
+            self::assertStringNotContainsString('jsondata', $encoded, "item {$item->id} leaked a path");
+            self::assertArrayNotHasKey('path', (array) json_decode($encoded, true, 512, JSON_THROW_ON_ERROR));
+        }
+    }
+}

--- a/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
+++ b/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
@@ -48,6 +48,7 @@ final class InventoryDriftTest extends TestCase
         $missalDirs = glob($root . '/rite/*/missals/*', GLOB_ONLYDIR);
         self::assertNotEmpty($missalDirs, 'no missal directories found — is the glob root right?');
 
+        $i18nDirsFound = 0;
         foreach ($missalDirs as $dir) {
             foreach (glob($dir . '/*.json') ?: [] as $file) {
                 self::assertContains(
@@ -57,6 +58,7 @@ final class InventoryDriftTest extends TestCase
                 );
             }
             if (is_dir($dir . '/i18n')) {
+                ++$i18nDirsFound;
                 self::assertContains(
                     $dir . '/i18n',
                     $covered,
@@ -64,6 +66,12 @@ final class InventoryDriftTest extends TestCase
                 );
             }
         }
+
+        self::assertGreaterThan(
+            0,
+            $i18nDirsFound,
+            'no i18n directories found under any missal; if the convention moved, this test has stopped checking translations'
+        );
     }
 
     public function testEveryDecreesDataFileAndI18nFolderIsCovered(): void
@@ -74,13 +82,21 @@ final class InventoryDriftTest extends TestCase
         $decreeDirs = glob($root . '/rite/*/decrees', GLOB_ONLYDIR);
         self::assertNotEmpty($decreeDirs, 'no decrees directories found — is the glob root right?');
 
+        $i18nDirsFound = 0;
         foreach ($decreeDirs as $dir) {
             foreach (glob($dir . '/*.json') ?: [] as $file) {
                 self::assertContains($file, $covered, "source data with no inventory entry: {$file}");
             }
             if (is_dir($dir . '/i18n')) {
+                ++$i18nDirsFound;
                 self::assertContains($dir . '/i18n', $covered, "i18n folder with no inventory entry: {$dir}/i18n");
             }
         }
+
+        self::assertGreaterThan(
+            0,
+            $i18nDirsFound,
+            'no i18n directories found under any decrees folder; if the convention moved, this test has stopped checking translations'
+        );
     }
 }

--- a/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
+++ b/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
@@ -12,7 +12,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Source data that exists on disk but appears in no inventory entry.
+ * Source data that exists on disk but appears in no inventory entry — for the directories this
+ * test walks.
  *
  * This is the failure #800 was: the Ambrosian temporale was present and unvalidatable, because
  * nothing listed it. Divergence between the data and the list that describes it was silent, and
@@ -22,6 +23,12 @@ use PHPUnit\Framework\TestCase;
  * failure here: that is what the `exists` step reports at check time, and asserting it would stop
  * the inventory from advertising data a given deployment is missing — reintroducing the same
  * blindness from the other side.
+ *
+ * Coverage is not exhaustive. This test walks only the `missals` and `decrees` directories under
+ * each `rite`. The `calendars` tree under each rite, and the `lectionary` tree under `roman`, are
+ * outside `CheckableInventory`'s scope entirely and are never visited here. Within the directories
+ * that are walked, only top-level JSON files and an `i18n` subfolder are checked — a `lectionary`
+ * subfolder nested inside a missal or decrees directory is not covered either.
  */
 #[CoversClass(CheckableInventory::class)]
 final class InventoryDriftTest extends TestCase

--- a/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
+++ b/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\ValidationsPath;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Source data that exists on disk but appears in no inventory entry.
+ *
+ * This is the failure #800 was: the Ambrosian temporale was present and unvalidatable, because
+ * nothing listed it. Divergence between the data and the list that describes it was silent, and
+ * stayed silent until someone went looking. Here it is a red test.
+ *
+ * Only this direction is asserted. An inventory entry with nothing on disk is deliberately NOT a
+ * failure here: that is what the `exists` step reports at check time, and asserting it would stop
+ * the inventory from advertising data a given deployment is missing — reintroducing the same
+ * blindness from the other side.
+ */
+#[CoversClass(CheckableInventory::class)]
+final class InventoryDriftTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        Router::$apiFilePath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR;
+    }
+
+    /** @return list<string> every path the inventory claims to cover */
+    private static function coveredPaths(): array
+    {
+        return array_map(
+            static fn (CheckableItem $i): string => rtrim($i->path, '/'),
+            CheckableInventory::all()
+        );
+    }
+
+    public function testEveryMissalDataFileAndI18nFolderIsCovered(): void
+    {
+        $covered = self::coveredPaths();
+        $root    = rtrim(JsonData::SOURCEDATA_FOLDER->path(), '/');
+
+        $missalDirs = glob($root . '/rite/*/missals/*', GLOB_ONLYDIR);
+        self::assertNotEmpty($missalDirs, 'no missal directories found — is the glob root right?');
+
+        foreach ($missalDirs as $dir) {
+            foreach (glob($dir . '/*.json') ?: [] as $file) {
+                self::assertContains(
+                    $file,
+                    $covered,
+                    "source data with no inventory entry: {$file} — add it to CheckableInventory"
+                );
+            }
+            if (is_dir($dir . '/i18n')) {
+                self::assertContains(
+                    $dir . '/i18n',
+                    $covered,
+                    "i18n folder with no inventory entry: {$dir}/i18n — add it to CheckableInventory"
+                );
+            }
+        }
+    }
+
+    public function testEveryDecreesDataFileAndI18nFolderIsCovered(): void
+    {
+        $covered = self::coveredPaths();
+        $root    = rtrim(JsonData::SOURCEDATA_FOLDER->path(), '/');
+
+        $decreeDirs = glob($root . '/rite/*/decrees', GLOB_ONLYDIR);
+        self::assertNotEmpty($decreeDirs, 'no decrees directories found — is the glob root right?');
+
+        foreach ($decreeDirs as $dir) {
+            foreach (glob($dir . '/*.json') ?: [] as $file) {
+                self::assertContains($file, $covered, "source data with no inventory entry: {$file}");
+            }
+            if (is_dir($dir . '/i18n')) {
+                self::assertContains($dir . '/i18n', $covered, "i18n folder with no inventory entry: {$dir}/i18n");
+            }
+        }
+    }
+}

--- a/phpunit_tests/Schemas/SchemaConventionsTest.php
+++ b/phpunit_tests/Schemas/SchemaConventionsTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * House conventions every file in `jsondata/schemas/` follows.
+ *
+ * These are already asserted, but only from `Routes/Readonly/SchemasTest`, which fetches each schema
+ * over HTTP and therefore needs a running server. That makes a convention slip invisible locally and
+ * discoverable only in CI — which is exactly how a schema declaring draft 2020-12 in a draft-07
+ * corpus reached a pull request.
+ *
+ * Reading the files off disk costs nothing and moves the same failure to `composer test:quick`.
+ */
+#[CoversNothing]
+final class SchemaConventionsTest extends TestCase
+{
+    /**
+     * The folder is located from this file rather than through `JsonData`, because PHPUnit runs a data
+     * provider before `setUpBeforeClass()`, and `JsonData::*->path()` needs `Router::$apiFilePath` to
+     * have been initialised. Reaching for the enum here throws before a single case is produced.
+     *
+     * @return array<string, array{string, array<string, mixed>}>
+     */
+    public static function schemaFileProvider(): array
+    {
+        $folder = dirname(__DIR__, 2) . '/jsondata/schemas';
+        $files  = glob($folder . '/*.json') ?: [];
+
+        $cases = [];
+        foreach ($files as $file) {
+            $decoded = json_decode((string) file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+            // The OpenAPI document lives in the same folder but is not a JSON Schema.
+            if (false === is_array($decoded) || array_key_exists('openapi', $decoded)) {
+                continue;
+            }
+            $cases[basename($file)] = [basename($file), $decoded];
+        }
+
+        return $cases;
+    }
+
+    /**
+     * @param array<string, mixed> $decoded
+     */
+    #[DataProvider('schemaFileProvider')]
+    public function testEverySchemaDeclaresTheCorpusDraft(string $name, array $decoded): void
+    {
+        self::assertArrayHasKey('$schema', $decoded, "{$name} declares no \$schema");
+        self::assertSame(
+            'https://json-schema.org/draft-07/schema#',
+            $decoded['$schema'],
+            "{$name} declares a different JSON Schema draft from the rest of the corpus. "
+                . 'Mixing drafts is what Routes/Readonly/SchemasTest rejects, and that test needs a live server, '
+                . 'so the mismatch would otherwise only surface in CI.'
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $decoded
+     */
+    #[DataProvider('schemaFileProvider')]
+    public function testNoSchemaCarriesAnAbsoluteId(string $name, array $decoded): void
+    {
+        self::assertArrayNotHasKey(
+            '$id',
+            $decoded,
+            "{$name} carries an \$id. The corpus deliberately omits it — cross-file \$refs here are relative "
+                . '(./Foo.json), and an absolute $id pins the base URI to one deployment.'
+        );
+    }
+}

--- a/src/Enum/LitSchema.php
+++ b/src/Enum/LitSchema.php
@@ -25,6 +25,7 @@ enum LitSchema: string
     case EASTER            = '/LitCalEasterPath.json';
     case DATA              = '/LitCalDataPath.json';
     case SCHEMAS           = '/LitCalSchemasPath.json';
+    case VALIDATIONS       = '/LitCalValidationsPath.json';
 
     public function path(): string
     {
@@ -52,7 +53,8 @@ enum LitSchema: string
             LitSchema::MISSALS  => $ERRMSG . 'Missals path data not valid',
             LitSchema::EASTER   => $ERRMSG . 'Easter path data not valid',
             LitSchema::DATA     => $ERRMSG . 'Data path data not valid',
-            LitSchema::SCHEMAS  => $ERRMSG . 'Schemas path data not valid'
+            LitSchema::SCHEMAS  => $ERRMSG . 'Schemas path data not valid',
+            LitSchema::VALIDATIONS => $ERRMSG . 'Validations path data not valid'
         };
     }
 
@@ -77,6 +79,7 @@ enum LitSchema: string
             LitSchema::EASTER->path()            => LitSchema::EASTER,
             LitSchema::DATA->path()              => LitSchema::DATA,
             LitSchema::SCHEMAS->path()           => LitSchema::SCHEMAS,
+            LitSchema::VALIDATIONS->path()       => LitSchema::VALIDATIONS,
             default                              => throw new ValidationException('Invalid schema URL: ' . $url)
         };
     }

--- a/src/Enum/Route.php
+++ b/src/Enum/Route.php
@@ -22,6 +22,7 @@ enum Route: string
     case EASTER             = '/easter';
     case SCHEMAS            = '/schemas';
     case MISSALS            = '/missals';
+    case VALIDATIONS        = '/validations';
     case OPS_MIGRATE        = '/_ops/migrate';
     case OPS_MIGRATE_STATUS = '/_ops/migrate/status';
 

--- a/src/Handlers/ValidationsHandler.php
+++ b/src/Handlers/ValidationsHandler.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * Advertise the source data this API can validate.
+ *
+ * Clients used to hardcode this repo's on-disk layout and had to be edited in lockstep with every
+ * change to it — see #806. They now read this list and send back an opaque id, so no filesystem
+ * path crosses the wire.
+ *
+ * This endpoint deliberately does not touch the filesystem. Advertising is not verification:
+ * `exists` is the first check, not a precondition for being listed, so a missing file surfaces as
+ * a failed check rather than as a silent absence from the list.
+ *
+ * @author    John Romano D'Orazio <priest@johnromanodorazio.com>
+ * @license   https://www.apache.org/licenses/LICENSE-2.0.txt Apache License 2.0
+ * @link      https://litcal.johnromanodorazio.com
+ */
+
+namespace LiturgicalCalendar\Api\Handlers;
+
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+final class ValidationsHandler extends AbstractHandler
+{
+    /** @param string[] $requestPathParams */
+    public function __construct(array $requestPathParams = [])
+    {
+        parent::__construct($requestPathParams);
+
+        // Read-only, JSON-only: the same restriction Router applies, held here too
+        // so the handler is self-consistent when instantiated directly (as in tests).
+        $this->allowedRequestMethods = [RequestMethod::GET];
+        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+
+        $method = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime);
+
+        $pathParamCount = count($this->requestPathParams);
+        if ($pathParamCount > 0) {
+            throw new ValidationException(
+                'Invalid number of path parameters, expected 0, received ' . $pathParamCount
+            );
+        }
+
+        $payload                     = new \stdClass();
+        $payload->litcal_validations = CheckableInventory::all();
+
+        return $this->encodeResponseBody($response, $payload);
+    }
+}

--- a/src/Handlers/ValidationsHandler.php
+++ b/src/Handlers/ValidationsHandler.php
@@ -33,8 +33,12 @@ final class ValidationsHandler extends AbstractHandler
     {
         parent::__construct($requestPathParams);
 
-        // Read-only, JSON-only: the same restriction Router applies, held here too
-        // so the handler is self-consistent when instantiated directly (as in tests).
+        // Read-only, JSON-only. Router's restriction here is about methods (GET only), not
+        // Accept — sibling read routes accept [JSON, YAML]. This endpoint deliberately narrows
+        // further: it's a machine-readable inventory for clients deciding what to validate, not
+        // a document meant for human viewing in alternate formats, so there's no reason to carry
+        // the YAML encoding cost. Held here too so the handler is self-consistent when
+        // instantiated directly (as in tests).
         $this->allowedRequestMethods = [RequestMethod::GET];
         $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
     }

--- a/src/Health.php
+++ b/src/Health.php
@@ -24,6 +24,7 @@ use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use Symfony\Component\Yaml\Yaml;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
@@ -2046,24 +2047,28 @@ class Health implements MessageComponentInterface
      */
     private static function getPathToSchemaFile(string $dataFile): ?string
     {
+        // Source-data files come from the one inventory (#806 step A); the arms below are API
+        // routes, which are a different kind of thing and stay here.
+        //
+        // CheckableInventory::byPath() already normalises between the two path representations
+        // in play: $dataFile here is the unprefixed repo-relative form (matching JsonData::*->value),
+        // while the inventory stores absolute paths prefixed with Router::$apiFilePath. No
+        // conversion is needed at this call site.
+        $item = CheckableInventory::byPath($dataFile);
+        if (null !== $item) {
+            return $item->schema->path();
+        }
+
         return match ($dataFile) {
-            JsonData::MISSALS_FOLDER->value . '/propriumdetempore/propriumdetempore.json'                 => LitSchema::PROPRIUMDETEMPORE->path(),
-            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_1970/propriumdesanctis_1970.json'       => LitSchema::PROPRIUMDESANCTIS->path(),
-            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_2002/propriumdesanctis_2002.json'       => LitSchema::PROPRIUMDESANCTIS->path(),
-            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_2008/propriumdesanctis_2008.json'       => LitSchema::PROPRIUMDESANCTIS->path(),
-            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_IT_1983/propriumdesanctis_IT_1983.json' => LitSchema::PROPRIUMDESANCTIS->path(),
-            JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_US_2011/propriumdesanctis_US_2011.json' => LitSchema::PROPRIUMDESANCTIS->path(),
-            JsonData::AMBROSIAN_TEMPORALE_FILE->value                                                     => LitSchema::PROPRIUMDETEMPORE->path(),
-            JsonData::AMBROSIAN_SANCTORALE_FILE->value                                                    => LitSchema::PROPRIUMDESANCTIS->path(),
-            Route::CALENDARS->path()                                                                      => LitSchema::METADATA->path(),
-            Route::DECREES->path()                                                                        => LitSchema::DECREES->path(),
-            Route::EVENTS->path()                                                                         => LitSchema::EVENTS->path(),
-            Route::TESTS->path()                                                                          => LitSchema::TESTS->path(),
-            Route::EASTER->path()                                                                         => LitSchema::EASTER->path(),
-            Route::MISSALS->path()                                                                        => LitSchema::MISSALS->path(),
-            Route::DATA->path()                                                                           => LitSchema::DATA->path(),
-            Route::SCHEMAS->path()                                                                        => LitSchema::SCHEMAS->path(),
-            default => null
+            Route::CALENDARS->path() => LitSchema::METADATA->path(),
+            Route::DECREES->path()   => LitSchema::DECREES->path(),
+            Route::EVENTS->path()    => LitSchema::EVENTS->path(),
+            Route::TESTS->path()     => LitSchema::TESTS->path(),
+            Route::EASTER->path()    => LitSchema::EASTER->path(),
+            Route::MISSALS->path()   => LitSchema::MISSALS->path(),
+            Route::DATA->path()      => LitSchema::DATA->path(),
+            Route::SCHEMAS->path()   => LitSchema::SCHEMAS->path(),
+            default                  => null
         };
     }
 
@@ -2175,6 +2180,20 @@ class Health implements MessageComponentInterface
                 }
                 return Health::getPathToSchemaFile($dataPath);
             case 'sourceDataCheck':
+                // Legacy slugs from the runner pages, mapped onto inventory ids. #806 step A gives
+                // every item an id; until the clients send those ids (UnitTestInterface#42), the
+                // old vocabulary keeps working through this table.
+                $legacySlugToId = [
+                    'memorials-from-decrees'      => 'decrees:roman',
+                    'memorials-from-decrees-i18n' => 'decrees:roman:i18n',
+                    'proprium-de-tempore'         => 'temporale:roman',
+                    'proprium-de-tempore-i18n'    => 'temporale:roman:i18n'
+                ];
+                $item           = CheckableInventory::byId($legacySlugToId[$dataPath] ?? $dataPath);
+                if (null !== $item) {
+                    return $item->schema->path();
+                }
+
                 if (preg_match('/-i18n$/', $dataPath)) {
                     return LitSchema::I18N->path();
                 }

--- a/src/Health.php
+++ b/src/Health.php
@@ -2183,6 +2183,13 @@ class Health implements MessageComponentInterface
                 // Legacy slugs from the runner pages, mapped onto inventory ids. #806 step A gives
                 // every item an id; until the clients send those ids (UnitTestInterface#42), the
                 // old vocabulary keeps working through this table.
+                //
+                // proprium-de-sanctis-* is deliberately absent: those slugs are hyphenated (e.g.
+                // proprium-de-sanctis-IT-1983) while the matching inventory ids are underscored
+                // (sanctorale:roman:IT_1983), so mapping them here would mean hand-listing the
+                // five editions again — exactly the restatement the derivation removed. They keep
+                // resolving through the surviving regex below instead, until clients send inventory
+                // ids.
                 $legacySlugToId = [
                     'memorials-from-decrees'      => 'decrees:roman',
                     'memorials-from-decrees-i18n' => 'decrees:roman:i18n',

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\ValidationsPath;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Enum\RomanMissal;
+use LiturgicalCalendar\Api\Router;
+
+/**
+ * The source data this API can validate, in one place.
+ *
+ * Previously the same knowledge lived in `Health`'s path-to-schema table, in a parallel branch
+ * that matched on slugs instead of paths, and in each client's hardcoded copy of the layout —
+ * with nothing detecting divergence. See #806.
+ *
+ * Half of it need not be written down at all: `RomanMissal` already registers every missal edition
+ * and already knows which have a sanctorale file, so those items are derived. The rest have
+ * dedicated `JsonData` constants and are listed explicitly.
+ *
+ * Paths always come from `JsonData` cases. `JsonData` is where this repo's layout is written down;
+ * this class must not become a second copy of it.
+ */
+final class CheckableInventory
+{
+    /** @var list<string> Every item is checked the same three ways today. */
+    private const STEPS = ['exists', 'parses', 'validates'];
+
+    /** @var list<CheckableItem>|null */
+    private static ?array $items = null;
+
+    /** @return list<CheckableItem> */
+    public static function all(): array
+    {
+        if (null === self::$items) {
+            self::$items = array_merge(self::derivedRomanSanctorale(), self::explicitItems());
+        }
+
+        return self::$items;
+    }
+
+    public static function byId(string $id): ?CheckableItem
+    {
+        return array_find(self::all(), static fn (CheckableItem $i): bool => $i->id === $id);
+    }
+
+    /**
+     * `Health` compares against `JsonData::*->value`, i.e. repo-relative paths, while this
+     * inventory stores the absolute form the `JsonData` and `RomanMissal` accessors return.
+     * Normalise here so neither caller has to know which representation it is holding.
+     */
+    public static function byPath(string $path): ?CheckableItem
+    {
+        $needle = str_starts_with($path, Router::$apiFilePath)
+            ? $path
+            : Router::$apiFilePath . ltrim($path, '/');
+        $needle = rtrim($needle, '/');
+
+        return array_find(
+            self::all(),
+            static fn (CheckableItem $i): bool => rtrim($i->path, '/') === $needle
+        );
+    }
+
+    /**
+     * The Roman sanctorale, derived from the missal registry rather than restated.
+     *
+     * `getSanctoraleFileName()` returns false for the editions that have no sanctorale file on
+     * disk, which is exactly how the five that do were picked in the old hand-written table. A new
+     * edition with a sanctorale file joins the inventory with no edit here.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function derivedRomanSanctorale(): array
+    {
+        $items = [];
+        foreach (RomanMissal::getMissalIds() as $missalId) {
+            $file = RomanMissal::getSanctoraleFileName($missalId);
+            if (false === $file) {
+                continue;
+            }
+
+            $name = RomanMissal::getName($missalId);
+            // 'VA' in produceMetadata() means "not nation-specific"; this inventory says so with null.
+            $region = str_starts_with($missalId, 'EDITIO_TYPICA_') ? null : explode('_', $missalId)[0];
+
+            $items[] = new CheckableItem(
+                "sanctorale:roman:{$missalId}",
+                'file',
+                Rite::ROMAN,
+                $region,
+                $name,
+                LitSchema::PROPRIUMDESANCTIS,
+                self::STEPS,
+                $file
+            );
+
+            $i18n = RomanMissal::getSanctoraleI18nFilePath($missalId);
+            if (false !== $i18n) {
+                $items[] = new CheckableItem(
+                    "sanctorale:roman:{$missalId}:i18n",
+                    'folder',
+                    Rite::ROMAN,
+                    $region,
+                    "{$name} translations",
+                    LitSchema::I18N,
+                    self::STEPS,
+                    rtrim($i18n, '/')
+                );
+            }
+        }
+
+        return $items;
+    }
+
+    /** @return list<CheckableItem> */
+    private static function explicitItems(): array
+    {
+        return [
+            new CheckableItem(
+                'temporale:roman',
+                'file',
+                Rite::ROMAN,
+                null,
+                'Roman Proprium de Tempore',
+                LitSchema::PROPRIUMDETEMPORE,
+                self::STEPS,
+                JsonData::TEMPORALE_FILE->path()
+            ),
+            new CheckableItem(
+                'temporale:roman:i18n',
+                'folder',
+                Rite::ROMAN,
+                null,
+                'Roman Proprium de Tempore translations',
+                LitSchema::I18N,
+                self::STEPS,
+                JsonData::TEMPORALE_I18N_FOLDER->path()
+            ),
+            new CheckableItem(
+                'decrees:roman',
+                'file',
+                Rite::ROMAN,
+                null,
+                'Memorials from Decrees',
+                LitSchema::DECREES_SRC,
+                self::STEPS,
+                JsonData::DECREES_FILE->path()
+            ),
+            new CheckableItem(
+                'decrees:roman:i18n',
+                'folder',
+                Rite::ROMAN,
+                null,
+                'Memorials from Decrees translations',
+                LitSchema::I18N,
+                self::STEPS,
+                JsonData::DECREES_I18N_FOLDER->path()
+            ),
+            new CheckableItem(
+                'temporale:ambrosian',
+                'file',
+                Rite::AMBROSIAN,
+                null,
+                'Ambrosian Proprium de Tempore',
+                LitSchema::PROPRIUMDETEMPORE,
+                self::STEPS,
+                JsonData::AMBROSIAN_TEMPORALE_FILE->path()
+            ),
+            new CheckableItem(
+                'temporale:ambrosian:i18n',
+                'folder',
+                Rite::AMBROSIAN,
+                null,
+                'Ambrosian Proprium de Tempore translations',
+                LitSchema::I18N,
+                self::STEPS,
+                JsonData::AMBROSIAN_TEMPORALE_I18N_FOLDER->path()
+            ),
+            new CheckableItem(
+                'sanctorale:ambrosian',
+                'file',
+                Rite::AMBROSIAN,
+                null,
+                'Ambrosian Proprium de Sanctis',
+                LitSchema::PROPRIUMDESANCTIS,
+                self::STEPS,
+                JsonData::AMBROSIAN_SANCTORALE_FILE->path()
+            ),
+            new CheckableItem(
+                'sanctorale:ambrosian:i18n',
+                'folder',
+                Rite::AMBROSIAN,
+                null,
+                'Ambrosian Proprium de Sanctis translations',
+                LitSchema::I18N,
+                self::STEPS,
+                JsonData::AMBROSIAN_SANCTORALE_I18N_FOLDER->path()
+            )
+        ];
+    }
+}

--- a/src/Models/ValidationsPath/CheckableItem.php
+++ b/src/Models/ValidationsPath/CheckableItem.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\ValidationsPath;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+
+/**
+ * One thing the API can be asked to validate: a source-data file, or a folder of i18n files.
+ *
+ * `$path` is the server-side location a check resolves against, and is deliberately absent from
+ * the serialized form. Keeping filesystem paths off the wire is the whole point of `/validations`
+ * (#806 step A): clients that hardcoded them had to be edited in lockstep with every layout
+ * change, which is #737/UnitTestInterface#38, #795 and #800. The omission lives in this class
+ * rather than in the handler so that a second caller cannot forget it.
+ *
+ * `$region` is `null` when the item applies to its whole rite, and an ISO nation code when it
+ * applies only to that nation's calendar. This differs on purpose from
+ * {@see \LiturgicalCalendar\Api\Enum\RomanMissal::produceMetadata()}, which reports `'VA'` for the
+ * editiones typicae: `'VA'` is a nation code that only reads as "universal" because the General
+ * Roman Calendar happens to be served under nation VA, and it would be false on Ambrosian items.
+ */
+final readonly class CheckableItem implements \JsonSerializable
+{
+    /**
+     * @param 'file'|'folder' $kind
+     * @param list<string> $steps
+     */
+    public function __construct(
+        public string $id,
+        public string $kind,
+        public Rite $rite,
+        public ?string $region,
+        public string $label,
+        public LitSchema $schema,
+        public array $steps,
+        public string $path
+    ) {
+    }
+
+    /**
+     * @return array{id:string,kind:string,rite:string,region:string|null,label:string,schema:string,steps:list<string>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'id'     => $this->id,
+            'kind'   => $this->kind,
+            'rite'   => $this->rite->value,
+            'region' => $this->region,
+            'label'  => $this->label,
+            // LitSchema values are '/Foo.json'; the wire carries the bare filename.
+            'schema' => ltrim($this->schema->value, '/'),
+            'steps'  => $this->steps
+        ];
+    }
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -18,6 +18,7 @@ use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
 use LiturgicalCalendar\Api\Handlers\MissalsHandler;
 use LiturgicalCalendar\Api\Handlers\DecreesHandler;
 use LiturgicalCalendar\Api\Handlers\SchemasHandler;
+use LiturgicalCalendar\Api\Handlers\ValidationsHandler;
 use LiturgicalCalendar\Api\Handlers\TemporaleHandler;
 use LiturgicalCalendar\Api\Handlers\Auth\LoginHandler;
 use LiturgicalCalendar\Api\Handlers\Auth\LogoutHandler;
@@ -450,6 +451,11 @@ class Router
                     AcceptHeader::YAML
                 ]);
                 $this->handler = $schemasHandler;
+                break;
+            case 'validations':
+                $validationsHandler = new ValidationsHandler($requestPathParts);
+                $validationsHandler->setAllowedRequestMethods([RequestMethod::GET]);
+                $this->handler = $validationsHandler;
                 break;
             case 'auth':
                 // Handle authentication routes


### PR DESCRIPTION
## The fault this removes

Clients hardcode this repository's on-disk source-data layout, so every change to it has to be made in lockstep somewhere else. That one fault produced three separate incidents:

| Incident | What broke |
|---|---|
| #737 → Liturgical-Calendar/UnitTestInterface#38 | data moved under `rite/roman/`; the client's copy of the layout had to follow — its fix commit says "lockstep with API #737" |
| #795 | twelve `.vscode` schema globs silently matching nothing — a third copy of the layout, never chased |
| #800 | Ambrosian temporale present on disk and unvalidatable by any client, because nothing listed it |

`GET /validations` publishes what the API can check. Clients iterate it and send back an opaque id, so no filesystem path crosses the wire.

This is step A of #806, and it ships useful on its own: nothing needs to change client-side for it to be correct, and the client adoption is Liturgical-Calendar/UnitTestInterface#42 and #48.

## Half of the inventory isn't written down

`RomanMissal` already registers every missal edition and already knows which have a sanctorale file — `getSanctoraleFileName()` returns a path for five of the eleven and `false` for the rest. Those five are *exactly* the five Roman sanctorale arms of the old hand-written table, so the inventory derives them instead of restating them, along with their `i18n` folders, labels, and region. A new edition with a sanctorale file joins the inventory with no edit to it.

The remaining four pairs — Roman temporale, Roman decrees, Ambrosian temporale, Ambrosian sanctorale — are explicit, built from `JsonData` enum constants. 18 items in total: 9 files and 9 `i18n` folders.

Paths only ever come from `JsonData` cases or `RomanMissal` accessors. The point is not to add a better copy of the layout; it is to stop having copies.

## `Health` loses two lookups

`Health` resolved the same files two ways: `getPathToSchemaFile()` matched on a path, and a separate branch matched the same files on a *slug*, with different vocabularies depending on which runner page asked — ambiguity 4 in #806. Both now consult the inventory first.

Nothing lost a capability. The route arms of the path table are API endpoints rather than source data and stay put; the per-calendar patterns in the slug branch (wider region, national, diocesan, tests) are out of this scope and stay too. The change is additive on purpose: legacy slugs keep working through a small mapping table, so no client changes behaviour today. Retiring them belongs with UnitTestInterface#42, once clients send inventory ids.

`HealthSchemaMappingTest` and `HealthSchemaCategoryTest` pass **unchanged**, and no test file was edited — which is what makes that meaningful.

## Deliberately not done

- **The endpoint never stats the filesystem.** Advertising is not verification: `exists` is the first *check*, not a precondition for being listed. A missing file must surface as a failed check, not as a silent absence from the list — that blindness is exactly how #800 stayed invisible.
- **No query parameters.** Both consumers fetch once at load and filter in the browser, so changing rite or calendar re-filters an array instead of making another request.
- **No `protocol` field.** Versioning and capability negotiation are #806 section F; stamping a version on one endpoint before that contract exists is a guess that would then have to be supported.

## The drift test

`InventoryDriftTest` fails when source data exists on disk with no inventory entry. It would have failed the moment the Ambrosian data landed without a match-table entry, which is #800.

It asserts that direction only. An entry with nothing on disk is deliberately *not* a failure — that is what the `exists` step reports at check time, and asserting it would stop the inventory advertising data a given deployment is missing, which is the same blindness from the other side.

It was verified by mutation, not just by being green: removing an inventory entry makes it fail and name the orphaned file; renaming the `i18n` directories makes the coverage guard fire.

## Review findings fixed before this PR opened

A whole-branch review found one Important issue worth naming, because it is the sort a passing suite hides. `$legacySlugToId` is the one new hand-maintained table the refactor introduces, and two of its four entries were untested — while the `-i18n$` regex that would have caught a wrong id in them is now *shadowed* by the inventory lookup running first. So the refactor had removed the safety net covering its own new table. All four slugs are now in `sourceDataCheckSlugProvider()`, and the rows were verified by deliberately pointing one entry at the wrong id and watching the new case fail.

Four factual slips in the design document were corrected in the same pass, including a described test that was never written and an overclaim that this work cures #795 — it does not. #799 fixed #795 by re-copying the layout into `.vscode/settings.json`, which is the recurring move rather than a cure; those globs stay outside this design's reach, and nothing here would notice if they went stale again. A follow-up worth filing: the same inventory could back a test asserting they still match real paths.

## Verification

```
phpunit HealthSchemaCategoryTest + HealthSchemaMappingTest    OK (42 tests)   identical before and after the refactor
phpunit Models/ValidationsPath + ValidationsHandlerTest       OK (58 tests, 461 assertions)
ReadonlyPathsResponseSchemaTest                               OK, incl. the new /validations case
composer lint / analyse (PHPStan level 10) / lint:openapi     clean
composer test:quick                                           no new failures
markdownlint                                                  clean
```

The `Routes/*` errors visible in `composer test:quick` target a server belonging to a different checkout and were confirmed pre-existing by stash-and-rerun against unmodified code, not attributed from memory.

Design and plan are committed under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `GET /validations` endpoint that lists available validation sources and supported validation steps.
  * Added metadata for Roman, Ambrosian, temporal, decree, and translation validation resources.
  * Responses omit server-side filesystem paths for improved security.
  * Added JSON Schema and OpenAPI documentation for the endpoint.

* **Bug Fixes**
  * Improved validation schema resolution, including compatibility with legacy identifiers.

* **Tests**
  * Added coverage for response validation, request handling, path redaction, inventory completeness, and source-data drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->