### PR TITLE
fix(health): make schema lookup and diocesan source paths rite-aware

### DIFF
--- a/phpunit_tests/HealthRiteSourcePathTest.php
+++ b/phpunit_tests/HealthRiteSourcePathTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * Coverage for the rite partitioning of the diocesan source paths `executeValidation()` derives
+ * (issue #812).
+ *
+ * The diocesan tier is the only one that exists under more than one rite: an Ambrosian diocese
+ * keeps its calendar file and its i18n folder under `sourcedata/rite/ambrosian/...`, reached
+ * through `JsonData::diocesanCalendarFileFor()` / `diocesanCalendarI18nFolderFor()`. `Health`
+ * used the bare Roman constants, so validating any of the four Ambrosian dioceses looked for
+ * data in a tree that does not contain it.
+ *
+ * Both branches are driven through `executeValidation()` rather than by re-deriving the path in
+ * the test, because a test that built the path itself would pass whether or not the production
+ * call site had been fixed. Neither branch needs an event loop: the file branch echoes the path
+ * it is about to read before handing off to the (never-run) promise, and the folder branch
+ * short-circuits synchronously when the folder is missing.
+ */
+#[CoversClass(Health::class)]
+final class HealthRiteSourcePathTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        Router::getApiPaths();
+    }
+
+    // ---------------------------------------------------------------- source file
+
+    public function testAmbrosianDiocesanSourceFileResolvesUnderTheAmbrosianTree(): void
+    {
+        $expected = strtr(JsonData::AMBROSIAN_DIOCESAN_CALENDAR_FILE->path(), [
+            '{nation}'       => 'IT',
+            '{diocese}'      => 'milano_it',
+            '{diocese_name}' => 'Arcidiocesi di Milano'
+        ]);
+
+        self::assertStringContainsString(
+            'Reading data from file ' . $expected,
+            self::captureSourceFileRead('milano_it')
+        );
+    }
+
+    public function testRomanDiocesanSourceFileStaysUnderTheRomanTree(): void
+    {
+        $expected = strtr(JsonData::DIOCESAN_CALENDAR_FILE->path(), [
+            '{nation}'       => 'NL',
+            '{diocese}'      => 'rotter_nl',
+            '{diocese_name}' => 'Rotterdam'
+        ]);
+
+        $output = self::captureSourceFileRead('rotter_nl');
+
+        self::assertStringContainsString('Reading data from file ' . $expected, $output);
+        self::assertStringNotContainsString(JsonData::AMBROSIAN_DIOCESAN_CALENDARS_FOLDER->value, $output);
+    }
+
+    /**
+     * The server derives the path from the diocese id and its rite; whatever the client put in
+     * `sourceFile` is not what gets read.
+     */
+    public function testTheClientSuppliedSourceFileIsNotWhatIsRead(): void
+    {
+        $output = self::captureSourceFileRead('milano_it');
+
+        self::assertStringNotContainsString('client/supplied/nonsense.json', $output);
+    }
+
+    // ---------------------------------------------------------------- i18n folder
+
+    /**
+     * The direct regression guard, on the real fixture: the Ambrosian i18n folder for `milano_it`
+     * exists and its files validate, so a correctly derived path yields three *success* frames.
+     * With the Roman constant the derived folder does not exist and the missing-folder short
+     * circuit fired three error frames instead.
+     */
+    public function testAmbrosianDiocesanI18nFolderIsFoundAndValidatedOnDisk(): void
+    {
+        $conn = self::runI18nFolderCheck([self::diocese('milano_it', 'Arcidiocesi di Milano', 'IT', Rite::AMBROSIAN)], 'milano_it');
+
+        self::assertCount(3, $conn->sent);
+        foreach (self::decode($conn) as $frame) {
+            self::assertSame('success', $frame->type, 'the Ambrosian i18n folder exists; the check must not report it missing');
+        }
+    }
+
+    /**
+     * The same guard from the Roman side, so the rite branch cannot be "fixed" by pointing
+     * everything at the Ambrosian tree.
+     */
+    public function testRomanDiocesanI18nFolderIsFoundAndValidatedOnDisk(): void
+    {
+        $conn = self::runI18nFolderCheck([self::diocese('rotter_nl', 'Rotterdam', 'NL', Rite::ROMAN)], 'rotter_nl');
+
+        self::assertCount(3, $conn->sent);
+        foreach (self::decode($conn) as $frame) {
+            self::assertSame('success', $frame->type);
+        }
+    }
+
+    /**
+     * The exact-path assertion. A diocese that is absent from *both* trees takes the
+     * missing-folder short circuit, whose message quotes the path that was derived — the only
+     * synchronous window onto it.
+     */
+    public function testAnAmbrosianDioceseDerivesItsI18nFolderFromTheAmbrosianTemplate(): void
+    {
+        $expected = strtr(JsonData::AMBROSIAN_DIOCESAN_CALENDAR_I18N_FOLDER->path(), [
+            '{nation}'  => 'ZZ',
+            '{diocese}' => 'nowher_zz'
+        ]);
+
+        $conn = self::runI18nFolderCheck([self::diocese('nowher_zz', 'Nowhere', 'ZZ', Rite::AMBROSIAN)], 'nowher_zz');
+
+        self::assertCount(3, $conn->sent);
+        foreach (self::decode($conn) as $frame) {
+            self::assertStringContainsString($expected, (string) $frame->text);
+        }
+    }
+
+    public function testARomanDioceseDerivesItsI18nFolderFromTheRomanTemplate(): void
+    {
+        $expected = strtr(JsonData::DIOCESAN_CALENDAR_I18N_FOLDER->path(), [
+            '{nation}'  => 'ZZ',
+            '{diocese}' => 'nowher_zz'
+        ]);
+
+        $conn = self::runI18nFolderCheck([self::diocese('nowher_zz', 'Nowhere', 'ZZ', Rite::ROMAN)], 'nowher_zz');
+
+        self::assertCount(3, $conn->sent);
+        foreach (self::decode($conn) as $frame) {
+            self::assertStringContainsString($expected, (string) $frame->text);
+            self::assertStringNotContainsString(JsonData::AMBROSIAN_DIOCESAN_CALENDARS_FOLDER->value, (string) $frame->text);
+        }
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    /**
+     * Run a diocesan `sourceFile` check and return everything `executeValidation()` echoed. The
+     * path is echoed before the read is handed to a promise that is never resolved, so this
+     * needs neither the event loop nor the file to exist.
+     */
+    private static function captureSourceFileRead(string $dioceseId): string
+    {
+        $conn   = self::createStubConnection(1);
+        $health = self::healthWithRunToken($conn);
+
+        ob_start();
+        try {
+            self::withMetadata(
+                [
+                    self::diocese('milano_it', 'Arcidiocesi di Milano', 'IT', Rite::AMBROSIAN),
+                    self::diocese('rotter_nl', 'Rotterdam', 'NL', Rite::ROMAN),
+                ],
+                static function () use ($health, $conn, $dioceseId): void {
+                    $method = new \ReflectionMethod(Health::class, 'executeValidation');
+                    $method->invoke($health, (object) [
+                        'action'     => 'executeValidation',
+                        'category'   => 'sourceDataCheck',
+                        'validate'   => "diocesan-calendar-$dioceseId",
+                        'sourceFile' => 'client/supplied/nonsense.json',
+                    ], $conn);
+                }
+            );
+        } finally {
+            $output = (string) ob_get_clean();
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param list<\stdClass> $dioceses
+     */
+    private static function runI18nFolderCheck(array $dioceses, string $dioceseId): ConnectionInterface
+    {
+        $conn   = self::createStubConnection(2);
+        $health = self::healthWithRunToken($conn);
+
+        ob_start();
+        try {
+            self::withMetadata($dioceses, static function () use ($health, $conn, $dioceseId): void {
+                $method = new \ReflectionMethod(Health::class, 'executeValidation');
+                $method->invoke($health, (object) [
+                    'action'       => 'executeValidation',
+                    'category'     => 'sourceDataCheck',
+                    'validate'     => "diocesan-calendar-$dioceseId-i18n",
+                    'sourceFolder' => 'client/supplied/nonsense',
+                ], $conn);
+            });
+        } finally {
+            ob_end_clean();
+        }
+
+        return $conn;
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    private static function decode(ConnectionInterface $conn): array
+    {
+        /** @var object{sent: list<string>} $conn */
+        return array_map(static fn(string $raw): \stdClass => json_decode($raw), $conn->sent);
+    }
+
+    private static function healthWithRunToken(ConnectionInterface $conn): Health
+    {
+        $health = new Health();
+        /** @var object{resourceId: int} $conn */
+        ( new \ReflectionProperty(Health::class, 'runTokens') )->setValue($health, [$conn->resourceId => 'run-token-1']);
+
+        return $health;
+    }
+
+    /**
+     * A minimal Ratchet connection recording every outbound frame, following the stub convention
+     * of HealthFolderStepResultTest rather than a PHPUnit mock (which would trip a
+     * dynamic-property deprecation on `resourceId`).
+     */
+    private static function createStubConnection(int $resourceId): ConnectionInterface
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    private static function diocese(string $calendarId, string $name, string $nation, Rite $rite): \stdClass
+    {
+        return (object) [
+            'calendar_id' => $calendarId,
+            'diocese'     => $name,
+            'nation'      => $nation,
+            'locales'     => ['it_IT'],
+            'timezone'    => 'Europe/Rome',
+            'rite'        => $rite->value,
+        ];
+    }
+
+    /**
+     * Populate `Health::$metadata` for the duration of $fn, then restore. The property is a typed
+     * static with no default, so an initially-uninitialised one is left holding an *empty*
+     * MetadataCalendars rather than this fixture — see HealthRiteRequestPathTest, which uses the
+     * same approach for the same reason.
+     *
+     * @param list<\stdClass> $dioceses
+     */
+    private static function withMetadata(array $dioceses, callable $fn): void
+    {
+        $property = new \ReflectionProperty(Health::class, 'metadata');
+        $wasSet   = $property->isInitialized();
+        $previous = $wasSet ? $property->getValue() : null;
+
+        $property->setValue(null, self::metadata($dioceses));
+
+        try {
+            $fn();
+        } finally {
+            if ($wasSet && $previous instanceof MetadataCalendars) {
+                $property->setValue(null, $previous);
+            } else {
+                $property->setValue(null, self::metadata([]));
+            }
+        }
+    }
+
+    /**
+     * @param list<\stdClass> $dioceses
+     */
+    private static function metadata(array $dioceses): MetadataCalendars
+    {
+        return MetadataCalendars::fromObject((object) [
+            'national_calendars'       => [],
+            'national_calendars_keys'  => [],
+            'diocesan_calendars'       => $dioceses,
+            'diocesan_calendars_keys'  => array_map(static fn(\stdClass $d): string => (string) $d->calendar_id, $dioceses),
+            'diocesan_groups'          => [],
+            'wider_regions'            => [],
+            'wider_regions_keys'       => [],
+            'ambrosian_calendars'      => [],
+            'ambrosian_calendars_keys' => [],
+            'locales'                  => ['en'],
+        ]);
+    }
+}

--- a/phpunit_tests/HealthRiteSourcePathTest.php
+++ b/phpunit_tests/HealthRiteSourcePathTest.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\WithoutErrorHandler;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ratchet\ConnectionInterface;
 
@@ -94,7 +95,6 @@ final class HealthRiteSourcePathTest extends TestCase
      * admits a diocesan id, that arm starts executing, and with the bare Roman constant it would
      * have sent every Ambrosian diocese to a Roman path.
      */
-    #[WithoutErrorHandler]
     public function testANationalSlugTheTrailingBlockCannotMatchIsDerivedServerSide(): void
     {
         $expected = strtr(JsonData::NATIONAL_CALENDAR_FILE->path(), ['{nation}' => 'USA']);
@@ -105,7 +105,6 @@ final class HealthRiteSourcePathTest extends TestCase
         self::assertStringNotContainsString('client/supplied/nonsense.json', $output);
     }
 
-    #[WithoutErrorHandler]
     public function testADiocesanSlugTheTrailingBlockCannotMatchKeepsItsRite(): void
     {
         $ambrosian = strtr(JsonData::AMBROSIAN_DIOCESAN_CALENDAR_FILE->path(), [
@@ -126,6 +125,60 @@ final class HealthRiteSourcePathTest extends TestCase
 
         self::assertStringContainsString('Reading data from file ' . $ambrosian, $output);
         self::assertStringNotContainsString($roman, $output);
+    }
+
+    // ------------------------------------------------- the two slug grammars must agree
+
+    /**
+     * One identifier, described twice in one file: `retrieveSchemaForCategory()` matches the
+     * `validate` slug to pick a schema, and `executeValidation()` matches the same slug to derive
+     * the source path. They have to agree, and nothing but this test makes them.
+     *
+     * Widening `executeValidation()`'s pattern to `[A-Za-z_]+` left the schema side on
+     * `[A-Z]{2}` / `[a-z]{6}_[a-z]{2}`, so an id outside the conventional shapes would have had
+     * its path derived and its schema resolve to null — the "Unable to detect schema" failure
+     * again, from the other direction. Every id in jsondata today satisfies both forms, so the
+     * canonical rows below pass either way; the off-convention rows are what pins the grammars
+     * together.
+     *
+     * @return array<string, array{0: string, 1: LitSchema, 2: list<\stdClass>|null}>
+     */
+    public static function slugGrammarProvider(): array
+    {
+        return [
+            'national, canonical'      => ['national-calendar-IT', LitSchema::NATIONAL, null],
+            'national, off-convention' => ['national-calendar-USA', LitSchema::NATIONAL, null],
+            'diocesan, canonical'      => ['diocesan-calendar-milano_it', LitSchema::DIOCESAN, null],
+            'diocesan, off-convention' => [
+                'diocesan-calendar-nowhere_zz',
+                LitSchema::DIOCESAN,
+                [self::diocese('nowhere_zz', 'Nowhere', 'ZZ', Rite::AMBROSIAN)]
+            ],
+        ];
+    }
+
+    /**
+     * @param list<\stdClass>|null $dioceses
+     */
+    #[DataProvider('slugGrammarProvider')]
+    public function testTheSchemaAndPathGrammarsAcceptTheSameSlug(string $slug, LitSchema $expected, ?array $dioceses): void
+    {
+        $method = new \ReflectionMethod(Health::class, 'retrieveSchemaForCategory');
+        self::assertSame(
+            $expected->path(),
+            $method->invoke(null, 'sourceDataCheck', $slug),
+            "the schema side must accept the slug the path side accepts: $slug"
+        );
+
+        // Reaching a derived path at all is the proof that `executeValidation()`'s own pattern
+        // matched: had it not, $dataPath would still be the client's `sourceFile`.
+        $output = self::captureSourceFileRead($slug, $dioceses);
+        self::assertStringContainsString('Reading data from file ', $output);
+        self::assertStringNotContainsString(
+            'client/supplied/nonsense.json',
+            $output,
+            "the path side must accept the slug the schema side accepts: $slug"
+        );
     }
 
     // ---------------------------------------------------------------- i18n folder
@@ -210,6 +263,13 @@ final class HealthRiteSourcePathTest extends TestCase
         $conn   = self::createStubConnection(1);
         $health = self::healthWithRunToken($conn);
 
+        // Several of these slugs name files that deliberately do not exist — that is the point of
+        // them — and react/filesystem's fallback adapter stat()s and reads unconditionally, so it
+        // emits PHP warnings the assertions have no interest in. Swallow them here rather than
+        // per test: what is under assertion is the path Health echoed, not whether the read
+        // succeeded.
+        set_error_handler(static fn(): bool => true);
+
         ob_start();
         try {
             self::withMetadata(
@@ -229,6 +289,7 @@ final class HealthRiteSourcePathTest extends TestCase
             );
         } finally {
             $output = (string) ob_get_clean();
+            restore_error_handler();
         }
 
         return $output;

--- a/phpunit_tests/HealthRiteSourcePathTest.php
+++ b/phpunit_tests/HealthRiteSourcePathTest.php
@@ -10,6 +10,7 @@ use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\WithoutErrorHandler;
 use PHPUnit\Framework\TestCase;
 use Ratchet\ConnectionInterface;
 
@@ -49,7 +50,7 @@ final class HealthRiteSourcePathTest extends TestCase
 
         self::assertStringContainsString(
             'Reading data from file ' . $expected,
-            self::captureSourceFileRead('milano_it')
+            self::captureSourceFileRead('diocesan-calendar-milano_it')
         );
     }
 
@@ -61,7 +62,7 @@ final class HealthRiteSourcePathTest extends TestCase
             '{diocese_name}' => 'Rotterdam'
         ]);
 
-        $output = self::captureSourceFileRead('rotter_nl');
+        $output = self::captureSourceFileRead('diocesan-calendar-rotter_nl');
 
         self::assertStringContainsString('Reading data from file ' . $expected, $output);
         self::assertStringNotContainsString(JsonData::AMBROSIAN_DIOCESAN_CALENDARS_FOLDER->value, $output);
@@ -73,9 +74,58 @@ final class HealthRiteSourcePathTest extends TestCase
      */
     public function testTheClientSuppliedSourceFileIsNotWhatIsRead(): void
     {
-        $output = self::captureSourceFileRead('milano_it');
+        $output = self::captureSourceFileRead('diocesan-calendar-milano_it');
 
         self::assertStringNotContainsString('client/supplied/nonsense.json', $output);
+    }
+
+    // ------------------------------------------------- slugs the trailing block cannot match
+
+    /**
+     * The `sourceFile` branch's own slug pattern was `([A-Z][a-z]+)`, which matches `Europe` but
+     * neither `IT` nor `milano_it` — so its national and diocesan arms never ran and `$dataPath`
+     * kept whatever the client sent. For the *canonical* id shapes that went unnoticed, because
+     * the block at the tail of `executeValidation()` re-derives the path for `[A-Z]{2}` nations
+     * and `[a-z]{6}_[a-z]{2}` dioceses anyway.
+     *
+     * These two exercise ids that the trailing block's stricter patterns cannot match, which is
+     * the only window in which the widened pattern is observable. They also show why the widened
+     * pattern and the rite-aware diocesan constant had to land together: the moment the pattern
+     * admits a diocesan id, that arm starts executing, and with the bare Roman constant it would
+     * have sent every Ambrosian diocese to a Roman path.
+     */
+    #[WithoutErrorHandler]
+    public function testANationalSlugTheTrailingBlockCannotMatchIsDerivedServerSide(): void
+    {
+        $expected = strtr(JsonData::NATIONAL_CALENDAR_FILE->path(), ['{nation}' => 'USA']);
+
+        $output = self::captureSourceFileRead('national-calendar-USA');
+
+        self::assertStringContainsString('Reading data from file ' . $expected, $output);
+        self::assertStringNotContainsString('client/supplied/nonsense.json', $output);
+    }
+
+    #[WithoutErrorHandler]
+    public function testADiocesanSlugTheTrailingBlockCannotMatchKeepsItsRite(): void
+    {
+        $ambrosian = strtr(JsonData::AMBROSIAN_DIOCESAN_CALENDAR_FILE->path(), [
+            '{nation}'       => 'ZZ',
+            '{diocese}'      => 'nowhere_zz',
+            '{diocese_name}' => 'Nowhere'
+        ]);
+        $roman     = strtr(JsonData::DIOCESAN_CALENDAR_FILE->path(), [
+            '{nation}'       => 'ZZ',
+            '{diocese}'      => 'nowhere_zz',
+            '{diocese_name}' => 'Nowhere'
+        ]);
+
+        $output = self::captureSourceFileRead(
+            'diocesan-calendar-nowhere_zz',
+            [self::diocese('nowhere_zz', 'Nowhere', 'ZZ', Rite::AMBROSIAN)]
+        );
+
+        self::assertStringContainsString('Reading data from file ' . $ambrosian, $output);
+        self::assertStringNotContainsString($roman, $output);
     }
 
     // ---------------------------------------------------------------- i18n folder
@@ -149,11 +199,13 @@ final class HealthRiteSourcePathTest extends TestCase
     // ---------------------------------------------------------------- helpers
 
     /**
-     * Run a diocesan `sourceFile` check and return everything `executeValidation()` echoed. The
-     * path is echoed before the read is handed to a promise that is never resolved, so this
-     * needs neither the event loop nor the file to exist.
+     * Run a `sourceFile` check and return everything `executeValidation()` echoed. The path is
+     * echoed before the read is handed off, so this needs neither the file to exist nor the
+     * validation to succeed.
+     *
+     * @param list<\stdClass>|null $dioceses metadata stand-in, or null for the two real fixtures
      */
-    private static function captureSourceFileRead(string $dioceseId): string
+    private static function captureSourceFileRead(string $validateSlug, ?array $dioceses = null): string
     {
         $conn   = self::createStubConnection(1);
         $health = self::healthWithRunToken($conn);
@@ -161,16 +213,16 @@ final class HealthRiteSourcePathTest extends TestCase
         ob_start();
         try {
             self::withMetadata(
-                [
+                $dioceses ?? [
                     self::diocese('milano_it', 'Arcidiocesi di Milano', 'IT', Rite::AMBROSIAN),
                     self::diocese('rotter_nl', 'Rotterdam', 'NL', Rite::ROMAN),
                 ],
-                static function () use ($health, $conn, $dioceseId): void {
+                static function () use ($health, $conn, $validateSlug): void {
                     $method = new \ReflectionMethod(Health::class, 'executeValidation');
                     $method->invoke($health, (object) [
                         'action'     => 'executeValidation',
                         'category'   => 'sourceDataCheck',
-                        'validate'   => "diocesan-calendar-$dioceseId",
+                        'validate'   => $validateSlug,
                         'sourceFile' => 'client/supplied/nonsense.json',
                     ], $conn);
                 }

--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -129,12 +129,13 @@ final class HealthSchemaCategoryTest extends TestCase
         self::initRouter();
 
         return [
-            'missal by id'      => [Route::MISSALS->path() . '/EDITIO_TYPICA_1970', LitSchema::PROPRIUMDESANCTIS],
-            'events for nation' => [Route::EVENTS->path() . '/nation/US', LitSchema::EVENTS],
-            'data for nation'   => [Route::DATA->path() . '/nation/US', LitSchema::NATIONAL],
-            'data for diocese'  => [Route::DATA->path() . '/diocese/romamo_it', LitSchema::DIOCESAN],
-            'data for region'   => [Route::DATA->path() . '/widerregion/Europe', LitSchema::WIDERREGION],
-            'bare route'        => [Route::CALENDARS->path(), LitSchema::METADATA],
+            'missal by id'       => [Route::MISSALS->path() . '/EDITIO_TYPICA_1970', LitSchema::PROPRIUMDESANCTIS],
+            'events for nation'  => [Route::EVENTS->path() . '/nation/US', LitSchema::EVENTS],
+            'events for diocese' => [Route::EVENTS->path() . '/diocese/romamo_it', LitSchema::EVENTS],
+            'data for nation'    => [Route::DATA->path() . '/nation/US', LitSchema::NATIONAL],
+            'data for diocese'   => [Route::DATA->path() . '/diocese/romamo_it', LitSchema::DIOCESAN],
+            'data for region'    => [Route::DATA->path() . '/widerregion/Europe', LitSchema::WIDERREGION],
+            'bare route'         => [Route::CALENDARS->path(), LitSchema::METADATA],
         ];
     }
 
@@ -142,6 +143,98 @@ final class HealthSchemaCategoryTest extends TestCase
     public function testResourceDataCheckResolvesFromTheEndpointUrl(string $url, LitSchema $expected): void
     {
         self::assertSame($expected->path(), self::retrieveSchemaForCategory('resourceDataCheck', $url));
+    }
+
+    // ---------------------------------------------------------------- the optional rite segment
+
+    /**
+     * `Router::extractRiteSegment()` admits an optional `roman`/`ambrosian` segment immediately
+     * after `events` and `data`, and per `Router::canonicalRiteUrl()` the explicit form is the
+     * *canonical* one — so it is the form a rite-aware client sends. Before #812 neither pattern
+     * admitted it, `ambrosian` sat where the pattern demanded `diocese`, and the call fell
+     * through to a null schema: the "Unable to detect schema for dataPath …" failure that
+     * blocked UnitTestInterface#48.
+     *
+     * The `/data` expectations double as the guard that the rite group stayed NON-capturing:
+     * the numbered groups feed the switch that picks between NATIONAL, DIOCESAN and WIDERREGION,
+     * so a capturing rite group would shift them all and every one of these would fall back to
+     * the generic DATA schema.
+     *
+     * @return array<string, array{string, LitSchema}>
+     */
+    public static function riteQualifiedUrlProvider(): array
+    {
+        self::initRouter();
+
+        return [
+            'events, roman nation'         => [Route::EVENTS->path() . '/roman/nation/US', LitSchema::EVENTS],
+            'events, roman diocese'        => [Route::EVENTS->path() . '/roman/diocese/romamo_it', LitSchema::EVENTS],
+            'events, ambrosian diocese'    => [Route::EVENTS->path() . '/ambrosian/diocese/milano_it', LitSchema::EVENTS],
+            'events, with locale'          => [Route::EVENTS->path() . '/ambrosian/diocese/lugano_ch?locale=it_IT', LitSchema::EVENTS],
+            'data, roman nation'           => [Route::DATA->path() . '/roman/nation/US', LitSchema::NATIONAL],
+            'data, roman diocese'          => [Route::DATA->path() . '/roman/diocese/romamo_it', LitSchema::DIOCESAN],
+            'data, ambrosian diocese'      => [Route::DATA->path() . '/ambrosian/diocese/milano_it', LitSchema::DIOCESAN],
+            'data, roman wider region'     => [Route::DATA->path() . '/roman/widerregion/Europe', LitSchema::WIDERREGION],
+            'data, ambrosian wider region' => [Route::DATA->path() . '/ambrosian/widerregion/Europe', LitSchema::WIDERREGION],
+            'data, with locale'            => [Route::DATA->path() . '/ambrosian/diocese/bergam_it?locale=it_IT', LitSchema::DIOCESAN],
+        ];
+    }
+
+    #[DataProvider('riteQualifiedUrlProvider')]
+    public function testResourceDataCheckResolvesTheCanonicalRiteQualifiedUrl(string $url, LitSchema $expected): void
+    {
+        self::assertSame($expected->path(), self::retrieveSchemaForCategory('resourceDataCheck', $url));
+    }
+
+    /**
+     * The regression guard for the un-prefixed form. The rite segment is *optional* and its
+     * absence means Roman, so admitting it must not have cost the legacy URLs their match —
+     * every client that predates rite awareness still sends these.
+     *
+     * @return array<string, array{string, LitSchema}>
+     */
+    public static function riteLessUrlProvider(): array
+    {
+        self::initRouter();
+
+        return [
+            'events for nation'  => [Route::EVENTS->path() . '/nation/US', LitSchema::EVENTS],
+            'events for diocese' => [Route::EVENTS->path() . '/diocese/romamo_it', LitSchema::EVENTS],
+            'events with locale' => [Route::EVENTS->path() . '/diocese/romamo_it?locale=it_IT', LitSchema::EVENTS],
+            'data for nation'    => [Route::DATA->path() . '/nation/US', LitSchema::NATIONAL],
+            'data for diocese'   => [Route::DATA->path() . '/diocese/romamo_it', LitSchema::DIOCESAN],
+            'data for region'    => [Route::DATA->path() . '/widerregion/Europe', LitSchema::WIDERREGION],
+            'data with locale'   => [Route::DATA->path() . '/widerregion/Europe?locale=it_IT', LitSchema::WIDERREGION],
+        ];
+    }
+
+    #[DataProvider('riteLessUrlProvider')]
+    public function testResourceDataCheckStillResolvesTheUnprefixedUrl(string $url, LitSchema $expected): void
+    {
+        self::assertSame($expected->path(), self::retrieveSchemaForCategory('resourceDataCheck', $url));
+    }
+
+    /**
+     * Only the two rites the router knows are admitted; anything else in that position is just
+     * an unrecognised path, exactly as before.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function unknownRiteSegmentProvider(): array
+    {
+        self::initRouter();
+
+        return [
+            'events, invented rite' => [Route::EVENTS->path() . '/byzantine/diocese/milano_it'],
+            'data, invented rite'   => [Route::DATA->path() . '/byzantine/diocese/milano_it'],
+            'data, doubled rite'    => [Route::DATA->path() . '/roman/ambrosian/diocese/milano_it'],
+        ];
+    }
+
+    #[DataProvider('unknownRiteSegmentProvider')]
+    public function testResourceDataCheckRejectsAnUnknownRiteSegment(string $url): void
+    {
+        self::assertNull(self::retrieveSchemaForCategory('resourceDataCheck', $url));
     }
 
     public function testResourceDataCheckRejectsAnUnrecognisedUrl(): void

--- a/src/Health.php
+++ b/src/Health.php
@@ -636,8 +636,12 @@ class Health implements MessageComponentInterface
                                 $this->handleDioceseMetadataError($e, $to, $validation, $matches[2], $runToken);
                                 return;
                             }
+                            // The diocesan tree is partitioned by rite, and it is the only tier
+                            // that is: an Ambrosian diocese keeps its i18n files under
+                            // `sourcedata/rite/ambrosian/...`, so the bare Roman constant would
+                            // send every one of them to a folder that does not exist.
                             $dataPath = strtr(
-                                JsonData::DIOCESAN_CALENDAR_I18N_FOLDER->path(),
+                                JsonData::diocesanCalendarI18nFolderFor($dioceseMetadata->rite)->path(),
                                 [
                                     '{diocese}' => $matches[2],
                                     '{nation}'  => $dioceseMetadata->nation
@@ -863,7 +867,10 @@ class Health implements MessageComponentInterface
                 }
                 $nation      = $dioceseMetadata->nation;
                 $dioceseName = $dioceseMetadata->diocese;
-                $dataPath    = strtr(JsonData::DIOCESAN_CALENDAR_FILE->path(), [
+                // Rite-partitioned, exactly as the i18n-folder branch above: this is the site
+                // that actually governs a diocesan source-file check, because it reassigns
+                // $dataPath after the earlier `sourceFile` branch has run.
+                $dataPath = strtr(JsonData::diocesanCalendarFileFor($dioceseMetadata->rite)->path(), [
                     '{nation}'       => $nation,
                     '{diocese}'      => $dioceseId,
                     '{diocese_name}' => $dioceseName
@@ -2143,11 +2150,13 @@ class Health implements MessageComponentInterface
                 ) {
                     return $isVersionedDataPath ? preg_replace($versionedPattern, $versionedReplacement, LitSchema::PROPRIUMDESANCTIS->path()) : LitSchema::PROPRIUMDESANCTIS->path();
                 } elseif (
-                    preg_match('/\/events\/(?:nation\/[A-Z]{2}|diocese\/[a-z]{6}_[a-z]{2})(?:\?locale=[a-zA-Z0-9_]+)?$/', $dataPath)
+                    preg_match('/\/events\/(?:(?:roman|ambrosian)\/)?(?:nation\/[A-Z]{2}|diocese\/[a-z]{6}_[a-z]{2})(?:\?locale=[a-zA-Z0-9_]+)?$/', $dataPath)
                 ) {
                     return $isVersionedDataPath ? preg_replace($versionedPattern, $versionedReplacement, LitSchema::EVENTS->path()) : LitSchema::EVENTS->path();
                 } elseif (
-                    preg_match('/\/data\/(?:(nation)\/[A-Z]{2}|(diocese)\/[a-z]{6}_[a-z]{2}|(widerregion)\/[A-Z][a-z]+)(?:\?locale=[a-zA-Z0-9_]+)?$/', $dataPath, $matches)
+                    // The rite segment is NON-capturing on purpose: the numbered groups below drive
+                    // the switch, so a capturing group here would shift them all by one.
+                    preg_match('/\/data\/(?:(?:roman|ambrosian)\/)?(?:(nation)\/[A-Z]{2}|(diocese)\/[a-z]{6}_[a-z]{2}|(widerregion)\/[A-Z][a-z]+)(?:\?locale=[a-zA-Z0-9_]+)?$/', $dataPath, $matches)
                 ) {
                     $schema = LitSchema::DATA->path();
                     foreach ($matches as $idx => $match) {

--- a/src/Health.php
+++ b/src/Health.php
@@ -2235,10 +2235,17 @@ class Health implements MessageComponentInterface
                 if (preg_match('/^wider-region-[A-Z][a-z]+$/', $dataPath)) {
                     return LitSchema::WIDERREGION->path();
                 }
-                if (preg_match('/^national-calendar-[A-Z]{2}$/', $dataPath)) {
+                // These two deliberately mirror the identifier grammar `executeValidation()` uses
+                // to derive the source path for the same slug. One identifier described by two
+                // patterns, in one file, that have to agree is precisely the drift this issue is
+                // about: every id in jsondata today satisfies both the narrow and the wide form,
+                // but a diocese that ever broke the six-character convention would have its path
+                // derived correctly and its schema silently resolve to null. `wider-region-`,
+                // `tests-` and `proprium-de-*` have no such sibling and keep their own patterns.
+                if (preg_match('/^national-calendar-[A-Za-z_]+$/', $dataPath)) {
                     return LitSchema::NATIONAL->path();
                 }
-                if (preg_match('/^diocesan-calendar-[a-z]{6}_[a-z]{2}$/', $dataPath)) {
+                if (preg_match('/^diocesan-calendar-[A-Za-z_]+$/', $dataPath)) {
                     return LitSchema::DIOCESAN->path();
                 }
                 if (preg_match('/^tests-[a-zA-Z0-9_]+$/', $dataPath)) {

--- a/src/Health.php
+++ b/src/Health.php
@@ -664,7 +664,12 @@ class Health implements MessageComponentInterface
                     /** @var ExecuteValidationSourceFile $validation */
                     $dataPath = (string) $validation->sourceFile;
                     $matches  = null;
-                    if (preg_match('/^(wider-region|national-calendar|diocesan-calendar)-([A-Z][a-z]+)$/', $validate, $matches)) {
+                    // `[A-Z][a-z]+` matched `Europe` but neither `IT` (no lowercase char) nor
+                    // `milano_it` (lowercase initial, and no `_` in the class), so the national
+                    // and diocesan arms below never ran and $dataPath silently kept the
+                    // client-supplied `sourceFile`. `[A-Za-z_]+` matches all three, the same way
+                    // the i18n branch above already does.
+                    if (preg_match('/^(wider-region|national-calendar|diocesan-calendar)-([A-Za-z_]+)$/', $validate, $matches)) {
                         switch ($matches[1]) {
                             case 'wider-region':
                                 $dataPath = strtr(
@@ -685,8 +690,13 @@ class Health implements MessageComponentInterface
                                     $this->handleDioceseMetadataError($e, $to, $validation, $matches[2], $runToken);
                                     return;
                                 }
+                                // Rite-partitioned, like every other diocesan path. This arm only
+                                // starts executing once the slug pattern above admits a diocesan
+                                // id, which is why the two changes belong together: widening the
+                                // pattern while leaving the bare Roman constant here would send
+                                // every Ambrosian diocese to a Roman path.
                                 $dataPath = strtr(
-                                    JsonData::DIOCESAN_CALENDAR_FILE->path(),
+                                    JsonData::diocesanCalendarFileFor($dioceseMetadata->rite)->path(),
                                     [
                                         '{diocese}'      => $matches[2],
                                         '{nation}'       => $dioceseMetadata->nation,


### PR DESCRIPTION
Closes #812. Unblocks [UnitTestInterface#48](https://github.com/Liturgical-Calendar/UnitTestInterface/issues/48).

`Health` was never made rite-aware when the rest of the API was. Five call sites resolved schemas and
source paths as though Roman were the only rite, so the canonical rite-qualified URL form —
`/events/ambrosian/diocese/milano_it` — could not be validated at all, and Ambrosian diocesan data was
looked for under the Roman tree.

## Commit 1 — `2790dd82` — the live defects

**Schema lookup ignored the rite segment.** `retrieveSchemaForCategory()`'s `resourceDataCheck` arm
matched `/events/` and `/data/` with no rite segment, so `/events/ambrosian/diocese/milano_it` matched
nothing, fell through to `getPathToSchemaFile()`, and returned `null` — the
`Unable to detect schema for dataPath …` failure. Both patterns now admit an optional
`(?:roman|ambrosian)/` segment. The `/data/` one uses a **non-capturing** group deliberately: its
numbered groups (`(nation)`, `(diocese)`, `(widerregion)`) drive the `switch` below it, and a capturing
rite group would shift them and silently break Roman schema selection.

**Diocesan paths assumed Roman.** Three sites built diocesan paths from the bare Roman
`JsonData::DIOCESAN_CALENDAR_FILE` / `DIOCESAN_CALENDAR_I18N_FOLDER` constants. All three now use
`JsonData::diocesanCalendarFileFor($rite)` / `diocesanCalendarI18nFolderFor($rite)`, the resolvers that
exist so call sites don't repeat this branch and that `RegionalDataHandler` already uses. The rite comes
from `$dioceseMetadata->rite` — `MetadataDiocesanCalendarItem` already carries a `readonly Rite`, so no
new lookup was needed.

One of those three, `Health.php:870`, was **missed by the original issue report** and is the one that
matters most: it sits in the execution phase and re-derives `$dataPath` *after* the resolution phase has
run, and its regex does match real diocese ids. It is what actually governs a diocesan source-file check
today. See the [correction comment](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/812#issuecomment-5349383550)
on the issue.

## Commit 2 — `85a2f587` — the dead slug arms

The resolution phase's slug regex was `^(wider-region|national-calendar|diocesan-calendar)-([A-Z][a-z]+)$`.
`[A-Z][a-z]+` matches `Europe` but not `IT` (no lowercase char) and not `milano_it` (lowercase initial, no
`_` in the class), so its national and diocesan arms were dead. Widened to `([A-Za-z_]+)`, matching the
i18n branch four lines above, and the diocesan arm it revives is made rite-aware in the same commit.

**These two changes had to land together.** The diocesan path site was unreachable *because* the regex
blocked it; fixing the regex alone makes it start executing and sends every Ambrosian diocese to a Roman
path. Verified mechanically — with commit 1 applied plus the regex change only, the Ambrosian diocese test
fails.

**This commit is behaviourally inert on today's data**, and that is stated plainly rather than hidden: all
16 diocese ids match `[a-z]{6}_[a-z]{2}` and all 5 nation ids match `[A-Z]{2}`, so the execution-phase
block shadows both sites. It is included because leaving those arms dead but wrong is a trap — the next
person to notice the broken regex will fix it and, unless they also notice the path site, reintroduce the
bug this PR removes.

## Scope

Deliberately untouched: the unsanitised `glob()` / path-containment gap in `executeValidation()`. #806
section B removes client-supplied paths entirely, which is the real fix.

Note the original issue described defect 3 as letting a client-supplied path through. That was overstated
— the execution-phase block re-derives the path server-side for diocesan and national, and wider-region
ids matched the old regex, so all three kinds were already server-derived. It is a correctness and
dead-code problem, not a security one. Corrected on the issue.

Section B's `Health` rewiring will delete the `resourceDataCheck` regex arms outright and resolve
everything through the `/validations` inventory id, so commit 1's regex work and commit 2 are short-lived
by design. The rite-resolver changes survive, being about path templates rather than URL parsing.

## Verification

```text
vendor/bin/phpunit phpunit_tests/Health*.php   130 tests, 199 assertions, OK (3 pre-existing skips)
composer lint                                  clean
composer analyse (PHPStan level 10)            clean
```

The tests were confirmed **discriminating**, not merely passing:

| Source state                          | Result                                          |
|---------------------------------------|-------------------------------------------------|
| pre-fix                               | 13 failures                                     |
| commit 1 only                         | commit 2's 2 new tests fail                     |
| commit 1 + the regex change only      | the Ambrosian diocese test fails (3+4 coupling) |

Fixtures are real, not invented: `jsondata/sourcedata/rite/ambrosian/calendars/dioceses/` holds
`IT/milano_it`, `IT/bergam_it`, `IT/novara_it` and `CH/lugano_ch`.

Two tests carry `#[WithoutErrorHandler]` because they read deliberately-absent paths and
`react/filesystem`'s `stat()` warns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for optional Roman and Ambrosian path segments on events and data URLs.
  * Added rite-aware resolution for diocesan source files, translation folders, and validation paths.
  * Improved handling of uppercase and underscore-containing diocesan identifiers.

* **Bug Fixes**
  * Preserved compatibility with existing URLs without rite segments.
  * Rejected unknown or duplicated rite segments during schema resolution.
  * Improved support for diocesan identifiers such as `IT` and `milano_it`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->