### PR TITLE
feat(validations): enumerate every checkable source artifact

### DIFF
--- a/docs/superpowers/plans/2026-08-20-inventory-covers-everything.md
+++ b/docs/superpowers/plans/2026-08-20-inventory-covers-everything.md
@@ -1,0 +1,879 @@
+# Inventory Covers Everything Checkable — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Grow `/validations` from 18 static items to every checkable source artifact, so a later change can make the
+inventory id the only address a client ever sends.
+
+**Architecture:** `CheckableInventory` gains a second half: per-calendar source data enumerated from
+`CalendarMetadataProvider::create()`, the same builder `/calendars` uses, plus test definitions read from the
+rite-partitioned tests folders. The static half is untouched. No message shape changes in this plan.
+
+**Tech Stack:** PHP 8.4, PHPUnit 12.
+
+**This is plan 1 of 2 for the section B spec.** It grows the inventory only, and ships useful on its own: `/validations`
+becomes complete, and a client can derive its whole check list from one fetch while still speaking the legacy protocol.
+Plan 2 adds the typed `target`, the tagged calendar identity, and the `Health` rewiring that consumes these ids.
+
+## Global Constraints
+
+- Work in the worktree `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target` on branch
+  `feat/806-typed-target` (PR base: `development`). **Never commit in the main checkout**
+  `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI` — shared with other agents.
+- Never use `git commit --no-verify`. Commits are GPG-signed; if signing fails, stop and ask.
+- PSR-12 per `phpcs.xml`; short array syntax; 4-space indent; single quotes unless interpolating.
+- PHPStan level 10 over `src` only.
+- **Paths come from `JsonData` enum cases, never string literals.**
+- **`CheckableItem` must never serialize its `path`.**
+- **The endpoint never stats a target to decide whether to list it.** An item appears because a calendar is *registered*,
+  not because a file was found. Presence stays the `exists` step's job.
+- Id vocabulary is `kind:rite[:qualifier][:i18n]`, fully qualified. Ids are opaque to clients.
+- **No message-shape changes in this plan.** `executeValidation`, `validateCalendar`, `executeUnitTest` are untouched.
+- New schema files must declare `https://json-schema.org/draft-07/schema#` and carry no `$id` — `SchemaConventionsTest`
+  enforces both.
+- Spec: `docs/superpowers/specs/2026-08-20-typed-target-design.md`.
+
+---
+
+## File Structure
+
+| File                                                              | Responsibility                                                    |
+|-------------------------------------------------------------------|-------------------------------------------------------------------|
+| `src/Models/ValidationsPath/CheckableInventory.php`               | Gains per-calendar and test enumeration alongside the static half |
+| `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php` | Extended: the new kinds, their regions, their ids                 |
+| `phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php`     | Extended: every registered calendar has an inventory entry        |
+| `phpunit_tests/Handlers/ValidationsHandlerTest.php`               | Count assertion updated; no path may still leak                   |
+| `docs/superpowers/specs/2026-08-19-checkable-inventory-design.md` | Amended: the filesystem principle, and the inventory's new reach  |
+
+### The four new kinds
+
+| Id form                          | Source                                   | Schema                     |
+|----------------------------------|------------------------------------------|----------------------------|
+| `nation:roman:IT`                | `MetadataCalendars::$national_calendars` | `NationalCalendar.json`    |
+| `widerregion:roman:Europe`       | `MetadataCalendars::$wider_regions`      | `WiderRegionCalendar.json` |
+| `diocese:{rite}:roma_lazio_it`   | `MetadataCalendars::$diocesan_calendars` | `DiocesanCalendar.json`    |
+| `test:{rite}:StIgnatiusOfLoyola` | `jsondata/tests/{rite}/*.json`           | `LitCalTest.json`          |
+
+Each file-kind item gets an `:i18n` folder sibling where the folder exists on disk, except tests, which have no `i18n`.
+
+### `region` on the new kinds
+
+`region` answers one question: *is this item specific to one nation's calendar?*
+
+- `nation:roman:IT` → `'IT'`.
+- `diocese:roman:roma_lazio_it` → its nation, `'IT'`.
+- `test:roman:X` → `null`; a test definition is not nation-scoped.
+- `widerregion:roman:Europe` → `null`, **and this is a known limitation to document, not to paper over.** A wider region
+  applies to several nations, which a scalar cannot express. Clients already have the mapping — `/calendars` gives each
+  national calendar its `wider_region` — so a client scoping to one calendar reads that field rather than relying on
+  `region`. Do not invent a `nations` array to fix this; that is a wire-contract change and belongs to the section B
+  plan if it is wanted at all.
+
+---
+
+## Task 1: National calendars and wider regions
+
+**Files:**
+
+- Modify: `src/Models/ValidationsPath/CheckableInventory.php`
+- Test: `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php`
+
+**Interfaces:**
+
+- Consumes: `CalendarMetadataProvider::create(): MetadataCalendars` (static, reads source data on every call);
+  `MetadataCalendars::$national_calendars` — a list of `MetadataNationalCalendarItem`, each with public
+  `string $calendar_id` (e.g. `'IT'`), `array $locales`, `array $missals`, `?string $wider_region`;
+  `MetadataCalendars::$wider_regions` — a list of `MetadataWiderRegionItem`, each with public `string $name`
+  (e.g. `'Europe'`), `array $locales`, `string $api_path`. Path templates
+  `JsonData::NATIONAL_CALENDAR_FILE` (`{nation}`), `JsonData::NATIONAL_CALENDAR_I18N_FOLDER` (`{nation}`),
+  `JsonData::WIDER_REGION_FILE` (`{wider_region}`), `JsonData::WIDER_REGION_I18N_FOLDER` (`{wider_region}`).
+- Produces: inventory items with ids `nation:roman:{calendar_id}`, `nation:roman:{calendar_id}:i18n`,
+  `widerregion:roman:{name}`, `widerregion:roman:{name}:i18n`.
+
+- [ ] **Step 1: Confirm the worktree**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+git rev-parse --show-toplevel   # must end in -target
+git branch --show-current       # expect: feat/806-typed-target
+ls vendor/bin/phpunit
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php`:
+
+```php
+    public function testNationalCalendarsAreEnumeratedFromTheMetadataProvider(): void
+    {
+        $ids = array_map(static fn (CheckableItem $i): string => $i->id, CheckableInventory::all());
+
+        // Italy is a national calendar the repository ships; if it ever stops being one, this test
+        // should be updated deliberately rather than the assertion loosened.
+        self::assertContains('nation:roman:IT', $ids);
+        self::assertContains('nation:roman:IT:i18n', $ids);
+
+        $italy = CheckableInventory::byId('nation:roman:IT');
+        self::assertNotNull($italy);
+        self::assertSame('file', $italy->kind);
+        self::assertSame(Rite::ROMAN, $italy->rite);
+        self::assertSame('IT', $italy->region, 'a national calendar is specific to its own nation');
+        self::assertSame(LitSchema::NATIONAL, $italy->schema);
+        self::assertStringContainsString('/calendars/nations/IT/IT.json', $italy->path);
+
+        $italyI18n = CheckableInventory::byId('nation:roman:IT:i18n');
+        self::assertNotNull($italyI18n);
+        self::assertSame('folder', $italyI18n->kind);
+        self::assertSame(LitSchema::I18N, $italyI18n->schema);
+    }
+
+    public function testWiderRegionsAreEnumeratedAndAreNotNationScoped(): void
+    {
+        $europe = CheckableInventory::byId('widerregion:roman:Europe');
+        self::assertNotNull($europe);
+        self::assertSame('file', $europe->kind);
+        self::assertSame(LitSchema::WIDERREGION, $europe->schema);
+        self::assertNull(
+            $europe->region,
+            'a wider region spans several nations, which the scalar region cannot express; '
+                . 'clients scope it via the wider_region field on /calendars instead'
+        );
+
+        self::assertNotNull(CheckableInventory::byId('widerregion:roman:Europe:i18n'));
+    }
+
+    public function testEveryEnumeratedItemStillHidesItsPath(): void
+    {
+        foreach (CheckableInventory::all() as $item) {
+            self::assertStringNotContainsString('jsondata', json_encode($item, JSON_THROW_ON_ERROR));
+        }
+    }
+```
+
+Add `use LiturgicalCalendar\Api\Enum\LitSchema;` and `use LiturgicalCalendar\Api\Enum\Rite;` to the test's imports if
+they are not already present.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+```
+
+Expected: the two new enumeration tests fail on `assertContains` / `assertNotNull` — no such ids exist yet.
+`testEveryEnumeratedItemStillHidesItsPath` should pass already; that is intentional, it is a guard for later steps.
+
+- [ ] **Step 4: Add the enumeration**
+
+In `src/Models/ValidationsPath/CheckableInventory.php`, add these imports:
+
+```php
+use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
+```
+
+Change `all()` to merge the new source, and add a memoized provider accessor:
+
+```php
+    /** @var MetadataCalendars|null */
+    private static ?MetadataCalendars $metadata = null;
+
+    /**
+     * The calendar index, from the same builder that serves `/calendars`.
+     *
+     * Memoized for the lifetime of the request only. `CalendarMetadataProvider` deliberately re-reads
+     * source data on every call because the `/data` write endpoints can mutate calendar definitions at
+     * runtime; caching it here for one request keeps a single `/validations` response internally
+     * consistent without outliving the write that would invalidate it.
+     */
+    private static function metadata(): MetadataCalendars
+    {
+        return self::$metadata ??= CalendarMetadataProvider::create();
+    }
+
+    /** @return list<CheckableItem> */
+    public static function all(): array
+    {
+        if (null === self::$items) {
+            self::$items = array_merge(
+                self::derivedRomanSanctorale(),
+                self::explicitItems(),
+                self::nationalCalendarItems(),
+                self::widerRegionItems()
+            );
+        }
+
+        return self::$items;
+    }
+```
+
+Add the two producers:
+
+```php
+    /**
+     * National calendar definitions, enumerated from the calendar index rather than listed.
+     *
+     * A national calendar is specific to its own nation, so `region` is its calendar id — that is what
+     * lets a client scoping to one calendar keep it and drop the other nine.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function nationalCalendarItems(): array
+    {
+        $items = [];
+        foreach (self::metadata()->national_calendars as $nation) {
+            $id   = $nation->calendar_id;
+            $file = strtr(JsonData::NATIONAL_CALENDAR_FILE->path(), ['{nation}' => $id]);
+
+            $items[] = new CheckableItem(
+                "nation:roman:{$id}",
+                'file',
+                Rite::ROMAN,
+                $id,
+                "National calendar: {$id}",
+                LitSchema::NATIONAL,
+                self::STEPS,
+                $file
+            );
+
+            $items[] = new CheckableItem(
+                "nation:roman:{$id}:i18n",
+                'folder',
+                Rite::ROMAN,
+                $id,
+                "National calendar translations: {$id}",
+                LitSchema::I18N,
+                self::STEPS,
+                rtrim(strtr(JsonData::NATIONAL_CALENDAR_I18N_FOLDER->path(), ['{nation}' => $id]), '/')
+            );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Wider region definitions.
+     *
+     * `region` is null: a wider region spans several nations, which a scalar cannot express. Clients
+     * scoping to one calendar use the `wider_region` field `/calendars` already gives them, rather than
+     * this field. Widening `region` into a list would be a wire-contract change, not a fix here.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function widerRegionItems(): array
+    {
+        $items = [];
+        foreach (self::metadata()->wider_regions as $region) {
+            $name = $region->name;
+            $file = strtr(JsonData::WIDER_REGION_FILE->path(), ['{wider_region}' => $name]);
+
+            $items[] = new CheckableItem(
+                "widerregion:roman:{$name}",
+                'file',
+                Rite::ROMAN,
+                null,
+                "Wider region: {$name}",
+                LitSchema::WIDERREGION,
+                self::STEPS,
+                $file
+            );
+
+            $items[] = new CheckableItem(
+                "widerregion:roman:{$name}:i18n",
+                'folder',
+                Rite::ROMAN,
+                null,
+                "Wider region translations: {$name}",
+                LitSchema::I18N,
+                self::STEPS,
+                rtrim(strtr(JsonData::WIDER_REGION_I18N_FOLDER->path(), ['{wider_region}' => $name]), '/')
+            );
+        }
+
+        return $items;
+    }
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+```
+
+Expected: all tests pass **except** `testItHoldsNineFilesAndNineFolders`, which asserts the old static counts and must
+now fail. That failure is correct and expected — fix it in the next step rather than reverting the enumeration.
+
+- [ ] **Step 6: Replace the fixed count assertion with a structural one**
+
+`testItHoldsNineFilesAndNineFolders` pinned 9 and 9. Those numbers described a hand-listed inventory; the inventory is
+now partly enumerated, so a fixed total would fail whenever a calendar is added — a false alarm rather than drift.
+Replace that test with one that asserts the properties that still hold:
+
+```php
+    public function testEveryItemIsEitherAFileOrAFolderAndFoldersAreI18n(): void
+    {
+        $files = 0;
+        $folders = 0;
+        foreach (CheckableInventory::all() as $item) {
+            if ('folder' === $item->kind) {
+                ++$folders;
+                self::assertStringEndsWith(':i18n', $item->id, "folder item {$item->id} is not an i18n folder");
+                self::assertSame(LitSchema::I18N, $item->schema, "folder item {$item->id} must validate as i18n");
+            } else {
+                ++$files;
+                self::assertStringEndsNotWith(':i18n', $item->id, "file item {$item->id} looks like an i18n folder");
+            }
+        }
+
+        // The static half alone contributes nine of each; enumeration only adds.
+        self::assertGreaterThanOrEqual(9, $files);
+        self::assertGreaterThanOrEqual(9, $folders);
+    }
+```
+
+- [ ] **Step 7: Run lint, analysis and the model suite**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/
+composer lint
+composer analyse
+```
+
+Expected: all clean. If `composer analyse` reports a path "is not a file", the PHPStan cache is shared across worktrees
+and stale: `rm -rf /tmp/phpstan` and retry.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+git add src/Models/ValidationsPath/CheckableInventory.php phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+git commit -m "feat(validations): enumerate national and wider-region source data
+
+The inventory listed only static source data, so a client still had to
+construct its own identifiers for everything per-calendar — which is the
+duplication #806 exists to end.
+
+These come from CalendarMetadataProvider, the same builder that serves
+/calendars, so the two lists cannot disagree: a calendar that exists is a
+calendar that is checkable.
+
+region is the nation's own id for a national calendar, and null for a wider
+region — a wider region spans several nations and a scalar cannot say so.
+Clients scoping to one calendar use the wider_region field /calendars
+already gives them; widening region into a list would be a wire-contract
+change rather than a fix.
+
+The fixed 9-and-9 count assertion is replaced by a structural one. Those
+numbers described a hand-listed inventory; now that it is partly
+enumerated, a fixed total would fail whenever a calendar is added, which is
+a false alarm rather than drift.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Diocesan calendars
+
+**Files:**
+
+- Modify: `src/Models/ValidationsPath/CheckableInventory.php`
+- Test: `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php`
+
+**Interfaces:**
+
+- Consumes: `MetadataCalendars::$diocesan_calendars` — a list of `MetadataDiocesanCalendarItem`, each with public
+  `string $calendar_id` (e.g. `'roma_lazio_it'`), `string $diocese` (the diocese *name*), `string $nation`,
+  `readonly Rite $rite`. Path templates `JsonData::DIOCESAN_CALENDAR_FILE` and
+  `JsonData::AMBROSIAN_DIOCESAN_CALENDAR_FILE`, both carrying **three** placeholders — `{nation}`, `{diocese}`,
+  `{diocese_name}` — plus their `*_I18N_FOLDER` siblings, which carry only `{nation}` and `{diocese}`.
+- Produces: ids `diocese:{rite}:{calendar_id}` and `diocese:{rite}:{calendar_id}:i18n`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php`:
+
+```php
+    public function testDiocesanCalendarsAreEnumeratedUnderTheirOwnRite(): void
+    {
+        $roman = CheckableInventory::byId('diocese:roman:roma_lazio_it');
+        self::assertNotNull($roman, 'the Diocese of Rome should be a checkable target');
+        self::assertSame(Rite::ROMAN, $roman->rite);
+        self::assertSame('IT', $roman->region, 'a diocesan calendar is scoped to its nation');
+        self::assertSame(LitSchema::DIOCESAN, $roman->schema);
+        self::assertNotNull(CheckableInventory::byId('diocese:roman:roma_lazio_it:i18n'));
+    }
+
+    /**
+     * The rite is not cosmetic here: an Ambrosian diocese lives under a different path template
+     * entirely, so getting it wrong produces an item pointing at a file that does not exist — which
+     * the exists step would report as a failure of the data rather than of this class.
+     */
+    public function testAnAmbrosianDioceseResolvesToTheAmbrosianTree(): void
+    {
+        $ambrosian = array_values(array_filter(
+            CheckableInventory::all(),
+            static fn (CheckableItem $i): bool => str_starts_with($i->id, 'diocese:ambrosian:')
+                && false === str_ends_with($i->id, ':i18n')
+        ));
+
+        self::assertNotEmpty($ambrosian, 'the repository ships Ambrosian dioceses; none were enumerated');
+
+        foreach ($ambrosian as $item) {
+            self::assertSame(Rite::AMBROSIAN, $item->rite);
+            self::assertStringContainsString('/rite/ambrosian/calendars/dioceses/', $item->path);
+            self::assertFileExists($item->path, "{$item->id} points at a file that does not exist");
+        }
+    }
+```
+
+Note that `assertFileExists` here is checking **this class's path construction**, not deciding whether to list the item.
+The inventory still lists what is registered; the test is what verifies the constructed path is right.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+```
+
+Expected: both new tests fail — `assertNotNull` on a missing id, and `assertNotEmpty` on an empty Ambrosian list.
+
+- [ ] **Step 3: Add the enumeration**
+
+Add `diocesanCalendarItems()` to the `all()` merge, and implement it:
+
+```php
+    /**
+     * Diocesan calendar definitions.
+     *
+     * The rite selects the path template, not just a label: an Ambrosian diocese lives under
+     * `rite/ambrosian/calendars/dioceses/`, and the file name is the diocese *name* rather than its id,
+     * which is why the template carries three placeholders.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function diocesanCalendarItems(): array
+    {
+        $items = [];
+        foreach (self::metadata()->diocesan_calendars as $diocese) {
+            $isAmbrosian = Rite::AMBROSIAN === $diocese->rite;
+
+            $fileTemplate = $isAmbrosian
+                ? JsonData::AMBROSIAN_DIOCESAN_CALENDAR_FILE->path()
+                : JsonData::DIOCESAN_CALENDAR_FILE->path();
+            $i18nTemplate = $isAmbrosian
+                ? JsonData::AMBROSIAN_DIOCESAN_CALENDAR_I18N_FOLDER->path()
+                : JsonData::DIOCESAN_CALENDAR_I18N_FOLDER->path();
+
+            $replacements = [
+                '{nation}'       => $diocese->nation,
+                '{diocese}'      => $diocese->calendar_id,
+                '{diocese_name}' => $diocese->diocese
+            ];
+
+            $items[] = new CheckableItem(
+                "diocese:{$diocese->rite->value}:{$diocese->calendar_id}",
+                'file',
+                $diocese->rite,
+                $diocese->nation,
+                "Diocesan calendar: {$diocese->diocese}",
+                LitSchema::DIOCESAN,
+                self::STEPS,
+                strtr($fileTemplate, $replacements)
+            );
+
+            $items[] = new CheckableItem(
+                "diocese:{$diocese->rite->value}:{$diocese->calendar_id}:i18n",
+                'folder',
+                $diocese->rite,
+                $diocese->nation,
+                "Diocesan calendar translations: {$diocese->diocese}",
+                LitSchema::I18N,
+                self::STEPS,
+                rtrim(strtr($i18nTemplate, $replacements), '/')
+            );
+        }
+
+        return $items;
+    }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+```
+
+Expected: OK. If `assertFileExists` fails for an Ambrosian diocese, the path template or a placeholder is wrong — fix
+the construction, do not relax the assertion.
+
+- [ ] **Step 5: Lint, analyse, commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+composer lint
+composer analyse
+git add src/Models/ValidationsPath/CheckableInventory.php phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+git commit -m "feat(validations): enumerate diocesan calendar definitions
+
+Adds the 32 diocesan definitions, each with its translations folder.
+
+The rite selects the path template rather than merely labelling the item:
+an Ambrosian diocese lives under rite/ambrosian/calendars/dioceses/, and
+the file name is the diocese NAME while the directory is its id, which is
+why the template carries three placeholders. Getting that wrong would
+produce an item pointing at a file that does not exist, and the exists
+step would then report it as a failure of the data rather than of this
+class — so the test asserts the constructed paths resolve.
+
+region is the diocese's nation, so a client scoped to one national calendar
+keeps its own dioceses and drops the rest.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Test definitions
+
+**Files:**
+
+- Modify: `src/Models/ValidationsPath/CheckableInventory.php`
+- Test: `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php`
+
+**Interfaces:**
+
+- Consumes: `JsonData::ROMAN_TESTS_FOLDER` and `JsonData::AMBROSIAN_TESTS_FOLDER`, each a directory of `*.json` test
+  definitions. `LitSchema::TEST_SRC` is the schema a test definition validates against.
+- Produces: ids `test:{rite}:{basename without .json}`. Tests have **no** `i18n` sibling.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+    /**
+     * A test *definition* is a source artifact: does the JSON match LitCalTest.json. That is a different
+     * thing from running the test against a computed calendar, which stays a separate action.
+     */
+    public function testTestDefinitionsAreEnumeratedPerRite(): void
+    {
+        $ids = array_map(static fn (CheckableItem $i): string => $i->id, CheckableInventory::all());
+        $testIds = array_values(array_filter($ids, static fn (string $id): bool => str_starts_with($id, 'test:')));
+
+        self::assertNotEmpty($testIds, 'the repository ships test definitions; none were enumerated');
+
+        foreach ($testIds as $id) {
+            self::assertMatchesRegularExpression('/^test:(roman|ambrosian):[A-Za-z0-9_]+$/', $id);
+            self::assertStringEndsNotWith(':i18n', $id, 'test definitions have no translations folder');
+        }
+
+        foreach (CheckableInventory::all() as $item) {
+            if (str_starts_with($item->id, 'test:')) {
+                self::assertSame('file', $item->kind);
+                self::assertSame(LitSchema::TEST_SRC, $item->schema);
+                self::assertNull($item->region, 'a test definition is not nation-scoped');
+                self::assertFileExists($item->path, "{$item->id} points at a file that does not exist");
+            }
+        }
+    }
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+```
+
+Expected: fails on `assertNotEmpty` — no `test:` ids exist.
+
+- [ ] **Step 3: Add the enumeration**
+
+Add `testDefinitionItems()` to the `all()` merge, and implement it:
+
+```php
+    /**
+     * Test definitions, one per JSON file in each rite's tests folder.
+     *
+     * This item is the *definition* — does the file validate against LitCalTest.json. Running the test
+     * against a computed calendar is a separate action with its own addressing, and the two must not be
+     * conflated: a definition can be valid while the test it describes fails, and vice versa.
+     *
+     * Unlike every other kind here, a test has no `i18n` sibling.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function testDefinitionItems(): array
+    {
+        $items = [];
+        $folders = [
+            Rite::ROMAN->value     => JsonData::ROMAN_TESTS_FOLDER->path(),
+            Rite::AMBROSIAN->value => JsonData::AMBROSIAN_TESTS_FOLDER->path()
+        ];
+
+        foreach ($folders as $riteValue => $folder) {
+            $rite = Rite::from($riteValue);
+            foreach (glob(rtrim($folder, '/') . '/*.json') ?: [] as $file) {
+                $name = basename($file, '.json');
+                $items[] = new CheckableItem(
+                    "test:{$riteValue}:{$name}",
+                    'file',
+                    $rite,
+                    null,
+                    "Liturgical test: {$name}",
+                    LitSchema::TEST_SRC,
+                    self::STEPS,
+                    $file
+                );
+            }
+        }
+
+        return $items;
+    }
+```
+
+Note this kind is enumerated from the filesystem rather than from the metadata index, because test definitions are not
+calendars and the index does not carry them. That is reading a directory to learn what is *registered*, which is the
+same thing `CalendarMetadataProvider` does for calendars — it is still not stat-ing a target to decide whether to list it.
+
+- [ ] **Step 4: Run it to verify it passes, then lint and analyse**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/
+composer lint
+composer analyse
+```
+
+Expected: all clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+git add src/Models/ValidationsPath/CheckableInventory.php phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+git commit -m "feat(validations): enumerate test definitions per rite
+
+A test definition is a source artifact: does the file validate against
+LitCalTest.json. Running that test against a computed calendar is a
+different thing with its own addressing, and the current protocol blurs
+them — tests-X validates the definition while executeUnitTest runs it.
+Listing the definition here keeps the distinction explicit.
+
+Enumerated from the rite-partitioned tests folders rather than the calendar
+index, because test definitions are not calendars. That is still reading
+what is registered, not stat-ing a target to decide whether to list it.
+
+Tests are the one kind with no i18n sibling.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Drift coverage for the enumerated half, and the docs
+
+**Files:**
+
+- Modify: `phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php`
+- Modify: `phpunit_tests/Handlers/ValidationsHandlerTest.php`
+- Modify: `docs/superpowers/specs/2026-08-19-checkable-inventory-design.md`
+
+**Interfaces:**
+
+- Consumes: `CheckableInventory::all()` and `CheckableInventory::byId()`; `CalendarMetadataProvider::create()`.
+
+- [ ] **Step 1: Write the failing drift test**
+
+The section A drift test walks the source tree and asserts every file found has an entry. That guards the hand-listed
+half. The enumerated half needs the mirror guarantee: every calendar the index reports must have an entry, so a
+registered calendar that this class forgets to enumerate fails the build.
+
+Append to `phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php`:
+
+```php
+    /**
+     * Every registered calendar is a checkable target.
+     *
+     * The other tests in this class walk the filesystem; this one walks the calendar index, because the
+     * per-calendar half of the inventory is enumerated from that index rather than from disk. A diocese
+     * added to source data and picked up by /calendars, but missed here, would otherwise be
+     * unvalidatable by any client with no failure anywhere — which is #800 exactly.
+     */
+    public function testEveryRegisteredCalendarHasAnInventoryEntry(): void
+    {
+        $metadata = CalendarMetadataProvider::create();
+
+        self::assertNotEmpty($metadata->national_calendars, 'no national calendars in the index');
+        self::assertNotEmpty($metadata->diocesan_calendars, 'no diocesan calendars in the index');
+        self::assertNotEmpty($metadata->wider_regions, 'no wider regions in the index');
+
+        foreach ($metadata->national_calendars as $nation) {
+            self::assertNotNull(
+                CheckableInventory::byId("nation:roman:{$nation->calendar_id}"),
+                "national calendar {$nation->calendar_id} is registered but not checkable"
+            );
+        }
+
+        foreach ($metadata->diocesan_calendars as $diocese) {
+            $id = "diocese:{$diocese->rite->value}:{$diocese->calendar_id}";
+            self::assertNotNull(
+                CheckableInventory::byId($id),
+                "diocesan calendar {$diocese->calendar_id} is registered but not checkable as {$id}"
+            );
+        }
+
+        foreach ($metadata->wider_regions as $region) {
+            self::assertNotNull(
+                CheckableInventory::byId("widerregion:roman:{$region->name}"),
+                "wider region {$region->name} is registered but not checkable"
+            );
+        }
+    }
+```
+
+Add `use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;` to the test's imports.
+
+- [ ] **Step 2: Run it — it should pass**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+vendor/bin/phpunit phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
+```
+
+Expected: OK. Tasks 1-3 already added every kind this asserts, so a pass here is the point — it locks in what they
+built.
+
+- [ ] **Step 3: Prove it can fail**
+
+Temporarily comment `self::widerRegionItems()` out of the `all()` merge, re-run, and confirm the test fails naming a
+wider region. Restore it, re-run, confirm green, and check `git diff -- src/` is empty before continuing. Record the
+failure output. A drift test that cannot fail reads like cover.
+
+- [ ] **Step 4: Update the handler test's count assertion**
+
+`phpunit_tests/Handlers/ValidationsHandlerTest.php` asserts `assertCount(18, $body['litcal_validations'])`. That number
+described the static inventory. Replace it with a bound plus the invariants that still hold:
+
+```php
+        $body = $this->decodeJsonBody($response);
+        self::assertArrayHasKey('litcal_validations', $body);
+
+        // The static half alone is 18; enumeration only adds, so a fixed total would fail whenever a
+        // calendar is added — a false alarm rather than drift. The drift test is what pins coverage.
+        self::assertGreaterThan(18, count($body['litcal_validations']));
+
+        $ids = array_column($body['litcal_validations'], 'id');
+        self::assertSame(array_unique($ids), $ids, 'advertised ids must be unique');
+```
+
+- [ ] **Step 5: Run the handler and schema suites**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+vendor/bin/phpunit phpunit_tests/Handlers/ValidationsHandlerTest.php phpunit_tests/Handlers/ReadonlyPathsResponseSchemaTest.php phpunit_tests/Schemas/
+```
+
+Expected: OK. `ReadonlyPathsResponseSchemaTest` validates the real response against `LitCalValidationsPath.json`; if it
+fails, an enumerated item is emitting a field shape the schema rejects — most likely an id that breaks the schema's
+patterns, or a `region` that is neither null nor two uppercase letters. Fix the item, not the schema, unless the schema
+is genuinely wrong.
+
+- [ ] **Step 6: Amend the section A design document**
+
+Two statements in `docs/superpowers/specs/2026-08-19-checkable-inventory-design.md` are now false, and this branch is
+the reason:
+
+1. The scope table lists "Per-calendar items — wider regions, nations, dioceses, tests" as **out of scope**. It is now
+   in scope. Move that row, and add a sentence saying the scoping was revisited in the section B design because making
+   the id the only address requires the inventory to cover everything addressable.
+2. The "Deliberately not doing" section says "The endpoint **does not stat the filesystem**." Replace the absolute claim
+   with the principle that actually holds: it never stats a *target* to decide whether to list it — an item appears
+   because its calendar is registered — while enumeration does read the index and the tests folder. Keep the reason:
+   a list that quietly omitted what it could not stat would reintroduce #800's blindness.
+
+Do not rewrite the rest of the document. Lint it:
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+npx --yes markdownlint-cli docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+```
+
+- [ ] **Step 7: Run the full local suite**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+composer test:quick
+```
+
+Use the composer script, never a bare `phpunit --exclude-group` — a CLI `--exclude-group` overrides the XML config and
+un-fences the golden-master-generate group, which silently rewrites the fixtures it is checked against.
+
+Expected: no new failures. `Routes/*` tests fail with "Could not detect API binding" because they need a live server
+this worktree does not run; that is pre-existing. Check anything ambiguous against the base commit rather than guessing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+git add phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php \
+        phpunit_tests/Handlers/ValidationsHandlerTest.php \
+        docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+git commit -m "test(validations): guard the enumerated half against drift
+
+The section A drift test walks the source tree and asserts every file found
+has an entry, which guards the hand-listed half. The enumerated half needs
+the mirror guarantee: every calendar the index reports must have an entry.
+A diocese added to source data and picked up by /calendars but missed here
+would otherwise be unvalidatable with no failure anywhere — #800 exactly,
+arrived at from the other direction.
+
+Two fixed counts are replaced by bounds. 18, and 9-and-9, described a
+hand-listed inventory; now that it is partly enumerated they would fail
+whenever a calendar is added, which is a false alarm rather than drift. The
+drift tests are what pin coverage, and they do it by name.
+
+Amends the section A design document, which said per-calendar items were
+out of scope and that the endpoint does not stat the filesystem. The first
+was revisited deliberately in the section B design: making the id the only
+address requires the inventory to cover everything addressable. The second
+is narrowed to what actually mattered — it never stats a target to decide
+whether to list it.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Publish
+
+**Files:** none — repository metadata only.
+
+- [ ] **Step 1: Push**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-target
+git push -u origin feat/806-typed-target
+```
+
+- [ ] **Step 2: Open the PR**
+
+Base `development`. The body must state: that `/validations` now covers every checkable source artifact, enumerated
+from the same builder that serves `/calendars`; the id vocabulary and that nothing previously published was renamed;
+what `region` means for each new kind and why a wider region is `null`; that fixed counts were replaced by bounds and
+why; what the new drift test guards and that it was verified by mutation; and the verification output from each task.
+
+State plainly that **no message shape changed** in this PR — the protocol still speaks the legacy vocabulary, and the
+typed target that consumes these ids is the next PR.

--- a/docs/superpowers/plans/2026-08-20-inventory-covers-everything.md
+++ b/docs/superpowers/plans/2026-08-20-inventory-covers-everything.md
@@ -52,7 +52,7 @@ Plan 2 adds the typed `target`, the tagged calendar identity, and the `Health` r
 |----------------------------------|------------------------------------------|----------------------------|
 | `nation:roman:IT`                | `MetadataCalendars::$national_calendars` | `NationalCalendar.json`    |
 | `widerregion:roman:Europe`       | `MetadataCalendars::$wider_regions`      | `WiderRegionCalendar.json` |
-| `diocese:{rite}:roma_lazio_it`   | `MetadataCalendars::$diocesan_calendars` | `DiocesanCalendar.json`    |
+| `diocese:{rite}:romamo_it`       | `MetadataCalendars::$diocesan_calendars` | `DiocesanCalendar.json`    |
 | `test:{rite}:StIgnatiusOfLoyola` | `jsondata/tests/{rite}/*.json`           | `LitCalTest.json`          |
 
 Each file-kind item gets an `:i18n` folder sibling where the folder exists on disk, except tests, which have no `i18n`.
@@ -62,7 +62,7 @@ Each file-kind item gets an `:i18n` folder sibling where the folder exists on di
 `region` answers one question: *is this item specific to one nation's calendar?*
 
 - `nation:roman:IT` → `'IT'`.
-- `diocese:roman:roma_lazio_it` → its nation, `'IT'`.
+- `diocese:roman:romamo_it` → its nation, `'IT'`.
 - `test:roman:X` → `null`; a test definition is not nation-scoped.
 - `widerregion:roman:Europe` → `null`, **and this is a known limitation to document, not to paper over.** A wider region
   applies to several nations, which a scalar cannot express. Clients already have the mapping — `/calendars` gives each
@@ -388,7 +388,7 @@ Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
 **Interfaces:**
 
 - Consumes: `MetadataCalendars::$diocesan_calendars` — a list of `MetadataDiocesanCalendarItem`, each with public
-  `string $calendar_id` (e.g. `'roma_lazio_it'`), `string $diocese` (the diocese *name*), `string $nation`,
+  `string $calendar_id` (e.g. `'romamo_it'`), `string $diocese` (the diocese *name*), `string $nation`,
   `readonly Rite $rite`. Path templates `JsonData::DIOCESAN_CALENDAR_FILE` and
   `JsonData::AMBROSIAN_DIOCESAN_CALENDAR_FILE`, both carrying **three** placeholders — `{nation}`, `{diocese}`,
   `{diocese_name}` — plus their `*_I18N_FOLDER` siblings, which carry only `{nation}` and `{diocese}`.
@@ -401,12 +401,12 @@ Append to `phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php`:
 ```php
     public function testDiocesanCalendarsAreEnumeratedUnderTheirOwnRite(): void
     {
-        $roman = CheckableInventory::byId('diocese:roman:roma_lazio_it');
+        $roman = CheckableInventory::byId('diocese:roman:romamo_it');
         self::assertNotNull($roman, 'the Diocese of Rome should be a checkable target');
         self::assertSame(Rite::ROMAN, $roman->rite);
         self::assertSame('IT', $roman->region, 'a diocesan calendar is scoped to its nation');
         self::assertSame(LitSchema::DIOCESAN, $roman->schema);
-        self::assertNotNull(CheckableInventory::byId('diocese:roman:roma_lazio_it:i18n'));
+        self::assertNotNull(CheckableInventory::byId('diocese:roman:romamo_it:i18n'));
     }
 
     /**

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -41,9 +41,9 @@ Per-calendar items were originally out of scope; the scoping was revisited in th
 the id the only address a client ever needs requires the inventory to cover everything addressable, not just the
 statically-listed half.
 
-### Why only static files
+### The three kinds, and which of them are covered
 
-The runners check three different kinds of thing, and only one of them is the problem:
+The runners check three different kinds of thing, and they are not all covered here:
 
 1. **Static source files and folders** — missal propriums for both rites, decrees, and their `i18n` directories. These
    are hardcoded in the clients *as filesystem paths*.
@@ -52,8 +52,12 @@ The runners check three different kinds of thing, and only one of them is the pr
 3. **The API's own endpoints** — `/calendars`, `/decrees`, `/tests`, `/events`, `/easter`, `/schemas`, `/missals`. The
    client builds these from its `ENDPOINTS` map. No path is embedded.
 
-Only kind 1 caused #737/#38, #795 and #800. Advertising kinds 2 and 3 would add surface without removing duplication,
-so this endpoint covers kind 1 only.
+Only kind 1 caused #737/#38, #795 and #800, which is why the endpoint began with kind 1 alone. Kind 2 was added in the
+section B design, for the reason the paragraph above the taxonomy gives: an id that is the only address a client ever
+needs has to cover everything addressable. So this endpoint covers kinds 1 and 2.
+
+Kind 3 stays out. The client builds those paths from its `ENDPOINTS` map rather than embedding them, so advertising them
+would add surface without removing any duplication — which was the original argument, and it still holds for kind 3.
 
 ## Who consumes it, and how they differ
 

--- a/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
+++ b/docs/superpowers/specs/2026-08-19-checkable-inventory-design.md
@@ -31,12 +31,15 @@ match real paths, which would close that class too — worth noting, not this de
 
 | In scope                                                                   | Out of scope                                                                  |
 |----------------------------------------------------------------------------|-------------------------------------------------------------------------------|
-| A `GET /validations` endpoint advertising static source-data files/folders | Per-calendar items — wider regions, nations, dioceses, tests                  |
-| Collapsing the server's two schema-resolution vocabularies into one        | The API's own endpoints (`resourceDataChecks`)                                |
-| A drift test that fails when data exists with no inventory entry           | Any change to the WebSocket protocol itself                                   |
-| —                                                                          | The `hello` frame and `protocol` versioning (#806 section F)                  |
-| —                                                                          | Client adoption, and the client-side scope predicate (UnitTestInterface#42)   |
+| A `GET /validations` endpoint advertising static source-data files/folders | The API's own endpoints (`resourceDataChecks`)                                |
+| Collapsing the server's two schema-resolution vocabularies into one        | Any change to the WebSocket protocol itself                                   |
+| A drift test that fails when data exists with no inventory entry           | The `hello` frame and `protocol` versioning (#806 section F)                  |
+| Per-calendar items — wider regions, nations, dioceses, tests               | Client adoption, and the client-side scope predicate (UnitTestInterface#42)   |
 | —                                                                          | A RiteSelect control on either page (client work; UnitTestInterface#42 / #39) |
+
+Per-calendar items were originally out of scope; the scoping was revisited in the section B design, because making
+the id the only address a client ever needs requires the inventory to cover everything addressable, not just the
+statically-listed half.
 
 ### Why only static files
 
@@ -226,10 +229,14 @@ request.
 
 ## Deliberately not doing
 
-**The endpoint does not touch the filesystem.** Advertising is not verification. `exists` is the first *check*, not a
-precondition for being listed, so a missing file appears as a failed check in the UI rather than as a silent absence
-from the list. That distinction is exactly how #800 stayed invisible: the Ambrosian data was present and no client
-listed it. A list that quietly drops what it cannot stat reintroduces the same blindness from the other direction.
+**The endpoint never stats a target to decide whether to list it.** Advertising is not verification. `exists` is the
+first *check*, not a precondition for being listed, so a missing file appears as a failed check in the UI rather than
+as a silent absence from the list. An item appears because its calendar is registered, not because a file was found
+present — the per-calendar half enumeration added in the section B design does read the calendar index and the tests
+folder, so "does not touch the filesystem" is not literally true of the endpoint as a whole, but the narrower claim
+still holds for every item it lists. That distinction is exactly how #800 stayed invisible: the Ambrosian data was
+present and no client listed it. A list that quietly omitted what it could not stat would reintroduce the same
+blindness from the other direction.
 
 It also keeps the endpoint cheap and its output identical across environments.
 

--- a/docs/superpowers/specs/2026-08-20-typed-target-design.md
+++ b/docs/superpowers/specs/2026-08-20-typed-target-design.md
@@ -19,7 +19,7 @@ absolute API URL, or — for every per-calendar check — a *bare identifier*: `
 the `validate` slug. Its sibling `sourceFolder` is mutually exclusive with it but not modelled as such.
 
 **`validate` is already an id in all but name.** `national-calendar-IT`, `diocesan-calendar-romamo_it`,
-`wider-region-Europe`, `proprium-de-sanctis-IT-1983`, `tests-StIgnatiusOfLoyola` — the server parses these with eight
+`wider-region-Europe`, `proprium-de-sanctis-IT-1983`, `tests-StIgnatiusOfLoyolaTest` — the server parses these with eight
 anchored `preg_match` arms to recover what the client meant. It is simultaneously a schema selector, the human label
 rendered on the card, and a CSS class fragment.
 
@@ -50,9 +50,12 @@ name left alone through a redesign survives it.
 
 ## The inventory grows
 
-`/validations` goes from 18 items to roughly 130: the existing static source data, plus every per-calendar source
-artifact — 10 national calendars, 32 diocesan, 7 wider regions, 11 test definitions, each with its `i18n` folder where
-one exists.
+`/validations` goes from 18 items to 77: the existing static source data, plus every per-calendar source artifact.
+Each calendar contributes two items, its definition file and its `i18n` folder — 5 checkable national calendars give 10,
+16 dioceses give 32, 3 wider regions give 6. The 11 test definitions contribute one apiece, having no translations
+folder. (The Vatican is announced as a national calendar but is served by the General Roman Calendar and has no source
+data of its own, so it contributes nothing.) Those figures are what the bundled source data happens to yield today; the
+point is that they are enumerated rather than listed, so they move with the data.
 
 The enumeration comes from `CalendarMetadataProvider::create()`, which the codebase already calls "the single source of
 truth" for the calendar index and which `MetadataHandler` uses to serve `/calendars`. Deriving from the same builder
@@ -75,16 +78,16 @@ definitions at runtime; `/validations` inherits that and stays correct after a w
 
 `kind:rite[:qualifier][:i18n]`, fully qualified.
 
-| Id                              | What it addresses                        |
-|---------------------------------|------------------------------------------|
-| `temporale:roman`               | the Roman Proprium de Tempore file       |
-| `temporale:roman:i18n`          | its translations folder                  |
-| `sanctorale:roman:US_2011`      | the USA edition's sanctorale             |
-| `decrees:roman`                 | memorials from decrees                   |
-| `nation:roman:IT`               | the Italian national calendar definition |
-| `diocese:ambrosian:lugano_ch`   | a diocesan calendar definition           |
-| `widerregion:roman:Europe`      | a wider-region definition                |
-| `test:roman:StIgnatiusOfLoyola` | a test *definition* file                 |
+| Id                                      | What it addresses                        |
+|-----------------------------------------|------------------------------------------|
+| `temporale:roman`                       | the Roman Proprium de Tempore file       |
+| `temporale:roman:i18n`                  | its translations folder                  |
+| `sanctorale:roman:US_2011`              | the USA edition's sanctorale             |
+| `decrees:roman`                         | memorials from decrees                   |
+| `nation:roman:IT`                       | the Italian national calendar definition |
+| `diocese:ambrosian:lugano_ch`           | a diocesan calendar definition           |
+| `widerregion:roman:Europe`              | a wider-region definition                |
+| `test:ambrosian:StIgnatiusOfLoyolaTest` | a test *definition* file                 |
 
 All 18 ids already published in #811 satisfy this scheme unchanged, so nothing shipped needs renaming. The rite segment
 is always present even where it is not currently a discriminator — nations and tests are Roman-only today — because a
@@ -111,8 +114,8 @@ There are three domains here, and collapsing them into one `target` would be the
 
 // 3. Run a test — a test id plus the calendar to run it against.
 { "action": "runTest",
-  "test": "StIgnatiusOfLoyola",
-  "calendar": { "kind": "national", "id": "IT", "rite": "roman" },
+  "test": "StIgnatiusOfLoyolaTest",
+  "calendar": { "kind": "rite", "id": "ambrosian", "rite": "ambrosian" },
   "year": 2026 }
 ```
 
@@ -120,9 +123,9 @@ There are three domains here, and collapsing them into one `target` would be the
 
 ### Source check versus test run
 
-The current protocol blurs a distinction worth keeping explicit. `tests-StIgnatiusOfLoyola` today is a **source check**:
+The current protocol blurs a distinction worth keeping explicit. `tests-StIgnatiusOfLoyolaTest` today is a **source check**:
 does the test *definition* validate against `LitCalTest.json`. `executeUnitTest` **runs** that test against a computed
-calendar. Both survive, addressed differently — `test:roman:StIgnatiusOfLoyola` is an inventory item reached by shape 1;
+calendar. Both survive, addressed differently — `test:ambrosian:StIgnatiusOfLoyolaTest` is an inventory item reached by shape 1;
 running it is shape 3.
 
 ### Why `rite` is carried rather than inferred

--- a/docs/superpowers/specs/2026-08-20-typed-target-design.md
+++ b/docs/superpowers/specs/2026-08-20-typed-target-design.md
@@ -14,11 +14,11 @@ calendar type (`nationalcalendar`, `diocesancalendar`, `ritecalendar`). Two of t
 different things.
 
 **`sourceFile` is polymorphic with no discriminator, and worse than #806 recorded.** It is a repo-relative path, or an
-absolute API URL, or — for every per-calendar check — a *bare identifier*: `"IT"`, `"Europe"`, `"roma_lazio_it"`,
+absolute API URL, or — for every per-calendar check — a *bare identifier*: `"IT"`, `"Europe"`, `"romamo_it"`,
 `"EDITIO_TYPICA_1970"`. In that last case the server ignores it as a path entirely and reconstructs the real path from
 the `validate` slug. Its sibling `sourceFolder` is mutually exclusive with it but not modelled as such.
 
-**`validate` is already an id in all but name.** `national-calendar-IT`, `diocesan-calendar-roma_lazio_it`,
+**`validate` is already an id in all but name.** `national-calendar-IT`, `diocesan-calendar-romamo_it`,
 `wider-region-Europe`, `proprium-de-sanctis-IT-1983`, `tests-StIgnatiusOfLoyola` — the server parses these with eight
 anchored `preg_match` arms to recover what the client meant. It is simultaneously a schema selector, the human label
 rendered on the card, and a CSS class fragment.

--- a/docs/superpowers/specs/2026-08-20-typed-target-design.md
+++ b/docs/superpowers/specs/2026-08-20-typed-target-design.md
@@ -1,0 +1,205 @@
+# A typed target for the Health WebSocket protocol
+
+Design for section B of [#806](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/806). Section A
+([#811](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/811)) published the inventory; this makes it
+the address. Client counterpart: [UnitTestInterface#42](https://github.com/Liturgical-Calendar/UnitTestInterface/issues/42).
+
+## Problem
+
+Three properties on the wire are each doing more than one job, and they overlap.
+
+**`category` is one name carrying two disjoint enums.** On `executeValidation` it selects a schema-resolution strategy
+(`universalcalendar`, `sourceDataCheck`, `resourceDataCheck`). On `validateCalendar` and `executeUnitTest` it names a
+calendar type (`nationalcalendar`, `diocesancalendar`, `ritecalendar`). Two of those values appear in both enums meaning
+different things.
+
+**`sourceFile` is polymorphic with no discriminator, and worse than #806 recorded.** It is a repo-relative path, or an
+absolute API URL, or — for every per-calendar check — a *bare identifier*: `"IT"`, `"Europe"`, `"roma_lazio_it"`,
+`"EDITIO_TYPICA_1970"`. In that last case the server ignores it as a path entirely and reconstructs the real path from
+the `validate` slug. Its sibling `sourceFolder` is mutually exclusive with it but not modelled as such.
+
+**`validate` is already an id in all but name.** `national-calendar-IT`, `diocesan-calendar-roma_lazio_it`,
+`wider-region-Europe`, `proprium-de-sanctis-IT-1983`, `tests-StIgnatiusOfLoyola` — the server parses these with eight
+anchored `preg_match` arms to recover what the client meant. It is simultaneously a schema selector, the human label
+rendered on the card, and a CSS class fragment.
+
+So the protocol already has an addressing scheme. It is undeclared, hyphenated because of CSS, and recovered by regex.
+
+## The principle
+
+**Everything checkable has an id, and the id is the address.** A client picks an id out of a list the server published
+and sends it back. The server resolves it with one lookup.
+
+That is only true if the inventory covers everything checkable, which today it does not.
+
+## Scope
+
+| In scope                                                                 | Out of scope                                                                    |
+|--------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| Growing `/validations` to enumerate per-calendar source data             | Removing the legacy message shapes (a follow-up, gated on UnitTestInterface#42) |
+| A typed `target` on source validation, replacing `category`+`sourceFile` | Structured, DOM-agnostic responses (#806 section C)                             |
+| A tagged calendar identity on `validateCalendar` and test runs           | `requestId` correlation (#806 section E)                                        |
+| Retiring the eight `preg_match` slug arms for inventory-owned targets    | The terminal `complete` frame (#806 section D)                                  |
+| `responsetype` → `responseFormat` on the reshaped messages               | A `protocolError` response type (#806 section G)                                |
+| —                                                                        | The `hello` handshake and versioning (#806 section F)                           |
+
+### Why the naming clean-up rides along
+
+`responsetype` is renamed here rather than in a separate pass because these messages are being reshaped anyway. An odd
+name left alone through a redesign survives it.
+
+## The inventory grows
+
+`/validations` goes from 18 items to roughly 130: the existing static source data, plus every per-calendar source
+artifact — 10 national calendars, 32 diocesan, 7 wider regions, 11 test definitions, each with its `i18n` folder where
+one exists.
+
+The enumeration comes from `CalendarMetadataProvider::create()`, which the codebase already calls "the single source of
+truth" for the calendar index and which `MetadataHandler` uses to serve `/calendars`. Deriving from the same builder
+means the two lists cannot disagree: a calendar that exists is a calendar that is checkable.
+
+### An amendment to section A's stated principle
+
+Section A said the endpoint "does not touch the filesystem". That is no longer literally true — enumerating registered
+calendars reads source data, because that is what `CalendarMetadataProvider` does.
+
+The principle that actually mattered is narrower and still holds: **the endpoint never stats a target to decide whether
+to list it.** An item appears because the calendar is registered, not because a file was found present. Presence remains
+the `exists` step's job at check time. A list that quietly omitted what it could not stat would reintroduce exactly the
+blindness of #800.
+
+`CalendarMetadataProvider` deliberately re-reads on every call, because the `/data` write endpoints can mutate calendar
+definitions at runtime; `/validations` inherits that and stays correct after a write rather than serving a stale index.
+
+## Id vocabulary
+
+`kind:rite[:qualifier][:i18n]`, fully qualified.
+
+| Id                              | What it addresses                        |
+|---------------------------------|------------------------------------------|
+| `temporale:roman`               | the Roman Proprium de Tempore file       |
+| `temporale:roman:i18n`          | its translations folder                  |
+| `sanctorale:roman:US_2011`      | the USA edition's sanctorale             |
+| `decrees:roman`                 | memorials from decrees                   |
+| `nation:roman:IT`               | the Italian national calendar definition |
+| `diocese:ambrosian:lugano_ch`   | a diocesan calendar definition           |
+| `widerregion:roman:Europe`      | a wider-region definition                |
+| `test:roman:StIgnatiusOfLoyola` | a test *definition* file                 |
+
+All 18 ids already published in #811 satisfy this scheme unchanged, so nothing shipped needs renaming. The rite segment
+is always present even where it is not currently a discriminator — nations and tests are Roman-only today — because a
+uniform first-two-segments shape lets the server switch on `kind` without special cases, and an Ambrosian national
+calendar later would not force a vocabulary change.
+
+Ids stay **opaque to clients**: they are echoed back, never parsed. The structure exists for the server and for humans
+reading logs.
+
+## Three message shapes
+
+There are three domains here, and collapsing them into one `target` would be the same mistake `category` made.
+
+```jsonc
+// 1. Validate a source artifact — fully addressed by an inventory id.
+{ "action": "validateSource",
+  "target": { "id": "diocese:ambrosian:lugano_ch" } }
+
+// 2. Compute a calendar — an identity plus a year, not an inventory item.
+{ "action": "validateCalendar",
+  "calendar": { "kind": "diocesan", "id": "lugano_ch", "rite": "ambrosian" },
+  "year": 2026,
+  "responseFormat": "JSON" }
+
+// 3. Run a test — a test id plus the calendar to run it against.
+{ "action": "runTest",
+  "test": "StIgnatiusOfLoyola",
+  "calendar": { "kind": "national", "id": "IT", "rite": "roman" },
+  "year": 2026 }
+```
+
+`calendar.kind` is one of `general`, `national`, `diocesan`, `rite`. The word `category` disappears from the protocol.
+
+### Source check versus test run
+
+The current protocol blurs a distinction worth keeping explicit. `tests-StIgnatiusOfLoyola` today is a **source check**:
+does the test *definition* validate against `LitCalTest.json`. `executeUnitTest` **runs** that test against a computed
+calendar. Both survive, addressed differently — `test:roman:StIgnatiusOfLoyola` is an inventory item reached by shape 1;
+running it is shape 3.
+
+### Why `rite` is carried rather than inferred
+
+`Health::resolveRite()` can infer a rite from a calendar id, and does so today for clients that predate rite awareness.
+The typed calendar identity carries it explicitly because inference is how the rite arrived in the first place — as an
+optional field with a server-side guess — and #806's own complaint is that there was no way to state it. A client that
+selected an Ambrosian diocese knows the rite; making it say so removes a guess from the server.
+
+## What `Health` sheds
+
+- `retrieveSchemaForCategory()`'s `sourceDataCheck` branch — eight anchored `preg_match` arms — becomes a single
+  `CheckableInventory::byId()` lookup for every target the inventory owns, which after this design is all of them.
+- `executeValidation()` stops deriving a filesystem path from client input for v2 messages; it reads the resolved
+  inventory item's own `path` and `kind`.
+- The `universalcalendar` / `sourceDataCheck` / `resourceDataCheck` strategy enum stops being consulted on v2 messages.
+
+Nothing is deleted while a legacy client can still send the old shapes. The arms remain reachable from the legacy branch
+until it is removed.
+
+## Migration
+
+Additive, exactly as `cancelRun` was. How a message is recognised as v2 differs by action, and it is worth stating
+precisely rather than as one rule:
+
+| Action                                     | v2 recognised by                                                |
+|--------------------------------------------|-----------------------------------------------------------------|
+| `validateSource` (was `executeValidation`) | the action name itself — it is new, so every such message is v2 |
+| `runTest` (was `executeUnitTest`)          | the action name itself                                          |
+| `validateCalendar` (name unchanged)        | `calendar` being an **object** rather than a string             |
+| `cancelRun`                                | unaffected by this design                                       |
+
+Two of the three get a new name, which #806's capability sketch already uses, and a new name is a cleaner discriminator
+than a shape test: a v1 client cannot accidentally emit `validateSource`. `validateCalendar` keeps its name because the
+action itself is unchanged — only the calendar identity becomes typed — so there the shape of `calendar` is the signal.
+
+No client breaks on the day this lands, and UnitTestInterface can migrate one page at a time.
+
+Removal of the legacy branch is a separate, later change, gated on UnitTestInterface#42 shipping.
+
+## What this does not fix, yet
+
+`Health::executeValidation()` passes a client-supplied `sourceFolder` to `glob()` with no containment check, and an
+absolute path bypasses the `Router::$apiFilePath` prefix entirely — an arbitrary-directory read of `*.json` on the
+WebSocket host. It is pre-existing, and the maintainer's decision is to let section B remove client-supplied paths
+rather than patch it.
+
+**That fix lands at the *end* of B, not the start.** The additive phase leaves the legacy branch — and the exposure —
+in place. Anyone reading this design as "B closes the path issue" should read it as "the legacy-removal follow-up closes
+it", and that follow-up is gated on client adoption.
+
+## Error handling
+
+| Condition                                        | Behaviour                                                                      |
+|--------------------------------------------------|--------------------------------------------------------------------------------|
+| `target.id` is not in the inventory              | Rejected immediately, via the existing error frame                             |
+| `target` present but not an object               | Rejected as a malformed message                                                |
+| `calendar` is an object with an unknown `kind`   | Rejected immediately                                                           |
+| `calendar` is a string                           | Legacy path, unchanged behaviour                                               |
+| `rite` disagrees with the calendar's actual rite | Rejected, rather than silently preferring one — a disagreement is a client bug |
+
+Rejections reuse the **existing** `echobot` error shape. A dedicated `protocolError` type belongs to section G and
+cannot land before section C, because since UnitTestInterface PR #46 an unrecognised response `type` is painted as a
+visible failed check. Introducing one now would make every rejection look like a failing test to the user.
+
+## Testing
+
+**Equivalence is the safety net, as it was for section A.** Every legacy slug the current branch resolves must resolve
+to the same schema through its new id. The existing `HealthSchemaCategoryTest` provider is extended with the id form of
+each slug it already covers, and the old slug→schema table is pasted into the inventory tests as an oracle.
+
+**Round-trip:** every id `/validations` advertises resolves through `byId()`, and every resolved item yields the same
+schema its legacy slug did.
+
+**Drift, extended to the dynamic half:** every calendar `CalendarMetadataProvider::create()` reports must have a
+corresponding inventory entry. This is the section A drift test's guarantee applied to the part that is now enumerated
+rather than hand-listed — a diocese added to source data without appearing in `/validations` fails the build.
+
+**Legacy untouched:** the existing suites covering the legacy shapes must pass unchanged, which is what makes "additive"
+a claim rather than an intention.

--- a/phpunit_tests/Handlers/ValidationsHandlerTest.php
+++ b/phpunit_tests/Handlers/ValidationsHandlerTest.php
@@ -40,7 +40,13 @@ final class ValidationsHandlerTest extends AbstractHandlerTestCase
 
         $body = $this->decodeJsonBody($response);
         self::assertArrayHasKey('litcal_validations', $body);
-        self::assertCount(18, $body['litcal_validations']);
+
+        // The static half alone is 18; enumeration only adds, so a fixed total would fail whenever a
+        // calendar is added — a false alarm rather than drift. The drift test is what pins coverage.
+        self::assertGreaterThan(18, count($body['litcal_validations']));
+
+        $ids = array_column($body['litcal_validations'], 'id');
+        self::assertSame(array_unique($ids), $ids, 'advertised ids must be unique');
     }
 
     public function testEveryItemCarriesTheAdvertisedFields(): void

--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitSchema;
 use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -231,5 +232,116 @@ final class HealthSchemaCategoryTest extends TestCase
     public function testUnknownCategoryResolvesToNull(): void
     {
         self::assertNull(self::retrieveSchemaForCategory('definitelyNotACategory', 'US'));
+    }
+
+    // ---------------------------------------------------------------- a broken inventory is contained
+
+    /**
+     * Runs `$fn` with `CheckableInventory` pointed at a source tree containing one malformed
+     * national calendar file, so that every inventory lookup throws.
+     *
+     * This is the real failure, not a simulated one: the inventory enumerates per-calendar items via
+     * `CalendarMetadataProvider::create()`, which JSON-parses every national and diocesan calendar
+     * file, so a single unparseable file makes `all()` — and therefore `byPath()` and `byId()` —
+     * throw. Only the malformed file needs to exist: national calendars are built first, so the
+     * build aborts before it looks for anything else.
+     *
+     * The memoized statics are reset on the way in *and* on the way out: in on so the poisoned tree
+     * is actually read rather than a good index being served from an earlier test, out so the next
+     * test rebuilds against the real tree.
+     */
+    private static function withBrokenInventory(callable $fn): void
+    {
+        $savedApiFilePath = Router::$apiFilePath;
+        $root             = sys_get_temp_dir() . '/health-broken-inventory-' . getmypid() . '-' . uniqid() . '/';
+        $nationFolder     = $root . JsonData::NATIONAL_CALENDARS_FOLDER->value . '/ZZ';
+
+        self::assertTrue(mkdir($nationFolder, 0777, true), 'could not build the fixture source tree');
+        file_put_contents($nationFolder . '/ZZ.json', '{ this is not JSON');
+
+        Router::$apiFilePath = $root;
+        self::resetInventoryMemo();
+
+        try {
+            // Guard: if this ever stops throwing, the tests below would pass for the wrong reason.
+            try {
+                CheckableInventory::all();
+                self::fail('the fixture tree no longer breaks the inventory — this test proves nothing');
+            } catch (\JsonException) {
+                // expected
+            }
+
+            $fn();
+        } finally {
+            Router::$apiFilePath = $savedApiFilePath;
+            self::resetInventoryMemo();
+            @unlink($nationFolder . '/ZZ.json');
+            self::removeDirectoryTree($root);
+        }
+    }
+
+    private static function resetInventoryMemo(): void
+    {
+        $inventory = new \ReflectionClass(CheckableInventory::class);
+        $inventory->setStaticPropertyValue('items', null);
+        $inventory->setStaticPropertyValue('metadata', null);
+    }
+
+    private static function removeDirectoryTree(string $root): void
+    {
+        if (false === is_dir($root)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entry->isDir() ? @rmdir($entry->getPathname()) : @unlink($entry->getPathname());
+        }
+
+        @rmdir($root);
+    }
+
+    /**
+     * One malformed calendar file must not take out schema resolution for every unrelated check.
+     *
+     * `Health` is a long-running ReactPHP process, and `getPathToSchemaFile()` consults the inventory
+     * before its own route arms. Without containment, a broken diocesan or national JSON file would
+     * propagate out of that lookup and break `executeValidation` for the Roman temporale, the
+     * `/calendars` route and everything else — the detector failing on exactly what it exists to
+     * detect. `GET /validations` still answers 503 loudly; that is where the failure belongs.
+     */
+    public function testABrokenInventoryDoesNotBreakUnrelatedSchemaResolution(): void
+    {
+        self::withBrokenInventory(static function (): void {
+            // Resolved by the route arm that follows the inventory lookup in getPathToSchemaFile().
+            self::assertSame(
+                LitSchema::METADATA->path(),
+                self::retrieveSchemaForCategory('universalcalendar', Route::CALENDARS->path()),
+                'a Throwable from the inventory propagated instead of falling through to the route arms'
+            );
+
+            // Resolved by the legacy regex arms that follow the byId() lookup in sourceDataCheck.
+            self::assertSame(
+                LitSchema::NATIONAL->path(),
+                self::retrieveSchemaForCategory('sourceDataCheck', 'national-calendar-US'),
+                'a Throwable from the inventory propagated instead of falling through to the slug patterns'
+            );
+            self::assertSame(
+                LitSchema::DIOCESAN->path(),
+                self::retrieveSchemaForCategory('sourceDataCheck', 'diocesan-calendar-romamo_it')
+            );
+            self::assertSame(
+                LitSchema::TEST_SRC->path(),
+                self::retrieveSchemaForCategory('sourceDataCheck', 'tests-StIgnatiusOfLoyolaTest')
+            );
+
+            // The slugs that only the inventory resolves degrade to null rather than to an exception.
+            self::assertNull(self::retrieveSchemaForCategory('sourceDataCheck', 'not-a-known-slug'));
+        });
     }
 }

--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -573,4 +573,59 @@ final class HealthSchemaCategoryTest extends TestCase
             self::assertNull(self::retrieveSchemaForCategory('sourceDataCheck', 'not-a-known-slug'));
         });
     }
+
+    /**
+     * The static half of the inventory keeps resolving even when the enumerating half is broken.
+     *
+     * The two halves fail independently: `explicitItems()` and `derivedRomanSanctorale()` build their
+     * paths from the `RomanMissal` and `JsonData` registries and never call
+     * `CalendarMetadataProvider`, so a malformed calendar file cannot have broken them. Falling all
+     * the way through to the route arms would throw away a resolution that is still perfectly good —
+     * and the missal propriums, the temporale and the decrees are the targets most often checked.
+     *
+     * The contrast is the point of this test, so both directions are asserted: the static targets
+     * still resolve, the per-calendar ones do not. A test that only asserted the first half would
+     * pass just as well against a fallback that had quietly reintroduced the whole inventory.
+     */
+    public function testABrokenInventoryStillResolvesStaticSourceData(): void
+    {
+        $ambrosianTemporale = JsonData::AMBROSIAN_TEMPORALE_FILE->value;
+        $romanSanctorale    = JsonData::MISSALS_FOLDER->value . '/propriumdesanctis_US_2011/propriumdesanctis_US_2011.json';
+        $nationalCalendar   = strtr(JsonData::NATIONAL_CALENDAR_FILE->value, ['{nation}' => 'US']);
+
+        // Sanity: with a healthy inventory, all three resolve — so the nulls below are a degradation
+        // of something that worked, not an input that never resolved in the first place.
+        self::assertSame(LitSchema::PROPRIUMDETEMPORE->path(), self::retrieveSchemaForCategory('universalcalendar', $ambrosianTemporale));
+        self::assertSame(LitSchema::PROPRIUMDESANCTIS->path(), self::retrieveSchemaForCategory('universalcalendar', $romanSanctorale));
+        self::assertSame(LitSchema::NATIONAL->path(), self::retrieveSchemaForCategory('universalcalendar', $nationalCalendar));
+        self::assertSame(LitSchema::NATIONAL->path(), self::retrieveSchemaForCategory('sourceDataCheck', 'nation:roman:US'));
+
+        self::withBrokenInventory(static function () use ($ambrosianTemporale, $romanSanctorale, $nationalCalendar): void {
+            self::assertSame(
+                LitSchema::PROPRIUMDETEMPORE->path(),
+                self::retrieveSchemaForCategory('universalcalendar', $ambrosianTemporale),
+                'a static source path stopped resolving because an unrelated calendar file was malformed'
+            );
+            self::assertSame(
+                LitSchema::PROPRIUMDESANCTIS->path(),
+                self::retrieveSchemaForCategory('universalcalendar', $romanSanctorale)
+            );
+
+            // Inventory ids resolve through the same fallback, which is what plan 2 will rely on once
+            // clients send ids instead of slugs: sanctorale:roman:US_2011 matches no regex arm.
+            self::assertSame(
+                LitSchema::PROPRIUMDESANCTIS->path(),
+                self::retrieveSchemaForCategory('sourceDataCheck', 'sanctorale:roman:US_2011')
+            );
+
+            // And the other half of the contrast: per-calendar targets are genuinely unavailable, so
+            // they degrade to null rather than being resolved by a fallback that reads the same data
+            // that just failed.
+            self::assertNull(
+                self::retrieveSchemaForCategory('universalcalendar', $nationalCalendar),
+                'a per-calendar path resolved while the calendar index was broken — the fallback is not static-only'
+            );
+            self::assertNull(self::retrieveSchemaForCategory('sourceDataCheck', 'nation:roman:US'));
+        });
+    }
 }

--- a/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+++ b/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
@@ -10,6 +10,7 @@ use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\ResourceExistenceChecker;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -201,6 +202,19 @@ final class CheckableInventoryTest extends TestCase
         self::assertNotNull($italyI18n);
         self::assertSame('folder', $italyI18n->kind);
         self::assertSame(LitSchema::I18N, $italyI18n->schema);
+    }
+
+    public function testVaticanIsExcludedBecauseItHasNoSourceDataOfItsOwn(): void
+    {
+        // The Vatican is announced as a national calendar (CalendarMetadataProvider hardcodes it
+        // alongside the real per-nation entries) but is served by the General Roman Calendar and
+        // has no nations/VA/ source folder — nothing here is checkable, so it must not be listed.
+        self::assertNull(CheckableInventory::byId('nation:roman:' . ResourceExistenceChecker::VATICAN_NATIONAL_CALENDAR_ID));
+
+        $vaticanPrefix = 'nation:roman:' . ResourceExistenceChecker::VATICAN_NATIONAL_CALENDAR_ID;
+        foreach (CheckableInventory::all() as $item) {
+            self::assertStringStartsNotWith($vaticanPrefix, $item->id, "unexpected Vatican item {$item->id}");
+        }
     }
 
     public function testWiderRegionsAreEnumeratedAndAreNotNationScoped(): void

--- a/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+++ b/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
@@ -26,10 +26,23 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CheckableItem::class)]
 final class CheckableInventoryTest extends TestCase
 {
+    private static string $savedApiPath = '';
+
     public static function setUpBeforeClass(): void
     {
         // JsonData cases build filesystem paths from this prefix.
         Router::$apiFilePath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR;
+
+        // CalendarMetadataProvider::create() (pulled in via CheckableInventory::nationalCalendarItems()
+        // and ::widerRegionItems()) reads Router::$apiPath while building each wider region's api_path.
+        // isset() is false for typed-uninitialised properties.
+        self::$savedApiPath = isset(Router::$apiPath) ? Router::$apiPath : '';
+        Router::$apiPath    = '';
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath = self::$savedApiPath;
     }
 
     /**
@@ -76,15 +89,24 @@ final class CheckableInventoryTest extends TestCase
         self::assertSame(array_unique($ids), $ids, 'inventory ids must be unique');
     }
 
-    public function testItHoldsNineFilesAndNineFolders(): void
+    public function testEveryItemIsEitherAFileOrAFolderAndFoldersAreI18n(): void
     {
-        $kinds = array_count_values(array_map(
-            static fn (CheckableItem $i): string => $i->kind,
-            CheckableInventory::all()
-        ));
+        $files   = 0;
+        $folders = 0;
+        foreach (CheckableInventory::all() as $item) {
+            if ('folder' === $item->kind) {
+                ++$folders;
+                self::assertStringEndsWith(':i18n', $item->id, "folder item {$item->id} is not an i18n folder");
+                self::assertSame(LitSchema::I18N, $item->schema, "folder item {$item->id} must validate as i18n");
+            } else {
+                ++$files;
+                self::assertStringEndsNotWith(':i18n', $item->id, "file item {$item->id} looks like an i18n folder");
+            }
+        }
 
-        self::assertSame(9, $kinds['file']);
-        self::assertSame(9, $kinds['folder']);
+        // The static half alone contributes nine of each; enumeration only adds.
+        self::assertGreaterThanOrEqual(9, $files);
+        self::assertGreaterThanOrEqual(9, $folders);
     }
 
     public function testTheFiveMissalsWithASanctoraleArePresentAndTheOthersAbsent(): void
@@ -155,6 +177,51 @@ final class CheckableInventoryTest extends TestCase
             $encoded = json_encode($item, JSON_THROW_ON_ERROR);
             self::assertStringNotContainsString('jsondata', $encoded, "item {$item->id} leaked a path");
             self::assertArrayNotHasKey('path', (array) json_decode($encoded, true, 512, JSON_THROW_ON_ERROR));
+        }
+    }
+
+    public function testNationalCalendarsAreEnumeratedFromTheMetadataProvider(): void
+    {
+        $ids = array_map(static fn (CheckableItem $i): string => $i->id, CheckableInventory::all());
+
+        // Italy is a national calendar the repository ships; if it ever stops being one, this test
+        // should be updated deliberately rather than the assertion loosened.
+        self::assertContains('nation:roman:IT', $ids);
+        self::assertContains('nation:roman:IT:i18n', $ids);
+
+        $italy = CheckableInventory::byId('nation:roman:IT');
+        self::assertNotNull($italy);
+        self::assertSame('file', $italy->kind);
+        self::assertSame(Rite::ROMAN, $italy->rite);
+        self::assertSame('IT', $italy->region, 'a national calendar is specific to its own nation');
+        self::assertSame(LitSchema::NATIONAL, $italy->schema);
+        self::assertStringContainsString('/calendars/nations/IT/IT.json', $italy->path);
+
+        $italyI18n = CheckableInventory::byId('nation:roman:IT:i18n');
+        self::assertNotNull($italyI18n);
+        self::assertSame('folder', $italyI18n->kind);
+        self::assertSame(LitSchema::I18N, $italyI18n->schema);
+    }
+
+    public function testWiderRegionsAreEnumeratedAndAreNotNationScoped(): void
+    {
+        $europe = CheckableInventory::byId('widerregion:roman:Europe');
+        self::assertNotNull($europe);
+        self::assertSame('file', $europe->kind);
+        self::assertSame(LitSchema::WIDERREGION, $europe->schema);
+        self::assertNull(
+            $europe->region,
+            'a wider region spans several nations, which the scalar region cannot express; '
+                . 'clients scope it via the wider_region field on /calendars instead'
+        );
+
+        self::assertNotNull(CheckableInventory::byId('widerregion:roman:Europe:i18n'));
+    }
+
+    public function testEveryEnumeratedItemStillHidesItsPath(): void
+    {
+        foreach (CheckableInventory::all() as $item) {
+            self::assertStringNotContainsString('jsondata', json_encode($item, JSON_THROW_ON_ERROR));
         }
     }
 }

--- a/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+++ b/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
@@ -238,4 +238,39 @@ final class CheckableInventoryTest extends TestCase
             self::assertStringNotContainsString('jsondata', json_encode($item, JSON_THROW_ON_ERROR));
         }
     }
+
+    public function testDiocesanCalendarsAreEnumeratedUnderTheirOwnRite(): void
+    {
+        // The Diocese of Rome's registered calendar_id is `romamo_it` (the source folder basename
+        // under jsondata/sourcedata/rite/roman/calendars/dioceses/IT/), not the id sketched in the
+        // implementation plan this test is drawn from.
+        $roman = CheckableInventory::byId('diocese:roman:romamo_it');
+        self::assertNotNull($roman, 'the Diocese of Rome should be a checkable target');
+        self::assertSame(Rite::ROMAN, $roman->rite);
+        self::assertSame('IT', $roman->region, 'a diocesan calendar is scoped to its nation');
+        self::assertSame(LitSchema::DIOCESAN, $roman->schema);
+        self::assertNotNull(CheckableInventory::byId('diocese:roman:romamo_it:i18n'));
+    }
+
+    /**
+     * The rite is not cosmetic here: an Ambrosian diocese lives under a different path template
+     * entirely, so getting it wrong produces an item pointing at a file that does not exist — which
+     * the exists step would report as a failure of the data rather than of this class.
+     */
+    public function testAnAmbrosianDioceseResolvesToTheAmbrosianTree(): void
+    {
+        $ambrosian = array_values(array_filter(
+            CheckableInventory::all(),
+            static fn (CheckableItem $i): bool => str_starts_with($i->id, 'diocese:ambrosian:')
+                && false === str_ends_with($i->id, ':i18n')
+        ));
+
+        self::assertNotEmpty($ambrosian, 'the repository ships Ambrosian dioceses; none were enumerated');
+
+        foreach ($ambrosian as $item) {
+            self::assertSame(Rite::AMBROSIAN, $item->rite);
+            self::assertStringContainsString('/rite/ambrosian/calendars/dioceses/', $item->path);
+            self::assertFileExists($item->path, "{$item->id} points at a file that does not exist");
+        }
+    }
 }

--- a/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+++ b/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
@@ -307,4 +307,38 @@ final class CheckableInventoryTest extends TestCase
             }
         }
     }
+
+    /**
+     * A failed `glob()` raises; it does not quietly produce an empty set of test definitions.
+     *
+     * `glob()` returns an empty array — never `false` — for a readable directory with no matches, so
+     * `false` only ever means a filesystem error. Swallowing it would make all 11 test definitions
+     * vanish from `/validations` with nothing reported anywhere: #800's silent absence, in the one
+     * producer that reads the filesystem directly rather than going through the calendar index.
+     *
+     * The error is induced through `glob()`'s real 4096-character pattern limit rather than by
+     * mocking, so what is under test is the production call itself. PHP raises a warning before
+     * returning the sentinel; it is swallowed here so the assertion is about the exception and not
+     * about PHPUnit's warning handling.
+     */
+    public function testAFailedGlobRaisesInsteadOfDroppingEveryTestDefinition(): void
+    {
+        $savedApiFilePath = Router::$apiFilePath;
+
+        // Long enough that JsonData::testsFolderFor()'s pattern exceeds glob()'s maximum length.
+        Router::$apiFilePath = DIRECTORY_SEPARATOR . str_repeat('a', 5000) . DIRECTORY_SEPARATOR;
+
+        $producer = new \ReflectionMethod(CheckableInventory::class, 'testDefinitionItems');
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            $this->expectException(\RuntimeException::class);
+            $this->expectExceptionMessageMatches('/glob failed/');
+
+            $producer->invoke(null);
+        } finally {
+            restore_error_handler();
+            Router::$apiFilePath = $savedApiFilePath;
+        }
+    }
 }

--- a/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
+++ b/phpunit_tests/Models/ValidationsPath/CheckableInventoryTest.php
@@ -167,7 +167,15 @@ final class CheckableInventoryTest extends TestCase
         );
         sort($ambrosian);
         self::assertSame(
-            ['sanctorale:ambrosian', 'sanctorale:ambrosian:i18n', 'temporale:ambrosian', 'temporale:ambrosian:i18n'],
+            [
+                'sanctorale:ambrosian',
+                'sanctorale:ambrosian:i18n',
+                'temporale:ambrosian',
+                'temporale:ambrosian:i18n',
+                // Test definitions are rite-scoped, not nation-scoped (region is always null), so the
+                // repository's one Ambrosian test fixture is legitimately in scope here too.
+                'test:ambrosian:StIgnatiusOfLoyolaTest',
+            ],
             $ambrosian
         );
     }
@@ -271,6 +279,32 @@ final class CheckableInventoryTest extends TestCase
             self::assertSame(Rite::AMBROSIAN, $item->rite);
             self::assertStringContainsString('/rite/ambrosian/calendars/dioceses/', $item->path);
             self::assertFileExists($item->path, "{$item->id} points at a file that does not exist");
+        }
+    }
+
+    /**
+     * A test *definition* is a source artifact: does the JSON match LitCalTest.json. That is a different
+     * thing from running the test against a computed calendar, which stays a separate action.
+     */
+    public function testTestDefinitionsAreEnumeratedPerRite(): void
+    {
+        $ids     = array_map(static fn (CheckableItem $i): string => $i->id, CheckableInventory::all());
+        $testIds = array_values(array_filter($ids, static fn (string $id): bool => str_starts_with($id, 'test:')));
+
+        self::assertNotEmpty($testIds, 'the repository ships test definitions; none were enumerated');
+
+        foreach ($testIds as $id) {
+            self::assertMatchesRegularExpression('/^test:(roman|ambrosian):[A-Za-z0-9_]+$/', $id);
+            self::assertStringEndsNotWith(':i18n', $id, 'test definitions have no translations folder');
+        }
+
+        foreach (CheckableInventory::all() as $item) {
+            if (str_starts_with($item->id, 'test:')) {
+                self::assertSame('file', $item->kind);
+                self::assertSame(LitSchema::TEST_SRC, $item->schema);
+                self::assertNull($item->region, 'a test definition is not nation-scoped');
+                self::assertFileExists($item->path, "{$item->id} points at a file that does not exist");
+            }
         }
     }
 }

--- a/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
+++ b/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Models\ValidationsPath;
 
 use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\TestsHandler;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
+use LiturgicalCalendar\Api\Services\ResourceExistenceChecker;
+use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -33,9 +38,24 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(CheckableInventory::class)]
 final class InventoryDriftTest extends TestCase
 {
+    private static string $savedApiPath = '';
+
     public static function setUpBeforeClass(): void
     {
+        // JsonData cases build filesystem paths from this prefix.
         Router::$apiFilePath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR;
+
+        // CalendarMetadataProvider::create() (pulled in via CheckableInventory::nationalCalendarItems()
+        // and ::widerRegionItems(), now exercised by every test in this class) reads Router::$apiPath
+        // while building each wider region's api_path. isset() is false for typed-uninitialised
+        // properties, so save whatever was there before falling back to an initialised default.
+        self::$savedApiPath = isset(Router::$apiPath) ? Router::$apiPath : '';
+        Router::$apiPath    = '';
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath = self::$savedApiPath;
     }
 
     /** @return list<string> every path the inventory claims to cover */
@@ -105,5 +125,103 @@ final class InventoryDriftTest extends TestCase
             $i18nDirsFound,
             'no i18n directories found under any decrees folder; if the convention moved, this test has stopped checking translations'
         );
+    }
+
+    /**
+     * Every registered calendar is a checkable target.
+     *
+     * The other tests in this class walk the filesystem; this one walks the calendar index, because the
+     * per-calendar half of the inventory is enumerated from that index rather than from disk. A diocese
+     * added to source data and picked up by /calendars, but missed here, would otherwise be
+     * unvalidatable by any client with no failure anywhere — which is #800 exactly.
+     *
+     * The Vatican is a deliberate, documented exception: `buildNationalCalendarData()` announces it as
+     * a national calendar, but it is served by the General Roman Calendar and has no source folder of
+     * its own — `CheckableInventory::nationalCalendarItems()` skips it for the same reason
+     * `ResourceExistenceChecker` does, keyed on the same `VATICAN_NATIONAL_CALENDAR_ID` constant rather
+     * than a bare `'VA'` literal. Skipping it here without proof would let a second, accidental omission
+     * hide behind that one deliberate exception, so this test collects every national calendar missing
+     * an entry and asserts that set is exactly `[VA]` — not merely that VA is *among* the misses.
+     */
+    public function testEveryRegisteredCalendarHasAnInventoryEntry(): void
+    {
+        $metadata = CalendarMetadataProvider::create();
+
+        self::assertNotEmpty($metadata->national_calendars, 'no national calendars in the index');
+        self::assertNotEmpty($metadata->diocesan_calendars, 'no diocesan calendars in the index');
+        self::assertNotEmpty($metadata->wider_regions, 'no wider regions in the index');
+
+        $missingNationalCalendars = [];
+        foreach ($metadata->national_calendars as $nation) {
+            if (null === CheckableInventory::byId("nation:roman:{$nation->calendar_id}")) {
+                $missingNationalCalendars[] = $nation->calendar_id;
+            }
+        }
+        self::assertSame(
+            [ResourceExistenceChecker::VATICAN_NATIONAL_CALENDAR_ID],
+            $missingNationalCalendars,
+            'the only national calendar allowed to be missing an inventory entry is the Vatican — '
+                . 'it has no source data of its own, being served by the General Roman Calendar'
+        );
+
+        foreach ($metadata->diocesan_calendars as $diocese) {
+            $id = "diocese:{$diocese->rite->value}:{$diocese->calendar_id}";
+            self::assertNotNull(
+                CheckableInventory::byId($id),
+                "diocesan calendar {$diocese->calendar_id} is registered but not checkable as {$id}"
+            );
+        }
+
+        foreach ($metadata->wider_regions as $region) {
+            self::assertNotNull(
+                CheckableInventory::byId("widerregion:roman:{$region->name}"),
+                "wider region {$region->name} is registered but not checkable"
+            );
+        }
+    }
+
+    /**
+     * The test items the inventory advertises must be exactly the test definitions `/tests` serves.
+     *
+     * `CheckableInventory::testDefinitionItems()` enumerates via its own `glob(... . '/*Test.json')`,
+     * matching `TestsHandler::collectTests()`'s glob by construction rather than by shared code. A
+     * regression that widened either glob back to `*.json` would go uncaught by the drift tests above,
+     * because every fixture under `jsondata/tests/{roman,ambrosian}/` already ends in `Test.json` — a
+     * wider pattern would match the same files today and pass unnoticed.
+     *
+     * Driving both sides through the live handler, rather than re-implementing its glob, pins them
+     * together directly: this test fails the moment what `/tests` actually serves diverges from what
+     * the inventory advertises, regardless of which side's pattern moved.
+     */
+    public function testTestDefinitionItemsMatchWhatTestsEndpointServes(): void
+    {
+        foreach (Rite::cases() as $rite) {
+            $response = ( new TestsHandler([], $rite) )->handle(
+                new ServerRequest('GET', '/tests/' . $rite->value, ['Accept' => 'application/json'])
+            );
+            self::assertSame(200, $response->getStatusCode());
+
+            /** @var array{litcal_tests?: list<array<string,mixed>>} $body */
+            $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+            self::assertArrayHasKey('litcal_tests', $body);
+
+            $servedIds = array_map(
+                static fn (array $test): string => "test:{$rite->value}:{$test['name']}",
+                $body['litcal_tests']
+            );
+            sort($servedIds);
+
+            $inventoryIds = array_values(array_filter(
+                array_map(static fn (CheckableItem $i): string => $i->id, CheckableInventory::all()),
+                static fn (string $id): bool => str_starts_with($id, "test:{$rite->value}:")
+            ));
+            sort($inventoryIds);
+
+            self::assertSame(
+                $servedIds,
+                $inventoryIds,
+                "test inventory for rite {$rite->value} diverges from what GET /tests actually serves"
+            );
+        }
     }
 }

--- a/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
+++ b/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
@@ -29,11 +29,15 @@ use PHPUnit\Framework\TestCase;
  * the inventory from advertising data a given deployment is missing — reintroducing the same
  * blindness from the other side.
  *
- * Coverage is not exhaustive. This test walks only the `missals` and `decrees` directories under
- * each `rite`. The `calendars` tree under each rite, and the `lectionary` tree under `roman`, are
- * outside `CheckableInventory`'s scope entirely and are never visited here. Within the directories
- * that are walked, only top-level JSON files and an `i18n` subfolder are checked — a `lectionary`
- * subfolder nested inside a missal or decrees directory is not covered either.
+ * Coverage is split by how the inventory learns about each kind of source data, so where drift is
+ * caught differs by kind. The filesystem walks here visit only the `missals` and `decrees`
+ * directories under each `rite` — those are the items the inventory lists or derives statically. The
+ * `calendars` tree under each rite is in scope as well, but is not walked here: those items are
+ * enumerated from the calendar index, so drift in them is caught by
+ * `testEveryRegisteredCalendarHasAnInventoryEntry`, which walks that index instead. The `lectionary`
+ * tree under `roman` is outside `CheckableInventory`'s scope entirely and is covered by neither.
+ * Within the directories that are walked, only top-level JSON files and an `i18n` subfolder are
+ * checked — a `lectionary` subfolder nested inside a missal or decrees directory is not covered.
  */
 #[CoversClass(CheckableInventory::class)]
 final class InventoryDriftTest extends TestCase
@@ -146,6 +150,32 @@ final class InventoryDriftTest extends TestCase
     public function testEveryRegisteredCalendarHasAnInventoryEntry(): void
     {
         $metadata = CalendarMetadataProvider::create();
+
+        // The three loops below name their collections, so a fourth one added to MetadataCalendars
+        // later would simply go un-enumerated — the one way this half of the inventory could quietly
+        // stop covering something. Pinning the shape of the index makes that a red test instead, so a
+        // new collection has to be triaged rather than overlooked.
+        //
+        // `ambrosian_calendars` is already such a collection and is deliberately not looped over: its
+        // single entry is the rite-level Ambrosian calendar, whose source data is the rite temporale
+        // and sanctorale that `CheckableInventory::explicitItems()` already lists by hand. The `*_keys`
+        // and `diocesan_groups` entries are projections of the collections above them, not calendars.
+        self::assertSame(
+            [
+                'national_calendars',
+                'national_calendars_keys',
+                'diocesan_calendars',
+                'diocesan_calendars_keys',
+                'diocesan_groups',
+                'wider_regions',
+                'wider_regions_keys',
+                'locales',
+                'ambrosian_calendars',
+                'ambrosian_calendars_keys'
+            ],
+            array_keys(get_object_vars($metadata)),
+            'the calendar index gained or lost a collection — decide whether it needs inventory entries, then update this list'
+        );
 
         self::assertNotEmpty($metadata->national_calendars, 'no national calendars in the index');
         self::assertNotEmpty($metadata->diocesan_calendars, 'no diocesan calendars in the index');

--- a/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
+++ b/phpunit_tests/Models/ValidationsPath/InventoryDriftTest.php
@@ -190,14 +190,20 @@ final class InventoryDriftTest extends TestCase
      * wider pattern would match the same files today and pass unnoticed.
      *
      * Driving both sides through the live handler, rather than re-implementing its glob, pins them
-     * together directly: this test fails the moment what `/tests` actually serves diverges from what
-     * the inventory advertises, regardless of which side's pattern moved.
+     * together directly: this test set-compares the *resulting id sets* of the two enumerations, not
+     * either side's pattern, so it fails when either one drifts from the other — the inventory
+     * widening while the handler stays put, or the reverse. That symmetry is exactly why this is the
+     * live-handler form and not a basename-suffix check: it fails the moment what `/tests` actually
+     * serves diverges from what the inventory advertises, regardless of which side's pattern moved.
      */
     public function testTestDefinitionItemsMatchWhatTestsEndpointServes(): void
     {
         foreach (Rite::cases() as $rite) {
+            // The rite scoping comes from the constructor's $rite argument, not from the request URI —
+            // TestsHandler::handle() never parses the path for it. The URI below is a plain, unscoped
+            // /tests; it is only what a PSR-7 request needs to exist, not what selects the partition.
             $response = ( new TestsHandler([], $rite) )->handle(
-                new ServerRequest('GET', '/tests/' . $rite->value, ['Accept' => 'application/json'])
+                new ServerRequest('GET', '/tests', ['Accept' => 'application/json'])
             );
             self::assertSame(200, $response->getStatusCode());
 

--- a/src/Health.php
+++ b/src/Health.php
@@ -2054,9 +2054,22 @@ class Health implements MessageComponentInterface
         // in play: $dataFile here is the unprefixed repo-relative form (matching JsonData::*->value),
         // while the inventory stores absolute paths prefixed with Router::$apiFilePath. No
         // conversion is needed at this call site.
-        $item = CheckableInventory::byPath($dataFile);
-        if (null !== $item) {
-            return $item->schema->path();
+        try {
+            $item = CheckableInventory::byPath($dataFile);
+            if (null !== $item) {
+                return $item->schema->path();
+            }
+        } catch (\Throwable) {
+            // The inventory does not merely index folders: it enumerates per-calendar source data via
+            // CalendarMetadataProvider::create(), which reads and JSON-parses every national and
+            // diocesan calendar file. One malformed or missing file makes the whole lookup throw.
+            //
+            // Health is a long-running process serving every client, so letting that propagate would
+            // take out schema resolution for every other check — including the Roman temporale, which
+            // has nothing to do with the broken file. The detector would fail on exactly what it
+            // exists to detect. Fall through instead; the arms below and the legacy slug patterns in
+            // retrieveSchemaForCategory() still resolve generically. GET /validations reports the 503
+            // loudly, which is where that failure belongs.
         }
 
         return match ($dataFile) {
@@ -2196,9 +2209,17 @@ class Health implements MessageComponentInterface
                     'proprium-de-tempore'         => 'temporale:roman',
                     'proprium-de-tempore-i18n'    => 'temporale:roman:i18n'
                 ];
-                $item           = CheckableInventory::byId($legacySlugToId[$dataPath] ?? $dataPath);
-                if (null !== $item) {
-                    return $item->schema->path();
+                try {
+                    $item = CheckableInventory::byId($legacySlugToId[$dataPath] ?? $dataPath);
+                    if (null !== $item) {
+                        return $item->schema->path();
+                    }
+                } catch (\Throwable) {
+                    // Same containment as in getPathToSchemaFile(): the inventory reads and parses all
+                    // calendar source data, so one malformed file must not take out schema resolution
+                    // for every other check in a process that stays up. The regex arms below resolve
+                    // national-calendar-XX, diocesan-calendar-…, wider-region-…, tests-… and the
+                    // proprium-de-* slugs generically, so this fallback is real behaviour, not a stub.
                 }
 
                 if (preg_match('/-i18n$/', $dataPath)) {

--- a/src/Health.php
+++ b/src/Health.php
@@ -25,6 +25,7 @@ use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use Symfony\Component\Yaml\Yaml;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
@@ -2058,6 +2059,29 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * A schema path from the static half of the inventory, or null — never an exception.
+     *
+     * Used only from the catch blocks that contain a failed inventory lookup. Those callers have
+     * already lost their primary resolution and are choosing to degrade rather than propagate, so a
+     * fallback that could itself throw would defeat the containment it exists to provide. Anything
+     * going wrong here therefore yields null, and the caller falls through to its own arms.
+     *
+     * The static half is separable precisely because it never touches `CalendarMetadataProvider`
+     * — see `CheckableInventory::staticItems()`, which also explains why test definitions are left
+     * out of it.
+     *
+     * @param \Closure(): ?CheckableItem $lookup
+     */
+    private static function staticInventorySchema(\Closure $lookup): ?string
+    {
+        try {
+            return $lookup()?->schema->path();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
      * Mapping of data file paths to the LitSchema constants that their JSON data should validate against.
      * The paths are relative to the root of the project. The LitSchema constants are used to determine
      * which schema to use when validating the JSON data.
@@ -2084,9 +2108,21 @@ class Health implements MessageComponentInterface
             // Health is a long-running process serving every client, so letting that propagate would
             // take out schema resolution for every other check — including the Roman temporale, which
             // has nothing to do with the broken file. The detector would fail on exactly what it
-            // exists to detect. Fall through instead; the arms below and the legacy slug patterns in
-            // retrieveSchemaForCategory() still resolve generically. GET /validations reports the 503
+            // exists to detect.
+            //
+            // Retry against the static half, which is exactly the part that cannot have caused this:
+            // the missal propriums, the temporale, the decrees and their i18n folders, all built from
+            // in-memory registries. Those are also the paths most often checked, so this turns the
+            // common degradation back into a real answer instead of a null. Only per-calendar targets
+            // are left to fall through to the arms below. GET /validations still reports the 503
             // loudly, which is where that failure belongs.
+            $fallback = self::staticInventorySchema(
+                static fn (): ?CheckableItem => CheckableInventory::staticByPath($dataFile)
+            );
+
+            if (null !== $fallback) {
+                return $fallback;
+            }
         }
 
         // The rite segment is optional and its absence means the default rite, so the
@@ -2292,11 +2328,22 @@ class Health implements MessageComponentInterface
                         return $item->schema->path();
                     }
                 } catch (\Throwable) {
-                    // Same containment as in getPathToSchemaFile(): the inventory reads and parses all
-                    // calendar source data, so one malformed file must not take out schema resolution
-                    // for every other check in a process that stays up. The regex arms below resolve
-                    // national-calendar-XX, diocesan-calendar-…, wider-region-…, tests-… and the
-                    // proprium-de-* slugs generically, so this fallback is real behaviour, not a stub.
+                    // Same containment, and the same static-half retry, as in getPathToSchemaFile():
+                    // the inventory reads and parses all calendar source data, so one malformed file
+                    // must not take out schema resolution for every other check in a process that
+                    // stays up. The retry matters more once clients send inventory ids rather than
+                    // these slugs (UnitTestInterface#42): sanctorale:roman:US_2011 matches none of the
+                    // patterns below, while the slug it replaces does. Until then the regex arms
+                    // resolve national-calendar-XX, diocesan-calendar-…, wider-region-…, tests-… and
+                    // the proprium-de-* slugs generically, so the fall-through is real behaviour too,
+                    // not a stub.
+                    $fallback = self::staticInventorySchema(
+                        static fn (): ?CheckableItem => CheckableInventory::staticById($legacySlugToId[$dataPath] ?? $dataPath)
+                    );
+
+                    if (null !== $fallback) {
+                        return $fallback;
+                    }
                 }
 
                 if (preg_match('/-i18n$/', $dataPath)) {

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -60,7 +60,8 @@ final class CheckableInventory
                 self::explicitItems(),
                 self::nationalCalendarItems(),
                 self::widerRegionItems(),
-                self::diocesanCalendarItems()
+                self::diocesanCalendarItems(),
+                self::testDefinitionItems()
             );
         }
 
@@ -363,6 +364,50 @@ final class CheckableInventory
                 self::STEPS,
                 rtrim(strtr($i18nTemplate, $replacements), '/')
             );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Test definitions, one per JSON file in each rite's tests folder.
+     *
+     * This item is the *definition* — does the file validate against LitCalTest.json. Running the test
+     * against a computed calendar is a separate action with its own addressing, and the two must not be
+     * conflated: a definition can be valid while the test it describes fails, and vice versa.
+     *
+     * Unlike every other kind here, a test has no `i18n` sibling.
+     *
+     * Enumerated from the filesystem rather than from `CalendarMetadataProvider`, because test
+     * definitions are not calendars and the index does not carry them: `TestsHandler` itself
+     * discovers them the same way (see its own `glob(... . '/*Test.json')`), so here the glob
+     * *is* the registration lookup, not a stat gating an already-known item. The asymmetry this
+     * buys is real: unlike every calendar item above, a deleted test file here simply drops out of
+     * the inventory instead of staying listed and failing its `exists` step.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function testDefinitionItems(): array
+    {
+        $items = [];
+
+        foreach (Rite::cases() as $rite) {
+            $folder = JsonData::testsFolderFor($rite)->path();
+            $files  = glob($folder . '/*Test.json') ?: [];
+
+            foreach ($files as $file) {
+                $name    = basename($file, '.json');
+                $items[] = new CheckableItem(
+                    "test:{$rite->value}:{$name}",
+                    'file',
+                    $rite,
+                    null,
+                    "Liturgical test: {$name}",
+                    LitSchema::TEST_SRC,
+                    self::STEPS,
+                    $file
+                );
+            }
         }
 
         return $items;

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -59,7 +59,8 @@ final class CheckableInventory
                 self::derivedRomanSanctorale(),
                 self::explicitItems(),
                 self::nationalCalendarItems(),
-                self::widerRegionItems()
+                self::widerRegionItems(),
+                self::diocesanCalendarItems()
             );
         }
 
@@ -313,6 +314,54 @@ final class CheckableInventory
                 LitSchema::I18N,
                 self::STEPS,
                 rtrim(strtr(JsonData::WIDER_REGION_I18N_FOLDER->path(), ['{wider_region}' => $name]), '/')
+            );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Diocesan calendar definitions.
+     *
+     * The rite selects the path template, not just a label: an Ambrosian diocese lives under
+     * `rite/ambrosian/calendars/dioceses/`, and the file name is the diocese *name* rather than its id,
+     * which is why the template carries three placeholders.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function diocesanCalendarItems(): array
+    {
+        $items = [];
+        foreach (self::metadata()->diocesan_calendars as $diocese) {
+            $fileTemplate = JsonData::diocesanCalendarFileFor($diocese->rite)->path();
+            $i18nTemplate = JsonData::diocesanCalendarI18nFolderFor($diocese->rite)->path();
+
+            $replacements = [
+                '{nation}'       => $diocese->nation,
+                '{diocese}'      => $diocese->calendar_id,
+                '{diocese_name}' => $diocese->diocese
+            ];
+
+            $items[] = new CheckableItem(
+                "diocese:{$diocese->rite->value}:{$diocese->calendar_id}",
+                'file',
+                $diocese->rite,
+                $diocese->nation,
+                "Diocesan calendar: {$diocese->diocese}",
+                LitSchema::DIOCESAN,
+                self::STEPS,
+                strtr($fileTemplate, $replacements)
+            );
+
+            $items[] = new CheckableItem(
+                "diocese:{$diocese->rite->value}:{$diocese->calendar_id}:i18n",
+                'folder',
+                $diocese->rite,
+                $diocese->nation,
+                "Diocesan calendar translations: {$diocese->diocese}",
+                LitSchema::I18N,
+                self::STEPS,
+                rtrim(strtr($i18nTemplate, $replacements), '/')
             );
         }
 

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -78,8 +78,7 @@ final class CheckableInventory
     {
         if (null === self::$items) {
             self::$items = array_merge(
-                self::derivedRomanSanctorale(),
-                self::explicitItems(),
+                self::staticItems(),
                 self::nationalCalendarItems(),
                 self::widerRegionItems(),
                 self::diocesanCalendarItems(),
@@ -90,9 +89,46 @@ final class CheckableInventory
         return self::$items;
     }
 
+    /**
+     * The half of the inventory that does not read calendar source data.
+     *
+     * `derivedRomanSanctorale()` and `explicitItems()` build their paths from the `RomanMissal` and
+     * `JsonData` registries, both in-memory: neither calls {@see self::metadata()}, so neither can
+     * fail for the reason the enumerating producers can. That is what makes this half usable as a
+     * fallback when the full lookup throws — see {@see self::staticByPath()}.
+     *
+     * `testDefinitionItems()` is deliberately NOT part of this. It does not depend on
+     * `CalendarMetadataProvider` either, but it globs, and a failed glob raises here by design; a
+     * fallback that can itself throw is not a fallback.
+     *
+     * Not memoized: these are registry lookups and string joins with no I/O, and `all()` memoizes
+     * the merged list anyway.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function staticItems(): array
+    {
+        return array_merge(
+            self::derivedRomanSanctorale(),
+            self::explicitItems()
+        );
+    }
+
     public static function byId(string $id): ?CheckableItem
     {
         return array_find(self::all(), static fn (CheckableItem $i): bool => $i->id === $id);
+    }
+
+    /**
+     * As {@see self::byId()}, but over the static half alone.
+     *
+     * For callers that must still answer something when the full inventory is unavailable. It
+     * resolves strictly fewer ids, never different ones: these items are present in `all()` too,
+     * identical, so a hit here is a hit there.
+     */
+    public static function staticById(string $id): ?CheckableItem
+    {
+        return array_find(self::staticItems(), static fn (CheckableItem $i): bool => $i->id === $id);
     }
 
     /**
@@ -102,13 +138,30 @@ final class CheckableInventory
      */
     public static function byPath(string $path): ?CheckableItem
     {
+        return self::matchPath(self::all(), $path);
+    }
+
+    /**
+     * As {@see self::byPath()}, but over the static half alone — the same narrowing, for the same
+     * reason, as {@see self::staticById()}.
+     */
+    public static function staticByPath(string $path): ?CheckableItem
+    {
+        return self::matchPath(self::staticItems(), $path);
+    }
+
+    /**
+     * @param list<CheckableItem> $items
+     */
+    private static function matchPath(array $items, string $path): ?CheckableItem
+    {
         $needle = str_starts_with($path, Router::$apiFilePath)
             ? $path
             : Router::$apiFilePath . ltrim($path, '/');
         $needle = rtrim($needle, '/');
 
         return array_find(
-            self::all(),
+            $items,
             static fn (CheckableItem $i): bool => rtrim($i->path, '/') === $needle
         );
     }

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -397,6 +397,12 @@ final class CheckableInventory
      * buys is real: unlike every calendar item above, a deleted test file here simply drops out of
      * the inventory instead of staying listed and failing its `exists` step.
      *
+     * That tradeoff covers a *deleted file*, not a *failed glob*, which is a different thing.
+     * `glob()` returns an empty array — never `false` — for a readable directory with no matches, so
+     * `false` always means a filesystem error; treating it as "no tests" would drop every test
+     * definition from the inventory with nothing reported anywhere, which is the #800 silent absence
+     * again. It raises instead, matching `CalendarMetadataProvider::globOrThrow()`.
+     *
      * @return list<CheckableItem>
      */
     private static function testDefinitionItems(): array
@@ -405,7 +411,11 @@ final class CheckableInventory
 
         foreach (Rite::cases() as $rite) {
             $folder = JsonData::testsFolderFor($rite)->path();
-            $files  = glob($folder . '/*Test.json') ?: [];
+            $files  = glob($folder . '/*Test.json');
+
+            if (false === $files) {
+                throw new \RuntimeException('CheckableInventory::testDefinitionItems: glob failed for ' . $folder);
+            }
 
             foreach ($files as $file) {
                 $name    = basename($file, '.json');

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -11,6 +11,7 @@ use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
+use LiturgicalCalendar\Api\Services\ResourceExistenceChecker;
 
 /**
  * The source data this API can validate, in one place.
@@ -238,7 +239,16 @@ final class CheckableInventory
     {
         $items = [];
         foreach (self::metadata()->national_calendars as $nation) {
-            $id   = $nation->calendar_id;
+            $id = $nation->calendar_id;
+
+            // The Vatican is announced as a national calendar but is served by the General Roman
+            // Calendar and has no source folder of its own — see ResourceExistenceChecker, which
+            // special-cases the same id for the same reason. There is nothing here to check, so it
+            // is excluded rather than listed with a target that could never exist.
+            if (ResourceExistenceChecker::VATICAN_NATIONAL_CALENDAR_ID === $id) {
+                continue;
+            }
+
             $file = strtr(JsonData::NATIONAL_CALENDAR_FILE->path(), ['{nation}' => $id]);
 
             $items[] = new CheckableItem(

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -41,10 +41,22 @@ final class CheckableInventory
     /**
      * The calendar index, from the same builder that serves `/calendars`.
      *
-     * Memoized for the lifetime of the request only. `CalendarMetadataProvider` deliberately re-reads
-     * source data on every call because the `/data` write endpoints can mutate calendar definitions at
-     * runtime; caching it here for one request keeps a single `/validations` response internally
-     * consistent without outliving the write that would invalidate it.
+     * Memoized for the lifetime of the *process*, not the request. `CalendarMetadataProvider`
+     * deliberately re-reads source data on every call because the `/data` write endpoints can mutate
+     * calendar definitions at runtime; caching it here keeps a single `/validations` response
+     * internally consistent. Under PHP-FPM the process is the request, so the memo cannot outlive the
+     * write that would invalidate it — but `Health` is a long-running ReactPHP process and the primary
+     * consumer of `byPath()`/`byId()`, and there both this and `self::$items` live until the WebSocket
+     * server restarts. A calendar created via `/data` therefore does not appear to those clients until
+     * then. Harmless today only because `Health`'s legacy regex arms still resolve those slugs
+     * generically; #806 plan 2 replaces those arms with `byId()` and will need a reset hook.
+     *
+     * Building the index reads and JSON-parses every national and diocesan calendar file, so a single
+     * missing or malformed one throws (`ServiceUnavailableException` / `JsonException`) and
+     * `GET /validations` answers 503. That is deliberate and inherited from `/calendars`: degrading to
+     * a partial list would silently omit what could not be read, which is exactly the #800 blindness
+     * this endpoint exists to remove. `Health` contains the blast radius on its own side instead —
+     * see the catch in `Health::getPathToSchemaFile()`.
      */
     private static function metadata(): MetadataCalendars
     {

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -20,9 +20,19 @@ use LiturgicalCalendar\Api\Services\ResourceExistenceChecker;
  * that matched on slugs instead of paths, and in each client's hardcoded copy of the layout —
  * with nothing detecting divergence. See #806.
  *
- * Half of it need not be written down at all: `RomanMissal` already registers every missal edition
- * and already knows which have a sanctorale file, so those items are derived. The rest have
- * dedicated `JsonData` constants and are listed explicitly.
+ * The inventory has two halves, and only the smaller one is written down here.
+ *
+ * The *static* half is the source data that exists once per rite: the temporale, the decrees, and
+ * the Roman missal sanctorale editions. Even that is only half-listed — `RomanMissal` already
+ * registers every edition and already knows which have a sanctorale file, so those items are
+ * derived; the remainder have dedicated `JsonData` constants and are listed explicitly.
+ *
+ * The *enumerated* half is the per-calendar source data, which is not listed at all and today is
+ * the larger of the two. National calendars, wider regions and diocesan calendars come from
+ * `CalendarMetadataProvider::create()`, the same builder that serves `/calendars`, so a registered
+ * calendar is a checkable calendar by construction and the two lists cannot disagree. Test
+ * definitions come from the same glob `TestsHandler` discovers them with. Adding a calendar to
+ * source data therefore needs no edit here; adding a whole new *kind* of source data does.
  *
  * Paths always come from `JsonData` cases. `JsonData` is where this repo's layout is written down;
  * this class must not become a second copy of it.

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -8,7 +8,9 @@ use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitSchema;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Enum\RomanMissal;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
 
 /**
  * The source data this API can validate, in one place.
@@ -32,11 +34,32 @@ final class CheckableInventory
     /** @var list<CheckableItem>|null */
     private static ?array $items = null;
 
+    /** @var MetadataCalendars|null */
+    private static ?MetadataCalendars $metadata = null;
+
+    /**
+     * The calendar index, from the same builder that serves `/calendars`.
+     *
+     * Memoized for the lifetime of the request only. `CalendarMetadataProvider` deliberately re-reads
+     * source data on every call because the `/data` write endpoints can mutate calendar definitions at
+     * runtime; caching it here for one request keeps a single `/validations` response internally
+     * consistent without outliving the write that would invalidate it.
+     */
+    private static function metadata(): MetadataCalendars
+    {
+        return self::$metadata ??= CalendarMetadataProvider::create();
+    }
+
     /** @return list<CheckableItem> */
     public static function all(): array
     {
         if (null === self::$items) {
-            self::$items = array_merge(self::derivedRomanSanctorale(), self::explicitItems());
+            self::$items = array_merge(
+                self::derivedRomanSanctorale(),
+                self::explicitItems(),
+                self::nationalCalendarItems(),
+                self::widerRegionItems()
+            );
         }
 
         return self::$items;
@@ -201,5 +224,88 @@ final class CheckableInventory
                 JsonData::AMBROSIAN_SANCTORALE_I18N_FOLDER->path()
             )
         ];
+    }
+
+    /**
+     * National calendar definitions, enumerated from the calendar index rather than listed.
+     *
+     * A national calendar is specific to its own nation, so `region` is its calendar id — that is what
+     * lets a client scoping to one calendar keep it and drop the other nine.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function nationalCalendarItems(): array
+    {
+        $items = [];
+        foreach (self::metadata()->national_calendars as $nation) {
+            $id   = $nation->calendar_id;
+            $file = strtr(JsonData::NATIONAL_CALENDAR_FILE->path(), ['{nation}' => $id]);
+
+            $items[] = new CheckableItem(
+                "nation:roman:{$id}",
+                'file',
+                Rite::ROMAN,
+                $id,
+                "National calendar: {$id}",
+                LitSchema::NATIONAL,
+                self::STEPS,
+                $file
+            );
+
+            $items[] = new CheckableItem(
+                "nation:roman:{$id}:i18n",
+                'folder',
+                Rite::ROMAN,
+                $id,
+                "National calendar translations: {$id}",
+                LitSchema::I18N,
+                self::STEPS,
+                rtrim(strtr(JsonData::NATIONAL_CALENDAR_I18N_FOLDER->path(), ['{nation}' => $id]), '/')
+            );
+        }
+
+        return $items;
+    }
+
+    /**
+     * Wider region definitions.
+     *
+     * `region` is null: a wider region spans several nations, which a scalar cannot express. Clients
+     * scoping to one calendar use the `wider_region` field `/calendars` already gives them, rather than
+     * this field. Widening `region` into a list would be a wire-contract change, not a fix here.
+     *
+     * @return list<CheckableItem>
+     */
+    private static function widerRegionItems(): array
+    {
+        $items = [];
+        foreach (self::metadata()->wider_regions as $region) {
+            $name = $region->name;
+            $file = strtr(JsonData::WIDER_REGION_FILE->path(), ['{wider_region}' => $name]);
+
+            $items[] = new CheckableItem(
+                "widerregion:roman:{$name}",
+                'file',
+                Rite::ROMAN,
+                null,
+                "Wider region: {$name}",
+                LitSchema::WIDERREGION,
+                self::STEPS,
+                $file
+            );
+
+            $items[] = new CheckableItem(
+                "widerregion:roman:{$name}:i18n",
+                'folder',
+                Rite::ROMAN,
+                null,
+                "Wider region translations: {$name}",
+                LitSchema::I18N,
+                self::STEPS,
+                rtrim(strtr(JsonData::WIDER_REGION_I18N_FOLDER->path(), ['{wider_region}' => $name]), '/')
+            );
+        }
+
+        return $items;
     }
 }

--- a/src/Services/ResourceExistenceChecker.php
+++ b/src/Services/ResourceExistenceChecker.php
@@ -34,8 +34,12 @@ final class ResourceExistenceChecker implements ResourceExistenceCheckerInterfac
     /**
      * The Vatican is announced as a national calendar but is still served by the
      * General Roman Calendar, so it has no source folder of its own yet.
+     *
+     * Public: {@see \LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory} excludes this
+     * id from the checkable inventory for the same reason, and references this constant rather than
+     * repeating the literal.
      */
-    private const VATICAN_NATIONAL_CALENDAR_ID = 'VA';
+    public const VATICAN_NATIONAL_CALENDAR_ID = 'VA';
 
     /** @var list<string> */
     private const RESOURCE_TYPES = [


### PR DESCRIPTION
Refs #806. **Plan 1 of 2 for section B.**

`GET /validations` shipped in #811 advertising 18 hand-listed static items. This grows it to **77** by
*enumerating* per-calendar source data — national calendars, wider regions, diocesan calendars and test
definitions — so a client can derive its whole check list from one fetch instead of constructing
identifiers itself, which is the duplication #806 exists to end.

**No message shape changes in this PR.** `executeValidation`, `validateCalendar` and `executeUnitTest`
are untouched and the WebSocket protocol still speaks its legacy vocabulary. The typed `target` that
consumes these ids is the next PR. Nothing published in #811 was renamed.

## Where the items come from

Enumerated from `CalendarMetadataProvider::create()` — the same builder that serves `/calendars` — so
the two lists cannot disagree: a calendar that exists is a calendar that is checkable. Test definitions
come from globbing `*Test.json`, matching `TestsHandler`'s own glob.

| Id form                             | Source                                   | Schema                     |
|-------------------------------------|------------------------------------------|----------------------------|
| `nation:roman:IT`                   | `MetadataCalendars::$national_calendars` | `NationalCalendar.json`    |
| `widerregion:roman:Europe`          | `MetadataCalendars::$wider_regions`      | `WiderRegionCalendar.json` |
| `diocese:{rite}:milano_it`          | `MetadataCalendars::$diocesan_calendars` | `DiocesanCalendar.json`    |
| `test:{rite}:StIgnatiusOfLoyolaTest`| `jsondata/tests/{rite}/*Test.json`        | `LitCalTest.json`          |

77 items = 18 static + 5 nations ×2 + 16 dioceses ×2 + 3 wider regions ×2 + 11 tests. Each file-kind
item gets an `:i18n` folder sibling; tests have none.

## `region` semantics

`region` answers one question: *is this item specific to one nation's calendar?*

- `nation:roman:IT` → `'IT'`; `diocese:roman:romamo_it` → its nation, `'IT'`.
- `test:{rite}:X` → `null`; a test definition is not nation-scoped.
- `widerregion:roman:Europe` → `null`, **and this is a documented limitation, not an oversight.** A
  wider region spans several nations and a scalar cannot say so. Clients already have the mapping —
  `/calendars` gives each national calendar its `wider_region` — so a client scoping to one calendar
  reads that field. Widening `region` to a list would be a wire-contract change and belongs to plan 2
  if it is wanted at all.

## The Vatican is deliberately excluded

`CalendarMetadataProvider` hardcodes a `calendar_id = 'VA'` national entry, but the Vatican is served by
the General Roman Calendar and has **no source data of its own by design** — there is no
`.../nations/VA/` and there is not meant to be. Listing it would hand every client a target whose
`exists` step fails forever. It is skipped on `ResourceExistenceChecker::VATICAN_NATIONAL_CALENDAR_ID`,
the constant that already encoded this fact (widened to `public` so the two places that know it are
linked rather than duplicating a `'VA'` literal).

This is a categorical exclusion of one statically-known id, not a filesystem check — the endpoint still
never stats a target to decide whether to list it.

## Fixed counts replaced by bounds

`assertCount(18, …)` and an exact 9-and-9 both described a *hand-listed* inventory. Now that it is partly
enumerated they would fail whenever a calendar is added — a false alarm rather than drift. They are
replaced by a floor plus a **structural** invariant (folder ⟺ `:i18n` suffix ⟺ `LitSchema::I18N`) that is
strictly more informative than the number was, plus an id-uniqueness assertion the old count never
provided. Coverage is pinned by name in the drift tests, not by arithmetic.

## Drift coverage

The section A drift test walks the source tree and asserts every file found has an entry, which guards
the hand-listed half. The enumerated half needs the mirror guarantee, and now has it: every calendar the
index reports must have an inventory entry. A diocese added to source data, picked up by `/calendars` and
missed here would otherwise be unvalidatable with no failure anywhere — #800 exactly, arrived at from the
other direction.

Two properties worth calling out:

- The missing-national set is asserted to be **exactly** `[VA]`, not "VA is among the misses", so the one
  deliberate exception cannot become a hiding place for an accidental one.
- The test-definition guard drives both `CheckableInventory` and the live `TestsHandler` and set-compares
  the resulting **ids**, so it fails if either side's glob drifts from the other. `TestsHandler` enforces
  payload-name == filename on write, so the coupling it relies on is checked at both ends.

Every guard was verified by mutation — removing a producer, narrowing a glob — and confirmed to fail
naming the missing thing. A drift test that has never been seen to fail is not evidence.

## Two robustness fixes from the final review

**A broken inventory no longer takes out unrelated checks.** `CheckableInventory` calls
`CalendarMetadataProvider::create()`, which does not merely index folders — it reads and JSON-parses every
national and diocesan calendar file. One malformed file therefore threw all the way out, and in `Health`
— a long-running process — that broke schema resolution for *every* check, including the Roman temporale,
which has nothing to do with it. The inventory lookups in `Health` now contain that and fall through to
the legacy slug arms.

`/validations` itself still returns 503 in that case, deliberately: degrading to an empty index would
convert a loud failure into exactly the silent absence this endpoint exists to prevent. That inheritance
from `CalendarMetadataProvider` is now documented rather than accidental.

One consequence, stated plainly: containment restores the *process* and restores resolution for
`sourceDataCheck`, but a `universalcalendar` source-path check under a broken inventory degrades to
"Unable to detect schema" rather than validating. That is deliberate — the only richer fallback would be
to reintroduce the duplicated path table #811 deleted.

**A failed `glob()` now raises instead of silently emptying.** `glob()` returns `[]` for a
readable-but-empty directory and `false` only on a system error, so `?: []` was swallowing the sentinel:
an unreadable `jsondata/tests/{rite}/` would have dropped all 11 test definitions with no error anywhere.

## Behaviour change outside `/validations`

Growing `CheckableInventory` grows what `Health::getPathToSchemaFile()` resolves, so a per-calendar source
path passed on a `universalcalendar` message now resolves to a schema where it previously returned `null`.
This is strictly additive — the legacy `sourceDataCheck` arms key on hyphenated *slugs*, not paths, so
nothing is shadowed — but it is a change outside the inventory in a PR otherwise scoped to it.

## Verification

`development` (including #813, which rewrote `Health.php`'s schema resolution) is merged in and the result
verified, since CI tests the branch rather than the merge result:

```text
phpunit_tests/Health*.php + phpunit_tests/Models/ValidationsPath/   154 tests, 1218 assertions, OK
composer test:quick                                                 baseline byte-identical to base
composer lint                                                       clean
composer analyse (PHPStan level 10, 317 files)                      no errors
composer lint:md                                                    clean
```

The two `Health.php` changes were confirmed to compose semantically, not just textually: they touch
disjoint regions, the new `try` wraps only the inventory lookup with #813's widened arms sitting below the
`catch` in the fallback path, and inventory ids are `kind:rite:subject` so `byId()` can never intercept
#813's hyphenated slugs. #813's own test for `national-calendar-USA` proves this directly — that slug is
resolvable only by its widened arm and reachable only by passing through this branch's `byId()` first.
Both sides also derive diocesan paths through the same pre-existing `JsonData::diocesanCalendarFileFor()`
resolvers, so the inventory cannot advertise a path `Health` does not check.

## Docs

The section A design document is amended where this work revisits it — per-calendar items were previously
out of scope, and the "never stats the filesystem" principle is narrowed to what actually mattered: it
never stats *a target* to decide whether to list it. Both are amended in place rather than quietly
deleted.

A diocese id used throughout the planning docs, `roma_lazio_it`, turned out to be fabricated — it exists
nowhere in the source data. Corrected to the real `romamo_it`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the `/validations` inventory to include national, regional, diocesan, and rite-specific test checks.
  * Added comprehensive discovery of all checkable calendar and test resources.
  * Preserved stable validation identifiers while keeping underlying file paths hidden.

* **Bug Fixes**
  * Improved schema and route resolution when inventory data is unavailable or malformed.
  * Excluded calendars without independent source data from the inventory.

* **Documentation**
  * Added implementation and design documentation covering inventory coverage, typed targets, compatibility, and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->