### PR TITLE
fix(health): resolve schemas for bare rite-qualified collection paths

### DIFF
--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Router;
@@ -54,6 +55,15 @@ final class HealthSchemaCategoryTest extends TestCase
         $method = new \ReflectionMethod(Health::class, 'retrieveSchemaForCategory');
         /** @var string|null $result */
         $result = $method->invoke(null, $category, $dataPath);
+
+        return $result;
+    }
+
+    private static function getPathToSchemaFile(string $dataFile): ?string
+    {
+        $method = new \ReflectionMethod(Health::class, 'getPathToSchemaFile');
+        /** @var string|null $result */
+        $result = $method->invoke(null, $dataFile);
 
         return $result;
     }
@@ -225,9 +235,12 @@ final class HealthSchemaCategoryTest extends TestCase
         self::initRouter();
 
         return [
-            'events, invented rite' => [Route::EVENTS->path() . '/byzantine/diocese/milano_it'],
-            'data, invented rite'   => [Route::DATA->path() . '/byzantine/diocese/milano_it'],
-            'data, doubled rite'    => [Route::DATA->path() . '/roman/ambrosian/diocese/milano_it'],
+            'events, invented rite'            => [Route::EVENTS->path() . '/byzantine/diocese/milano_it'],
+            'data, invented rite'              => [Route::DATA->path() . '/byzantine/diocese/milano_it'],
+            'data, doubled rite'               => [Route::DATA->path() . '/roman/ambrosian/diocese/milano_it'],
+            'events, invented rite collection' => [Route::EVENTS->path() . '/byzantine'],
+            'data, invented rite collection'   => [Route::DATA->path() . '/byzantine'],
+            'data, doubled rite collection'    => [Route::DATA->path() . '/roman/ambrosian'],
         ];
     }
 
@@ -235,6 +248,96 @@ final class HealthSchemaCategoryTest extends TestCase
     public function testResourceDataCheckRejectsAnUnknownRiteSegment(string $url): void
     {
         self::assertNull(self::retrieveSchemaForCategory('resourceDataCheck', $url));
+    }
+
+    // ------------------------------------------- the rite-qualified COLLECTION form (issue #814)
+
+    /**
+     * The general invariant of #814: for **every** route, the rite-qualified collection form
+     * resolves to exactly what the bare form resolves to.
+     *
+     * #813 made the *item* routes (`/events/roman/nation/IT`) rite-aware but left the collection
+     * form (`/events/roman`) falling between the regex arms and the exact-match map, resolving to
+     * null — the form a `RiteSelect` produces when no nation or diocese is selected, and the
+     * canonical form per `Router::canonicalRiteUrl()`.
+     *
+     * The cross product is driven from `Route` and `Rite` rather than a hand-written list on
+     * purpose: a route added to the map in `Health::getPathToSchemaFile()`, or a third rite added
+     * to `Rite`, is covered the moment it is declared and cannot reintroduce the asymmetry
+     * silently. Routes that resolve to null bare (`/calendar` among them) are asserted to stay
+     * null when qualified, which is the guard that `/calendar/{rite}` is left alone.
+     *
+     * `testRiteQualifiedCollectionFormsResolveTheExpectedSchema()` below pins the non-null half,
+     * so this invariant cannot be satisfied by resolving everything to null.
+     *
+     * @return array<string, array{string, string}>
+     */
+    public static function riteQualifiedCollectionProvider(): array
+    {
+        self::initRouter();
+
+        $cases = [];
+        foreach (Route::cases() as $route) {
+            foreach (Rite::cases() as $rite) {
+                $cases[$route->value . ' + ' . $rite->value] = [$route->path(), $rite->value];
+            }
+        }
+
+        return $cases;
+    }
+
+    #[DataProvider('riteQualifiedCollectionProvider')]
+    public function testRiteQualifiedCollectionFormResolvesLikeTheBareForm(string $routePath, string $rite): void
+    {
+        self::assertSame(
+            self::getPathToSchemaFile($routePath),
+            self::getPathToSchemaFile($routePath . '/' . $rite)
+        );
+    }
+
+    #[DataProvider('riteQualifiedCollectionProvider')]
+    public function testResourceDataCheckResolvesTheRiteQualifiedCollectionFormLikeTheBareForm(string $routePath, string $rite): void
+    {
+        // The same invariant one layer up, through the category selector the `executeValidation`
+        // message actually goes through: no regex arm may swallow the collection form either.
+        self::assertSame(
+            self::retrieveSchemaForCategory('resourceDataCheck', $routePath),
+            self::retrieveSchemaForCategory('resourceDataCheck', $routePath . '/' . $rite)
+        );
+    }
+
+    /**
+     * The non-null half of the invariant: the three routes that carry a rite segment
+     * (`Router::extractRiteSegment()` for events and data, `Router::extractTestsRite()` for tests)
+     * resolve to their real schema, not merely to the same thing as the bare form.
+     *
+     * @return array<string, array{string, LitSchema}>
+     */
+    public static function riteQualifiedCollectionSchemaProvider(): array
+    {
+        self::initRouter();
+
+        $expected = [
+            Route::EVENTS->value => [Route::EVENTS, LitSchema::EVENTS],
+            Route::DATA->value   => [Route::DATA, LitSchema::DATA],
+            Route::TESTS->value  => [Route::TESTS, LitSchema::TESTS],
+        ];
+
+        $cases = [];
+        foreach ($expected as $label => [$route, $schema]) {
+            foreach (Rite::cases() as $rite) {
+                $cases[$label . '/' . $rite->value] = [$route->path() . '/' . $rite->value, $schema];
+            }
+        }
+
+        return $cases;
+    }
+
+    #[DataProvider('riteQualifiedCollectionSchemaProvider')]
+    public function testRiteQualifiedCollectionFormsResolveTheExpectedSchema(string $url, LitSchema $expected): void
+    {
+        self::assertSame($expected->path(), self::getPathToSchemaFile($url));
+        self::assertSame($expected->path(), self::retrieveSchemaForCategory('resourceDataCheck', $url));
     }
 
     public function testResourceDataCheckRejectsAnUnrecognisedUrl(): void

--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -340,6 +340,39 @@ final class HealthSchemaCategoryTest extends TestCase
         self::assertSame($expected->path(), self::retrieveSchemaForCategory('resourceDataCheck', $url));
     }
 
+    /**
+     * The rite segment is stripped UNIFORMLY, not gated on the routes that actually carry one, so
+     * a rite on a route that has none still resolves to that route's schema.
+     *
+     * **This is a deliberate choice, pinned here so nobody "fixes" it back into a stale list.**
+     * `Health::getPathToSchemaFile()` answers "which schema would validate a response of this
+     * shape", not "is this path routable" — `Router` stays the sole authority on what routes
+     * exist, and `/missals/roman` resolving here costs nothing because the fetch that follows
+     * 404s and the check fails loudly regardless. The alternative, gating the strip on a
+     * hardcoded list of rite-carrying routes, would reintroduce exactly the staleness class that
+     * produced #814: `Router::extractRiteSegment()` keeps that knowledge in an inline condition
+     * with `/tests` handled separately elsewhere, so there is no registry to derive it from.
+     * Trading the structural invariant above for a list that will go stale is the wrong direction.
+     *
+     * @return array<string, array{string, LitSchema}>
+     */
+    public static function riteOnANonRiteCarryingRouteProvider(): array
+    {
+        self::initRouter();
+
+        return [
+            'missals'   => [Route::MISSALS->path() . '/roman', LitSchema::MISSALS],
+            'decrees'   => [Route::DECREES->path() . '/ambrosian', LitSchema::DECREES],
+            'calendars' => [Route::CALENDARS->path() . '/roman', LitSchema::METADATA],
+        ];
+    }
+
+    #[DataProvider('riteOnANonRiteCarryingRouteProvider')]
+    public function testARiteOnANonRiteCarryingRouteStillResolves(string $url, LitSchema $expected): void
+    {
+        self::assertSame($expected->path(), self::getPathToSchemaFile($url));
+    }
+
     public function testResourceDataCheckRejectsAnUnrecognisedUrl(): void
     {
         self::assertNull(self::retrieveSchemaForCategory('resourceDataCheck', 'https://example.test/not/a/route'));

--- a/src/Health.php
+++ b/src/Health.php
@@ -2076,7 +2076,16 @@ class Health implements MessageComponentInterface
             return $item->schema->path();
         }
 
-        return match ($dataFile) {
+        // The rite segment is optional and its absence means the default rite, so the
+        // rite-qualified COLLECTION form (`/events/roman`) has to resolve to whatever the bare
+        // form (`/events`) resolves to — see issue #814. It is normalised away *before* the match
+        // rather than added as arms of its own, so every arm below is rite-aware by construction
+        // and a route added later cannot reintroduce the asymmetry. Paths that do not end in a
+        // rite segment come through unchanged, leaving the bare forms matching exactly as before.
+        //
+        // `/calendar/{rite}` is unaffected: Route::CALENDAR has no arm here, so both forms
+        // resolve to null exactly as they did.
+        return match (self::stripTrailingRiteSegment($dataFile)) {
             Route::CALENDARS->path() => LitSchema::METADATA->path(),
             Route::DECREES->path()   => LitSchema::DECREES->path(),
             Route::EVENTS->path()    => LitSchema::EVENTS->path(),
@@ -2087,6 +2096,38 @@ class Health implements MessageComponentInterface
             Route::SCHEMAS->path()   => LitSchema::SCHEMAS->path(),
             default                  => null
         };
+    }
+
+    /**
+     * Remove a trailing rite segment from an API collection path.
+     *
+     * `/events/roman` becomes `/events`; a path that does not end in a rite segment is returned
+     * unchanged, and only one segment is ever removed (so a doubled rite stays unresolvable).
+     *
+     * @param string $path the path to normalise
+     * @return string the path without its trailing rite segment
+     */
+    private static function stripTrailingRiteSegment(string $path): string
+    {
+        $stripped = preg_replace('/\/(?:' . self::riteAlternation() . ')$/', '', $path);
+
+        return $stripped ?? $path;
+    }
+
+    /**
+     * The regex alternation of every known rite, e.g. `roman|ambrosian`.
+     *
+     * Derived from {@see Rite} rather than written out, so a third rite is admitted by every
+     * pattern that uses it the moment the case is declared.
+     *
+     * @return string the alternation, ready to drop inside a `(?:…)` group in a `/`-delimited pattern
+     */
+    private static function riteAlternation(): string
+    {
+        return implode('|', array_map(
+            static fn (Rite $rite): string => preg_quote($rite->value, '/'),
+            Rite::cases()
+        ));
     }
 
     /**
@@ -2160,13 +2201,13 @@ class Health implements MessageComponentInterface
                 ) {
                     return $isVersionedDataPath ? preg_replace($versionedPattern, $versionedReplacement, LitSchema::PROPRIUMDESANCTIS->path()) : LitSchema::PROPRIUMDESANCTIS->path();
                 } elseif (
-                    preg_match('/\/events\/(?:(?:roman|ambrosian)\/)?(?:nation\/[A-Z]{2}|diocese\/[a-z]{6}_[a-z]{2})(?:\?locale=[a-zA-Z0-9_]+)?$/', $dataPath)
+                    preg_match('/\/events\/(?:(?:' . self::riteAlternation() . ')\/)?(?:nation\/[A-Z]{2}|diocese\/[a-z]{6}_[a-z]{2})(?:\?locale=[a-zA-Z0-9_]+)?$/', $dataPath)
                 ) {
                     return $isVersionedDataPath ? preg_replace($versionedPattern, $versionedReplacement, LitSchema::EVENTS->path()) : LitSchema::EVENTS->path();
                 } elseif (
                     // The rite segment is NON-capturing on purpose: the numbered groups below drive
                     // the switch, so a capturing group here would shift them all by one.
-                    preg_match('/\/data\/(?:(?:roman|ambrosian)\/)?(?:(nation)\/[A-Z]{2}|(diocese)\/[a-z]{6}_[a-z]{2}|(widerregion)\/[A-Z][a-z]+)(?:\?locale=[a-zA-Z0-9_]+)?$/', $dataPath, $matches)
+                    preg_match('/\/data\/(?:(?:' . self::riteAlternation() . ')\/)?(?:(nation)\/[A-Z]{2}|(diocese)\/[a-z]{6}_[a-z]{2}|(widerregion)\/[A-Z][a-z]+)(?:\?locale=[a-zA-Z0-9_]+)?$/', $dataPath, $matches)
                 ) {
                     $schema = LitSchema::DATA->path();
                     foreach ($matches as $idx => $match) {

--- a/src/Health.php
+++ b/src/Health.php
@@ -2085,6 +2085,19 @@ class Health implements MessageComponentInterface
         //
         // `/calendar/{rite}` is unaffected: Route::CALENDAR has no arm here, so both forms
         // resolve to null exactly as they did.
+        //
+        // The strip is UNIFORM across the map, not gated on the routes that actually carry a rite
+        // — so `/missals/roman` and `/decrees/ambrosian` resolve too, even though the Router 404s
+        // them (`Router::extractRiteSegment()` admits a rite only on calendar, events and data,
+        // and `Router::extractTestsRite()` on tests). That is deliberate, not an oversight. This
+        // function answers "which schema would validate a response of this shape", NOT "is this
+        // path routable": the Router remains the sole authority on what routes exist, and a schema
+        // resolved for a non-route costs nothing because the fetch that follows 404s and the check
+        // fails loudly anyway. Gating the strip would mean hardcoding the list of rite-carrying
+        // routes here — precisely the staleness that produced #814 — and there is no registry to
+        // derive such a list from, the knowledge living in an inline condition in
+        // `Router::extractRiteSegment()` with `/tests` handled separately. Do not add routability
+        // checks to this lookup.
         return match (self::stripTrailingRiteSegment($dataFile)) {
             Route::CALENDARS->path() => LitSchema::METADATA->path(),
             Route::DECREES->path()   => LitSchema::DECREES->path(),
@@ -2103,6 +2116,10 @@ class Health implements MessageComponentInterface
      *
      * `/events/roman` becomes `/events`; a path that does not end in a rite segment is returned
      * unchanged, and only one segment is ever removed (so a doubled rite stays unresolvable).
+     *
+     * The rule is intentionally shape-based rather than route-aware: it strips the segment from any
+     * path, including one whose route carries no rite. See the note at the call site in
+     * {@see self::getPathToSchemaFile()} for why that is the right trade.
      *
      * @param string $path the path to normalise
      * @return string the path without its trailing rite segment


### PR DESCRIPTION
Closes #814. Follow-up to #813, which made `Health`'s schema lookup rite-aware for *item* routes and
missed the bare rite-qualified **collection** form.

## The gap

`Health::getPathToSchemaFile()` ends in a `match` on **exact** string equality with `default => null`,
and #813's `resourceDataCheck` regex arm requires a `nation/`, `diocese/` or `widerregion/` segment
*after* the optional rite. The collection form with a rite fell between the two:

| Path                       | Exact `match` | Regex arm | Before   | After    |
|----------------------------|---------------|-----------|----------|----------|
| `/events`                  | ✅ hit        | —         | resolved | resolved |
| `/events/roman/nation/IT`  | —             | ✅ hit    | resolved | resolved |
| `/events/roman`            | ❌ miss       | ❌ miss   | **null** | resolved |
| `/events/ambrosian`        | ❌ miss       | ❌ miss   | **null** | resolved |
| `/data/ambrosian`          | ❌ miss       | ❌ miss   | **null** | resolved |
| `/tests/ambrosian`         | ❌ miss       | ❌ miss   | **null** | resolved |

All three are valid routes — `Router::extractRiteSegment()` accepts a rite on `calendar`, `events` and
`data`, and `/tests/{rite}` is handled at `Router.php:620-624` and "behaves exactly like `/tests`". The
`/events/{rite}` collection case is already exercised as the *comune* case in `SettingsRiteEchoTest`.

This is the form a `RiteSelect` produces when no nation or diocese is selected — the whole-rite calendar
— so UnitTestInterface#48 hits it immediately. It is also the canonical explicit form per
`Router::canonicalRiteUrl()`.

## The fix

A trailing rite segment is stripped before the `match`, so the rite-qualified collection form resolves to
the same schema as its bare equivalent.

**The rite alternation is derived from the `Rite` enum**, and both of #813's `resourceDataCheck` regex
arms now interpolate the same helper instead of a hardcoded `roman|ambrosian`. That literal is what would
have let a third rite silently reopen this hole and #812's; fixing the symptom with another hardcoded
alternation would only have reset the trap.

### One deliberate consequence

The strip is **uniform**, not gated on the three rite-carrying routes. So `/missals/roman`,
`/decrees/ambrosian` and `/calendars/roman` now also resolve to their bare form's schema, even though the
`Router` 404s them.

This is intentional, and is recorded in the code and pinned by a test rather than left to be rediscovered:

- `getPathToSchemaFile()` answers *"which schema would validate a response from this path"*, not *"is this
  path routable"*. Those are different questions and the `Router` remains the sole authority on the second.
  A bogus path still fails loudly — the fetch 404s — arguably with a clearer message than "Unable to
  detect schema".
- The alternative, gating on a list of rite-carrying routes, would reintroduce exactly the staleness that
  produced this bug. That knowledge currently lives in an inline condition inside
  `Router::extractRiteSegment()` with `/tests` handled separately, so there is no registry to derive from.
  Trading a structural invariant for a hand-maintained list is the wrong direction.

`testARiteOnANonRiteCarryingRouteStillResolves()` pins the behaviour so a later reader cannot mistake it
for an oversight and "fix" it back into a stale list. The lookup consults nothing about routability.

## `/calendar/{rite}` is unaffected, and here is why

Not because of anything to do with rite handling: `Route::CALENDAR` simply has no arm in that `match` and
never had one. Calendar responses are never validated through `getPathToSchemaFile()` — they go down the
`validateCalendar` action, which fetches `Route::CALENDAR->path() . $req` and validates against
`LitSchema::LITCAL->path()` directly. So `/calendar/roman` strips to `/calendar` and falls to
`default => null` exactly as before.

The `Route::CALENDAR` × `Rite` pairs are in the invariant test's cross product and passed *before* the fix
as well as after — both sides null — which is what makes them a guard rather than a coincidence.

## The test encodes the invariant, not the cases

For every route carrying a rite segment, the bare and rite-qualified collection forms must resolve to the
same schema — driven from the enums as a cross product rather than a hand-written list, so a route added
to the `match` later cannot reintroduce the asymmetry silently. A test enumerating exactly `/events/roman`,
`/data/ambrosian` and `/tests/roman` would pass today and guard nothing tomorrow.

## Verification

```text
vendor/bin/phpunit phpunit_tests/Health*.php   222 tests, 305 assertions, OK (3 pre-existing skips)
composer lint                                  clean
composer analyse (PHPStan level 10, 317 files) no errors
```

Confirmed discriminating: against pre-fix source the new tests fail **38 data sets** (16 + 16 + 6).

## How this was missed

#813 was scoped outward from the resolution arms, and its issue text framed the problem as "the regexes
lack a rite segment". Five reviews and CodeRabbit all checked that framing and none asked the prior
question — which rite-qualified paths exist at all. A precise issue description narrows reviewers'
attention as effectively as it directs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rite-qualified collection URLs now resolve to the same schemas as their equivalent bare URLs.
  * Improved schema validation for events, data, and tests collections when a rite suffix is included.
  * Added support for all recognized rites, ensuring new rite values are handled consistently.
  * Rite suffixes on routes that do not require them no longer prevent schema resolution.
  * Unknown rite values continue to be rejected appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->