### PR TITLE
feat(health): a typed target and tagged calendar identity for the WebSocket protocol

### DIFF
--- a/docs/superpowers/plans/2026-08-20-typed-target-messages.md
+++ b/docs/superpowers/plans/2026-08-20-typed-target-messages.md
@@ -543,12 +543,36 @@ Whichever file, the reference must state: the three v2 shapes; how each is discr
 `calendar.kind` is one of `general`, `national`, `diocesan`, `rite`; that ids are opaque and come from `/validations`;
 and that v1 remains supported until UnitTestInterface#42 ships.
 
-- [ ] **Step 3: Amend the spec's status**
+- [ ] **Step 3: Record the `steps` caveat from issue #819**
+
+`GET /validations` publishes a `steps` array per item, and `Health` emits one frame per step — but the two use
+different words. `CheckableInventory::STEPS` is `['exists', 'parses', 'validates']`; the emitted frame classes are
+`file-exists`, `json-valid`, `schema-valid`. Nothing in the API relates them, so a client that takes `steps` literally
+waits for a `.<label>.exists` frame that never arrives. Present since #811; filed as
+[#819](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/819).
+
+**Do not change either vocabulary here.** The maintainer's decision is that section C dissolves this — once responses
+are structured and DOM-agnostic, the frame carries the step identity and the CSS class becomes a client-side rendering
+choice, leaving nothing to reconcile. Renaming the published values down to the frame classes now would bake
+presentation detail into the discovery endpoint, which is the coupling `/validations` exists to remove, and C would
+undo it immediately. Renaming the frames is not additive and would break the live UnitTestInterface runners, which
+match on those classes.
+
+What to write, wherever the `/validations` contract is documented: that **`steps` is authoritative for its length,
+not for its values** — a client sizes a phase by `count(steps)`, which is correct today and is what replaces
+UnitTestInterface#42's four hardcoded `* 3` constants — and that its values do not yet correspond to emitted frame
+classes, with a pointer to #819.
+
+This exists to prevent one specific failure: UnitTestInterface#42 shipping before section C, needing step names, and
+hardcoding a client-side mapping. That would reintroduce exactly the duplication #806 exists to end, and it would
+then be load-bearing.
+
+- [ ] **Step 4: Amend the spec's status**
 
 Add a short section recording what plan 2 shipped and what it deliberately did not: the legacy branch survives, and the
 `glob()` containment exposure survives with it until the legacy-removal follow-up.
 
-- [ ] **Step 4: Lint and commit**
+- [ ] **Step 5: Lint and commit**
 
 ```bash
 cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg

--- a/docs/superpowers/plans/2026-08-20-typed-target-messages.md
+++ b/docs/superpowers/plans/2026-08-20-typed-target-messages.md
@@ -1,0 +1,588 @@
+# Typed Target Messages Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the inventory id the address a client sends, by adding typed `target` and typed calendar identity to the
+Health WebSocket protocol alongside the legacy shapes.
+
+**Architecture:** `executeValidation()` currently derives a filesystem path and a schema from client input across a
+resolution phase and an execution phase. The execution phase is extracted into a seam that takes an already-resolved
+path, kind and schema. v2 messages skip resolution entirely: `CheckableInventory::byId()` hands back a `CheckableItem`
+whose `path`, `kind` and `schema` are exactly that seam's inputs. Legacy messages keep their resolution phase and enter
+the same seam. Nothing legacy is deleted.
+
+**Tech Stack:** PHP 8.4, Ratchet/ReactPHP, PHPUnit 12, PHPStan level 10.
+
+**This is plan 2 of 2 for the section B spec.** Plan 1 (#815, merged `bb6b5f55`) grew `/validations` to 77 enumerated
+items. This plan makes those ids addressable on the wire. Removing the legacy branch is a **separate, later** change
+gated on UnitTestInterface#42 — and it is that follow-up, not this plan, that closes the `glob()` path-containment
+exposure.
+
+## Global Constraints
+
+- Work in the worktree `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg` on branch
+  `feat/806-typed-target-messages` (PR base: `development`). **Never commit in the main checkout**
+  `/home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI` — shared with other agents.
+- Never use `git commit --no-verify`. Commits are GPG-signed; if signing fails, stop and ask.
+- PSR-12 per `phpcs.xml`; short array syntax; 4-space indent; single quotes unless interpolating.
+- PHPStan level 10 over `src` only.
+- **Additive only.** `executeValidation`, `executeUnitTest` and the string form of `validateCalendar.calendar` keep
+  working byte-for-byte. Every existing test must pass **unchanged** — that is what makes "additive" a claim rather
+  than an intention. Do not delete a legacy arm, and do not "tidy" one.
+- **Ids are opaque to clients.** The server may parse an id; the client only echoes what `/validations` published.
+- **No new response `type` values.** Since UnitTestInterface PR #46 an unrecognised response `type` is painted as a
+  visible failed check, so a new type would make every rejection look like a failing test. Rejections reuse the
+  existing `echobot` error frame. `protocolError` is section G and is gated on section C.
+- **Do not touch the `glob()` / path-containment gap** in `executeValidation()`. It is removed by the legacy-removal
+  follow-up, per the maintainer's standing decision.
+- Message shapes are declared as `@phpstan-type` aliases in `Health`'s class docblock. New shapes get aliases there,
+  in the same style.
+- Spec: `docs/superpowers/specs/2026-08-20-typed-target-design.md`.
+
+---
+
+## File Structure
+
+| File                                                | Responsibility                                                   |
+|-----------------------------------------------------|------------------------------------------------------------------|
+| `src/Health.php`                                    | Action vocabulary, dispatch, the execution seam, v2 handlers     |
+| `src/Models/ValidationsPath/CheckableInventory.php` | Gains a per-run reset so v2 lookups cannot serve a stale index   |
+| `phpunit_tests/HealthValidateSourceTest.php`        | New: `validateSource` resolution, rejection, equivalence         |
+| `phpunit_tests/HealthTypedCalendarTest.php`         | New: typed calendar identity on `validateCalendar` and `runTest` |
+| `phpunit_tests/HealthSchemaCategoryTest.php`        | Extended: the id form of every slug it already covers            |
+| `jsondata/schemas/openapi.json`                     | The WebSocket message shapes, where documented                   |
+
+### The seam
+
+`executeValidation()` today runs two phases. Lines ~610-732 resolve `$pathForSchema` and `$dataPath` from
+`category`/`validate`/`sourceFile`/`sourceFolder`. Lines ~738-939 execute: a folder branch that globs and validates each
+file, and a file branch that re-derives diocesan/national paths from the slug, then reads over HTTP or from disk and
+validates.
+
+Task 1 extracts the execution phase behind:
+
+```php
+private function runValidationSteps(
+    string $dataPath,
+    string $kind,
+    ?string $schema,
+    string $label,
+    ConnectionInterface $to,
+    ?string $runToken
+): void
+```
+
+`$kind` is `'file'` or `'folder'` — the same vocabulary `CheckableItem::$kind` already uses, which is why the seam
+lands there and not somewhere else. `$dataPath` is **final**: the legacy slug re-derivation moves up into the
+resolution phase, so the seam never re-derives.
+
+### Why a per-run inventory reset is in scope
+
+`CheckableInventory::metadata()` memoizes with `self::$metadata ??= CalendarMetadataProvider::create()`. Under PHP-FPM
+that lasts one request. `Health` is a long-running ReactPHP process, so there it lasts until restart.
+
+Today that is masked: the legacy `sourceDataCheck` arms resolve `national-calendar-XX` and `diocesan-calendar-xxxxxx_xx`
+generically, so a calendar created via `/data` mid-process is still checkable. **`validateSource` resolves solely
+through `byId()`**, so for a v2 client that masking is gone and a newly-created calendar would be invisible until the
+WebSocket server restarts.
+
+An invalidation hook on the write path cannot work: `/data` writes happen in the HTTP process, and `Health` is a
+different process that would never see the call. The fix that fits the actual topology is to **reset the memo once per
+run**, bounding staleness to a single run at the cost of one rebuild per run rather than per lookup.
+
+---
+
+## Task 1: The execution-phase seam
+
+Pure refactor. No behaviour change, no new action. Its deliverable is that the existing suites still pass while
+`executeValidation()` has an entry point a v2 handler can call.
+
+**Files:**
+
+- Modify: `src/Health.php`
+
+**Interfaces:**
+
+- Produces: `runValidationSteps(string $dataPath, string $kind, ?string $schema, string $label, ConnectionInterface $to, ?string $runToken): void`.
+  `$kind` is `'file'|'folder'`. `$label` is what the legacy code passes as `$validate` — it is the human label and the
+  CSS-class fragment, and stays a plain string.
+- Consumes: nothing new.
+
+- [ ] **Step 1: Confirm the worktree**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+git rev-parse --show-toplevel   # must end in -msg
+git branch --show-current       # expect: feat/806-typed-target-messages
+ls vendor/bin/phpunit
+```
+
+- [ ] **Step 2: Record the legacy baseline before touching anything**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+vendor/bin/phpunit phpunit_tests/Health*.php 2>&1 | tail -5
+```
+
+Write the exact counts into your report. This is the number the refactor must not change. A refactor whose "before"
+figure was never recorded cannot be shown to have preserved behaviour.
+
+- [ ] **Step 3: Move the legacy slug re-derivation up into the resolution phase**
+
+In `executeValidation()`, the file branch of the execution phase (~line 868) re-derives diocesan and national paths:
+
+```php
+if (preg_match('/^diocesan-calendar-([a-z]{6}_[a-z]{2})$/', $pathForSchema, $matches)) {
+```
+
+Move that block so it runs at the end of the resolution phase, assigning `$dataPath` there. The execution phase must
+receive a path that is already final. Behaviour is unchanged because nothing between the two points reads `$dataPath`.
+
+Verify that claim rather than assuming it: read the lines between and confirm none of them reads `$dataPath`. Say so
+explicitly in your report.
+
+- [ ] **Step 4: Extract the execution phase**
+
+Move lines from the `if (property_exists($validation, 'sourceFolder') && is_string($validation->sourceFolder))` test
+through the end of the execution phase into the new method, replacing the `sourceFolder` test with `$kind === 'folder'`
+and the local `$validate` / `$dataPath` / `$schema` reads with the parameters. Call it from `executeValidation()`:
+
+```php
+$this->runValidationSteps(
+    $dataPath,
+    property_exists($validation, 'sourceFolder') ? 'folder' : 'file',
+    $schema,
+    $validate,
+    $to,
+    $runToken
+);
+```
+
+Keep the method private and place it directly after `executeValidation()`.
+
+- [ ] **Step 5: Prove behaviour is unchanged**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+vendor/bin/phpunit phpunit_tests/Health*.php 2>&1 | tail -5
+composer lint
+composer analyse
+```
+
+Expected: **identical** counts to Step 2. If any figure moved, the refactor changed behaviour — stop and report rather
+than adjusting a test to match.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+git add src/Health.php
+git commit -m "refactor(health): give executeValidation an execution-phase seam
+
+The function resolves a path and a schema from client input, then executes
+the checks. A typed target makes the first half unnecessary: the inventory
+already knows the path, the kind and the schema. Splitting the two lets a v2
+handler enter at the second half without duplicating it.
+
+The legacy slug re-derivation moves up into the resolution phase so the seam
+receives a final path and never re-derives one. Nothing between the two points
+read \$dataPath, so this is behaviour-preserving.
+
+No behaviour change: the legacy suites pass with identical counts.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: `validateSource`, and a per-run inventory reset
+
+**Files:**
+
+- Modify: `src/Health.php`, `src/Models/ValidationsPath/CheckableInventory.php`
+- Create: `phpunit_tests/HealthValidateSourceTest.php`
+- Modify: `phpunit_tests/HealthSchemaCategoryTest.php`
+
+**Interfaces:**
+
+- Consumes: `runValidationSteps()` from Task 1; `CheckableInventory::byId(string $id): ?CheckableItem`;
+  `CheckableItem` public readonly `id`, `kind` (`'file'|'folder'`), `rite`, `region`, `label`, `schema` (`LitSchema`),
+  `steps`, `path`.
+- Produces: `CheckableInventory::reset(): void`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `phpunit_tests/HealthValidateSourceTest.php`. Follow the stub-`ConnectionInterface`-plus-reflection pattern used
+by `HealthCancelRunTest` and `HealthSchemaCategoryTest`; read one of them first and match it rather than inventing a
+harness.
+
+Cover, at minimum:
+
+- A `validateSource` message carrying `{"target":{"id":"temporale:roman"}}` resolves to the same schema the legacy
+  slug `proprium-de-tempore` resolves to.
+- The same for a per-calendar id: `nation:roman:IT` versus `national-calendar-IT`.
+- An unknown `target.id` is rejected via the existing `echobot` frame and no validation runs.
+- `target` present but a string, not an object, is rejected as malformed.
+- `target` absent is rejected by `validateMessageProperties()`.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+vendor/bin/phpunit phpunit_tests/HealthValidateSourceTest.php
+```
+
+Expected: FAIL — the action does not exist yet.
+
+- [ ] **Step 3: Add the reset hook**
+
+In `CheckableInventory`:
+
+```php
+    /**
+     * Drop the memoized index.
+     *
+     * The memo is per-process, which is a request under PHP-FPM but the whole server lifetime in
+     * Health's long-running ReactPHP process. A v2 `validateSource` resolves solely through
+     * byId(), so without this a calendar created via /data would stay invisible to the WebSocket
+     * until restart — the legacy slug arms used to mask that by resolving generically.
+     *
+     * An invalidation hook on the write path cannot work: /data writes happen in the HTTP process,
+     * which Health never observes. Health therefore resets once per run, bounding staleness to a
+     * single run at the cost of one rebuild per run rather than one per lookup.
+     */
+    public static function reset(): void
+    {
+        self::$items    = null;
+        self::$metadata = null;
+    }
+```
+
+Match the existing property names — read them rather than trusting these.
+
+- [ ] **Step 4: Add the action**
+
+Add to `ACTION_PROPERTIES`:
+
+```php
+        'validateSource'    => ['target'],
+```
+
+Add a `@phpstan-type` alias in the class docblock, in the existing style:
+
+```php
+ * @phpstan-type ValidateSource \stdClass&object{action:'validateSource',target:\stdClass&object{id:string},runToken?:string}
+```
+
+Add the dispatch case, and call `CheckableInventory::reset()` where a run begins — the same place `runToken` is first
+stored for a connection, so a reset happens once per run rather than once per message. Read that block before editing;
+`cancelRun` is deliberately exempt from it and must stay exempt.
+
+```php
+                case 'validateSource':
+                    /** @var ValidateSource $messageReceived */
+                    $this->validateSource($messageReceived, $from);
+                    break;
+```
+
+- [ ] **Step 5: Implement the handler**
+
+```php
+    private function validateSource(\stdClass $message, ConnectionInterface $to): void
+    {
+        if (false === ( $message->target instanceof \stdClass ) || false === property_exists($message->target, 'id')) {
+            $this->rejectMessage($to, 'validateSource requires a target object with an id.');
+            return;
+        }
+
+        $id = $message->target->id;
+        if (false === is_string($id)) {
+            $this->rejectMessage($to, 'validateSource target id must be a string.');
+            return;
+        }
+
+        $item = CheckableInventory::byId($id);
+        if (null === $item) {
+            $this->rejectMessage($to, "Unknown validation target: {$id}");
+            return;
+        }
+
+        $this->runValidationSteps(
+            $item->path,
+            $item->kind,
+            $item->schema->path(),
+            $item->label,
+            $to,
+            $this->resolveRunToken($to)
+        );
+    }
+```
+
+`$this->resolveRunToken(ConnectionInterface $to): ?string` already exists and is what `executeValidation()` itself
+calls — use it, do not read `runToken` off the message.
+
+`rejectMessage()` does **not** exist. The only `echobot` frame is built inline in `onMessage()`'s `default` arm
+(~line 420). Three call sites in this plan need it, so add one private helper next to `sendMessage()` and build the
+frame exactly as that arm does:
+
+```php
+    /**
+     * Reject a malformed or unresolvable v2 message.
+     *
+     * Reuses the existing `echobot` error shape deliberately. Since UnitTestInterface PR #46 an
+     * unrecognised response `type` is painted as a visible failed check, so a dedicated
+     * `protocolError` type would make every rejection look like a failing test. That type belongs
+     * to #806 section G and is gated on section C.
+     */
+    private function rejectMessage(ConnectionInterface $to, string $text): void
+    {
+        $message       = new \stdClass();
+        $message->type = 'echobot';
+        $message->text = $text;
+        $this->sendMessage($to, $message);
+    }
+```
+
+Read the `default` arm first and match whatever it actually sets — if it carries fields beyond `type` and `text`,
+carry them too.
+
+- [ ] **Step 6: Extend the equivalence oracle, and add the round-trip**
+
+Two distinct guarantees, both named by the spec. Write both.
+
+**Equivalence.** In `HealthSchemaCategoryTest`, extend the existing provider so every legacy slug it covers is also
+asserted in its id form, resolving to the same schema. This is what proves the new address is the *same* address.
+
+**Round-trip.** In `HealthValidateSourceTest`, assert that **every** id `/validations` advertises resolves through
+`CheckableInventory::byId()` to a non-null item whose `schema` is non-empty — driven from
+`CheckableInventory::all()`, not a hand-written list, so a newly enumerated kind is covered the day it appears. This
+is what proves the published list and the addressable set are the same set: an id a client can read but not send
+would be worse than not publishing it.
+
+- [ ] **Step 7: Verify**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+vendor/bin/phpunit phpunit_tests/Health*.php phpunit_tests/Models/ValidationsPath/
+composer lint
+composer analyse
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+git add src/Health.php src/Models/ValidationsPath/CheckableInventory.php \
+        phpunit_tests/HealthValidateSourceTest.php phpunit_tests/HealthSchemaCategoryTest.php
+git commit -m "feat(health): address source validation by inventory id
+
+validateSource takes a target object holding an id the server published, and
+resolves it with one lookup instead of eight anchored preg_match arms. The
+legacy executeValidation shape is untouched and its arms stay reachable.
+
+The inventory memo is reset once per run. It is per-process, which is a request
+under PHP-FPM but the server lifetime in Health, and a v2 message resolves only
+through byId() — so without the reset a calendar created via /data would be
+invisible until restart. The legacy arms used to mask that by resolving
+generically. A write-path hook cannot work: /data writes happen in a different
+process.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Typed calendar identity on `validateCalendar`
+
+**Files:**
+
+- Modify: `src/Health.php`
+- Create: `phpunit_tests/HealthTypedCalendarTest.php`
+
+**Interfaces:**
+
+- Consumes: `resolveRite(string $calendar, string $category, ?string $riteHint = null): Rite`;
+  `validateCalendar(string $calendar, int $year, string $category, string $responseType, ConnectionInterface $to, ?string $riteHint = null): void`.
+- Produces: v2 recognition on `validateCalendar` — `calendar` being an **object** rather than a string.
+
+`calendar.kind` maps to the internal category: `general` and `rite` → `ritecalendar`, `national` → `nationalcalendar`,
+`diocesan` → `diocesancalendar`. The internal vocabulary is not being renamed in this plan; only the wire changes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `phpunit_tests/HealthTypedCalendarTest.php` covering:
+
+- `{"calendar":{"kind":"diocesan","id":"lugano_ch","rite":"ambrosian"},"year":2026,"responseFormat":"JSON"}` reaches
+  `validateCalendar()` with category `diocesancalendar`, calendar `lugano_ch`, rite Ambrosian.
+- A string `calendar` still takes the legacy path with `responsetype`, unchanged.
+- An unknown `kind` is rejected.
+- A `rite` that disagrees with the calendar's actual rite is **rejected**, not silently resolved. Use a real diocese:
+  `lugano_ch` is Ambrosian, so `{"kind":"diocesan","id":"lugano_ch","rite":"roman"}` must be rejected.
+- `responseFormat` is honoured on the object form; `responsetype` remains honoured on the string form.
+
+- [ ] **Step 2: Run them to verify they fail**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+vendor/bin/phpunit phpunit_tests/HealthTypedCalendarTest.php
+```
+
+- [ ] **Step 3: Implement**
+
+`validateMessageProperties()` requires `['category','calendar','year','responsetype']` for `validateCalendar`. The v2
+form has neither `category` nor `responsetype`, so that check must branch on whether `calendar` is an object **before**
+the property list is applied. Make that branch explicit and commented — it is the discriminator the spec names, and a
+reader must not have to infer it.
+
+Map `kind` to the internal category, take the rite from `calendar.rite`, and verify it against the calendar's actual
+rite before proceeding. The disagreement check is the point: `resolveRite()` currently treats the hint as authoritative
+when it parses, which is right for a hint and wrong for an assertion.
+
+- [ ] **Step 4: Verify and commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+vendor/bin/phpunit phpunit_tests/Health*.php
+composer lint
+composer analyse
+git add src/Health.php phpunit_tests/HealthTypedCalendarTest.php
+git commit -m "feat(health): accept a tagged calendar identity on validateCalendar
+
+calendar becomes an object carrying kind, id and rite, which is also the v2
+discriminator: the action name is unchanged because the action is unchanged.
+category disappears from the wire, and responsetype becomes responseFormat on
+the reshaped form only.
+
+A rite that disagrees with the calendar's actual rite is rejected rather than
+silently preferred. A hint may be guessed at; an assertion that is wrong is a
+client bug and saying so is more useful than papering over it.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `runTest`
+
+**Files:**
+
+- Modify: `src/Health.php`
+- Modify: `phpunit_tests/HealthTypedCalendarTest.php`
+
+**Interfaces:**
+
+- Consumes: `executeUnitTest(string $test, string $calendar, int $year, string $category, ConnectionInterface $to, ?string $riteHint = null): void`,
+  and the `kind`→category mapping and rite-disagreement check from Task 3. Factor those out of Task 3 rather than
+  copying them — a second verbatim copy of the mapping is a defect, not a convenience.
+- Produces: the `runTest` action.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `HealthTypedCalendarTest` with `runTest` cases mirroring Task 3's: correct dispatch, unknown `kind` rejected,
+rite disagreement rejected, and `executeUnitTest` still working unchanged.
+
+Note the distinction the spec draws and assert it: `test:ambrosian:StIgnatiusOfLoyolaTest` is a source check reached by
+`validateSource`, whereas `runTest` **runs** that test against a computed calendar. Both must work, addressed
+differently.
+
+- [ ] **Step 2: Run them, implement, verify**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+vendor/bin/phpunit phpunit_tests/HealthTypedCalendarTest.php
+```
+
+Add `'runTest' => ['test', 'calendar', 'year']` to `ACTION_PROPERTIES`, a `@phpstan-type RunTest` alias, and the
+dispatch case delegating to `executeUnitTest()` with the mapped category and verified rite.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+git add src/Health.php phpunit_tests/HealthTypedCalendarTest.php
+git commit -m "feat(health): add runTest with a tagged calendar identity
+
+executeUnitTest keeps working. The new name is the v2 discriminator, as it is
+for validateSource: a v1 client cannot accidentally emit it.
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Document the protocol
+
+**Files:**
+
+- Modify: `jsondata/schemas/openapi.json`
+- Modify: `docs/superpowers/specs/2026-08-20-typed-target-design.md`
+
+- [ ] **Step 1: Find where the WebSocket protocol is documented**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+grep -rn 'executeValidation\|validateCalendar' jsondata/schemas/ docs/ --include=*.json --include=*.md | grep -v superpowers | head
+```
+
+If the WebSocket messages are not in `openapi.json` at all — they may not be, being a different transport — do **not**
+invent a place for them. Say so in your report and document the three shapes in the spec instead, marking it as the
+protocol reference until section F's `hello` frame supersedes it.
+
+- [ ] **Step 2: Record the v1/v2 mapping**
+
+Whichever file, the reference must state: the three v2 shapes; how each is discriminated from its v1 form; that
+`calendar.kind` is one of `general`, `national`, `diocesan`, `rite`; that ids are opaque and come from `/validations`;
+and that v1 remains supported until UnitTestInterface#42 ships.
+
+- [ ] **Step 3: Amend the spec's status**
+
+Add a short section recording what plan 2 shipped and what it deliberately did not: the legacy branch survives, and the
+`glob()` containment exposure survives with it until the legacy-removal follow-up.
+
+- [ ] **Step 4: Lint and commit**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+composer lint:md
+composer lint:openapi
+git add -A && git commit -m "docs(protocol): record the v2 message shapes and their discriminators
+
+Refs #806
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Publish
+
+**Files:** none — repository metadata only.
+
+- [ ] **Step 1: Merge development and verify the merge result**
+
+```bash
+cd /home/johnrdorazio/development/LiturgicalCalendar/LiturgicalCalendarAPI-msg
+git fetch origin development
+git merge origin/development --no-edit
+vendor/bin/phpunit phpunit_tests/Health*.php phpunit_tests/Models/ValidationsPath/
+composer lint && composer analyse
+```
+
+CI tests the branch, not the merge result. If `Health.php` conflicts, resolve it by hand and re-run — an auto-merge that
+succeeds textually is not evidence that two edits to the same function compose.
+
+- [ ] **Step 2: Push and open the PR**
+
+Base `development`. The body must state: the three new shapes and how each is discriminated; that **nothing legacy was
+removed** and every existing test passes unchanged; the per-run inventory reset and why a write-path hook cannot work;
+that the rite-disagreement case is rejected rather than resolved; and that the `glob()` exposure is **still open**,
+closed only by the legacy-removal follow-up gated on UnitTestInterface#42.

--- a/docs/superpowers/specs/2026-08-20-typed-target-design.md
+++ b/docs/superpowers/specs/2026-08-20-typed-target-design.md
@@ -4,6 +4,14 @@ Design for section B of [#806](https://github.com/Liturgical-Calendar/Liturgical
 ([#811](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/811)) published the inventory; this makes it
 the address. Client counterpart: [UnitTestInterface#42](https://github.com/Liturgical-Calendar/UnitTestInterface/issues/42).
 
+**This document is the protocol reference** for the three v2 message shapes (`validateSource`, the typed-`calendar`
+form of `validateCalendar`, and `runTest`) until section F's `hello` handshake frame ships and supersedes it. The
+Health WebSocket protocol is not documented in `jsondata/schemas/openapi.json`: that file describes the HTTP API, the
+WebSocket endpoint is a separate transport with no path entry there, and a search of `jsondata/schemas/` and `docs/`
+for these action names turns up nothing outside this design and the `Health` class's own docblock. Read the two
+together — this file for the wire shapes and the reasoning behind each rule, the `Health` class docblock
+(`src/Health.php`) for the exact PHPStan `@phpstan-type` definitions and per-action implementation detail.
+
 ## Problem
 
 Three properties on the wire are each doing more than one job, and they overlap.
@@ -121,6 +129,14 @@ There are three domains here, and collapsing them into one `target` would be the
 
 `calendar.kind` is one of `general`, `national`, `diocesan`, `rite`. The word `category` disappears from the protocol.
 
+**`general` is an alias, not a fifth kind.** It names the General Roman Calendar and is exactly equivalent to
+`{"kind": "rite", "id": "roman"}` — its only difference is that `id` may be omitted, because `general` is the one kind
+with nothing to choose between: there is exactly one General Roman Calendar, so no id is needed to pick it out. Read it
+as a convenience spelling for the client that means "the default", not as a distinct calendar type with its own
+resolution path; both forms resolve through the same rite-level handling and must never be treated as two different
+things. (An `id` sent alongside `kind: general` is accepted only if it is `roman` — anything else is rejected, since it
+would be asserting a calendar `general` cannot name.)
+
 ### Source check versus test run
 
 The current protocol blurs a distinction worth keeping explicit. `tests-StIgnatiusOfLoyolaTest` today is a **source check**:
@@ -166,6 +182,34 @@ No client breaks on the day this lands, and UnitTestInterface can migrate one pa
 
 Removal of the legacy branch is a separate, later change, gated on UnitTestInterface#42 shipping.
 
+## Retired properties
+
+Being additive is not the same as being permissive. Each reshaped message replaces specific legacy properties with a
+typed equivalent, and a v2 message that *also* carries the property it replaced is rejected rather than silently
+ignored:
+
+| v2 action          | v1 predecessor      | rejects if present                                   |
+|--------------------|---------------------|------------------------------------------------------|
+| `validateSource`   | `executeValidation` | `category`, `validate`, `sourceFile`, `sourceFolder` |
+| `validateCalendar` | `validateCalendar`  | `category`, `responsetype`                           |
+| `runTest`          | `executeUnitTest`   | `category`                                           |
+
+`runTest` retires only `category`, because `executeUnitTest` never had a `responsetype` to retire in the first place.
+`runToken` is retired by nothing on any of the three — it predates this design, is shared across all three actions, and
+stays current.
+
+This is not a breaking change: a v1 client sends a string `calendar` or an old action name and never reaches these
+checks, so nothing that worked yesterday stops working. What it catches is the client in between — one that has
+switched to the new action name or the object `calendar`, but is still sending fields the old shape used. Without this
+rule that client's mistake is invisible: a retired property is simply never read, the response looks correct, and the
+bug surfaces only later, on the day the legacy branch is finally removed and there is no fallback left to mask it. A
+loud rejection *now*, while both branches still exist side by side to compare against, is strictly more useful than a
+quiet one that waits for removal to become a symptom.
+
+The rule is applied uniformly across all three actions on purpose, even though `runTest` retires only one property.
+Rejecting a stale field on two actions and tolerating it on the third would leave a client unable to predict which
+behaviour it will get without checking the action name — worse than either answer applied consistently.
+
 ## What this does not fix, yet
 
 `Health::executeValidation()` passes a client-supplied `sourceFolder` to `glob()` with no containment check, and an
@@ -179,13 +223,14 @@ it", and that follow-up is gated on client adoption.
 
 ## Error handling
 
-| Condition                                        | Behaviour                                                                      |
-|--------------------------------------------------|--------------------------------------------------------------------------------|
-| `target.id` is not in the inventory              | Rejected immediately, via the existing error frame                             |
-| `target` present but not an object               | Rejected as a malformed message                                                |
-| `calendar` is an object with an unknown `kind`   | Rejected immediately                                                           |
-| `calendar` is a string                           | Legacy path, unchanged behaviour                                               |
-| `rite` disagrees with the calendar's actual rite | Rejected, rather than silently preferring one — a disagreement is a client bug |
+| Condition                                                     | Behaviour                                                                      |
+|---------------------------------------------------------------|--------------------------------------------------------------------------------|
+| `target.id` is not in the inventory                           | Rejected immediately, via the existing error frame                             |
+| `target` present but not an object                            | Rejected as a malformed message                                                |
+| `calendar` is an object with an unknown `kind`                | Rejected immediately                                                           |
+| `calendar` is a string                                        | Legacy path, unchanged behaviour                                               |
+| `rite` disagrees with the calendar's actual rite              | Rejected, rather than silently preferring one — a disagreement is a client bug |
+| A v2 message also carries a legacy property its shape retired | Rejected before anything else runs — see Retired properties, above             |
 
 Rejections reuse the **existing** `echobot` error shape. A dedicated `protocolError` type belongs to section G and
 cannot land before section C, because since UnitTestInterface PR #46 an unrecognised response `type` is painted as a
@@ -206,3 +251,53 @@ rather than hand-listed — a diocese added to source data without appearing in 
 
 **Legacy untouched:** the existing suites covering the legacy shapes must pass unchanged, which is what makes "additive"
 a claim rather than an intention.
+
+## A caveat on `steps`, not fixed here
+
+`GET /validations` publishes a `steps` array per item (`['exists', 'parses', 'validates']`, from
+`CheckableInventory::STEPS`), and `Health` emits one WebSocket frame per step during a check — but the frame classes
+are `file-exists`, `json-valid`, `schema-valid`, and nothing in the API relates the two vocabularies. A client that
+takes a step name literally and waits for a `.<label>.exists` frame waits forever. This is present since #811,
+unrelated to the reshaping this document describes, and filed separately as
+[#819](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/819); the substantive documentation of the
+caveat lives on the `steps` property itself, in `jsondata/schemas/LitCalValidationsPath.json` and the `/validations`
+description in `openapi.json`, because that is where a client discovers the array in the first place. **`steps` is
+authoritative for its length, not for its values** — sizing a check's progress as `count(steps)` is correct today and
+is exactly what replaces UnitTestInterface#42's four hardcoded `* 3` constants.
+
+Deliberately not fixed by renaming either vocabulary to match the other: the maintainer's decision is that #806
+section C dissolves this on its own. Once responses are structured and DOM-agnostic, the frame itself carries the step
+identity and the CSS class becomes a client-side rendering choice, leaving nothing left to reconcile. Renaming
+`steps`' published values down to the frame classes now would bake a presentation detail into the discovery endpoint
+— the exact coupling `/validations` exists to remove — and section C would immediately undo it. Renaming the frame
+classes instead is not an additive change and would break the live UnitTestInterface runners, which match on those
+classes today. The risk this guards against is specific: UnitTestInterface#42 shipping before section C, needing step
+names for something more than a count, and hardcoding a client-side mapping between the two vocabularies — which would
+reintroduce exactly the duplication #806 exists to end, and once written it would be load-bearing.
+
+## Status
+
+Section B, as designed above, is implemented. `validateSource` resolves a `target.id` through
+`CheckableInventory::byId()` instead of the eight anchored `preg_match` slug arms; the typed (object-`calendar`) form
+of `validateCalendar` exists alongside the legacy string form, with `rite` enforced as an assertion rather than taken
+as a hint; `runTest` reshapes `executeUnitTest` behind a new action name; and all three reject a legacy property their
+own shape retired, per [Retired properties](#retired-properties) above.
+
+What shipped deliberately stopped short of what "additive" promised, in two ways that were always meant to survive
+this pass and are not oversights:
+
+- **The legacy branch survives.** `executeValidation`, the string form of `validateCalendar`, and `executeUnitTest`
+  remain fully reachable, byte-for-byte, exactly as [Migration](#migration) above committed to. Removing them is a
+  separate, later change gated on [UnitTestInterface#42](https://github.com/Liturgical-Calendar/UnitTestInterface/issues/42).
+- **The `glob()` containment exposure survives with it.** `Health::executeValidation()` still passes a client-supplied
+  `sourceFolder` to `glob()` with no containment check, exactly as [What this does not fix, yet](#what-this-does-not-fix-yet)
+  above recorded before implementation began. `validateSource`'s `target.id` path never reaches `glob()` with
+  client-supplied input — it resolves paths from `CheckableInventory`'s own records — so the new code carries none of
+  the exposure. But the exposure was never section B's to fix: it lives entirely in the legacy branch, and closing it
+  is bundled into the later legacy-removal change rather than patched opportunistically here, per the maintainer's
+  original decision.
+
+Also implemented, settled after this document was first written and recorded here rather than left to drift from the
+code: the uniform retired-property rejection ([Retired properties](#retired-properties)), and `general` as a
+literal alias for `{"kind": "rite", "id": "roman"}` rather than a fifth calendar kind (documented under
+[Three message shapes](#three-message-shapes)).

--- a/docs/superpowers/specs/2026-08-20-typed-target-design.md
+++ b/docs/superpowers/specs/2026-08-20-typed-target-design.md
@@ -233,12 +233,25 @@ ignored:
 | v2 action          | v1 predecessor      | rejects if present                                   |
 |--------------------|---------------------|------------------------------------------------------|
 | `validateSource`   | `executeValidation` | `category`, `validate`, `sourceFile`, `sourceFolder` |
-| `validateCalendar` | `validateCalendar`  | `category`, `responsetype`                           |
-| `runTest`          | `executeUnitTest`   | `category`                                           |
+| `validateCalendar` | `validateCalendar`  | `category`, `responsetype`, `rite`                   |
+| `runTest`          | `executeUnitTest`   | `category`, `rite`                                   |
 
-`runTest` retires only `category`, because `executeUnitTest` never had a `responsetype` to retire in the first place.
-`runToken` is retired by nothing on any of the three — it predates this design, is shared across all three actions, and
-stays current.
+`runTest` retires no `responsetype`, because `executeUnitTest` never had one to retire in the first place. `runToken`
+is retired by nothing on any of the three — it predates this design, is shared across all three actions, and stays
+current.
+
+**The retired set is not the required-property list.** `rite` was missed on both calendar actions on the first pass,
+and the cause is worth writing down because it will recur: the audit derived the retired set from
+`Health::ACTION_PROPERTIES`, which lists only the properties an action *requires*, so every **optional** v1 property was
+structurally invisible to it. `rite` was optional on both v1 `validateCalendar` and `executeUnitTest` — read by
+`readRiteHint()`, honoured by `resolveRite()` — and the v2 shapes moved it inside `calendar.rite` and stopped reading
+the top-level one. Silently ignoring it is the worst possible outcome for this particular property: what goes unsaid is
+a **rite disagreement**, the one thing the typed identity went out of its way to make loud. When reshaping a further
+message, read the predecessor's `@phpstan-type` alias, where the optional properties are the ones marked `?`.
+
+`responsetype` is the one optional v1 property deliberately **not** retired: `executeValidation` accepted it, but
+`executeValidation()` never read it and `validateSource` has no response representation to choose, so retiring it would
+answer a question no client is asking.
 
 This is not a breaking change: a v1 client sends a string `calendar` or an old action name and never reaches these
 checks, so nothing that worked yesterday stops working. What it catches is the client in between — one that has

--- a/docs/superpowers/specs/2026-08-20-typed-target-design.md
+++ b/docs/superpowers/specs/2026-08-20-typed-target-design.md
@@ -105,6 +105,48 @@ calendar later would not force a vocabulary change.
 Ids stay **opaque to clients**: they are echoed back, never parsed. The structure exists for the server and for humans
 reading logs.
 
+### The frame class fragment
+
+A `validateSource` check answers with one frame per step, and each frame carries a `classes` string of the form
+`.<fragment>.<step>` — the address the client matches a result card by. **The fragment is derived from the item's `id`,
+and the derivation is part of the protocol**: a client that holds an id must be able to compute the same string without
+asking the server, because that is how it finds the card to paint before any frame arrives.
+
+**The rule, in full:**
+
+> Take the item's `id` and replace every character outside `[A-Za-z0-9_-]` with a single `-`. Nothing else — no case
+> folding, no collapsing of runs of `-`, no trimming.
+
+In JavaScript that is `id.replace(/[^A-Za-z0-9_-]/g, '-')`; in PHP, `preg_replace('/[^A-Za-z0-9_-]/', '-', $id)`.
+
+| Id                                      | Fragment                                | Frame class                                          |
+|-----------------------------------------|-----------------------------------------|------------------------------------------------------|
+| `temporale:roman`                       | `temporale-roman`                       | `.temporale-roman.file-exists`                       |
+| `nation:roman:US`                       | `nation-roman-US`                       | `.nation-roman-US.json-valid`                        |
+| `diocese:ambrosian:lugano_ch`           | `diocese-ambrosian-lugano_ch`           | `.diocese-ambrosian-lugano_ch.schema-valid`          |
+| `test:ambrosian:StIgnatiusOfLoyolaTest` | `test-ambrosian-StIgnatiusOfLoyolaTest` | `.test-ambrosian-StIgnatiusOfLoyolaTest.file-exists` |
+
+Three properties of this rule are load-bearing, and none of them is an accident:
+
+- **It is derived from the `id`, never from the item's `label`.** The id is stable, opaque and server-minted; the label
+  is human-facing prose that is expected to change with translation and rewording. An address that moved when someone
+  reworded a caption would be worse than no address at all. (The first implementation of `validateSource` used the label
+  and was unusable for exactly this reason: labels such as `National calendar: US` contain a space — matching zero
+  cards — or a `:`, which makes the client's `querySelectorAll()` throw outright.)
+- **The raw id is not a drop-in.** `.diocese:ambrosian:lugano_ch` parses as a class followed by a pseudo-class, so the
+  substitution is required and is not merely cosmetic.
+- **A fragment never contains a `.`.** That is what makes `.<fragment>.<step>` unambiguously splittable, and it follows
+  from the rule because `.` is outside `[A-Za-z0-9_-]`.
+
+Every id the inventory currently publishes yields a fragment matching `^[A-Za-z][A-Za-z0-9_-]*$`, and no two ids
+collide on one fragment. Neither is guaranteed by the substitution alone — an id kind introduced later that began with a
+digit, or that differed from another only in punctuation, would break one or the other — so both are asserted over the
+whole published set in `HealthValidateSourceTest`, and a new id kind that violates either fails the build rather than
+the client.
+
+The steps themselves are `file-exists`, `json-valid` and `schema-valid`, which are **not** the values `/validations`
+publishes in `steps`; see [A caveat on `steps`](#a-caveat-on-steps-not-fixed-here) below.
+
 ## Three message shapes
 
 There are three domains here, and collapsing them into one `target` would be the same mistake `category` made.

--- a/docs/superpowers/specs/2026-08-20-typed-target-design.md
+++ b/docs/superpowers/specs/2026-08-20-typed-target-design.md
@@ -119,6 +119,17 @@ asking the server, because that is how it finds the card to paint before any fra
 
 In JavaScript that is `id.replace(/[^A-Za-z0-9_-]/g, '-')`; in PHP, `preg_replace('/[^A-Za-z0-9_-]/', '-', $id)`.
 
+**Fragment matching is case-insensitive on the client, and a client MUST put the card's class and the selector it
+matches with through the same case treatment.** The server does not case-fold, so the fragments it emits are mixed case
+across most of the inventory — `nation-roman-US`, `sanctorale-roman-EDITIO_TYPICA_1970`,
+`test-ambrosian-StIgnatiusOfLoyolaTest`. UnitTestInterface lowercases: `slugifySelector()` (`assets/js/common.js`) runs
+every class token through `slugify()`, which begins with `toLowerCase()`, before handing the selector to
+`querySelectorAll()`. So a client that writes `class="nation-roman-US"` onto the card and then matches through
+`slugifySelector` searches for `.nation-roman-us` and finds **zero cards** — the same paint-nothing failure this whole
+section exists to prevent, one layer down. Today's v1 slugs are safe only because the card class is built by the *same*
+`slugify()` (`assets/js/index.js`, `slugify(item.validate)`), so both sides are lowered together. Whichever convention a
+client picks — lowercase both, or neither — it has to be the same on both sides.
+
 | Id                                      | Fragment                                | Frame class                                          |
 |-----------------------------------------|-----------------------------------------|------------------------------------------------------|
 | `temporale:roman`                       | `temporale-roman`                       | `.temporale-roman.file-exists`                       |
@@ -139,10 +150,12 @@ Three properties of this rule are load-bearing, and none of them is an accident:
   from the rule because `.` is outside `[A-Za-z0-9_-]`.
 
 Every id the inventory currently publishes yields a fragment matching `^[A-Za-z][A-Za-z0-9_-]*$`, and no two ids
-collide on one fragment. Neither is guaranteed by the substitution alone — an id kind introduced later that began with a
-digit, or that differed from another only in punctuation, would break one or the other — so both are asserted over the
-whole published set in `HealthValidateSourceTest`, and a new id kind that violates either fails the build rather than
-the client.
+collide on one fragment **once lowercased**. Neither is guaranteed by the substitution alone — the substitution is
+many-to-one, so an id kind introduced later that differed from another only in punctuation or only in case would break
+uniqueness, and one beginning with a digit would break the shape — so both are asserted over the whole published set by
+`HealthValidateSourceTest::testEveryPublishedIdIsAddressableThroughValidateSource`, and a new id kind that violates
+either fails the build rather than the client. The uniqueness check compares lowercased fragments for the reason given
+above: a pair that collides only after the client lowers them collides for real.
 
 The steps themselves are `file-exists`, `json-valid` and `schema-valid`, which are **not** the values `/validations`
 publishes in `steps`; see [A caveat on `steps`](#a-caveat-on-steps-not-fixed-here) below.

--- a/docs/superpowers/specs/2026-08-20-typed-target-design.md
+++ b/docs/superpowers/specs/2026-08-20-typed-target-design.md
@@ -262,8 +262,23 @@ unrelated to the reshaping this document describes, and filed separately as
 [#819](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/819); the substantive documentation of the
 caveat lives on the `steps` property itself, in `jsondata/schemas/LitCalValidationsPath.json` and the `/validations`
 description in `openapi.json`, because that is where a client discovers the array in the first place. **`steps` is
-authoritative for its length, not for its values** — sizing a check's progress as `count(steps)` is correct today and
-is exactly what replaces UnitTestInterface#42's four hardcoded `* 3` constants.
+authoritative for its values in no case, and for its length in all but one** — sizing a check's progress as
+`count(steps)` is what replaces UnitTestInterface#42's four hardcoded `* 3` constants, and it is right everywhere
+except the exception below.
+
+### The one place `count(steps)` is wrong today
+
+`Health::processValidationData()` — the **file** branch of a check — emits only **two** frames when the file exists but
+its contents will not decode as JSON: `file-exists` and `json-valid`, and no `schema-valid` at all. A client sizing the
+check at three frames waits forever for the third. `handleValidationDataError()` (file unreadable) correctly emits
+three, and the folder branch was fixed for precisely this in commit `ea29b678` on `development`; the file branch was
+not, and `validateSource` now routes roughly sixty file checks through it.
+
+Deliberately **not** fixed here. Adding the third frame changes v1 `executeValidation` output, and this branch's whole
+guarantee is that it does not. It is filed as a follow-up, and it is distinct from
+[#819](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/819), which is about the step *names* rather
+than the step *count*. Until it lands, a client should treat `count(steps)` as an upper bound on the file branch and
+finish a check on a terminal frame rather than on a full count.
 
 Deliberately not fixed by renaming either vocabulary to match the other: the maintainer's decision is that #806
 section C dissolves this on its own. Once responses are structured and DOM-agnostic, the frame itself carries the step

--- a/jsondata/schemas/LitCalValidationsPath.json
+++ b/jsondata/schemas/LitCalValidationsPath.json
@@ -63,6 +63,7 @@
                     "steps": {
                         "type": "array",
                         "minItems": 1,
+                        "description": "The ordered checks this item passes through when validated. Authoritative for its length, not for its values: a client sizes a check's progress as count(steps), which is correct today, but these step names do not yet correspond to the WebSocket protocol's per-step frame classes (file-exists, json-valid, schema-valid) emitted while a check runs -- nothing in the API relates the two vocabularies. See https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/819.",
                         "items": {
                             "type": "string",
                             "enum": [

--- a/jsondata/schemas/LitCalValidationsPath.json
+++ b/jsondata/schemas/LitCalValidationsPath.json
@@ -63,7 +63,7 @@
                     "steps": {
                         "type": "array",
                         "minItems": 1,
-                        "description": "The ordered checks this item passes through when validated. Authoritative for its length, not for its values: a client sizes a check's progress as count(steps), which is correct today, but these step names do not yet correspond to the WebSocket protocol's per-step frame classes (file-exists, json-valid, schema-valid) emitted while a check runs -- nothing in the API relates the two vocabularies. See https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/819.",
+                        "description": "The ordered checks this item passes through when validated. Its length is an UPPER BOUND on the number of per-step frames a check emits, not an exact count: a file whose JSON fails to decode stops after json-valid and never emits schema-valid, so a client should finish a check when it sees a terminal frame rather than waiting for count(steps) of them. See https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/821. Its values are not the frame classes either: these step names do not yet correspond to the WebSocket protocol's per-step frame classes (file-exists, json-valid, schema-valid), and nothing in the API relates the two vocabularies. See https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/819.",
                         "items": {
                             "type": "string",
                             "enum": [

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -7324,7 +7324,7 @@
           {}
         ],
         "summary": "Retrieve the source data this API can be asked to validate",
-        "description": "Clients iterate this list and send back an item's opaque id, so no filesystem path crosses the wire. Advertising is not verification: an item appearing here does not assert that the underlying data is present, only that it is checkable. Filtering by rite and region is done by the client. Each item's `steps` array is authoritative for its length only -- see the property description on `steps` in LitCalValidationsPath.json for the caveat about its values versus the Health WebSocket protocol's frame classes (issue #819).",
+        "description": "Clients iterate this list and send back an item's opaque id, so no filesystem path crosses the wire. Advertising is not verification: an item appearing here does not assert that the underlying data is present, only that it is checkable. Filtering by rite and region is done by the client. Each item's `steps` array is an upper bound on its length, not an exact frame count -- see the property description on `steps` in LitCalValidationsPath.json for both caveats: the short-circuit on a JSON decode failure (issue #821) and its values versus the Health WebSocket protocol's frame classes (issue #819).",
         "operationId": "validationsGET",
         "responses": {
           "200": {

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -7324,7 +7324,7 @@
           {}
         ],
         "summary": "Retrieve the source data this API can be asked to validate",
-        "description": "Clients iterate this list and send back an item's opaque id, so no filesystem path crosses the wire. Advertising is not verification: an item appearing here does not assert that the underlying data is present, only that it is checkable. Filtering by rite and region is done by the client.",
+        "description": "Clients iterate this list and send back an item's opaque id, so no filesystem path crosses the wire. Advertising is not verification: an item appearing here does not assert that the underlying data is present, only that it is checkable. Filtering by rite and region is done by the client. Each item's `steps` array is authoritative for its length only -- see the property description on `steps` in LitCalValidationsPath.json for the caveat about its values versus the Health WebSocket protocol's frame classes (issue #819).",
         "operationId": "validationsGET",
         "responses": {
           "200": {

--- a/phpunit_tests/HealthCancelRunTest.php
+++ b/phpunit_tests/HealthCancelRunTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ratchet\ConnectionInterface;
@@ -24,6 +25,11 @@ use Ratchet\ConnectionInterface;
 #[CoversClass(Health::class)]
 final class HealthCancelRunTest extends TestCase
 {
+    // These tests seed the queue directly rather than through cachedGet(), so nothing here is
+    // currently dispatched at shutdown — but the protection belongs to anything that builds a
+    // Health, not to whichever file last remembered it. See the trait.
+    use HealthQueueIsolationTrait;
+
     /**
      * A minimal Ratchet connection that records every outbound frame. `resourceId` is a dynamic public
      * property Ratchet assigns and is not part of `ConnectionInterface`, so this mirrors the stub
@@ -107,7 +113,7 @@ final class HealthCancelRunTest extends TestCase
 
     public function testCancellingTheCurrentRunDropsItsQueuedRequestsAndSaysNothing(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection(1);
 
         self::setRunTokens($health, [1 => 'run-a']);
@@ -125,7 +131,7 @@ final class HealthCancelRunTest extends TestCase
 
     public function testUntaggedAndOtherConnectionsRequestsSurvive(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection(1);
 
         self::setRunTokens($health, [1 => 'run-a', 2 => 'run-b']);
@@ -147,7 +153,7 @@ final class HealthCancelRunTest extends TestCase
 
     public function testAStaleCancelDoesNotTouchTheRunThatReplacedIt(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection(1);
 
         // The user stopped and restarted faster than the cancel frame travelled: the connection is
@@ -164,7 +170,7 @@ final class HealthCancelRunTest extends TestCase
 
     public function testACancelWithoutARunTokenIsRejectedAndChangesNothing(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection(1);
 
         self::setRunTokens($health, [1 => 'run-a']);
@@ -197,7 +203,7 @@ final class HealthCancelRunTest extends TestCase
      */
     public function testAnOrdinaryMessageStillStoresItsRunToken(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection(1);
 
         $health->onMessage($conn, (string) json_encode(['action' => 'validateCalendar', 'runToken' => 'run-a']));
@@ -221,7 +227,7 @@ final class HealthCancelRunTest extends TestCase
      */
     public function testACancelWithANonStringRunTokenIsASilentNoOp(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection(1);
 
         self::setRunTokens($health, [1 => 'run-a']);

--- a/phpunit_tests/HealthFolderStepResultTest.php
+++ b/phpunit_tests/HealthFolderStepResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -164,6 +165,53 @@ final class HealthFolderStepResultTest extends TestCase
         foreach ($frames as $frame) {
             self::assertSame('error', $frame->type);
             self::assertSame('run-token-1', $frame->runToken);
+        }
+    }
+
+    /**
+     * The frames quote the folder the *client* named, while the server reads the folder it
+     * derived from the `validate` slug. The two are not the same string: for the reconstructed
+     * i18n slugs a client sends a bare id and the server rebuilds the real path from it, which is
+     * why `runValidationSteps()` takes the caller's folder string as a parameter instead of
+     * quoting the path it reads.
+     *
+     * Nothing pinned this before, so a refactor could have silently swapped one for the other in
+     * six message texts and every assertion would still have passed.
+     */
+    public function testTheFramesQuoteTheFolderTheClientNamedNotTheOneTheServerReads(): void
+    {
+        Router::getApiPaths();
+
+        $derived = strtr(JsonData::NATIONAL_CALENDAR_I18N_FOLDER->path(), ['{nation}' => 'ZZ']);
+
+        $conn   = self::createStubConnection(4);
+        $health = new Health();
+
+        $tokens = new \ReflectionProperty(Health::class, 'runTokens');
+        $tokens->setValue($health, [$conn->resourceId => 'run-token-1']);
+
+        $method = new \ReflectionMethod(Health::class, 'executeValidation');
+        $method->invoke($health, (object) [
+            'action'       => 'executeValidation',
+            'category'     => 'sourceDataCheck',
+            'validate'     => 'national-calendar-ZZ-i18n',
+            'sourceFolder' => 'client/supplied/nonsense',
+        ], $conn);
+
+        $frames = array_map(static fn(string $raw): \stdClass => json_decode($raw), $conn->sent);
+
+        self::assertCount(3, $frames);
+        foreach ($frames as $frame) {
+            self::assertStringContainsString(
+                'Data folder client/supplied/nonsense could not be checked',
+                (string) $frame->text,
+                'the frames must quote the folder the client named'
+            );
+            self::assertStringContainsString(
+                $derived,
+                (string) $frame->text,
+                'and must report on the folder the server derived from the slug and actually read'
+            );
         }
     }
 }

--- a/phpunit_tests/HealthFolderStepResultTest.php
+++ b/phpunit_tests/HealthFolderStepResultTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Ratchet\ConnectionInterface;
@@ -27,6 +28,8 @@ use Ratchet\ConnectionInterface;
 #[CoversClass(Health::class)]
 final class HealthFolderStepResultTest extends TestCase
 {
+    use HealthQueueIsolationTrait;
+
     /**
      * A minimal Ratchet connection that records every outbound frame. `resourceId` is a dynamic
      * public property Ratchet assigns and is not part of `ConnectionInterface`, so this mirrors
@@ -66,7 +69,7 @@ final class HealthFolderStepResultTest extends TestCase
 
         $method = new \ReflectionMethod(Health::class, 'sendFolderStepResult');
         $method->invoke(
-            new Health(),
+            $this->newHealth(),
             $conn,
             'national-calendar-IT-i18n.json-valid',
             $errors,
@@ -141,7 +144,7 @@ final class HealthFolderStepResultTest extends TestCase
         Router::getApiPaths();
 
         $conn   = self::createStubConnection(3);
-        $health = new Health();
+        $health = $this->newHealth();
 
         $tokens = new \ReflectionProperty(Health::class, 'runTokens');
         $tokens->setValue($health, [$conn->resourceId => 'run-token-1']);
@@ -185,7 +188,7 @@ final class HealthFolderStepResultTest extends TestCase
         $derived = strtr(JsonData::NATIONAL_CALENDAR_I18N_FOLDER->path(), ['{nation}' => 'ZZ']);
 
         $conn   = self::createStubConnection(4);
-        $health = new Health();
+        $health = $this->newHealth();
 
         $tokens = new \ReflectionProperty(Health::class, 'runTokens');
         $tokens->setValue($health, [$conn->resourceId => 'run-token-1']);

--- a/phpunit_tests/HealthFolderStepResultTest.php
+++ b/phpunit_tests/HealthFolderStepResultTest.php
@@ -172,6 +172,61 @@ final class HealthFolderStepResultTest extends TestCase
     }
 
     /**
+     * A v1 folder check that *passes* is still addressed by the client's own slug.
+     *
+     * This is the success arm of the folder branch — the three `sendFolderStepResult()` calls that
+     * run once every file promise has resolved — and until this test it was reached in-process only
+     * through a **v2** `validateSource` message. That mattered because splitting the CSS class
+     * fragment out of `$label` inside `runValidationSteps()` touched exactly these three call sites:
+     * a mutation that broke the fragment's default (`$classFragment ??= $label`) failed only the
+     * missing-folder arm and the file branch, leaving the arm that carries roughly sixty real i18n
+     * checks unpinned.
+     *
+     * No fixture is needed. `executeValidation()` re-derives the real i18n folder from the slug for
+     * anything matching `^(wider-region|national-calendar|diocesan-calendar)-([A-Za-z_]+)-i18n$`, so
+     * a v1 message naming `national-calendar-US-i18n` reads the same folder the v2 id
+     * `nation:roman:US:i18n` reads — a folder the suite already proves passes in-process — while the
+     * `sourceFolder` the client sent is ignored for reading and quoted in the text.
+     *
+     * The whole point is byte-identity with what a v1 client received before this branch: a v1
+     * caller passes no class fragment, so the fragment defaults to its `validate` slug and the
+     * frames must be addressed by that slug and nothing else.
+     */
+    public function testAPassingV1FolderCheckIsAddressedByTheClientSlug(): void
+    {
+        Router::getApiPaths();
+
+        $conn   = self::createStubConnection(5);
+        $health = $this->newHealth();
+
+        $tokens = new \ReflectionProperty(Health::class, 'runTokens');
+        $tokens->setValue($health, [$conn->resourceId => 'run-token-1']);
+
+        $validate = 'national-calendar-US-i18n';
+        $method   = new \ReflectionMethod(Health::class, 'executeValidation');
+        $method->invoke($health, (object) [
+            'action'       => 'executeValidation',
+            'category'     => 'sourceDataCheck',
+            'validate'     => $validate,
+            // Ignored for reading — the slug re-derivation above wins — and quoted in the text.
+            'sourceFolder' => 'client/supplied/nonsense',
+        ], $conn);
+
+        $frames = array_map(static fn(string $raw): \stdClass => json_decode($raw), $conn->sent);
+
+        self::assertCount(3, $frames, 'a folder check reports exactly one frame per step');
+        self::assertSame(
+            [".$validate.file-exists", ".$validate.json-valid", ".$validate.schema-valid"],
+            array_map(static fn(\stdClass $f): string => $f->classes, $frames),
+            'a v1 folder check must still be addressed by its own slug, unchanged'
+        );
+        foreach ($frames as $frame) {
+            self::assertSame('success', $frame->type, "the US i18n folder failed its own check: {$frame->text}");
+            self::assertSame('run-token-1', $frame->runToken);
+        }
+    }
+
+    /**
      * The frames quote the folder the *client* named, while the server reads the folder it
      * derived from the `validate` slug. The two are not the same string: for the reconstructed
      * i18n slugs a client sends a bare id and the server rebuilds the real path from it, which is

--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -11,6 +11,7 @@ use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\BrokenInventoryTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Health::class)]
 final class HealthSchemaCategoryTest extends TestCase
 {
+    use BrokenInventoryTrait;
+
     private static bool $routerInitialized = false;
 
     /**
@@ -115,8 +118,12 @@ final class HealthSchemaCategoryTest extends TestCase
             'national calendar'    => ['national-calendar-US', LitSchema::NATIONAL, 'nation:roman:US'],
             'diocesan calendar'    => ['diocesan-calendar-romamo_it', LitSchema::DIOCESAN, 'diocese:roman:romamo_it'],
             'decrees'              => ['memorials-from-decrees', LitSchema::DECREES_SRC, 'decrees:roman'],
-            // The slug is rite-blind — its pattern is `tests-<name>` — while ids are not, and this
-            // particular test definition exists only in the Ambrosian folder.
+            // The two vocabularies are NOT one-to-one, and this row is the standing evidence:
+            // the slug is rite-blind — its pattern is `tests-<name>`, and it resolves to TEST_SRC
+            // whatever the rite — while every inventory id is rite-qualified. One slug therefore
+            // maps to as many ids as there are rites holding a definition of that name, and the
+            // right one cannot be derived from the slug. This definition happens to exist only in
+            // the Ambrosian folder, so `test:roman:StIgnatiusOfLoyolaTest` resolves to nothing.
             'test definition'      => ['tests-StIgnatiusOfLoyolaTest', LitSchema::TEST_SRC, 'test:ambrosian:StIgnatiusOfLoyolaTest'],
             'i18n folder suffix'   => ['national-calendar-US-i18n', LitSchema::I18N, 'nation:roman:US:i18n'],
             'decrees i18n'         => ['memorials-from-decrees-i18n', LitSchema::I18N, 'decrees:roman:i18n'],
@@ -494,76 +501,6 @@ final class HealthSchemaCategoryTest extends TestCase
     }
 
     // ---------------------------------------------------------------- a broken inventory is contained
-
-    /**
-     * Runs `$fn` with `CheckableInventory` pointed at a source tree containing one malformed
-     * national calendar file, so that every inventory lookup throws.
-     *
-     * This is the real failure, not a simulated one: the inventory enumerates per-calendar items via
-     * `CalendarMetadataProvider::create()`, which JSON-parses every national and diocesan calendar
-     * file, so a single unparseable file makes `all()` — and therefore `byPath()` and `byId()` —
-     * throw. Only the malformed file needs to exist: national calendars are built first, so the
-     * build aborts before it looks for anything else.
-     *
-     * The memoized statics are reset on the way in *and* on the way out: in on so the poisoned tree
-     * is actually read rather than a good index being served from an earlier test, out so the next
-     * test rebuilds against the real tree.
-     */
-    private static function withBrokenInventory(callable $fn): void
-    {
-        $savedApiFilePath = Router::$apiFilePath;
-        $root             = sys_get_temp_dir() . '/health-broken-inventory-' . getmypid() . '-' . uniqid() . '/';
-        $nationFolder     = $root . JsonData::NATIONAL_CALENDARS_FOLDER->value . '/ZZ';
-
-        self::assertTrue(mkdir($nationFolder, 0777, true), 'could not build the fixture source tree');
-        file_put_contents($nationFolder . '/ZZ.json', '{ this is not JSON');
-
-        Router::$apiFilePath = $root;
-        self::resetInventoryMemo();
-
-        try {
-            // Guard: if this ever stops throwing, the tests below would pass for the wrong reason.
-            try {
-                CheckableInventory::all();
-                self::fail('the fixture tree no longer breaks the inventory — this test proves nothing');
-            } catch (\JsonException) {
-                // expected
-            }
-
-            $fn();
-        } finally {
-            Router::$apiFilePath = $savedApiFilePath;
-            self::resetInventoryMemo();
-            @unlink($nationFolder . '/ZZ.json');
-            self::removeDirectoryTree($root);
-        }
-    }
-
-    private static function resetInventoryMemo(): void
-    {
-        $inventory = new \ReflectionClass(CheckableInventory::class);
-        $inventory->setStaticPropertyValue('items', null);
-        $inventory->setStaticPropertyValue('metadata', null);
-    }
-
-    private static function removeDirectoryTree(string $root): void
-    {
-        if (false === is_dir($root)) {
-            return;
-        }
-
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST
-        );
-
-        /** @var \SplFileInfo $entry */
-        foreach ($iterator as $entry) {
-            $entry->isDir() ? @rmdir($entry->getPathname()) : @unlink($entry->getPathname());
-        }
-
-        @rmdir($root);
-    }
 
     /**
      * One malformed calendar file must not take out schema resolution for every unrelated check.

--- a/phpunit_tests/HealthSchemaCategoryTest.php
+++ b/phpunit_tests/HealthSchemaCategoryTest.php
@@ -97,29 +97,59 @@ final class HealthSchemaCategoryTest extends TestCase
     /**
      * `sourceDataCheck` resolves from the `validate` SLUG.
      *
-     * @return array<string, array{string, LitSchema}>
+     * The third column is the inventory id that names the *same* artifact — the address a
+     * `validateSource` message carries (#806 section C). Both columns are here rather than in two
+     * providers because the pairing is the assertion: a slug and its id are two spellings of one
+     * target, and the day they stop resolving alike is the day a client migrating from one to the
+     * other silently starts checking something else against the wrong schema.
+     *
+     * @return array<string, array{string, LitSchema, string}>
      */
     public static function sourceDataCheckSlugProvider(): array
     {
         return [
-            'temporale'            => ['proprium-de-tempore', LitSchema::PROPRIUMDETEMPORE],
-            'editio typica missal' => ['proprium-de-sanctis-2002', LitSchema::PROPRIUMDESANCTIS],
-            'regional missal'      => ['proprium-de-sanctis-IT-1983', LitSchema::PROPRIUMDESANCTIS],
-            'wider region'         => ['wider-region-Europe', LitSchema::WIDERREGION],
-            'national calendar'    => ['national-calendar-US', LitSchema::NATIONAL],
-            'diocesan calendar'    => ['diocesan-calendar-romamo_it', LitSchema::DIOCESAN],
-            'decrees'              => ['memorials-from-decrees', LitSchema::DECREES_SRC],
-            'test definition'      => ['tests-StIgnatiusOfLoyolaTest', LitSchema::TEST_SRC],
-            'i18n folder suffix'   => ['national-calendar-US-i18n', LitSchema::I18N],
-            'decrees i18n'         => ['memorials-from-decrees-i18n', LitSchema::I18N],
-            'temporale i18n'       => ['proprium-de-tempore-i18n', LitSchema::I18N],
+            'temporale'            => ['proprium-de-tempore', LitSchema::PROPRIUMDETEMPORE, 'temporale:roman'],
+            'editio typica missal' => ['proprium-de-sanctis-2002', LitSchema::PROPRIUMDESANCTIS, 'sanctorale:roman:EDITIO_TYPICA_2002'],
+            'regional missal'      => ['proprium-de-sanctis-IT-1983', LitSchema::PROPRIUMDESANCTIS, 'sanctorale:roman:IT_1983'],
+            'wider region'         => ['wider-region-Europe', LitSchema::WIDERREGION, 'widerregion:roman:Europe'],
+            'national calendar'    => ['national-calendar-US', LitSchema::NATIONAL, 'nation:roman:US'],
+            'diocesan calendar'    => ['diocesan-calendar-romamo_it', LitSchema::DIOCESAN, 'diocese:roman:romamo_it'],
+            'decrees'              => ['memorials-from-decrees', LitSchema::DECREES_SRC, 'decrees:roman'],
+            // The slug is rite-blind — its pattern is `tests-<name>` — while ids are not, and this
+            // particular test definition exists only in the Ambrosian folder.
+            'test definition'      => ['tests-StIgnatiusOfLoyolaTest', LitSchema::TEST_SRC, 'test:ambrosian:StIgnatiusOfLoyolaTest'],
+            'i18n folder suffix'   => ['national-calendar-US-i18n', LitSchema::I18N, 'nation:roman:US:i18n'],
+            'decrees i18n'         => ['memorials-from-decrees-i18n', LitSchema::I18N, 'decrees:roman:i18n'],
+            'temporale i18n'       => ['proprium-de-tempore-i18n', LitSchema::I18N, 'temporale:roman:i18n'],
         ];
     }
 
     #[DataProvider('sourceDataCheckSlugProvider')]
-    public function testSourceDataCheckResolvesFromTheValidateSlug(string $slug, LitSchema $expected): void
+    public function testSourceDataCheckResolvesFromTheValidateSlug(string $slug, LitSchema $expected, string $id): void
     {
         self::assertSame($expected->path(), self::retrieveSchemaForCategory('sourceDataCheck', $slug));
+    }
+
+    /**
+     * The equivalence oracle for #806 section C: the id is the same address as the slug.
+     *
+     * `retrieveSchemaForCategory()` is asked both ways round, so this pins the *pair* rather than
+     * either half — the inventory id must reach the schema the anchored slug patterns reach, for
+     * every kind of source data the legacy vocabulary covers.
+     */
+    #[DataProvider('sourceDataCheckSlugProvider')]
+    public function testAnInventoryIdResolvesToTheSameSchemaAsItsLegacySlug(string $slug, LitSchema $expected, string $id): void
+    {
+        self::assertSame(
+            self::retrieveSchemaForCategory('sourceDataCheck', $slug),
+            self::retrieveSchemaForCategory('sourceDataCheck', $id),
+            "{$id} and {$slug} name the same artifact and must resolve to the same schema"
+        );
+        self::assertSame($expected->path(), self::retrieveSchemaForCategory('sourceDataCheck', $id));
+
+        $item = CheckableInventory::byId($id);
+        self::assertNotNull($item, "the inventory publishes no item with id {$id}");
+        self::assertSame($expected, $item->schema, "the published item {$id} carries the wrong schema");
     }
 
     public function testSourceDataCheckRejectsAnUnrecognisedSlug(): void

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -985,8 +985,110 @@ final class HealthTypedCalendarTest extends TestCase
     }
 
     /**
-     * `runTest` retires `category` and nothing else, because there is nothing else to retire:
-     * `ACTION_PROPERTIES['executeUnitTest']` is `['category', 'calendar', 'year', 'test']`, so no
+     * A top-level `rite` is retired on both calendar actions, and it is the retired property whose
+     * silent acceptance would do real damage.
+     *
+     * `rite` was **optional** on v1 `validateCalendar` and on `executeUnitTest` — read by
+     * `readRiteHint()`, honoured by `resolveRite()` — and the v2 shapes moved it inside
+     * `calendar.rite` and stopped reading the top-level one. So a client that objectified `calendar`
+     * but kept its old `rite` gets a *rite disagreement* ignored, which is the one thing the typed
+     * identity went out of its way to make loud: `resolveCalendarIdentity()` refuses to pick a
+     * winner when `calendar.rite` contradicts the calendar's actual rite, and a stale top-level
+     * `rite` reintroduces exactly that ambiguity one level up.
+     *
+     * The payloads deliberately carry a `rite` that **agrees** with `calendar.rite`, so what is
+     * rejected is the retired property itself and not a disagreement — the message would otherwise
+     * be dispatched perfectly and say nothing.
+     *
+     * This property was missed by the original retired-property audit because that audit derived the
+     * retired set from `ACTION_PROPERTIES`, which lists only *required* properties. Optional v1
+     * properties were structurally invisible to it; see `Health::RETIRED_PROPERTIES`.
+     *
+     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function retiredRiteMessageProvider(): array
+    {
+        return [
+            'validateCalendar' => [
+                [
+                    'action'         => 'validateCalendar',
+                    'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+                    'year'           => 2026,
+                    'responseFormat' => 'JSON',
+                    'rite'           => 'roman'
+                ],
+                'rite is not part of a validateCalendar message with an object calendar: calendar.rite replaces it.'
+            ],
+            'runTest'          => [
+                [
+                    'action'   => 'runTest',
+                    'test'     => 'StIgnatiusOfLoyolaTest',
+                    'calendar' => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+                    'year'     => 2026,
+                    'rite'     => 'roman'
+                ],
+                'rite is not part of a runTest message: calendar.rite replaces it.'
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('retiredRiteMessageProvider')]
+    public function testALeftoverTopLevelRiteIsRejected(array $payload, string $expectedText): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, $payload);
+
+        self::assertCount(1, $conn->sent, 'a half-migrated message is answered once and not dispatched');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame($expectedText, $frame->text);
+        self::assertSame([], self::queuedPaths($health), 'a rejected message must not have queued a request');
+    }
+
+    /**
+     * The rule must not reach the v1 actions it is named after: `rite` is a *current, supported*
+     * optional hint on the string form of `validateCalendar` and on `executeUnitTest`, and a rule
+     * that swept it up there would delete v1 rite awareness (issue #767) rather than guard the v2
+     * shapes. The queued path is what is asserted, because that is where the hint has its effect —
+     * an accepted-but-ignored `rite` would leave no trace in the frames.
+     *
+     * The hint deliberately *contradicts* what the metadata says, so the assertion distinguishes a
+     * hint that was honoured from a rite that was merely looked up: `rotter_nl` is Roman in the
+     * fixture, and only the top-level `rite` can put `/ambrosian/` in front of it.
+     */
+    public function testTheV1ShapeStillHonoursATopLevelRite(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn): void {
+            self::send($health, $conn, [
+                'action'       => 'validateCalendar',
+                'calendar'     => 'rotter_nl',
+                'category'     => 'diocesancalendar',
+                'year'         => 2026,
+                'responsetype' => 'JSON',
+                'rite'         => 'ambrosian'
+            ]);
+        });
+
+        self::assertSame([], $conn->sent, 'the legacy shape was refused a property it still supports');
+        self::assertSame(
+            '/ambrosian/diocese/rotter_nl/2026?year_type=CIVIL',
+            self::soleQueuedPath($health),
+            'the v1 rite hint stopped reaching the request path'
+        );
+    }
+
+    /**
+     * `runTest` retires `category` and `rite`, and no third property, because there is no third
+     * property to retire: `ACTION_PROPERTIES['executeUnitTest']` is
+     * `['category', 'calendar', 'year', 'test']` and its only optional property was `rite`, so no
      * `responsetype` ever named anything on it. A rule that invented one would reject a property no
      * client was ever told to send, for a reason that is not true.
      */

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -254,9 +254,14 @@ final class HealthTypedCalendarTest extends TestCase
 
     /**
      * The mirrored half-migration, asserted rather than reasoned about: a typed `calendar` with the
-     * *old* spelling of the format. It needs no check of its own — `responseFormat` is a required
-     * property of this shape, so its absence fails the property list — but "needs no check" is a
-     * claim about behaviour, and behaviour is what tests are for.
+     * *old* spelling of the format and no new one. This is the **absent-`responseFormat`** reading,
+     * and it is answered by the property list, which requires `responseFormat` — so the message
+     * never reaches a handler and the answer is the generic protocol error.
+     *
+     * Sending `responsetype` *alongside* a correct `responseFormat` is a different case with a
+     * different answer; see `testResponsetypeAlongsideResponseFormatIsRejected()`. Keeping the two
+     * readings separate is the point: one is a missing required property, the other is a retired one
+     * still being sent.
      */
     public function testTheOldSpellingOfTheFormatOnTheObjectFormIsRejected(): void
     {
@@ -706,13 +711,19 @@ final class HealthTypedCalendarTest extends TestCase
      * `TypeError` — an `\Error`, which Ratchet's `IoServer::handleData` does not catch, so one
      * malformed message would take the whole WebSocket process down rather than be answered.
      *
+     * Every row here has its property **present**, which is what carries it past the property list
+     * and into the handler these rejections belong to. A property that is genuinely absent never
+     * gets that far — see `testRunTestRequiresItsThreeProperties()`, which is a different code path
+     * with a different answer. `null` is the case most easily mistaken for absence and is therefore
+     * spelled `test null`, not `test missing`.
+     *
      * @return array<string, array{0: array<string, mixed>, 1: string}>
      */
     public static function runTestMalformedScalarProvider(): array
     {
         return [
             'test not a string' => [['test' => 42], 'runTest test must be a string.'],
-            'test missing'      => [['test' => null], 'runTest test must be a string.'],
+            'test null'         => [['test' => null], 'runTest test must be a string.'],
             'year not an int'   => [['year' => '2026'], 'runTest year must be an integer.'],
             'year null'         => [['year' => null], 'runTest year must be an integer.'],
         ];
@@ -899,6 +910,151 @@ final class HealthTypedCalendarTest extends TestCase
         $frame = json_decode($crossConn->sent[0]);
         self::assertSame('echobot', $frame->type);
         self::assertSame('Unknown validation target: StIgnatiusOfLoyolaTest', $frame->text, 'the bare test name is a runTest address, not an inventory id');
+    }
+
+    // ---------------------------------------------------------------- retired properties
+
+    /**
+     * Task 3 accepted this and the maintainer has overruled it.
+     *
+     * The old reasoning was that `responsetype` sent alongside a correct `responseFormat` is stale
+     * noise from a client that has already done the rename right, not a misunderstanding about what
+     * names the format. That is exactly backwards as a diagnostic: a client still sending the old
+     * property has *not* finished migrating, and this is the cheapest moment it will ever get to
+     * find out — the message works today because `responseFormat` is what gets read, and it breaks
+     * the day the legacy branch is removed.
+     *
+     * The message names the property and its replacement, so a migrating client is told what to do
+     * rather than only that it is wrong.
+     */
+    public function testResponsetypeAlongsideResponseFormatIsRejected(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            // Both spellings, and — note — naming the same format, so this message would otherwise
+            // be dispatched correctly and say nothing.
+            'responseFormat' => 'JSON',
+            'responsetype'   => 'JSON'
+        ]);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame(
+            'responsetype is not part of a validateCalendar message with an object calendar: responseFormat replaces it.',
+            $frame->text
+        );
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    /**
+     * The same rule on `runTest`, and the reason it is not merely symmetry: `runTest`'s predecessor
+     * `executeUnitTest` *required* `category`, so a client that renamed the action and kept the
+     * property is the likeliest half-migration there is. `calendar.kind` supplies the category, so
+     * the message would otherwise work while the client kept believing `category` selected it.
+     */
+    public function testALeftoverCategoryOnRunTestIsRejected(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn): void {
+            self::send($health, $conn, [
+                'action'   => 'runTest',
+                'test'     => 'StIgnatiusOfLoyolaTest',
+                'calendar' => ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'ambrosian'],
+                // Left over from executeUnitTest, and naming the very category `kind` implies.
+                'category' => 'diocesancalendar',
+                'year'     => 2026
+            ]);
+        });
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('category is not part of a runTest message: calendar.kind replaces it.', $frame->text);
+        self::assertSame([], self::queuedPaths($health), 'a rejected message must not have queued a request');
+    }
+
+    /**
+     * `runTest` retires `category` and nothing else, because there is nothing else to retire:
+     * `ACTION_PROPERTIES['executeUnitTest']` is `['category', 'calendar', 'year', 'test']`, so no
+     * `responsetype` ever named anything on it. A rule that invented one would reject a property no
+     * client was ever told to send, for a reason that is not true.
+     */
+    public function testRunTestDoesNotRetireAResponsetypeItNeverHad(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'       => 'runTest',
+            'test'         => 'StIgnatiusOfLoyolaTest',
+            'calendar'     => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'         => 2026,
+            'responsetype' => 'JSON'
+        ]);
+
+        self::assertSame([], $conn->sent, 'runTest rejected a property that was never part of executeUnitTest');
+        self::assertSame('/roman/nation/IT/2026?year_type=CIVIL', self::soleQueuedPath($health));
+    }
+
+    /**
+     * `runToken` is shared, current, and retired by nothing — a rule that swept it up would break
+     * run correlation on every v2 message at once, which is the failure mode a blanket
+     * "reject unknown properties" would have had.
+     *
+     * Tolerating it is not enough to assert, so the queued request's own `runToken` tag is what is
+     * checked: that is what `processQueue()` reads to drop the backlog of a superseded run, so a
+     * token that arrived and was discarded would look identical from the frames alone.
+     *
+     * @return array<string, array{0: array<string, mixed>}>
+     */
+    public static function runTokenBearingMessageProvider(): array
+    {
+        return [
+            'validateCalendar' => [
+                [
+                    'action'         => 'validateCalendar',
+                    'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+                    'year'           => 2026,
+                    'responseFormat' => 'JSON',
+                    'runToken'       => 'run-a'
+                ]
+            ],
+            'runTest'          => [
+                [
+                    'action'   => 'runTest',
+                    'test'     => 'StIgnatiusOfLoyolaTest',
+                    'calendar' => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+                    'year'     => 2026,
+                    'runToken' => 'run-a'
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('runTokenBearingMessageProvider')]
+    public function testARunTokenIsNotARetiredProperty(array $payload): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, $payload);
+
+        self::assertSame([], $conn->sent, 'a runToken was mistaken for a retired property');
+        self::assertSame('/roman/nation/IT/2026?year_type=CIVIL', self::soleQueuedPath($health));
+
+        $queued = self::queuedRequests($health);
+        self::assertSame('run-a', $queued[0]['runToken'], 'the run token reached the queue, where cancelRun reads it');
     }
 
     // ---------------------------------------------------------------- harness

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -42,43 +43,13 @@ use Ratchet\ConnectionInterface;
 #[CoversClass(Health::class)]
 final class HealthTypedCalendarTest extends TestCase
 {
-    /** @var list<Health> every instance this test created, so tearDown can defuse its queue */
-    private array $healths = [];
+    // Every Health here queues a real calendar URL; see the trait for why that must be defused.
+    use HealthQueueIsolationTrait;
 
     public static function setUpBeforeClass(): void
     {
         // Route::CALENDAR->path() is built from the resolved API paths.
         Router::getApiPaths();
-    }
-
-    /**
-     * Empty the request queue of every Health this test built.
-     *
-     * Not hygiene — necessary. `cachedGet()` parks the request *and* registers a ReactPHP
-     * `futureTick`, and `React\EventLoop\Loop` installs a shutdown function that runs the loop when
-     * the process ends. Without this, every queued URL would be fetched for real at the end of the
-     * PHPUnit run: the suite would start depending on an API server being up, and would hammer it
-     * with dozens of full calendar computations to no purpose. `drainHandler()` stops ticking the
-     * moment it finds nothing queued and nothing in flight, so emptying the queue is enough.
-     */
-    protected function tearDown(): void
-    {
-        $queue = new \ReflectionProperty(Health::class, 'queue');
-        foreach ($this->healths as $health) {
-            $queue->setValue($health, []);
-        }
-        $this->healths = [];
-    }
-
-    /**
-     * A Health whose queue tearDown will defuse. Always use this rather than `new Health()`.
-     */
-    private function newHealth(): Health
-    {
-        $health          = new Health();
-        $this->healths[] = $health;
-
-        return $health;
     }
 
     // ---------------------------------------------------------------- the typed identity dispatches
@@ -220,6 +191,65 @@ final class HealthTypedCalendarTest extends TestCase
         self::assertSame([], self::queuedPaths($health), 'an invalid message must not have queued a request');
     }
 
+    // ---------------------------------------------------------------- half-migrated clients
+
+    /**
+     * The failure mode this guards against is a message that *works*.
+     *
+     * A client that typed its `calendar` but left `category` behind gets the right calendar anyway —
+     * `calendar.kind` supplies the category and the stale property is simply never read — so nothing
+     * tells it that `category` has stopped meaning anything. It finds out the day the two disagree,
+     * which is the worst possible day. Silently-correct is not the same as correct.
+     */
+    public function testALeftoverCategoryOnTheObjectFormIsRejected(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn): void {
+            self::send($health, $conn, [
+                'action'         => 'validateCalendar',
+                'calendar'       => ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'ambrosian'],
+                // Left over from the v1 shape, and — note — naming the very category `kind` implies,
+                // so this message would otherwise be dispatched correctly and say nothing.
+                'category'       => 'diocesancalendar',
+                'year'           => 2026,
+                'responseFormat' => 'JSON'
+            ]);
+        });
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('category is not part of a validateCalendar message with an object calendar: calendar.kind replaces it.', $frame->text);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    /**
+     * The mirrored half-migration, asserted rather than reasoned about: a typed `calendar` with the
+     * *old* spelling of the format. It needs no check of its own — `responseFormat` is a required
+     * property of this shape, so its absence fails the property list — but "needs no check" is a
+     * claim about behaviour, and behaviour is what tests are for.
+     */
+    public function testTheOldSpellingOfTheFormatOnTheObjectFormIsRejected(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'       => 'validateCalendar',
+            'calendar'     => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'         => 2026,
+            'responsetype' => 'JSON'
+        ]);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
     // ---------------------------------------------------------------- the response format
 
     /**
@@ -304,12 +334,9 @@ final class HealthTypedCalendarTest extends TestCase
     /**
      * The rite-disagreement rejections, one per kind that can be checked.
      *
-     * A `rite` on a v1 message is a *hint*: `resolveRite()` prefers it whenever it parses, which is
-     * the right thing to do for a value the client may have guessed at. On a v2 message it is an
-     * *assertion* about a calendar the server already knows the rite of, and an assertion that is
-     * wrong is a client bug. Preferring the assertion would compute the wrong calendar silently;
-     * preferring the metadata would compute the right one while leaving the client convinced of
-     * something false. Saying so is more useful than either.
+     * Why a wrong `rite` is rejected rather than resolved is argued once, in
+     * `Health::resolveCalendarIdentity()`'s docblock; these rows are that argument's coverage, one
+     * per kind whose actual rite the server can establish.
      *
      * @return array<string, array{0: array<string, mixed>}>
      */
@@ -416,12 +443,19 @@ final class HealthTypedCalendarTest extends TestCase
     public static function malformedIdentityProvider(): array
     {
         return [
-            'kind missing'      => [['id' => 'IT', 'rite' => 'roman'], 'calendar.kind must be a string naming one of: general, national, diocesan, rite.'],
-            'kind not a string' => [['kind' => 42, 'id' => 'IT', 'rite' => 'roman'], 'calendar.kind must be a string naming one of: general, national, diocesan, rite.'],
-            'rite missing'      => [['kind' => 'national', 'id' => 'IT'], 'calendar.rite must be a string naming a known rite.'],
-            'rite unknown'      => [['kind' => 'national', 'id' => 'IT', 'rite' => 'byzantine'], 'Unknown rite: byzantine'],
-            'id missing'        => [['kind' => 'national', 'rite' => 'roman'], 'calendar.id is required for kind national.'],
-            'id not a string'   => [['kind' => 'diocesan', 'id' => 42, 'rite' => 'roman'], 'calendar.id must be a string.'],
+            'kind missing'         => [['id' => 'IT', 'rite' => 'roman'], 'calendar.kind must be a string naming one of: general, national, diocesan, rite.'],
+            'kind not a string'    => [['kind' => 42, 'id' => 'IT', 'rite' => 'roman'], 'calendar.kind must be a string naming one of: general, national, diocesan, rite.'],
+            'rite missing'         => [['kind' => 'national', 'id' => 'IT'], 'calendar.rite must be a string naming a known rite.'],
+            'rite unknown'         => [['kind' => 'national', 'id' => 'IT', 'rite' => 'byzantine'], 'Unknown rite: byzantine'],
+            'id missing'           => [['kind' => 'national', 'rite' => 'roman'], 'calendar.id is required for kind national.'],
+            'id not a string'      => [['kind' => 'diocesan', 'id' => 42, 'rite' => 'roman'], 'calendar.id must be a string.'],
+            // `general` accepts no id but `roman`. The message must not name a kind to try instead:
+            // `IT` would want `national`, and `kind: rite` — the obvious thing to suggest — rejects
+            // `IT` in turn, so the advice would point at another failure.
+            'nation id on general' => [['kind' => 'general', 'id' => 'IT', 'rite' => 'roman'], 'Kind general names the General Roman Calendar; its only valid id is roman, not IT.'],
+            // The same message for an id that *is* a rite, which is the case a "use kind rite"
+            // wording would have got right and is exactly why it read as good advice.
+            'rite id on general'   => [['kind' => 'general', 'id' => 'ambrosian', 'rite' => 'roman'], 'Kind general names the General Roman Calendar; its only valid id is roman, not ambrosian.'],
         ];
     }
 
@@ -589,6 +623,13 @@ final class HealthTypedCalendarTest extends TestCase
      * the genuinely uninitialised state. When it started out uninitialised we therefore leave an
      * *empty* MetadataCalendars behind rather than the fixture, so a later test in the same process
      * cannot resolve `lugano_ch` or `rotter_nl` from data this helper invented.
+     *
+     * **Warning for a future test.** Calling this leaves `Health::$metadata` initialised for the
+     * rest of the process — empty, but initialised. `findDioceseMetadata()` has two failure arms and
+     * only the `NotFoundException` one is reachable afterwards; its `\RuntimeException` arm needs
+     * `isset(self::$metadata) === false`, which nothing can restore. A test written against that arm
+     * would pass or fail depending on which file PHPUnit loaded first. Reach it in a process that
+     * has not touched this helper, or not at all.
      */
     private static function withMetadata(callable $fn): void
     {

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -14,7 +15,16 @@ use PHPUnit\Framework\TestCase;
 use Ratchet\ConnectionInterface;
 
 /**
- * `validateCalendar` with a typed calendar identity — #806 section D.
+ * The typed calendar identity — #806 sections D and E.
+ *
+ * Two actions carry one, and they live in the same file because the identity is what they share:
+ * `validateCalendar` (section D), which computes a calendar and validates the response, and
+ * `runTest` (section E), which computes a calendar and runs one named unit test against it. The
+ * `kind`→category mapping and the rite-disagreement check are resolved once, by
+ * `Health::resolveCalendarIdentity()`, for both — so the rejection rules asserted below are asserted
+ * for one implementation, not for two copies that could drift apart.
+ *
+ * ## `validateCalendar`
  *
  * The action keeps its name because the action is unchanged: compute a calendar for a year and
  * validate the response. What changes is how the calendar is named. A v1 message spreads the
@@ -30,6 +40,16 @@ use Ratchet\ConnectionInterface;
  *
  * Nothing legacy is touched: a string `calendar` still takes the old path byte for byte.
  *
+ * ## `runTest`
+ *
+ * `runTest` replaces `executeUnitTest` the way `validateSource` replaced the `executeValidation`
+ * slugs: by taking a **new name**, which is the whole of its discrimination — a v1 client cannot
+ * accidentally emit a name it does not know, so there is no shape to test. It carries a `test` name,
+ * the same `CalendarIdentity`, and a year; there is no `responseFormat`, because a test runs against
+ * the parsed calendar rather than against a chosen representation of it.
+ *
+ * `executeUnitTest` keeps working byte for byte, and is asserted below to.
+ *
  * ## What these tests assert against
  *
  * `validateCalendar()` is asynchronous — it hands a URL to `cachedGet()`, which appends it to
@@ -38,7 +58,14 @@ use Ratchet\ConnectionInterface;
  * dispatch made: the URL encodes the category (`/nation/`, `/diocese/`, or neither), the calendar
  * id and the rite segment, and the request options carry the Accept header the response format
  * chose. That is the whole of what this task decides, observable without a WebSocket server, an
- * HTTP API, or a mock of the method under test.
+ * HTTP API, or a mock of the method under test. `executeUnitTest()` queues the same way, so the same
+ * assertions reach it.
+ *
+ * One thing the queued URL does *not* record is which test `runTest` asked for — that is closed over
+ * by the promise handlers rather than written into the request. {@see failSoleQueuedRequest()}
+ * settles the queued entry as a failure, which makes `executeUnitTest()` emit the frame it addresses
+ * `.<test>.year-<year>.test-valid`; that frame names the test, the category, the calendar id and the
+ * URL at once, which is the whole dispatch in a single observation and still no network.
  */
 #[CoversClass(Health::class)]
 final class HealthTypedCalendarTest extends TestCase
@@ -527,6 +554,353 @@ final class HealthTypedCalendarTest extends TestCase
         self::assertSame([], self::queuedPaths($health));
     }
 
+    // ---------------------------------------------------------------- runTest: the identity is the same identity
+
+    /**
+     * The same rows as `validateCalendar`, deliberately: `runTest` resolves its calendar through the
+     * very same `resolveCalendarIdentity()`, so the two actions must agree about what every identity
+     * names. A row that passed here and failed there — or the reverse — would mean the mapping had
+     * been copied rather than shared, which is the one outcome this task exists to prevent.
+     *
+     * @param array<string, mixed> $calendar
+     */
+    #[DataProvider('typedIdentityProvider')]
+    public function testRunTestReachesTheCalendarRequestItsIdentityNames(array $calendar, string $expectedPath): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn, $calendar): void {
+            self::send($health, $conn, [
+                'action'   => 'runTest',
+                'test'     => 'StIgnatiusOfLoyolaTest',
+                'calendar' => $calendar,
+                'year'     => 2026
+            ]);
+        });
+
+        self::assertSame([], $conn->sent, 'a well-formed runTest must not be answered with a frame before its calendar is fetched');
+        self::assertSame($expectedPath, self::soleQueuedPath($health));
+    }
+
+    /**
+     * The dispatch in full: the test name, the mapped category, the id and the rite, all four read
+     * back off the frame `executeUnitTest()` emits.
+     *
+     * The queued URL alone would leave the test name unasserted — it is closed over by the promise
+     * handler, not written into the request — and a `runTest` that dropped or transposed `test`
+     * would fetch exactly the right calendar and then run the wrong test, or none. Settling the
+     * queued request as a failure is what makes that observable here.
+     *
+     * `diocesancalendar` in the text is the assertion that `kind: diocesan` was *mapped* rather than
+     * passed through: `diocesan` is the wire word and `diocesancalendar` is the internal one, and
+     * only the internal one builds a `/diocese/` URL.
+     */
+    public function testRunTestCarriesTheTestNameAndTheMappedCategoryIntoTheRun(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn): void {
+            self::send($health, $conn, [
+                'action'   => 'runTest',
+                'test'     => 'StIgnatiusOfLoyolaTest',
+                'calendar' => ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'ambrosian'],
+                'year'     => 2026
+            ]);
+        });
+
+        self::failSoleQueuedRequest($health);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('error', $frame->type);
+        self::assertSame('.StIgnatiusOfLoyolaTest.year-2026.test-valid', $frame->classes, 'the frame a client matches on must name the test that was asked for');
+        self::assertStringContainsString(
+            'The diocesancalendar of lugano_ch for the year 2026 was not retrieved at the URL '
+                . \LiturgicalCalendar\Api\Enum\Route::CALENDAR->path() . '/ambrosian/diocese/lugano_ch/2026?year_type=CIVIL',
+            (string) $frame->text
+        );
+    }
+
+    // ---------------------------------------------------------------- runTest: rejections
+
+    /**
+     * The rejection rules are `resolveCalendarIdentity()`'s, so these two rows are not a second
+     * corpus — they are the assertion that `runTest` reaches the same resolver rather than a copy of
+     * it. `lugano_ch` is one of the four Ambrosian dioceses, so `rite: roman` contradicts what
+     * `/calendars` says and must be refused rather than quietly corrected.
+     *
+     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function runTestRejectedIdentityProvider(): array
+    {
+        return [
+            'unknown kind'      => [
+                ['kind' => 'widerregion', 'id' => 'Europe', 'rite' => 'roman'],
+                'Unknown calendar kind: widerregion'
+            ],
+            'rite disagreement' => [
+                ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'roman'],
+                'calendar.rite says roman but lugano_ch is ambrosian.'
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $calendar
+     */
+    #[DataProvider('runTestRejectedIdentityProvider')]
+    public function testRunTestRefusesAnIdentityItCannotHonour(array $calendar, string $expected): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn, $calendar): void {
+            self::send($health, $conn, [
+                'action'   => 'runTest',
+                'test'     => 'StIgnatiusOfLoyolaTest',
+                'calendar' => $calendar,
+                'year'     => 2026
+            ]);
+        });
+
+        self::assertCount(1, $conn->sent, 'an unusable identity is answered once and no test is run');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type, 'rejections reuse the echobot shape: since UnitTestInterface#46 an unknown type is painted as a failed check');
+        self::assertSame($expected, $frame->text);
+        self::assertSame([], self::queuedPaths($health), 'a rejected message must not have queued a request');
+    }
+
+    /**
+     * `runTest` needs no *shape* test — its name is its discriminator — but the typed identity is the
+     * entire point of the action, so a `calendar` that is not an object is not a legacy message to
+     * fall back for; there is no legacy `runTest`. It is a malformed one.
+     *
+     * The string used here is the one a client would reach for by habit, copied straight from an
+     * `executeUnitTest` message.
+     */
+    public function testRunTestRefusesACalendarThatIsNotAnObject(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'   => 'runTest',
+            'test'     => 'StIgnatiusOfLoyolaTest',
+            'calendar' => 'lugano_ch',
+            'year'     => 2026
+        ]);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('runTest calendar must be an object carrying kind, id and rite.', $frame->text);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    /**
+     * Both scalars are type-checked rather than trusted, and for the same reason: the property list
+     * establishes only that a property is *present*. A non-string `test` or a non-integer `year`
+     * would reach `executeUnitTest(string $test, string $calendar, int $year, …)` and raise a
+     * `TypeError` — an `\Error`, which Ratchet's `IoServer::handleData` does not catch, so one
+     * malformed message would take the whole WebSocket process down rather than be answered.
+     *
+     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function runTestMalformedScalarProvider(): array
+    {
+        return [
+            'test not a string' => [['test' => 42], 'runTest test must be a string.'],
+            'test missing'      => [['test' => null], 'runTest test must be a string.'],
+            'year not an int'   => [['year' => '2026'], 'runTest year must be an integer.'],
+            'year null'         => [['year' => null], 'runTest year must be an integer.'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     */
+    #[DataProvider('runTestMalformedScalarProvider')]
+    public function testRunTestRefusesAScalarItWouldOtherwiseThrowOn(array $overrides, string $expected): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, array_merge([
+            'action'   => 'runTest',
+            'test'     => 'StIgnatiusOfLoyolaTest',
+            'calendar' => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'     => 2026
+        ], $overrides));
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame($expected, $frame->text);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    /**
+     * A property the action declares required is turned away by `validateMessageProperties()` before
+     * any handler sees it, on the generic protocol-error path — which is how the absence of `test`
+     * differs from `test` being present and unusable, tested above.
+     *
+     * @return array<string, array{0: array<string, mixed>}>
+     */
+    public static function runTestMissingPropertyProvider(): array
+    {
+        return [
+            'no test'     => [['action' => 'runTest', 'calendar' => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'], 'year' => 2026]],
+            'no calendar' => [['action' => 'runTest', 'test' => 'StIgnatiusOfLoyolaTest', 'year' => 2026]],
+            'no year'     => [['action' => 'runTest', 'test' => 'StIgnatiusOfLoyolaTest', 'calendar' => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman']]],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    #[DataProvider('runTestMissingPropertyProvider')]
+    public function testRunTestRequiresItsThreeProperties(array $payload): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, $payload);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    // ---------------------------------------------------------------- executeUnitTest is untouched
+
+    /**
+     * The legacy action, byte for byte: `category` names the calendar type, the test name is a bare
+     * string, and the rite is *resolved* from the diocese metadata rather than asserted — which is
+     * how a rite-unaware client gets the `/ambrosian/` segment its Ambrosian diocese needs (#767).
+     */
+    public function testExecuteUnitTestStillTakesTheLegacyPath(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn): void {
+            self::send($health, $conn, [
+                'action'   => 'executeUnitTest',
+                'test'     => 'StIgnatiusOfLoyolaTest',
+                'calendar' => 'lugano_ch',
+                'category' => 'diocesancalendar',
+                'year'     => 2026
+            ]);
+        });
+
+        self::assertSame([], $conn->sent);
+        self::assertSame('/ambrosian/diocese/lugano_ch/2026?year_type=CIVIL', self::soleQueuedPath($health));
+
+        self::failSoleQueuedRequest($health);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('.StIgnatiusOfLoyolaTest.year-2026.test-valid', $frame->classes);
+    }
+
+    /**
+     * A legacy message that has *not* migrated is still judged by the legacy list. `runTest` gaining
+     * a shorter property list must not loosen `executeUnitTest`'s, which still requires `category`.
+     */
+    public function testExecuteUnitTestStillRequiresCategory(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'   => 'executeUnitTest',
+            'test'     => 'StIgnatiusOfLoyolaTest',
+            'calendar' => 'lugano_ch',
+            'year'     => 2026
+        ]);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    // ---------------------------------------------------------------- a source check is not a test run
+
+    /**
+     * The same test file, two operations, two addresses — and the distinction is easy to lose,
+     * because the word "test" appears in both.
+     *
+     * `test:ambrosian:StIgnatiusOfLoyolaTest` is an **inventory id**. `validateSource` resolves it to
+     * a file on disk and asks the source-data question: does the test *definition* exist, parse, and
+     * validate against `LitCalTest.json`. No calendar is computed; nothing is run.
+     *
+     * `runTest` names the same test as the bare `StIgnatiusOfLoyolaTest` and asks the other question
+     * entirely: does the calendar this identity names, computed for this year, satisfy the test the
+     * definition describes. A calendar *is* fetched; the definition is not schema-checked here.
+     *
+     * A definition can be valid while the test it describes fails, and a definition can be malformed
+     * while the calendar is perfectly correct, so neither answer substitutes for the other. The third
+     * assertion is what makes the addressing explicit rather than implied: the bare name is not an
+     * inventory id, and the inventory rejects it — the two vocabularies do not overlap even though
+     * one string is a substring of the other.
+     */
+    public function testTheTestDefinitionCheckAndTheTestRunAreDifferentOperations(): void
+    {
+        // The memo is per-process and an earlier test class may have built it against a fixture
+        // tree; this test is about addressing, so it must resolve against the real source data.
+        CheckableInventory::reset();
+
+        // --- the source check: the definition, addressed by its inventory id.
+        $sourceHealth = $this->newHealth();
+        $sourceConn   = self::createStubConnection();
+        self::send($sourceHealth, $sourceConn, [
+            'action' => 'validateSource',
+            'target' => ['id' => 'test:ambrosian:StIgnatiusOfLoyolaTest']
+        ]);
+
+        self::assertNotEmpty($sourceConn->sent, 'the test definition was not checked at all');
+        foreach ($sourceConn->sent as $raw) {
+            $frame = json_decode($raw);
+            self::assertNotSame('echobot', $frame->type, "the definition check was refused: {$frame->text}");
+            self::assertStringStartsWith(
+                '.Liturgical test: StIgnatiusOfLoyolaTest.',
+                (string) $frame->classes,
+                'a source check addresses its frames by the inventory item label'
+            );
+        }
+        self::assertSame([], self::queuedPaths($sourceHealth), 'a source check reads the filesystem; it must not compute a calendar');
+
+        // --- the test run: the same test, addressed by its bare name against a calendar.
+        $runHealth = $this->newHealth();
+        $runConn   = self::createStubConnection();
+        self::send($runHealth, $runConn, [
+            'action'   => 'runTest',
+            'test'     => 'StIgnatiusOfLoyolaTest',
+            'calendar' => ['kind' => 'rite', 'id' => 'ambrosian', 'rite' => 'ambrosian'],
+            'year'     => 2026
+        ]);
+
+        self::assertSame([], $runConn->sent, 'a test run emits nothing until its calendar has been fetched');
+        self::assertSame('/ambrosian/2026?year_type=CIVIL', self::soleQueuedPath($runHealth), 'a test run computes a calendar; it must not read the definition off disk instead');
+
+        // --- and the two addresses are not interchangeable.
+        $crossHealth = $this->newHealth();
+        $crossConn   = self::createStubConnection();
+        self::send($crossHealth, $crossConn, [
+            'action' => 'validateSource',
+            'target' => ['id' => 'StIgnatiusOfLoyolaTest']
+        ]);
+
+        self::assertCount(1, $crossConn->sent);
+        $frame = json_decode($crossConn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('Unknown validation target: StIgnatiusOfLoyolaTest', $frame->text, 'the bare test name is a runTest address, not an inventory id');
+    }
+
     // ---------------------------------------------------------------- harness
 
     /**
@@ -592,6 +966,35 @@ final class HealthTypedCalendarTest extends TestCase
         self::assertCount(1, $paths, 'expected exactly one queued calendar request, got: ' . json_encode($paths));
 
         return $paths[0];
+    }
+
+    /**
+     * Settle the sole queued request as a network failure, synchronously.
+     *
+     * The queue entry carries the promise's own `reject` closure, so calling it drives the handler
+     * the dispatching method registered — without a loop, an HTTP client, or a server. That is the
+     * only way to observe what a handler closed over rather than wrote into the URL, which for
+     * `executeUnitTest()` is the test name.
+     *
+     * The *failure* arm is used rather than the success one on purpose: the success arm would have
+     * to be fed a plausible calendar document and would then run a real `LitTestRunner`, making this
+     * a test of the test corpus. The failure arm names the test, the category, the calendar and the
+     * URL and does nothing else, which is exactly the dispatch and nothing beyond it.
+     *
+     * One cosmetic artifact, so a reader of the run log is not puzzled by it: the closure decrements
+     * `inFlight`, which `processQueue()` would have incremented on dispatch and which nothing did
+     * here, so this instance is left at `-1`. `drainHandler()` reads `inFlight > 0`, so a negative
+     * count stops ticking exactly as zero does, and the queue is emptied by the isolation trait in
+     * any case.
+     */
+    private static function failSoleQueuedRequest(Health $health): void
+    {
+        $queued = self::queuedRequests($health);
+        self::assertCount(1, $queued, 'expected exactly one queued calendar request to settle');
+        self::assertArrayHasKey('reject', $queued[0]);
+        /** @var \Closure(\Throwable):void $reject */
+        $reject = $queued[0]['reject'];
+        $reject(new \RuntimeException('the network is not this test\'s business'));
     }
 
     private static function soleQueuedAccept(Health $health): string

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -877,10 +877,13 @@ final class HealthTypedCalendarTest extends TestCase
         foreach ($sourceConn->sent as $raw) {
             $frame = json_decode($raw);
             self::assertNotSame('echobot', $frame->type, "the definition check was refused: {$frame->text}");
+            // Addressed by the fragment derived from the id, not by the item's label — which for
+            // this item is `Liturgical test: StIgnatiusOfLoyolaTest`, prose whose `: ` would make
+            // the client's querySelectorAll() throw. See Health::cssClassFragmentForId().
             self::assertStringStartsWith(
-                '.Liturgical test: StIgnatiusOfLoyolaTest.',
+                '.test-ambrosian-StIgnatiusOfLoyolaTest.',
                 (string) $frame->classes,
-                'a source check addresses its frames by the inventory item label'
+                'a source check addresses its frames by the fragment derived from the inventory id'
             );
         }
         self::assertSame([], self::queuedPaths($sourceHealth), 'a source check reads the filesystem; it must not compute a calendar');

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -1,0 +1,676 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * `validateCalendar` with a typed calendar identity — #806 section D.
+ *
+ * The action keeps its name because the action is unchanged: compute a calendar for a year and
+ * validate the response. What changes is how the calendar is named. A v1 message spreads the
+ * identity across two properties — an opaque `calendar` string plus a `category` whose vocabulary
+ * is shared, confusingly, with `executeValidation`'s unrelated schema-resolution strategies — and
+ * carries the rite as an optional hint the server is free to guess at. A v2 message carries one
+ * `calendar` **object** holding `kind`, `id` and `rite`.
+ *
+ * Because the action name is unchanged, the shape of `calendar` is the only discriminator there
+ * is, and it has to be applied before `validateMessageProperties()` compares against
+ * `ACTION_PROPERTIES['validateCalendar']` — the v2 form has neither `category` nor `responsetype`,
+ * so the list would turn every v2 message away before it reached a handler.
+ *
+ * Nothing legacy is touched: a string `calendar` still takes the old path byte for byte.
+ *
+ * ## What these tests assert against
+ *
+ * `validateCalendar()` is asynchronous — it hands a URL to `cachedGet()`, which appends it to
+ * `Health::$queue` and returns a promise. Nothing is dispatched until the ReactPHP loop runs, which
+ * it never does here, so the queued entry is a complete and inert record of the decision the
+ * dispatch made: the URL encodes the category (`/nation/`, `/diocese/`, or neither), the calendar
+ * id and the rite segment, and the request options carry the Accept header the response format
+ * chose. That is the whole of what this task decides, observable without a WebSocket server, an
+ * HTTP API, or a mock of the method under test.
+ */
+#[CoversClass(Health::class)]
+final class HealthTypedCalendarTest extends TestCase
+{
+    /** @var list<Health> every instance this test created, so tearDown can defuse its queue */
+    private array $healths = [];
+
+    public static function setUpBeforeClass(): void
+    {
+        // Route::CALENDAR->path() is built from the resolved API paths.
+        Router::getApiPaths();
+    }
+
+    /**
+     * Empty the request queue of every Health this test built.
+     *
+     * Not hygiene — necessary. `cachedGet()` parks the request *and* registers a ReactPHP
+     * `futureTick`, and `React\EventLoop\Loop` installs a shutdown function that runs the loop when
+     * the process ends. Without this, every queued URL would be fetched for real at the end of the
+     * PHPUnit run: the suite would start depending on an API server being up, and would hammer it
+     * with dozens of full calendar computations to no purpose. `drainHandler()` stops ticking the
+     * moment it finds nothing queued and nothing in flight, so emptying the queue is enough.
+     */
+    protected function tearDown(): void
+    {
+        $queue = new \ReflectionProperty(Health::class, 'queue');
+        foreach ($this->healths as $health) {
+            $queue->setValue($health, []);
+        }
+        $this->healths = [];
+    }
+
+    /**
+     * A Health whose queue tearDown will defuse. Always use this rather than `new Health()`.
+     */
+    private function newHealth(): Health
+    {
+        $health          = new Health();
+        $this->healths[] = $health;
+
+        return $health;
+    }
+
+    // ---------------------------------------------------------------- the typed identity dispatches
+
+    /**
+     * Each row is one message and the request it must produce.
+     *
+     * The URL is the assertion that matters: `/{rite}/nation/{id}`, `/{rite}/diocese/{id}` and
+     * `/{rite}` are three different categories, so a row that lands on the right URL has had its
+     * `kind` mapped, its `id` carried and its `rite` honoured, all three at once.
+     *
+     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function typedIdentityProvider(): array
+    {
+        return [
+            'ambrosian diocesan' => [
+                ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'ambrosian'],
+                '/ambrosian/diocese/lugano_ch/2026?year_type=CIVIL'
+            ],
+            'roman diocesan'     => [
+                ['kind' => 'diocesan', 'id' => 'rotter_nl', 'rite' => 'roman'],
+                '/roman/diocese/rotter_nl/2026?year_type=CIVIL'
+            ],
+            'roman national'     => [
+                ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+                '/roman/nation/IT/2026?year_type=CIVIL'
+            ],
+            'rite level'         => [
+                ['kind' => 'rite', 'id' => 'ambrosian', 'rite' => 'ambrosian'],
+                '/ambrosian/2026?year_type=CIVIL'
+            ],
+            // `general` names the one General Roman Calendar, so it is the only kind that needs no
+            // id: there is nothing to choose between.
+            'general'            => [
+                ['kind' => 'general', 'rite' => 'roman'],
+                '/roman/2026?year_type=CIVIL'
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $calendar
+     */
+    #[DataProvider('typedIdentityProvider')]
+    public function testATypedIdentityReachesTheCalendarRequestItNames(array $calendar, string $expectedPath): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn, $calendar): void {
+            self::send($health, $conn, [
+                'action'         => 'validateCalendar',
+                'calendar'       => $calendar,
+                'year'           => 2026,
+                'responseFormat' => 'JSON'
+            ]);
+        });
+
+        self::assertSame([], $conn->sent, 'a well-formed v2 message must not be answered with a frame before it is checked: ' . implode(' ', $conn->sent));
+        self::assertSame($expectedPath, self::soleQueuedPath($health));
+    }
+
+    /**
+     * The discriminator has to be applied ahead of the `ACTION_PROPERTIES` list, not inside the
+     * handler. This is the test that says so: the message below carries neither `category` nor
+     * `responsetype`, both of which that list requires, so if the list ran first the message would
+     * come back as the generic `Invalid message properties` and never reach a calendar request at
+     * all.
+     */
+    public function testTheV2FormIsNotTurnedAwayForMissingCategoryAndResponsetype(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn): void {
+            self::send($health, $conn, [
+                'action'         => 'validateCalendar',
+                'calendar'       => ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'ambrosian'],
+                'year'           => 2026,
+                'responseFormat' => 'JSON'
+            ]);
+        });
+
+        self::assertSame(
+            [],
+            array_map(static fn (string $raw): mixed => json_decode($raw)->errorMsg ?? null, $conn->sent),
+            'the v2 shape was rejected by the property list that only the legacy shape satisfies'
+        );
+    }
+
+    // ---------------------------------------------------------------- the legacy shape is untouched
+
+    /**
+     * A string `calendar` is a v1 message and must behave exactly as it did: `category` names the
+     * calendar type, `responsetype` names the format, and the rite is *resolved* rather than
+     * asserted — here from the diocese metadata, which is how a rite-unaware client gets the
+     * `/ambrosian/` segment its Ambrosian diocese needs (issue #767).
+     */
+    public function testTheStringFormStillTakesTheLegacyPath(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::withMetadata(static function () use ($health, $conn): void {
+            self::send($health, $conn, [
+                'action'       => 'validateCalendar',
+                'calendar'     => 'lugano_ch',
+                'category'     => 'diocesancalendar',
+                'year'         => 2026,
+                'responsetype' => 'JSON'
+            ]);
+        });
+
+        self::assertSame([], $conn->sent);
+        self::assertSame('/ambrosian/diocese/lugano_ch/2026?year_type=CIVIL', self::soleQueuedPath($health));
+    }
+
+    /**
+     * The branch must not have loosened the legacy list on its way past. A v1 message missing
+     * `category` is still an invalid v1 message — it is not a v2 message merely because it is
+     * missing the properties a v2 message would also be missing.
+     */
+    public function testTheStringFormStillRequiresCategoryAndResponsetype(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'   => 'validateCalendar',
+            'calendar' => 'lugano_ch',
+            'year'     => 2026
+        ]);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame([], self::queuedPaths($health), 'an invalid message must not have queued a request');
+    }
+
+    // ---------------------------------------------------------------- the response format
+
+    /**
+     * @return array<string, array{0: string, 1: string}>
+     */
+    public static function responseFormatProvider(): array
+    {
+        return [
+            'JSON' => ['JSON', 'application/json'],
+            'XML'  => ['XML', 'application/xml'],
+            'ICS'  => ['ICS', 'text/calendar'],
+            'YML'  => ['YML', 'application/yaml'],
+        ];
+    }
+
+    /**
+     * `responseFormat` is the v2 spelling of `responsetype`, and it has to reach the Accept header
+     * the request is made with — a format that is accepted and then ignored would validate the
+     * wrong representation and say nothing about it.
+     */
+    #[DataProvider('responseFormatProvider')]
+    public function testResponseFormatIsHonouredOnTheObjectForm(string $format, string $expectedAccept): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => $format
+        ]);
+
+        self::assertSame([], $conn->sent);
+        self::assertSame($expectedAccept, self::soleQueuedAccept($health));
+    }
+
+    /**
+     * And the v1 spelling keeps working on the v1 shape. The two spellings are not interchangeable
+     * across shapes on purpose: `responsetype` on a v2 message is a client that half-migrated, and
+     * `responseFormat` on a v1 message is the same mistake mirrored.
+     */
+    #[DataProvider('responseFormatProvider')]
+    public function testResponsetypeIsHonouredOnTheStringForm(string $format, string $expectedAccept): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'       => 'validateCalendar',
+            'calendar'     => 'IT',
+            'category'     => 'nationalcalendar',
+            'year'         => 2026,
+            'responsetype' => $format
+        ]);
+
+        self::assertSame([], $conn->sent);
+        self::assertSame($expectedAccept, self::soleQueuedAccept($health));
+    }
+
+    // ---------------------------------------------------------------- rejections
+
+    public function testAnUnknownKindIsRejected(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'widerregion', 'id' => 'Europe', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON'
+        ]);
+
+        self::assertCount(1, $conn->sent, 'an unusable identity is answered once and not computed');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type, 'rejections reuse the echobot shape: since UnitTestInterface#46 an unknown type is painted as a failed check');
+        self::assertSame('Unknown calendar kind: widerregion', $frame->text);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    /**
+     * The rite-disagreement rejections, one per kind that can be checked.
+     *
+     * A `rite` on a v1 message is a *hint*: `resolveRite()` prefers it whenever it parses, which is
+     * the right thing to do for a value the client may have guessed at. On a v2 message it is an
+     * *assertion* about a calendar the server already knows the rite of, and an assertion that is
+     * wrong is a client bug. Preferring the assertion would compute the wrong calendar silently;
+     * preferring the metadata would compute the right one while leaving the client convinced of
+     * something false. Saying so is more useful than either.
+     *
+     * @return array<string, array{0: array<string, mixed>}>
+     */
+    public static function riteDisagreementProvider(): array
+    {
+        return [
+            // lugano_ch is one of the four Ambrosian dioceses; /calendars says so.
+            'diocesan claimed roman'        => [['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'roman']],
+            'diocesan claimed ambrosian'    => [['kind' => 'diocesan', 'id' => 'rotter_nl', 'rite' => 'ambrosian']],
+            // There are no Ambrosian national calendars: /calendar/ambrosian/nation/IT is a 400.
+            'national claimed ambrosian'    => [['kind' => 'national', 'id' => 'IT', 'rite' => 'ambrosian']],
+            // For a rite-level calendar the id IS the rite, so the message contradicts itself.
+            'rite level contradicts itself' => [['kind' => 'rite', 'id' => 'ambrosian', 'rite' => 'roman']],
+            // `general` is the General *Roman* Calendar; a rite-level Ambrosian calendar is kind `rite`.
+            'general claimed ambrosian'     => [['kind' => 'general', 'rite' => 'ambrosian']],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $calendar
+     */
+    #[DataProvider('riteDisagreementProvider')]
+    public function testARiteThatDisagreesWithTheCalendarIsRejected(array $calendar): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        // Inside withMetadata: the diocesan rows are only *checkable* when /calendars has been
+        // fetched. Without it the server has no opinion to disagree with and, deliberately, lets
+        // the request through — see testARiteIsNotCheckedWhenTheServerHasNoOpinionToCheckItAgainst().
+        self::withMetadata(static function () use ($health, $conn, $calendar): void {
+            self::send($health, $conn, [
+                'action'         => 'validateCalendar',
+                'calendar'       => $calendar,
+                'year'           => 2026,
+                'responseFormat' => 'JSON'
+            ]);
+        });
+
+        self::assertCount(1, $conn->sent, 'a contradicted rite is answered once and not computed');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertStringContainsString('calendar.rite says', (string) $frame->text);
+        self::assertSame([], self::queuedPaths($health), 'a rejected message must not have queued a request');
+    }
+
+    /**
+     * What the server cannot check it must not pretend to have checked.
+     *
+     * A diocese's real rite comes from `/calendars`, which `Health` fetches asynchronously when the
+     * WebSocket connection opens. Two states have no answer to compare an assertion against: the
+     * metadata not being loaded at all, and its being loaded without the diocese in it. Rejecting on
+     * either would turn a server-side condition into a reported client bug — the #800 blindness in
+     * miniature — so the assertion is taken at its word and the request goes out.
+     * `resolveRite()` already makes the same call, for the same reason: the request itself reports
+     * the real problem, as a 404 the client can see.
+     *
+     * This drives the second of the two states. The first cannot be driven deterministically:
+     * `Health::$metadata` is a typed static with no default, and once any test in the process has
+     * set it PHP offers no way back to genuinely uninitialised. Both funnel into the same `null`
+     * from `actualRiteForKind()`, so the branch is covered either way.
+     *
+     * Both rites are asserted because each catches a different way of getting this wrong, and
+     * either alone would pass against the other's mutation. `roman` catches an implementation that
+     * *rejects* what it cannot look up — the honest-sounding mistake. `ambrosian` catches one that
+     * substitutes the default rite for "unknown", which reads as a check and is not one: it would
+     * agree with `roman` for every diocese in the world and disagree with `ambrosian` for all four
+     * that are.
+     *
+     * @return array<string, array{0: string}>
+     */
+    public static function unknowableRiteProvider(): array
+    {
+        return [
+            'roman'     => ['roman'],
+            'ambrosian' => ['ambrosian'],
+        ];
+    }
+
+    #[DataProvider('unknowableRiteProvider')]
+    public function testARiteIsNotCheckedWhenTheServerHasNoOpinionToCheckItAgainst(string $rite): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        // Force the state rather than inheriting whatever an earlier test left: lugano_ch really is
+        // Ambrosian, and the whole point is that nothing loaded here knows that.
+        self::withEmptyMetadata(static function () use ($health, $conn, $rite): void {
+            self::send($health, $conn, [
+                'action'         => 'validateCalendar',
+                'calendar'       => ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => $rite],
+                'year'           => 2026,
+                'responseFormat' => 'JSON'
+            ]);
+        });
+
+        self::assertSame([], $conn->sent, 'an unverifiable assertion was reported as a client bug');
+        self::assertSame("/{$rite}/diocese/lugano_ch/2026?year_type=CIVIL", self::soleQueuedPath($health));
+    }
+
+    /**
+     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     */
+    public static function malformedIdentityProvider(): array
+    {
+        return [
+            'kind missing'      => [['id' => 'IT', 'rite' => 'roman'], 'calendar.kind must be a string naming one of: general, national, diocesan, rite.'],
+            'kind not a string' => [['kind' => 42, 'id' => 'IT', 'rite' => 'roman'], 'calendar.kind must be a string naming one of: general, national, diocesan, rite.'],
+            'rite missing'      => [['kind' => 'national', 'id' => 'IT'], 'calendar.rite must be a string naming a known rite.'],
+            'rite unknown'      => [['kind' => 'national', 'id' => 'IT', 'rite' => 'byzantine'], 'Unknown rite: byzantine'],
+            'id missing'        => [['kind' => 'national', 'rite' => 'roman'], 'calendar.id is required for kind national.'],
+            'id not a string'   => [['kind' => 'diocesan', 'id' => 42, 'rite' => 'roman'], 'calendar.id must be a string.'],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $calendar
+     */
+    #[DataProvider('malformedIdentityProvider')]
+    public function testAMalformedIdentityIsRejectedWithWhatIsWrongWithIt(array $calendar, string $expected): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => $calendar,
+            'year'           => 2026,
+            'responseFormat' => 'JSON'
+        ]);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame($expected, $frame->text);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    /**
+     * A format `validateCalendar()` has no branch for must be turned away here rather than reaching
+     * `ReturnTypeParam::from()`, which throws a `\ValueError` on an unknown case. That is an
+     * `\Error`, and Ratchet's `IoServer::handleData` catches only `\Exception`, so it escapes and
+     * takes the whole WebSocket process down over one malformed message — the hazard `cancelRun()`
+     * documents, reached by a different door.
+     */
+    public function testAResponseFormatWithNoValidationBranchIsRejectedRatherThanThrown(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'PDF'
+        ]);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('validateCalendar responseFormat must be one of: JSON, XML, ICS, YML.', $frame->text);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    public function testAYearThatIsNotAnIntegerIsRejectedRatherThanThrown(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => null,
+            'responseFormat' => 'JSON'
+        ]);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('validateCalendar year must be an integer.', $frame->text);
+        self::assertSame([], self::queuedPaths($health));
+    }
+
+    // ---------------------------------------------------------------- harness
+
+    /**
+     * A minimal Ratchet connection that records every outbound frame. `resourceId` is a dynamic
+     * public property Ratchet assigns and is not part of `ConnectionInterface`, so this mirrors the
+     * stub convention already used by HealthValidateSourceTest and HealthCancelRunTest rather than
+     * a PHPUnit mock, which would trigger a dynamic-property deprecation.
+     */
+    private static function createStubConnection(int $resourceId = 1)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function send(Health $health, ConnectionInterface $conn, array $payload): void
+    {
+        $health->onMessage($conn, (string) json_encode($payload));
+    }
+
+    /**
+     * The requests `cachedGet()` parked on the queue, as paths relative to `/calendar`.
+     *
+     * @return list<string>
+     */
+    private static function queuedPaths(Health $health): array
+    {
+        $prefix = \LiturgicalCalendar\Api\Enum\Route::CALENDAR->path();
+
+        return array_map(
+            static function (array $entry) use ($prefix): string {
+                /** @var array{url:string} $entry */
+                self::assertStringStartsWith($prefix, $entry['url'], 'a calendar request was made against something other than /calendar');
+
+                return substr($entry['url'], strlen($prefix));
+            },
+            self::queuedRequests($health)
+        );
+    }
+
+    private static function soleQueuedPath(Health $health): string
+    {
+        $paths = self::queuedPaths($health);
+        self::assertCount(1, $paths, 'expected exactly one queued calendar request, got: ' . json_encode($paths));
+
+        return $paths[0];
+    }
+
+    private static function soleQueuedAccept(Health $health): string
+    {
+        $queued = self::queuedRequests($health);
+        self::assertCount(1, $queued, 'expected exactly one queued calendar request');
+        /** @var array{options:array{headers?:array<string, string>}} $entry */
+        $entry = $queued[0];
+        self::assertArrayHasKey('headers', $entry['options']);
+        self::assertArrayHasKey('Accept', $entry['options']['headers']);
+
+        return $entry['options']['headers']['Accept'];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function queuedRequests(Health $health): array
+    {
+        /** @var list<array<string, mixed>> */
+        return ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+    }
+
+    /**
+     * Populate `Health::$metadata` with the same two-diocese stand-in HealthRiteRequestPathTest
+     * uses — one Ambrosian, one Roman — for the duration of $fn, then put back what was there.
+     *
+     * `Health::$metadata` is a typed static with no default, so PHP offers no way to return it to
+     * the genuinely uninitialised state. When it started out uninitialised we therefore leave an
+     * *empty* MetadataCalendars behind rather than the fixture, so a later test in the same process
+     * cannot resolve `lugano_ch` or `rotter_nl` from data this helper invented.
+     */
+    private static function withMetadata(callable $fn): void
+    {
+        $property = new \ReflectionProperty(Health::class, 'metadata');
+        $wasSet   = $property->isInitialized();
+        $previous = $wasSet ? $property->getValue() : null;
+
+        $property->setValue(null, MetadataCalendars::fromObject((object) [
+            'national_calendars'       => [],
+            'national_calendars_keys'  => [],
+            'diocesan_calendars_keys'  => ['lugano_ch', 'rotter_nl'],
+            'diocesan_groups'          => [],
+            'wider_regions'            => [],
+            'wider_regions_keys'       => [],
+            'ambrosian_calendars'      => [],
+            'ambrosian_calendars_keys' => [],
+            'locales'                  => ['en'],
+            'diocesan_calendars'       => [
+                (object) [
+                    'calendar_id' => 'lugano_ch',
+                    'diocese'     => 'Lugano',
+                    'nation'      => 'CH',
+                    'locales'     => ['it_IT'],
+                    'timezone'    => 'Europe/Zurich',
+                    'rite'        => 'ambrosian',
+                ],
+                (object) [
+                    'calendar_id' => 'rotter_nl',
+                    'diocese'     => 'Rotterdam',
+                    'nation'      => 'NL',
+                    'locales'     => ['nl_NL'],
+                    'timezone'    => 'Europe/Amsterdam',
+                    'rite'        => 'roman',
+                ],
+            ],
+        ]));
+
+        try {
+            $fn();
+        } finally {
+            if ($wasSet && $previous !== null) {
+                $property->setValue(null, $previous);
+            } else {
+                $property->setValue(null, self::emptyMetadata());
+            }
+        }
+    }
+
+    /**
+     * Run $fn with `Health::$metadata` populated but empty — the state in which the server has no
+     * opinion about any diocese's rite.
+     */
+    private static function withEmptyMetadata(callable $fn): void
+    {
+        $property = new \ReflectionProperty(Health::class, 'metadata');
+        $wasSet   = $property->isInitialized();
+        $previous = $wasSet ? $property->getValue() : null;
+
+        $property->setValue(null, self::emptyMetadata());
+
+        try {
+            $fn();
+        } finally {
+            if ($wasSet && $previous !== null) {
+                $property->setValue(null, $previous);
+            }
+        }
+    }
+
+    private static function emptyMetadata(): MetadataCalendars
+    {
+        return MetadataCalendars::fromObject((object) [
+            'national_calendars'       => [],
+            'national_calendars_keys'  => [],
+            'diocesan_calendars'       => [],
+            'diocesan_calendars_keys'  => [],
+            'diocesan_groups'          => [],
+            'wider_regions'            => [],
+            'wider_regions_keys'       => [],
+            'ambrosian_calendars'      => [],
+            'ambrosian_calendars_keys' => [],
+            'locales'                  => ['en'],
+        ]);
+    }
+}

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -10,6 +10,7 @@ use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Tests\Support\BrokenInventoryTrait;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -31,6 +32,7 @@ use Ratchet\ConnectionInterface;
 final class HealthValidateSourceTest extends TestCase
 {
     use BrokenInventoryTrait;
+    use HealthQueueIsolationTrait;
 
     public static function setUpBeforeClass(): void
     {
@@ -221,7 +223,7 @@ final class HealthValidateSourceTest extends TestCase
 
     public function testAnUnknownIdIsRejectedAndNothingIsChecked(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => 'nation:roman:ZZ']]);
@@ -234,7 +236,7 @@ final class HealthValidateSourceTest extends TestCase
 
     public function testATargetThatIsNotAnObjectIsRejectedAsMalformed(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         self::send($health, $conn, ['action' => 'validateSource', 'target' => 'temporale:roman']);
@@ -247,7 +249,7 @@ final class HealthValidateSourceTest extends TestCase
 
     public function testATargetIdThatIsNotAStringIsRejected(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => 42]]);
@@ -264,7 +266,7 @@ final class HealthValidateSourceTest extends TestCase
      */
     public function testAMessageWithNoTargetIsRejectedByPropertyValidation(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         self::send($health, $conn, ['action' => 'validateSource']);
@@ -305,7 +307,7 @@ final class HealthValidateSourceTest extends TestCase
     #[DataProvider('retiredPropertyProvider')]
     public function testALegacyAddressingPropertyAlongsideATargetIsRejected(string $property, mixed $value): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         self::send($health, $conn, [
@@ -356,7 +358,7 @@ final class HealthValidateSourceTest extends TestCase
      */
     public function testARunTokenIsNotARetiredProperty(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         self::send($health, $conn, [
@@ -412,7 +414,7 @@ final class HealthValidateSourceTest extends TestCase
      */
     public function testANewRunTokenDropsTheMemoizedInventory(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         CheckableInventory::all();
@@ -442,7 +444,7 @@ final class HealthValidateSourceTest extends TestCase
      */
     public function testAContinuingRunKeepsTheMemoizedInventory(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         self::setRunTokens($health, [1 => 'run-a']);
@@ -466,7 +468,7 @@ final class HealthValidateSourceTest extends TestCase
      */
     public function testCancelRunNeitherStoresATokenNorRebuildsTheInventory(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         CheckableInventory::all();
@@ -499,7 +501,9 @@ final class HealthValidateSourceTest extends TestCase
     {
         $realRoot = Router::$apiFilePath;
 
-        self::withBrokenInventory(static function () use ($realRoot): void {
+        // Not a static closure: the Health built inside it has to be tracked by
+        // HealthQueueIsolationTrait, whose newHealth() is an instance method.
+        self::withBrokenInventory(function () use ($realRoot): void {
             // The fixture tree holds one malformed calendar and nothing else, so give it the two
             // things a temporale check reads — the temporale file and the schemas it validates
             // against — and the check can succeed or fail on its own merits rather than on the
@@ -508,7 +512,7 @@ final class HealthValidateSourceTest extends TestCase
             self::copyIntoFixture($realRoot, JsonData::TEMPORALE_FILE->value);
             self::copyIntoFixture($realRoot, JsonData::SCHEMAS_FOLDER->value);
 
-            $health = new Health();
+            $health = $this->newHealth();
 
             $staticTarget = self::createStubConnection(1);
             self::send($health, $staticTarget, ['action' => 'validateSource', 'target' => ['id' => 'temporale:roman']]);
@@ -606,7 +610,7 @@ final class HealthValidateSourceTest extends TestCase
         $published = CheckableInventory::all();
         self::assertNotEmpty($published, 'the inventory published nothing to round-trip');
 
-        $health = new Health();
+        $health = $this->newHealth();
 
         /** @var array<string, string> $unaddressable */
         $unaddressable = [];

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -97,14 +97,67 @@ final class HealthValidateSourceTest extends TestCase
     /**
      * The point of the action: `temporale:roman` names exactly what `proprium-de-tempore` named.
      *
+     * Not every row proves as much as it looks like it does. `retrieveSchemaForCategory()`'s
+     * `sourceDataCheck` arm carries a `$legacySlugToId` table that rewrites four legacy slugs —
+     * `proprium-de-tempore`, `proprium-de-tempore-i18n`, `memorials-from-decrees` and
+     * `memorials-from-decrees-i18n` — into inventory ids *before* calling `byId()`. For those the
+     * two sides of the comparison are literally the same lookup, so the row pins the mapping table
+     * rather than proving two independent resolutions agree. The `national-calendar-…` rows are the
+     * ones that genuinely exercise both paths: the slug goes through the anchored regex arms and
+     * the id through `byId()`, and nothing rewrites one into the other. Marked below so a later
+     * reader does not over-trust the cheap rows.
+     *
+     * The folder row matters for a different reason: `kind` selects between two entirely separate
+     * branches of `runValidationSteps()`, and without it the folder branch is never reached through
+     * this action at all.
+     *
      * @return array<string, array{string, string}>
      */
     public static function equivalentAddressProvider(): array
     {
         return [
-            'temporale'         => ['temporale:roman', 'proprium-de-tempore'],
-            'national calendar' => ['nation:roman:IT', 'national-calendar-IT']
+            // Same lookup on both sides — $legacySlugToId rewrites the slug into this very id.
+            'temporale'              => ['temporale:roman', 'proprium-de-tempore'],
+            // Two independent resolutions: regex arm vs byId().
+            'national calendar'      => ['nation:roman:IT', 'national-calendar-IT'],
+            // Likewise independent, and the only row whose kind is 'folder'.
+            'national calendar i18n' => ['nation:roman:US:i18n', 'national-calendar-US-i18n']
         ];
+    }
+
+    /**
+     * The published `steps` vocabulary is not the emitted frame-class vocabulary.
+     *
+     * `CheckableInventory::STEPS` publishes `exists|parses|validates` on the wire, while the frames
+     * are addressed `.<label>.file-exists`, `.<label>.json-valid`, `.<label>.schema-valid`. The two
+     * describe the same three steps in different words, and nothing in the codebase relates them,
+     * so the correspondence is written down here — once — and asserted rather than restated as a
+     * hardcoded list at each call site. A newly published step with no entry here fails loudly,
+     * which is the point: it would also be a step no client could match a frame to.
+     *
+     * @var array<string, string>
+     */
+    private const FRAME_CLASS_FOR_STEP = [
+        'exists'    => 'file-exists',
+        'parses'    => 'json-valid',
+        'validates' => 'schema-valid'
+    ];
+
+    /**
+     * The frame classes an item's *published* steps say it should emit, in order.
+     *
+     * @return list<string>
+     */
+    private static function expectedFrameClasses(CheckableItem $item): array
+    {
+        return array_map(
+            static function (string $step) use ($item): string {
+                self::assertArrayHasKey($step, self::FRAME_CLASS_FOR_STEP, "published step '{$step}' has no frame class");
+
+                return ".{$item->label}." . self::FRAME_CLASS_FOR_STEP[$step];
+            },
+            $item->steps
+        );
     }
 
     /**
@@ -115,8 +168,10 @@ final class HealthValidateSourceTest extends TestCase
      * `byId()`, and the slug's, through `retrieveSchemaForCategory()`'s anchored patterns — rather
      * than comparing one resolution with itself.
      *
-     * The three frames matter too: a client sizes the phase as exactly three per check, so an
-     * accepted-but-silent target would wedge the run just as surely as a rejected one.
+     * The frame expectations are derived from the item's own published `steps` rather than
+     * hardcoded, because that is the contract a client sizes the phase with: it reads `steps` from
+     * `/validations` and waits for exactly that many frames per check. Publishing one count and
+     * emitting another wedges the run just as surely as emitting none.
      *
      * @param string $id   the inventory id a v2 client sends
      * @param string $slug the `validate` slug a v1 client sends for the same artifact
@@ -131,7 +186,11 @@ final class HealthValidateSourceTest extends TestCase
         $conn   = self::createStubConnection();
         self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => $id]]);
 
-        self::assertCount(3, $conn->sent, "{$id} did not produce the three frames a check is made of");
+        self::assertCount(
+            count($item->steps),
+            $conn->sent,
+            "{$id} publishes " . count($item->steps) . ' steps but emitted ' . count($conn->sent) . ' frames'
+        );
 
         $frames = array_map(
             /** @return \stdClass */
@@ -140,9 +199,9 @@ final class HealthValidateSourceTest extends TestCase
         );
 
         self::assertSame(
-            [".{$item->label}.file-exists", ".{$item->label}.json-valid", ".{$item->label}.schema-valid"],
+            self::expectedFrameClasses($item),
             array_map(static fn (\stdClass $f): mixed => $f->classes, $frames),
-            'the frames are addressed by the item label, in step order'
+            'the frames are addressed by the item label, one per published step, in step order'
         );
 
         foreach ($frames as $frame) {
@@ -274,6 +333,14 @@ final class HealthValidateSourceTest extends TestCase
      * every calendar source file, so resetting on each would trade an unbounded staleness window
      * for an unbounded cost. Resetting on the token *change* bounds staleness to a single run and
      * pays for it once.
+     *
+     * Identity, not populated-ness, is what is asserted here, and the distinction is the whole
+     * test. `validateSource` resolves through `byId()`, which calls `all()`, which re-memoizes on
+     * the spot — so under the very mutation this test exists to catch (an unconditional reset) the
+     * memo would be nulled and immediately rebuilt, and any "is it populated?" check would still
+     * be green. A rebuild mints fresh `CheckableItem` instances, so holding one from before the
+     * message and asserting it is the *same object* afterwards is a claim only a surviving memo
+     * can satisfy.
      */
     public function testAContinuingRunKeepsTheMemoizedInventory(): void
     {
@@ -281,12 +348,16 @@ final class HealthValidateSourceTest extends TestCase
         $conn   = self::createStubConnection();
 
         self::setRunTokens($health, [1 => 'run-a']);
-        CheckableInventory::all();
-        self::assertTrue(self::inventoryIsMemoized(), 'precondition: the index is built');
+        $before = CheckableInventory::all();
+        self::assertNotEmpty($before, 'precondition: the index is built');
 
         self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => 'temporale:roman'], 'runToken' => 'run-a']);
 
-        self::assertTrue(self::inventoryIsMemoized(), 'a second message of the same run must not rebuild the index');
+        self::assertSame(
+            $before[0],
+            CheckableInventory::all()[0],
+            'a second message of the same run rebuilt the index instead of reusing it'
+        );
     }
 
     /**
@@ -347,7 +418,11 @@ final class HealthValidateSourceTest extends TestCase
             $item = CheckableInventory::staticById('temporale:roman');
             self::assertInstanceOf(CheckableItem::class, $item, 'precondition: the temporale is in the static half');
 
-            self::assertCount(3, $staticTarget->sent, 'a static target stopped being checkable because an unrelated calendar file was malformed');
+            self::assertCount(
+                count($item->steps),
+                $staticTarget->sent,
+                'a static target stopped being checkable because an unrelated calendar file was malformed'
+            );
 
             $frames = array_map(
                 /** @return \stdClass */
@@ -355,7 +430,7 @@ final class HealthValidateSourceTest extends TestCase
                 $staticTarget->sent
             );
             self::assertSame(
-                [".{$item->label}.file-exists", ".{$item->label}.json-valid", ".{$item->label}.schema-valid"],
+                self::expectedFrameClasses($item),
                 array_map(static fn (\stdClass $f): mixed => $f->classes, $frames),
                 'the frames were not addressed to the static item the retry was supposed to resolve'
             );
@@ -409,26 +484,60 @@ final class HealthValidateSourceTest extends TestCase
     // ---------------------------------------------------------------- round trip
 
     /**
-     * Everything `/validations` publishes can be sent back.
+     * Everything `/validations` publishes can be sent back — through the surface a client uses.
      *
      * The published set and the addressable set have to be the same set: an id a client can read
      * out of the catalogue but cannot use as an address would be worse than not publishing it at
-     * all, because the client has no way to tell the two cases apart. Driven from
-     * `CheckableInventory::all()` rather than a hand-written list, so a newly enumerated *kind* of
-     * source data is covered the day it appears rather than the day someone remembers to add it
-     * here.
+     * all, because the client has no way to tell the two cases apart.
+     *
+     * The obvious way to write this — iterate `all()` and look each id up with `byId()` — proves
+     * nothing. `byId()` is a linear identity scan over the very array `all()` just returned, so it
+     * cannot miss, and the assertions would hold against a `validateSource` that had been deleted
+     * outright. What has to be exercised is the *action*: each id goes out as a real
+     * `validateSource` message and must come back as a check rather than a rejection. That takes
+     * `Health::validateSource()` across all of the published ids instead of the three the happy-path
+     * provider covers, and it fails the day an advertised id stops being addressable — which is the
+     * guarantee this test is named after.
+     *
+     * Silence counts as a failure too. A message that resolves but emits nothing leaves the client
+     * waiting on frames that will never arrive, which is the same wedge as a rejection, arriving
+     * more slowly.
      */
-    public function testEveryPublishedIdResolvesBackToACheckableItem(): void
+    public function testEveryPublishedIdIsAddressableThroughValidateSource(): void
     {
-        $all = CheckableInventory::all();
-        self::assertNotEmpty($all, 'the inventory published nothing to round-trip');
+        $published = CheckableInventory::all();
+        self::assertNotEmpty($published, 'the inventory published nothing to round-trip');
 
-        foreach ($all as $published) {
-            $resolved = CheckableInventory::byId($published->id);
-            self::assertInstanceOf(CheckableItem::class, $resolved, "published id {$published->id} does not resolve");
-            self::assertSame($published->id, $resolved->id);
-            self::assertNotSame('', $resolved->schema->path(), "published id {$published->id} resolves to no schema");
-            self::assertContains($resolved->kind, ['file', 'folder'], "published id {$published->id} has no usable kind");
+        $health = new Health();
+
+        /** @var array<string, string> $unaddressable */
+        $unaddressable = [];
+
+        foreach ($published as $index => $item) {
+            $conn = self::createStubConnection($index + 1);
+            self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => $item->id]]);
+
+            if ([] === $conn->sent) {
+                $unaddressable[$item->id] = 'answered with no frames at all';
+                continue;
+            }
+
+            foreach ($conn->sent as $raw) {
+                $frame = json_decode($raw);
+                if ($frame instanceof \stdClass && 'echobot' === ( $frame->type ?? null )) {
+                    // `echobot` is the rejection shape: the server declined to check this at all.
+                    // An `error` frame is a different thing entirely and is fine here — it means the
+                    // target was addressed and checked, and the check reported something. This test
+                    // is about whether an id can be sent, not about whether its data is valid.
+                    $unaddressable[$item->id] = (string) ( $frame->text ?? '' );
+                }
+            }
         }
+
+        self::assertSame(
+            [],
+            $unaddressable,
+            'ids that GET /validations advertises but validateSource will not accept: ' . json_encode($unaddressable)
+        );
     }
 }

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * `validateSource` — asking for a check by the id the server published.
+ *
+ * A client used to have to name a check with a hyphenated slug (`proprium-de-tempore`,
+ * `national-calendar-IT`) that the server recovered with eight anchored `preg_match` arms, each
+ * one a second copy of a naming convention written down elsewhere. `GET /validations` already
+ * publishes a stable opaque id for every checkable artifact, so `validateSource` takes that id and
+ * resolves it with a single {@see CheckableInventory::byId()} lookup.
+ *
+ * The legacy `executeValidation` shape is untouched and its arms stay reachable; this is purely
+ * additive. See #806 section C.
+ */
+#[CoversClass(Health::class)]
+final class HealthValidateSourceTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // Health resolves relative source paths against Router::$apiFilePath, and the inventory
+        // builds every path from it. Drop the memo so the index is built against these paths
+        // rather than against whatever an earlier test class in this process left behind.
+        Router::getApiPaths();
+        CheckableInventory::reset();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        CheckableInventory::reset();
+    }
+
+    /**
+     * A minimal Ratchet connection that records every outbound frame. `resourceId` is a dynamic
+     * public property Ratchet assigns and is not part of `ConnectionInterface`, so this mirrors the
+     * stub convention already used by HealthCancelRunTest and HealthFolderStepResultTest rather
+     * than a PHPUnit mock, which would trigger a dynamic-property deprecation.
+     */
+    private static function createStubConnection(int $resourceId = 1)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function send(Health $health, ConnectionInterface $conn, array $payload): void
+    {
+        $health->onMessage($conn, (string) json_encode($payload));
+    }
+
+    private static function retrieveSchemaForCategory(string $category, string $dataPath): ?string
+    {
+        $method = new \ReflectionMethod(Health::class, 'retrieveSchemaForCategory');
+        /** @var string|null $result */
+        $result = $method->invoke(null, $category, $dataPath);
+
+        return $result;
+    }
+
+    // ---------------------------------------------------------------- the id IS the slug's address
+
+    /**
+     * The point of the action: `temporale:roman` names exactly what `proprium-de-tempore` named.
+     *
+     * @return array<string, array{string, string}>
+     */
+    public static function equivalentAddressProvider(): array
+    {
+        return [
+            'temporale'         => ['temporale:roman', 'proprium-de-tempore'],
+            'national calendar' => ['nation:roman:IT', 'national-calendar-IT']
+        ];
+    }
+
+    /**
+     * A `validateSource` naming an id runs the very same check the legacy slug ran.
+     *
+     * The schema is the load-bearing assertion, and it is taken from the *frame* rather than from
+     * the inventory, so this compares two resolutions of the same artifact — the id's, through
+     * `byId()`, and the slug's, through `retrieveSchemaForCategory()`'s anchored patterns — rather
+     * than comparing one resolution with itself.
+     *
+     * The three frames matter too: a client sizes the phase as exactly three per check, so an
+     * accepted-but-silent target would wedge the run just as surely as a rejected one.
+     *
+     * @param string $id   the inventory id a v2 client sends
+     * @param string $slug the `validate` slug a v1 client sends for the same artifact
+     */
+    #[DataProvider('equivalentAddressProvider')]
+    public function testAKnownIdRunsTheSameCheckAsItsLegacySlug(string $id, string $slug): void
+    {
+        $item = CheckableInventory::byId($id);
+        self::assertInstanceOf(CheckableItem::class, $item, "the inventory has no entry for {$id}");
+
+        $health = new Health();
+        $conn   = self::createStubConnection();
+        self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => $id]]);
+
+        self::assertCount(3, $conn->sent, "{$id} did not produce the three frames a check is made of");
+
+        $frames = array_map(
+            /** @return \stdClass */
+            static fn (string $raw): object => (object) json_decode($raw),
+            $conn->sent
+        );
+
+        self::assertSame(
+            [".{$item->label}.file-exists", ".{$item->label}.json-valid", ".{$item->label}.schema-valid"],
+            array_map(static fn (\stdClass $f): mixed => $f->classes, $frames),
+            'the frames are addressed by the item label, in step order'
+        );
+
+        foreach ($frames as $frame) {
+            self::assertSame('success', $frame->type, "{$id} did not pass its own check: {$frame->text}");
+        }
+
+        $legacySchema = self::retrieveSchemaForCategory('sourceDataCheck', $slug);
+        self::assertIsString($legacySchema, "the legacy slug {$slug} resolves to no schema at all");
+        self::assertStringContainsString(
+            $legacySchema,
+            (string) $frames[2]->text,
+            "{$id} was validated against a different schema than {$slug} resolves to"
+        );
+    }
+
+    // ---------------------------------------------------------------- rejections
+
+    public function testAnUnknownIdIsRejectedAndNothingIsChecked(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => 'nation:roman:ZZ']]);
+
+        self::assertCount(1, $conn->sent, 'an unresolvable target is answered once and not checked');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type, 'rejections reuse the echobot shape: since UnitTestInterface#46 an unknown type is painted as a failed check');
+        self::assertSame('Unknown validation target: nation:roman:ZZ', $frame->text);
+    }
+
+    public function testATargetThatIsNotAnObjectIsRejectedAsMalformed(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, ['action' => 'validateSource', 'target' => 'temporale:roman']);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('validateSource requires a target object with an id.', $frame->text);
+    }
+
+    public function testATargetIdThatIsNotAStringIsRejected(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => 42]]);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('validateSource target id must be a string.', $frame->text);
+    }
+
+    /**
+     * A missing `target` never reaches the handler: `ACTION_PROPERTIES` declares it required, so
+     * `validateMessageProperties()` turns the message away on the generic protocol-error path.
+     */
+    public function testAMessageWithNoTargetIsRejectedByPropertyValidation(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, ['action' => 'validateSource']);
+
+        self::assertCount(1, $conn->sent);
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame('Invalid message properties', $frame->errorMsg);
+    }
+
+    // ---------------------------------------------------------------- the per-run inventory reset
+
+    /**
+     * Whether the memoized index is currently populated.
+     *
+     * There is no accessor for this and there should not be — the memo is an implementation
+     * detail. Where it is dropped is not: a v2 message resolves *solely* through `byId()`, so a
+     * memo that outlives a `/data` write makes the new calendar unaddressable, and that is a
+     * property of `onMessage()`, not of the inventory.
+     */
+    private static function inventoryIsMemoized(): bool
+    {
+        return null !== ( new \ReflectionProperty(CheckableInventory::class, 'items') )->getValue();
+    }
+
+    /** @param array<int, string> $tokens */
+    private static function setRunTokens(Health $health, array $tokens): void
+    {
+        ( new \ReflectionProperty(Health::class, 'runTokens') )->setValue($health, $tokens);
+    }
+
+    /** @return array<int, string> */
+    private static function getRunTokens(Health $health): array
+    {
+        /** @var array<int, string> */
+        return ( new \ReflectionProperty(Health::class, 'runTokens') )->getValue($health);
+    }
+
+    /**
+     * A run beginning is the one safe moment to rebuild the index.
+     *
+     * The memo is per-*process*, which is a single request under PHP-FPM but the entire server
+     * lifetime in Health's long-running ReactPHP process, so without this a calendar created
+     * through `/data` would stay invisible to the WebSocket until someone restarted it. A
+     * write-path invalidation hook cannot close the gap: `/data` writes happen in the HTTP process,
+     * which never runs this code.
+     */
+    public function testANewRunTokenDropsTheMemoizedInventory(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        CheckableInventory::all();
+        self::assertTrue(self::inventoryIsMemoized(), 'precondition: the index is built');
+
+        self::send($health, $conn, ['action' => 'validateCalendar', 'runToken' => 'run-a']);
+
+        self::assertFalse(self::inventoryIsMemoized(), 'a run beginning rebuilds the index');
+        self::assertSame([1 => 'run-a'], self::getRunTokens($health));
+    }
+
+    /**
+     * Once per run, not once per message.
+     *
+     * A run sends one message per checked item — dozens of them — and rebuilding reads and parses
+     * every calendar source file, so resetting on each would trade an unbounded staleness window
+     * for an unbounded cost. Resetting on the token *change* bounds staleness to a single run and
+     * pays for it once.
+     */
+    public function testAContinuingRunKeepsTheMemoizedInventory(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        self::setRunTokens($health, [1 => 'run-a']);
+        CheckableInventory::all();
+        self::assertTrue(self::inventoryIsMemoized(), 'precondition: the index is built');
+
+        self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => 'temporale:roman'], 'runToken' => 'run-a']);
+
+        self::assertTrue(self::inventoryIsMemoized(), 'a second message of the same run must not rebuild the index');
+    }
+
+    /**
+     * `cancelRun` is exempt from the ambient run-token store — it names the run it wants abandoned,
+     * not the run this connection is on — and the reset lives inside that same exemption, so it
+     * must stay exempt from the reset too. A cancel is the end of a run, not the beginning of one;
+     * rebuilding the index there would pay the full cost for a client that has stopped asking.
+     */
+    public function testCancelRunNeitherStoresATokenNorRebuildsTheInventory(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        CheckableInventory::all();
+        self::assertTrue(self::inventoryIsMemoized(), 'precondition: the index is built');
+
+        self::send($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertTrue(self::inventoryIsMemoized(), 'a cancel is not a run beginning');
+        self::assertSame([], self::getRunTokens($health), 'cancelRun stays exempt from the ambient token store');
+    }
+
+    // ---------------------------------------------------------------- round trip
+
+    /**
+     * Everything `/validations` publishes can be sent back.
+     *
+     * The published set and the addressable set have to be the same set: an id a client can read
+     * out of the catalogue but cannot use as an address would be worse than not publishing it at
+     * all, because the client has no way to tell the two cases apart. Driven from
+     * `CheckableInventory::all()` rather than a hand-written list, so a newly enumerated *kind* of
+     * source data is covered the day it appears rather than the day someone remembers to add it
+     * here.
+     */
+    public function testEveryPublishedIdResolvesBackToACheckableItem(): void
+    {
+        $all = CheckableInventory::all();
+        self::assertNotEmpty($all, 'the inventory published nothing to round-trip');
+
+        foreach ($all as $published) {
+            $resolved = CheckableInventory::byId($published->id);
+            self::assertInstanceOf(CheckableItem::class, $resolved, "published id {$published->id} does not resolve");
+            self::assertSame($published->id, $resolved->id);
+            self::assertNotSame('', $resolved->schema->path(), "published id {$published->id} resolves to no schema");
+            self::assertContains($resolved->kind, ['file', 'folder'], "published id {$published->id} has no usable kind");
+        }
+    }
+}

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -275,6 +275,104 @@ final class HealthValidateSourceTest extends TestCase
         self::assertSame('Invalid message properties', $frame->errorMsg);
     }
 
+    // ---------------------------------------------------------------- retired properties
+
+    /**
+     * The four properties an inventory id replaces outright.
+     *
+     * `executeValidation` spread a check's address across a schema-resolution strategy (`category`),
+     * a slug (`validate`) and a path (`sourceFile`/`sourceFolder`). An id is the whole address: the
+     * server minted it, published it, and resolves all of that from it. A message carrying both is a
+     * half-migrated client naming its check twice and being read once — it works today, because
+     * `target` is what gets read, and it breaks the day the slug arms are removed.
+     *
+     * Each row's payload is a *valid* `validateSource` message with one retired property added, and
+     * the added value is a *legitimate* legacy value taken from the same enums `executeValidation`
+     * resolves against — so what fails is the retired property itself, not a bad value in it.
+     *
+     * @return array<string, array{0: string, 1: mixed}>
+     */
+    public static function retiredPropertyProvider(): array
+    {
+        return [
+            'category'     => ['category', 'sourceDataCheck'],
+            'validate'     => ['validate', 'proprium-de-tempore'],
+            'sourceFile'   => ['sourceFile', JsonData::TEMPORALE_FILE->value],
+            'sourceFolder' => ['sourceFolder', JsonData::TEMPORALE_FOLDER->value],
+        ];
+    }
+
+    #[DataProvider('retiredPropertyProvider')]
+    public function testALegacyAddressingPropertyAlongsideATargetIsRejected(string $property, mixed $value): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'  => 'validateSource',
+            'target'  => ['id' => 'temporale:roman'],
+            $property => $value
+        ]);
+
+        self::assertCount(1, $conn->sent, 'a half-migrated message is answered once and not checked');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('echobot', $frame->type);
+        self::assertSame(
+            "{$property} is not part of a validateSource message: target.id replaces it.",
+            $frame->text,
+            'the rejection must name the property and its replacement, so a migrating client is told what to do'
+        );
+    }
+
+    /**
+     * The rule must not reach the legacy action it is named after. `executeValidation` *requires*
+     * these properties; rejecting them there would delete the v1 surface rather than guard the v2
+     * one, and the slug arms stay reachable until clients have moved over (UnitTestInterface#42).
+     */
+    public function testExecuteValidationStillAcceptsTheVeryPropertiesValidateSourceRetires(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'     => 'executeValidation',
+            'category'   => 'sourceDataCheck',
+            'validate'   => 'proprium-de-tempore',
+            'sourceFile' => JsonData::TEMPORALE_FILE->value
+        ]);
+
+        self::assertNotEmpty($conn->sent, 'the legacy action stopped being usable');
+        foreach ($conn->sent as $raw) {
+            $frame = json_decode($raw);
+            self::assertNotSame('echobot', $frame->type, "the legacy slug shape was refused: {$frame->text}");
+        }
+    }
+
+    /**
+     * `runToken` is shared and current, not retired: it correlates responses on every action,
+     * including this one, and a rule that swept it up would break run correlation everywhere at
+     * once. Asserted through the frames rather than merely by absence of a rejection — the token
+     * has to come back stamped on the answers, which is what a client matches them with.
+     */
+    public function testARunTokenIsNotARetiredProperty(): void
+    {
+        $health = new Health();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'   => 'validateSource',
+            'target'   => ['id' => 'temporale:roman'],
+            'runToken' => 'run-a'
+        ]);
+
+        self::assertNotEmpty($conn->sent, 'a runToken was mistaken for a retired property');
+        foreach ($conn->sent as $raw) {
+            $frame = json_decode($raw);
+            self::assertNotSame('echobot', $frame->type, "the message was refused: {$frame->text}");
+            self::assertSame('run-a', $frame->runToken, 'the answers must carry the token the client correlates them by');
+        }
+    }
+
     // ---------------------------------------------------------------- the per-run inventory reset
 
     /**

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\BrokenInventoryTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -28,6 +30,8 @@ use Ratchet\ConnectionInterface;
 #[CoversClass(Health::class)]
 final class HealthValidateSourceTest extends TestCase
 {
+    use BrokenInventoryTrait;
+
     public static function setUpBeforeClass(): void
     {
         // Health resolves relative source paths against Router::$apiFilePath, and the inventory
@@ -303,6 +307,103 @@ final class HealthValidateSourceTest extends TestCase
 
         self::assertTrue(self::inventoryIsMemoized(), 'a cancel is not a run beginning');
         self::assertSame([], self::getRunTokens($health), 'cancelRun stays exempt from the ambient token store');
+    }
+
+    // ---------------------------------------------------------------- a broken inventory is contained
+
+    /**
+     * One malformed calendar file must not cost a client its connection, nor its static targets.
+     *
+     * `byId()` reads and JSON-parses every national and diocesan calendar file, so one unparseable
+     * file makes it throw — and a `Throwable` escaping `onMessage()` is caught by Ratchet's
+     * `IoServer`, which closes the connection: an entire run lost to one bad file, by the tool whose
+     * job is to find bad files. `validateSource()` therefore retries against the inventory's static
+     * half, which builds its paths from the `RomanMissal` and `JsonData` registries and never reads
+     * a calendar file, so it cannot have been broken by one.
+     *
+     * Both directions are asserted, because either alone would pass against the wrong thing. The
+     * static id must still reach the execution phase — a retry that resolved nothing would look
+     * identical to no retry at all from the outside. The per-calendar id must NOT, because a
+     * "fallback" that resolved it would have to have read the very data that just failed.
+     */
+    public function testABrokenInventoryStillLetsStaticTargetsBeChecked(): void
+    {
+        $realRoot = Router::$apiFilePath;
+
+        self::withBrokenInventory(static function () use ($realRoot): void {
+            // The fixture tree holds one malformed calendar and nothing else, so give it the two
+            // things a temporale check reads — the temporale file and the schemas it validates
+            // against — and the check can succeed or fail on its own merits rather than on the
+            // fixture's poverty. Nothing here touches the malformed calendar, so the inventory
+            // stays broken; the guard in withBrokenInventory() already proved it.
+            self::copyIntoFixture($realRoot, JsonData::TEMPORALE_FILE->value);
+            self::copyIntoFixture($realRoot, JsonData::SCHEMAS_FOLDER->value);
+
+            $health = new Health();
+
+            $staticTarget = self::createStubConnection(1);
+            self::send($health, $staticTarget, ['action' => 'validateSource', 'target' => ['id' => 'temporale:roman']]);
+
+            $item = CheckableInventory::staticById('temporale:roman');
+            self::assertInstanceOf(CheckableItem::class, $item, 'precondition: the temporale is in the static half');
+
+            self::assertCount(3, $staticTarget->sent, 'a static target stopped being checkable because an unrelated calendar file was malformed');
+
+            $frames = array_map(
+                /** @return \stdClass */
+                static fn (string $raw): object => (object) json_decode($raw),
+                $staticTarget->sent
+            );
+            self::assertSame(
+                [".{$item->label}.file-exists", ".{$item->label}.json-valid", ".{$item->label}.schema-valid"],
+                array_map(static fn (\stdClass $f): mixed => $f->classes, $frames),
+                'the frames were not addressed to the static item the retry was supposed to resolve'
+            );
+            foreach ($frames as $frame) {
+                self::assertSame('success', $frame->type, "the temporale failed its own check: {$frame->text}");
+            }
+
+            $enumeratedTarget = self::createStubConnection(2);
+            self::send($health, $enumeratedTarget, ['action' => 'validateSource', 'target' => ['id' => 'nation:roman:IT']]);
+
+            self::assertCount(1, $enumeratedTarget->sent, 'a target that genuinely cannot be resolved must be answered once, not checked');
+            $frame = json_decode($enumeratedTarget->sent[0]);
+            self::assertSame('echobot', $frame->type);
+            // The message says the index could not be built, not that the id is unknown:
+            // nation:roman:IT is perfectly well known, and reporting a server-side failure as a
+            // client-side one sends the reader hunting a bug that is not there.
+            self::assertStringStartsWith(
+                'Could not resolve validation target nation:roman:IT: the source data inventory could not be built',
+                (string) $frame->text
+            );
+        });
+    }
+
+    /**
+     * Copy one repo-relative file or folder from the real source tree into the fixture tree, at the
+     * same relative position, so that `Router::$apiFilePath` being repointed still finds it.
+     */
+    private static function copyIntoFixture(string $realRoot, string $relative): void
+    {
+        $relative = trim($relative, '/');
+        $from     = $realRoot . $relative;
+        $to       = Router::$apiFilePath . $relative;
+
+        if (is_dir($from)) {
+            self::assertTrue(is_dir($to) || mkdir($to, 0777, true), "could not create fixture folder {$to}");
+            $entries = scandir($from);
+            self::assertIsArray($entries, "could not read {$from}");
+            foreach ($entries as $entry) {
+                if ('.' !== $entry && '..' !== $entry) {
+                    self::copyIntoFixture($realRoot, $relative . '/' . $entry);
+                }
+            }
+            return;
+        }
+
+        $parent = dirname($to);
+        self::assertTrue(is_dir($parent) || mkdir($parent, 0777, true), "could not create fixture folder {$parent}");
+        self::assertTrue(copy($from, $to), "could not copy {$from} into the fixture tree");
     }
 
     // ---------------------------------------------------------------- round trip

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -113,17 +113,23 @@ final class HealthValidateSourceTest extends TestCase
      * branches of `runValidationSteps()`, and without it the folder branch is never reached through
      * this action at all.
      *
-     * @return array<string, array{string, string}>
+     * The third column is the class fragment the frames must be addressed by, written out in full
+     * rather than computed. `temporale:roman` is an explicit inventory item and `nation:roman:IT` /
+     * `nation:roman:US:i18n` are enumerated per-calendar ones, whose labels (`National calendar: IT`)
+     * are the prose that made the shipped fragments unusable — so the two categories the derivation
+     * has to cover are both pinned by a literal here.
+     *
+     * @return array<string, array{string, string, string}>
      */
     public static function equivalentAddressProvider(): array
     {
         return [
             // Same lookup on both sides — $legacySlugToId rewrites the slug into this very id.
-            'temporale'              => ['temporale:roman', 'proprium-de-tempore'],
+            'temporale'              => ['temporale:roman', 'proprium-de-tempore', 'temporale-roman'],
             // Two independent resolutions: regex arm vs byId().
-            'national calendar'      => ['nation:roman:IT', 'national-calendar-IT'],
+            'national calendar'      => ['nation:roman:IT', 'national-calendar-IT', 'nation-roman-IT'],
             // Likewise independent, and the only row whose kind is 'folder'.
-            'national calendar i18n' => ['nation:roman:US:i18n', 'national-calendar-US-i18n']
+            'national calendar i18n' => ['nation:roman:US:i18n', 'national-calendar-US-i18n', 'nation-roman-US-i18n']
         ];
     }
 
@@ -131,7 +137,8 @@ final class HealthValidateSourceTest extends TestCase
      * The published `steps` vocabulary is not the emitted frame-class vocabulary.
      *
      * `CheckableInventory::STEPS` publishes `exists|parses|validates` on the wire, while the frames
-     * are addressed `.<label>.file-exists`, `.<label>.json-valid`, `.<label>.schema-valid`. The two
+     * are addressed `.<fragment>.file-exists`, `.<fragment>.json-valid`, `.<fragment>.schema-valid`.
+     * The two
      * describe the same three steps in different words, and nothing in the codebase relates them,
      * so the correspondence is written down here — once — and asserted rather than restated as a
      * hardcoded list at each call site. A newly published step with no entry here fails loudly,
@@ -146,20 +153,55 @@ final class HealthValidateSourceTest extends TestCase
     ];
 
     /**
+     * What a frame's class fragment has to look like for the client to be able to use it at all.
+     *
+     * `UnitTestInterface/assets/js/testResults.js` feeds the whole `classes` string to
+     * `document.querySelectorAll()` after passing it through `slugifySelector()`, which only
+     * rewrites tokens matching `\.([a-zA-Z][a-zA-Z0-9_-]*)`. A fragment outside this shape is
+     * therefore not merely ugly: one containing a space matches zero cards, and one containing `:`
+     * makes `querySelectorAll()` throw a `SyntaxError` and paints nothing at all.
+     *
+     * Stated here as a literal, independent of anything the server computes. That is the whole
+     * point — an earlier version of the expectation below built it out of `$item->label`, the very
+     * value under test, and so could never have failed on the fragment being unusable.
+     */
+    private const USABLE_CLASS_FRAGMENT = '/^[A-Za-z][A-Za-z0-9_-]*$/';
+
+    /**
      * The frame classes an item's *published* steps say it should emit, in order.
+     *
+     * $fragment is passed in by the caller rather than derived from the item, so that the
+     * expectation is stated rather than recomputed.
      *
      * @return list<string>
      */
-    private static function expectedFrameClasses(CheckableItem $item): array
+    private static function expectedFrameClasses(CheckableItem $item, string $fragment): array
     {
         return array_map(
-            static function (string $step) use ($item): string {
+            static function (string $step) use ($fragment): string {
                 self::assertArrayHasKey($step, self::FRAME_CLASS_FOR_STEP, "published step '{$step}' has no frame class");
 
-                return ".{$item->label}." . self::FRAME_CLASS_FOR_STEP[$step];
+                return ".{$fragment}." . self::FRAME_CLASS_FOR_STEP[$step];
             },
             $item->steps
         );
+    }
+
+    /**
+     * The class fragment a frame is addressed by: everything between the leading dot and the
+     * trailing step.
+     *
+     * A fragment may not contain a `.` — that is what makes `.<fragment>.<step>` parseable at all —
+     * so a frame whose `classes` does not split into exactly three pieces is itself the failure.
+     */
+    private static function classFragmentOf(\stdClass $frame): string
+    {
+        $parts = explode('.', (string) $frame->classes);
+        self::assertCount(3, $parts, "a frame class must be .<fragment>.<step>, got: {$frame->classes}");
+        self::assertSame('', $parts[0], "a frame class must start with a dot, got: {$frame->classes}");
+        self::assertContains($parts[2], self::FRAME_CLASS_FOR_STEP, "unknown step in frame class: {$frame->classes}");
+
+        return $parts[1];
     }
 
     /**
@@ -175,16 +217,25 @@ final class HealthValidateSourceTest extends TestCase
      * `/validations` and waits for exactly that many frames per check. Publishing one count and
      * emitting another wedges the run just as surely as emitting none.
      *
-     * @param string $id   the inventory id a v2 client sends
-     * @param string $slug the `validate` slug a v1 client sends for the same artifact
+     * The frames are addressed by a fragment **derived from the id**, not by the item's label. The
+     * label is human prose (`National calendar: IT`) and the shipped code used it verbatim, which
+     * made the client's `querySelectorAll()` throw on the ~60 per-calendar items and match nothing
+     * on the rest — so the new addressing path painted no card at all. The expectation is written
+     * out in the provider and cross-checked against {@see self::USABLE_CLASS_FRAGMENT}: the literal
+     * pins the exact derivation, and the pattern says what any fragment must satisfy, so a change of
+     * shape fails the first and a change to an equally-broken shape fails the second.
+     *
+     * @param string $id       the inventory id a v2 client sends
+     * @param string $slug     the `validate` slug a v1 client sends for the same artifact
+     * @param string $fragment the CSS class fragment the frames must be addressed by
      */
     #[DataProvider('equivalentAddressProvider')]
-    public function testAKnownIdRunsTheSameCheckAsItsLegacySlug(string $id, string $slug): void
+    public function testAKnownIdRunsTheSameCheckAsItsLegacySlug(string $id, string $slug, string $fragment): void
     {
         $item = CheckableInventory::byId($id);
         self::assertInstanceOf(CheckableItem::class, $item, "the inventory has no entry for {$id}");
 
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
         self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => $id]]);
 
@@ -201,12 +252,17 @@ final class HealthValidateSourceTest extends TestCase
         );
 
         self::assertSame(
-            self::expectedFrameClasses($item),
+            self::expectedFrameClasses($item, $fragment),
             array_map(static fn (\stdClass $f): mixed => $f->classes, $frames),
-            'the frames are addressed by the item label, one per published step, in step order'
+            'the frames are addressed by the fragment derived from the id, one per published step, in step order'
         );
 
         foreach ($frames as $frame) {
+            self::assertMatchesRegularExpression(
+                self::USABLE_CLASS_FRAGMENT,
+                self::classFragmentOf($frame),
+                "the frame class for {$id} is not a selector a client can use: {$frame->classes}"
+            );
             self::assertSame('success', $frame->type, "{$id} did not pass its own check: {$frame->text}");
         }
 
@@ -330,10 +386,17 @@ final class HealthValidateSourceTest extends TestCase
      * The rule must not reach the legacy action it is named after. `executeValidation` *requires*
      * these properties; rejecting them there would delete the v1 surface rather than guard the v2
      * one, and the slug arms stay reachable until clients have moved over (UnitTestInterface#42).
+     *
+     * The `classes` values are asserted literally, and that is the point of the second half of this
+     * test rather than an incidental extra: splitting the class fragment out of `$label` inside
+     * `runValidationSteps()` is the one change on this branch that could have moved a v1 frame, and
+     * the file branch of that method is reached from nowhere else in the in-process suite. A v1
+     * caller passes no fragment, the fragment defaults to the label, and the frames must come out
+     * addressed by the slug exactly as they always were.
      */
     public function testExecuteValidationStillAcceptsTheVeryPropertiesValidateSourceRetires(): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::createStubConnection();
 
         self::send($health, $conn, [
@@ -344,10 +407,18 @@ final class HealthValidateSourceTest extends TestCase
         ]);
 
         self::assertNotEmpty($conn->sent, 'the legacy action stopped being usable');
+        $frames = [];
         foreach ($conn->sent as $raw) {
             $frame = json_decode($raw);
             self::assertNotSame('echobot', $frame->type, "the legacy slug shape was refused: {$frame->text}");
+            $frames[] = $frame;
         }
+
+        self::assertSame(
+            ['.proprium-de-tempore.file-exists', '.proprium-de-tempore.json-valid', '.proprium-de-tempore.schema-valid'],
+            array_map(static fn (\stdClass $f): mixed => $f->classes, $frames),
+            'a v1 message must still be addressed by its own slug, unchanged'
+        );
     }
 
     /**
@@ -532,7 +603,7 @@ final class HealthValidateSourceTest extends TestCase
                 $staticTarget->sent
             );
             self::assertSame(
-                self::expectedFrameClasses($item),
+                self::expectedFrameClasses($item, 'temporale-roman'),
                 array_map(static fn (\stdClass $f): mixed => $f->classes, $frames),
                 'the frames were not addressed to the static item the retry was supposed to resolve'
             );
@@ -632,6 +703,19 @@ final class HealthValidateSourceTest extends TestCase
                     // target was addressed and checked, and the check reported something. This test
                     // is about whether an id can be sent, not about whether its data is valid.
                     $unaddressable[$item->id] = (string) ( $frame->text ?? '' );
+                    continue;
+                }
+
+                // Sent is not the same as usable. A frame the client cannot address is as good as
+                // no frame — a fragment with a space in it matches zero cards and one with a colon
+                // makes `querySelectorAll()` throw — so the whole published set is swept for the
+                // shape a selector has to have, not only the three ids the happy-path rows cover.
+                if ($frame instanceof \stdClass) {
+                    self::assertMatchesRegularExpression(
+                        self::USABLE_CLASS_FRAGMENT,
+                        self::classFragmentOf($frame),
+                        "{$item->id} is addressable but its frames are not: {$frame->classes}"
+                    );
                 }
             }
         }

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -686,6 +686,13 @@ final class HealthValidateSourceTest extends TestCase
         /** @var array<string, string> $unaddressable */
         $unaddressable = [];
 
+        /**
+         * The id that first claimed each lowercased class fragment, so a second claimant is caught.
+         *
+         * @var array<string, string> $fragmentOwners
+         */
+        $fragmentOwners = [];
+
         foreach ($published as $index => $item) {
             $conn = self::createStubConnection($index + 1);
             self::send($health, $conn, ['action' => 'validateSource', 'target' => ['id' => $item->id]]);
@@ -711,11 +718,32 @@ final class HealthValidateSourceTest extends TestCase
                 // makes `querySelectorAll()` throw — so the whole published set is swept for the
                 // shape a selector has to have, not only the three ids the happy-path rows cover.
                 if ($frame instanceof \stdClass) {
+                    $fragment = self::classFragmentOf($frame);
                     self::assertMatchesRegularExpression(
                         self::USABLE_CLASS_FRAGMENT,
-                        self::classFragmentOf($frame),
+                        $fragment,
                         "{$item->id} is addressable but its frames are not: {$frame->classes}"
                     );
+
+                    // Two ids that address the same card are worse than one id that addresses none:
+                    // the client paints one check's result over another's and neither reader can
+                    // tell. The substitution is many-to-one — `a:b` and `a-b` would both yield
+                    // `a-b` — so uniqueness of the *ids*, which CheckableInventoryTest already
+                    // asserts, does not carry over to the fragments and has to be asserted here.
+                    //
+                    // Compared lowercased, because the client lowercases: `slugifySelector()` runs
+                    // every class token through `slugify()`, which begins with `toLowerCase()`, so a
+                    // pair colliding only after lowering collides for real. No realizable collision
+                    // exists in the published set today; this is the guard that keeps it that way
+                    // when a new id kind is added.
+                    $key   = strtolower($fragment);
+                    $owner = $fragmentOwners[$key] ?? $item->id;
+                    self::assertSame(
+                        $owner,
+                        $item->id,
+                        "the class fragment {$fragment} is claimed by both {$owner} and {$item->id}"
+                    );
+                    $fragmentOwners[$key] = $item->id;
                 }
             }
         }

--- a/phpunit_tests/Support/BrokenInventoryTrait.php
+++ b/phpunit_tests/Support/BrokenInventoryTrait.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Router;
+
+/**
+ * Run a closure against a deliberately unreadable source-data inventory.
+ *
+ * Every consumer of `CheckableInventory` has to survive one malformed calendar file, because
+ * `Health` is a long-running ReactPHP process: a `Throwable` that escapes a lookup there does not
+ * fail one check, it takes down schema resolution for every unrelated check — and, from inside
+ * `onMessage()`, closes the client's connection mid-run. Each consumer contains that blast radius
+ * with a retry against the inventory's static half, which cannot have been broken by a calendar
+ * file because it never reads one.
+ *
+ * Untested error handling is how a fallback quietly stops falling back, so the fixture is shared
+ * rather than reimplemented per consumer. It lives here because there are now two: the schema
+ * resolver (`Health::retrieveSchemaForCategory()` / `::getPathToSchemaFile()`) and the
+ * `validateSource` handler.
+ */
+trait BrokenInventoryTrait
+{
+    /**
+     * Runs `$fn` with `CheckableInventory` pointed at a source tree containing one malformed
+     * national calendar file, so that every inventory lookup throws.
+     *
+     * This is the real failure, not a simulated one: the inventory enumerates per-calendar items via
+     * `CalendarMetadataProvider::create()`, which JSON-parses every national and diocesan calendar
+     * file, so a single unparseable file makes `all()` — and therefore `byPath()` and `byId()` —
+     * throw. Only the malformed file needs to exist: national calendars are built first, so the
+     * build aborts before it looks for anything else.
+     *
+     * The memoized statics are reset on the way in *and* on the way out: in on so the poisoned tree
+     * is actually read rather than a good index being served from an earlier test, out so the next
+     * test rebuilds against the real tree.
+     */
+    private static function withBrokenInventory(callable $fn): void
+    {
+        $savedApiFilePath = Router::$apiFilePath;
+        $root             = sys_get_temp_dir() . '/health-broken-inventory-' . getmypid() . '-' . uniqid() . '/';
+        $nationFolder     = $root . JsonData::NATIONAL_CALENDARS_FOLDER->value . '/ZZ';
+
+        self::assertTrue(mkdir($nationFolder, 0777, true), 'could not build the fixture source tree');
+        file_put_contents($nationFolder . '/ZZ.json', '{ this is not JSON');
+
+        Router::$apiFilePath = $root;
+        CheckableInventory::reset();
+
+        try {
+            // Guard: if this ever stops throwing, the tests below would pass for the wrong reason.
+            try {
+                CheckableInventory::all();
+                self::fail('the fixture tree no longer breaks the inventory — this test proves nothing');
+            } catch (\JsonException) {
+                // expected
+            }
+
+            $fn();
+        } finally {
+            Router::$apiFilePath = $savedApiFilePath;
+            CheckableInventory::reset();
+            @unlink($nationFolder . '/ZZ.json');
+            self::removeDirectoryTree($root);
+        }
+    }
+
+    private static function removeDirectoryTree(string $root): void
+    {
+        if (false === is_dir($root)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        /** @var \SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            $entry->isDir() ? @rmdir($entry->getPathname()) : @unlink($entry->getPathname());
+        }
+
+        @rmdir($root);
+    }
+}

--- a/phpunit_tests/Support/HealthQueueIsolationTrait.php
+++ b/phpunit_tests/Support/HealthQueueIsolationTrait.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use LiturgicalCalendar\Api\Health;
+
+/**
+ * Stops a test's queued `Health` requests from being fetched for real once the test is over.
+ *
+ * `Health::cachedGet()` does two things: it appends the request to the private `$queue`, and it
+ * registers a ReactPHP `futureTick`. Neither runs during the test — nothing drives the loop — so a
+ * queued entry is an inert record, which is exactly what makes it a good thing to assert against.
+ * The catch is what happens afterwards: `React\EventLoop\Loop` installs a **shutdown function that
+ * runs the loop when the process ends**, so anything still queued when PHPUnit finishes is
+ * dispatched for real, outside any test, with no assertions watching and no failure if it fails.
+ *
+ * For `Health` those requests are full calendar computations against the API server named in
+ * `.env.local` — hundreds of kilobytes each, and a suite that quietly stops being runnable when
+ * that server is down. Emptying the queue is sufficient: `drainHandler()` stops ticking as soon as
+ * it finds `inFlight === 0` and an empty queue.
+ *
+ * The protection is a trait, and not a `tearDown()` copied into each test class, because the trap
+ * is invisible from the test that falls into it — the test passes, and the damage happens after the
+ * run. Anything that builds a `Health` should get this for free rather than by remembering.
+ *
+ * Build instances with {@see newHealth()}; a `new Health()` written by hand is not tracked and not
+ * protected.
+ */
+trait HealthQueueIsolationTrait
+{
+    /**
+     * Every Health this test built, so tearDown can empty its queue.
+     *
+     * @var list<Health>
+     */
+    private array $trackedHealths = [];
+
+    /**
+     * A Health whose queue will be defused when the test ends.
+     */
+    protected function newHealth(): Health
+    {
+        $health                 = new Health();
+        $this->trackedHealths[] = $health;
+
+        return $health;
+    }
+
+    /**
+     * Empty the request queue of every tracked Health.
+     *
+     * `$queue` is a private *instance* property, so this writes the real one rather than a copy.
+     */
+    protected function defuseHealthQueues(): void
+    {
+        $queue = new \ReflectionProperty(Health::class, 'queue');
+        foreach ($this->trackedHealths as $health) {
+            $queue->setValue($health, []);
+        }
+        $this->trackedHealths = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $this->defuseHealthQueues();
+        parent::tearDown();
+    }
+}

--- a/src/Health.php
+++ b/src/Health.php
@@ -391,6 +391,12 @@ class Health implements MessageComponentInterface
             // this code. Resetting on the token *change* rather than on every message bounds
             // staleness to one run while still costing one rebuild per run, not one per check;
             // a run issues one message per checked item, and there are dozens.
+            //
+            // Known bound, not an oversight: a *new* run that reuses the previous run's token on
+            // the same connection reads as a continuation and skips the reset. Tokens are minted
+            // per run by the client and onClose() drops the entry, so this is theoretical — but if
+            // it ever stops being, the fix is a run-start signal in the protocol, not a reset here
+            // on every message.
             if (( $this->runTokens[$resourceId] ?? null ) !== $messageReceived->runToken) {
                 CheckableInventory::reset();
             }

--- a/src/Health.php
+++ b/src/Health.php
@@ -61,11 +61,20 @@ use Psr\Http\Message\ResponseInterface;
  * Do not confuse these with the *calendar type* named by `category` on `validateCalendar` and `executeUnitTest` below;
  * that is an unrelated vocabulary that merely shares the property name. See issue #806.
  *
+ * `validateCalendar` accepts two message shapes, and the property `calendar` is what tells them apart. A **string**
+ * `calendar` is the legacy (v1) form aliased as `ValidateCalendar`: the identity is spread across `calendar` plus
+ * `category`, and `rite` is an optional *hint* the server may guess at. An **object** `calendar` is the reshaped (v2)
+ * form aliased as `ValidateTypedCalendar`: one `CalendarIdentity` carrying `kind`, `id` and `rite`, no `category`, and
+ * `responsetype` respelled `responseFormat`. The action name is the same in both because the action is the same; only
+ * the identity became typed. See {@see Health::isTypedCalendarMessage()} and issue #806 section D.
+ *
  * @phpstan-type ExecuteValidationCategory 'universalcalendar'|'sourceDataCheck'|'resourceDataCheck'
  * @phpstan-type ExecuteValidationSourceFolder \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFolder:string,responsetype?:string}
  * @phpstan-type ExecuteValidationSourceFile \stdClass&object{action:'executeValidation',category:'universalcalendar'|'sourceDataCheck',validate:string,sourceFile:string,responsetype?:string}
  * @phpstan-type ExecuteValidationResource \stdClass&object{action:'executeValidation',category:'resourceDataCheck',validate:string,sourceFile:string,responsetype?:string}
  * @phpstan-type ValidateCalendar \stdClass&object{action:'validateCalendar',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',responsetype:'JSON'|'XML'|'ICS'|'YML',rite?:string}
+ * @phpstan-type CalendarIdentity \stdClass&object{kind:'general'|'national'|'diocesan'|'rite',id?:string,rite:string}
+ * @phpstan-type ValidateTypedCalendar \stdClass&object{action:'validateCalendar',calendar:CalendarIdentity,year:int,responseFormat:'JSON'|'XML'|'ICS'|'YML',runToken?:string}
  * @phpstan-type ExecuteUnitTest \stdClass&object{action:'executeUnitTest',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',test:string,rite?:string}
  * @phpstan-type CancelRun \stdClass&object{action:'cancelRun',runToken:string}
  * @phpstan-type ValidateSource \stdClass&object{action:'validateSource',target:\stdClass&object{id:string},runToken?:string}
@@ -95,6 +104,30 @@ class Health implements MessageComponentInterface
         'cancelRun'         => ['runToken'],
         'validateSource'    => ['target']
     ];
+
+    /**
+     * Properties required by the *reshaped* `validateCalendar` message — the one whose `calendar` is
+     * a typed identity object rather than a string.
+     *
+     * Deliberately not an entry in ACTION_PROPERTIES: that array is keyed by action name, and this
+     * shape shares its action name with the legacy form. See {@see Health::validateMessageProperties()}.
+     *
+     * @var string[]
+     */
+    private const TYPED_CALENDAR_PROPERTIES = ['calendar', 'year', 'responseFormat'];
+
+    /**
+     * The response formats {@see Health::validateCalendar()} has a validation branch for.
+     *
+     * Narrower than {@see ReturnTypeParam}, on purpose: `ReturnTypeParam::from()` throws a
+     * `\ValueError` on anything it does not know, and a `\ValueError` is an `\Error`, which Ratchet's
+     * `IoServer::handleData` does not catch — so an unusable format on a reshaped message would kill
+     * the whole WebSocket process rather than being answered. Same hazard {@see Health::cancelRun()}
+     * documents, reached by a different door. A format outside this list is rejected instead.
+     *
+     * @var string[]
+     */
+    private const VALIDATABLE_RESPONSE_FORMATS = ['JSON', 'XML', 'ICS', 'YML'];
 
     private const RED    = "\033[0;31m";
     private const GREEN  = "\033[0;32m";
@@ -368,7 +401,7 @@ class Health implements MessageComponentInterface
         // Reset per-connection cache hit counter for each new message (test run)
         $this->cacheHitCounters[$resourceId] = 0;
         echo sprintf('Receiving message from connection %d: %s', $resourceId, $msg . "\n");
-        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest|CancelRun|ValidateSource $messageReceived */
+        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ValidateTypedCalendar|ExecuteUnitTest|CancelRun|ValidateSource $messageReceived */
         $messageReceived = json_decode($msg);
         // Store optional run token for response correlation. `cancelRun` is exempt: it names the run it
         // wants abandoned rather than the run this connection is on, and storing it here would install
@@ -420,6 +453,13 @@ class Health implements MessageComponentInterface
                     $this->executeValidation($messageReceived, $from);
                     break;
                 case 'validateCalendar':
+                    // Same action, two shapes; see isTypedCalendarMessage(). The legacy arm below
+                    // is untouched and stays reachable until UnitTestInterface#42 ships.
+                    if (self::isTypedCalendarMessage($messageReceived)) {
+                        /** @var ValidateTypedCalendar $messageReceived */
+                        $this->validateTypedCalendar($messageReceived, $from);
+                        break;
+                    }
                     /** @var ValidateCalendar $messageReceived */
                     $this->validateCalendar(
                         $messageReceived->calendar,
@@ -1353,6 +1393,155 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * Map a typed identity's `kind` onto the internal calendar category.
+     *
+     * The wire vocabulary and the internal one are deliberately different words for the same four
+     * things, and only the wire half is new: nothing in this plan renames `nationalcalendar`,
+     * `diocesancalendar` or `ritecalendar`, which are threaded through
+     * {@see Health::buildCalendarRequestPath()}, {@see Health::resolveRite()} and
+     * {@see Health::executeUnitTest()}.
+     *
+     * `general` and `rite` both land on `ritecalendar` because they are the same route:
+     * `/calendar/{rite}/{year}` is *the* calendar of a rite, and the General Roman Calendar is that
+     * route with the Roman rite. They stay separate words on the wire because "General Roman
+     * Calendar" is what the thing is called, and because `general` fixes the rite while `rite`
+     * chooses it.
+     *
+     * @return 'nationalcalendar'|'diocesancalendar'|'ritecalendar'|null null when the kind is not one of the four.
+     */
+    private static function categoryForKind(string $kind): ?string
+    {
+        return match ($kind) {
+            'general', 'rite' => 'ritecalendar',
+            'national'        => 'nationalcalendar',
+            'diocesan'        => 'diocesancalendar',
+            default           => null
+        };
+    }
+
+    /**
+     * The rite a calendar identity *actually* has, as far as the server can tell.
+     *
+     * Returning null means "the server has no opinion", which is not the same as "any rite will
+     * do": it is the one case in which a client's assertion is taken at its word, because
+     * contradicting it would require knowledge this process does not have. Only the diocesan kind
+     * can reach that state, and only transiently — `Health::$metadata` is fetched asynchronously
+     * when the WebSocket connection opens.
+     *
+     * @param 'general'|'national'|'diocesan'|'rite' $kind
+     * @param ?string $id The identity's `id`, already known to be a string when the kind requires one.
+     * @return Rite|null The rite this calendar is computed under, or null when it cannot be known here.
+     * @throws \InvalidArgumentException When the id and the kind cannot describe the same calendar at all.
+     */
+    private function actualRiteForKind(string $kind, ?string $id): ?Rite
+    {
+        switch ($kind) {
+            case 'diocesan':
+                try {
+                    return $this->findDioceseMetadata((string) $id)->rite;
+                } catch (\RuntimeException | NotFoundException) {
+                    // Metadata not loaded yet, or an id naming no diocese. Neither is a rite
+                    // disagreement, and reporting either as one would send the reader hunting the
+                    // wrong bug: the first is a server-side timing condition, the second is
+                    // answered honestly by the calendar request itself, which 404s. This is the
+                    // same call {@see Health::resolveRite()} makes, for the same reason.
+                    return null;
+                }
+            case 'national':
+                // National calendars are Roman-only: `/calendars` announces a rite for dioceses and
+                // not for nations, and `/calendar/ambrosian/nation/XX` is a 400 because there is no
+                // such calendar to compute. resolveRite() encodes the same fact by falling through
+                // to the default for this category.
+                return Rite::default();
+            case 'rite':
+                // For a rite-level calendar the id *is* the rite, so an id that names no rite is
+                // not a rite disagreement — it is an identity that describes nothing.
+                $rite = Rite::tryFrom((string) $id);
+                if (null === $rite) {
+                    throw new \InvalidArgumentException("Unknown rite calendar: {$id}");
+                }
+                return $rite;
+            default:
+                // `general` is the General *Roman* Calendar — the rite is in the name. A rite-level
+                // calendar of any other rite is `kind: rite`, which is why the two words both exist.
+                if (null !== $id && Rite::ROMAN !== Rite::tryFrom($id)) {
+                    throw new \InvalidArgumentException("Kind general names the General Roman Calendar; use kind rite for {$id}.");
+                }
+                return Rite::ROMAN;
+        }
+    }
+
+    /**
+     * Resolve a typed calendar identity into the internal triple the calendar routines take.
+     *
+     * Shared by every action that carries a `calendar` object, so that the `kind`→category mapping
+     * and the rite check exist once rather than once per action.
+     *
+     * **A `rite` here is an assertion, not a hint, and a wrong one is rejected.** The distinction is
+     * the point of the typed identity. On a legacy message `rite` is optional and
+     * {@see Health::resolveRite()} prefers it whenever it parses — correct for a value a
+     * rite-unaware client may have guessed at, since a guess is all the protocol could carry. A
+     * client sending a typed identity selected the calendar and knows its rite, so a disagreement is
+     * a client bug. Silently preferring the assertion would compute the wrong calendar; silently
+     * preferring the metadata would compute the right one while leaving the client believing
+     * something false. Saying so is more useful than either.
+     *
+     * @param \stdClass $calendar The identity object; its properties are untrusted, only its type is known.
+     * @return array{category: 'nationalcalendar'|'diocesancalendar'|'ritecalendar', calendar: string, rite: Rite}
+     * @throws \InvalidArgumentException Whose message is the client-facing rejection text.
+     */
+    private function resolveCalendarIdentity(\stdClass $calendar): array
+    {
+        $kind = property_exists($calendar, 'kind') ? $calendar->kind : null;
+        if (false === is_string($kind)) {
+            throw new \InvalidArgumentException('calendar.kind must be a string naming one of: general, national, diocesan, rite.');
+        }
+        $category = self::categoryForKind($kind);
+        if (null === $category) {
+            throw new \InvalidArgumentException("Unknown calendar kind: {$kind}");
+        }
+        /** @var 'general'|'national'|'diocesan'|'rite' $kind */
+
+        $riteName = property_exists($calendar, 'rite') ? $calendar->rite : null;
+        if (false === is_string($riteName)) {
+            throw new \InvalidArgumentException('calendar.rite must be a string naming a known rite.');
+        }
+        $assertedRite = Rite::tryFrom($riteName);
+        if (null === $assertedRite) {
+            throw new \InvalidArgumentException("Unknown rite: {$riteName}");
+        }
+
+        $id = property_exists($calendar, 'id') ? $calendar->id : null;
+        if (null !== $id && false === is_string($id)) {
+            throw new \InvalidArgumentException('calendar.id must be a string.');
+        }
+        // `general` is the only kind that needs no id: there is exactly one General Roman Calendar,
+        // so there is nothing to choose between. Every other kind names one of many.
+        if (null === $id && 'general' !== $kind) {
+            throw new \InvalidArgumentException("calendar.id is required for kind {$kind}.");
+        }
+
+        $actualRite = $this->actualRiteForKind($kind, $id);
+        if (null !== $actualRite && $actualRite !== $assertedRite) {
+            throw new \InvalidArgumentException(sprintf(
+                'calendar.rite says %s but %s is %s.',
+                $assertedRite->value,
+                $id ?? $kind,
+                $actualRite->value
+            ));
+        }
+
+        // A rite-level calendar carries no separate identifier: buildCalendarRequestPath() emits
+        // `/{rite}/{year}` for `ritecalendar` and resolveRite() reads the rite back off the calendar
+        // id, so the rite is what has to be passed as the id. `general` may not have sent one at all.
+        return [
+            'category' => $category,
+            'calendar' => 'ritecalendar' === $category ? $assertedRite->value : (string) $id,
+            'rite'     => $assertedRite
+        ];
+    }
+
+    /**
      * Build the calendar API request path based on calendar ID, year, category and rite.
      *
      * The rite segment is always emitted explicitly (`/roman/...`, `/ambrosian/...`),
@@ -1381,6 +1570,62 @@ class Health implements MessageComponentInterface
             'diocesancalendar'  => "$ritePath/diocese/$calendar/$year?year_type=CIVIL",
             default             => throw new \InvalidArgumentException("Unknown calendar category: {$category}")
         };
+    }
+
+    /**
+     * Handle a `validateCalendar` message carrying a typed calendar identity.
+     *
+     * Purely a translation layer: it resolves the identity, checks the two scalars the legacy shape
+     * never had to type-check, and hands the result to the unchanged
+     * {@see Health::validateCalendar()}. Nothing about *how* a calendar is fetched and validated
+     * changes with the message shape, and this method exists so that nothing about it has to.
+     *
+     * The resolved rite is passed in the `$riteHint` slot. `resolveRite()` treats a parsable hint as
+     * authoritative, which is exactly right here — by this point the hint is not a guess but an
+     * assertion that has been checked against what the server knows.
+     *
+     * `year` and `responseFormat` are type-checked rather than trusted because
+     * `validateMessageProperties()` establishes only that a property is *present*. A null `year`
+     * would reach `validateCalendar(int $year, …)` and raise a `TypeError`, and an unusable
+     * `responseFormat` would reach `ReturnTypeParam::from()` and raise a `\ValueError`; both are
+     * `\Error`s, which Ratchet's `IoServer::handleData` does not catch, so either would take the
+     * whole WebSocket process down over one malformed message. See {@see Health::cancelRun()}, which
+     * documents the same hazard on the property it was found on.
+     *
+     * @param ValidateTypedCalendar $message The message naming the calendar to compute and check.
+     * @param ConnectionInterface $to The connection to send the result frames to.
+     */
+    private function validateTypedCalendar(\stdClass $message, ConnectionInterface $to): void
+    {
+        try {
+            /** @var \stdClass $calendar isTypedCalendarMessage() established the type; nothing establishes the contents. */
+            $calendar = $message->calendar;
+            $identity = $this->resolveCalendarIdentity($calendar);
+        } catch (\InvalidArgumentException $e) {
+            $this->rejectMessage($to, $e->getMessage());
+            return;
+        }
+
+        $year = property_exists($message, 'year') ? $message->year : null;
+        if (false === is_int($year)) {
+            $this->rejectMessage($to, 'validateCalendar year must be an integer.');
+            return;
+        }
+
+        $responseFormat = property_exists($message, 'responseFormat') ? $message->responseFormat : null;
+        if (false === is_string($responseFormat) || false === in_array($responseFormat, self::VALIDATABLE_RESPONSE_FORMATS, true)) {
+            $this->rejectMessage($to, 'validateCalendar responseFormat must be one of: ' . implode(', ', self::VALIDATABLE_RESPONSE_FORMATS) . '.');
+            return;
+        }
+
+        $this->validateCalendar(
+            $identity['calendar'],
+            $year,
+            $identity['category'],
+            $responseFormat,
+            $to,
+            $identity['rite']->value
+        );
     }
 
     /**
@@ -2390,6 +2635,26 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * Is this a `validateCalendar` message in the reshaped (v2) form?
+     *
+     * The whole discriminator, in one place, because it is consulted twice — once by
+     * {@see Health::validateMessageProperties()}, which must know before it applies a property list,
+     * and once by {@see Health::onMessage()}, which must know before it picks a handler. Two
+     * literal copies of "is `calendar` an object?" would be two places to forget.
+     *
+     * `validateCalendar` is the only action that needs a shape test at all. `validateSource` and
+     * `runTest` are new *names*, and a v1 client cannot accidentally emit a name it does not know;
+     * `validateCalendar` kept its name because the action it names did not change.
+     */
+    private static function isTypedCalendarMessage(\stdClass $message): bool
+    {
+        return property_exists($message, 'action')
+            && 'validateCalendar' === $message->action
+            && property_exists($message, 'calendar')
+            && $message->calendar instanceof \stdClass;
+    }
+
+    /**
      * Validates the properties of a message object.
      *
      * This function checks the properties of a given message object to ensure
@@ -2397,11 +2662,29 @@ class Health implements MessageComponentInterface
      * specified action. If any expected property is missing from the message
      * object, the function returns false, indicating the message is invalid.
      *
-     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest|CancelRun|ValidateSource $message The message object to validate.
+     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ValidateTypedCalendar|ExecuteUnitTest|CancelRun|ValidateSource $message The message object to validate.
      * @return bool True if all required properties are present, false otherwise.
      */
     private static function validateMessageProperties(\stdClass $message): bool
     {
+        // ------------------------------------------------------------------ the v2 discriminator
+        // This branch has to be here — ahead of the ACTION_PROPERTIES list — and not inside
+        // validateCalendar(). `validateCalendar` keeps its action name because the *action* is
+        // unchanged, so unlike `validateSource` and `runTest` there is no new name to discriminate
+        // on: the shape of `calendar` is the only signal a reshaped message gives. And a reshaped
+        // message carries neither `category` (folded into `calendar.kind`) nor `responsetype`
+        // (respelled `responseFormat`), both of which ACTION_PROPERTIES['validateCalendar']
+        // requires. Applying that list first would therefore turn away *every* v2 message as
+        // "Invalid message properties" before any handler ever saw it.
+        if (self::isTypedCalendarMessage($message)) {
+            foreach (self::TYPED_CALENDAR_PROPERTIES as $prop) {
+                if (false === property_exists($message, $prop)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        // ------------------------------------------------------------------ everything else, as before
         $valid = true;
         foreach (Health::ACTION_PROPERTIES[$message->action] as $prop) {
             if (false === property_exists($message, $prop)) {

--- a/src/Health.php
+++ b/src/Health.php
@@ -879,6 +879,12 @@ class Health implements MessageComponentInterface
      * The raw id is not usable as-is: `.diocese:ambrosian:lugano_ch` parses as a class followed by a
      * pseudo-class, and the ~60 per-calendar labels contain `: `, which makes `querySelectorAll()`
      * throw outright rather than merely match nothing.
+     *
+     * No case folding **here**, but the fragments this produces are mixed case (`nation-roman-US`,
+     * `sanctorale-roman-EDITIO_TYPICA_1970`) and UnitTestInterface lowercases every class token
+     * before matching. Matching is therefore case-insensitive on the client, which must put the
+     * card's class and its selector through the same treatment; the spec section named above states
+     * that as part of the rule, because a client that lowered only one side would find no cards.
      */
     private static function cssClassFragmentForId(string $id): string
     {

--- a/src/Health.php
+++ b/src/Health.php
@@ -734,8 +734,13 @@ class Health implements MessageComponentInterface
         $schema = Health::retrieveSchemaForCategory($category, $pathForSchema);
 
         // A folder check is recognised exactly as the execution phase used to recognise it, so a
-        // message carrying a non-string `sourceFolder` keeps taking the file branch as before.
-        $isFolderCheck = property_exists($validation, 'sourceFolder') && is_string($validation->sourceFolder);
+        // message carrying a non-string `sourceFolder` keeps taking the file branch as before. The
+        // same predicate yields the folder string the frames quote: the one the client supplied,
+        // which for a reconstructed slug is not the folder the server ends up reading.
+        $sourceFolder  = property_exists($validation, 'sourceFolder') && is_string($validation->sourceFolder)
+            ? $validation->sourceFolder
+            : null;
+        $isFolderCheck = null !== $sourceFolder;
 
         // The slug re-derivation used to open the file branch of the execution phase, but it is
         // resolution work: the seam below must receive a path that is already final, and must
@@ -776,7 +781,9 @@ class Health implements MessageComponentInterface
             $validate,
             $to,
             $runToken,
-            $validation
+            $category,
+            $pathForSchema,
+            $sourceFolder
         );
     }
 
@@ -795,11 +802,16 @@ class Health implements MessageComponentInterface
      * @param string $label The human label and CSS-class fragment for the result frames (what a v1 message calls `validate`).
      * @param ConnectionInterface $to The connection to send the result frames to.
      * @param ?string $runToken The originating run token to echo back on responses, or null to use the per-connection fallback.
-     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|null $legacyMessage
-     *        The originating v1 message, when the caller has one. It takes no part in control flow: it only keeps the
-     *        diagnostic text byte-identical to the pre-extraction output, which quotes the `sourceFolder` the client
-     *        supplied and the `category` it named — neither of which is derivable from a resolved target. A caller
-     *        without a v1 message omits it.
+     * @param string $category The check's category, one of ExecuteValidationCategory. It never touches control flow — the
+     *        schema is already resolved by the time we are called — and appears only in the two "could not detect / verify
+     *        the schema" diagnostics. It is a parameter rather than something rebuilt here so that the rule that produces
+     *        it lives in exactly one place. The default is the right value for an inventory-driven source-data check; a
+     *        caller checking anything else passes its own.
+     * @param ?string $pathForSchema The value the schema was resolved from, quoted in the same two diagnostics; defaults to $label,
+     *        which is what a sourceDataCheck resolves from.
+     * @param ?string $sourceFolder For a folder check, the folder as the *caller* named it — what the result frames quote.
+     *        It is not always $dataPath: a v1 client sends a bare id (`IT`) for the reconstructed i18n slugs and the server
+     *        reads the folder it derived from it. Defaults to $dataPath, for a caller whose two are the same.
      */
     private function runValidationSteps(
         string $dataPath,
@@ -808,33 +820,17 @@ class Health implements MessageComponentInterface
         string $label,
         ConnectionInterface $to,
         ?string $runToken,
-        ?\stdClass $legacyMessage = null
+        string $category = 'sourceDataCheck',
+        ?string $pathForSchema = null,
+        ?string $sourceFolder = null
     ): void {
-        $category = null !== $legacyMessage ? (string) $legacyMessage->category : 'sourceDataCheck';
-
-        // The value the schema was resolved from: the `validate` slug for a sourceDataCheck, the
-        // `sourceFile` itself for the other two categories. It appears only in the "unable to
-        // detect a schema" diagnostic.
-        $pathForSchema = ( null !== $legacyMessage && $category !== 'sourceDataCheck' && property_exists($legacyMessage, 'sourceFile') && is_string($legacyMessage->sourceFile) )
-            ? $legacyMessage->sourceFile
-            : $label;
-
-        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource $validationForMessages */
-        $validationForMessages = $legacyMessage ?? (object) [
-            'action'     => 'executeValidation',
-            'category'   => $category,
-            'validate'   => $label,
-            'sourceFile' => $dataPath
-        ];
+        $pathForSchema ??= $label;
+        // Read before $dataPath is made absolute below, so the two stay distinguishable.
+        $sourceFolder ??= $dataPath;
 
         // Now that we have the correct schema to validate against,
         // we will perform the actual validation either for all files in a folder, or for a single file
         if ($kind === 'folder') {
-            // The folder as the client named it, which is what the messages quote; $dataPath is
-            // the folder the server resolved and actually reads.
-            $sourceFolder = ( null !== $legacyMessage && property_exists($legacyMessage, 'sourceFolder') && is_string($legacyMessage->sourceFolder) )
-                ? $legacyMessage->sourceFolder
-                : $dataPath;
             // Resolve relative paths against the project root
             if (!str_starts_with($dataPath, '/')) {
                 $dataPath = Router::$apiFilePath . $dataPath;
@@ -952,11 +948,25 @@ class Health implements MessageComponentInterface
                         $runToken
                     );
                 },
-                function (\Throwable $e) use ($validationForMessages) {
-                    echo 'Error verifying i18n folder for validation ' . json_encode($validationForMessages) . ': ' . $e->getMessage() . "\n";
+                function (\Throwable $e) use ($label, $dataPath) {
+                    echo 'Error verifying i18n folder for validation ' . $label . ' (' . $dataPath . '): ' . $e->getMessage() . "\n";
                 }
             );
         } else {
+            // {@see Health::processValidationData()} and {@see Health::handleValidationDataError()} take a
+            // whole v1 message and read exactly two properties off it: `validate` and `category`. Both are
+            // parameters here, so this is a pure adapter for their signatures — it carries no information
+            // the caller did not pass. The annotation asserts the *shape* those two require; the literal
+            // category cannot be proven, because an unrecognised category has to reach the diagnostic
+            // verbatim (telling a client that its category was wrong is the diagnostic's whole job).
+            /** @var ExecuteValidationSourceFile|ExecuteValidationResource $validationForMessages */
+            $validationForMessages = (object) [
+                'action'     => 'executeValidation',
+                'category'   => $category,
+                'validate'   => $label,
+                'sourceFile' => $dataPath
+            ];
+
             // If we are validating an API path, we check for a 200 OK HTTP response from the API
             // rather than checking for existence of the file in the filesystem
             if (str_starts_with($dataPath, 'http://') || str_starts_with($dataPath, 'https://')) {

--- a/src/Health.php
+++ b/src/Health.php
@@ -63,10 +63,12 @@ use Psr\Http\Message\ResponseInterface;
  *
  * `validateCalendar` accepts two message shapes, and the property `calendar` is what tells them apart. A **string**
  * `calendar` is the legacy (v1) form aliased as `ValidateCalendar`: the identity is spread across `calendar` plus
- * `category`, and `rite` is an optional *hint* the server may guess at. An **object** `calendar` is the reshaped (v2)
- * form aliased as `ValidateTypedCalendar`: one `CalendarIdentity` carrying `kind`, `id` and `rite`, no `category`, and
- * `responsetype` respelled `responseFormat`. The action name is the same in both because the action is the same; only
- * the identity became typed. See {@see Health::isTypedCalendarMessage()} and issue #806 section D.
+ * `category`, and `rite` is an optional hint. An **object** `calendar` is the reshaped (v2) form aliased as
+ * `ValidateTypedCalendar`: one `CalendarIdentity` carrying `kind`, `id` and `rite`, no `category`, and `responsetype`
+ * respelled `responseFormat`. The action name is the same in both because the action is the same; only the identity
+ * became typed — and with it the standing of `rite`, which stops being a hint and becomes an assertion the server
+ * checks; {@see Health::resolveCalendarIdentity()} is where that is argued and enforced.
+ * See {@see Health::isTypedCalendarMessage()} and issue #806 section D.
  *
  * @phpstan-type ExecuteValidationCategory 'universalcalendar'|'sourceDataCheck'|'resourceDataCheck'
  * @phpstan-type ExecuteValidationSourceFolder \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFolder:string,responsetype?:string}
@@ -1443,8 +1445,17 @@ class Health implements MessageComponentInterface
                     // Metadata not loaded yet, or an id naming no diocese. Neither is a rite
                     // disagreement, and reporting either as one would send the reader hunting the
                     // wrong bug: the first is a server-side timing condition, the second is
-                    // answered honestly by the calendar request itself, which 404s. This is the
-                    // same call {@see Health::resolveRite()} makes, for the same reason.
+                    // answered honestly by the calendar request itself, which 404s.
+                    //
+                    // {@see Health::resolveRite()} swallows the same two exceptions for the same
+                    // reason but returns a different value — `Rite::default()`, not null — so do
+                    // not read this as delegating to it. The two cannot agree on a return value:
+                    // resolveRite() must name a rite because a URL has to be built, while null here
+                    // means "no opinion to contradict the client with", and ROMAN would be an
+                    // opinion. The observable behaviour is nevertheless identical, because a null
+                    // here means the client's rite survives as the hint validateTypedCalendar()
+                    // passes on, and resolveRite() honours a parsable hint at step 1 and never
+                    // reaches its own diocesan lookup.
                     return null;
                 }
             case 'national':
@@ -1464,8 +1475,13 @@ class Health implements MessageComponentInterface
             default:
                 // `general` is the General *Roman* Calendar — the rite is in the name. A rite-level
                 // calendar of any other rite is `kind: rite`, which is why the two words both exist.
+                //
+                // The message says what is wrong and stops there, deliberately. Naming a kind to
+                // try instead would be wrong as often as right: `ambrosian` would indeed want
+                // `kind: rite`, but `IT` would want `kind: national` and `kind: rite` would reject
+                // it in turn, so the advice would send the reader somewhere that also fails.
                 if (null !== $id && Rite::ROMAN !== Rite::tryFrom($id)) {
-                    throw new \InvalidArgumentException("Kind general names the General Roman Calendar; use kind rite for {$id}.");
+                    throw new \InvalidArgumentException("Kind general names the General Roman Calendar; its only valid id is roman, not {$id}.");
                 }
                 return Rite::ROMAN;
         }
@@ -1581,8 +1597,8 @@ class Health implements MessageComponentInterface
      * changes with the message shape, and this method exists so that nothing about it has to.
      *
      * The resolved rite is passed in the `$riteHint` slot. `resolveRite()` treats a parsable hint as
-     * authoritative, which is exactly right here — by this point the hint is not a guess but an
-     * assertion that has been checked against what the server knows.
+     * authoritative, which is exactly right here because by this point it has been checked — see
+     * {@see Health::resolveCalendarIdentity()}.
      *
      * `year` and `responseFormat` are type-checked rather than trusted because
      * `validateMessageProperties()` establishes only that a property is *present*. A null `year`
@@ -1597,6 +1613,22 @@ class Health implements MessageComponentInterface
      */
     private function validateTypedCalendar(\stdClass $message, ConnectionInterface $to): void
     {
+        // A leftover `category` is a half-migrated client, and silently ignoring it is the worst of
+        // the available answers: the message happens to work, because `calendar.kind` supplies the
+        // category and the stale property is simply never read, so the client keeps believing
+        // `category` still selects the calendar type and only finds out otherwise the day the two
+        // disagree. Say so now, while the two still agree.
+        //
+        // `responsetype` needs no equivalent check and does not get one. Sent *instead of*
+        // `responseFormat` it never arrives here at all — the property list rejects the message for
+        // the missing `responseFormat`. Sent *alongside* a correct `responseFormat` it is stale
+        // noise from a client that has already done the rename right, not a misunderstanding about
+        // what names the format. `category` has no such harmless reading.
+        if (property_exists($message, 'category')) {
+            $this->rejectMessage($to, 'category is not part of a validateCalendar message with an object calendar: calendar.kind replaces it.');
+            return;
+        }
+
         try {
             /** @var \stdClass $calendar isTypedCalendarMessage() established the type; nothing establishes the contents. */
             $calendar = $message->calendar;

--- a/src/Health.php
+++ b/src/Health.php
@@ -70,6 +70,20 @@ use Psr\Http\Message\ResponseInterface;
  * checks; {@see Health::resolveCalendarIdentity()} is where that is argued and enforced.
  * See {@see Health::isTypedCalendarMessage()} and issue #806 section D.
  *
+ * `runTest` is the reshaped `executeUnitTest`, aliased as `RunTest`: a `test` name, the same
+ * `CalendarIdentity` — resolved by the same {@see Health::resolveCalendarIdentity()}, so the mapping
+ * and the rite check exist once for both actions — and a year. It carries no `responseFormat`
+ * because a test runs against the parsed calendar rather than against a chosen representation of it.
+ * Unlike `validateCalendar` it took a new *name*, which is the whole of its discrimination: a v1
+ * client cannot emit a name it does not know. `executeUnitTest` is untouched and stays reachable
+ * until UnitTestInterface#42 ships. See issue #806 section E.
+ *
+ * Do not confuse `runTest` with the inventory item `test:{rite}:{Name}` that `validateSource`
+ * addresses. That item is a *source check*: does the test definition exist, parse, and validate
+ * against `LitCalTest.json`. `runTest` *runs* the test that definition describes against a computed
+ * calendar. A definition can be valid while the test it describes fails, and vice versa, so the two
+ * are separate operations with separate addresses.
+ *
  * @phpstan-type ExecuteValidationCategory 'universalcalendar'|'sourceDataCheck'|'resourceDataCheck'
  * @phpstan-type ExecuteValidationSourceFolder \stdClass&object{action:'executeValidation',category:'sourceDataCheck',validate:string,sourceFolder:string,responsetype?:string}
  * @phpstan-type ExecuteValidationSourceFile \stdClass&object{action:'executeValidation',category:'universalcalendar'|'sourceDataCheck',validate:string,sourceFile:string,responsetype?:string}
@@ -78,6 +92,7 @@ use Psr\Http\Message\ResponseInterface;
  * @phpstan-type CalendarIdentity \stdClass&object{kind:'general'|'national'|'diocesan'|'rite',id?:string,rite:string}
  * @phpstan-type ValidateTypedCalendar \stdClass&object{action:'validateCalendar',calendar:CalendarIdentity,year:int,responseFormat:'JSON'|'XML'|'ICS'|'YML',runToken?:string}
  * @phpstan-type ExecuteUnitTest \stdClass&object{action:'executeUnitTest',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',test:string,rite?:string}
+ * @phpstan-type RunTest \stdClass&object{action:'runTest',test:string,calendar:CalendarIdentity,year:int,runToken?:string}
  * @phpstan-type CancelRun \stdClass&object{action:'cancelRun',runToken:string}
  * @phpstan-type ValidateSource \stdClass&object{action:'validateSource',target:\stdClass&object{id:string},runToken?:string}
  *
@@ -103,6 +118,9 @@ class Health implements MessageComponentInterface
         'executeValidation' => ['category', 'validate', 'sourceFile'],
         'validateCalendar'  => ['category', 'calendar', 'year', 'responsetype'],
         'executeUnitTest'   => ['category', 'calendar', 'year', 'test'],
+        // No `category`: `calendar.kind` carries it. No `responseFormat` either — a test runs
+        // against the parsed calendar, so the representation is not the client's to choose.
+        'runTest'           => ['test', 'calendar', 'year'],
         'cancelRun'         => ['runToken'],
         'validateSource'    => ['target']
     ];
@@ -403,7 +421,7 @@ class Health implements MessageComponentInterface
         // Reset per-connection cache hit counter for each new message (test run)
         $this->cacheHitCounters[$resourceId] = 0;
         echo sprintf('Receiving message from connection %d: %s', $resourceId, $msg . "\n");
-        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ValidateTypedCalendar|ExecuteUnitTest|CancelRun|ValidateSource $messageReceived */
+        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ValidateTypedCalendar|ExecuteUnitTest|RunTest|CancelRun|ValidateSource $messageReceived */
         $messageReceived = json_decode($msg);
         // Store optional run token for response correlation. `cancelRun` is exempt: it names the run it
         // wants abandoned rather than the run this connection is on, and storing it here would install
@@ -482,6 +500,10 @@ class Health implements MessageComponentInterface
                         $from,
                         self::readRiteHint($messageReceived)
                     );
+                    break;
+                case 'runTest':
+                    /** @var RunTest $messageReceived */
+                    $this->runTest($messageReceived, $from);
                     break;
                 case 'cancelRun':
                     /** @var CancelRun $messageReceived */
@@ -1558,6 +1580,53 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * Read a message's `calendar` property as a typed identity.
+     *
+     * Both actions that carry one come through here, and the shared step is the *read*, not the
+     * guarantee: `validateCalendar` is discriminated on `calendar` being an object
+     * ({@see Health::isTypedCalendarMessage()}), so by the time it arrives the check below cannot
+     * fail; `runTest` is discriminated on its name, so nothing has looked at `calendar` at all. The
+     * one that needs the check and the one that does not therefore call the same thing, which is
+     * what stops the second from being written without it.
+     *
+     * @param string $action The action name, so the rejection says which message is wrong.
+     * @return array{category: 'nationalcalendar'|'diocesancalendar'|'ritecalendar', calendar: string, rite: Rite}
+     * @throws \InvalidArgumentException Whose message is the client-facing rejection text.
+     */
+    private function readCalendarIdentity(\stdClass $message, string $action): array
+    {
+        $calendar = property_exists($message, 'calendar') ? $message->calendar : null;
+        if (false === $calendar instanceof \stdClass) {
+            throw new \InvalidArgumentException("{$action} calendar must be an object carrying kind, id and rite.");
+        }
+
+        return $this->resolveCalendarIdentity($calendar);
+    }
+
+    /**
+     * Read a message's `year` as the integer the calendar routines take.
+     *
+     * Type-checked rather than trusted because {@see Health::validateMessageProperties()} establishes
+     * only that a property is *present*. A null or string `year` would reach
+     * `validateCalendar(…, int $year, …)` or `executeUnitTest(…, int $year, …)` and raise a
+     * `TypeError` — an `\Error`, which Ratchet's `IoServer::handleData` does not catch, so one
+     * malformed message would take the whole WebSocket process down rather than be answered. Same
+     * hazard {@see Health::cancelRun()} documents, on the property it was first found on.
+     *
+     * @param string $action The action name, so the rejection says which message is wrong.
+     * @throws \InvalidArgumentException Whose message is the client-facing rejection text.
+     */
+    private static function readYear(\stdClass $message, string $action): int
+    {
+        $year = property_exists($message, 'year') ? $message->year : null;
+        if (false === is_int($year)) {
+            throw new \InvalidArgumentException("{$action} year must be an integer.");
+        }
+
+        return $year;
+    }
+
+    /**
      * Build the calendar API request path based on calendar ID, year, category and rite.
      *
      * The rite segment is always emitted explicitly (`/roman/...`, `/ambrosian/...`),
@@ -1601,10 +1670,10 @@ class Health implements MessageComponentInterface
      * {@see Health::resolveCalendarIdentity()}.
      *
      * `year` and `responseFormat` are type-checked rather than trusted because
-     * `validateMessageProperties()` establishes only that a property is *present*. A null `year`
-     * would reach `validateCalendar(int $year, …)` and raise a `TypeError`, and an unusable
-     * `responseFormat` would reach `ReturnTypeParam::from()` and raise a `\ValueError`; both are
-     * `\Error`s, which Ratchet's `IoServer::handleData` does not catch, so either would take the
+     * `validateMessageProperties()` establishes only that a property is *present*. `year` is checked
+     * by the shared {@see Health::readYear()}; `responseFormat` is checked here because it belongs
+     * to this action alone — an unusable one would reach `ReturnTypeParam::from()` and raise a
+     * `\ValueError`, which is an `\Error` and so escapes Ratchet's `IoServer::handleData`, taking the
      * whole WebSocket process down over one malformed message. See {@see Health::cancelRun()}, which
      * documents the same hazard on the property it was found on.
      *
@@ -1630,17 +1699,10 @@ class Health implements MessageComponentInterface
         }
 
         try {
-            /** @var \stdClass $calendar isTypedCalendarMessage() established the type; nothing establishes the contents. */
-            $calendar = $message->calendar;
-            $identity = $this->resolveCalendarIdentity($calendar);
+            $identity = $this->readCalendarIdentity($message, 'validateCalendar');
+            $year     = self::readYear($message, 'validateCalendar');
         } catch (\InvalidArgumentException $e) {
             $this->rejectMessage($to, $e->getMessage());
-            return;
-        }
-
-        $year = property_exists($message, 'year') ? $message->year : null;
-        if (false === is_int($year)) {
-            $this->rejectMessage($to, 'validateCalendar year must be an integer.');
             return;
         }
 
@@ -1926,6 +1988,64 @@ class Health implements MessageComponentInterface
             $errorStrings[] = $errorLevel . ': ' . $error['message'] . " at line {$lineIndex} ({$lineString})";
         }
         return $errorStrings;
+    }
+
+    /**
+     * Handle a `runTest` message: run one named unit test against a computed calendar.
+     *
+     * A translation layer in the same sense as {@see Health::validateTypedCalendar()}, and for the
+     * same reason: it resolves the identity, type-checks the two scalars the property list can only
+     * prove present, and hands the result to the unchanged {@see Health::executeUnitTest()}. Nothing
+     * about *how* a test is run changes with the message shape, and this method exists so that
+     * nothing about it has to.
+     *
+     * The resolved rite goes in the `$riteHint` slot, where `resolveRite()` treats a parsable value
+     * as authoritative — correct here because {@see Health::resolveCalendarIdentity()} has already
+     * checked it against what the server knows.
+     *
+     * **Not the same thing as checking the test definition.** `test:{rite}:{Name}` is an inventory id
+     * addressed by {@see Health::validateSource()}, and it asks whether the definition file exists,
+     * parses and validates against `LitCalTest.json`. `runTest` names the test by its bare name and
+     * runs it. A definition can be valid while the test it describes fails, and a definition can be
+     * malformed while the calendar is perfectly correct, so neither answer substitutes for the other.
+     *
+     * Nothing here mirrors `validateTypedCalendar()`'s rejection of a leftover `category`, and the
+     * asymmetry is deliberate. That check exists because `validateCalendar` *shares its name* with
+     * the shape `category` belonged to, so a stale `category` is evidence of a half-migrated message
+     * that would otherwise work silently. `category` never named anything on a message called
+     * `runTest`; a client that sent one has renamed the action, so it has read the new shape. An
+     * unread extra property on a new name is just an extra property — which is how `validateSource`,
+     * the other new name, treats them too.
+     *
+     * @param RunTest $message The message naming the test, the calendar and the year.
+     * @param ConnectionInterface $to The connection to send the result frames to.
+     */
+    private function runTest(\stdClass $message, ConnectionInterface $to): void
+    {
+        // Checked rather than trusted for the reason readYear() sets out: a non-string here would
+        // reach executeUnitTest(string $test, …) as a TypeError, which Ratchet does not catch.
+        $test = property_exists($message, 'test') ? $message->test : null;
+        if (false === is_string($test)) {
+            $this->rejectMessage($to, 'runTest test must be a string.');
+            return;
+        }
+
+        try {
+            $identity = $this->readCalendarIdentity($message, 'runTest');
+            $year     = self::readYear($message, 'runTest');
+        } catch (\InvalidArgumentException $e) {
+            $this->rejectMessage($to, $e->getMessage());
+            return;
+        }
+
+        $this->executeUnitTest(
+            $test,
+            $identity['calendar'],
+            $year,
+            $identity['category'],
+            $to,
+            $identity['rite']->value
+        );
     }
 
     /**
@@ -2694,7 +2814,7 @@ class Health implements MessageComponentInterface
      * specified action. If any expected property is missing from the message
      * object, the function returns false, indicating the message is invalid.
      *
-     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ValidateTypedCalendar|ExecuteUnitTest|CancelRun|ValidateSource $message The message object to validate.
+     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ValidateTypedCalendar|ExecuteUnitTest|RunTest|CancelRun|ValidateSource $message The message object to validate.
      * @return bool True if all required properties are present, false otherwise.
      */
     private static function validateMessageProperties(\stdClass $message): bool

--- a/src/Health.php
+++ b/src/Health.php
@@ -68,6 +68,7 @@ use Psr\Http\Message\ResponseInterface;
  * @phpstan-type ValidateCalendar \stdClass&object{action:'validateCalendar',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',responsetype:'JSON'|'XML'|'ICS'|'YML',rite?:string}
  * @phpstan-type ExecuteUnitTest \stdClass&object{action:'executeUnitTest',calendar:string,year:int,category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',test:string,rite?:string}
  * @phpstan-type CancelRun \stdClass&object{action:'cancelRun',runToken:string}
+ * @phpstan-type ValidateSource \stdClass&object{action:'validateSource',target:\stdClass&object{id:string},runToken?:string}
  *
  * @phpstan-import-type LiturgicalEvent from \LiturgicalCalendar\Api\Test\LitTestRunner
  */
@@ -91,7 +92,8 @@ class Health implements MessageComponentInterface
         'executeValidation' => ['category', 'validate', 'sourceFile'],
         'validateCalendar'  => ['category', 'calendar', 'year', 'responsetype'],
         'executeUnitTest'   => ['category', 'calendar', 'year', 'test'],
-        'cancelRun'         => ['runToken']
+        'cancelRun'         => ['runToken'],
+        'validateSource'    => ['target']
     ];
 
     private const RED    = "\033[0;31m";
@@ -366,7 +368,7 @@ class Health implements MessageComponentInterface
         // Reset per-connection cache hit counter for each new message (test run)
         $this->cacheHitCounters[$resourceId] = 0;
         echo sprintf('Receiving message from connection %d: %s', $resourceId, $msg . "\n");
-        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest|CancelRun $messageReceived */
+        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest|CancelRun|ValidateSource $messageReceived */
         $messageReceived = json_decode($msg);
         // Store optional run token for response correlation. `cancelRun` is exempt: it names the run it
         // wants abandoned rather than the run this connection is on, and storing it here would install
@@ -380,6 +382,18 @@ class Health implements MessageComponentInterface
             && is_string($messageReceived->runToken)
             && preg_match('/^[A-Za-z0-9_\-]{1,64}$/', $messageReceived->runToken)
         ) {
+            // A token this connection was not already on is a run *beginning*, and that is the one
+            // moment the inventory may safely be rebuilt: `validateSource` addresses source data
+            // solely through `CheckableInventory::byId()`, whose index is memoized for the lifetime
+            // of this process rather than of a request, so a calendar added through `/data` would
+            // otherwise stay unaddressable until the WebSocket server restarts. A write-path hook
+            // cannot close that gap — `/data` writes happen in the HTTP process, which never runs
+            // this code. Resetting on the token *change* rather than on every message bounds
+            // staleness to one run while still costing one rebuild per run, not one per check;
+            // a run issues one message per checked item, and there are dozens.
+            if (( $this->runTokens[$resourceId] ?? null ) !== $messageReceived->runToken) {
+                CheckableInventory::reset();
+            }
             $this->runTokens[$resourceId] = $messageReceived->runToken;
         }
         if (
@@ -418,6 +432,10 @@ class Health implements MessageComponentInterface
                 case 'cancelRun':
                     /** @var CancelRun $messageReceived */
                     $this->cancelRun($messageReceived->runToken, $from);
+                    break;
+                case 'validateSource':
+                    /** @var ValidateSource $messageReceived */
+                    $this->validateSource($messageReceived, $from);
                     break;
                 default:
                     $message       = new \stdClass();
@@ -506,6 +524,25 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * Reject a malformed or unresolvable v2 message.
+     *
+     * Reuses the existing `echobot` error shape deliberately. Since UnitTestInterface PR #46 an
+     * unrecognised response `type` is painted as a visible failed check, so a dedicated
+     * `protocolError` type would make every rejection look like a failing test. That type belongs
+     * to #806 section G and is gated on section C.
+     *
+     * @param ConnectionInterface $to The connection that sent the message being rejected.
+     * @param string $text Why the message could not be acted on.
+     */
+    private function rejectMessage(ConnectionInterface $to, string $text): void
+    {
+        $message       = new \stdClass();
+        $message->type = 'echobot';
+        $message->text = $text;
+        $this->sendMessage($to, $message);
+    }
+
+    /**
      * Capture the run token currently associated with a connection. Called synchronously at the
      * start of each request handler (before any async work), so the value is the originating
      * request's token; that token is then threaded into the handler's async responses so they
@@ -578,6 +615,79 @@ class Health implements MessageComponentInterface
             throw new NotFoundException("No diocese found for calendar id: {$calendarId}");
         }
         return $dioceseMetadata;
+    }
+
+    /**
+     * Check one source-data artifact, named by the id `GET /validations` published for it.
+     *
+     * This is the addressing half of {@see Health::executeValidation()}, done the other way round.
+     * A v1 message carries a hyphenated `validate` slug that the server has to recover a path and a
+     * schema from, through eight anchored patterns that are each a second copy of a naming
+     * convention written down somewhere else — which is the drift #806 exists to remove. An id is
+     * opaque: the server minted it, published it, and looks it up. One lookup, no grammar.
+     *
+     * Nothing here is subtracted from `executeValidation()`; both address the same execution phase,
+     * and the slug arms stay reachable until clients have moved over (UnitTestInterface#42).
+     *
+     * The six-argument call is deliberate: an inventory entry is a source-data check whose data path
+     * and quoted folder are the same path, and whose schema was resolved from its own id — exactly
+     * the three defaults {@see Health::runValidationSteps()} supplies.
+     *
+     * @param ValidateSource $message The message naming the target to check.
+     * @param ConnectionInterface $to The connection to send the result frames to.
+     */
+    private function validateSource(\stdClass $message, ConnectionInterface $to): void
+    {
+        // `validateMessageProperties()` has already established that `target` is present; what it
+        // cannot establish is its shape, since ACTION_PROPERTIES only names required properties.
+        $target = property_exists($message, 'target') ? $message->target : null;
+        if (false === ( $target instanceof \stdClass ) || false === property_exists($target, 'id')) {
+            $this->rejectMessage($to, 'validateSource requires a target object with an id.');
+            return;
+        }
+
+        $id = $target->id;
+        if (false === is_string($id)) {
+            $this->rejectMessage($to, 'validateSource target id must be a string.');
+            return;
+        }
+
+        $inventoryError = null;
+        try {
+            $item = CheckableInventory::byId($id);
+        } catch (\Throwable $e) {
+            // The same containment, and the same static-half retry, as in getPathToSchemaFile() and
+            // retrieveSchemaForCategory(): building the index reads and parses every calendar source
+            // file, so one malformed file must not cost every other check in a process that stays
+            // up. It matters more here than there, because an exception escaping onMessage() is
+            // caught by Ratchet's IoServer, which closes the client's connection mid-run — the
+            // whole run lost to one unreadable file.
+            $inventoryError = $e;
+            $item           = CheckableInventory::staticById($id);
+        }
+
+        if (null === $item) {
+            // The two misses are not the same thing and must not read as though they were: an id
+            // nobody published is a client bug, while an id that could not be looked up is a server
+            // one, and reporting the second as "unknown" would send the reader hunting the wrong
+            // one — the #800 blindness in miniature.
+            $this->rejectMessage(
+                $to,
+                null === $inventoryError
+                    ? "Unknown validation target: {$id}"
+                    : "Could not resolve validation target {$id}: the source data inventory could not be built ({$inventoryError->getMessage()})"
+            );
+            return;
+        }
+
+        $this->runValidationSteps(
+            $item->path,
+            $item->kind,
+            $item->schema->path(),
+            $item->label,
+            $to,
+            $this->resolveRunToken($to)
+        );
     }
 
     /**
@@ -2275,7 +2385,7 @@ class Health implements MessageComponentInterface
      * specified action. If any expected property is missing from the message
      * object, the function returns false, indicating the message is invalid.
      *
-     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest|CancelRun $message The message object to validate.
+     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ExecuteUnitTest|CancelRun|ValidateSource $message The message object to validate.
      * @return bool True if all required properties are present, false otherwise.
      */
     private static function validateMessageProperties(\stdClass $message): bool

--- a/src/Health.php
+++ b/src/Health.php
@@ -397,6 +397,12 @@ class Health implements MessageComponentInterface
             // per run by the client and onClose() drops the entry, so this is theoretical — but if
             // it ever stops being, the fix is a run-start signal in the protocol, not a reset here
             // on every message.
+            //
+            // Second bound, worth knowing before relying on this: `runToken` is optional, and a
+            // client that omits it never reaches this block at all — so it never resets, and never
+            // sees a calendar written through `/data` until the server restarts. The reset gives
+            // freshness to clients that opt into run correlation; a tokenless client opts out of
+            // both together.
             if (( $this->runTokens[$resourceId] ?? null ) !== $messageReceived->runToken) {
                 CheckableInventory::reset();
             }

--- a/src/Health.php
+++ b/src/Health.php
@@ -78,6 +78,10 @@ use Psr\Http\Message\ResponseInterface;
  * client cannot emit a name it does not know. `executeUnitTest` is untouched and stays reachable
  * until UnitTestInterface#42 ships. See issue #806 section E.
  *
+ * All three reshaped messages — `validateSource`, `validateCalendar` and `runTest` — reject a legacy
+ * property their own shape retired, rather than ignoring it. See {@see Health::RETIRED_PROPERTIES}
+ * for the rule and {@see Health::rejectRetiredProperties()} for the one implementation of it.
+ *
  * Do not confuse `runTest` with the inventory item `test:{rite}:{Name}` that `validateSource`
  * addresses. That item is a *source check*: does the test definition exist, parse, and validate
  * against `LitCalTest.json`. `runTest` *runs* the test that definition describes against a computed
@@ -135,6 +139,66 @@ class Health implements MessageComponentInterface
      * @var string[]
      */
     private const TYPED_CALENDAR_PROPERTIES = ['calendar', 'year', 'responseFormat'];
+
+    /**
+     * The legacy properties each reshaped message *replaced*, and what replaced them.
+     *
+     * **A v2 message that also carries a legacy property its own shape retired is rejected**, on all
+     * three reshaped actions, by maintainer ruling. Not a breaking change: a v1 client sends a string
+     * `calendar` or an old action name and never reaches these checks. What it catches is the
+     * half-migrated client — one that has adopted the new shape and is still sending the old fields —
+     * which otherwise gets behaviour that looks correct, because a retired property is simply never
+     * read, and breaks on the day the legacy branch is removed. A loud error while the two still
+     * agree is the whole value.
+     *
+     * Uniform on purpose. Making a client's mistake loud on one action and silent on two would be
+     * worse than either answer applied consistently, because the client cannot tell which it is
+     * getting.
+     *
+     * `runTest` retires only `category`: `ACTION_PROPERTIES['executeUnitTest']` is
+     * `['category', 'calendar', 'year', 'test']`, so there was never a `responsetype` on it to
+     * retire. `runToken` is retired by nothing — it is shared, current, and valid on all three.
+     *
+     * Keyed by action; `shape` completes the sentence "… is not part of a %s" and is why
+     * `validateCalendar`'s reads "a validateCalendar message with an object calendar": on a *string*
+     * calendar `category` is required, not retired, and a message that said otherwise would be lying
+     * to a v1 client. `retired` maps each retired property to the clause naming its replacement, so
+     * the rejection tells a migrating client what to do rather than only that it is wrong.
+     *
+     * @var array<string, array{shape: string, retired: array<string, string>}>
+     */
+    private const RETIRED_PROPERTIES = [
+        'validateSource'   => [
+            'shape'   => 'validateSource message',
+            'retired' => [
+                // `executeValidation` spread the address across a schema-resolution strategy and a
+                // path; an inventory id is the whole address, and the server resolves both from it.
+                'category'     => 'target.id replaces it.',
+                'validate'     => 'target.id replaces it.',
+                'sourceFile'   => 'target.id replaces it.',
+                'sourceFolder' => 'target.id replaces it.'
+            ]
+        ],
+        'validateCalendar' => [
+            'shape'   => 'validateCalendar message with an object calendar',
+            'retired' => [
+                'category'     => 'calendar.kind replaces it.',
+                // Task 3 left this one accepted, reasoning that alongside a correct `responseFormat`
+                // it was stale noise from a client that had already done the rename right. The
+                // uniform rule overrules that: it is precisely the half-migration signal worth
+                // seeing. Sent *instead of* `responseFormat` it never reaches here at all — the
+                // property list turns the message away for the missing required property, and that
+                // reading is unchanged.
+                'responsetype' => 'responseFormat replaces it.'
+            ]
+        ],
+        'runTest'          => [
+            'shape'   => 'runTest message',
+            'retired' => [
+                'category' => 'calendar.kind replaces it.'
+            ]
+        ]
+    ];
 
     /**
      * The response formats {@see Health::validateCalendar()} has a validation branch for.
@@ -703,7 +767,11 @@ class Health implements MessageComponentInterface
      * opaque: the server minted it, published it, and looks it up. One lookup, no grammar.
      *
      * Nothing here is subtracted from `executeValidation()`; both address the same execution phase,
-     * and the slug arms stay reachable until clients have moved over (UnitTestInterface#42).
+     * and the slug arms stay reachable until clients have moved over (UnitTestInterface#42). What is
+     * refused is a message that tries to be both: `category`, `validate`, `sourceFile` and
+     * `sourceFolder` are the four properties an id replaces outright, so carrying one alongside a
+     * `target` is a half-migrated client naming its check twice and being read once. See
+     * {@see Health::RETIRED_PROPERTIES}.
      *
      * The six-argument call is deliberate: an inventory entry is a source-data check whose data path
      * and quoted folder are the same path, and whose schema was resolved from its own id — exactly
@@ -714,6 +782,10 @@ class Health implements MessageComponentInterface
      */
     private function validateSource(\stdClass $message, ConnectionInterface $to): void
     {
+        if ($this->rejectRetiredProperties($message, 'validateSource', $to)) {
+            return;
+        }
+
         // `validateMessageProperties()` has already established that `target` is present; what it
         // cannot establish is its shape, since ACTION_PROPERTIES only names required properties.
         $target = property_exists($message, 'target') ? $message->target : null;
@@ -1580,6 +1652,37 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * Reject a v2 message that still carries a legacy property its own shape retired.
+     *
+     * One implementation for all three reshaped actions, called from
+     * {@see Health::validateSource()}, {@see Health::validateTypedCalendar()} and
+     * {@see Health::runTest()}. Three hand-written copies of this rule is exactly the shape that lets
+     * one of them quietly stop rejecting — the same argument that put the `kind`→category mapping in
+     * one place.
+     *
+     * Runs before anything else in each handler, so a half-migrated message is answered for what is
+     * actually wrong with it rather than for whatever its retired property happened to make of the
+     * rest. The first offender in declaration order is named and the rest are not: each message then
+     * says one true, specific thing, and a client sending two retired properties hears about the
+     * second on its next attempt. See {@see Health::RETIRED_PROPERTIES} for why the rule exists.
+     *
+     * @param 'validateSource'|'validateCalendar'|'runTest' $action The reshaped action being handled.
+     * @return bool True when the message was rejected and the caller must stop.
+     */
+    private function rejectRetiredProperties(\stdClass $message, string $action, ConnectionInterface $to): bool
+    {
+        $shape = self::RETIRED_PROPERTIES[$action]['shape'];
+        foreach (self::RETIRED_PROPERTIES[$action]['retired'] as $property => $replacement) {
+            if (property_exists($message, $property)) {
+                $this->rejectMessage($to, sprintf('%s is not part of a %s: %s', $property, $shape, $replacement));
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
      * Read a message's `calendar` property as a typed identity.
      *
      * Both actions that carry one come through here, and the shared step is the *read*, not the
@@ -1682,19 +1785,12 @@ class Health implements MessageComponentInterface
      */
     private function validateTypedCalendar(\stdClass $message, ConnectionInterface $to): void
     {
-        // A leftover `category` is a half-migrated client, and silently ignoring it is the worst of
-        // the available answers: the message happens to work, because `calendar.kind` supplies the
-        // category and the stale property is simply never read, so the client keeps believing
-        // `category` still selects the calendar type and only finds out otherwise the day the two
-        // disagree. Say so now, while the two still agree.
-        //
-        // `responsetype` needs no equivalent check and does not get one. Sent *instead of*
-        // `responseFormat` it never arrives here at all — the property list rejects the message for
-        // the missing `responseFormat`. Sent *alongside* a correct `responseFormat` it is stale
-        // noise from a client that has already done the rename right, not a misunderstanding about
-        // what names the format. `category` has no such harmless reading.
-        if (property_exists($message, 'category')) {
-            $this->rejectMessage($to, 'category is not part of a validateCalendar message with an object calendar: calendar.kind replaces it.');
+        // A leftover `category` or `responsetype` is a half-migrated client: the message happens to
+        // work, because `calendar.kind` and `responseFormat` supply what is actually read and the
+        // stale property never is, so the client keeps believing the old property still selects
+        // something and only finds out otherwise the day the two disagree. Say so now, while they
+        // still agree. See Health::RETIRED_PROPERTIES.
+        if ($this->rejectRetiredProperties($message, 'validateCalendar', $to)) {
             return;
         }
 
@@ -2009,19 +2105,22 @@ class Health implements MessageComponentInterface
      * runs it. A definition can be valid while the test it describes fails, and a definition can be
      * malformed while the calendar is perfectly correct, so neither answer substitutes for the other.
      *
-     * Nothing here mirrors `validateTypedCalendar()`'s rejection of a leftover `category`, and the
-     * asymmetry is deliberate. That check exists because `validateCalendar` *shares its name* with
-     * the shape `category` belonged to, so a stale `category` is evidence of a half-migrated message
-     * that would otherwise work silently. `category` never named anything on a message called
-     * `runTest`; a client that sent one has renamed the action, so it has read the new shape. An
-     * unread extra property on a new name is just an extra property — which is how `validateSource`,
-     * the other new name, treats them too.
+     * A leftover `category` is rejected here exactly as it is on `validateTypedCalendar()`, through
+     * the shared {@see Health::rejectRetiredProperties()}. `runTest` has a mechanical predecessor in
+     * `executeUnitTest`, which required `category`, so a client that renamed the action and kept the
+     * property is as plausible here as anywhere — and `calendar.kind` supplies the category, so the
+     * message would otherwise work while the client kept believing `category` selected something.
+     * Only `category` is retired: `executeUnitTest` never had a `responsetype` to retire.
      *
      * @param RunTest $message The message naming the test, the calendar and the year.
      * @param ConnectionInterface $to The connection to send the result frames to.
      */
     private function runTest(\stdClass $message, ConnectionInterface $to): void
     {
+        if ($this->rejectRetiredProperties($message, 'runTest', $to)) {
+            return;
+        }
+
         // Checked rather than trusted for the reason readYear() sets out: a non-string here would
         // reach executeUnitTest(string $test, …) as a TypeError, which Ratchet does not catch.
         $test = property_exists($message, 'test') ? $message->test : null;

--- a/src/Health.php
+++ b/src/Health.php
@@ -733,12 +733,108 @@ class Health implements MessageComponentInterface
 
         $schema = Health::retrieveSchemaForCategory($category, $pathForSchema);
 
+        // A folder check is recognised exactly as the execution phase used to recognise it, so a
+        // message carrying a non-string `sourceFolder` keeps taking the file branch as before.
+        $isFolderCheck = property_exists($validation, 'sourceFolder') && is_string($validation->sourceFolder);
+
+        // The slug re-derivation used to open the file branch of the execution phase, but it is
+        // resolution work: the seam below must receive a path that is already final, and must
+        // never re-derive one. Nothing between the two positions reads $dataPath, so the move is
+        // behaviour-preserving.
+        if (false === $isFolderCheck) {
+            $matches = null;
+            if (preg_match('/^diocesan-calendar-([a-z]{6}_[a-z]{2})$/', $pathForSchema, $matches)) {
+                $dioceseId = $matches[1];
+                try {
+                    $dioceseMetadata = $this->findDioceseMetadata($dioceseId);
+                } catch (\RuntimeException | NotFoundException $e) {
+                    $this->handleDioceseMetadataError($e, $to, $validation, $dioceseId, $runToken);
+                    return;
+                }
+                $nation      = $dioceseMetadata->nation;
+                $dioceseName = $dioceseMetadata->diocese;
+                // Rite-partitioned, exactly as the i18n-folder branch above: this is the site
+                // that actually governs a diocesan source-file check, because it reassigns
+                // $dataPath after the earlier `sourceFile` branch has run.
+                $dataPath = strtr(JsonData::diocesanCalendarFileFor($dioceseMetadata->rite)->path(), [
+                    '{nation}'       => $nation,
+                    '{diocese}'      => $dioceseId,
+                    '{diocese_name}' => $dioceseName
+                ]);
+            } elseif (preg_match('/^national-calendar-([A-Z]{2})$/', $pathForSchema, $matches)) {
+                $nation   = $matches[1];
+                $dataPath = strtr(JsonData::NATIONAL_CALENDAR_FILE->path(), [
+                    '{nation}' => $nation
+                ]);
+            }
+        }
+
+        $this->runValidationSteps(
+            $dataPath,
+            $isFolderCheck ? 'folder' : 'file',
+            $schema,
+            $validate,
+            $to,
+            $runToken,
+            $validation
+        );
+    }
+
+    /**
+     * Run the validation steps for one already-resolved target.
+     *
+     * This is the execution half of {@see Health::executeValidation()}: given a final path, a
+     * kind and a schema, it emits the `file-exists` / `json-valid` / `schema-valid` frames.
+     * Resolving that path and that schema from a client message happens before the call and
+     * never here, so a caller that already knows its target — an inventory entry, whose `kind`
+     * uses this same `file`/`folder` vocabulary — can enter directly.
+     *
+     * @param string $dataPath The final path to check: a project-relative or absolute file or folder path, or an API URL.
+     * @param 'file'|'folder' $kind Whether $dataPath names a folder of i18n files or a single file/endpoint.
+     * @param ?string $schema The schema to validate against, or null when none could be resolved.
+     * @param string $label The human label and CSS-class fragment for the result frames (what a v1 message calls `validate`).
+     * @param ConnectionInterface $to The connection to send the result frames to.
+     * @param ?string $runToken The originating run token to echo back on responses, or null to use the per-connection fallback.
+     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|null $legacyMessage
+     *        The originating v1 message, when the caller has one. It takes no part in control flow: it only keeps the
+     *        diagnostic text byte-identical to the pre-extraction output, which quotes the `sourceFolder` the client
+     *        supplied and the `category` it named — neither of which is derivable from a resolved target. A caller
+     *        without a v1 message omits it.
+     */
+    private function runValidationSteps(
+        string $dataPath,
+        string $kind,
+        ?string $schema,
+        string $label,
+        ConnectionInterface $to,
+        ?string $runToken,
+        ?\stdClass $legacyMessage = null
+    ): void {
+        $category = null !== $legacyMessage ? (string) $legacyMessage->category : 'sourceDataCheck';
+
+        // The value the schema was resolved from: the `validate` slug for a sourceDataCheck, the
+        // `sourceFile` itself for the other two categories. It appears only in the "unable to
+        // detect a schema" diagnostic.
+        $pathForSchema = ( null !== $legacyMessage && $category !== 'sourceDataCheck' && property_exists($legacyMessage, 'sourceFile') && is_string($legacyMessage->sourceFile) )
+            ? $legacyMessage->sourceFile
+            : $label;
+
+        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource $validationForMessages */
+        $validationForMessages = $legacyMessage ?? (object) [
+            'action'     => 'executeValidation',
+            'category'   => $category,
+            'validate'   => $label,
+            'sourceFile' => $dataPath
+        ];
+
         // Now that we have the correct schema to validate against,
         // we will perform the actual validation either for all files in a folder, or for a single file
-        if (property_exists($validation, 'sourceFolder') && is_string($validation->sourceFolder)) {
-            $sourceFolder = (string) $validation->sourceFolder;
-            // If the 'sourceFolder' property is set, then we are validating a folder of i18n files
-            /** @var ExecuteValidationSourceFolder $validation */
+        if ($kind === 'folder') {
+            // The folder as the client named it, which is what the messages quote; $dataPath is
+            // the folder the server resolved and actually reads.
+            $sourceFolder = ( null !== $legacyMessage && property_exists($legacyMessage, 'sourceFolder') && is_string($legacyMessage->sourceFolder) )
+                ? $legacyMessage->sourceFolder
+                : $dataPath;
             // Resolve relative paths against the project root
             if (!str_starts_with($dataPath, '/')) {
                 $dataPath = Router::$apiFilePath . $dataPath;
@@ -752,7 +848,7 @@ class Health implements MessageComponentInterface
                 foreach (['file-exists', 'json-valid', 'schema-valid'] as $step) {
                     $this->sendFolderStepResult(
                         $to,
-                        "$validate.$step",
+                        "$label.$step",
                         $missing,
                         '', // unreachable: $missing is non-empty, so the failure text is used
                         "Data folder $sourceFolder could not be checked",
@@ -790,11 +886,9 @@ class Health implements MessageComponentInterface
                 /** @var PromiseInterface<array{data: string, fromCache: bool}> $promise */
                 $promise    = $this->cachedFileGetContents($file);
                 $promises[] = $promise->then(
-                    function (array $result) use ($validation, $filename, $schema, $pathForSchema, &$jsonErrors, &$schemaErrors) {
+                    function (array $result) use ($filename, $schema, $label, $category, $pathForSchema, &$jsonErrors, &$schemaErrors) {
                         /** @var array{data: string, fromCache: bool} $result */
                         $fileData = $result['data'];
-                        $validate = (string) $validation->validate;
-                        $category = (string) $validation->category;
                         $jsonData = json_decode($fileData);
                         if (json_last_error() !== JSON_ERROR_NONE) {
                             $jsonErrors[] = "$filename: " . json_last_error_msg();
@@ -810,7 +904,7 @@ class Health implements MessageComponentInterface
                                     $schemaErrors[] = "$filename: " . $validationText;
                                 }
                             } else {
-                                $schemaErrors[] = "$filename: unable to detect a schema for {$validate} and category {$category} (path for schema: $pathForSchema)";
+                                $schemaErrors[] = "$filename: unable to detect a schema for {$label} and category {$category} (path for schema: $pathForSchema)";
                             }
                         }
                     },
@@ -827,16 +921,13 @@ class Health implements MessageComponentInterface
             $allPromises = Promise\all($promises);
 
             $allPromises->then(
-                function () use ($to, $validation, $schema, &$fileExistsErrors, &$jsonErrors, &$schemaErrors, $runToken) {
-                    $validate     = (string) $validation->validate;
-                    $sourceFolder = (string) $validation->sourceFolder;
-
+                function () use ($to, $label, $sourceFolder, $schema, &$fileExistsErrors, &$jsonErrors, &$schemaErrors, $runToken) {
                     // Exactly one frame per step, pass or fail. A folder check is a statement
                     // about the folder, so a failure names the offending files inside a single
                     // frame instead of emitting one frame each.
                     $this->sendFolderStepResult(
                         $to,
-                        "$validate.file-exists",
+                        "$label.file-exists",
                         $fileExistsErrors,
                         "The Data folder $sourceFolder exists and contains valid i18n json files",
                         "Data folder $sourceFolder",
@@ -845,7 +936,7 @@ class Health implements MessageComponentInterface
 
                     $this->sendFolderStepResult(
                         $to,
-                        "$validate.json-valid",
+                        "$label.json-valid",
                         $jsonErrors,
                         "The i18n json files in Data folder $sourceFolder were successfully decoded as JSON",
                         "The i18n json files in Data folder $sourceFolder were not all decoded as JSON",
@@ -854,64 +945,34 @@ class Health implements MessageComponentInterface
 
                     $this->sendFolderStepResult(
                         $to,
-                        "$validate.schema-valid",
+                        "$label.schema-valid",
                         $schemaErrors,
                         "The i18n json files in Data folder $sourceFolder were successfully validated against the Schema $schema",
                         "The i18n json files in Data folder $sourceFolder were not all valid against the Schema $schema",
                         $runToken
                     );
                 },
-                function (\Throwable $e) use ($validation) {
-                    echo 'Error verifying i18n folder for validation ' . json_encode($validation) . ': ' . $e->getMessage() . "\n";
+                function (\Throwable $e) use ($validationForMessages) {
+                    echo 'Error verifying i18n folder for validation ' . json_encode($validationForMessages) . ': ' . $e->getMessage() . "\n";
                 }
             );
         } else {
-            // If the 'sourceFolder' property is not set, then we are validating a single source file or API path
-            $matches = null;
-            if (preg_match('/^diocesan-calendar-([a-z]{6}_[a-z]{2})$/', $pathForSchema, $matches)) {
-                $dioceseId = $matches[1];
-                try {
-                    $dioceseMetadata = $this->findDioceseMetadata($dioceseId);
-                } catch (\RuntimeException | NotFoundException $e) {
-                    $this->handleDioceseMetadataError($e, $to, $validation, $dioceseId, $runToken);
-                    return;
-                }
-                $nation      = $dioceseMetadata->nation;
-                $dioceseName = $dioceseMetadata->diocese;
-                // Rite-partitioned, exactly as the i18n-folder branch above: this is the site
-                // that actually governs a diocesan source-file check, because it reassigns
-                // $dataPath after the earlier `sourceFile` branch has run.
-                $dataPath = strtr(JsonData::diocesanCalendarFileFor($dioceseMetadata->rite)->path(), [
-                    '{nation}'       => $nation,
-                    '{diocese}'      => $dioceseId,
-                    '{diocese_name}' => $dioceseName
-                ]);
-            } elseif (preg_match('/^national-calendar-([A-Z]{2})$/', $pathForSchema, $matches)) {
-                $nation   = $matches[1];
-                $dataPath = strtr(JsonData::NATIONAL_CALENDAR_FILE->path(), [
-                    '{nation}' => $nation
-                ]);
-            }
-
             // If we are validating an API path, we check for a 200 OK HTTP response from the API
             // rather than checking for existence of the file in the filesystem
-            $category = (string) $validation->category;
-            $validate = (string) $validation->validate;
-
             if (str_starts_with($dataPath, 'http://') || str_starts_with($dataPath, 'https://')) {
                 // $dataPath is an API path in this case
                 echo 'Retrieving data from URL ' . $dataPath . "\n";
                 /** @var PromiseInterface<array{data: string, fromCache: bool}> $httpPromise */
                 $httpPromise = $this->cachedGet($dataPath, [], 300, $to);
                 $httpPromise->then(
-                    function (array $result) use ($to, $validation, $dataPath, $schema, $pathForSchema, $runToken) {
+                    function (array $result) use ($to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken) {
                         /** @var array{data: string, fromCache: bool} $result */
                         $data = $result['data'];
                         echo 'Fetched data for ' . $dataPath . ': got ' . strlen($data) . " bytes\n";
-                        $this->processValidationData($data, $to, $validation, $dataPath, $schema, $pathForSchema, $runToken);
+                        $this->processValidationData($data, $to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken);
                     },
-                    function (\Throwable $e) use ($to, $validation, $dataPath, $runToken) {
-                        $this->handleValidationDataError($e, $to, $validation, $dataPath, $runToken);
+                    function (\Throwable $e) use ($to, $validationForMessages, $dataPath, $runToken) {
+                        $this->handleValidationDataError($e, $to, $validationForMessages, $dataPath, $runToken);
                     }
                 );
             } else {
@@ -925,14 +986,14 @@ class Health implements MessageComponentInterface
                 /** @var PromiseInterface<array{data: string, fromCache: bool}> $promise */
                 $promise = $this->cachedFileGetContents($fsPath);
                 $promise->then(
-                    function (array $result) use ($to, $validation, $dataPath, $schema, $pathForSchema, $runToken) {
+                    function (array $result) use ($to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken) {
                         /** @var array{data: string, fromCache: bool} $result */
                         $data = $result['data'];
                         echo 'Fetched data for ' . $dataPath . ': got ' . strlen($data) . " bytes\n";
-                        $this->processValidationData($data, $to, $validation, $dataPath, $schema, $pathForSchema, $runToken);
+                        $this->processValidationData($data, $to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken);
                     },
-                    function (\Throwable $e) use ($to, $validation, $dataPath, $runToken) {
-                        $this->handleValidationDataError($e, $to, $validation, $dataPath, $runToken);
+                    function (\Throwable $e) use ($to, $validationForMessages, $dataPath, $runToken) {
+                        $this->handleValidationDataError($e, $to, $validationForMessages, $dataPath, $runToken);
                     }
                 );
             }

--- a/src/Health.php
+++ b/src/Health.php
@@ -155,9 +155,19 @@ class Health implements MessageComponentInterface
      * worse than either answer applied consistently, because the client cannot tell which it is
      * getting.
      *
-     * `runTest` retires only `category`: `ACTION_PROPERTIES['executeUnitTest']` is
+     * `runTest` retires `category` and `rite`: `ACTION_PROPERTIES['executeUnitTest']` is
      * `['category', 'calendar', 'year', 'test']`, so there was never a `responsetype` on it to
      * retire. `runToken` is retired by nothing — it is shared, current, and valid on all three.
+     *
+     * **The retired set is not derivable from `ACTION_PROPERTIES`**, and an audit that assumed it
+     * was is how `rite` came to be missed on both calendar actions: `ACTION_PROPERTIES` lists only
+     * *required* properties, so every optional v1 property — `rite` on `validateCalendar` and
+     * `executeUnitTest`, `responsetype` on `executeValidation` — was structurally invisible to it.
+     * When adding a shape here, read the v1 predecessor's `@phpstan-type` alias at the top of this
+     * file, where the optional properties are the ones marked `?`. (`responsetype` on
+     * `executeValidation` is the one optional property deliberately *not* retired: `validateSource`
+     * has no response representation to choose, `executeValidation()` never read it, and retiring it
+     * would answer a question no client is asking.)
      *
      * Keyed by action; `shape` completes the sentence "… is not part of a %s" and is why
      * `validateCalendar`'s reads "a validateCalendar message with an object calendar": on a *string*
@@ -189,13 +199,22 @@ class Health implements MessageComponentInterface
                 // seeing. Sent *instead of* `responseFormat` it never reaches here at all — the
                 // property list turns the message away for the missing required property, and that
                 // reading is unchanged.
-                'responsetype' => 'responseFormat replaces it.'
+                'responsetype' => 'responseFormat replaces it.',
+                // Optional on v1, and therefore invisible to an audit that read ACTION_PROPERTIES —
+                // which lists required properties only. It is the one retired property whose silent
+                // acceptance would be actively dangerous: a half-migrated client that objectified
+                // `calendar` but kept its old top-level `rite` gets a *rite disagreement* ignored,
+                // which is exactly what the typed identity went out of its way to make loud.
+                'rite'         => 'calendar.rite replaces it.'
             ]
         ],
         'runTest'          => [
             'shape'   => 'runTest message',
             'retired' => [
-                'category' => 'calendar.kind replaces it.'
+                'category' => 'calendar.kind replaces it.',
+                // Same optional property, same predecessor treatment: `executeUnitTest` read a
+                // top-level `rite` through readRiteHint(); `runTest` reads only `calendar.rite`.
+                'rite'     => 'calendar.rite replaces it.'
             ]
         ]
     ];
@@ -1829,11 +1848,13 @@ class Health implements MessageComponentInterface
      */
     private function validateTypedCalendar(\stdClass $message, ConnectionInterface $to): void
     {
-        // A leftover `category` or `responsetype` is a half-migrated client: the message happens to
-        // work, because `calendar.kind` and `responseFormat` supply what is actually read and the
-        // stale property never is, so the client keeps believing the old property still selects
-        // something and only finds out otherwise the day the two disagree. Say so now, while they
-        // still agree. See Health::RETIRED_PROPERTIES.
+        // A leftover `category`, `responsetype` or top-level `rite` is a half-migrated client: the
+        // message happens to work, because `calendar.kind`, `responseFormat` and `calendar.rite`
+        // supply what is actually read and the stale property never is, so the client keeps
+        // believing the old property still selects something and only finds out otherwise the day
+        // the two disagree. Say so now, while they still agree — most sharply for `rite`, where a
+        // disagreement is the very thing resolveCalendarIdentity() refuses to resolve silently.
+        // See Health::RETIRED_PROPERTIES.
         if ($this->rejectRetiredProperties($message, 'validateCalendar', $to)) {
             return;
         }

--- a/src/Health.php
+++ b/src/Health.php
@@ -834,8 +834,36 @@ class Health implements MessageComponentInterface
             $item->schema->path(),
             $item->label,
             $to,
-            $this->resolveRunToken($to)
+            $this->resolveRunToken($to),
+            // The label is prose — `National calendar: US` — and is fine as the human half of a
+            // frame, but it is not a selector. The address comes from the id instead.
+            classFragment: self::cssClassFragmentForId($item->id)
         );
+    }
+
+    /**
+     * Derive the CSS class fragment a `validateSource` result frame is addressed by, from an inventory id.
+     *
+     * **The rule, in full: replace every character outside `[A-Za-z0-9_-]` with `-`.** Nothing else —
+     * no case folding, no collapsing of runs, no trimming. `temporale:roman` becomes
+     * `temporale-roman`, `nation:roman:US` becomes `nation-roman-US`, and
+     * `diocese:ambrosian:lugano_ch` becomes `diocese-ambrosian-lugano_ch`. A client holding an id
+     * computes the same string with one substitution and matches `.<fragment>.<step>`; this is
+     * written down as a client-implementable rule in the design spec (`Id vocabulary` → *the frame
+     * class fragment*) precisely because UnitTestInterface#42 has to reproduce it, and a derivation
+     * only the server knows would be no better than not publishing the id.
+     *
+     * Derived from the **id**, never from the label. The id is stable and opaque and the server
+     * minted it; the label is human-facing prose that is expected to change, and an address that
+     * moved when someone reworded a caption would be worse than no address at all.
+     *
+     * The raw id is not usable as-is: `.diocese:ambrosian:lugano_ch` parses as a class followed by a
+     * pseudo-class, and the ~60 per-calendar labels contain `: `, which makes `querySelectorAll()`
+     * throw outright rather than merely match nothing.
+     */
+    private static function cssClassFragmentForId(string $id): string
+    {
+        return (string) preg_replace('/[^A-Za-z0-9_-]/', '-', $id);
     }
 
     /**
@@ -1057,7 +1085,8 @@ class Health implements MessageComponentInterface
      * @param string $dataPath The final path to check: a project-relative or absolute file or folder path, or an API URL.
      * @param 'file'|'folder' $kind Whether $dataPath names a folder of i18n files or a single file/endpoint.
      * @param ?string $schema The schema to validate against, or null when none could be resolved.
-     * @param string $label The human label and CSS-class fragment for the result frames (what a v1 message calls `validate`).
+     * @param string $label The human label for the result frames (what a v1 message calls `validate`). It reaches only the
+     *        message *text*; what the frames are addressed by is $classFragment, which defaults to it.
      * @param ConnectionInterface $to The connection to send the result frames to.
      * @param ?string $runToken The originating run token to echo back on responses, or null to use the per-connection fallback.
      * @param string $category The check's category, one of ExecuteValidationCategory. It never touches control flow — the
@@ -1070,6 +1099,13 @@ class Health implements MessageComponentInterface
      * @param ?string $sourceFolder For a folder check, the folder as the *caller* named it — what the result frames quote.
      *        It is not always $dataPath: a v1 client sends a bare id (`IT`) for the reconstructed i18n slugs and the server
      *        reads the folder it derived from it. Defaults to $dataPath, for a caller whose two are the same.
+     * @param ?string $classFragment The CSS class fragment the result frames are addressed by, without the leading dot and
+     *        without the trailing `.file-exists` / `.json-valid` / `.schema-valid` step. Split out from $label because the
+     *        two are only *accidentally* the same thing: a v1 `validate` slug is hyphenated precisely so that it can serve
+     *        as both, but an inventory label is human prose (`National calendar: US`) and would produce a selector that
+     *        matches nothing — or, once it contains `: `, one that makes the client's `querySelectorAll()` throw. Defaults
+     *        to $label so that every v1 caller keeps emitting byte-identical frames; a caller whose label is not slug-safe
+     *        passes its own, derived from a stable id via {@see Health::cssClassFragmentForId()}.
      */
     private function runValidationSteps(
         string $dataPath,
@@ -1080,11 +1116,15 @@ class Health implements MessageComponentInterface
         ?string $runToken,
         string $category = 'sourceDataCheck',
         ?string $pathForSchema = null,
-        ?string $sourceFolder = null
+        ?string $sourceFolder = null,
+        ?string $classFragment = null
     ): void {
         $pathForSchema ??= $label;
         // Read before $dataPath is made absolute below, so the two stay distinguishable.
         $sourceFolder ??= $dataPath;
+        // The v1 conflation, preserved exactly: with no fragment of its own a caller addresses its
+        // frames by its label, which is what `executeValidation` has always done.
+        $classFragment ??= $label;
 
         // Now that we have the correct schema to validate against,
         // we will perform the actual validation either for all files in a folder, or for a single file
@@ -1102,7 +1142,7 @@ class Health implements MessageComponentInterface
                 foreach (['file-exists', 'json-valid', 'schema-valid'] as $step) {
                     $this->sendFolderStepResult(
                         $to,
-                        "$label.$step",
+                        "$classFragment.$step",
                         $missing,
                         '', // unreachable: $missing is non-empty, so the failure text is used
                         "Data folder $sourceFolder could not be checked",
@@ -1175,13 +1215,13 @@ class Health implements MessageComponentInterface
             $allPromises = Promise\all($promises);
 
             $allPromises->then(
-                function () use ($to, $label, $sourceFolder, $schema, &$fileExistsErrors, &$jsonErrors, &$schemaErrors, $runToken) {
+                function () use ($to, $classFragment, $sourceFolder, $schema, &$fileExistsErrors, &$jsonErrors, &$schemaErrors, $runToken) {
                     // Exactly one frame per step, pass or fail. A folder check is a statement
                     // about the folder, so a failure names the offending files inside a single
                     // frame instead of emitting one frame each.
                     $this->sendFolderStepResult(
                         $to,
-                        "$label.file-exists",
+                        "$classFragment.file-exists",
                         $fileExistsErrors,
                         "The Data folder $sourceFolder exists and contains valid i18n json files",
                         "Data folder $sourceFolder",
@@ -1190,7 +1230,7 @@ class Health implements MessageComponentInterface
 
                     $this->sendFolderStepResult(
                         $to,
-                        "$label.json-valid",
+                        "$classFragment.json-valid",
                         $jsonErrors,
                         "The i18n json files in Data folder $sourceFolder were successfully decoded as JSON",
                         "The i18n json files in Data folder $sourceFolder were not all decoded as JSON",
@@ -1199,7 +1239,7 @@ class Health implements MessageComponentInterface
 
                     $this->sendFolderStepResult(
                         $to,
-                        "$label.schema-valid",
+                        "$classFragment.schema-valid",
                         $schemaErrors,
                         "The i18n json files in Data folder $sourceFolder were successfully validated against the Schema $schema",
                         "The i18n json files in Data folder $sourceFolder were not all valid against the Schema $schema",
@@ -1217,11 +1257,15 @@ class Health implements MessageComponentInterface
             // the caller did not pass. The annotation asserts the *shape* those two require; the literal
             // category cannot be proven, because an unrecognised category has to reach the diagnostic
             // verbatim (telling a client that its category was wrong is the diagnostic's whole job).
+            //
+            // `validate` carries the *class fragment* rather than the label: both readers use it
+            // for nothing but `$message->classes`, and for a v1 caller the two are the same string,
+            // so the legacy frames come out unchanged.
             /** @var ExecuteValidationSourceFile|ExecuteValidationResource $validationForMessages */
             $validationForMessages = (object) [
                 'action'     => 'executeValidation',
                 'category'   => $category,
-                'validate'   => $label,
+                'validate'   => $classFragment,
                 'sourceFile' => $dataPath
             ];
 

--- a/src/Models/ValidationsPath/CheckableInventory.php
+++ b/src/Models/ValidationsPath/CheckableInventory.php
@@ -58,8 +58,9 @@ final class CheckableInventory
      * write that would invalidate it — but `Health` is a long-running ReactPHP process and the primary
      * consumer of `byPath()`/`byId()`, and there both this and `self::$items` live until the WebSocket
      * server restarts. A calendar created via `/data` therefore does not appear to those clients until
-     * then. Harmless today only because `Health`'s legacy regex arms still resolve those slugs
-     * generically; #806 plan 2 replaces those arms with `byId()` and will need a reset hook.
+     * then. That is what {@see self::reset()} is for: `Health` calls it as each run begins, because
+     * its `validateSource` action resolves solely through `byId()` and cannot fall back on the
+     * legacy regex arms that used to resolve those slugs generically.
      *
      * Building the index reads and JSON-parses every national and diocesan calendar file, so a single
      * missing or malformed one throws (`ServiceUnavailableException` / `JsonException`) and
@@ -71,6 +72,25 @@ final class CheckableInventory
     private static function metadata(): MetadataCalendars
     {
         return self::$metadata ??= CalendarMetadataProvider::create();
+    }
+
+    /**
+     * Drop the memoized index.
+     *
+     * The memo is per-process, which is a request under PHP-FPM but the whole server lifetime in
+     * `Health`'s long-running ReactPHP process. A v2 `validateSource` resolves solely through
+     * {@see self::byId()}, so without this a calendar created via `/data` would stay invisible to
+     * the WebSocket until restart — the legacy slug arms used to mask that by resolving
+     * generically.
+     *
+     * An invalidation hook on the write path cannot work: `/data` writes happen in the HTTP
+     * process, which `Health` never observes. `Health` therefore resets once per run, bounding
+     * staleness to a single run at the cost of one rebuild per run rather than one per lookup.
+     */
+    public static function reset(): void
+    {
+        self::$items    = null;
+        self::$metadata = null;
     }
 
     /** @return list<CheckableItem> */


### PR DESCRIPTION
Refs #806. **Plan 2 of 2 for section B**, completing it. Plan 1 was #815.

#811 published an inventory of checkable artifacts; #815 grew it to 77 by enumerating per-calendar
source data. This makes those ids **the address a client sends**, and gives calendar identity a type.

## Three new message shapes

```jsonc
{ "action": "validateSource",
  "target": { "id": "diocese:ambrosian:lugano_ch" } }

{ "action": "validateCalendar",
  "calendar": { "kind": "diocesan", "id": "lugano_ch", "rite": "ambrosian" },
  "year": 2026, "responseFormat": "JSON" }

{ "action": "runTest", "test": "StIgnatiusOfLoyolaTest",
  "calendar": { "kind": "rite", "id": "ambrosian", "rite": "ambrosian" },
  "year": 2026 }
```

`validateSource` resolves an id with **one lookup** where the server previously recovered meaning from a
hyphenated slug with eight anchored `preg_match` arms. `calendar.kind` is one of `general`, `national`,
`diocesan`, `rite`, and the overloaded `category` — one name that carried two disjoint enums, two of whose
values meant different things in each — disappears from the wire.

`general` is documented as an **alias** for `{"kind":"rite","id":"roman"}`, differing only in that `id` may
be omitted. Stated as an alias so nobody later invents a distinction that is not there.

## Nothing v1 was removed

`executeValidation`, `executeUnitTest` and the string form of `validateCalendar.calendar` all still work.
No client breaks the day this lands, and UnitTestInterface can migrate a page at a time.

Discrimination is per-action, deliberately: `validateSource` and `runTest` are **new names**, so a v1 client
cannot accidentally emit them; `validateCalendar` keeps its name because the *action* is unchanged, so
`calendar` being an **object** is the signal.

Removing the legacy branch is a separate later change gated on UnitTestInterface#42 — and it is that
follow-up, not this PR, which closes the unsanitised `glob()` path-containment gap. That gap is untouched
here by explicit decision. Anyone reading section B as "closes the path issue" should read it as "the
legacy-removal follow-up closes it".

## A rite that disagrees is rejected, not resolved

If `calendar.rite` contradicts the calendar's actual rite, the message is rejected. A *hint* may be guessed
at — that is what `resolveRite()` does for clients predating rite awareness — but an *assertion* that is
wrong is a client bug, and saying so beats papering over it. The check is real for all four kinds, not just
diocesan.

## Retired properties are rejected on all three v2 shapes

A v2 message carrying a legacy property its own shape replaced is rejected:

| v2 action          | v1 predecessor      | rejects if present                                          |
|--------------------|---------------------|-------------------------------------------------------------|
| `validateSource`   | `executeValidation` | `category`, `validate`, `sourceFile`, `sourceFolder`        |
| `validateCalendar` | `validateCalendar`  | `category`, `responsetype`, `rite`                          |
| `runTest`          | `executeUnitTest`   | `category`, `rite`                                          |

Not a breaking change — a v1 client sends a string `calendar` or an old action name and never reaches these
checks. It exists so a **half-migrated** client fails loudly at development time instead of getting behaviour
that looks correct now and breaks when the legacy branch is removed. `runTest` rejects no `responsetype`
because `executeUnitTest` never had one. `runToken` is **not** retired: it is shared and current.

One implementation (`RETIRED_PROPERTIES` + `rejectRetiredProperties()`) drives all three, called first in
each handler.

## Frames are addressed by an id-derived fragment

`runValidationSteps()` used one value as both the human label and the CSS class fragment. That was harmless
for v1, where `validate` is a hyphenated slug — but inventory labels are prose (`"National calendar: US"`),
and a label containing `: ` makes the client's `querySelectorAll` **throw**, painting nothing.

So `validateSource` now passes a fragment derived from the **id**, which is stable and opaque, rather than
the label, which is prose that will change:

> Replace every character outside `[A-Za-z0-9_-]` with `-`. Nothing else.

`diocese:ambrosian:lugano_ch` → `diocese-ambrosian-lugano_ch`. Every id begins with a literal lowercase kind
prefix, so a fragment can never start with a digit or be empty. The rule is documented in the spec beside the
id vocabulary — with the client-side note that the card's class and the selector must go through the **same
case treatment**, since `slugifySelector` lowercases and a client following the rule literally would otherwise
match nothing. Fragment uniqueness (once lowercased) is asserted across the whole published set.

## Verification

```text
Health*.php + Models/ValidationsPath/ + Handlers/ValidationsHandlerTest   344 tests, 2989 assertions, OK
composer lint                                                            clean
composer analyse (PHPStan level 10)                                      no errors
composer lint:md                                                         clean
```

The additive claim was tested end-to-end rather than by test counts: dispatch, property validation, argument
equality through the extracted seam, frame text, rejection reachability, and rite handling were each checked
for a path by which a v1 message could reach different code, arguments or output. None was found. The only
observable change on a v1 path is non-functional — one stdout log line, and a per-run inventory rebuild.

Guards were verified by mutation rather than assumed. Neutering the retired-property helper fails exactly
seven cases, one per rejection row; making it over-reach fails exactly the two negative guards; substituting
the class fragment fails three tests spanning the folder-missing, folder-success and file branches.

## Reviews

Thirteen review passes, of which four found tests that could not fail for the properties they were named
after — including one caused by a specification error of mine, and one that was the same defect as the
frame-addressing bug reached one layer down, in the documentation written to fix it.

## Known and recorded, not fixed here

- `steps` values match no emitted frame class (#819). `steps` is authoritative for its **length**, not its
  values. Neither vocabulary is changed here; section C dissolves it.
- `count(steps)` has one exception: the file branch emits two frames, not three, when JSON fails to decode.
  Pre-existing and equally true of v1, so fixing it here would break the additive guarantee. Documented, and
  filed separately.
- `src/Health.php` is past the point where it should be one file. The +843 lines are coherent and well-placed;
  the split is its own piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added WebSocket v2 support for typed calendar identities, source validation by inventory ID, and calendar test execution.
  * Added validation for calendar kinds, rites, years, response formats, and malformed requests.
* **Bug Fixes**
  * Improved inventory freshness between validation runs.
  * Ensured validation results use stable identifiers for consistent client display.
* **Documentation**
  * Documented protocol formats, opaque IDs, calendar rules, and validation-step limitations.
* **Compatibility**
  * Existing v1 message formats remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->