### PR TITLE
feat(health): strict inbound validation and typed protocol errors (#806 section G)

### DIFF
--- a/docs/superpowers/plans/2026-08-20-strict-validation.md
+++ b/docs/superpowers/plans/2026-08-20-strict-validation.md
@@ -1,0 +1,1307 @@
+# Strict Validation and Typed Protocol Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a malformed WebSocket message impossible to crash the `Health` process, and answer it with a typed, machine-readable protocol error.
+
+**Architecture:** A published draft-07 schema, `jsondata/schemas/WebSocketMessage.json`, becomes the authority for what an inbound message may look like. A new
+`WebSocketMessageValidator` service validates every message against it before dispatch and — only for messages carrying a `requestId` — refuses properties the schema does not
+declare, reading the allowed names out of the schema rather than from a list of its own. Rejections become `type: "protocolError"` frames carrying a `ProtocolErrorCode`. A
+`\Throwable` backstop around the dispatch `switch` guarantees the daemon survives anything a handler does.
+
+**Tech Stack:** PHP 8.4, `swaggest/json-schema` v0.12.43 (draft-07), Ratchet/ReactPHP, PHPUnit 12, PHPStan level 10, PSR-12 via phpcs.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-strict-validation-design.md` — read it before Task 1. Every "why" below is short because the spec carries the reasoning.
+
+## Global Constraints
+
+- **No v1 message that works today may stop working**, except ones that currently kill the process. This is the single most important constraint; Task 1's compatibility test
+is what enforces it.
+- Unknown-property rejection applies **only** when the message carries a `requestId`. Type and enum validation applies to **all** messages.
+- The schema declares `"$schema": "https://json-schema.org/draft-07/schema#"` and puts shapes under `definitions`, matching the other 21 schemas in `jsondata/schemas/`.
+- `swaggest/json-schema` v0.12.43 implements draft-07 only. **Do not use `unevaluatedProperties`, `$defs`, `$dynamicRef`, or any 2019-09+ keyword** — see spec §4 and issue #826.
+- The new error frame uses **`text`**, never `message`. `errorCode` is the new field.
+- Retired-property checks stay in `Health` and keep running **before** schema validation.
+- Tests drive `Health::onMessage()` with a real JSON message. Do not test the private validator by invoking it directly except where a step explicitly says to.
+- Every test class that builds a `Health` must `use HealthQueueIsolationTrait` and build via `$this->newHealth()`. A hand-written `new Health()` leaks queued HTTP requests
+that fire for real at PHPUnit shutdown.
+- Commits are GPG-signed and pre-commit hooks run `composer lint` / `lint:md`. Never pass `--no-verify`.
+- Run `composer test:quick`, never a bare `phpunit --exclude-group`.
+
+## File Structure
+
+| File                                                         | Responsibility                                                   |
+|--------------------------------------------------------------|------------------------------------------------------------------|
+| `jsondata/schemas/WebSocketMessage.json` (new)               | The authority: every inbound message shape, types, enums         |
+| `src/Enum/LitSchema.php` (modify)                            | One new case so the schema resolves by path like every other     |
+| `src/Enum/ProtocolErrorCode.php` (new)                       | The error-code vocabulary                                        |
+| `src/Services/WebSocketMessageValidator.php` (new)           | Schema validation + the `requestId`-gated unknown-property check |
+| `src/Health.php` (modify)                                    | Wire the validator in, emit typed errors, add the backstop       |
+| `phpunit_tests/Schemas/WebSocketMessageSchemaTest.php` (new) | The schema is correct and accepts what the shipped client sends  |
+| `phpunit_tests/HealthProtocolValidationTest.php` (new)       | The crash vectors are refused; codes are right; gate works       |
+
+`WebSocketMessageValidator` is a separate class rather than more methods on `Health` because `src/Health.php` is already 4108 lines, and validating an inbound message is a
+distinct responsibility with a clean interface. `src/Services/` is where `JwtService` lives.
+
+---
+
+### Task 1: The published schema and its compatibility test
+
+**Files:**
+
+- Create: `jsondata/schemas/WebSocketMessage.json`
+- Modify: `src/Enum/LitSchema.php` (add a case; extend `error()` and `fromURL()`)
+- Test: `phpunit_tests/Schemas/WebSocketMessageSchemaTest.php`
+
+**Interfaces:**
+
+- Consumes: nothing from earlier tasks.
+- Produces: `LitSchema::WEBSOCKET_MESSAGE` (path `/WebSocketMessage.json`), and a schema whose `definitions` keys are exactly `executeValidation`, `validateCalendarLegacy`,
+`validateCalendarTyped`, `executeUnitTest`, `runTest`, `cancelRun`, `validateSource`, `calendarIdentity`. Task 3 reads `definitions.<shape>.properties` by those names.
+
+**Background you need:** the shapes are already specified as `@phpstan-type` annotations in the `Health` class docblock (`src/Health.php:55-65`). PHPStan level 10 enforces
+them against the implementation, so they are the closest thing to a written contract that exists. Transcribe them; do not invent constraints.
+
+Two deliberate decisions, both of which you must not "improve":
+
+1. **`year` is `"type": "integer"`.** PHP's coercive typing means a client sending `"2024"` works today. Requiring an integer is a deliberate, narrow tightening; the shipped
+client sends numbers (`assets/js/index.js:686-693`), which Step 3's test proves.
+2. **`category` enums are closed.** A misspelled category currently survives to "Unable to detect schema" much later; closing the enum is the point of #806 §7. It is still an
+error either way — just earlier and legible.
+
+- [ ] **Step 1: Write the schema file**
+
+Create `jsondata/schemas/WebSocketMessage.json`:
+
+```json
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "$id": "https://litcal.johnromanodorazio.com/api/dev/jsondata/schemas/WebSocketMessage.json",
+    "title": "Health WebSocket inbound message",
+    "description": "Every message the Health WebSocket endpoint accepts. Shapes are discriminated by `action`, and for `validateCalendar` additionally by whether `calendar` is a string (v1) or an object (v2). Properties a shape does not declare are refused only for messages carrying a `requestId`; see API issue #806 section G.",
+    "oneOf": [
+        { "$ref": "#/definitions/executeValidation" },
+        { "$ref": "#/definitions/validateCalendarLegacy" },
+        { "$ref": "#/definitions/validateCalendarTyped" },
+        { "$ref": "#/definitions/executeUnitTest" },
+        { "$ref": "#/definitions/runTest" },
+        { "$ref": "#/definitions/cancelRun" },
+        { "$ref": "#/definitions/validateSource" }
+    ],
+    "definitions": {
+        "correlationId": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,64}$",
+            "description": "An opaque client-minted handle the server echoes back. One alphabet for runToken and requestId alike."
+        },
+        "calendarIdentity": {
+            "type": "object",
+            "required": ["kind", "rite"],
+            "properties": {
+                "kind": { "enum": ["general", "national", "diocesan", "rite"] },
+                "id": { "type": "string" },
+                "rite": { "type": "string" }
+            }
+        },
+        "executeValidation": {
+            "type": "object",
+            "required": ["action", "category", "validate"],
+            "oneOf": [
+                { "required": ["sourceFile"] },
+                { "required": ["sourceFolder"] }
+            ],
+            "properties": {
+                "action": { "const": "executeValidation" },
+                "category": { "enum": ["universalcalendar", "sourceDataCheck", "resourceDataCheck"] },
+                "validate": { "type": "string" },
+                "sourceFile": { "type": "string" },
+                "sourceFolder": { "type": "string" },
+                "responsetype": { "type": "string" },
+                "rite": { "type": "string" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "validateCalendarLegacy": {
+            "type": "object",
+            "required": ["action", "calendar", "year", "category", "responsetype"],
+            "properties": {
+                "action": { "const": "validateCalendar" },
+                "calendar": { "type": "string" },
+                "year": { "type": "integer" },
+                "category": { "enum": ["nationalcalendar", "diocesancalendar", "ritecalendar"] },
+                "responsetype": { "enum": ["JSON", "XML", "ICS", "YML"] },
+                "rite": { "type": "string" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "validateCalendarTyped": {
+            "type": "object",
+            "required": ["action", "calendar", "year", "responseFormat"],
+            "properties": {
+                "action": { "const": "validateCalendar" },
+                "calendar": { "$ref": "#/definitions/calendarIdentity" },
+                "year": { "type": "integer" },
+                "responseFormat": { "enum": ["JSON", "XML", "ICS", "YML"] },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "executeUnitTest": {
+            "type": "object",
+            "required": ["action", "calendar", "year", "category", "test"],
+            "properties": {
+                "action": { "const": "executeUnitTest" },
+                "calendar": { "type": "string" },
+                "year": { "type": "integer" },
+                "category": { "enum": ["nationalcalendar", "diocesancalendar", "ritecalendar"] },
+                "test": { "type": "string" },
+                "rite": { "type": "string" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "runTest": {
+            "type": "object",
+            "required": ["action", "test", "calendar", "year"],
+            "properties": {
+                "action": { "const": "runTest" },
+                "test": { "type": "string" },
+                "calendar": { "$ref": "#/definitions/calendarIdentity" },
+                "year": { "type": "integer" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "cancelRun": {
+            "type": "object",
+            "required": ["action", "runToken"],
+            "properties": {
+                "action": { "const": "cancelRun" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "validateSource": {
+            "type": "object",
+            "required": ["action", "target"],
+            "properties": {
+                "action": { "const": "validateSource" },
+                "target": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": { "id": { "type": "string" } }
+                },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add the `LitSchema` case**
+
+In `src/Enum/LitSchema.php`, add the case after `VALIDATIONS`:
+
+```php
+    case WEBSOCKET_MESSAGE = '/WebSocketMessage.json';
+```
+
+Add an arm to `error()` (the `match` is exhaustive — omitting it is a PHPStan error):
+
+```php
+            LitSchema::WEBSOCKET_MESSAGE => $ERRMSG . 'WebSocket message not valid',
+```
+
+And an arm to `fromURL()`, in the same style as its neighbours:
+
+```php
+            LitSchema::WEBSOCKET_MESSAGE->path() => LitSchema::WEBSOCKET_MESSAGE,
+```
+
+- [ ] **Step 3: Write the failing compatibility test**
+
+Create `phpunit_tests/Schemas/WebSocketMessageSchemaTest.php`. The shapes in `clientMessageProvider()` are transcribed from `UnitTestInterface/assets/js/wsProtocol.js`
+(`UNIVERSAL_CHECKS`), `assets/js/index.js:531` (`sendMessage()` injects `runToken` into every message) and `assets/js/index.js:686-693`.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * `WebSocketMessage.json` — the published contract for an inbound Health message.
+ *
+ * The load-bearing test here is compatibility, not correctness in the abstract. The shipped
+ * UnitTestInterface sends properties the server neither declares nor reads: `sendMessage()` injects
+ * `runToken` into every message, and the source-data checks are built by spreading a config object
+ * that carries `rite` onto an `executeValidation` that never looks at it. A schema that refused
+ * those would take the test interface down on the day it shipped.
+ *
+ * The fixtures are therefore transcribed from the client's own source, not imagined.
+ */
+final class WebSocketMessageSchemaTest extends TestCase
+{
+    private static function schema(): Schema
+    {
+        $schema = Schema::import(LitSchema::WEBSOCKET_MESSAGE->path());
+        self::assertInstanceOf(Schema::class, $schema);
+
+        return $schema;
+    }
+
+    /**
+     * Messages the shipped client actually sends. Every one must validate.
+     *
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function clientMessageProvider(): array
+    {
+        return [
+            // resources.js:1221 and index.js:647 — `{ action, ...check }` where check carries `rite`.
+            'source-data check with the spread rite' => [[
+                'action'     => 'executeValidation',
+                'rite'       => 'roman',
+                'validate'   => 'PropriumDeTempore',
+                'sourceFile' => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json',
+                'category'   => 'universalcalendar',
+                'runToken'   => 'abc123'
+            ]],
+            'i18n folder check with the spread rite' => [[
+                'action'       => 'executeValidation',
+                'rite'         => 'roman',
+                'validate'     => 'proprium-de-tempore-i18n',
+                'sourceFolder' => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/i18n',
+                'category'     => 'sourceDataCheck',
+                'runToken'     => 'abc123'
+            ]],
+            // resources.js:1184 — the resource arm adds responsetype.
+            'resource check with responsetype' => [[
+                'action'       => 'executeValidation',
+                'responsetype' => 'JSON',
+                'rite'         => 'roman',
+                'validate'     => 'calendars',
+                'sourceFile'   => 'http://localhost:8000/calendars',
+                'category'     => 'resourceDataCheck',
+                'runToken'     => 'abc123'
+            ]],
+            // index.js:686-693 — note `year` is a number, which is why the schema may require integer.
+            'legacy validateCalendar' => [[
+                'action'       => 'validateCalendar',
+                'year'         => 2024,
+                'calendar'     => 'IT',
+                'category'     => 'nationalcalendar',
+                'rite'         => 'roman',
+                'responsetype' => 'JSON',
+                'runToken'     => 'abc123'
+            ]],
+            'legacy executeUnitTest' => [[
+                'action'   => 'executeUnitTest',
+                'test'     => 'AllSaintsTest',
+                'calendar' => 'IT',
+                'year'     => 2024,
+                'category' => 'nationalcalendar',
+                'runToken' => 'abc123'
+            ]],
+            // wsProtocol.js:31
+            'cancelRun' => [[
+                'action'   => 'cancelRun',
+                'runToken' => 'abc123'
+            ]],
+            'v2 validateSource' => [[
+                'action'    => 'validateSource',
+                'target'    => ['id' => 'temporale:roman'],
+                'runToken'  => 'abc123',
+                'requestId' => 'req-1'
+            ]],
+            'v2 typed validateCalendar' => [[
+                'action'         => 'validateCalendar',
+                'calendar'       => ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'ambrosian'],
+                'year'           => 2026,
+                'responseFormat' => 'JSON',
+                'requestId'      => 'req-2'
+            ]],
+            'v2 runTest' => [[
+                'action'    => 'runTest',
+                'test'      => 'AllSaintsTest',
+                'calendar'  => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+                'year'      => 2024,
+                'requestId' => 'req-3'
+            ]],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    #[DataProvider('clientMessageProvider')]
+    public function testAMessageTheShippedClientSendsValidates(array $message): void
+    {
+        $decoded = json_decode((string) json_encode($message));
+        self::schema()->in($decoded);
+        // in() throws on failure; reaching here is the assertion.
+        self::assertTrue(true);
+    }
+
+    /**
+     * Exactly one arm may match, or the shape discrimination is ambiguous and which handler runs
+     * becomes a matter of arm order.
+     */
+    #[DataProvider('clientMessageProvider')]
+    public function testEachMessageMatchesExactlyOneArm(array $message): void
+    {
+        $raw     = json_decode((string) file_get_contents(LitSchema::WEBSOCKET_MESSAGE->path()));
+        $decoded = json_decode((string) json_encode($message));
+        $matches = 0;
+        foreach ($raw->oneOf as $arm) {
+            $name = substr((string) $arm->{'$ref'}, strlen('#/definitions/'));
+            try {
+                Schema::import((object) ['$schema' => 'https://json-schema.org/draft-07/schema#'] + (array) $raw->definitions->{$name})
+                    ->in($decoded);
+                $matches++;
+            } catch (\Throwable) {
+                // not this arm
+            }
+        }
+        self::assertSame(1, $matches, 'a message must match exactly one shape');
+    }
+
+    /**
+     * The definition names Task 3's unknown-property check looks up. Renaming one without updating
+     * that lookup would silently disable the gate, so the names are pinned here.
+     */
+    public function testTheDefinitionNamesAreTheOnesTheValidatorLooksUp(): void
+    {
+        $raw = json_decode((string) file_get_contents(LitSchema::WEBSOCKET_MESSAGE->path()));
+        self::assertEqualsCanonicalizing(
+            [
+                'correlationId', 'calendarIdentity', 'executeValidation', 'validateCalendarLegacy',
+                'validateCalendarTyped', 'executeUnitTest', 'runTest', 'cancelRun', 'validateSource'
+            ],
+            array_keys((array) $raw->definitions)
+        );
+    }
+
+    /**
+     * The crash vectors, at the schema level. Task 3 asserts what the *server* does with them; this
+     * asserts the schema is what refuses them, so a later loosening of the schema fails here first.
+     *
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function malformedMessageProvider(): array
+    {
+        return [
+            'year as a non-numeric string' => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 'not-a-year', 'category' => 'nationalcalendar', 'responsetype' => 'JSON']],
+            'category as an array'         => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => [], 'responsetype' => 'JSON']],
+            'unknown response format'      => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar', 'responsetype' => 'NOT_A_FORMAT']],
+            'test as an object'            => [['action' => 'executeUnitTest', 'test' => ['a' => 1], 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar']],
+            'executeValidation category as an object' => [['action' => 'executeValidation', 'category' => ['k' => 'v'], 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
+            'misspelled category'          => [['action' => 'executeValidation', 'category' => 'sourceDataChek', 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
+            'neither sourceFile nor sourceFolder' => [['action' => 'executeValidation', 'category' => 'sourceDataCheck', 'validate' => 'x']],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    #[DataProvider('malformedMessageProvider')]
+    public function testAMalformedMessageIsRefusedByTheSchema(array $message): void
+    {
+        $this->expectException(\Throwable::class);
+        self::schema()->in(json_decode((string) json_encode($message)));
+    }
+}
+```
+
+- [ ] **Step 4: Run the test and watch it fail for the right reason**
+
+```bash
+vendor/bin/phpunit --no-coverage --filter WebSocketMessageSchemaTest
+```
+
+Expected before Steps 1-2 are in place: errors about `LitSchema::WEBSOCKET_MESSAGE` not existing. After them: all green. If any *client* fixture fails, **the schema is wrong,
+not the fixture** — the fixtures describe shipped behaviour.
+
+- [ ] **Step 5: Verify the schema is served and self-consistent**
+
+```bash
+vendor/bin/phpunit --no-coverage --filter 'SchemaValidationTest|WebSocketMessageSchemaTest'
+composer analyse
+composer lint
+```
+
+`SchemaValidationTest::testSchemaCanBeImported` is data-provided from `LitSchema` cases, so the new case is exercised automatically. `SchemasHandler` globs the schema folder,
+so no handler change is needed for `/schemas/WebSocketMessage.json` to be served.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add jsondata/schemas/WebSocketMessage.json src/Enum/LitSchema.php phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
+git commit -m "feat(health): publish WebSocketMessage.json as the inbound message contract
+
+Transcribed from the @phpstan-type annotations in the Health class docblock,
+which PHPStan level 10 already enforces against the implementation, so the
+schema, the annotation and the code now agree by construction.
+
+The load-bearing test is compatibility: the shipped UnitTestInterface injects
+runToken into every message and spreads rite onto an executeValidation that
+never reads it, so the fixtures are transcribed from the client source rather
+than imagined. Nothing is wired to this yet.
+
+Refs #806"
+```
+
+---
+
+### Task 2: Typed protocol errors
+
+**Files:**
+
+- Create: `src/Enum/ProtocolErrorCode.php`
+- Modify: `src/Health.php` (`rejectMessage()` and its call sites)
+- Modify: `phpunit_tests/HealthValidateSourceTest.php`, `phpunit_tests/HealthTypedCalendarTest.php`, `phpunit_tests/HealthCancelRunTest.php` (existing assertions on `type ===
+'echobot'`)
+
+**Interfaces:**
+
+- Consumes: nothing from Task 1.
+- Produces: `ProtocolErrorCode` (a string-backed enum) and the new signature
+  `private function rejectMessage(ConnectionInterface $to, ProtocolErrorCode $code, string $text, ?string $requestId = null): void`.
+  Task 3 calls it with `ProtocolErrorCode::INVALID_MESSAGE`; Task 4 with `ProtocolErrorCode::INTERNAL_ERROR`.
+
+**Background:** `rejectMessage()` currently sends `type: 'echobot'`. Changing it to `protocolError` is safe **ungated**: `UnitTestInterface/assets/js/index.js:932-937` treats
+*any* unrecognised type — `echobot` included — as a visible failure via `countUnattributableFailure()`. Its docblock says a dedicated type "would make every rejection look
+like a failing test"; that is now equally true of `echobot`, so the comment must be corrected rather than preserved.
+
+- [ ] **Step 1: Write the enum**
+
+Create `src/Enum/ProtocolErrorCode.php`:
+
+```php
+<?php
+
+namespace LiturgicalCalendar\Api\Enum;
+
+/**
+ * Why a message was refused, in a form a client can branch on.
+ *
+ * A code exists where a client would *act* differently; where it would only display the reason, the
+ * reason is prose in the frame's `text`. That is why `INVALID_MESSAGE` covers every schema
+ * violation — a wrong type, an unknown enum value and an undeclared property all mean "fix the
+ * message", and the text says which — while `RETIRED_PROPERTY` (you are half-migrated) and
+ * `UNKNOWN_TARGET_ID` (refetch /validations) are separate.
+ */
+enum ProtocolErrorCode: string
+{
+    case INVALID_JSON       = 'invalid_json';
+    case NOT_AN_OBJECT      = 'not_an_object';
+    case MISSING_ACTION     = 'missing_action';
+    case UNKNOWN_ACTION     = 'unknown_action';
+    case INVALID_REQUEST_ID = 'invalid_request_id';
+    case RETIRED_PROPERTY   = 'retired_property';
+    case UNKNOWN_TARGET_ID  = 'unknown_target_id';
+    case INVALID_MESSAGE    = 'invalid_message';
+    case INTERNAL_ERROR     = 'internal_error';
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `phpunit_tests/HealthProtocolValidationTest.php` with the stub connection and this first test. (Task 3 adds more tests to this same class.)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * What `Health` does with a message it cannot act on.
+ *
+ * Every test here drives `onMessage()` with a real JSON string. The private validator is never
+ * invoked directly: #825's lesson was that an emitter can be correct and tested while nothing routes
+ * to it, and a test that calls the right function directly passes against exactly that bug.
+ */
+#[CoversClass(Health::class)]
+final class HealthProtocolValidationTest extends TestCase
+{
+    use HealthQueueIsolationTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+    }
+
+    private static function createStubConnection(int $resourceId = 1)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * Send one raw message and return the frames it produced.
+     *
+     * @return list<\stdClass>
+     */
+    private function frames(string $raw): array
+    {
+        $conn = self::createStubConnection();
+        ob_start();
+        $this->newHealth()->onMessage($conn, $raw);
+        ob_end_clean();
+
+        return array_map(static fn (string $f): \stdClass => json_decode($f), $conn->sent);
+    }
+
+    public function testARejectionIsATypedProtocolErrorRatherThanAnEchobot(): void
+    {
+        $frames = $this->frames((string) json_encode(['action' => 'validateSource', 'target' => ['id' => 'nation:roman:ZZ']]));
+
+        self::assertCount(1, $frames);
+        self::assertSame('protocolError', $frames[0]->type, 'rejections are typed now, not echoes');
+        self::assertSame(ProtocolErrorCode::UNKNOWN_TARGET_ID->value, $frames[0]->errorCode);
+        self::assertSame('Unknown validation target: nation:roman:ZZ', $frames[0]->text, 'the prose is unchanged; only the envelope is typed');
+    }
+}
+```
+
+- [ ] **Step 3: Run it and confirm it fails**
+
+```bash
+vendor/bin/phpunit --no-coverage --filter HealthProtocolValidationTest
+```
+
+Expected: fails asserting `'protocolError'` against the actual `'echobot'`.
+
+- [ ] **Step 4: Change `rejectMessage()` and its call sites**
+
+In `src/Health.php`, replace the body and docblock of `rejectMessage()`:
+
+```php
+    /**
+     * Reject a message that cannot be acted on, saying why in a form a client can branch on.
+     *
+     * Ungated, unlike the terminal `complete` frame, and the difference is real rather than an
+     * inconsistency: a new frame changes the stream a v1 client counts, while a new *type* on a
+     * frame it was already going to receive changes nothing for it. Since UnitTestInterface#46 an
+     * unrecognised type is painted as a visible failed check — which is what `echobot` already
+     * became — so `protocolError` reads to a v1 client exactly as its predecessor did.
+     *
+     * `text` carries the prose, as every other frame in this protocol does. #806's sketch spells it
+     * `message`; a second name for an existing field is the duplication that issue exists to remove.
+     */
+    private function rejectMessage(ConnectionInterface $to, ProtocolErrorCode $code, string $text, ?string $requestId = null): void
+    {
+        $message            = new \stdClass();
+        $message->type      = 'protocolError';
+        $message->errorCode = $code->value;
+        $message->text      = $text;
+        $this->sendMessage($to, $message, requestId: $requestId);
+    }
+```
+
+Add `use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;` to the imports.
+
+Then update every existing `rejectMessage(` call to pass a code. Find them with:
+
+```bash
+grep -n 'rejectMessage(' src/Health.php
+```
+
+Use `ProtocolErrorCode::INVALID_REQUEST_ID` for the correlation-id refusal in `onMessage()`, `ProtocolErrorCode::RETIRED_PROPERTY` inside `rejectRetiredProperties()`,
+`ProtocolErrorCode::UNKNOWN_TARGET_ID` for an unresolvable `validateSource` target, and `ProtocolErrorCode::INVALID_MESSAGE` for every remaining shape complaint (a malformed
+`calendar` identity, an unusable response format, and similar).
+
+Also replace the two inline `echobot` frames in `onMessage()`'s `default:` arm and its `else` branch with `rejectMessage()` calls carrying `ProtocolErrorCode::UNKNOWN_ACTION`
+and, respectively, the code matching `$errorMsg`: `INVALID_JSON`, `NOT_AN_OBJECT`, `MISSING_ACTION`, or `INVALID_MESSAGE`.
+
+- [ ] **Step 5: Update the existing assertions on `echobot`**
+
+```bash
+grep -rn "echobot" phpunit_tests/ src/
+```
+
+Every remaining occurrence is either an assertion to update to `'protocolError'` or a comment describing the old behaviour, which must be corrected rather than left. Add the
+matching `errorCode` assertion wherever you update a `type` assertion — that is what stops two codes silently collapsing into one later.
+
+- [ ] **Step 6: Run the Health suite**
+
+```bash
+vendor/bin/phpunit --no-coverage --filter 'Health'
+composer analyse
+composer lint
+```
+
+Expected: green.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Enum/ProtocolErrorCode.php src/Health.php phpunit_tests/
+git commit -m "feat(health): answer refusals with a typed protocolError frame
+
+type becomes protocolError and carries an errorCode a client can branch on.
+Ungated: since UnitTestInterface#46 an unrecognised type is painted as a visible
+failed check, which is what echobot already became, so this reads to a v1 client
+exactly as its predecessor did. The docblock claiming otherwise is corrected.
+
+Codes exist where a client would act differently. INVALID_MESSAGE deliberately
+covers every schema violation: wrong type, unknown enum value and undeclared
+property all mean fix the message, and text says which.
+
+Refs #806"
+```
+
+---
+
+### Task 3: The validator, wired in
+
+**Files:**
+
+- Create: `src/Services/WebSocketMessageValidator.php`
+- Modify: `src/Health.php` (`onMessage()`; delete `validateMessageProperties()`, `ACTION_PROPERTIES`, `TYPED_CALENDAR_PROPERTIES`)
+- Test: `phpunit_tests/HealthProtocolValidationTest.php` (extend)
+
+**Interfaces:**
+
+- Consumes: `LitSchema::WEBSOCKET_MESSAGE` (Task 1), `ProtocolErrorCode` and the new `rejectMessage()` signature (Task 2).
+- Produces:
+
+```php
+final class WebSocketMessageValidator
+{
+    public function __construct(?string $schemaPath = null);
+    /**
+     * @param list<string> $deferToHandler property names to leave for a handler to diagnose
+     * @return string|null null when the message is acceptable, else the reason for the client
+     */
+    public function validate(\stdClass $message, array $deferToHandler = []): ?string;
+    public function warm(): void;
+    public static function shapeOf(\stdClass $message): ?string;
+    public static function reset(): void;
+}
+```
+
+**Background:** `Health::isTypedCalendarMessage()` stays — it is the discriminator for `validateCalendar`'s two shapes and is used by the dispatch too. `RETIRED_PROPERTIES`
+and `rejectRetiredProperties()` stay and keep running **before** this validator. `ACTION_PROPERTIES`, `TYPED_CALENDAR_PROPERTIES` and `validateMessageProperties()` are used
+only for required-property checking and are replaced by the schema.
+
+- [ ] **Step 1: Write the validator**
+
+Create `src/Services/WebSocketMessageValidator.php`:
+
+```php
+<?php
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * Validates an inbound Health WebSocket message against the published contract.
+ *
+ * Two rules, deliberately different in reach:
+ *
+ *  - **Types, enums and required properties** are checked for every message. A message that fails
+ *    these is one that would otherwise reach a typed parameter and throw a `TypeError` — an
+ *    `\Error`, which Ratchet's `IoServer::handleData` does not catch, so it would kill the process
+ *    rather than fail the request. Refusing it is better for a v1 client too.
+ *  - **Undeclared properties** are refused only for messages carrying a `requestId`, the same v2
+ *    opt-in the terminal `complete` frame is gated on. The shipped client sends `runToken` on every
+ *    message and spreads `rite` onto an `executeValidation` that never reads it; a uniform rule
+ *    would take the test interface down.
+ *
+ * The second rule is applied here rather than in the schema because `swaggest/json-schema` v0.12.43
+ * implements draft-07, where `additionalProperties` sees only the properties declared in the same
+ * schema object — so the natural `if`/`then`/`unevaluatedProperties` spelling needs 2019-09. The
+ * allowed *names* still come from the schema; only the gate is here. See issue #826.
+ */
+final class WebSocketMessageValidator
+{
+    private static ?Schema $schema = null;
+
+    /** @var array<string, list<string>>|null */
+    private static ?array $propertyNames = null;
+
+    private string $schemaPath;
+
+    public function __construct(?string $schemaPath = null)
+    {
+        $this->schemaPath = $schemaPath ?? LitSchema::WEBSOCKET_MESSAGE->path();
+    }
+
+    /**
+     * @param list<string> $deferToHandler Property names this must not report, because a handler says
+     *        something better about them. See the note on retired properties below.
+     * @return string|null null when the message is acceptable, otherwise the reason, phrased for the
+     *         client that sent it.
+     */
+    public function validate(\stdClass $message, array $deferToHandler = []): ?string
+    {
+        try {
+            $this->schema()->in($message);
+        } catch (\Throwable $e) {
+            return $e->getMessage();
+        }
+
+        if (false === property_exists($message, 'requestId')) {
+            return null;
+        }
+
+        $shape = self::shapeOf($message);
+        if (null === $shape) {
+            return null;
+        }
+
+        $allowed = $this->propertyNamesFor($shape);
+        foreach (array_keys((array) $message) as $property) {
+            if (in_array((string) $property, $deferToHandler, true)) {
+                continue;
+            }
+            if (false === in_array((string) $property, $allowed, true)) {
+                return sprintf(
+                    '%s is not a property of a %s message. A message carrying a requestId may only use the properties the contract declares: %s.',
+                    (string) $property,
+                    $shape,
+                    implode(', ', $allowed)
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Which published shape a message claims to be. Mirrors the dispatch: the action name, plus the
+     * type of `calendar` for the one action that carries two shapes.
+     */
+    public static function shapeOf(\stdClass $message): ?string
+    {
+        if (false === property_exists($message, 'action') || false === is_string($message->action)) {
+            return null;
+        }
+
+        if ('validateCalendar' === $message->action) {
+            return property_exists($message, 'calendar') && $message->calendar instanceof \stdClass
+                ? 'validateCalendarTyped'
+                : 'validateCalendarLegacy';
+        }
+
+        return in_array($message->action, ['executeValidation', 'executeUnitTest', 'runTest', 'cancelRun', 'validateSource'], true)
+            ? $message->action
+            : null;
+    }
+
+    /**
+     * The property names the contract declares for a shape, read from the schema itself so that this
+     * class carries no list of its own.
+     *
+     * @return list<string>
+     */
+    private function propertyNamesFor(string $shape): array
+    {
+        if (null === self::$propertyNames) {
+            $raw = json_decode((string) file_get_contents($this->schemaPath));
+            if (false === $raw instanceof \stdClass || false === isset($raw->definitions)) {
+                throw new \RuntimeException("WebSocket message schema at {$this->schemaPath} has no definitions.");
+            }
+            $names = [];
+            foreach ((array) $raw->definitions as $name => $definition) {
+                if ($definition instanceof \stdClass && isset($definition->properties)) {
+                    $names[(string) $name] = array_map('strval', array_keys((array) $definition->properties));
+                }
+            }
+            self::$propertyNames = $names;
+        }
+
+        return self::$propertyNames[$shape] ?? [];
+    }
+
+    private function schema(): Schema
+    {
+        if (null === self::$schema) {
+            $imported = Schema::import($this->schemaPath);
+            if (false === $imported instanceof Schema) {
+                throw new \RuntimeException("WebSocket message schema at {$this->schemaPath} could not be imported.");
+            }
+            self::$schema = $imported;
+        }
+
+        return self::$schema;
+    }
+
+    /**
+     * Drop the memoized schema. Tests that point the validator at a different file need this; nothing
+     * in production does.
+     */
+    public static function reset(): void
+    {
+        self::$schema        = null;
+        self::$propertyNames = null;
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append to `phpunit_tests/HealthProtocolValidationTest.php`:
+
+```php
+    /**
+     * The crash vectors. Each of these terminated the WebSocket process before this work: Ratchet's
+     * `IoServer::handleData` catches `\Exception`, and `TypeError`, `ValueError` and `Error` are not
+     * `\Exception`. The assertion is therefore two-part — a typed refusal came back, *and* nothing
+     * escaped — because a test that only checked the frame would pass on a process that had already
+     * died in a real server.
+     *
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function crashVectorProvider(): array
+    {
+        return [
+            'year as a non-numeric string'  => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 'not-a-year', 'category' => 'nationalcalendar', 'responsetype' => 'JSON']],
+            'category as an array'          => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => [], 'responsetype' => 'JSON']],
+            'unknown response format'       => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar', 'responsetype' => 'NOT_A_FORMAT']],
+            'test as an object'             => [['action' => 'executeUnitTest', 'test' => ['a' => 1], 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar']],
+            'executeValidation category as an object' => [['action' => 'executeValidation', 'category' => ['k' => 'v'], 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    #[DataProvider('crashVectorProvider')]
+    public function testAMessageThatUsedToKillTheProcessIsRefused(array $message): void
+    {
+        $frames = $this->frames((string) json_encode($message));
+
+        self::assertCount(1, $frames, 'a refused message must not also start work');
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frames[0]->errorCode);
+    }
+
+    /**
+     * The gate, both directions, in one place: the same message is accepted without a `requestId`
+     * and refused with one. Asserting only the refusal would pass on a build that refused everything.
+     */
+    public function testAnUndeclaredPropertyIsRefusedOnlyWhenTheMessageOptedIn(): void
+    {
+        $lenient = [
+            'action'     => 'executeValidation',
+            'category'   => 'sourceDataCheck',
+            'validate'   => 'proprium-de-tempore',
+            'sourceFile' => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json',
+            'notAThing'  => 'whatever'
+        ];
+
+        $acceptedFrames = $this->frames((string) json_encode($lenient));
+        self::assertNotEmpty($acceptedFrames, 'a v1 message with a stray property must still be served');
+        self::assertNotSame('protocolError', $acceptedFrames[0]->type, "a v1 message was refused: {$acceptedFrames[0]->text}");
+
+        $refusedFrames = $this->frames((string) json_encode($lenient + ['requestId' => 'req-1']));
+        self::assertSame('protocolError', $refusedFrames[0]->type, 'a message carrying a requestId opted into strictness');
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $refusedFrames[0]->errorCode);
+        self::assertStringContainsString('notAThing', (string) $refusedFrames[0]->text, 'the refusal must name the offending property');
+    }
+
+    /**
+     * `rite` on an `executeValidation` is the concrete case: the shipped client spreads it onto every
+     * source-data check and the server never reads it. It is declared, so it survives even under the
+     * strict gate — which is what stops a future tidy-up from removing it from the schema.
+     */
+    public function testTheSpreadRiteSurvivesEvenUnderTheStrictGate(): void
+    {
+        $frames = $this->frames((string) json_encode([
+            'action'     => 'executeValidation',
+            'rite'       => 'roman',
+            'category'   => 'sourceDataCheck',
+            'validate'   => 'proprium-de-tempore',
+            'sourceFile' => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json',
+            'requestId'  => 'req-2'
+        ]));
+
+        self::assertNotSame('protocolError', $frames[0]->type, "rite was refused: {$frames[0]->text}");
+    }
+
+    /**
+     * Every action the schema declares has a dispatch arm and vice versa. Adding an action without a
+     * schema entry would otherwise fall through to `unknown_action` in production rather than in CI.
+     */
+    public function testEverySchemaShapeHasADispatchArmAndEveryArmHasAShape(): void
+    {
+        $raw    = json_decode((string) file_get_contents(\LiturgicalCalendar\Api\Enum\LitSchema::WEBSOCKET_MESSAGE->path()));
+        $actions = [];
+        foreach ((array) $raw->definitions as $definition) {
+            if ($definition instanceof \stdClass && isset($definition->properties->action->const)) {
+                $actions[(string) $definition->properties->action->const] = true;
+            }
+        }
+
+        $source = (string) file_get_contents(__DIR__ . '/../src/Health.php');
+        preg_match_all("/case '([a-zA-Z]+)':/", $source, $matches);
+        $dispatched = array_unique($matches[1]);
+
+        self::assertEqualsCanonicalizing(
+            array_keys($actions),
+            array_values(array_intersect($dispatched, array_keys($actions))),
+            'schema shapes and dispatch arms have drifted apart'
+        );
+        foreach ($dispatched as $arm) {
+            self::assertArrayHasKey($arm, $actions, "the dispatch handles {$arm} but the schema does not declare it");
+        }
+    }
+```
+
+Add `use PHPUnit\Framework\Attributes\DataProvider;` to the class imports.
+
+- [ ] **Step 3: Run and confirm they fail**
+
+```bash
+vendor/bin/phpunit --no-coverage --filter HealthProtocolValidationTest
+```
+
+Expected: the crash-vector tests fail with an uncaught `TypeError` / `ValueError` — which is the bug, reproduced.
+
+- [ ] **Step 4: Wire the validator into `onMessage()`**
+
+In `src/Health.php`, add the import `use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;` and a property:
+
+```php
+    private WebSocketMessageValidator $messageValidator;
+```
+
+initialised in the constructor with `$this->messageValidator = new WebSocketMessageValidator();`.
+
+In `onMessage()`, replace the `&& self::validateMessageProperties($messageReceived)` condition in the big `if` with a preceding explicit check, so the reason is available.
+After the existing `requestId` block and before the `if`, insert:
+
+```php
+        if (
+            json_last_error() === JSON_ERROR_NONE
+            && $messageReceived instanceof \stdClass
+            && property_exists($messageReceived, 'action')
+        ) {
+            $invalid = $this->messageValidator->validate($messageReceived);
+            if (null !== $invalid) {
+                echo sprintf('Invalid message from connection %1$d: %2$s (%3$s)', $resourceId, $invalid, $msg);
+                $this->rejectMessage($from, ProtocolErrorCode::INVALID_MESSAGE, $invalid, requestId: $requestId);
+                return;
+            }
+        }
+```
+
+Then change the big `if`'s condition to drop `self::validateMessageProperties($messageReceived)`, leaving the JSON, object and `action` checks.
+
+- [ ] **Step 5: Keep the retired-property diagnosis ahead of the schema's**
+
+The spec (§3) requires a half-migrated message to be answered for what is actually wrong with it. `rejectRetiredProperties()`
+runs inside each v2 handler — that is, *after* the validator — so without this step a `validateSource` carrying both a
+`requestId` and a retired `category` would be refused as "category is not a property of a validateSource message" instead of
+"category is not part of a validateSource message: target.id replaces it." The second sentence is the whole value of that
+check, and the client that needs it is exactly the half-migrated one.
+
+Rather than hoisting the handler check into `onMessage()`, pass the retired names for the shape so the validator steps aside
+and lets the handler speak. In `Health::onMessage()`, build the list from the existing constant and hand it over:
+
+```php
+            $retiredForAction = array_keys(self::RETIRED_PROPERTIES[$messageReceived->action]['retired'] ?? []);
+            $invalid          = $this->messageValidator->validate($messageReceived, $retiredForAction);
+```
+
+Note `RETIRED_PROPERTIES` is keyed by action (`validateSource`, `validateCalendar`, `runTest`), not by shape, which is why
+this indexes by `$messageReceived->action` and not by `WebSocketMessageValidator::shapeOf()`.
+
+Add the test to `phpunit_tests/HealthProtocolValidationTest.php`:
+
+```php
+    /**
+     * A half-migrated message hears the sentence that helps it, not the generic one.
+     *
+     * `rejectRetiredProperties()` runs inside the handler, so it is reached only if the validator
+     * declines to report the property first. Without the deferral this comes back as
+     * INVALID_MESSAGE and the client is told the property is unknown rather than what replaced it.
+     */
+    public function testARetiredPropertyIsDiagnosedByTheHandlerNotTheSchema(): void
+    {
+        $frames = $this->frames((string) json_encode([
+            'action'    => 'validateSource',
+            'target'    => ['id' => 'temporale:roman'],
+            'category'  => 'sourceDataCheck',
+            'requestId' => 'req-4'
+        ]));
+
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::RETIRED_PROPERTY->value, $frames[0]->errorCode, 'the generic schema complaint won the race');
+        self::assertSame('category is not part of a validateSource message: target.id replaces it.', $frames[0]->text);
+    }
+```
+
+- [ ] **Step 6: Import the schema at startup, not on the first message**
+
+Spec §8: a WebSocket server that cannot validate is misconfigured and should say so before a client connects. In `Health`'s
+constructor, after building the validator, force the import so an unreadable or malformed schema throws there:
+
+```php
+        $this->messageValidator = new WebSocketMessageValidator();
+        $this->messageValidator->warm();
+```
+
+Add the method to `WebSocketMessageValidator`:
+
+```php
+    /**
+     * Import the schema now rather than on the first message. A server that cannot validate is
+     * misconfigured, and should fail where an operator sees it rather than answering every message
+     * with an internal error.
+     */
+    public function warm(): void
+    {
+        $this->schema();
+        $this->propertyNamesFor('validateSource');
+    }
+```
+
+- [ ] **Step 7: Delete what the schema replaced**
+
+Remove `validateMessageProperties()`, the `ACTION_PROPERTIES` constant and the `TYPED_CALENDAR_PROPERTIES` constant, along with the `else` branch's now-unreachable `'Invalid
+message properties'` arm. Keep `isTypedCalendarMessage()`, `RETIRED_PROPERTIES` and `rejectRetiredProperties()`.
+
+Fix the class-docblock references to the deleted constants: search for `ACTION_PROPERTIES` and rewrite each mention to name the schema instead. Several are long explanations
+of why the retired set is not derivable from it — those stay true and valuable; they just need to point at `WebSocketMessage.json`.
+
+- [ ] **Step 8: Run everything**
+
+```bash
+vendor/bin/phpunit --no-coverage --filter 'Health|WebSocketMessage'
+composer test:quick
+composer analyse
+composer lint
+```
+
+Expected: green. If a pre-existing Health test now fails, read it before changing it — it may be describing behaviour this task deliberately changed, in which case update the
+test *and* its docblock, or it may be a real regression.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/Services/WebSocketMessageValidator.php src/Health.php phpunit_tests/HealthProtocolValidationTest.php
+git commit -m "feat(health): validate every inbound message against the published contract
+
+Five message shapes could terminate the WebSocket process for every connected
+client: validateMessageProperties() checked that required keys existed and never
+what they were, and the v1 dispatch arms unpack straight into typed parameters.
+Ratchet catches \\Exception; TypeError, ValueError and Error are not \\Exception.
+
+Types and enums are now checked for every message. Undeclared properties are
+refused only for messages carrying a requestId, because the shipped client sends
+runToken on every message and spreads rite onto an executeValidation that never
+reads it. The allowed names are read from the schema, so this class carries no
+list of its own.
+
+ACTION_PROPERTIES and validateMessageProperties() are deleted rather than kept
+beside the schema. A second copy is the disease.
+
+Refs #806"
+```
+
+---
+
+### Task 4: The backstop
+
+**Files:**
+
+- Modify: `src/Health.php` (`onMessage()` dispatch `switch`)
+- Test: `phpunit_tests/HealthProtocolValidationTest.php` (extend)
+
+**Interfaces:**
+
+- Consumes: `ProtocolErrorCode::INTERNAL_ERROR` (Task 2), `WebSocketMessageValidator::reset()` and its `__construct(?string $schemaPath)` (Task 3).
+- Produces: nothing later tasks depend on.
+
+**Background:** the schema is the primary gate. The backstop exists because a crash that kills the process for every connected client must not depend on a schema file being
+correct. The test therefore has to isolate the backstop *from* the schema — otherwise it only proves the schema works, which Task 3 already proved.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `phpunit_tests/HealthProtocolValidationTest.php`:
+
+```php
+    /**
+     * The backstop, isolated from the gate that normally stands in front of it.
+     *
+     * Pointing the validator at a permissive schema lets a crash vector through to the dispatch, so
+     * this asserts what happens when the schema is *wrong* — which is the only circumstance in which
+     * the backstop matters, and the reason it is not redundant with Task 3's tests. Without it the
+     * process dies; with it, one request fails and the daemon keeps serving.
+     */
+    public function testAHandlerThatThrowsIsContainedRatherThanKillingTheProcess(): void
+    {
+        $permissive = sys_get_temp_dir() . '/permissive-ws-schema-' . getmypid() . '.json';
+        file_put_contents($permissive, (string) json_encode([
+            '$schema' => 'https://json-schema.org/draft-07/schema#',
+            'type'    => 'object'
+        ]));
+
+        $health    = $this->newHealth();
+        $validator = new \ReflectionProperty(Health::class, 'messageValidator');
+        $validator->setValue($health, new \LiturgicalCalendar\Api\Services\WebSocketMessageValidator($permissive));
+        \LiturgicalCalendar\Api\Services\WebSocketMessageValidator::reset();
+
+        $conn = self::createStubConnection();
+        ob_start();
+        try {
+            $health->onMessage($conn, (string) json_encode([
+                'action'       => 'validateCalendar',
+                'calendar'     => 'IT',
+                'year'         => 'not-a-year',
+                'category'     => 'nationalcalendar',
+                'responsetype' => 'JSON'
+            ]));
+        } finally {
+            ob_end_clean();
+            @unlink($permissive);
+            \LiturgicalCalendar\Api\Services\WebSocketMessageValidator::reset();
+        }
+
+        $frames = array_map(static fn (string $f): \stdClass => json_decode($f), $conn->sent);
+        self::assertNotEmpty($frames, 'the connection was told nothing at all');
+        $last = $frames[count($frames) - 1];
+        self::assertSame('protocolError', $last->type);
+        self::assertSame(ProtocolErrorCode::INTERNAL_ERROR->value, $last->errorCode);
+    }
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+```bash
+vendor/bin/phpunit --no-coverage --filter testAHandlerThatThrowsIsContainedRatherThanKillingTheProcess
+```
+
+Expected: an uncaught `TypeError` escapes the test — the crash, reproduced with the gate removed.
+
+- [ ] **Step 3: Add the backstop**
+
+In `src/Health.php`, wrap the dispatch `switch` in `onMessage()`:
+
+```php
+            try {
+                switch ($messageReceived->action) {
+                    // … existing arms, unchanged …
+                }
+            } catch (\Throwable $e) {
+                // Ratchet's IoServer::handleData catches \Exception, and TypeError, ValueError and
+                // Error are not \Exception — so without this, anything a handler throws terminates
+                // the process for every connected client rather than failing one request.
+                //
+                // Schema validation stands in front of this and is the real gate. The backstop is
+                // here because a process-wide crash must not depend on a schema file being correct.
+                // A catch-all can mask a bug, which is why this logs before it answers: the log line
+                // is what keeps the masked bug findable.
+                //
+                // It does NOT cover #823. Those throws happen inside promise callbacks, after this
+                // method has returned, where no try around the dispatch can see them.
+                echo sprintf(
+                    "Uncaught %s handling %s from connection %d: %s\n",
+                    get_class($e),
+                    (string) $messageReceived->action,
+                    $resourceId,
+                    $e->getMessage()
+                );
+                $this->rejectMessage(
+                    $from,
+                    ProtocolErrorCode::INTERNAL_ERROR,
+                    'The server failed while handling this message. This is a bug; the run may be incomplete.',
+                    requestId: $requestId
+                );
+            }
+```
+
+- [ ] **Step 4: Run the suites**
+
+```bash
+vendor/bin/phpunit --no-coverage --filter 'Health|WebSocketMessage'
+composer test:quick
+composer analyse
+composer lint
+composer lint:md
+```
+
+Expected: green.
+
+- [ ] **Step 5: Mutation-check every guard this branch added**
+
+For each of the three, remove it, confirm the named tests fail, then restore it. A guard whose removal breaks nothing is not a guard.
+
+1. Delete the `catch (\Throwable)` block → `testAHandlerThatThrowsIsContainedRatherThanKillingTheProcess` must fail.
+2. Make `WebSocketMessageValidator::validate()` return `null` immediately → all five `crashVectorProvider` cases must fail.
+3. Delete the `property_exists($message, 'requestId')` early return in `validate()` → `testAnUndeclaredPropertyIsRefusedOnlyWhenTheMessageOptedIn` must fail on its *accept*
+half, and the `WebSocketMessageSchemaTest` client fixtures must still pass (they carry no `requestId` except the v2 ones).
+
+Record the result of each in the task report.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Health.php phpunit_tests/HealthProtocolValidationTest.php
+git commit -m "feat(health): contain a throwing handler instead of losing the process
+
+Ratchet's IoServer::handleData catches \\Exception; TypeError, ValueError and
+Error are not \\Exception. Schema validation is the real gate, but a crash that
+kills the process for every connected client must not depend on a schema file
+being correct, so the dispatch is wrapped and answers INTERNAL_ERROR.
+
+The test points the validator at a permissive schema so a crash vector reaches
+the dispatch: the backstop only matters when the schema is wrong, and a test
+that did not isolate it would merely re-prove the gate.
+
+This does not cover #823 — those throws happen inside promise callbacks, after
+onMessage() has returned — and the comment says so.
+
+Refs #806"
+```
+
+---
+
+## Notes for the reviewer of the final branch
+
+- The one intentional behaviour change for a *working* v1 client is that `year` must now be a JSON number rather than a numeric string, and `category` must be a known value.
+Both are argued in the spec; the shipped client satisfies both, which `WebSocketMessageSchemaTest::clientMessageProvider` proves.
+- `#823` is untouched and stays open.
+- Issue #826 tracks the validator upgrade that would let §4's gate move into the schema.

--- a/docs/superpowers/plans/2026-08-20-strict-validation.md
+++ b/docs/superpowers/plans/2026-08-20-strict-validation.md
@@ -348,9 +348,14 @@ final class WebSocketMessageSchemaTest extends TestCase
     public function testAMessageTheShippedClientSendsValidates(array $message): void
     {
         $decoded = json_decode((string) json_encode($message));
-        self::schema()->in($decoded);
-        // in() throws on failure; reaching here is the assertion.
-        self::assertTrue(true);
+
+        // in() throws on failure and returns the processed value on success, so the assertions
+        // below are on that value rather than on having survived the call. `assertTrue(true)`
+        // would pass on a build where in() silently became a no-op.
+        $processed = self::schema()->in($decoded);
+
+        self::assertInstanceOf(\stdClass::class, $processed);
+        self::assertSame($message['action'], $processed->action, 'the validated message is not the one that went in');
     }
 
     /**
@@ -364,10 +369,16 @@ final class WebSocketMessageSchemaTest extends TestCase
         $decoded = json_decode((string) json_encode($message));
         $matches = 0;
         foreach ($raw->oneOf as $arm) {
-            $name = substr((string) $arm->{'$ref'}, strlen('#/definitions/'));
+            // The arm is wrapped rather than extracted: several definitions `$ref` their siblings
+            // (`calendarIdentity`, `correlationId`), and a definition lifted out on its own takes
+            // its unresolvable pointers with it. Keeping `definitions` alongside preserves them.
+            $armDocument = (object) [
+                '$schema'     => 'https://json-schema.org/draft-07/schema#',
+                'allOf'       => [$arm],
+                'definitions' => $raw->definitions
+            ];
             try {
-                Schema::import((object) ['$schema' => 'https://json-schema.org/draft-07/schema#'] + (array) $raw->definitions->{$name})
-                    ->in($decoded);
+                Schema::import($armDocument)->in($decoded);
                 $matches++;
             } catch (\Throwable) {
                 // not this arm

--- a/docs/superpowers/specs/2026-08-20-strict-validation-design.md
+++ b/docs/superpowers/specs/2026-08-20-strict-validation-design.md
@@ -1,0 +1,240 @@
+# Strict inbound validation and typed protocol errors
+
+**API#806 section G.** Sections A, B, C, E and H are merged; D's server half is complete
+([#811](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/811) publishes `steps`,
+[#824](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/824) emits the terminal frame, and
+[#825](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/825) made the count exact). What remains of D is
+client work in UnitTestInterface#42. This is the next server-side section. F — the versioned handshake — comes last,
+because negotiation is pointless until two protocols exist.
+
+## Why this is not a tidying exercise
+
+`Health::validateMessageProperties()` checks that required keys **exist**. It never checks what they are. The v1 dispatch
+arms then unpack straight into typed parameters:
+
+```php
+$this->validateCalendar($m->calendar, $m->year, $m->category, $m->responsetype, ...);
+//                       string        int       string        string
+```
+
+Ratchet's `IoServer::handleData` catches `\Exception`. `TypeError`, `ValueError` and `Error` are **not** `\Exception`.
+So a malformed message does not fail — it terminates the WebSocket process, for every connected client.
+
+Measured against `c38dbb97`, driving `Health::onMessage()` directly:
+
+| message                                                             | outcome                                      |
+|---------------------------------------------------------------------|----------------------------------------------|
+| `validateCalendar` with `"year": "not-a-year"`                      | `TypeError` — process dies                   |
+| `validateCalendar` with `"category": []`                            | `TypeError` — process dies                   |
+| `validateCalendar` with `"responsetype": "NOT_A_FORMAT"`            | `ValueError` — process dies                  |
+| `executeUnitTest` with `"test": {…}`                                | `TypeError` — process dies                   |
+| `executeValidation` with `"category": {…}`                          | `Error` (the `(string)` cast) — process dies |
+| `runTest`, `validateSource`, `cancelRun`, malformed every which way | rejected cleanly, process survives           |
+
+The split is not accidental: **the three v1 actions crash and the three v2 actions do not.** The v2 handlers take the
+whole message and validate defensively, because they were written after the hazard was understood. Two places in
+`Health` already document it — `VALIDATABLE_RESPONSE_FORMATS` exists precisely because `ReturnTypeParam::from()` throws
+a `\ValueError`, and `cancelRun()` takes `mixed` for the same reason — but each guard was applied at the one door its
+author was standing in front of. Section G is where the rule stops being applied door by door.
+
+No authentication stands in front of this. `Health` is the WebSocket endpoint the test interface connects to.
+
+## The shape of the fix
+
+### 1. A published schema is the authority
+
+`jsondata/schemas/WebSocketMessage.json`: a `oneOf` over the message shapes, discriminated by `action` and — for
+`validateCalendar`, which has two shapes under one action — by whether `calendar` is a string or an object. That is the
+same discriminator `Health::isTypedCalendarMessage()` already uses, not a second one invented here.
+
+This follows the precedent set by [#717](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/pull/717): schema
+files are authoritative and wired into `Health`, not documentation kept beside the code and hoped to match. It also
+answers #806's own thesis directly — the vocabulary currently lives in copies that must be edited in lockstep, and
+nothing fails loudly when they diverge.
+
+It declares `"$schema": "https://json-schema.org/draft-07/schema#"` and puts its shapes under `definitions`, matching
+every other schema in `jsondata/schemas/` and the draft `swaggest/json-schema` v0.12.43 actually implements. §4 explains
+why that version matters more than a convention here.
+
+`ACTION_PROPERTIES` and the list-walking half of `validateMessageProperties()` are **replaced** by the schema's
+`required` arrays rather than kept beside it. A second copy is the disease, not the cure.
+
+### 2. The schema is derived from the `@phpstan-type` annotations, and a test says so
+
+`Health`'s class docblock already carries a complete typed specification of every message shape — types, optionality and
+enum membership:
+
+```php
+@phpstan-type ValidateCalendar \stdClass&object{action:'validateCalendar',calendar:string,year:int,
+    category:'nationalcalendar'|'diocesancalendar'|'ritecalendar',responsetype:'JSON'|'XML'|'ICS'|'YML',rite?:string}
+```
+
+These annotations are the reason [#805](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/805) exists:
+they were the only written spec, and they disagreed with the code. PHPStan level 10 already enforces them **against the
+implementation**. Wiring the schema to agree with the annotations therefore ties three things together — annotation,
+implementation and published contract — with a failure at any corner breaking a check rather than escaping silently.
+
+Two drift tests hold the corners, and they are stated separately because they check different things:
+
+- **Schema against annotation:** for each `@phpstan-type` shape, a fixture message conforming to that annotation must
+  validate. The annotations are enforced against the implementation by PHPStan, so a fixture that satisfies the
+  annotation and fails the schema means the schema and the code disagree. Parsing the docblocks themselves is
+  deliberately not attempted — the fixtures are transcribed by hand and reviewed, which is the readable half of the
+  same guarantee.
+- **Schema against dispatch:** every action the schema declares has a dispatch arm, and every dispatch arm has a schema
+  arm. Adding an action without a schema entry fails in CI rather than falling through to `unknown_action` in
+  production.
+
+### 3. Where the gate sits
+
+In `onMessage()`, before dispatch:
+
+```text
+parse JSON → requestId check → retired-property check → schema validation → dispatch
+```
+
+**The retired-property check stays in PHP and runs first.** JSON Schema can express the rejection
+(`not: {required: [...]}`) but cannot express the sentence:
+
+```text
+category is not part of a validateSource message: target.id replaces it.
+```
+
+The value of `rejectRetiredProperties()` is the diagnosis, not the refusal — a half-migrated client is exactly the
+caller who needs to be told which property replaced which. Running it ahead of the schema means a half-migrated message
+is answered for what is actually wrong with it, which is the ordering `rejectRetiredProperties()` already documents.
+
+### 4. Strictness gates on `requestId`, and the allowed names still come from the schema
+
+Unknown-property rejection applies only to messages that opted in by carrying a `requestId` — the same v2 opt-in signal
+the terminal `complete` frame is gated on.
+
+**It cannot be expressed in the schema, and the reason is worth recording.** The natural spelling is
+`allOf: [{$ref: shape}, {if: {required: [requestId]}, then: {unevaluatedProperties: false}}]`. `unevaluatedProperties`
+is draft 2019-09; `swaggest/json-schema` v0.12.43 implements draft-07, where `additionalProperties: false` sees only the
+properties declared in the *same* schema object — so inside a `then` it would reject everything. The remaining schema-only
+option is two arms per action, lenient and strict, with every property list written twice. That is the second copy this
+section exists to eliminate, traded for an aesthetic.
+
+So the gate is applied in PHP, and the **vocabulary it applies stays in the schema**, which was the actual goal:
+
+- each shape is a named entry under `definitions` (`executeValidation`, `validateCalendarLegacy`, `validateCalendarTyped`,
+  `executeUnitTest`, `runTest`, `cancelRun`, `validateSource`), and the `oneOf` arms `$ref` those entries;
+- the unknown-property check reads the allowed names from `definitions[<shape>].properties` — it does not carry a list;
+- which shape a message is gets decided by the discriminator that already exists: the action name, plus
+  `isTypedCalendarMessage()` for `validateCalendar`'s two forms.
+
+A test asserts the check rejects a name absent from the schema's `properties` and accepts every name present, so the two
+cannot drift apart without failing.
+
+If [#826](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/826) ever moves the project to a
+draft-2019-09 or 2020-12 validator, this gate can move into the schema as originally drawn. It is recorded here so that
+the workaround is understood as forced rather than preferred — and so nobody re-proposes the elegant spelling without
+finding out why it was not used.
+
+**This is load-bearing, not caution.** The shipped client sends properties the server does not declare and does not
+read:
+
+- `assets/js/index.js:531` — `sendMessage()` sets `data.runToken` on **every** message, and `runToken` is declared only
+  for `cancelRun`.
+- `assets/js/index.js:647` and `assets/js/resources.js:1221` — `{ action: 'executeValidation', ...check }` spreads a
+  config object carrying `rite`, which `executeValidation` never reads: `readRiteHint()` is called only from the
+  `validateCalendar` and `executeUnitTest` arms.
+
+A uniform `additionalProperties: false` would refuse every source-data check the current UI sends. Type checking, by
+contrast, applies to **all** messages, v1 included: refusing a message that would otherwise kill the server is strictly
+better for a v1 client too.
+
+Envelope properties — `action`, `runToken`, `requestId` — are declared on every shape, since they are cross-cutting
+rather than per-action.
+
+### 5. Typed protocol errors
+
+```jsonc
+{ "type": "protocolError", "errorCode": "unknown_target_id",
+  "text": "…", "runToken": "…", "requestId": "…" }
+```
+
+**Ungated, and this is a finding rather than an assumption.** #806 section 8 says protocol errors are invisible because
+the client dispatches only on `success`/`error`. That is now **stale**: UnitTestInterface#46 added an `else` branch that
+treats *any* unrecognised type — `echobot` included — as a visible failure via `countUnattributableFailure()`
+(`assets/js/index.js:932-937`). A `protocolError` frame therefore behaves in the shipped client exactly as `echobot`
+does today. Nothing regresses, so nothing needs a gate.
+
+**`text`, not `message`.** #806's sketch shows a `message` field. Every other frame in this protocol carries `text`, and
+introducing a second name for the same thing is the duplication #806 exists to remove. `errorCode` is the genuinely new
+part: machine-readable, and the reason the frame is worth typing at all.
+
+### 6. Error codes exist where a client would act differently
+
+```php
+enum ProtocolErrorCode: string {
+    case INVALID_JSON       = 'invalid_json';        // the body did not parse
+    case NOT_AN_OBJECT      = 'not_an_object';       // parsed to a scalar or an array
+    case MISSING_ACTION     = 'missing_action';
+    case UNKNOWN_ACTION     = 'unknown_action';
+    case INVALID_REQUEST_ID = 'invalid_request_id';  // the existing correlation-id check
+    case RETIRED_PROPERTY   = 'retired_property';    // you are half-migrated
+    case UNKNOWN_TARGET_ID  = 'unknown_target_id';   // refetch /validations
+    case INVALID_MESSAGE    = 'invalid_message';     // schema violation
+    case INTERNAL_ERROR     = 'internal_error';      // see §7
+}
+```
+
+`INVALID_MESSAGE` is deliberately **not** split into `wrong_type` / `unknown_enum_value` / `unknown_property`, though
+the #806 example gestures at that granularity. A client cannot act differently on those three: each means "fix the
+message", and `text` carries the validator's own account of which one it was. `RETIRED_PROPERTY` and
+`UNKNOWN_TARGET_ID` do imply different client behaviour, so they are separate. The rule: a code where behaviour
+diverges, text where it does not.
+
+### 7. A `\Throwable` backstop around dispatch
+
+Schema validation is the primary gate. It is not the only one, because a crash that kills the process for every
+connected client must not depend on a schema file being correct. The dispatch `switch` is wrapped in
+`catch (\Throwable)`: log loudly, answer `INTERNAL_ERROR`, keep serving.
+
+The tradeoff is real and worth naming rather than hiding: a catch-all can mask bugs. For a long-running daemon,
+converting "the process dies" into "one request fails, loudly logged" is the right trade — and the log line is what
+makes the masked bug findable.
+
+**It does not cover [#823](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/823).** Those throws
+happen inside promise callbacks, after `onMessage()` has returned, so no `try` around dispatch can see them. #823 stays
+open and is not in scope here.
+
+### 8. Import the schema once
+
+`validateDataAgainstSchema()` calls `Schema::import()` per invocation. That is fine for a handful of source files and
+wrong for every inbound message. The message schema is imported once into a static and reused. If the schema file is
+unreadable, that fails at startup rather than once per message: a WebSocket server that cannot validate is
+misconfigured, and should say so before a client connects rather than answering every message with an internal error.
+
+## Testing
+
+**The highest-value test is compatibility, not the crash vectors.** Every message shape the shipped client actually
+sends must pass validation. `UnitTestInterface/assets/js/wsProtocol.js` holds that table literally, so the fixtures are
+transcribed from the real thing rather than imagined — including the `rite` spread and the injected `runToken` that a
+uniform strict rule would have broken on day one.
+
+Then:
+
+- **Each confirmed crash vector** from the table above asserts a `protocolError` frame *and* that nothing was thrown.
+  Deleting the guard must fail these — the mutation check every guard on this rollout has had to pass.
+- **v1 leniency, both directions:** an `executeValidation` carrying a stray property is accepted; the same message with
+  a `requestId` is refused. One test, two assertions, and it pins the gate rather than the general idea of a gate.
+- **The drift test** of §2: schema arms ⟷ dispatch arms.
+- **Error codes:** each rejection path asserts its own code, so a refactor cannot quietly collapse two codes into one.
+
+Tests drive `onMessage()` with a real message, never the private validator directly. #825 is the precedent and the
+reason: the emitters there were correct and tested, and the bug was that no request reached them — a test calling the
+right function directly passed against the bug.
+
+## Scope
+
+**In:** the message schema, type and enum validation, unknown-property rejection for v2, typed `protocolError` frames
+with codes, the dispatch backstop, and the tests above.
+
+**Out:** #823's promise-callback hole; the `hello` handshake and capability negotiation (section F); any change to
+response frames beyond the new error type; UnitTestInterface's adoption of `errorCode`, which is #42's business.
+
+**Compatibility:** no v1 message that works today stops working. The only v1 messages this refuses are ones that
+currently kill the server.

--- a/docs/superpowers/specs/2026-08-20-strict-validation-design.md
+++ b/docs/superpowers/specs/2026-08-20-strict-validation-design.md
@@ -90,19 +90,34 @@ Two drift tests hold the corners, and they are stated separately because they ch
 In `onMessage()`, before dispatch:
 
 ```text
-parse JSON → requestId check → retired-property check → schema validation → dispatch
+parse JSON → requestId check → schema validation (retired names deferred) → dispatch → handler's own retired-property check
 ```
 
-**The retired-property check stays in PHP and runs first.** JSON Schema can express the rejection
-(`not: {required: [...]}`) but cannot express the sentence:
+**The retired-property check stays in PHP, but it does not run first — it runs inside each v2 handler, after schema
+validation and after dispatch.** JSON Schema can express the rejection (`not: {required: [...]}`) but cannot express
+the sentence:
 
 ```text
 category is not part of a validateSource message: target.id replaces it.
 ```
 
 The value of `rejectRetiredProperties()` is the diagnosis, not the refusal — a half-migrated client is exactly the
-caller who needs to be told which property replaced which. Running it ahead of the schema means a half-migrated message
-is answered for what is actually wrong with it, which is the ordering `rejectRetiredProperties()` already documents.
+caller who needs to be told which property replaced which. Schema validation runs first and would otherwise report a
+retired property as an unrecognised one (`category is not a property of a validateSource message …`, naming nothing to
+replace it with), so `WebSocketMessageValidator::validate()` takes a `$deferToHandler` list of the names each action
+retired and skips them in its unknown-property check. That is what lets a half-migrated message reach dispatch at all;
+`rejectRetiredProperties()`, called from inside `validateTypedCalendar()`, `runTest()` and `validateSource()`, then
+gives it the specific diagnosis before the handler does anything else with the message.
+
+This ordering has one corner it does not cover cleanly: `{"action":"validateSource","category":…,"validate":…}` with
+no `target` is refused by the schema — `validateSource: Required property missing: target` — before it ever reaches
+`rejectRetiredProperties()`, so the answer is a missing-required-property error rather than the retired-property
+diagnosis a fully half-migrated message gets. That is acceptable rather than a bug: a message missing `target`
+entirely is not a *renamed* property being carried alongside its replacement, which is what the retired-property check
+diagnoses — it is a `validateSource` message that is malformed on its own terms, `target` being required regardless
+of what else the client did or did not migrate. The realistic half-migrated case — `target` present, `category` and
+`validate` carried alongside it — reaches the handler and gets the specific diagnosis correctly; only the
+already-broken case answers with a different, still-correct, error.
 
 ### 4. Strictness gates on `requestId`, and the allowed names still come from the schema
 

--- a/jsondata/schemas/WebSocketMessage.json
+++ b/jsondata/schemas/WebSocketMessage.json
@@ -29,9 +29,20 @@
         "executeValidation": {
             "type": "object",
             "required": ["action", "category", "validate"],
-            "oneOf": [
-                { "required": ["sourceFile"] },
-                { "required": ["sourceFolder"] }
+            "anyOf": [
+                {
+                    "description": "`sourceFolder` is read only inside the `category === 'sourceDataCheck'` branch of Health::executeValidation(). Every other category falls into the branch that requires `sourceFile` and throws when only `sourceFolder` is present, and that exception closes the WebSocket connection instead of returning a result (see UnitTestInterface's assets/js/wsProtocol.js). anyOf (not oneOf) is deliberate: a sourceDataCheck message carrying both sourceFile and sourceFolder matches two arms below, and today sourceFolder simply wins that race rather than being refused, so oneOf would tighten behaviour the server does not enforce.",
+                    "properties": { "category": { "const": "sourceDataCheck" } },
+                    "required": ["sourceFolder"]
+                },
+                {
+                    "properties": { "category": { "enum": ["universalcalendar", "sourceDataCheck"] } },
+                    "required": ["sourceFile"]
+                },
+                {
+                    "properties": { "category": { "const": "resourceDataCheck" } },
+                    "required": ["sourceFile"]
+                }
             ],
             "properties": {
                 "action": { "const": "executeValidation" },

--- a/jsondata/schemas/WebSocketMessage.json
+++ b/jsondata/schemas/WebSocketMessage.json
@@ -47,9 +47,9 @@
             "properties": {
                 "action": { "const": "executeValidation" },
                 "category": { "enum": ["universalcalendar", "sourceDataCheck", "resourceDataCheck"] },
-                "validate": { "type": "string" },
-                "sourceFile": { "type": "string" },
-                "sourceFolder": { "type": "string" },
+                "validate": { "type": "string", "pattern": "^[^\\x00]*$" },
+                "sourceFile": { "type": "string", "pattern": "^[^\\x00]*$" },
+                "sourceFolder": { "type": "string", "pattern": "^[^\\x00]*$" },
                 "responsetype": { "type": "string" },
                 "rite": { "type": "string" },
                 "runToken": { "$ref": "#/definitions/correlationId" },

--- a/jsondata/schemas/WebSocketMessage.json
+++ b/jsondata/schemas/WebSocketMessage.json
@@ -1,0 +1,124 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Health WebSocket inbound message",
+    "description": "Every message the Health WebSocket endpoint accepts. Shapes are discriminated by `action`, and for `validateCalendar` additionally by whether `calendar` is a string (v1) or an object (v2). Properties a shape does not declare are refused only for messages carrying a `requestId`; see API issue #806 section G.",
+    "oneOf": [
+        { "$ref": "#/definitions/executeValidation" },
+        { "$ref": "#/definitions/validateCalendarLegacy" },
+        { "$ref": "#/definitions/validateCalendarTyped" },
+        { "$ref": "#/definitions/executeUnitTest" },
+        { "$ref": "#/definitions/runTest" },
+        { "$ref": "#/definitions/cancelRun" },
+        { "$ref": "#/definitions/validateSource" }
+    ],
+    "definitions": {
+        "correlationId": {
+            "type": "string",
+            "pattern": "^[A-Za-z0-9_-]{1,64}$",
+            "description": "An opaque client-minted handle the server echoes back. One alphabet for runToken and requestId alike."
+        },
+        "calendarIdentity": {
+            "type": "object",
+            "required": ["kind", "rite"],
+            "properties": {
+                "kind": { "enum": ["general", "national", "diocesan", "rite"] },
+                "id": { "type": "string" },
+                "rite": { "type": "string" }
+            }
+        },
+        "executeValidation": {
+            "type": "object",
+            "required": ["action", "category", "validate"],
+            "oneOf": [
+                { "required": ["sourceFile"] },
+                { "required": ["sourceFolder"] }
+            ],
+            "properties": {
+                "action": { "const": "executeValidation" },
+                "category": { "enum": ["universalcalendar", "sourceDataCheck", "resourceDataCheck"] },
+                "validate": { "type": "string" },
+                "sourceFile": { "type": "string" },
+                "sourceFolder": { "type": "string" },
+                "responsetype": { "type": "string" },
+                "rite": { "type": "string" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "validateCalendarLegacy": {
+            "type": "object",
+            "required": ["action", "calendar", "year", "category", "responsetype"],
+            "properties": {
+                "action": { "const": "validateCalendar" },
+                "calendar": { "type": "string" },
+                "year": { "type": "integer" },
+                "category": { "enum": ["nationalcalendar", "diocesancalendar", "ritecalendar"] },
+                "responsetype": { "enum": ["JSON", "XML", "ICS", "YML"] },
+                "rite": { "type": "string" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "validateCalendarTyped": {
+            "type": "object",
+            "required": ["action", "calendar", "year", "responseFormat"],
+            "properties": {
+                "action": { "const": "validateCalendar" },
+                "calendar": { "$ref": "#/definitions/calendarIdentity" },
+                "year": { "type": "integer" },
+                "responseFormat": { "enum": ["JSON", "XML", "ICS", "YML"] },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "executeUnitTest": {
+            "type": "object",
+            "required": ["action", "calendar", "year", "category", "test"],
+            "properties": {
+                "action": { "const": "executeUnitTest" },
+                "calendar": { "type": "string" },
+                "year": { "type": "integer" },
+                "category": { "enum": ["nationalcalendar", "diocesancalendar", "ritecalendar"] },
+                "test": { "type": "string" },
+                "rite": { "type": "string" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "runTest": {
+            "type": "object",
+            "required": ["action", "test", "calendar", "year"],
+            "properties": {
+                "action": { "const": "runTest" },
+                "test": { "type": "string" },
+                "calendar": { "$ref": "#/definitions/calendarIdentity" },
+                "year": { "type": "integer" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "cancelRun": {
+            "type": "object",
+            "required": ["action", "runToken"],
+            "properties": {
+                "action": { "const": "cancelRun" },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "validateSource": {
+            "type": "object",
+            "required": ["action", "target"],
+            "properties": {
+                "action": { "const": "validateSource" },
+                "target": {
+                    "type": "object",
+                    "required": ["id"],
+                    "properties": { "id": { "type": "string" } }
+                },
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        }
+    }
+}

--- a/jsondata/schemas/WebSocketMessage.json
+++ b/jsondata/schemas/WebSocketMessage.json
@@ -19,12 +19,14 @@
         },
         "calendarIdentity": {
             "type": "object",
+            "description": "additionalProperties is unconditional here, unlike the root-level shapes above: unknown-property rejection at the root is gated on the message carrying a requestId (WebSocketMessageValidator, API issue #806 section G), because the shipped UnitTestInterface predates that field and sends other properties a strict root gate would refuse. This nested object is reachable only from validateCalendarTyped and runTest, both v2-only shapes the shipped client never sends, so there is no compatibility guarantee to protect here. Do not loosen this to match the root's gating — that would remove the only strictness these v2 nested objects have.",
             "required": ["kind", "rite"],
             "properties": {
                 "kind": { "enum": ["general", "national", "diocesan", "rite"] },
                 "id": { "type": "string" },
                 "rite": { "type": "string" }
-            }
+            },
+            "additionalProperties": false
         },
         "executeValidation": {
             "type": "object",
@@ -124,8 +126,10 @@
                 "action": { "const": "validateSource" },
                 "target": {
                     "type": "object",
+                    "description": "additionalProperties is unconditional here, unlike the root-level shapes above: unknown-property rejection at the root is gated on the message carrying a requestId (WebSocketMessageValidator, API issue #806 section G), because the shipped UnitTestInterface predates that field and sends other properties a strict root gate would refuse. validateSource is a v2-only shape the shipped client never sends, so there is no compatibility guarantee to protect here. Do not loosen this to match the root's gating — that would remove the only strictness this nested object has.",
                     "required": ["id"],
-                    "properties": { "id": { "type": "string" } }
+                    "properties": { "id": { "type": "string" } },
+                    "additionalProperties": false
                 },
                 "runToken": { "$ref": "#/definitions/correlationId" },
                 "requestId": { "$ref": "#/definitions/correlationId" }

--- a/phpunit_tests/HealthCancelRunTest.php
+++ b/phpunit_tests/HealthCancelRunTest.php
@@ -200,7 +200,7 @@ final class HealthCancelRunTest extends TestCase
      *
      * `validateCalendar` is used as the "ordinary message" here because, sent with only `runToken`, it
      * is missing every other required property (`category`, `calendar`, `year`, `responsetype`), so
-     * `validateMessageProperties()` rejects it and `onMessage()` falls straight to the protocol-error
+     * `WebSocketMessageValidator` rejects it and `onMessage()` falls straight to the protocol-error
      * path — confirmed by the asserted echoed frame below — without dispatching an HTTP request or file
      * read. That is what makes it safe to drive through the real entry point in a unit test.
      */

--- a/phpunit_tests/HealthCancelRunTest.php
+++ b/phpunit_tests/HealthCancelRunTest.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -26,6 +27,7 @@ use Ratchet\ConnectionInterface;
  * See UnitTestInterface#43 and #806 section H.
  */
 #[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
 final class HealthCancelRunTest extends TestCase
 {
     // These tests seed the queue directly rather than through cachedGet(), so nothing here is

--- a/phpunit_tests/HealthCancelRunTest.php
+++ b/phpunit_tests/HealthCancelRunTest.php
@@ -18,8 +18,10 @@ use Ratchet\ConnectionInterface;
  * kept working through the abandoned run's backlog. The server already knew how to discard such
  * requests — `dropSupersededQueuedRequests()` filters queue entries whose `runToken` no longer matches
  * the connection's stored token — but only a *restart* ever advanced that token. `cancelRun` clears it
- * on demand, which is why these tests assert on the queue rather than on any response frame: the
- * action is deliberately silent.
+ * on demand, which is why most of these tests assert on the queue rather than on any response frame:
+ * a cancel the server *can* act on, or a stale one it deliberately ignores, is silent. A cancel the
+ * server cannot even parse — a non-string `runToken` — is a different case and is now refused with a
+ * frame; see {@see testACancelWithANonStringRunTokenIsRejectedByTheSchema()}.
  *
  * See UnitTestInterface#43 and #806 section H.
  */
@@ -217,16 +219,18 @@ final class HealthCancelRunTest extends TestCase
     }
 
     /**
-     * `validateMessageProperties()` checks only that `runToken` is *present*, not that it is a string —
-     * `{"action":"cancelRun","runToken":null}` (same for an array or object) passes validation and
-     * reaches `cancelRun()`. Before its `is_string()` guard, PHP's weak-mode parameter coercion throws
-     * `TypeError` for a non-string argument against a `string` parameter; Ratchet's `IoServer::handleData`
-     * only catches `\Exception`, so that `\Error` would escape uncaught and take the whole WebSocket
-     * process down over one malformed cancel. A cancel the server cannot act on is already a documented
-     * no-op for a stale token (see `cancelRun()`'s docblock); this asserts a non-string token folds into
-     * that same no-op instead of crashing.
+     * `{"action":"cancelRun","runToken":null}` (same for an array or object) is now refused by
+     * `WebSocketMessageValidator` before dispatch ever reaches `cancelRun()`: `cancelRun`'s schema
+     * entry types `runToken` via `#/definitions/correlationId`, so a non-string value fails schema
+     * validation and is answered with a typed `protocolError` instead. `cancelRun()`'s own
+     * `is_string()` guard — which kept a `TypeError` a v1 client would otherwise have caused from
+     * escaping Ratchet's `IoServer::handleData`, which only catches `\Exception` — is therefore no
+     * longer reachable through this path; it stays in place as a backstop, per its own docblock.
+     *
+     * The queue and the stored token being untouched is still worth asserting: the rejection must
+     * happen before any dispatch, not merely produce the right frame alongside unrelated side effects.
      */
-    public function testACancelWithANonStringRunTokenIsASilentNoOp(): void
+    public function testACancelWithANonStringRunTokenIsRejectedByTheSchema(): void
     {
         $health = $this->newHealth();
         $conn   = self::createStubConnection(1);
@@ -238,6 +242,9 @@ final class HealthCancelRunTest extends TestCase
 
         self::assertCount(1, self::getQueue($health), 'the queued request survives an unusable cancel');
         self::assertSame([1 => 'run-a'], self::getRunTokens($health), 'the stored token is untouched');
-        self::assertSame([], $conn->sent, 'a cancel the server cannot act on stays silent, same as a stale token');
+        self::assertCount(1, $conn->sent, 'an unusable cancel is now refused rather than silently dropped');
+        $frame = json_decode($conn->sent[0]);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
     }
 }

--- a/phpunit_tests/HealthCancelRunTest.php
+++ b/phpunit_tests/HealthCancelRunTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -183,8 +184,8 @@ final class HealthCancelRunTest extends TestCase
 
         self::assertCount(1, $conn->sent, 'a malformed cancel is a protocol error, and those are visible');
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
-        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
     }
 
     /**
@@ -212,7 +213,7 @@ final class HealthCancelRunTest extends TestCase
 
         self::assertCount(1, $conn->sent, 'confirms the message short-circuited on the protocol-error path, not real work');
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('Invalid message properties', $frame->errorMsg, 'confirms it never reached the validateCalendar dispatch');
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode, 'confirms it never reached the validateCalendar dispatch');
     }
 
     /**

--- a/phpunit_tests/HealthCorrelationTest.php
+++ b/phpunit_tests/HealthCorrelationTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -49,6 +50,7 @@ use Ratchet\ConnectionInterface;
  * outbound request really is queued rather than served from a cache.
  */
 #[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
 final class HealthCorrelationTest extends TestCase
 {
     use HealthQueueIsolationTrait;

--- a/phpunit_tests/HealthCorrelationTest.php
+++ b/phpunit_tests/HealthCorrelationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
@@ -114,7 +115,7 @@ final class HealthCorrelationTest extends TestCase
         $frames = self::framesOf($conn);
         self::assertCount(4, $frames, 'a source check answers with one frame per published step, and then terminates');
         foreach ($frames as $frame) {
-            self::assertNotSame('echobot', $frame->type, "the message was refused: {$frame->text}");
+            self::assertNotSame('protocolError', $frame->type, "the message was refused: {$frame->text}");
             self::assertSame('req-alpha', $frame->requestId, 'every frame must name the request that caused it');
         }
         self::assertSame('complete', $frames[3]->step, 'the terminal frame carries the id too: it is the frame a client stops on');
@@ -168,7 +169,8 @@ final class HealthCorrelationTest extends TestCase
 
         $frames = self::framesOf($conn);
         self::assertCount(1, $frames, 'a malformed requestId is answered once and nothing is checked');
-        self::assertSame('echobot', $frames[0]->type, 'rejections reuse the echobot shape: since UnitTestInterface#46 an unknown type is painted as a failed check');
+        self::assertSame('protocolError', $frames[0]->type, 'rejections are a typed protocolError: since UnitTestInterface#46 an unrecognised type is painted as a failed check');
+        self::assertSame(ProtocolErrorCode::INVALID_REQUEST_ID->value, $frames[0]->errorCode);
         self::assertStringContainsString('requestId', (string) $frames[0]->text);
         self::assertObjectNotHasProperty('requestId', $frames[0], 'the id that could not be validated is not echoed back');
     }
@@ -219,7 +221,7 @@ final class HealthCorrelationTest extends TestCase
         ]);
 
         $frames = self::framesOf($conn);
-        self::assertNotSame('echobot', $frames[0]->type, "a well-formed requestId was refused: {$frames[0]->text}");
+        self::assertNotSame('protocolError', $frames[0]->type, "a well-formed requestId was refused: {$frames[0]->text}");
         self::assertCount(4, $frames, 'three step frames and the terminal one');
         self::assertSame($requestId, $frames[0]->requestId);
     }
@@ -257,7 +259,8 @@ final class HealthCorrelationTest extends TestCase
 
         $frames = self::framesOf($conn);
         self::assertCount(1, $frames);
-        self::assertSame('echobot', $frames[0]->type);
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::UNKNOWN_TARGET_ID->value, $frames[0]->errorCode);
         self::assertSame('Unknown validation target: nation:roman:ZZ', $frames[0]->text);
         self::assertSame('req-alpha', $frames[0]->requestId);
     }
@@ -604,7 +607,7 @@ final class HealthCorrelationTest extends TestCase
         $frames = self::framesOf($conn);
         self::assertCount(4, $frames, 'a folder check answers with exactly one frame per step, and then terminates');
         foreach ($frames as $frame) {
-            self::assertNotSame('echobot', $frame->type, "the message was refused: {$frame->text}");
+            self::assertNotSame('protocolError', $frame->type, "the message was refused: {$frame->text}");
             self::assertSame('req-alpha', $frame->requestId);
         }
         foreach (array_slice($frames, 0, 3) as $frame) {
@@ -636,11 +639,12 @@ final class HealthCorrelationTest extends TestCase
         $frames = self::framesOf($conn);
         self::assertCount(2, $frames);
 
-        self::assertSame('echobot', $frames[0]->type);
-        self::assertSame('Invalid message properties', $frames[0]->errorMsg);
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frames[0]->errorCode);
         self::assertSame('req-alpha', $frames[0]->requestId, 'a refusal must name the request it refuses');
 
-        self::assertSame('echobot', $frames[1]->type);
+        self::assertSame('protocolError', $frames[1]->type);
+        self::assertSame(ProtocolErrorCode::INVALID_JSON->value, $frames[1]->errorCode);
         self::assertObjectNotHasProperty('requestId', $frames[1], 'nothing may be invented for a message that could not be read');
     }
 

--- a/phpunit_tests/HealthHelpersTest.php
+++ b/phpunit_tests/HealthHelpersTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -402,5 +403,58 @@ final class HealthHelpersTest extends TestCase
         $remaining = $queueProp->getValue($health);
         $this->assertIsArray($remaining);
         $this->assertSame(['current', 'other', 'untagged'], array_column($remaining, 'url'));
+    }
+
+    // ---------------------------------------------------------------- isTypedCalendarMessage() vs shapeOf()
+
+    private static function isTypedCalendarMessage(\stdClass $message): bool
+    {
+        $method = new \ReflectionMethod(Health::class, 'isTypedCalendarMessage');
+        /** @var bool $result */
+        $result = $method->invoke(null, $message);
+
+        return $result;
+    }
+
+    /**
+     * Every shape `Health::isTypedCalendarMessage()` and `WebSocketMessageValidator::shapeOf()`
+     * disagreeing about would matter: a v2 `validateCalendar` mistaken for v1 (or the reverse) picks
+     * the wrong dispatch path, or the wrong schema arm.
+     *
+     * @return array<string, array{string}>
+     */
+    public static function typedCalendarDiscriminatorProvider(): array
+    {
+        return [
+            'typed calendar object'  => ['{"action":"validateCalendar","calendar":{"kind":"national","id":"IT","rite":"roman"}}'],
+            'legacy calendar string' => ['{"action":"validateCalendar","calendar":"IT"}'],
+            'calendar missing'       => ['{"action":"validateCalendar"}'],
+            // A JSON array decodes to a PHP array, not \stdClass — neither predicate must treat it
+            // as an object calendar.
+            'calendar is an array'   => ['{"action":"validateCalendar","calendar":[1,2,3]}'],
+            'calendar is null'       => ['{"action":"validateCalendar","calendar":null}'],
+            'action missing'         => ['{"calendar":{"kind":"national","id":"IT","rite":"roman"}}'],
+            'action not a string'    => ['{"action":42,"calendar":{"kind":"national","id":"IT","rite":"roman"}}'],
+            'a different action'     => ['{"action":"runTest","calendar":{"kind":"national","id":"IT","rite":"roman"}}'],
+        ];
+    }
+
+    /**
+     * The I1 fix: `Health::isTypedCalendarMessage()` is now a thin wrapper over
+     * `WebSocketMessageValidator::shapeOf()` rather than a second literal copy of the same
+     * predicate. This pins the promise the docblock makes — that the two cannot drift apart —
+     * rather than merely restating it.
+     */
+    #[DataProvider('typedCalendarDiscriminatorProvider')]
+    public function testIsTypedCalendarMessageAgreesWithShapeOf(string $json): void
+    {
+        /** @var \stdClass $message */
+        $message = json_decode($json);
+
+        $this->assertSame(
+            'validateCalendarTyped' === WebSocketMessageValidator::shapeOf($message),
+            self::isTypedCalendarMessage($message),
+            'Health::isTypedCalendarMessage() must agree with WebSocketMessageValidator::shapeOf(), its single source of truth'
+        );
     }
 }

--- a/phpunit_tests/HealthHelpersTest.php
+++ b/phpunit_tests/HealthHelpersTest.php
@@ -24,6 +24,7 @@ use React\Promise\Deferred;
  * reflection without standing up the WebSocket server.
  */
 #[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
 final class HealthHelpersTest extends TestCase
 {
     private ?string $apiHostBackup  = null;

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -254,4 +254,28 @@ final class HealthProtocolValidationTest extends TestCase
         $malformed = $this->frames((string) json_encode(['action' => 'cancelRun', 'runToken' => ['an', 'array']]));
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $malformed[0]->errorCode);
     }
+
+    /**
+     * A rejection must not tell an unauthenticated client where the server keeps its files.
+     *
+     * The validator quotes the schema library's own message, and that message embeds the absolute
+     * path of the schema it was validating against. Asserting on the project root rather than on
+     * one known path keeps the check honest if the wording changes.
+     */
+    public function testARejectionNeverLeaksTheServerFilesystemPath(): void
+    {
+        foreach (
+            [
+                ['action' => 'runTest', 'test' => 'X', 'calendar' => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'], 'year' => '2026'],
+                ['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 'nope', 'category' => 'nationalcalendar', 'responsetype' => 'JSON'],
+            ] as $message
+        ) {
+            $frames = $this->frames((string) json_encode($message));
+            self::assertStringNotContainsString(
+                rtrim(Router::$apiFilePath, '/'),
+                (string) $frames[0]->text,
+                'a rejection leaked the server filesystem path'
+            );
+        }
+    }
 }

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -173,6 +173,64 @@ final class HealthProtocolValidationTest extends TestCase
     }
 
     /**
+     * The undeclared-property gate reaches into `calendarIdentity` and `validateSource`'s inline
+     * `target` object unconditionally, unlike the root-level gate above: `additionalProperties: false`
+     * is declared directly on those two nested objects in WebSocketMessage.json (issue #806 section
+     * G), not funnelled through `requestId`. That is safe only because neither nested shape is
+     * reachable by the shipped UnitTestInterface — it sends no `validateSource`, no `runTest`, and no
+     * object-shaped `calendar` at all — so there is no v1 compatibility guarantee being broken here.
+     * Both refusals are asserted without a `requestId` on the message, to prove the nested gate does
+     * not depend on it.
+     */
+    public function testNestedUndeclaredPropertiesAreRefusedUnconditionally(): void
+    {
+        $targetFrames = $this->frames((string) json_encode([
+            'action' => 'validateSource',
+            'target' => ['id' => 'temporale:roman', 'extra' => 'x']
+        ]));
+        self::assertSame('protocolError', $targetFrames[0]->type, 'target.extra must be refused even without a requestId');
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $targetFrames[0]->errorCode);
+
+        $calendarFrames = $this->frames((string) json_encode([
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman', 'extra' => 'x'],
+            'year'           => 2024,
+            'responseFormat' => 'JSON'
+        ]));
+        self::assertSame('protocolError', $calendarFrames[0]->type, 'calendar.extra must be refused even without a requestId');
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $calendarFrames[0]->errorCode);
+    }
+
+    /**
+     * The companion to {@see testNestedUndeclaredPropertiesAreRefusedUnconditionally()}: a
+     * well-formed `target`/`calendar` is still accepted. Asserting only the refusal above would also
+     * pass against a schema that refused every nested object regardless of content.
+     *
+     * `target` resolves synchronously, so its acceptance is checked the same way as everywhere else
+     * in this file: no `protocolError` frame comes back. A well-formed typed `calendar`, by contrast,
+     * is queued for an async upstream fetch rather than answered inline — see
+     * `HealthTypedCalendarTest::testResponseFormatIsHonouredOnTheObjectForm()`, which asserts the
+     * same `[] === $conn->sent` on acceptance — so its acceptance is checked by the absence of any
+     * frame at all rather than by inspecting one that was never sent.
+     */
+    public function testAWellFormedNestedObjectIsStillAccepted(): void
+    {
+        $targetFrames = $this->frames((string) json_encode([
+            'action' => 'validateSource',
+            'target' => ['id' => 'temporale:roman']
+        ]));
+        self::assertNotSame('protocolError', $targetFrames[0]->type, "a well-formed target was refused: {$targetFrames[0]->text}");
+
+        $calendarFrames = $this->frames((string) json_encode([
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2024,
+            'responseFormat' => 'JSON'
+        ]));
+        self::assertSame([], $calendarFrames, 'a well-formed calendar identity must be queued for async validation, not refused synchronously');
+    }
+
+    /**
      * `rite` on an `executeValidation` is the concrete case: the shipped client spreads it onto every
      * source-data check and the server never reads it. It is declared, so it survives even under the
      * strict gate — which is what stops a future tidy-up from removing it from the schema.

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -500,4 +500,37 @@ final class HealthProtocolValidationTest extends TestCase
         self::assertSame('protocolError', $last->type);
         self::assertSame(ProtocolErrorCode::INTERNAL_ERROR->value, $last->errorCode);
     }
+
+    /**
+     * A NUL byte in `sourceFile` reaches `clearstatcache()` — an `\Error`-throwing filesystem
+     * primitive `Health::cachedFileGetContents()` calls to stat the file before reading it — before
+     * this test was written. `{"type": "string"}` accepts a NUL byte just fine, so this used to be
+     * caught only by the `\Throwable` backstop tested above, and come back `internal_error`.
+     *
+     * That is not the same outcome as the crash vectors in `crashVectorProvider()`: the backstop
+     * exists for bugs, not for input this trivially reachable from an unauthenticated socket, so
+     * `sourceFile`, `sourceFolder` and `validate` now carry a `pattern` that refuses an embedded NUL
+     * at the schema gate. This message must never reach `executeValidation()`, let alone its
+     * filesystem calls — the distinction between `invalid_message` and `internal_error` is the whole
+     * point, so both are asserted, not just that a `protocolError` frame came back.
+     */
+    public function testANulByteInSourceFileIsRefusedAtTheGateNotTheBackstop(): void
+    {
+        $message = [
+            'action'     => 'executeValidation',
+            'category'   => 'universalcalendar',
+            'validate'   => 'PropriumDeTempore',
+            'sourceFile' => 'a' . chr(0) . 'b'
+        ];
+
+        $frames = $this->frames((string) json_encode($message));
+
+        self::assertCount(1, $frames, 'a refused message must not also start work');
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(
+            ProtocolErrorCode::INVALID_MESSAGE->value,
+            $frames[0]->errorCode,
+            'a NUL byte in sourceFile must be refused by the schema pattern, not fall through to the \Throwable backstop as internal_error'
+        );
+    }
 }

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests;
 use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -21,6 +22,7 @@ use Ratchet\ConnectionInterface;
  * to it, and a test that calls the right function directly passes against exactly that bug.
  */
 #[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
 final class HealthProtocolValidationTest extends TestCase
 {
     use HealthQueueIsolationTrait;

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -278,4 +278,54 @@ final class HealthProtocolValidationTest extends TestCase
             );
         }
     }
+
+    /**
+     * The two rejections judged directly against live output while this wording was designed,
+     * pinned as literals. This is client-facing wording now: `runTest.year: Integer expected, "2026"
+     * received` reads as a message a client can act on, not a schema-library stack trace. A
+     * `swaggest/json-schema` upgrade, a schema restructuring, or a change to
+     * {@see \LiturgicalCalendar\Api\Services\WebSocketMessageValidator::humanize()} changing either
+     * of these has to be a deliberate, reviewed choice, not a side effect nobody noticed.
+     */
+    public function testTheHumanizedRejectionTextIsExactlyThis(): void
+    {
+        $runTestFrames = $this->frames((string) json_encode([
+            'action'   => 'runTest',
+            'test'     => 'X',
+            'calendar' => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'     => '2026'
+        ]));
+        self::assertSame('runTest.year: Integer expected, "2026" received', (string) $runTestFrames[0]->text);
+
+        $validateCalendarFrames = $this->frames((string) json_encode([
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'widerregion', 'id' => 'Europe', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON'
+        ]));
+        self::assertSame(
+            'validateCalendar.calendar.kind: Enum failed, enum: ["general","national","diocesan","rite"], data: "widerregion"',
+            (string) $validateCalendarFrames[0]->text
+        );
+    }
+
+    /**
+     * The schema's own internal vocabulary — which `allOf`/`anyOf` branch matched, `$ref` pointers
+     * into `definitions` — must never reach a client. It describes how the schema *document* is
+     * assembled, not what is wrong with the *message*, and a client cannot look any of it up:
+     * `WebSocketMessage.json` publishes shapes by action name, never by these internal traversal
+     * terms.
+     *
+     * @param array<string, mixed> $message
+     */
+    #[DataProvider('crashVectorProvider')]
+    public function testARejectionNeverLeaksSchemaInternalVocabulary(array $message): void
+    {
+        $frames = $this->frames((string) json_encode($message));
+        $text   = (string) $frames[0]->text;
+
+        foreach (['allOf', '$ref', 'definitions'] as $forbidden) {
+            self::assertStringNotContainsString($forbidden, $text, "the rejection leaked schema internal vocabulary: {$forbidden}");
+        }
+    }
 }

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -76,4 +76,32 @@ final class HealthProtocolValidationTest extends TestCase
         self::assertSame(ProtocolErrorCode::UNKNOWN_TARGET_ID->value, $frames[0]->errorCode);
         self::assertSame('Unknown validation target: nation:roman:ZZ', $frames[0]->text, 'the prose is unchanged; only the envelope is typed');
     }
+
+    /**
+     * The reason a message was refused must reach the client, not only the server log.
+     *
+     * `errorCode` classifies the failure but does not describe it: `INVALID_JSON` cannot say
+     * "Control character error", which is the part that tells whoever is debugging the client what
+     * to look at. An earlier revision of this branch sent the reason to stdout and echoed only the
+     * raw message back, which is why this is asserted rather than assumed.
+     *
+     * Asserted against the literal string `'Syntax error'`, not a fresh `json_last_error_msg()` call
+     * made here: `frames()` json_decodes the server's (valid JSON) *response* after `onMessage()`
+     * returns, and that decode succeeds, so by the time this method runs, the global JSON error state
+     * has already been reset to `JSON_ERROR_NONE` — a call here would read "No error", not the
+     * decode failure being asserted against. `'Syntax error'` is what PHP 8.4 actually produces for
+     * this malformed input, confirmed by running this test.
+     */
+    public function testTheReasonForARefusalReachesTheClientAndNotOnlyTheLog(): void
+    {
+        $frames = $this->frames('{ this is not json');
+
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::INVALID_JSON->value, $frames[0]->errorCode);
+        self::assertStringContainsString(
+            'Syntax error',
+            (string) $frames[0]->text,
+            'the specific decode failure has no errorCode equivalent, so it has to be in the text'
+        );
+    }
 }

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -437,4 +437,67 @@ final class HealthProtocolValidationTest extends TestCase
             'the untransformed reason must still be there'
         );
     }
+
+    /**
+     * The backstop, isolated from the gate that normally stands in front of it.
+     *
+     * Pointing the validator at a permissive schema lets a crash vector through to the dispatch, so
+     * this asserts what happens when the schema is *wrong* — which is the only circumstance in which
+     * the backstop matters, and the reason it is not redundant with Task 3's tests. Without it the
+     * process dies; with it, one request fails and the daemon keeps serving.
+     *
+     * Two things differ from a naive reading of the schema-only tests above:
+     *
+     *  - The vector is `executeValidation` with `category` as an object, not `validateCalendar` with
+     *    a non-numeric `year`. `year` is now read through `readYear()`, which does its own `is_int()`
+     *    check on both legacy arms, so that message would be refused cleanly even with the schema
+     *    bypassed — proving nothing about this catch block. `executeValidation()` does
+     *    `(string) $validation->category` before any of its own checks, and casting a `stdClass` to
+     *    string throws `\Error` (`Object of class stdClass could not be converted to string`), which
+     *    is not a `\TypeError` from a typed parameter but is still an `\Error` — not `\Exception` —
+     *    so it reaches this catch exactly the way the documented vectors do.
+     *  - The permissive schema carries the same nine `definitions` keys as the real
+     *    `WebSocketMessage.json` (`correlationId`, `calendarIdentity`, `executeValidation`,
+     *    `validateCalendarLegacy`, `validateCalendarTyped`, `executeUnitTest`, `runTest`, `cancelRun`,
+     *    `validateSource`), each one permissive. `WebSocketMessageValidator::raw()` requires a
+     *    `definitions` key to exist at all, and `schemaFor()` requires the claimed shape's own entry
+     *    to exist within it — a bare `{"type": "object"}` document satisfies neither, so it would
+     *    fail *inside* the validator rather than letting the message through.
+     */
+    public function testAHandlerThatThrowsIsContainedRatherThanKillingTheProcess(): void
+    {
+        $shapes     = ['correlationId', 'calendarIdentity', 'executeValidation', 'validateCalendarLegacy', 'validateCalendarTyped', 'executeUnitTest', 'runTest', 'cancelRun', 'validateSource'];
+        $permissive = sys_get_temp_dir() . '/permissive-ws-schema-' . getmypid() . '.json';
+        file_put_contents($permissive, (string) json_encode([
+            '$schema'     => 'https://json-schema.org/draft-07/schema#',
+            'type'        => 'object',
+            'definitions' => array_fill_keys($shapes, (object) ['type' => 'object'])
+        ]));
+
+        $health    = $this->newHealth();
+        $validator = new \ReflectionProperty(Health::class, 'messageValidator');
+        $validator->setValue($health, new \LiturgicalCalendar\Api\Services\WebSocketMessageValidator($permissive));
+        \LiturgicalCalendar\Api\Services\WebSocketMessageValidator::reset();
+
+        $conn = self::createStubConnection();
+        ob_start();
+        try {
+            $health->onMessage($conn, (string) json_encode([
+                'action'     => 'executeValidation',
+                'category'   => ['k' => 'v'],
+                'validate'   => 'x',
+                'sourceFile' => 'jsondata/x.json'
+            ]));
+        } finally {
+            ob_end_clean();
+            @unlink($permissive);
+            \LiturgicalCalendar\Api\Services\WebSocketMessageValidator::reset();
+        }
+
+        $frames = array_map(static fn (string $f): \stdClass => json_decode($f), $conn->sent);
+        self::assertNotEmpty($frames, 'the connection was told nothing at all');
+        $last = $frames[count($frames) - 1];
+        self::assertSame('protocolError', $last->type);
+        self::assertSame(ProtocolErrorCode::INTERNAL_ERROR->value, $last->errorCode);
+    }
 }

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Ratchet\ConnectionInterface;
 
@@ -103,5 +104,154 @@ final class HealthProtocolValidationTest extends TestCase
             (string) $frames[0]->text,
             'the specific decode failure has no errorCode equivalent, so it has to be in the text'
         );
+    }
+
+    /**
+     * The crash vectors. Each of these terminated the WebSocket process before this work: Ratchet's
+     * `IoServer::handleData` catches `\Exception`, and `TypeError`, `ValueError` and `Error` are not
+     * `\Exception`. The assertion is therefore two-part — a typed refusal came back, *and* nothing
+     * escaped — because a test that only checked the frame would pass on a process that had already
+     * died in a real server.
+     *
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function crashVectorProvider(): array
+    {
+        return [
+            'year as a non-numeric string'            => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 'not-a-year', 'category' => 'nationalcalendar', 'responsetype' => 'JSON']],
+            'category as an array'                    => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => [], 'responsetype' => 'JSON']],
+            'unknown response format'                 => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar', 'responsetype' => 'NOT_A_FORMAT']],
+            'test as an object'                       => [['action' => 'executeUnitTest', 'test' => ['a' => 1], 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar']],
+            'executeValidation category as an object' => [['action' => 'executeValidation', 'category' => ['k' => 'v'], 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    #[DataProvider('crashVectorProvider')]
+    public function testAMessageThatUsedToKillTheProcessIsRefused(array $message): void
+    {
+        $frames = $this->frames((string) json_encode($message));
+
+        self::assertCount(1, $frames, 'a refused message must not also start work');
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frames[0]->errorCode);
+    }
+
+    /**
+     * The gate, both directions, in one place: the same message is accepted without a `requestId`
+     * and refused with one. Asserting only the refusal would pass on a build that refused everything.
+     */
+    public function testAnUndeclaredPropertyIsRefusedOnlyWhenTheMessageOptedIn(): void
+    {
+        $lenient = [
+            'action'     => 'executeValidation',
+            'category'   => 'sourceDataCheck',
+            'validate'   => 'proprium-de-tempore',
+            'sourceFile' => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json',
+            'notAThing'  => 'whatever'
+        ];
+
+        $acceptedFrames = $this->frames((string) json_encode($lenient));
+        self::assertNotEmpty($acceptedFrames, 'a v1 message with a stray property must still be served');
+        self::assertNotSame('protocolError', $acceptedFrames[0]->type, "a v1 message was refused: {$acceptedFrames[0]->text}");
+
+        $refusedFrames = $this->frames((string) json_encode($lenient + ['requestId' => 'req-1']));
+        self::assertSame('protocolError', $refusedFrames[0]->type, 'a message carrying a requestId opted into strictness');
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $refusedFrames[0]->errorCode);
+        self::assertStringContainsString('notAThing', (string) $refusedFrames[0]->text, 'the refusal must name the offending property');
+    }
+
+    /**
+     * `rite` on an `executeValidation` is the concrete case: the shipped client spreads it onto every
+     * source-data check and the server never reads it. It is declared, so it survives even under the
+     * strict gate — which is what stops a future tidy-up from removing it from the schema.
+     */
+    public function testTheSpreadRiteSurvivesEvenUnderTheStrictGate(): void
+    {
+        $frames = $this->frames((string) json_encode([
+            'action'     => 'executeValidation',
+            'rite'       => 'roman',
+            'category'   => 'sourceDataCheck',
+            'validate'   => 'proprium-de-tempore',
+            'sourceFile' => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json',
+            'requestId'  => 'req-2'
+        ]));
+
+        self::assertNotSame('protocolError', $frames[0]->type, "rite was refused: {$frames[0]->text}");
+    }
+
+    /**
+     * Every action the schema declares has a dispatch arm and vice versa. Adding an action without a
+     * schema entry would otherwise fall through to `unknown_action` in production rather than in CI.
+     */
+    public function testEverySchemaShapeHasADispatchArmAndEveryArmHasAShape(): void
+    {
+        $raw     = json_decode((string) file_get_contents(\LiturgicalCalendar\Api\Enum\LitSchema::WEBSOCKET_MESSAGE->path()));
+        $actions = [];
+        foreach ((array) $raw->definitions as $definition) {
+            if ($definition instanceof \stdClass && isset($definition->properties->action->const)) {
+                $actions[(string) $definition->properties->action->const] = true;
+            }
+        }
+
+        // Scoped to onMessage()'s own body, not the whole file: Health.php has several other
+        // switch statements over plain-letter string literals ('diocesan', 'national', 'XML',
+        // 'universalcalendar', …) that are not action names at all, and a file-wide scan would
+        // false-positive on every one of them.
+        $source         = (string) file_get_contents(__DIR__ . '/../src/Health.php');
+        $onMessageStart = strpos($source, 'public function onMessage(');
+        $onMessageEnd   = strpos($source, 'public function onClose(', (int) $onMessageStart);
+        self::assertNotFalse($onMessageStart, 'onMessage() moved or was renamed');
+        self::assertNotFalse($onMessageEnd, 'onClose() moved or was renamed; used as the end-of-method marker');
+        $dispatchSource = substr($source, $onMessageStart, $onMessageEnd - $onMessageStart);
+        preg_match_all("/case '([a-zA-Z]+)':/", $dispatchSource, $matches);
+        $dispatched = array_unique($matches[1]);
+
+        self::assertEqualsCanonicalizing(
+            array_keys($actions),
+            array_values(array_intersect($dispatched, array_keys($actions))),
+            'schema shapes and dispatch arms have drifted apart'
+        );
+        foreach ($dispatched as $arm) {
+            self::assertArrayHasKey($arm, $actions, "the dispatch handles {$arm} but the schema does not declare it");
+        }
+    }
+
+    /**
+     * A half-migrated message hears the sentence that helps it, not the generic one.
+     *
+     * `rejectRetiredProperties()` runs inside the handler, so it is reached only if the validator
+     * declines to report the property first. Without the deferral this comes back as
+     * INVALID_MESSAGE and the client is told the property is unknown rather than what replaced it.
+     */
+    public function testARetiredPropertyIsDiagnosedByTheHandlerNotTheSchema(): void
+    {
+        $frames = $this->frames((string) json_encode([
+            'action'    => 'validateSource',
+            'target'    => ['id' => 'temporale:roman'],
+            'category'  => 'sourceDataCheck',
+            'requestId' => 'req-4'
+        ]));
+
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::RETIRED_PROPERTY->value, $frames[0]->errorCode, 'the generic schema complaint won the race');
+        self::assertSame('category is not part of a validateSource message: target.id replaces it.', $frames[0]->text);
+    }
+
+    /**
+     * An unknown action and a malformed known action are different failures, and a client acts on
+     * them differently: the first means "you are speaking a protocol I do not have", the second
+     * means "fix this message". Schema validation alone would report both as INVALID_MESSAGE,
+     * because an unrecognised action matches no arm of the top-level oneOf.
+     */
+    public function testAnUnknownActionIsDistinguishedFromAMalformedKnownOne(): void
+    {
+        $unknown = $this->frames((string) json_encode(['action' => 'danceTheFandango']));
+        self::assertSame(ProtocolErrorCode::UNKNOWN_ACTION->value, $unknown[0]->errorCode);
+
+        $malformed = $this->frames((string) json_encode(['action' => 'cancelRun', 'runToken' => ['an', 'array']]));
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $malformed[0]->errorCode);
     }
 }

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * What `Health` does with a message it cannot act on.
+ *
+ * Every test here drives `onMessage()` with a real JSON string. The private validator is never
+ * invoked directly: #825's lesson was that an emitter can be correct and tested while nothing routes
+ * to it, and a test that calls the right function directly passes against exactly that bug.
+ */
+#[CoversClass(Health::class)]
+final class HealthProtocolValidationTest extends TestCase
+{
+    use HealthQueueIsolationTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+    }
+
+    private static function createStubConnection(int $resourceId = 1)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * Send one raw message and return the frames it produced.
+     *
+     * @return list<\stdClass>
+     */
+    private function frames(string $raw): array
+    {
+        $conn = self::createStubConnection();
+        ob_start();
+        $this->newHealth()->onMessage($conn, $raw);
+        ob_end_clean();
+
+        return array_map(static fn (string $f): \stdClass => json_decode($f), $conn->sent);
+    }
+
+    public function testARejectionIsATypedProtocolErrorRatherThanAnEchobot(): void
+    {
+        $frames = $this->frames((string) json_encode(['action' => 'validateSource', 'target' => ['id' => 'nation:roman:ZZ']]));
+
+        self::assertCount(1, $frames);
+        self::assertSame('protocolError', $frames[0]->type, 'rejections are typed now, not echoes');
+        self::assertSame(ProtocolErrorCode::UNKNOWN_TARGET_ID->value, $frames[0]->errorCode);
+        self::assertSame('Unknown validation target: nation:roman:ZZ', $frames[0]->text, 'the prose is unchanged; only the envelope is typed');
+    }
+}

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -118,11 +118,18 @@ final class HealthProtocolValidationTest extends TestCase
     public static function crashVectorProvider(): array
     {
         return [
-            'year as a non-numeric string'            => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 'not-a-year', 'category' => 'nationalcalendar', 'responsetype' => 'JSON']],
-            'category as an array'                    => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => [], 'responsetype' => 'JSON']],
-            'unknown response format'                 => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar', 'responsetype' => 'NOT_A_FORMAT']],
-            'test as an object'                       => [['action' => 'executeUnitTest', 'test' => ['a' => 1], 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar']],
-            'executeValidation category as an object' => [['action' => 'executeValidation', 'category' => ['k' => 'v'], 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
+            'year as a non-numeric string'                => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 'not-a-year', 'category' => 'nationalcalendar', 'responsetype' => 'JSON']],
+            'category as an array'                        => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => [], 'responsetype' => 'JSON']],
+            'unknown response format'                     => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar', 'responsetype' => 'NOT_A_FORMAT']],
+            'test as an object'                           => [['action' => 'executeUnitTest', 'test' => ['a' => 1], 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar']],
+            'executeValidation category as an object'     => [['action' => 'executeValidation', 'category' => ['k' => 'v'], 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
+            // A number too large for PHP's int is still an integer *by value* under JSON Schema, so
+            // the schema correctly accepts it — json_decode() then hands PHP a float, because the
+            // value is outside PHP_INT_MAX, and these two arms used to unpack it straight into a
+            // typed `int $year` parameter. That is a TypeError, an \Error Ratchet does not catch. See
+            // Health::readYear(), now shared by all four arms that read a `year` for exactly this.
+            'validateCalendar year too large for PHP int' => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 1.0e30, 'category' => 'nationalcalendar', 'responsetype' => 'JSON']],
+            'executeUnitTest year too large for PHP int'  => [['action' => 'executeUnitTest', 'test' => 'X', 'calendar' => 'IT', 'year' => 1.0e30, 'category' => 'nationalcalendar']],
         ];
     }
 
@@ -310,15 +317,71 @@ final class HealthProtocolValidationTest extends TestCase
     }
 
     /**
+     * Every message `crashVectorProvider()` supplies, plus messages that trip the *other* rejection
+     * path this class has — the `requestId`-gated undeclared-property check — which the crash
+     * vectors alone never reach, because none of them carries a `requestId`. Both paths build their
+     * own sentence, and both have to honour the same rule.
+     *
+     * The typed `validateCalendar` row is not incidental: `validateCalendarTyped` is the one
+     * internal definition name that does not equal its action's spelling anywhere else, which is
+     * exactly why it is the row that caught I2 and none of the others would have.
+     *
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function vocabularyLeakProvider(): array
+    {
+        return array_merge(self::crashVectorProvider(), [
+            'gated: typed validateCalendar with a stray property' => [
+                [
+                    'action'         => 'validateCalendar',
+                    'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+                    'year'           => 2026,
+                    'responseFormat' => 'JSON',
+                    'zzz'            => 'stray',
+                    'requestId'      => 'req-vocab-1'
+                ]
+            ],
+            'gated: executeValidation with a stray property'      => [
+                [
+                    'action'     => 'executeValidation',
+                    'category'   => 'sourceDataCheck',
+                    'validate'   => 'proprium-de-tempore',
+                    'sourceFile' => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json',
+                    'notAThing'  => 'whatever',
+                    'requestId'  => 'req-vocab-2'
+                ]
+            ],
+            'gated: runTest with a stray property'                => [
+                [
+                    'action'    => 'runTest',
+                    'test'      => 'X',
+                    'calendar'  => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+                    'year'      => 2026,
+                    'zzz'       => 'stray',
+                    'requestId' => 'req-vocab-3'
+                ]
+            ],
+        ]);
+    }
+
+    /**
      * The schema's own internal vocabulary — which `allOf`/`anyOf` branch matched, `$ref` pointers
-     * into `definitions` — must never reach a client. It describes how the schema *document* is
-     * assembled, not what is wrong with the *message*, and a client cannot look any of it up:
-     * `WebSocketMessage.json` publishes shapes by action name, never by these internal traversal
-     * terms.
+     * into `definitions`, and every definition name that is not also a valid action — must never
+     * reach a client. It describes how the schema *document* is assembled, not what is wrong with
+     * the *message*, and a client cannot look any of it up: `WebSocketMessage.json` publishes shapes
+     * by action name, never by these internal traversal or definition terms.
+     *
+     * The forbidden definition names are read from the schema itself, minus whichever of them are
+     * also a `properties.action.const` somewhere in it — those are legitimate, client-facing action
+     * words (`executeValidation` names both a definition and the action a client sends) and must
+     * stay allowed. What is left — `validateCalendarLegacy`, `validateCalendarTyped`,
+     * `calendarIdentity`, `correlationId` at the time of writing — exists only inside this codebase
+     * and the schema document, never on the wire, and a new definition added later is covered
+     * automatically rather than requiring this list to be kept in sync by hand.
      *
      * @param array<string, mixed> $message
      */
-    #[DataProvider('crashVectorProvider')]
+    #[DataProvider('vocabularyLeakProvider')]
     public function testARejectionNeverLeaksSchemaInternalVocabulary(array $message): void
     {
         $frames = $this->frames((string) json_encode($message));
@@ -327,5 +390,51 @@ final class HealthProtocolValidationTest extends TestCase
         foreach (['allOf', '$ref', 'definitions'] as $forbidden) {
             self::assertStringNotContainsString($forbidden, $text, "the rejection leaked schema internal vocabulary: {$forbidden}");
         }
+
+        $raw             = json_decode((string) file_get_contents(\LiturgicalCalendar\Api\Enum\LitSchema::WEBSOCKET_MESSAGE->path()));
+        $definitionNames = array_keys((array) $raw->definitions);
+        $actionNames     = [];
+        foreach ((array) $raw->definitions as $definition) {
+            if (isset($definition->properties->action->const)) {
+                $actionNames[] = (string) $definition->properties->action->const;
+            }
+        }
+        $internalOnlyNames = array_diff($definitionNames, $actionNames);
+
+        foreach ($internalOnlyNames as $internalName) {
+            self::assertStringNotContainsString(
+                (string) $internalName,
+                $text,
+                "the rejection leaked the internal definition name {$internalName}"
+            );
+        }
+    }
+
+    /**
+     * `humanize()`'s balanced-brace recursion over an echoed `data: {...}` clause can hit PCRE's
+     * backtrack/recursion limit on a large enough message — measured fine around 5.6 KB, broken
+     * around 14 KB — at which point `preg_replace()` returns `null`. A guard that fell back to `''`
+     * would pass every other test here while silently discarding the entire reason on this one input,
+     * which is exactly the failure Task 2's `testTheReasonForARefusalReachesTheClientAndNotOnlyTheLog`
+     * exists to catch for JSON decode errors; this is the same guarantee for this later stage.
+     */
+    public function testALargeMessageStillCarriesAReasonWhenTheTransformCannotRun(): void
+    {
+        $frames = $this->frames((string) json_encode([
+            'action'     => 'executeValidation',
+            'category'   => ['k' => 'v'],
+            'validate'   => 'x',
+            'sourceFile' => 'jsondata/x.json',
+            'padding'    => str_repeat('x', 20000)
+        ]));
+
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frames[0]->errorCode);
+        self::assertNotSame('', (string) $frames[0]->text, 'the reason must not be discarded when the transform cannot run');
+        self::assertStringContainsString(
+            'Required property missing: sourceFolder',
+            (string) $frames[0]->text,
+            'the untransformed reason must still be there'
+        );
     }
 }

--- a/phpunit_tests/HealthRiteRequestPathTest.php
+++ b/phpunit_tests/HealthRiteRequestPathTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -24,6 +25,8 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(Health::class)]
 final class HealthRiteRequestPathTest extends TestCase
 {
+    use HealthQueueIsolationTrait;
+
     /**
      * @return array<string, array{0: string, 1: int, 2: string, 3: Rite, 4: string}>
      */
@@ -116,9 +119,13 @@ final class HealthRiteRequestPathTest extends TestCase
      * or a rite-aware client's selection is silently dropped and every Ambrosian
      * diocesan request 400s (issue #767).
      *
-     * Driven with a category the builder rejects, so the assertion lands on the
-     * synchronous path-building step and no HTTP request is ever queued — this
-     * needs neither the WS server nor the API to be running.
+     * Driven with a `category` the builder honours (`nationalcalendar`) and inspected through the
+     * queued request URL instead of an exception: an unusable `category` such as the former
+     * `widerregioncalendar` no longer reaches `buildCalendarRequestPath()` at all — since #806
+     * section G, `WebSocketMessageValidator` refuses it against the schema's `category` enum before
+     * dispatch — so a test built on that exception would now assert something that can no longer
+     * happen. Reading the queue proves the same thing the exception used to: the rite made it all
+     * the way to the URL, rather than being dropped somewhere between the message and the request.
      *
      * @return array<string, array{0: array<string, mixed>}>
      */
@@ -128,7 +135,7 @@ final class HealthRiteRequestPathTest extends TestCase
             'executeUnitTest'  => [
                 [
                     'action'   => 'executeUnitTest',
-                    'category' => 'widerregioncalendar',
+                    'category' => 'nationalcalendar',
                     'calendar' => 'europe',
                     'year'     => 2026,
                     'test'     => 'SomeTest',
@@ -138,7 +145,7 @@ final class HealthRiteRequestPathTest extends TestCase
             'validateCalendar' => [
                 [
                     'action'       => 'validateCalendar',
-                    'category'     => 'widerregioncalendar',
+                    'category'     => 'nationalcalendar',
                     'calendar'     => 'europe',
                     'year'         => 2026,
                     'responsetype' => 'JSON',
@@ -154,11 +161,8 @@ final class HealthRiteRequestPathTest extends TestCase
     #[DataProvider('dispatchedActionProvider')]
     public function testWebSocketDispatchReachesTheRiteAwarePathBuilder(array $payload): void
     {
-        $health = new Health();
+        $health = $this->newHealth();
         $conn   = self::stubConnection();
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown calendar category: widerregioncalendar');
 
         // onMessage() echoes progress; swallow it so the assertion output stays clean.
         ob_start();
@@ -167,23 +171,29 @@ final class HealthRiteRequestPathTest extends TestCase
         } finally {
             ob_end_clean();
         }
+
+        self::assertSame(
+            '/ambrosian/nation/europe/2026?year_type=CIVIL',
+            self::soleQueuedPath($health),
+            'the rite the message carried must reach the request URL, not the default'
+        );
     }
 
     public function testDispatchAcceptsAMessageWithNoRiteProperty(): void
     {
         // A client that predates rite awareness must still dispatch; its rite is
-        // resolved from metadata instead of the message.
-        $health = new Health();
+        // resolved from metadata instead of the message. `nationalcalendar` always
+        // resolves to the default rite regardless (see
+        // testNationalCalendarAlwaysResolvesToTheDefaultRite()), which is exactly
+        // what a missing `rite` must fall back to here as well.
+        $health = $this->newHealth();
         $conn   = self::stubConnection();
-
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Unknown calendar category: widerregioncalendar');
 
         ob_start();
         try {
             $health->onMessage($conn, (string) json_encode([
                 'action'   => 'executeUnitTest',
-                'category' => 'widerregioncalendar',
+                'category' => 'nationalcalendar',
                 'calendar' => 'europe',
                 'year'     => 2026,
                 'test'     => 'SomeTest',
@@ -191,6 +201,25 @@ final class HealthRiteRequestPathTest extends TestCase
         } finally {
             ob_end_clean();
         }
+
+        self::assertSame('/roman/nation/europe/2026?year_type=CIVIL', self::soleQueuedPath($health));
+    }
+
+    /**
+     * The queued request's path, with the `/calendar` prefix `Route::CALENDAR->path()` stripped —
+     * the same convention `HealthTypedCalendarTest::soleQueuedPath()` uses, kept local here rather
+     * than shared because the two suites do not otherwise depend on each other.
+     */
+    private static function soleQueuedPath(Health $health): string
+    {
+        /** @var list<array{url:string}> $queue */
+        $queue = ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+        self::assertCount(1, $queue, 'exactly one calendar request must have been queued');
+
+        $prefix = \LiturgicalCalendar\Api\Enum\Route::CALENDAR->path();
+        self::assertStringStartsWith($prefix, $queue[0]['url'], 'a calendar request was made against something other than /calendar');
+
+        return substr($queue[0]['url'], strlen($prefix));
     }
 
     /**

--- a/phpunit_tests/HealthRiteRequestPathTest.php
+++ b/phpunit_tests/HealthRiteRequestPathTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -23,6 +24,7 @@ use PHPUnit\Framework\TestCase;
  * without standing up Ratchet or the HTTP API.
  */
 #[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
 final class HealthRiteRequestPathTest extends TestCase
 {
     use HealthQueueIsolationTrait;

--- a/phpunit_tests/HealthSourceFileFailureArmsTest.php
+++ b/phpunit_tests/HealthSourceFileFailureArmsTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -42,6 +43,7 @@ use Ratchet\ConnectionInterface;
  * {@see CheckableInventory}, the frames are composed in {@see Health}.
  */
 #[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
 final class HealthSourceFileFailureArmsTest extends TestCase
 {
     use HealthQueueIsolationTrait;

--- a/phpunit_tests/HealthTerminalFrameTest.php
+++ b/phpunit_tests/HealthTerminalFrameTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
@@ -336,7 +337,8 @@ final class HealthTerminalFrameTest extends TestCase
 
         $frames = self::framesOf($conn);
         self::assertCount(1, $frames, 'an unresolvable target is answered by the rejection alone');
-        self::assertSame('echobot', $frames[0]->type);
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::UNKNOWN_TARGET_ID->value, $frames[0]->errorCode);
         self::assertNotContains('complete', self::stepsOf($frames), 'nothing was started, so nothing terminates');
     }
 

--- a/phpunit_tests/HealthTerminalFrameTest.php
+++ b/phpunit_tests/HealthTerminalFrameTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -41,6 +42,7 @@ use Ratchet\ConnectionInterface;
  * in a synchronous test.
  */
 #[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
 final class HealthTerminalFrameTest extends TestCase
 {
     use HealthQueueIsolationTrait;

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
@@ -213,8 +214,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
-        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame([], self::queuedPaths($health), 'an invalid message must not have queued a request');
     }
 
@@ -247,7 +248,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::RETIRED_PROPERTY->value, $frame->errorCode);
         self::assertSame('category is not part of a validateCalendar message with an object calendar: calendar.kind replaces it.', $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
@@ -277,8 +279,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
-        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame([], self::queuedPaths($health));
     }
 
@@ -358,7 +360,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent, 'an unusable identity is answered once and not computed');
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type, 'rejections reuse the echobot shape: since UnitTestInterface#46 an unknown type is painted as a failed check');
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame('Unknown calendar kind: widerregion', $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
@@ -410,7 +413,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent, 'a contradicted rite is answered once and not computed');
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertStringContainsString('calendar.rite says', (string) $frame->text);
         self::assertSame([], self::queuedPaths($health), 'a rejected message must not have queued a request');
     }
@@ -509,7 +513,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame($expected, $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
@@ -535,7 +540,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame('validateCalendar responseFormat must be one of: JSON, XML, ICS, YML.', $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
@@ -554,7 +560,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame('validateCalendar year must be an integer.', $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
@@ -672,7 +679,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent, 'an unusable identity is answered once and no test is run');
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type, 'rejections reuse the echobot shape: since UnitTestInterface#46 an unknown type is painted as a failed check');
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame($expected, $frame->text);
         self::assertSame([], self::queuedPaths($health), 'a rejected message must not have queued a request');
     }
@@ -699,7 +707,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame('runTest calendar must be an object carrying kind, id and rite.', $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
@@ -747,7 +756,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame($expected, $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
@@ -781,8 +791,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
-        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame([], self::queuedPaths($health));
     }
 
@@ -834,8 +844,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
-        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame([], self::queuedPaths($health));
     }
 
@@ -876,7 +886,7 @@ final class HealthTypedCalendarTest extends TestCase
         self::assertNotEmpty($sourceConn->sent, 'the test definition was not checked at all');
         foreach ($sourceConn->sent as $raw) {
             $frame = json_decode($raw);
-            self::assertNotSame('echobot', $frame->type, "the definition check was refused: {$frame->text}");
+            self::assertNotSame('protocolError', $frame->type, "the definition check was refused: {$frame->text}");
             // Addressed by the fragment derived from the id, not by the item's label — which for
             // this item is `Liturgical test: StIgnatiusOfLoyolaTest`, prose whose `: ` would make
             // the client's querySelectorAll() throw. See Health::cssClassFragmentForId().
@@ -911,7 +921,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $crossConn->sent);
         $frame = json_decode($crossConn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::UNKNOWN_TARGET_ID->value, $frame->errorCode);
         self::assertSame('Unknown validation target: StIgnatiusOfLoyolaTest', $frame->text, 'the bare test name is a runTest address, not an inventory id');
     }
 
@@ -947,7 +958,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::RETIRED_PROPERTY->value, $frame->errorCode);
         self::assertSame(
             'responsetype is not part of a validateCalendar message with an object calendar: responseFormat replaces it.',
             $frame->text
@@ -979,7 +991,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::RETIRED_PROPERTY->value, $frame->errorCode);
         self::assertSame('category is not part of a runTest message: calendar.kind replaces it.', $frame->text);
         self::assertSame([], self::queuedPaths($health), 'a rejected message must not have queued a request');
     }
@@ -1045,7 +1058,8 @@ final class HealthTypedCalendarTest extends TestCase
 
         self::assertCount(1, $conn->sent, 'a half-migrated message is answered once and not dispatched');
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::RETIRED_PROPERTY->value, $frame->errorCode);
         self::assertSame($expectedText, $frame->text);
         self::assertSame([], self::queuedPaths($health), 'a rejected message must not have queued a request');
     }

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -35,9 +35,10 @@ use Ratchet\ConnectionInterface;
  * `calendar` **object** holding `kind`, `id` and `rite`.
  *
  * Because the action name is unchanged, the shape of `calendar` is the only discriminator there
- * is, and it has to be applied before `validateMessageProperties()` compares against
- * `ACTION_PROPERTIES['validateCalendar']` — the v2 form has neither `category` nor `responsetype`,
- * so the list would turn every v2 message away before it reached a handler.
+ * is, and `WebSocketMessageValidator::shapeOf()` has to apply it before choosing which schema
+ * definition to validate against — the v2 form has neither `category` nor `responsetype`, so
+ * validating it against the wrong one would turn every v2 message away before it reached a
+ * handler.
  *
  * Nothing legacy is touched: a string `calendar` still takes the old path byte for byte.
  *
@@ -142,11 +143,11 @@ final class HealthTypedCalendarTest extends TestCase
     }
 
     /**
-     * The discriminator has to be applied ahead of the `ACTION_PROPERTIES` list, not inside the
-     * handler. This is the test that says so: the message below carries neither `category` nor
-     * `responsetype`, both of which that list requires, so if the list ran first the message would
-     * come back as the generic `Invalid message properties` and never reach a calendar request at
-     * all.
+     * The discriminator has to be applied ahead of choosing which schema definition to validate
+     * against, not inside the handler. This is the test that says so: the message below carries
+     * neither `category` nor `responsetype`, both of which `validateCalendarLegacy` requires, so if
+     * that were the definition chosen for it, the message would come back rejected for missing
+     * properties it was never supposed to carry, and never reach a calendar request at all.
      */
     public function testTheV2FormIsNotTurnedAwayForMissingCategoryAndResponsetype(): void
     {
@@ -349,10 +350,13 @@ final class HealthTypedCalendarTest extends TestCase
     /**
      * `resolveCalendarIdentity()`'s own "Unknown calendar kind" message is no longer reachable
      * through the WebSocket dispatch: `calendarIdentity.kind` in `WebSocketMessage.json` is a closed
-     * enum of the four known kinds, so `WebSocketMessageValidator` refuses `widerregion` at the door
-     * with the schema's own (verbose, library-generated) message before `resolveCalendarIdentity()`
-     * ever runs. Only the error code is asserted here for that reason — the exact text belongs to
-     * `swaggest/json-schema`, not to this codebase, and is not a contract worth pinning.
+     * enum of the four known kinds, so `WebSocketMessageValidator` refuses `widerregion` at the door,
+     * before `resolveCalendarIdentity()` ever runs. `WebSocketMessageValidator::humanize()` turns
+     * that rejection into `validateCalendar.calendar.kind: Enum failed, enum: […], data:
+     * "widerregion"` — deterministic wording, but wording this test does not pin, since
+     * `HealthProtocolValidationTest::testTheHumanizedRejectionTextIsExactlyThis()` already pins
+     * that exact string once, centrally; asserting it again here would be a second copy to keep in
+     * sync rather than a second guarantee.
      */
     public function testAnUnknownKindIsRejected(): void
     {
@@ -484,11 +488,12 @@ final class HealthTypedCalendarTest extends TestCase
      * `$expected === null` marks a row `WebSocketMessageValidator` now intercepts before
      * `resolveCalendarIdentity()` runs at all: `calendarIdentity` in `WebSocketMessage.json` requires
      * `kind` and `rite` and types `id` as a string, so a missing `kind`/`rite` or a non-string
-     * `kind`/`id` fails schema validation with the library's own (verbose) message rather than
-     * reaching this method's curated one. Only `rite` being an *unknown* value, and `id` being
-     * *absent*, survive to reach `resolveCalendarIdentity()` — the schema types `rite` as any string
-     * and does not require `id` at all — which is why those two rows, and the two `general` rows
-     * built on `id` being present-but-wrong, still assert exact text.
+     * `kind`/`id` fails schema validation with `humanize()`'s deterministic wording rather than
+     * reaching this method's curated one — wording this provider does not pin, since
+     * `HealthProtocolValidationTest` already covers it. Only `rite` being an *unknown* value, and
+     * `id` being *absent*, survive to reach `resolveCalendarIdentity()` — the schema types `rite` as
+     * any string and does not require `id` at all — which is why those two rows, and the two
+     * `general` rows built on `id` being present-but-wrong, still assert exact text.
      *
      * @return array<string, array{0: array<string, mixed>, 1: ?string}>
      */
@@ -544,8 +549,12 @@ final class HealthTypedCalendarTest extends TestCase
      * process down over one malformed message, the hazard `cancelRun()` documents, reached by a
      * different door. `WebSocketMessageValidator` now catches it first: `responseFormat` on
      * `validateCalendarTyped` is a closed schema enum, so `'PDF'` never reaches
-     * `validateTypedCalendar()`'s own check, and the client sees the schema's own (verbose) message
-     * instead of the curated one. Only the error code is asserted for that reason.
+     * `validateTypedCalendar()`'s own check. `WebSocketMessageValidator::humanize()` turns the
+     * rejection into deterministic, human-readable wording rather than a raw library dump, but
+     * this test's job is confirming the schema catches it pre-dispatch, not pinning that wording —
+     * `HealthProtocolValidationTest` already covers the wording itself, generically (no schema
+     * internal vocabulary leaks) and for two specific cases pinned exactly. Only the error code is
+     * asserted here for that reason.
      */
     public function testAResponseFormatWithNoValidationBranchIsRejectedRatherThanThrown(): void
     {
@@ -569,9 +578,11 @@ final class HealthTypedCalendarTest extends TestCase
     /**
      * `year` used to be re-checked by hand in `readYear()` because the old required-property check
      * established only that `year` was *present*, not what it was. `WebSocketMessageValidator` now
-     * types `year: integer` on the schema itself, so a `null` year is refused there — with the
-     * schema's own message, not `readYear()`'s — before `validateTypedCalendar()` runs at all. Only
-     * the error code is asserted for that reason.
+     * types `year: integer` on the schema itself, so a `null` year is refused there — humanized by
+     * `WebSocketMessageValidator::humanize()`, not `readYear()`'s wording — before
+     * `validateTypedCalendar()` runs at all. This test's job is confirming that, not pinning the
+     * generated wording; see `HealthProtocolValidationTest` for coverage of the wording itself.
+     * Only the error code is asserted here for that reason.
      */
     public function testAYearThatIsNotAnIntegerIsRejectedRatherThanThrown(): void
     {
@@ -671,8 +682,10 @@ final class HealthTypedCalendarTest extends TestCase
      *
      * `unknown kind`'s expected text is `null`: `calendarIdentity.kind` is a closed schema enum, so
      * `WebSocketMessageValidator` now refuses `widerregion` before `resolveCalendarIdentity()` runs,
-     * with the schema's own message rather than "Unknown calendar kind: widerregion". `rite
-     * disagreement` uses a schema-valid `kind`, so it still reaches the resolver unchanged.
+     * with `WebSocketMessageValidator::humanize()`'s deterministic wording rather than "Unknown
+     * calendar kind: widerregion" — this test does not pin that wording, since
+     * `HealthProtocolValidationTest` already covers it. `rite disagreement` uses a schema-valid
+     * `kind`, so it still reaches the resolver unchanged.
      *
      * @return array<string, array{0: array<string, mixed>, 1: ?string}>
      */
@@ -728,8 +741,9 @@ final class HealthTypedCalendarTest extends TestCase
      *
      * `runTest.calendar` is typed as `#/definitions/calendarIdentity` — an object — on the schema, so
      * `WebSocketMessageValidator` now refuses a string `calendar` before `readCalendarIdentity()`'s
-     * own "runTest calendar must be an object…" check ever runs. Only the error code is asserted for
-     * that reason.
+     * own "runTest calendar must be an object…" check ever runs, with `humanize()`'s deterministic
+     * wording rather than that curated sentence. This test's job is confirming the schema catches
+     * it pre-dispatch, not pinning that wording; only the error code is asserted for that reason.
      */
     public function testRunTestRefusesACalendarThatIsNotAnObject(): void
     {
@@ -800,9 +814,10 @@ final class HealthTypedCalendarTest extends TestCase
     }
 
     /**
-     * A property the action declares required is turned away by `validateMessageProperties()` before
-     * any handler sees it, on the generic protocol-error path — which is how the absence of `test`
-     * differs from `test` being present and unusable, tested above.
+     * A property the schema's `runTest` definition declares required is turned away by
+     * `WebSocketMessageValidator::validate()` before any handler sees it, on the generic
+     * protocol-error path — which is how the absence of `test` differs from `test` being present
+     * and unusable, tested above.
      *
      * @return array<string, array{0: array<string, mixed>}>
      */
@@ -1051,8 +1066,8 @@ final class HealthTypedCalendarTest extends TestCase
      * be dispatched perfectly and say nothing.
      *
      * This property was missed by the original retired-property audit because that audit derived the
-     * retired set from `ACTION_PROPERTIES`, which lists only *required* properties. Optional v1
-     * properties were structurally invisible to it; see `Health::RETIRED_PROPERTIES`.
+     * retired set from the schema's own `required` lists, which name only *required* properties.
+     * Optional v1 properties were structurally invisible to it; see `Health::RETIRED_PROPERTIES`.
      *
      * @return array<string, array{0: array<string, mixed>, 1: string}>
      */
@@ -1138,10 +1153,10 @@ final class HealthTypedCalendarTest extends TestCase
 
     /**
      * `runTest` retires `category` and `rite`, and no third property, because there is no third
-     * property to retire: `ACTION_PROPERTIES['executeUnitTest']` is
-     * `['category', 'calendar', 'year', 'test']` and its only optional property was `rite`, so no
-     * `responsetype` ever named anything on it. A rule that invented one would reject a property no
-     * client was ever told to send, for a reason that is not true.
+     * property to retire: the schema's `executeUnitTest` definition requires `category`, `calendar`,
+     * `year` and `test`, and its only optional property was `rite`, so no `responsetype` ever named
+     * anything on it. A rule that invented one would reject a property no client was ever told to
+     * send, for a reason that is not true.
      */
     public function testRunTestDoesNotRetireAResponsetypeItNeverHad(): void
     {

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -346,6 +346,14 @@ final class HealthTypedCalendarTest extends TestCase
 
     // ---------------------------------------------------------------- rejections
 
+    /**
+     * `resolveCalendarIdentity()`'s own "Unknown calendar kind" message is no longer reachable
+     * through the WebSocket dispatch: `calendarIdentity.kind` in `WebSocketMessage.json` is a closed
+     * enum of the four known kinds, so `WebSocketMessageValidator` refuses `widerregion` at the door
+     * with the schema's own (verbose, library-generated) message before `resolveCalendarIdentity()`
+     * ever runs. Only the error code is asserted here for that reason — the exact text belongs to
+     * `swaggest/json-schema`, not to this codebase, and is not a contract worth pinning.
+     */
     public function testAnUnknownKindIsRejected(): void
     {
         $health = $this->newHealth();
@@ -362,7 +370,6 @@ final class HealthTypedCalendarTest extends TestCase
         $frame = json_decode($conn->sent[0]);
         self::assertSame('protocolError', $frame->type);
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
-        self::assertSame('Unknown calendar kind: widerregion', $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
 
@@ -474,17 +481,26 @@ final class HealthTypedCalendarTest extends TestCase
     }
 
     /**
-     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     * `$expected === null` marks a row `WebSocketMessageValidator` now intercepts before
+     * `resolveCalendarIdentity()` runs at all: `calendarIdentity` in `WebSocketMessage.json` requires
+     * `kind` and `rite` and types `id` as a string, so a missing `kind`/`rite` or a non-string
+     * `kind`/`id` fails schema validation with the library's own (verbose) message rather than
+     * reaching this method's curated one. Only `rite` being an *unknown* value, and `id` being
+     * *absent*, survive to reach `resolveCalendarIdentity()` — the schema types `rite` as any string
+     * and does not require `id` at all — which is why those two rows, and the two `general` rows
+     * built on `id` being present-but-wrong, still assert exact text.
+     *
+     * @return array<string, array{0: array<string, mixed>, 1: ?string}>
      */
     public static function malformedIdentityProvider(): array
     {
         return [
-            'kind missing'         => [['id' => 'IT', 'rite' => 'roman'], 'calendar.kind must be a string naming one of: general, national, diocesan, rite.'],
-            'kind not a string'    => [['kind' => 42, 'id' => 'IT', 'rite' => 'roman'], 'calendar.kind must be a string naming one of: general, national, diocesan, rite.'],
-            'rite missing'         => [['kind' => 'national', 'id' => 'IT'], 'calendar.rite must be a string naming a known rite.'],
+            'kind missing'         => [['id' => 'IT', 'rite' => 'roman'], null],
+            'kind not a string'    => [['kind' => 42, 'id' => 'IT', 'rite' => 'roman'], null],
+            'rite missing'         => [['kind' => 'national', 'id' => 'IT'], null],
             'rite unknown'         => [['kind' => 'national', 'id' => 'IT', 'rite' => 'byzantine'], 'Unknown rite: byzantine'],
             'id missing'           => [['kind' => 'national', 'rite' => 'roman'], 'calendar.id is required for kind national.'],
-            'id not a string'      => [['kind' => 'diocesan', 'id' => 42, 'rite' => 'roman'], 'calendar.id must be a string.'],
+            'id not a string'      => [['kind' => 'diocesan', 'id' => 42, 'rite' => 'roman'], null],
             // `general` accepts no id but `roman`. The message must not name a kind to try instead:
             // `IT` would want `national`, and `kind: rite` — the obvious thing to suggest — rejects
             // `IT` in turn, so the advice would point at another failure.
@@ -499,7 +515,7 @@ final class HealthTypedCalendarTest extends TestCase
      * @param array<string, mixed> $calendar
      */
     #[DataProvider('malformedIdentityProvider')]
-    public function testAMalformedIdentityIsRejectedWithWhatIsWrongWithIt(array $calendar, string $expected): void
+    public function testAMalformedIdentityIsRejectedWithWhatIsWrongWithIt(array $calendar, ?string $expected): void
     {
         $health = $this->newHealth();
         $conn   = self::createStubConnection();
@@ -515,16 +531,21 @@ final class HealthTypedCalendarTest extends TestCase
         $frame = json_decode($conn->sent[0]);
         self::assertSame('protocolError', $frame->type);
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
-        self::assertSame($expected, $frame->text);
+        if (null !== $expected) {
+            self::assertSame($expected, $frame->text);
+        }
         self::assertSame([], self::queuedPaths($health));
     }
 
     /**
-     * A format `validateCalendar()` has no branch for must be turned away here rather than reaching
-     * `ReturnTypeParam::from()`, which throws a `\ValueError` on an unknown case. That is an
-     * `\Error`, and Ratchet's `IoServer::handleData` catches only `\Exception`, so it escapes and
-     * takes the whole WebSocket process down over one malformed message — the hazard `cancelRun()`
-     * documents, reached by a different door.
+     * A format `validateCalendar()` has no branch for used to have to be turned away by hand, ahead
+     * of `ReturnTypeParam::from()`, which throws a `\ValueError` on an unknown case — an `\Error`
+     * that Ratchet's `IoServer::handleData` does not catch, so it would take the whole WebSocket
+     * process down over one malformed message, the hazard `cancelRun()` documents, reached by a
+     * different door. `WebSocketMessageValidator` now catches it first: `responseFormat` on
+     * `validateCalendarTyped` is a closed schema enum, so `'PDF'` never reaches
+     * `validateTypedCalendar()`'s own check, and the client sees the schema's own (verbose) message
+     * instead of the curated one. Only the error code is asserted for that reason.
      */
     public function testAResponseFormatWithNoValidationBranchIsRejectedRatherThanThrown(): void
     {
@@ -542,10 +563,16 @@ final class HealthTypedCalendarTest extends TestCase
         $frame = json_decode($conn->sent[0]);
         self::assertSame('protocolError', $frame->type);
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
-        self::assertSame('validateCalendar responseFormat must be one of: JSON, XML, ICS, YML.', $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
 
+    /**
+     * `year` used to be re-checked by hand in `readYear()` because the old required-property check
+     * established only that `year` was *present*, not what it was. `WebSocketMessageValidator` now
+     * types `year: integer` on the schema itself, so a `null` year is refused there — with the
+     * schema's own message, not `readYear()`'s — before `validateTypedCalendar()` runs at all. Only
+     * the error code is asserted for that reason.
+     */
     public function testAYearThatIsNotAnIntegerIsRejectedRatherThanThrown(): void
     {
         $health = $this->newHealth();
@@ -562,7 +589,6 @@ final class HealthTypedCalendarTest extends TestCase
         $frame = json_decode($conn->sent[0]);
         self::assertSame('protocolError', $frame->type);
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
-        self::assertSame('validateCalendar year must be an integer.', $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
 
@@ -643,14 +669,19 @@ final class HealthTypedCalendarTest extends TestCase
      * it. `lugano_ch` is one of the four Ambrosian dioceses, so `rite: roman` contradicts what
      * `/calendars` says and must be refused rather than quietly corrected.
      *
-     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     * `unknown kind`'s expected text is `null`: `calendarIdentity.kind` is a closed schema enum, so
+     * `WebSocketMessageValidator` now refuses `widerregion` before `resolveCalendarIdentity()` runs,
+     * with the schema's own message rather than "Unknown calendar kind: widerregion". `rite
+     * disagreement` uses a schema-valid `kind`, so it still reaches the resolver unchanged.
+     *
+     * @return array<string, array{0: array<string, mixed>, 1: ?string}>
      */
     public static function runTestRejectedIdentityProvider(): array
     {
         return [
             'unknown kind'      => [
                 ['kind' => 'widerregion', 'id' => 'Europe', 'rite' => 'roman'],
-                'Unknown calendar kind: widerregion'
+                null
             ],
             'rite disagreement' => [
                 ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'roman'],
@@ -663,7 +694,7 @@ final class HealthTypedCalendarTest extends TestCase
      * @param array<string, mixed> $calendar
      */
     #[DataProvider('runTestRejectedIdentityProvider')]
-    public function testRunTestRefusesAnIdentityItCannotHonour(array $calendar, string $expected): void
+    public function testRunTestRefusesAnIdentityItCannotHonour(array $calendar, ?string $expected): void
     {
         $health = $this->newHealth();
         $conn   = self::createStubConnection();
@@ -681,7 +712,9 @@ final class HealthTypedCalendarTest extends TestCase
         $frame = json_decode($conn->sent[0]);
         self::assertSame('protocolError', $frame->type);
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
-        self::assertSame($expected, $frame->text);
+        if (null !== $expected) {
+            self::assertSame($expected, $frame->text);
+        }
         self::assertSame([], self::queuedPaths($health), 'a rejected message must not have queued a request');
     }
 
@@ -692,6 +725,11 @@ final class HealthTypedCalendarTest extends TestCase
      *
      * The string used here is the one a client would reach for by habit, copied straight from an
      * `executeUnitTest` message.
+     *
+     * `runTest.calendar` is typed as `#/definitions/calendarIdentity` — an object — on the schema, so
+     * `WebSocketMessageValidator` now refuses a string `calendar` before `readCalendarIdentity()`'s
+     * own "runTest calendar must be an object…" check ever runs. Only the error code is asserted for
+     * that reason.
      */
     public function testRunTestRefusesACalendarThatIsNotAnObject(): void
     {
@@ -709,32 +747,32 @@ final class HealthTypedCalendarTest extends TestCase
         $frame = json_decode($conn->sent[0]);
         self::assertSame('protocolError', $frame->type);
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
-        self::assertSame('runTest calendar must be an object carrying kind, id and rite.', $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
 
     /**
-     * Both scalars are type-checked rather than trusted, and for the same reason: the property list
-     * establishes only that a property is *present*. A non-string `test` or a non-integer `year`
-     * would reach `executeUnitTest(string $test, string $calendar, int $year, …)` and raise a
-     * `TypeError` — an `\Error`, which Ratchet's `IoServer::handleData` does not catch, so one
-     * malformed message would take the whole WebSocket process down rather than be answered.
+     * Both scalars used to be re-checked by hand because the old required-property check established
+     * only that `test`/`year` were *present*, not what they were. `WebSocketMessageValidator` now
+     * types both on the schema — `test: string`, `year: integer` — so every row here is now refused
+     * by the schema, with its own message, before `runTest()`'s own checks ever run. Only the error
+     * code is asserted for that reason; see `testAMessageThatUsedToKillTheProcessIsRefused()` in
+     * `HealthProtocolValidationTest` for the crash-vector coverage this now overlaps with.
      *
-     * Every row here has its property **present**, which is what carries it past the property list
-     * and into the handler these rejections belong to. A property that is genuinely absent never
-     * gets that far — see `testRunTestRequiresItsThreeProperties()`, which is a different code path
-     * with a different answer. `null` is the case most easily mistaken for absence and is therefore
+     * Every row here has its property **present**, which is what used to carry it past the property
+     * list and into the handler these rejections belonged to. A property that is genuinely absent
+     * never got that far — see `testRunTestRequiresItsThreeProperties()`, a different code path with
+     * a different answer. `null` is the case most easily mistaken for absence and is therefore
      * spelled `test null`, not `test missing`.
      *
-     * @return array<string, array{0: array<string, mixed>, 1: string}>
+     * @return array<string, array{0: array<string, mixed>}>
      */
     public static function runTestMalformedScalarProvider(): array
     {
         return [
-            'test not a string' => [['test' => 42], 'runTest test must be a string.'],
-            'test null'         => [['test' => null], 'runTest test must be a string.'],
-            'year not an int'   => [['year' => '2026'], 'runTest year must be an integer.'],
-            'year null'         => [['year' => null], 'runTest year must be an integer.'],
+            'test not a string' => [['test' => 42]],
+            'test null'         => [['test' => null]],
+            'year not an int'   => [['year' => '2026']],
+            'year null'         => [['year' => null]],
         ];
     }
 
@@ -742,7 +780,7 @@ final class HealthTypedCalendarTest extends TestCase
      * @param array<string, mixed> $overrides
      */
     #[DataProvider('runTestMalformedScalarProvider')]
-    public function testRunTestRefusesAScalarItWouldOtherwiseThrowOn(array $overrides, string $expected): void
+    public function testRunTestRefusesAScalarItWouldOtherwiseThrowOn(array $overrides): void
     {
         $health = $this->newHealth();
         $conn   = self::createStubConnection();
@@ -758,7 +796,6 @@ final class HealthTypedCalendarTest extends TestCase
         $frame = json_decode($conn->sent[0]);
         self::assertSame('protocolError', $frame->type);
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
-        self::assertSame($expected, $frame->text);
         self::assertSame([], self::queuedPaths($health));
     }
 

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -70,6 +71,7 @@ use Ratchet\ConnectionInterface;
  * URL at once, which is the whole dispatch in a single observation and still no network.
  */
 #[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
 final class HealthTypedCalendarTest extends TestCase
 {
     // Every Health here queues a real calendar URL; see the trait for why that must be defused.

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
@@ -296,7 +297,8 @@ final class HealthValidateSourceTest extends TestCase
 
         self::assertCount(1, $conn->sent, 'an unresolvable target is answered once and not checked');
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type, 'rejections reuse the echobot shape: since UnitTestInterface#46 an unknown type is painted as a failed check');
+        self::assertSame('protocolError', $frame->type, 'rejections are a typed protocolError: since UnitTestInterface#46 an unrecognised type is painted as a failed check');
+        self::assertSame(ProtocolErrorCode::UNKNOWN_TARGET_ID->value, $frame->errorCode);
         self::assertSame('Unknown validation target: nation:roman:ZZ', $frame->text);
     }
 
@@ -309,7 +311,8 @@ final class HealthValidateSourceTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame('validateSource requires a target object with an id.', $frame->text);
     }
 
@@ -322,7 +325,8 @@ final class HealthValidateSourceTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
         self::assertSame('validateSource target id must be a string.', $frame->text);
     }
 
@@ -339,8 +343,8 @@ final class HealthValidateSourceTest extends TestCase
 
         self::assertCount(1, $conn->sent);
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
-        self::assertSame('Invalid message properties', $frame->errorMsg);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
     }
 
     // ---------------------------------------------------------------- retired properties
@@ -384,7 +388,8 @@ final class HealthValidateSourceTest extends TestCase
 
         self::assertCount(1, $conn->sent, 'a half-migrated message is answered once and not checked');
         $frame = json_decode($conn->sent[0]);
-        self::assertSame('echobot', $frame->type);
+        self::assertSame('protocolError', $frame->type);
+        self::assertSame(ProtocolErrorCode::RETIRED_PROPERTY->value, $frame->errorCode);
         self::assertSame(
             "{$property} is not part of a validateSource message: target.id replaces it.",
             $frame->text,
@@ -420,7 +425,7 @@ final class HealthValidateSourceTest extends TestCase
         $frames = [];
         foreach ($conn->sent as $raw) {
             $frame = json_decode($raw);
-            self::assertNotSame('echobot', $frame->type, "the legacy slug shape was refused: {$frame->text}");
+            self::assertNotSame('protocolError', $frame->type, "the legacy slug shape was refused: {$frame->text}");
             $frames[] = $frame;
         }
 
@@ -451,7 +456,7 @@ final class HealthValidateSourceTest extends TestCase
         self::assertNotEmpty($conn->sent, 'a runToken was mistaken for a retired property');
         foreach ($conn->sent as $raw) {
             $frame = json_decode($raw);
-            self::assertNotSame('echobot', $frame->type, "the message was refused: {$frame->text}");
+            self::assertNotSame('protocolError', $frame->type, "the message was refused: {$frame->text}");
             self::assertSame('run-a', $frame->runToken, 'the answers must carry the token the client correlates them by');
         }
     }
@@ -626,7 +631,8 @@ final class HealthValidateSourceTest extends TestCase
 
             self::assertCount(1, $enumeratedTarget->sent, 'a target that genuinely cannot be resolved must be answered once, not checked');
             $frame = json_decode($enumeratedTarget->sent[0]);
-            self::assertSame('echobot', $frame->type);
+            self::assertSame('protocolError', $frame->type);
+            self::assertSame(ProtocolErrorCode::UNKNOWN_TARGET_ID->value, $frame->errorCode);
             // The message says the index could not be built, not that the id is unknown:
             // nation:roman:IT is perfectly well known, and reporting a server-side failure as a
             // client-side one sends the reader hunting a bug that is not there.
@@ -714,11 +720,11 @@ final class HealthValidateSourceTest extends TestCase
 
             foreach ($conn->sent as $raw) {
                 $frame = json_decode($raw);
-                if ($frame instanceof \stdClass && 'echobot' === ( $frame->type ?? null )) {
-                    // `echobot` is the rejection shape: the server declined to check this at all.
-                    // An `error` frame is a different thing entirely and is fine here — it means the
-                    // target was addressed and checked, and the check reported something. This test
-                    // is about whether an id can be sent, not about whether its data is valid.
+                if ($frame instanceof \stdClass && 'protocolError' === ( $frame->type ?? null )) {
+                    // `protocolError` is the rejection shape: the server declined to check this at
+                    // all. An `error` frame is a different thing entirely and is fine here — it means
+                    // the target was addressed and checked, and the check reported something. This
+                    // test is about whether an id can be sent, not about whether its data is valid.
                     $unaddressable[$item->id] = (string) ( $frame->text ?? '' );
                     continue;
                 }

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -305,8 +305,10 @@ final class HealthValidateSourceTest extends TestCase
     /**
      * `validateSource.target` is typed as `{id: string}` on the schema, so
      * `WebSocketMessageValidator` now refuses a non-object `target` before `validateSource()`'s own
-     * "requires a target object with an id" check ever runs. Only the error code is asserted for
-     * that reason — the exact text belongs to `swaggest/json-schema`, not to this codebase.
+     * "requires a target object with an id" check ever runs, with `humanize()`'s deterministic
+     * wording rather than that curated sentence. This test's job is confirming the schema catches
+     * it pre-dispatch, not pinning that wording — see `HealthProtocolValidationTest` for coverage
+     * of the wording itself. Only the error code is asserted here for that reason.
      */
     public function testATargetThatIsNotAnObjectIsRejectedAsMalformed(): void
     {
@@ -340,8 +342,9 @@ final class HealthValidateSourceTest extends TestCase
     }
 
     /**
-     * A missing `target` never reaches the handler: `ACTION_PROPERTIES` declares it required, so
-     * `validateMessageProperties()` turns the message away on the generic protocol-error path.
+     * A missing `target` never reaches the handler: the schema's `validateSource` definition
+     * declares it required, so `WebSocketMessageValidator::validate()` turns the message away on
+     * the generic protocol-error path.
      */
     public function testAMessageWithNoTargetIsRejectedByPropertyValidation(): void
     {

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -10,6 +10,7 @@ use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\BrokenInventoryTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -30,6 +31,7 @@ use Ratchet\ConnectionInterface;
  * additive. See #806 section C.
  */
 #[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
 final class HealthValidateSourceTest extends TestCase
 {
     use BrokenInventoryTrait;

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -302,6 +302,12 @@ final class HealthValidateSourceTest extends TestCase
         self::assertSame('Unknown validation target: nation:roman:ZZ', $frame->text);
     }
 
+    /**
+     * `validateSource.target` is typed as `{id: string}` on the schema, so
+     * `WebSocketMessageValidator` now refuses a non-object `target` before `validateSource()`'s own
+     * "requires a target object with an id" check ever runs. Only the error code is asserted for
+     * that reason — the exact text belongs to `swaggest/json-schema`, not to this codebase.
+     */
     public function testATargetThatIsNotAnObjectIsRejectedAsMalformed(): void
     {
         $health = $this->newHealth();
@@ -313,9 +319,13 @@ final class HealthValidateSourceTest extends TestCase
         $frame = json_decode($conn->sent[0]);
         self::assertSame('protocolError', $frame->type);
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
-        self::assertSame('validateSource requires a target object with an id.', $frame->text);
     }
 
+    /**
+     * Same reasoning as {@see testATargetThatIsNotAnObjectIsRejectedAsMalformed()}: `target.id` is
+     * typed as `string` on the schema, so a non-string id is refused before `validateSource()`'s own
+     * "target id must be a string" check runs.
+     */
     public function testATargetIdThatIsNotAStringIsRejected(): void
     {
         $health = $this->newHealth();
@@ -327,7 +337,6 @@ final class HealthValidateSourceTest extends TestCase
         $frame = json_decode($conn->sent[0]);
         self::assertSame('protocolError', $frame->type);
         self::assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frame->errorCode);
-        self::assertSame('validateSource target id must be a string.', $frame->text);
     }
 
     /**

--- a/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
+++ b/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Swaggest\JsonSchema\Schema;
+use Swaggest\JsonSchema\Structure\ObjectItemContract;
+
+/**
+ * `WebSocketMessage.json` — the published contract for an inbound Health message.
+ *
+ * The load-bearing test here is compatibility, not correctness in the abstract. The shipped
+ * UnitTestInterface sends properties the server neither declares nor reads: `sendMessage()` injects
+ * `runToken` into every message, and the source-data checks are built by spreading a config object
+ * that carries `rite` onto an `executeValidation` that never looks at it. A schema that refused
+ * those would take the test interface down on the day it shipped.
+ *
+ * The fixtures are therefore transcribed from the client's own source, not imagined.
+ */
+final class WebSocketMessageSchemaTest extends TestCase
+{
+    private static function schema(): Schema
+    {
+        $schema = Schema::import(LitSchema::WEBSOCKET_MESSAGE->path());
+        self::assertInstanceOf(Schema::class, $schema);
+
+        return $schema;
+    }
+
+    /**
+     * Messages the shipped client actually sends. Every one must validate.
+     *
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function clientMessageProvider(): array
+    {
+        return [
+            // resources.js:1221 and index.js:647 — `{ action, ...check }` where check carries `rite`.
+            'source-data check with the spread rite' => [
+                [
+                    'action'     => 'executeValidation',
+                    'rite'       => 'roman',
+                    'validate'   => 'PropriumDeTempore',
+                    'sourceFile' => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json',
+                    'category'   => 'universalcalendar',
+                    'runToken'   => 'abc123'
+                ]
+            ],
+            'i18n folder check with the spread rite' => [
+                [
+                    'action'       => 'executeValidation',
+                    'rite'         => 'roman',
+                    'validate'     => 'proprium-de-tempore-i18n',
+                    'sourceFolder' => 'jsondata/sourcedata/rite/roman/missals/propriumdetempore/i18n',
+                    'category'     => 'sourceDataCheck',
+                    'runToken'     => 'abc123'
+                ]
+            ],
+            // resources.js:1184 — the resource arm adds responsetype.
+            'resource check with responsetype'       => [
+                [
+                    'action'       => 'executeValidation',
+                    'responsetype' => 'JSON',
+                    'rite'         => 'roman',
+                    'validate'     => 'calendars',
+                    'sourceFile'   => 'http://localhost:8000/calendars',
+                    'category'     => 'resourceDataCheck',
+                    'runToken'     => 'abc123'
+                ]
+            ],
+            // index.js:686-693 — note `year` is a number, which is why the schema may require integer.
+            'legacy validateCalendar'                => [
+                [
+                    'action'       => 'validateCalendar',
+                    'year'         => 2024,
+                    'calendar'     => 'IT',
+                    'category'     => 'nationalcalendar',
+                    'rite'         => 'roman',
+                    'responsetype' => 'JSON',
+                    'runToken'     => 'abc123'
+                ]
+            ],
+            'legacy executeUnitTest'                 => [
+                [
+                    'action'   => 'executeUnitTest',
+                    'test'     => 'AllSaintsTest',
+                    'calendar' => 'IT',
+                    'year'     => 2024,
+                    'category' => 'nationalcalendar',
+                    'runToken' => 'abc123'
+                ]
+            ],
+            // wsProtocol.js:31
+            'cancelRun'                              => [
+                [
+                    'action'   => 'cancelRun',
+                    'runToken' => 'abc123'
+                ]
+            ],
+            'v2 validateSource'                      => [
+                [
+                    'action'    => 'validateSource',
+                    'target'    => ['id' => 'temporale:roman'],
+                    'runToken'  => 'abc123',
+                    'requestId' => 'req-1'
+                ]
+            ],
+            'v2 typed validateCalendar'              => [
+                [
+                    'action'         => 'validateCalendar',
+                    'calendar'       => ['kind' => 'diocesan', 'id' => 'lugano_ch', 'rite' => 'ambrosian'],
+                    'year'           => 2026,
+                    'responseFormat' => 'JSON',
+                    'requestId'      => 'req-2'
+                ]
+            ],
+            'v2 runTest'                             => [
+                [
+                    'action'    => 'runTest',
+                    'test'      => 'AllSaintsTest',
+                    'calendar'  => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+                    'year'      => 2024,
+                    'requestId' => 'req-3'
+                ]
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    #[DataProvider('clientMessageProvider')]
+    public function testAMessageTheShippedClientSendsValidates(array $message): void
+    {
+        $decoded = json_decode((string) json_encode($message));
+
+        // in() throws on failure and returns the processed value on success, so the assertions
+        // below are on that value rather than on having survived the call. `assertTrue(true)`
+        // would pass on a build where in() silently became a no-op.
+        //
+        // NOTE: swaggest/json-schema 0.12.43's in() builds an ObjectItem (not stdClass) for any
+        // object-typed schema that doesn't set a custom objectItemClass — see
+        // Schema::processObject(), which does this unconditionally for every plain object result.
+        // The instanceof check below targets that actual contract rather than stdClass so it
+        // asserts "in() really processed this" without failing on a hardcoded, incorrect return type.
+        $processed = self::schema()->in($decoded);
+
+        self::assertInstanceOf(ObjectItemContract::class, $processed);
+        self::assertSame($message['action'], $processed->action, 'the validated message is not the one that went in');
+    }
+
+    /**
+     * Exactly one arm may match, or the shape discrimination is ambiguous and which handler runs
+     * becomes a matter of arm order.
+     */
+    #[DataProvider('clientMessageProvider')]
+    public function testEachMessageMatchesExactlyOneArm(array $message): void
+    {
+        $raw     = json_decode((string) file_get_contents(LitSchema::WEBSOCKET_MESSAGE->path()));
+        $decoded = json_decode((string) json_encode($message));
+        $matches = 0;
+        foreach ($raw->oneOf as $arm) {
+            // The arm is wrapped rather than extracted: several definitions `$ref` their siblings
+            // (`calendarIdentity`, `correlationId`), and a definition lifted out on its own takes
+            // its unresolvable pointers with it. Keeping `definitions` alongside preserves them.
+            $armDocument = (object) [
+                '$schema'     => 'https://json-schema.org/draft-07/schema#',
+                'allOf'       => [$arm],
+                'definitions' => $raw->definitions
+            ];
+            try {
+                Schema::import($armDocument)->in($decoded);
+                $matches++;
+            } catch (\Throwable) {
+                // not this arm
+            }
+        }
+        self::assertSame(1, $matches, 'a message must match exactly one shape');
+    }
+
+    /**
+     * The definition names Task 3's unknown-property check looks up. Renaming one without updating
+     * that lookup would silently disable the gate, so the names are pinned here.
+     */
+    public function testTheDefinitionNamesAreTheOnesTheValidatorLooksUp(): void
+    {
+        $raw = json_decode((string) file_get_contents(LitSchema::WEBSOCKET_MESSAGE->path()));
+        self::assertEqualsCanonicalizing(
+            [
+                'correlationId',
+                'calendarIdentity',
+                'executeValidation',
+                'validateCalendarLegacy',
+                'validateCalendarTyped',
+                'executeUnitTest',
+                'runTest',
+                'cancelRun', 'validateSource'
+            ],
+            array_keys((array) $raw->definitions)
+        );
+    }
+
+    /**
+     * The crash vectors, at the schema level. Task 3 asserts what the *server* does with them; this
+     * asserts the schema is what refuses them, so a later loosening of the schema fails here first.
+     *
+     * @return array<string, array{array<string, mixed>}>
+     */
+    public static function malformedMessageProvider(): array
+    {
+        return [
+            'year as a non-numeric string'            => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 'not-a-year', 'category' => 'nationalcalendar', 'responsetype' => 'JSON']],
+            'category as an array'                    => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => [], 'responsetype' => 'JSON']],
+            'unknown response format'                 => [['action' => 'validateCalendar', 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar', 'responsetype' => 'NOT_A_FORMAT']],
+            'test as an object'                       => [['action' => 'executeUnitTest', 'test' => ['a' => 1], 'calendar' => 'IT', 'year' => 2024, 'category' => 'nationalcalendar']],
+            'executeValidation category as an object' => [['action' => 'executeValidation', 'category' => ['k' => 'v'], 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
+            'misspelled category'                     => [['action' => 'executeValidation', 'category' => 'sourceDataChek', 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
+            'neither sourceFile nor sourceFolder'     => [['action' => 'executeValidation', 'category' => 'sourceDataCheck', 'validate' => 'x']],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $message
+     */
+    #[DataProvider('malformedMessageProvider')]
+    public function testAMalformedMessageIsRefusedByTheSchema(array $message): void
+    {
+        $this->expectException(\Throwable::class);
+        self::schema()->in(json_decode((string) json_encode($message)));
+    }
+}

--- a/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
+++ b/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
@@ -220,6 +220,8 @@ final class WebSocketMessageSchemaTest extends TestCase
             'executeValidation category as an object' => [['action' => 'executeValidation', 'category' => ['k' => 'v'], 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
             'misspelled category'                     => [['action' => 'executeValidation', 'category' => 'sourceDataChek', 'validate' => 'x', 'sourceFile' => 'jsondata/x.json']],
             'neither sourceFile nor sourceFolder'     => [['action' => 'executeValidation', 'category' => 'sourceDataCheck', 'validate' => 'x']],
+            'sourceFolder under universalcalendar'    => [['action' => 'executeValidation', 'category' => 'universalcalendar', 'validate' => 'x', 'sourceFolder' => 'jsondata/i18n']],
+            'sourceFolder under resourceDataCheck'    => [['action' => 'executeValidation', 'category' => 'resourceDataCheck', 'validate' => 'x', 'sourceFolder' => 'jsondata/i18n']],
         ];
     }
 

--- a/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
+++ b/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
@@ -60,13 +60,14 @@ final class WebSocketMessageSchemaTest extends TestCase
                     'runToken'     => 'abc123'
                 ]
             ],
-            // resources.js:1184 — the resource arm adds responsetype.
+            // resources.js:1184 wraps each entry of resourceDataChecks (resources.js:210-244) as
+            // `{ action, responsetype, ...check }`. The entries carry validate/sourceFile/category
+            // and nothing else — notably no `rite`, unlike the source-data checks above.
             'resource check with responsetype'       => [
                 [
                     'action'       => 'executeValidation',
                     'responsetype' => 'JSON',
-                    'rite'         => 'roman',
-                    'validate'     => 'calendars',
+                    'validate'     => 'calendars-path',
                     'sourceFile'   => 'http://localhost:8000/calendars',
                     'category'     => 'resourceDataCheck',
                     'runToken'     => 'abc123'
@@ -84,6 +85,7 @@ final class WebSocketMessageSchemaTest extends TestCase
                     'runToken'     => 'abc123'
                 ]
             ],
+            // index.js:724 — the spread always adds calendar, year, category and rite.
             'legacy executeUnitTest'                 => [
                 [
                     'action'   => 'executeUnitTest',
@@ -91,6 +93,7 @@ final class WebSocketMessageSchemaTest extends TestCase
                     'calendar' => 'IT',
                     'year'     => 2024,
                     'category' => 'nationalcalendar',
+                    'rite'     => 'roman',
                     'runToken' => 'abc123'
                 ]
             ],
@@ -101,6 +104,10 @@ final class WebSocketMessageSchemaTest extends TestCase
                     'runToken' => 'abc123'
                 ]
             ],
+            // Not sent by the shipped client: UnitTestInterface has no validateSource, runTest,
+            // responseFormat or requestId anywhere in assets/js/*.js at HEAD 9126ad9. This is the
+            // reshaped (v2) shape from issue #806 section D, which UnitTestInterface#42 has not
+            // shipped yet — there is no client source line to cite.
             'v2 validateSource'                      => [
                 [
                     'action'    => 'validateSource',
@@ -109,6 +116,8 @@ final class WebSocketMessageSchemaTest extends TestCase
                     'requestId' => 'req-1'
                 ]
             ],
+            // Not sent by the shipped client — see the note on 'v2 validateSource' above. Reshaped
+            // (v2) validateCalendar, issue #806 section D.
             'v2 typed validateCalendar'              => [
                 [
                     'action'         => 'validateCalendar',
@@ -118,6 +127,8 @@ final class WebSocketMessageSchemaTest extends TestCase
                     'requestId'      => 'req-2'
                 ]
             ],
+            // Not sent by the shipped client — see the note on 'v2 validateSource' above. Reshaped
+            // (v2) executeUnitTest, issue #806 section E.
             'v2 runTest'                             => [
                 [
                     'action'    => 'runTest',

--- a/phpunit_tests/WebSocket/ExecuteValidationTest.php
+++ b/phpunit_tests/WebSocket/ExecuteValidationTest.php
@@ -139,7 +139,7 @@ final class ExecuteValidationTest extends TestCase
     public function testMissingSourceFileReturnsProtocolErrorValidationError(): void
     {
         // executeValidation requires `sourceFile` (or `sourceFolder`).
-        // Omitting both should be rejected by validateMessageProperties()
+        // Omitting both should be rejected by WebSocketMessageValidator
         // before the action dispatches, so the reply is the standard
         // typed `protocolError` envelope rather than a sequence of
         // per-phase frames.

--- a/phpunit_tests/WebSocket/ExecuteValidationTest.php
+++ b/phpunit_tests/WebSocket/ExecuteValidationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\WebSocket;
 
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -135,21 +136,20 @@ final class ExecuteValidationTest extends TestCase
         $this->assertStringContainsString('decoded as JSON', $frames[1]->text);
     }
 
-    public function testMissingSourceFileReturnsEchobotValidationError(): void
+    public function testMissingSourceFileReturnsProtocolErrorValidationError(): void
     {
         // executeValidation requires `sourceFile` (or `sourceFolder`).
         // Omitting both should be rejected by validateMessageProperties()
         // before the action dispatches, so the reply is the standard
-        // "echobot"-typed validation-error envelope rather than a
-        // sequence of per-phase frames.
+        // typed `protocolError` envelope rather than a sequence of
+        // per-phase frames.
         $frames = $this->executeValidation([
             'action'   => 'executeValidation',
             'category' => 'resourceDataCheck',
             'validate' => 'metadata',
         ], 1);
 
-        $this->assertSame('echobot', $frames[0]->type);
-        $this->assertObjectHasProperty('errorMsg', $frames[0]);
-        $this->assertNotEmpty($frames[0]->errorMsg);
+        $this->assertSame('protocolError', $frames[0]->type);
+        $this->assertSame(ProtocolErrorCode::INVALID_MESSAGE->value, $frames[0]->errorCode);
     }
 }

--- a/phpunit_tests/WebSocket/LitCalTestServerTest.php
+++ b/phpunit_tests/WebSocket/LitCalTestServerTest.php
@@ -58,9 +58,10 @@ final class LitCalTestServerTest extends TestCase
         $client = WsTestClient::connect($this->wsHost, $this->wsPort);
 
         // The handler answers any well-formed JSON with an unknown action back
-        // as `{"type":"protocolError","errorCode":"unknown_action","text":<original>}`.
-        // That's enough to exercise onMessage's happy-path JSON decode + the
-        // default switch arm.
+        // as `{"type":"protocolError","errorCode":"unknown_action","text":"Unknown action from
+        // connection <id>: <original>"}` — the raw message is still in there, but now alongside a
+        // statement of what was wrong with it, not standing in for one. That's enough to exercise
+        // onMessage's happy-path JSON decode + the default switch arm.
         $payload = json_encode(['action' => 'this-is-not-a-real-action', 'foo' => 'bar']);
         $this->assertNotFalse($payload);
 
@@ -73,7 +74,8 @@ final class LitCalTestServerTest extends TestCase
         $this->assertSame('protocolError', $decoded->type);
         $this->assertSame(ProtocolErrorCode::UNKNOWN_ACTION->value, $decoded->errorCode);
         $this->assertObjectHasProperty('text', $decoded);
-        $this->assertSame($payload, $decoded->text);
+        $this->assertStringContainsString($payload, (string) $decoded->text, 'the raw message must still be recoverable from the text');
+        $this->assertStringContainsString('Unknown action', (string) $decoded->text, 'the text must say what was wrong, not only echo the message');
 
         $client->close();
     }
@@ -81,7 +83,9 @@ final class LitCalTestServerTest extends TestCase
     public function testMalformedJsonGetsValidationError(): void
     {
         // Exercises the else branch of onMessage where the JSON decode fails —
-        // server replies with a protocolError frame carrying errorCode invalid_json.
+        // server replies with a protocolError frame carrying errorCode invalid_json, and the text
+        // carries the same json_last_error_msg() reason the server logs, since errorCode alone
+        // cannot distinguish "Syntax error" from "Malformed UTF-8 characters".
         $client = WsTestClient::connect($this->wsHost, $this->wsPort);
         $client->sendText('definitely not json');
         $reply = $client->receiveText();
@@ -90,8 +94,8 @@ final class LitCalTestServerTest extends TestCase
         $this->assertIsObject($decoded);
         $this->assertSame('protocolError', $decoded->type);
         $this->assertSame(ProtocolErrorCode::INVALID_JSON->value, $decoded->errorCode);
-        // The text embeds json_last_error_msg(), whose phrasing isn't guaranteed
-        // across PHP versions, but it'll always be non-empty.
+        // json_last_error_msg() phrasing isn't guaranteed across PHP versions,
+        // but it'll always be non-empty.
         $this->assertNotEmpty($decoded->text);
 
         $client->close();
@@ -107,6 +111,7 @@ final class LitCalTestServerTest extends TestCase
         $this->assertIsObject($decoded);
         $this->assertSame('protocolError', $decoded->type);
         $this->assertSame(ProtocolErrorCode::MISSING_ACTION->value, $decoded->errorCode);
+        $this->assertStringContainsString('No action specified', (string) $decoded->text);
 
         $client->close();
     }

--- a/phpunit_tests/WebSocket/LitCalTestServerTest.php
+++ b/phpunit_tests/WebSocket/LitCalTestServerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\WebSocket;
 
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  * is set.
  *
  * Scope: validates the request/response shape for non-async actions
- * (echobot, JSON-validation errors, missing-action errors). The async
+ * (protocolError rejections, JSON-validation errors, missing-action errors). The async
  * actions (executeUnitTest, executeValidation, validateCalendar) involve
  * an internal HTTP call back into the API server + event-loop scheduling
  * and need a more sophisticated client (see the UnitTestInterface repo's
@@ -56,9 +57,10 @@ final class LitCalTestServerTest extends TestCase
     {
         $client = WsTestClient::connect($this->wsHost, $this->wsPort);
 
-        // The handler echoes any well-formed JSON with an unknown action back
-        // as `{"type":"echobot","text":<original>}`. That's enough to exercise
-        // onMessage's happy-path JSON decode + the default switch arm.
+        // The handler answers any well-formed JSON with an unknown action back
+        // as `{"type":"protocolError","errorCode":"unknown_action","text":<original>}`.
+        // That's enough to exercise onMessage's happy-path JSON decode + the
+        // default switch arm.
         $payload = json_encode(['action' => 'this-is-not-a-real-action', 'foo' => 'bar']);
         $this->assertNotFalse($payload);
 
@@ -68,7 +70,8 @@ final class LitCalTestServerTest extends TestCase
         $decoded = json_decode($reply);
         $this->assertIsObject($decoded, 'WS reply should decode as JSON object; got: ' . $reply);
         $this->assertObjectHasProperty('type', $decoded);
-        $this->assertSame('echobot', $decoded->type);
+        $this->assertSame('protocolError', $decoded->type);
+        $this->assertSame(ProtocolErrorCode::UNKNOWN_ACTION->value, $decoded->errorCode);
         $this->assertObjectHasProperty('text', $decoded);
         $this->assertSame($payload, $decoded->text);
 
@@ -78,18 +81,18 @@ final class LitCalTestServerTest extends TestCase
     public function testMalformedJsonGetsValidationError(): void
     {
         // Exercises the else branch of onMessage where the JSON decode fails —
-        // server replies with an echobot frame carrying an errorMsg.
+        // server replies with a protocolError frame carrying errorCode invalid_json.
         $client = WsTestClient::connect($this->wsHost, $this->wsPort);
         $client->sendText('definitely not json');
         $reply = $client->receiveText();
 
         $decoded = json_decode($reply);
         $this->assertIsObject($decoded);
-        $this->assertSame('echobot', $decoded->type);
-        $this->assertObjectHasProperty('errorMsg', $decoded);
-        // json_last_error_msg() phrasing isn't guaranteed across PHP versions,
-        // but it'll always be non-empty.
-        $this->assertNotEmpty($decoded->errorMsg);
+        $this->assertSame('protocolError', $decoded->type);
+        $this->assertSame(ProtocolErrorCode::INVALID_JSON->value, $decoded->errorCode);
+        // The text embeds json_last_error_msg(), whose phrasing isn't guaranteed
+        // across PHP versions, but it'll always be non-empty.
+        $this->assertNotEmpty($decoded->text);
 
         $client->close();
     }
@@ -102,8 +105,8 @@ final class LitCalTestServerTest extends TestCase
 
         $decoded = json_decode($reply);
         $this->assertIsObject($decoded);
-        $this->assertSame('echobot', $decoded->type);
-        $this->assertSame('No action specified', $decoded->errorMsg);
+        $this->assertSame('protocolError', $decoded->type);
+        $this->assertSame(ProtocolErrorCode::MISSING_ACTION->value, $decoded->errorCode);
 
         $client->close();
     }

--- a/src/Enum/LitSchema.php
+++ b/src/Enum/LitSchema.php
@@ -26,6 +26,7 @@ enum LitSchema: string
     case DATA              = '/LitCalDataPath.json';
     case SCHEMAS           = '/LitCalSchemasPath.json';
     case VALIDATIONS       = '/LitCalValidationsPath.json';
+    case WEBSOCKET_MESSAGE = '/WebSocketMessage.json';
 
     public function path(): string
     {
@@ -54,7 +55,8 @@ enum LitSchema: string
             LitSchema::EASTER   => $ERRMSG . 'Easter path data not valid',
             LitSchema::DATA     => $ERRMSG . 'Data path data not valid',
             LitSchema::SCHEMAS  => $ERRMSG . 'Schemas path data not valid',
-            LitSchema::VALIDATIONS => $ERRMSG . 'Validations path data not valid'
+            LitSchema::VALIDATIONS => $ERRMSG . 'Validations path data not valid',
+            LitSchema::WEBSOCKET_MESSAGE => $ERRMSG . 'WebSocket message not valid'
         };
     }
 
@@ -80,6 +82,7 @@ enum LitSchema: string
             LitSchema::DATA->path()              => LitSchema::DATA,
             LitSchema::SCHEMAS->path()           => LitSchema::SCHEMAS,
             LitSchema::VALIDATIONS->path()       => LitSchema::VALIDATIONS,
+            LitSchema::WEBSOCKET_MESSAGE->path() => LitSchema::WEBSOCKET_MESSAGE,
             default                              => throw new ValidationException('Invalid schema URL: ' . $url)
         };
     }

--- a/src/Enum/ProtocolErrorCode.php
+++ b/src/Enum/ProtocolErrorCode.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Enum;
+
+/**
+ * Why a message was refused, in a form a client can branch on.
+ *
+ * A code exists where a client would *act* differently; where it would only display the reason, the
+ * reason is prose in the frame's `text`. That is why `INVALID_MESSAGE` covers every schema
+ * violation — a wrong type, an unknown enum value and an undeclared property all mean "fix the
+ * message", and the text says which — while `RETIRED_PROPERTY` (you are half-migrated) and
+ * `UNKNOWN_TARGET_ID` (refetch /validations) are separate.
+ */
+enum ProtocolErrorCode: string
+{
+    case INVALID_JSON       = 'invalid_json';
+    case NOT_AN_OBJECT      = 'not_an_object';
+    case MISSING_ACTION     = 'missing_action';
+    case UNKNOWN_ACTION     = 'unknown_action';
+    case INVALID_REQUEST_ID = 'invalid_request_id';
+    case RETIRED_PROPERTY   = 'retired_property';
+    case UNKNOWN_TARGET_ID  = 'unknown_target_id';
+    case INVALID_MESSAGE    = 'invalid_message';
+    case INTERNAL_ERROR     = 'internal_error';
+}

--- a/src/Health.php
+++ b/src/Health.php
@@ -628,89 +628,116 @@ class Health implements MessageComponentInterface
             && $messageReceived instanceof \stdClass
             && property_exists($messageReceived, 'action')
         ) {
-            switch ($messageReceived->action) {
-                case 'executeValidation':
-                    /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource $messageReceived */
-                    $this->executeValidation($messageReceived, $from, requestId: $requestId);
-                    break;
-                case 'validateCalendar':
-                    // Same action, two shapes; see isTypedCalendarMessage(). The legacy arm below
-                    // is untouched and stays reachable until UnitTestInterface#42 ships.
-                    if (self::isTypedCalendarMessage($messageReceived)) {
-                        /** @var ValidateTypedCalendar $messageReceived */
-                        $this->validateTypedCalendar($messageReceived, $from, requestId: $requestId);
+            try {
+                switch ($messageReceived->action) {
+                    case 'executeValidation':
+                        /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource $messageReceived */
+                        $this->executeValidation($messageReceived, $from, requestId: $requestId);
                         break;
-                    }
-                    /** @var ValidateCalendar $messageReceived */
-                    // `year` is read through readYear() rather than trusted as `int`, even though
-                    // the schema declares `"type": "integer"`: JSON Schema and PHP disagree about
-                    // what that means. A number like 1e30 or a 30-digit literal is an integer *by
-                    // value* under JSON Schema, so the schema accepts it correctly — but json_decode()
-                    // hands PHP a float for it (it is outside PHP_INT_MAX), and this arm used to
-                    // unpack that straight into validateCalendar(..., int $year, ...). PHP's
-                    // coercive typing refuses an out-of-range float for an int parameter with a
-                    // TypeError, an \Error Ratchet's IoServer::handleData does not catch, so it took
-                    // the whole process down. readYear()'s is_int() check is exactly the guard the
-                    // typed arms (validateTypedCalendar(), runTest()) already apply for the same
-                    // reason; the schema cannot close this gap, because the schema is right.
-                    try {
-                        $year = self::readYear($messageReceived, 'validateCalendar');
-                    } catch (\InvalidArgumentException $e) {
-                        $this->rejectMessage($from, ProtocolErrorCode::INVALID_MESSAGE, $e->getMessage(), requestId: $requestId);
+                    case 'validateCalendar':
+                        // Same action, two shapes; see isTypedCalendarMessage(). The legacy arm below
+                        // is untouched and stays reachable until UnitTestInterface#42 ships.
+                        if (self::isTypedCalendarMessage($messageReceived)) {
+                            /** @var ValidateTypedCalendar $messageReceived */
+                            $this->validateTypedCalendar($messageReceived, $from, requestId: $requestId);
+                            break;
+                        }
+                        /** @var ValidateCalendar $messageReceived */
+                        // `year` is read through readYear() rather than trusted as `int`, even though
+                        // the schema declares `"type": "integer"`: JSON Schema and PHP disagree about
+                        // what that means. A number like 1e30 or a 30-digit literal is an integer *by
+                        // value* under JSON Schema, so the schema accepts it correctly — but json_decode()
+                        // hands PHP a float for it (it is outside PHP_INT_MAX), and this arm used to
+                        // unpack that straight into validateCalendar(..., int $year, ...). PHP's
+                        // coercive typing refuses an out-of-range float for an int parameter with a
+                        // TypeError, an \Error Ratchet's IoServer::handleData does not catch, so it took
+                        // the whole process down. readYear()'s is_int() check is exactly the guard the
+                        // typed arms (validateTypedCalendar(), runTest()) already apply for the same
+                        // reason; the schema cannot close this gap, because the schema is right.
+                        try {
+                            $year = self::readYear($messageReceived, 'validateCalendar');
+                        } catch (\InvalidArgumentException $e) {
+                            $this->rejectMessage($from, ProtocolErrorCode::INVALID_MESSAGE, $e->getMessage(), requestId: $requestId);
+                            break;
+                        }
+                        $this->validateCalendar(
+                            $messageReceived->calendar,
+                            $year,
+                            $messageReceived->category,
+                            $messageReceived->responsetype,
+                            $from,
+                            self::readRiteHint($messageReceived),
+                            requestId: $requestId
+                        );
                         break;
-                    }
-                    $this->validateCalendar(
-                        $messageReceived->calendar,
-                        $year,
-                        $messageReceived->category,
-                        $messageReceived->responsetype,
-                        $from,
-                        self::readRiteHint($messageReceived),
-                        requestId: $requestId
-                    );
-                    break;
-                case 'executeUnitTest':
-                    /** @var ExecuteUnitTest $messageReceived */
-                    // See the comment on the validateCalendar arm above: same hazard, same fix.
-                    try {
-                        $year = self::readYear($messageReceived, 'executeUnitTest');
-                    } catch (\InvalidArgumentException $e) {
-                        $this->rejectMessage($from, ProtocolErrorCode::INVALID_MESSAGE, $e->getMessage(), requestId: $requestId);
+                    case 'executeUnitTest':
+                        /** @var ExecuteUnitTest $messageReceived */
+                        // See the comment on the validateCalendar arm above: same hazard, same fix.
+                        try {
+                            $year = self::readYear($messageReceived, 'executeUnitTest');
+                        } catch (\InvalidArgumentException $e) {
+                            $this->rejectMessage($from, ProtocolErrorCode::INVALID_MESSAGE, $e->getMessage(), requestId: $requestId);
+                            break;
+                        }
+                        $this->executeUnitTest(
+                            $messageReceived->test,
+                            $messageReceived->calendar,
+                            $year,
+                            $messageReceived->category,
+                            $from,
+                            self::readRiteHint($messageReceived),
+                            requestId: $requestId
+                        );
                         break;
-                    }
-                    $this->executeUnitTest(
-                        $messageReceived->test,
-                        $messageReceived->calendar,
-                        $year,
-                        $messageReceived->category,
-                        $from,
-                        self::readRiteHint($messageReceived),
-                        requestId: $requestId
-                    );
-                    break;
-                case 'runTest':
-                    /** @var RunTest $messageReceived */
-                    $this->runTest($messageReceived, $from, requestId: $requestId);
-                    break;
-                case 'cancelRun':
-                    /** @var CancelRun $messageReceived */
-                    $this->cancelRun($messageReceived->runToken, $from);
-                    break;
-                case 'validateSource':
-                    /** @var ValidateSource $messageReceived */
-                    $this->validateSource($messageReceived, $from, requestId: $requestId);
-                    break;
-                default:
-                    // Unreachable: the block above already returned for any action
-                    // `WebSocketMessageValidator::shapeOf()` does not recognise, and it recognises
-                    // exactly the actions the case arms above handle. Kept as a cheap backstop
-                    // against a future action being added to `shapeOf()` without a matching arm here.
-                    $this->rejectMessage(
-                        $from,
-                        ProtocolErrorCode::UNKNOWN_ACTION,
-                        sprintf('Unknown action from connection %1$d: %2$s', $resourceId, $msg),
-                        requestId: $requestId
-                    );
+                    case 'runTest':
+                        /** @var RunTest $messageReceived */
+                        $this->runTest($messageReceived, $from, requestId: $requestId);
+                        break;
+                    case 'cancelRun':
+                        /** @var CancelRun $messageReceived */
+                        $this->cancelRun($messageReceived->runToken, $from);
+                        break;
+                    case 'validateSource':
+                        /** @var ValidateSource $messageReceived */
+                        $this->validateSource($messageReceived, $from, requestId: $requestId);
+                        break;
+                    default:
+                        // Unreachable: the block above already returned for any action
+                        // `WebSocketMessageValidator::shapeOf()` does not recognise, and it recognises
+                        // exactly the actions the case arms above handle. Kept as a cheap backstop
+                        // against a future action being added to `shapeOf()` without a matching arm here.
+                        $this->rejectMessage(
+                            $from,
+                            ProtocolErrorCode::UNKNOWN_ACTION,
+                            sprintf('Unknown action from connection %1$d: %2$s', $resourceId, $msg),
+                            requestId: $requestId
+                        );
+                }
+            } catch (\Throwable $e) {
+                // Ratchet's IoServer::handleData catches \Exception, and TypeError, ValueError and
+                // Error are not \Exception — so without this, anything a handler throws terminates
+                // the process for every connected client rather than failing one request.
+                //
+                // Schema validation stands in front of this and is the real gate. The backstop is
+                // here because a process-wide crash must not depend on a schema file being correct.
+                // A catch-all can mask a bug, which is why this logs before it answers: the log line
+                // is what keeps the masked bug findable.
+                //
+                // It does NOT cover #823. Those throws happen inside promise callbacks, after this
+                // method has returned, where no try around the dispatch can see them.
+                echo sprintf(
+                    "Uncaught %s handling %s from connection %d: %s\n",
+                    get_class($e),
+                    (string) $messageReceived->action,
+                    $resourceId,
+                    $e->getMessage()
+                );
+                $this->rejectMessage(
+                    $from,
+                    ProtocolErrorCode::INTERNAL_ERROR,
+                    'The server failed while handling this message. This is a bug; the run may be incomplete.',
+                    requestId: $requestId
+                );
             }
         } else {
             if (json_last_error() !== JSON_ERROR_NONE) {

--- a/src/Health.php
+++ b/src/Health.php
@@ -31,6 +31,7 @@ use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use Symfony\Component\Yaml\Yaml;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
@@ -131,35 +132,6 @@ class Health implements MessageComponentInterface
     protected \SplObjectStorage $clients;
 
     /**
-     * Array of actions that the Health endpoint can execute.
-     * Each key is an action name. The value is an array of strings that represent the names of the
-     * parameters that the action requires.
-     *
-     * @var array<string,string[]> $ACTION_PROPERTIES
-     */
-    private const ACTION_PROPERTIES = [
-        'executeValidation' => ['category', 'validate', 'sourceFile'],
-        'validateCalendar'  => ['category', 'calendar', 'year', 'responsetype'],
-        'executeUnitTest'   => ['category', 'calendar', 'year', 'test'],
-        // No `category`: `calendar.kind` carries it. No `responseFormat` either — a test runs
-        // against the parsed calendar, so the representation is not the client's to choose.
-        'runTest'           => ['test', 'calendar', 'year'],
-        'cancelRun'         => ['runToken'],
-        'validateSource'    => ['target']
-    ];
-
-    /**
-     * Properties required by the *reshaped* `validateCalendar` message — the one whose `calendar` is
-     * a typed identity object rather than a string.
-     *
-     * Deliberately not an entry in ACTION_PROPERTIES: that array is keyed by action name, and this
-     * shape shares its action name with the legacy form. See {@see Health::validateMessageProperties()}.
-     *
-     * @var string[]
-     */
-    private const TYPED_CALENDAR_PROPERTIES = ['calendar', 'year', 'responseFormat'];
-
-    /**
      * The legacy properties each reshaped message *replaced*, and what replaced them.
      *
      * **A v2 message that also carries a legacy property its own shape retired is rejected**, on all
@@ -174,14 +146,15 @@ class Health implements MessageComponentInterface
      * worse than either answer applied consistently, because the client cannot tell which it is
      * getting.
      *
-     * `runTest` retires `category` and `rite`: `ACTION_PROPERTIES['executeUnitTest']` is
-     * `['category', 'calendar', 'year', 'test']`, so there was never a `responsetype` on it to
-     * retire. `runToken` is retired by nothing — it is shared, current, and valid on all three.
+     * `runTest` retires `category` and `rite`: the `executeUnitTest` shape in `WebSocketMessage.json`
+     * requires `category`, `calendar`, `year` and `test`, so there was never a `responsetype` on it
+     * to retire. `runToken` is retired by nothing — it is shared, current, and valid on all three.
      *
-     * **The retired set is not derivable from `ACTION_PROPERTIES`**, and an audit that assumed it
-     * was is how `rite` came to be missed on both calendar actions: `ACTION_PROPERTIES` lists only
-     * *required* properties, so every optional v1 property — `rite` on `validateCalendar` and
-     * `executeUnitTest`, `responsetype` on `executeValidation` — was structurally invisible to it.
+     * **The retired set is not derivable from `WebSocketMessage.json`'s `required` lists**, and an
+     * audit that assumed it was is how `rite` came to be missed on both calendar actions: those
+     * lists name only *required* properties, so every optional v1 property — `rite` on
+     * `validateCalendar` and `executeUnitTest`, `responsetype` on `executeValidation` — was
+     * structurally invisible to it.
      * When adding a shape here, read the v1 predecessor's `@phpstan-type` alias at the top of this
      * file, where the optional properties are the ones marked `?`. (`responsetype` on
      * `executeValidation` is the one optional property deliberately *not* retired: `validateSource`
@@ -219,8 +192,8 @@ class Health implements MessageComponentInterface
                 // property list turns the message away for the missing required property, and that
                 // reading is unchanged.
                 'responsetype' => 'responseFormat replaces it.',
-                // Optional on v1, and therefore invisible to an audit that read ACTION_PROPERTIES —
-                // which lists required properties only. It is the one retired property whose silent
+                // Optional on v1, and therefore invisible to an audit that read the schema's
+                // required-property list only. It is the one retired property whose silent
                 // acceptance would be actively dangerous: a half-migrated client that objectified
                 // `calendar` but kept its old top-level `rite` gets a *rite disagreement* ignored,
                 // which is exactly what the typed identity went out of its way to make loud.
@@ -311,6 +284,8 @@ class Health implements MessageComponentInterface
     private array $runTokens = [];
     //private static PromiseInterface $metadataPromise;
 
+    private WebSocketMessageValidator $messageValidator;
+
     /**
      * Initializes the Health object with an empty SplObjectStorage.
      *
@@ -319,6 +294,12 @@ class Health implements MessageComponentInterface
     public function __construct()
     {
         $this->clients = new \SplObjectStorage();
+
+        // A server that cannot validate is misconfigured, and should fail here — where an operator
+        // sees it, before a client ever connects — rather than answering every message with an
+        // internal error. See {@see WebSocketMessageValidator::warm()}.
+        $this->messageValidator = new WebSocketMessageValidator();
+        $this->messageValidator->warm();
 
         // Create shared multi handler
         $multiHandler       = new CurlMultiHandler(['max_handles' => 50]);
@@ -611,7 +592,41 @@ class Health implements MessageComponentInterface
             json_last_error() === JSON_ERROR_NONE
             && $messageReceived instanceof \stdClass
             && property_exists($messageReceived, 'action')
-            && self::validateMessageProperties($messageReceived)
+        ) {
+            // `UNKNOWN_ACTION` must be checked ahead of schema validation, not derived from it: an
+            // unrecognised action matches no arm of the schema's top-level `oneOf`, so validating
+            // first would report it as `INVALID_MESSAGE` and collapse two error codes a client acts
+            // on differently into one. See #806 section G.
+            if (false === is_string($messageReceived->action)) {
+                $this->rejectMessage($from, ProtocolErrorCode::INVALID_MESSAGE, 'action must be a string naming a known action.', requestId: $requestId);
+                return;
+            }
+            if (null === WebSocketMessageValidator::shapeOf($messageReceived)) {
+                $this->rejectMessage(
+                    $from,
+                    ProtocolErrorCode::UNKNOWN_ACTION,
+                    sprintf('Unknown action from connection %1$d: %2$s', $resourceId, $msg),
+                    requestId: $requestId
+                );
+                return;
+            }
+
+            // Deferred rather than reported here: `rejectRetiredProperties()` runs inside each v2
+            // handler and can name what a retired property was replaced by, which this validator
+            // cannot. See {@see Health::RETIRED_PROPERTIES} and {@see Health::rejectRetiredProperties()}.
+            $retiredForAction = array_keys(self::RETIRED_PROPERTIES[$messageReceived->action]['retired'] ?? []);
+            $invalid          = $this->messageValidator->validate($messageReceived, $retiredForAction);
+            if (null !== $invalid) {
+                echo sprintf('Invalid message from connection %1$d: %2$s (%3$s)', $resourceId, $invalid, $msg);
+                $this->rejectMessage($from, ProtocolErrorCode::INVALID_MESSAGE, $invalid, requestId: $requestId);
+                return;
+            }
+        }
+
+        if (
+            json_last_error() === JSON_ERROR_NONE
+            && $messageReceived instanceof \stdClass
+            && property_exists($messageReceived, 'action')
         ) {
             switch ($messageReceived->action) {
                 case 'executeValidation':
@@ -662,6 +677,10 @@ class Health implements MessageComponentInterface
                     $this->validateSource($messageReceived, $from, requestId: $requestId);
                     break;
                 default:
+                    // Unreachable: the block above already returned for any action
+                    // `WebSocketMessageValidator::shapeOf()` does not recognise, and it recognises
+                    // exactly the actions the case arms above handle. Kept as a cheap backstop
+                    // against a future action being added to `shapeOf()` without a matching arm here.
                     $this->rejectMessage(
                         $from,
                         ProtocolErrorCode::UNKNOWN_ACTION,
@@ -679,9 +698,6 @@ class Health implements MessageComponentInterface
             } elseif (!property_exists($messageReceived, 'action')) {
                 $errorMsg  = 'No action specified';
                 $errorCode = ProtocolErrorCode::MISSING_ACTION;
-            } elseif (!self::validateMessageProperties($messageReceived)) {
-                $errorMsg  = 'Invalid message properties';
-                $errorCode = ProtocolErrorCode::INVALID_MESSAGE;
             } else {
                 $errorMsg  = 'Unknown error';
                 $errorCode = ProtocolErrorCode::INVALID_MESSAGE;
@@ -954,15 +970,14 @@ class Health implements MessageComponentInterface
      *
      * Nothing is sent back; see #806 section H.
      *
-     * `validateMessageProperties()` only checks that `runToken` is *present*, not that it is a string —
-     * `{"action":"cancelRun","runToken":null}` (or an array, or an object) passes validation and reaches
-     * here. In weak mode PHP does not coerce those into a `string` parameter; it throws `TypeError`, and
-     * Ratchet's `IoServer::handleData` only catches `\Exception`, so an `\Error` escapes and kills the
-     * whole WebSocket process over one malformed cancel. A cancel the server cannot act on is already a
-     * documented no-op (see above), so a non-string token folds into that same no-op path instead.
+     * `WebSocketMessageValidator` now rejects a non-string `runToken` — `cancelRun`'s schema entry
+     * types it via `#/definitions/correlationId` — before dispatch ever reaches here. `$runToken` is
+     * kept `mixed` and re-checked below anyway: a cancel the server cannot act on is already a
+     * documented no-op (see above), so treating an unexpected type as "not this connection's run"
+     * rather than trusting the schema is the cheaper of two ways to stay correct, and costs nothing.
      *
-     * @param mixed $runToken The run the client wants abandoned. Expected to be a string, but the caller
-     *                        only guarantees the property exists, not its type — see above.
+     * @param mixed $runToken The run the client wants abandoned. Expected to be a string; re-checked
+     *                        here rather than trusted, for the reason above.
      * @param ConnectionInterface $from The connection that asked.
      */
     private function cancelRun(mixed $runToken, ConnectionInterface $from): void
@@ -1033,8 +1048,10 @@ class Health implements MessageComponentInterface
             return;
         }
 
-        // `validateMessageProperties()` has already established that `target` is present; what it
-        // cannot establish is its shape, since ACTION_PROPERTIES only names required properties.
+        // `WebSocketMessageValidator` has already established that `target` is a `{id: string}`
+        // object, per the `validateSource` shape in `WebSocketMessage.json`. Re-checked here anyway,
+        // rather than trusted, so this method reads correctly on its own and stays correct if the
+        // schema and the dispatch ever drift.
         $target = property_exists($message, 'target') ? $message->target : null;
         if (false === ( $target instanceof \stdClass ) || false === property_exists($target, 'id')) {
             $this->rejectMessage($to, ProtocolErrorCode::INVALID_MESSAGE, 'validateSource requires a target object with an id.', requestId: $requestId);
@@ -1936,9 +1953,9 @@ class Health implements MessageComponentInterface
     /**
      * Read the optional `rite` property off an incoming WebSocket message.
      *
-     * `rite` is optional — it is deliberately absent from `ACTION_PROPERTIES`,
-     * which lists only required properties — so clients that predate rite
-     * awareness keep working and get their rite resolved from metadata instead.
+     * `rite` is optional — it is deliberately absent from the `required` list of every shape in
+     * `WebSocketMessage.json` that carries it — so clients that predate rite awareness keep working
+     * and get their rite resolved from metadata instead.
      * A non-string value is treated as absent rather than as an error; the
      * resolver validates the string against {@see Rite} in any case.
      */
@@ -2215,12 +2232,12 @@ class Health implements MessageComponentInterface
     /**
      * Read a message's `year` as the integer the calendar routines take.
      *
-     * Type-checked rather than trusted because {@see Health::validateMessageProperties()} establishes
-     * only that a property is *present*. A null or string `year` would reach
-     * `validateCalendar(…, int $year, …)` or `executeUnitTest(…, int $year, …)` and raise a
-     * `TypeError` — an `\Error`, which Ratchet's `IoServer::handleData` does not catch, so one
-     * malformed message would take the whole WebSocket process down rather than be answered. Same
-     * hazard {@see Health::cancelRun()} documents, on the property it was first found on.
+     * `WebSocketMessageValidator` now enforces `year: integer` on every shape that carries it, so the
+     * `TypeError` this once guarded against — `validateCalendar(…, int $year, …)` or
+     * `executeUnitTest(…, int $year, …)` reached with a null or string `year`, an `\Error` that
+     * Ratchet's `IoServer::handleData` does not catch — should no longer reach here. Kept as a
+     * type-narrowing backstop rather than trusted blindly, the same reasoning
+     * {@see Health::cancelRun()} documents on the property it was first found on.
      *
      * @param string $action The action name, so the rejection says which message is wrong.
      * @throws \InvalidArgumentException Whose message is the client-facing rejection text.
@@ -2278,13 +2295,14 @@ class Health implements MessageComponentInterface
      * authoritative, which is exactly right here because by this point it has been checked — see
      * {@see Health::resolveCalendarIdentity()}.
      *
-     * `year` and `responseFormat` are type-checked rather than trusted because
-     * `validateMessageProperties()` establishes only that a property is *present*. `year` is checked
-     * by the shared {@see Health::readYear()}; `responseFormat` is checked here because it belongs
-     * to this action alone — an unusable one would reach `ReturnTypeParam::from()` and raise a
-     * `\ValueError`, which is an `\Error` and so escapes Ratchet's `IoServer::handleData`, taking the
-     * whole WebSocket process down over one malformed message. See {@see Health::cancelRun()}, which
-     * documents the same hazard on the property it was found on.
+     * `year` and `responseFormat` are re-checked here rather than trusted outright, even though
+     * `WebSocketMessageValidator` now enforces `year: integer` and `responseFormat`'s enum on this
+     * shape. `year` goes through the shared {@see Health::readYear()}; `responseFormat` is checked
+     * here because it belongs to this action alone — an unusable one would reach
+     * `ReturnTypeParam::from()` and raise a `\ValueError`, which is an `\Error` and so escapes
+     * Ratchet's `IoServer::handleData`, taking the whole WebSocket process down over one malformed
+     * message. See {@see Health::cancelRun()}, which documents the same hazard on the property it
+     * was found on.
      *
      * @param ValidateTypedCalendar $message The message naming the calendar to compute and check.
      * @param ConnectionInterface $to The connection to send the result frames to.
@@ -3727,9 +3745,10 @@ class Health implements MessageComponentInterface
      * Is this a `validateCalendar` message in the reshaped (v2) form?
      *
      * The whole discriminator, in one place, because it is consulted twice — once by
-     * {@see Health::validateMessageProperties()}, which must know before it applies a property list,
-     * and once by {@see Health::onMessage()}, which must know before it picks a handler. Two
-     * literal copies of "is `calendar` an object?" would be two places to forget.
+     * {@see \LiturgicalCalendar\Api\Services\WebSocketMessageValidator::shapeOf()}, which must know
+     * which published shape a message claims to be before validating it, and once by
+     * {@see Health::onMessage()}, which must know before it picks a handler. Two literal copies of
+     * "is `calendar` an object?" would be two places to forget.
      *
      * `validateCalendar` is the only action that needs a shape test at all. `validateSource` and
      * `runTest` are new *names*, and a v1 client cannot accidentally emit a name it does not know;
@@ -3741,49 +3760,6 @@ class Health implements MessageComponentInterface
             && 'validateCalendar' === $message->action
             && property_exists($message, 'calendar')
             && $message->calendar instanceof \stdClass;
-    }
-
-    /**
-     * Validates the properties of a message object.
-     *
-     * This function checks the properties of a given message object to ensure
-     * they match the expected properties defined in ACTION_PROPERTIES for the
-     * specified action. If any expected property is missing from the message
-     * object, the function returns false, indicating the message is invalid.
-     *
-     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ValidateTypedCalendar|ExecuteUnitTest|RunTest|CancelRun|ValidateSource $message The message object to validate.
-     * @return bool True if all required properties are present, false otherwise.
-     */
-    private static function validateMessageProperties(\stdClass $message): bool
-    {
-        // ------------------------------------------------------------------ the v2 discriminator
-        // This branch has to be here — ahead of the ACTION_PROPERTIES list — and not inside
-        // validateCalendar(). `validateCalendar` keeps its action name because the *action* is
-        // unchanged, so unlike `validateSource` and `runTest` there is no new name to discriminate
-        // on: the shape of `calendar` is the only signal a reshaped message gives. And a reshaped
-        // message carries neither `category` (folded into `calendar.kind`) nor `responsetype`
-        // (respelled `responseFormat`), both of which ACTION_PROPERTIES['validateCalendar']
-        // requires. Applying that list first would therefore turn away *every* v2 message as
-        // "Invalid message properties" before any handler ever saw it.
-        if (self::isTypedCalendarMessage($message)) {
-            foreach (self::TYPED_CALENDAR_PROPERTIES as $prop) {
-                if (false === property_exists($message, $prop)) {
-                    return false;
-                }
-            }
-            return true;
-        }
-        // ------------------------------------------------------------------ everything else, as before
-        $valid = true;
-        foreach (Health::ACTION_PROPERTIES[$message->action] as $prop) {
-            if (false === property_exists($message, $prop)) {
-                if ($prop === 'sourceFile' && $message->action === 'executeValidation' && property_exists($message, 'sourceFolder')) {
-                    continue;
-                }
-                return false;
-            }
-        }
-        return $valid;
     }
 
     /**

--- a/src/Health.php
+++ b/src/Health.php
@@ -662,7 +662,12 @@ class Health implements MessageComponentInterface
                     $this->validateSource($messageReceived, $from, requestId: $requestId);
                     break;
                 default:
-                    $this->rejectMessage($from, ProtocolErrorCode::UNKNOWN_ACTION, $msg, requestId: $requestId);
+                    $this->rejectMessage(
+                        $from,
+                        ProtocolErrorCode::UNKNOWN_ACTION,
+                        sprintf('Unknown action from connection %1$d: %2$s', $resourceId, $msg),
+                        requestId: $requestId
+                    );
             }
         } else {
             if (json_last_error() !== JSON_ERROR_NONE) {
@@ -685,7 +690,7 @@ class Health implements MessageComponentInterface
             $this->rejectMessage(
                 $from,
                 $errorCode,
-                sprintf('Invalid message from connection %d: %s', $resourceId, $msg),
+                sprintf('Invalid message from connection %1$d: %2$s (%3$s)', $resourceId, $errorMsg, $msg),
                 requestId: $requestId
             );
         }

--- a/src/Health.php
+++ b/src/Health.php
@@ -602,10 +602,13 @@ class Health implements MessageComponentInterface
                 return;
             }
             if (null === WebSocketMessageValidator::shapeOf($messageReceived)) {
+                // The connection id has no reader on the wire; it is server-internal state and
+                // belongs in the log line, not in prose a client has to parse or display.
+                echo sprintf('Unknown action from connection %1$d: %2$s', $resourceId, $msg);
                 $this->rejectMessage(
                     $from,
                     ProtocolErrorCode::UNKNOWN_ACTION,
-                    sprintf('Unknown action from connection %1$d: %2$s', $resourceId, $msg),
+                    sprintf('Unknown action: %s', $msg),
                     requestId: $requestId
                 );
                 return;
@@ -706,10 +709,14 @@ class Health implements MessageComponentInterface
                         // `WebSocketMessageValidator::shapeOf()` does not recognise, and it recognises
                         // exactly the actions the case arms above handle. Kept as a cheap backstop
                         // against a future action being added to `shapeOf()` without a matching arm here.
+                        //
+                        // The connection id has no reader on the wire; it is server-internal state
+                        // and belongs in the log line, not in prose a client has to parse or display.
+                        echo sprintf('Unknown action from connection %1$d: %2$s', $resourceId, $msg);
                         $this->rejectMessage(
                             $from,
                             ProtocolErrorCode::UNKNOWN_ACTION,
-                            sprintf('Unknown action from connection %1$d: %2$s', $resourceId, $msg),
+                            sprintf('Unknown action: %s', $msg),
                             requestId: $requestId
                         );
                 }
@@ -754,10 +761,12 @@ class Health implements MessageComponentInterface
                 $errorCode = ProtocolErrorCode::INVALID_MESSAGE;
             }
             echo sprintf('Invalid message from connection %1$d: %2$s (%3$s)', $resourceId, $errorMsg, $msg);
+            // The connection id above is server-internal state and stays in the log line; the
+            // client gets the same reason and raw message, without it — it has no reader on the wire.
             $this->rejectMessage(
                 $from,
                 $errorCode,
-                sprintf('Invalid message from connection %1$d: %2$s (%3$s)', $resourceId, $errorMsg, $msg),
+                sprintf('Invalid message: %1$s (%2$s)', $errorMsg, $msg),
                 requestId: $requestId
             );
         }
@@ -3795,11 +3804,11 @@ class Health implements MessageComponentInterface
     /**
      * Is this a `validateCalendar` message in the reshaped (v2) form?
      *
-     * The whole discriminator, in one place, because it is consulted twice — once by
-     * {@see \LiturgicalCalendar\Api\Services\WebSocketMessageValidator::shapeOf()}, which must know
-     * which published shape a message claims to be before validating it, and once by
-     * {@see Health::onMessage()}, which must know before it picks a handler. Two literal copies of
-     * "is `calendar` an object?" would be two places to forget.
+     * A thin wrapper over {@see WebSocketMessageValidator::shapeOf()}, which is the single source of
+     * truth for "is `calendar` an object?": it must already resolve this to pick which arm of the
+     * schema to validate against, and {@see Health::onMessage()} needs the same answer to pick a
+     * handler. Delegating here keeps that predicate in one place instead of two literal copies that
+     * could drift apart.
      *
      * `validateCalendar` is the only action that needs a shape test at all. `validateSource` and
      * `runTest` are new *names*, and a v1 client cannot accidentally emit a name it does not know;
@@ -3807,10 +3816,7 @@ class Health implements MessageComponentInterface
      */
     private static function isTypedCalendarMessage(\stdClass $message): bool
     {
-        return property_exists($message, 'action')
-            && 'validateCalendar' === $message->action
-            && property_exists($message, 'calendar')
-            && $message->calendar instanceof \stdClass;
+        return 'validateCalendarTyped' === WebSocketMessageValidator::shapeOf($message);
     }
 
     /**

--- a/src/Health.php
+++ b/src/Health.php
@@ -18,6 +18,7 @@ use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Enum\FrameFamily;
 use LiturgicalCalendar\Api\Enum\ICSErrorLevel;
 use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Enum\Route;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\Rite;
@@ -600,7 +601,7 @@ class Health implements MessageComponentInterface
                 // Refused rather than quietly dropped. A client that sent an unusable id is about
                 // to wait for frames it intends to attribute by it; answering with frames that
                 // carry no id at all would look like success and correlate nothing.
-                $this->rejectMessage($from, 'requestId must be 1 to 64 characters of A-Z, a-z, 0-9, underscore or hyphen.');
+                $this->rejectMessage($from, ProtocolErrorCode::INVALID_REQUEST_ID, 'requestId must be 1 to 64 characters of A-Z, a-z, 0-9, underscore or hyphen.');
                 return;
             }
             $requestId = $candidateRequestId;
@@ -661,29 +662,32 @@ class Health implements MessageComponentInterface
                     $this->validateSource($messageReceived, $from, requestId: $requestId);
                     break;
                 default:
-                    $message       = new \stdClass();
-                    $message->type = 'echobot';
-                    $message->text = $msg;
-                    $this->sendMessage($from, $message, requestId: $requestId);
+                    $this->rejectMessage($from, ProtocolErrorCode::UNKNOWN_ACTION, $msg, requestId: $requestId);
             }
         } else {
             if (json_last_error() !== JSON_ERROR_NONE) {
-                $errorMsg = json_last_error_msg();
+                $errorMsg  = json_last_error_msg();
+                $errorCode = ProtocolErrorCode::INVALID_JSON;
             } elseif (!$messageReceived instanceof \stdClass) {
-                $errorMsg = 'Message is not an object';
+                $errorMsg  = 'Message is not an object';
+                $errorCode = ProtocolErrorCode::NOT_AN_OBJECT;
             } elseif (!property_exists($messageReceived, 'action')) {
-                $errorMsg = 'No action specified';
+                $errorMsg  = 'No action specified';
+                $errorCode = ProtocolErrorCode::MISSING_ACTION;
             } elseif (!self::validateMessageProperties($messageReceived)) {
-                $errorMsg = 'Invalid message properties';
+                $errorMsg  = 'Invalid message properties';
+                $errorCode = ProtocolErrorCode::INVALID_MESSAGE;
             } else {
-                $errorMsg = 'Unknown error';
+                $errorMsg  = 'Unknown error';
+                $errorCode = ProtocolErrorCode::INVALID_MESSAGE;
             }
             echo sprintf('Invalid message from connection %1$d: %2$s (%3$s)', $resourceId, $errorMsg, $msg);
-            $message           = new \stdClass();
-            $message->type     = 'echobot';
-            $message->errorMsg = $errorMsg;
-            $message->text     = sprintf('Invalid message from connection %d: %s', $resourceId, $msg);
-            $this->sendMessage($from, $message, requestId: $requestId);
+            $this->rejectMessage(
+                $from,
+                $errorCode,
+                sprintf('Invalid message from connection %d: %s', $resourceId, $msg),
+                requestId: $requestId
+            );
         }
     }
 
@@ -899,24 +903,23 @@ class Health implements MessageComponentInterface
     }
 
     /**
-     * Reject a malformed or unresolvable v2 message.
+     * Reject a message that cannot be acted on, saying why in a form a client can branch on.
      *
-     * Reuses the existing `echobot` error shape deliberately. Since UnitTestInterface PR #46 an
-     * unrecognised response `type` is painted as a visible failed check, so a dedicated
-     * `protocolError` type would make every rejection look like a failing test. That type belongs
-     * to #806 section G and is gated on section C.
+     * Ungated, unlike the terminal `complete` frame, and the difference is real rather than an
+     * inconsistency: a new frame changes the stream a v1 client counts, while a new *type* on a
+     * frame it was already going to receive changes nothing for it. Since UnitTestInterface#46 an
+     * unrecognised type is painted as a visible failed check — which is what `echobot` already
+     * became — so `protocolError` reads to a v1 client exactly as its predecessor did.
      *
-     * @param ConnectionInterface $to The connection that sent the message being rejected.
-     * @param string $text Why the message could not be acted on.
-     * @param ?string $requestId The correlation id of the message being rejected, so a client can tell *which* of its
-     *        in-flight requests was refused. Null when the message carried none, and — see {@see Health::onMessage()} —
-     *        when the id itself is what was malformed, since an unusable id is not worth echoing.
+     * `text` carries the prose, as every other frame in this protocol does. #806's sketch spells it
+     * `message`; a second name for an existing field is the duplication that issue exists to remove.
      */
-    private function rejectMessage(ConnectionInterface $to, string $text, ?string $requestId = null): void
+    private function rejectMessage(ConnectionInterface $to, ProtocolErrorCode $code, string $text, ?string $requestId = null): void
     {
-        $message       = new \stdClass();
-        $message->type = 'echobot';
-        $message->text = $text;
+        $message            = new \stdClass();
+        $message->type      = 'protocolError';
+        $message->errorCode = $code->value;
+        $message->text      = $text;
         $this->sendMessage($to, $message, requestId: $requestId);
     }
 
@@ -1029,13 +1032,13 @@ class Health implements MessageComponentInterface
         // cannot establish is its shape, since ACTION_PROPERTIES only names required properties.
         $target = property_exists($message, 'target') ? $message->target : null;
         if (false === ( $target instanceof \stdClass ) || false === property_exists($target, 'id')) {
-            $this->rejectMessage($to, 'validateSource requires a target object with an id.', requestId: $requestId);
+            $this->rejectMessage($to, ProtocolErrorCode::INVALID_MESSAGE, 'validateSource requires a target object with an id.', requestId: $requestId);
             return;
         }
 
         $id = $target->id;
         if (false === is_string($id)) {
-            $this->rejectMessage($to, 'validateSource target id must be a string.', requestId: $requestId);
+            $this->rejectMessage($to, ProtocolErrorCode::INVALID_MESSAGE, 'validateSource target id must be a string.', requestId: $requestId);
             return;
         }
 
@@ -1060,6 +1063,7 @@ class Health implements MessageComponentInterface
             // one — the #800 blindness in miniature.
             $this->rejectMessage(
                 $to,
+                ProtocolErrorCode::UNKNOWN_TARGET_ID,
                 null === $inventoryError
                     ? "Unknown validation target: {$id}"
                     : "Could not resolve validation target {$id}: the source data inventory could not be built ({$inventoryError->getMessage()})",
@@ -2171,7 +2175,7 @@ class Health implements MessageComponentInterface
         $shape = self::RETIRED_PROPERTIES[$action]['shape'];
         foreach (self::RETIRED_PROPERTIES[$action]['retired'] as $property => $replacement) {
             if (property_exists($message, $property)) {
-                $this->rejectMessage($to, sprintf('%s is not part of a %s: %s', $property, $shape, $replacement), requestId: $requestId);
+                $this->rejectMessage($to, ProtocolErrorCode::RETIRED_PROPERTY, sprintf('%s is not part of a %s: %s', $property, $shape, $replacement), requestId: $requestId);
                 return true;
             }
         }
@@ -2298,13 +2302,13 @@ class Health implements MessageComponentInterface
             $identity = $this->readCalendarIdentity($message, 'validateCalendar');
             $year     = self::readYear($message, 'validateCalendar');
         } catch (\InvalidArgumentException $e) {
-            $this->rejectMessage($to, $e->getMessage(), requestId: $requestId);
+            $this->rejectMessage($to, ProtocolErrorCode::INVALID_MESSAGE, $e->getMessage(), requestId: $requestId);
             return;
         }
 
         $responseFormat = property_exists($message, 'responseFormat') ? $message->responseFormat : null;
         if (false === is_string($responseFormat) || false === in_array($responseFormat, self::VALIDATABLE_RESPONSE_FORMATS, true)) {
-            $this->rejectMessage($to, 'validateCalendar responseFormat must be one of: ' . implode(', ', self::VALIDATABLE_RESPONSE_FORMATS) . '.', requestId: $requestId);
+            $this->rejectMessage($to, ProtocolErrorCode::INVALID_MESSAGE, 'validateCalendar responseFormat must be one of: ' . implode(', ', self::VALIDATABLE_RESPONSE_FORMATS) . '.', requestId: $requestId);
             return;
         }
 
@@ -2834,7 +2838,7 @@ class Health implements MessageComponentInterface
         // reach executeUnitTest(string $test, …) as a TypeError, which Ratchet does not catch.
         $test = property_exists($message, 'test') ? $message->test : null;
         if (false === is_string($test)) {
-            $this->rejectMessage($to, 'runTest test must be a string.', requestId: $requestId);
+            $this->rejectMessage($to, ProtocolErrorCode::INVALID_MESSAGE, 'runTest test must be a string.', requestId: $requestId);
             return;
         }
 
@@ -2842,7 +2846,7 @@ class Health implements MessageComponentInterface
             $identity = $this->readCalendarIdentity($message, 'runTest');
             $year     = self::readYear($message, 'runTest');
         } catch (\InvalidArgumentException $e) {
-            $this->rejectMessage($to, $e->getMessage(), requestId: $requestId);
+            $this->rejectMessage($to, ProtocolErrorCode::INVALID_MESSAGE, $e->getMessage(), requestId: $requestId);
             return;
         }
 

--- a/src/Health.php
+++ b/src/Health.php
@@ -642,9 +642,26 @@ class Health implements MessageComponentInterface
                         break;
                     }
                     /** @var ValidateCalendar $messageReceived */
+                    // `year` is read through readYear() rather than trusted as `int`, even though
+                    // the schema declares `"type": "integer"`: JSON Schema and PHP disagree about
+                    // what that means. A number like 1e30 or a 30-digit literal is an integer *by
+                    // value* under JSON Schema, so the schema accepts it correctly — but json_decode()
+                    // hands PHP a float for it (it is outside PHP_INT_MAX), and this arm used to
+                    // unpack that straight into validateCalendar(..., int $year, ...). PHP's
+                    // coercive typing refuses an out-of-range float for an int parameter with a
+                    // TypeError, an \Error Ratchet's IoServer::handleData does not catch, so it took
+                    // the whole process down. readYear()'s is_int() check is exactly the guard the
+                    // typed arms (validateTypedCalendar(), runTest()) already apply for the same
+                    // reason; the schema cannot close this gap, because the schema is right.
+                    try {
+                        $year = self::readYear($messageReceived, 'validateCalendar');
+                    } catch (\InvalidArgumentException $e) {
+                        $this->rejectMessage($from, ProtocolErrorCode::INVALID_MESSAGE, $e->getMessage(), requestId: $requestId);
+                        break;
+                    }
                     $this->validateCalendar(
                         $messageReceived->calendar,
-                        $messageReceived->year,
+                        $year,
                         $messageReceived->category,
                         $messageReceived->responsetype,
                         $from,
@@ -654,10 +671,17 @@ class Health implements MessageComponentInterface
                     break;
                 case 'executeUnitTest':
                     /** @var ExecuteUnitTest $messageReceived */
+                    // See the comment on the validateCalendar arm above: same hazard, same fix.
+                    try {
+                        $year = self::readYear($messageReceived, 'executeUnitTest');
+                    } catch (\InvalidArgumentException $e) {
+                        $this->rejectMessage($from, ProtocolErrorCode::INVALID_MESSAGE, $e->getMessage(), requestId: $requestId);
+                        break;
+                    }
                     $this->executeUnitTest(
                         $messageReceived->test,
                         $messageReceived->calendar,
-                        $messageReceived->year,
+                        $year,
                         $messageReceived->category,
                         $from,
                         self::readRiteHint($messageReceived),

--- a/src/Services/WebSocketMessageValidator.php
+++ b/src/Services/WebSocketMessageValidator.php
@@ -111,21 +111,40 @@ final class WebSocketMessageValidator
         }
 
         $allowed = $this->propertyNamesFor($shape);
+        // `$message->action` — the client's own word — not `$shape`: `$shape` is
+        // `validateCalendarTyped`/`validateCalendarLegacy`, an internal definition name a client
+        // sending `action: "validateCalendar"` has no way to look up in the published schema.
+        // Guaranteed present and a string here: `$shape` is non-null only when `shapeOf()` already
+        // confirmed both, and `$shape` is checked non-null just above.
+        /** @var string $action */
+        $action = $message->action;
         foreach (array_keys((array) $message) as $property) {
             if (in_array((string) $property, $deferToHandler, true)) {
                 continue;
             }
             if (false === in_array((string) $property, $allowed, true)) {
                 return sprintf(
-                    '%s is not a property of a %s message. A message carrying a requestId may only use the properties the contract declares: %s.',
+                    '%s is not a property of %s %s message. A message carrying a requestId may only use the properties the contract declares: %s.',
                     (string) $property,
-                    $shape,
+                    self::article($action),
+                    $action,
                     implode(', ', $allowed)
                 );
             }
         }
 
         return null;
+    }
+
+    /**
+     * "a" or "an", for the sentence above. A plain vowel-letter check is enough: every action name
+     * this ever sees comes from `WebSocketMessage.json`'s fixed, known set — `executeValidation`,
+     * `validateCalendar`, `executeUnitTest`, `runTest`, `cancelRun`, `validateSource` — not free
+     * text a client chose the spelling of.
+     */
+    private static function article(string $word): string
+    {
+        return in_array($word[0] ?? '', ['a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U'], true) ? 'an' : 'a';
     }
 
     /**
@@ -280,8 +299,15 @@ final class WebSocketMessageValidator
         // `data: {…}` — braces may nest (e.g. the value is itself an object with its own object
         // properties) — but never `data: [...]` or `data: "…"`/`data: 42`, which are the useful,
         // short cases and are left alone.
+        //
+        // `preg_replace()` returns `null` on failure — most concretely here, PCRE's backtrack/
+        // recursion limit on the balanced-brace recursion for a large echoed object (measured:
+        // fine around 5.6 KB, broken around 14 KB) — and `(string) null` used to silently become
+        // `''`, discarding the whole reason rather than merely failing to trim it. Falling back to
+        // the untransformed input keeps the reason on the wire; it is still `sanitize()`d, since
+        // that already ran on `$message` before this method was called.
         $balancedObject = '(?P<bal>\{(?:[^{}]|(?P>bal))*\})';
-        $withoutEchoes  = (string) preg_replace('/,?\s*data:\s*' . $balancedObject . '/', '', $message);
+        $withoutEchoes  = preg_replace('/,?\s*data:\s*' . $balancedObject . '/', '', $message) ?? $message;
 
         $trailPattern = '/ at (#(?:->\S+)*)/';
         preg_match_all($trailPattern, $withoutEchoes, $trails);
@@ -289,7 +315,7 @@ final class WebSocketMessageValidator
         $trailList = $trails[1];
         $path      = [] === $trailList ? $action : $this->pathFromTrail((string) end($trailList), $action);
 
-        $withoutTrails = (string) preg_replace($trailPattern, '', $withoutEchoes);
+        $withoutTrails = preg_replace($trailPattern, '', $withoutEchoes) ?? $withoutEchoes;
 
         return $path . ': ' . trim($withoutTrails);
     }

--- a/src/Services/WebSocketMessageValidator.php
+++ b/src/Services/WebSocketMessageValidator.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * Validates an inbound Health WebSocket message against the published contract.
+ *
+ * Two rules, deliberately different in reach:
+ *
+ *  - **Types, enums and required properties** are checked for every message. A message that fails
+ *    these is one that would otherwise reach a typed parameter and throw a `TypeError` — an
+ *    `\Error`, which Ratchet's `IoServer::handleData` does not catch, so it would kill the process
+ *    rather than fail the request. Refusing it is better for a v1 client too.
+ *  - **Undeclared properties** are refused only for messages carrying a `requestId`, the same v2
+ *    opt-in the terminal `complete` frame is gated on. The shipped client sends `runToken` on every
+ *    message and spreads `rite` onto an `executeValidation` that never reads it; a uniform rule
+ *    would take the test interface down.
+ *
+ * The second rule is applied here rather than in the schema because `swaggest/json-schema` v0.12.43
+ * implements draft-07, where `additionalProperties` sees only the properties declared in the same
+ * schema object — so the natural `if`/`then`/`unevaluatedProperties` spelling needs 2019-09. The
+ * allowed *names* still come from the schema; only the gate is here. See issue #826.
+ */
+final class WebSocketMessageValidator
+{
+    private static ?Schema $schema = null;
+
+    /** @var array<string, list<string>>|null */
+    private static ?array $propertyNames = null;
+
+    private string $schemaPath;
+
+    public function __construct(?string $schemaPath = null)
+    {
+        $this->schemaPath = $schemaPath ?? LitSchema::WEBSOCKET_MESSAGE->path();
+    }
+
+    /**
+     * @param list<string> $deferToHandler Property names this must not report, because a handler says
+     *        something better about them. See the note on retired properties below.
+     * @return string|null null when the message is acceptable, otherwise the reason, phrased for the
+     *         client that sent it.
+     */
+    public function validate(\stdClass $message, array $deferToHandler = []): ?string
+    {
+        try {
+            $this->schema()->in($message);
+        } catch (\Throwable $e) {
+            return $e->getMessage();
+        }
+
+        if (false === property_exists($message, 'requestId')) {
+            return null;
+        }
+
+        $shape = self::shapeOf($message);
+        if (null === $shape) {
+            return null;
+        }
+
+        $allowed = $this->propertyNamesFor($shape);
+        foreach (array_keys((array) $message) as $property) {
+            if (in_array((string) $property, $deferToHandler, true)) {
+                continue;
+            }
+            if (false === in_array((string) $property, $allowed, true)) {
+                return sprintf(
+                    '%s is not a property of a %s message. A message carrying a requestId may only use the properties the contract declares: %s.',
+                    (string) $property,
+                    $shape,
+                    implode(', ', $allowed)
+                );
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Which published shape a message claims to be. Mirrors the dispatch: the action name, plus the
+     * type of `calendar` for the one action that carries two shapes.
+     */
+    public static function shapeOf(\stdClass $message): ?string
+    {
+        if (false === property_exists($message, 'action') || false === is_string($message->action)) {
+            return null;
+        }
+
+        if ('validateCalendar' === $message->action) {
+            return property_exists($message, 'calendar') && $message->calendar instanceof \stdClass
+                ? 'validateCalendarTyped'
+                : 'validateCalendarLegacy';
+        }
+
+        return in_array($message->action, ['executeValidation', 'executeUnitTest', 'runTest', 'cancelRun', 'validateSource'], true)
+            ? $message->action
+            : null;
+    }
+
+    /**
+     * The property names the contract declares for a shape, read from the schema itself so that this
+     * class carries no list of its own.
+     *
+     * @return list<string>
+     */
+    private function propertyNamesFor(string $shape): array
+    {
+        if (null === self::$propertyNames) {
+            $raw = json_decode((string) file_get_contents($this->schemaPath));
+            if (false === $raw instanceof \stdClass || false === isset($raw->definitions)) {
+                throw new \RuntimeException("WebSocket message schema at {$this->schemaPath} has no definitions.");
+            }
+            $names = [];
+            foreach ((array) $raw->definitions as $name => $definition) {
+                if ($definition instanceof \stdClass && isset($definition->properties)) {
+                    $names[(string) $name] = array_map('strval', array_keys((array) $definition->properties));
+                }
+            }
+            self::$propertyNames = $names;
+        }
+
+        return self::$propertyNames[$shape] ?? [];
+    }
+
+    private function schema(): Schema
+    {
+        if (null === self::$schema) {
+            $imported = Schema::import($this->schemaPath);
+            if (false === $imported instanceof Schema) {
+                throw new \RuntimeException("WebSocket message schema at {$this->schemaPath} could not be imported.");
+            }
+            self::$schema = $imported;
+        }
+
+        return self::$schema;
+    }
+
+    /**
+     * Drop the memoized schema. Tests that point the validator at a different file need this; nothing
+     * in production does.
+     */
+    public static function reset(): void
+    {
+        self::$schema        = null;
+        self::$propertyNames = null;
+    }
+
+    /**
+     * Import the schema now rather than on the first message. A server that cannot validate is
+     * misconfigured, and should fail where an operator sees it rather than answering every message
+     * with an internal error.
+     */
+    public function warm(): void
+    {
+        $this->schema();
+        $this->propertyNamesFor('validateSource');
+    }
+}

--- a/src/Services/WebSocketMessageValidator.php
+++ b/src/Services/WebSocketMessageValidator.php
@@ -23,13 +23,49 @@ use Swaggest\JsonSchema\Schema;
  * implements draft-07, where `additionalProperties` sees only the properties declared in the same
  * schema object — so the natural `if`/`then`/`unevaluatedProperties` spelling needs 2019-09. The
  * allowed *names* still come from the schema; only the gate is here. See issue #826.
+ *
+ * **Validation is scoped to the one arm a message claims to be**, not run against the whole
+ * top-level `oneOf`. `shapeOf()` already has to resolve that arm to check `requestId`-gated
+ * properties, and reusing it here does more than save work: `swaggest/json-schema`'s `oneOf`
+ * failure text lists every arm's failure, including ones that have nothing to do with the message
+ * — a `runTest` with a bad `year` was, before this, told it was missing `executeValidation`'s
+ * `sourceFolder`. Scoping the validated schema to the claimed arm means the failure text can only
+ * ever be about that arm.
  */
 final class WebSocketMessageValidator
 {
-    private static ?Schema $schema = null;
+    /**
+     * The definition names {@see self::warm()} pre-imports. Not the same list `shapeOf()` matches
+     * action names against: `validateCalendar` is one action but two shapes, so this has seven
+     * entries where that has five action names plus a special case.
+     *
+     * @var list<string>
+     */
+    private const KNOWN_SHAPES = [
+        'executeValidation',
+        'validateCalendarLegacy',
+        'validateCalendarTyped',
+        'executeUnitTest',
+        'runTest',
+        'cancelRun',
+        'validateSource'
+    ];
+
+    /**
+     * The whole-document schema, used only when a message's shape cannot be determined at all.
+     * Unreachable through {@see \LiturgicalCalendar\Api\Health::onMessage()}, which already refuses
+     * an unrecognised action with `UNKNOWN_ACTION` before `validate()` ever runs — kept so a direct
+     * caller still gets a sensible answer instead of a fatal on a null shape.
+     */
+    private static ?Schema $topLevelSchema = null;
+
+    /** @var array<string, Schema> One imported Schema per shape, built once and reused. */
+    private static array $shapeSchemas = [];
 
     /** @var array<string, list<string>>|null */
     private static ?array $propertyNames = null;
+
+    private static ?\stdClass $rawDocument = null;
 
     private string $schemaPath;
 
@@ -46,18 +82,19 @@ final class WebSocketMessageValidator
      */
     public function validate(\stdClass $message, array $deferToHandler = []): ?string
     {
-        try {
-            $this->schema()->in($message);
-        } catch (\Throwable $e) {
-            return $e->getMessage();
-        }
-
-        if (false === property_exists($message, 'requestId')) {
-            return null;
-        }
-
         $shape = self::shapeOf($message);
-        if (null === $shape) {
+
+        try {
+            if (null !== $shape) {
+                $this->schemaFor($shape)->in($message);
+            } else {
+                $this->schema()->in($message);
+            }
+        } catch (\Throwable $e) {
+            return $this->sanitize($e->getMessage());
+        }
+
+        if (null === $shape || false === property_exists($message, 'requestId')) {
             return null;
         }
 
@@ -109,12 +146,8 @@ final class WebSocketMessageValidator
     private function propertyNamesFor(string $shape): array
     {
         if (null === self::$propertyNames) {
-            $raw = json_decode((string) file_get_contents($this->schemaPath));
-            if (false === $raw instanceof \stdClass || false === isset($raw->definitions)) {
-                throw new \RuntimeException("WebSocket message schema at {$this->schemaPath} has no definitions.");
-            }
             $names = [];
-            foreach ((array) $raw->definitions as $name => $definition) {
+            foreach ((array) $this->raw()->definitions as $name => $definition) {
                 if ($definition instanceof \stdClass && isset($definition->properties)) {
                     $names[(string) $name] = array_map('strval', array_keys((array) $definition->properties));
                 }
@@ -125,17 +158,83 @@ final class WebSocketMessageValidator
         return self::$propertyNames[$shape] ?? [];
     }
 
+    /**
+     * The schema document, decoded once and reused by both {@see self::propertyNamesFor()} and
+     * {@see self::schemaFor()} — the latter needs `definitions` alongside the arm it wraps, so the
+     * two must agree on what "the schema" is.
+     */
+    private function raw(): \stdClass
+    {
+        if (null === self::$rawDocument) {
+            $decoded = json_decode((string) file_get_contents($this->schemaPath));
+            if (false === $decoded instanceof \stdClass || false === isset($decoded->definitions)) {
+                throw new \RuntimeException("WebSocket message schema at {$this->schemaPath} has no definitions.");
+            }
+            self::$rawDocument = $decoded;
+        }
+
+        return self::$rawDocument;
+    }
+
+    /**
+     * A schema scoped to exactly one published shape, imported once per shape and reused after
+     * that — {@see self::warm()} is what keeps importing off the per-message path.
+     *
+     * The arm is wrapped rather than validated as a bare `$ref`: several definitions `$ref` their
+     * siblings (`calendarIdentity`, `correlationId`), and a definition lifted out on its own takes
+     * its unresolvable pointers with it. Keeping `definitions` alongside preserves them. Same
+     * construction {@see \LiturgicalCalendar\Tests\Schemas\WebSocketMessageSchemaTest::testEachMessageMatchesExactlyOneArm()}
+     * uses to check the schema itself.
+     */
+    private function schemaFor(string $shape): Schema
+    {
+        if (false === isset(self::$shapeSchemas[$shape])) {
+            if (false === isset($this->raw()->definitions->{$shape})) {
+                throw new \RuntimeException("WebSocket message schema at {$this->schemaPath} has no definition for {$shape}.");
+            }
+
+            $armDocument = (object) [
+                '$schema'     => 'https://json-schema.org/draft-07/schema#',
+                'allOf'       => [(object) ['$ref' => '#/definitions/' . $shape]],
+                'definitions' => $this->raw()->definitions
+            ];
+
+            $imported = Schema::import($armDocument);
+            if (false === $imported instanceof Schema) {
+                throw new \RuntimeException("WebSocket message schema shape {$shape} could not be imported.");
+            }
+            self::$shapeSchemas[$shape] = $imported;
+        }
+
+        return self::$shapeSchemas[$shape];
+    }
+
     private function schema(): Schema
     {
-        if (null === self::$schema) {
+        if (null === self::$topLevelSchema) {
             $imported = Schema::import($this->schemaPath);
             if (false === $imported instanceof Schema) {
                 throw new \RuntimeException("WebSocket message schema at {$this->schemaPath} could not be imported.");
             }
-            self::$schema = $imported;
+            self::$topLevelSchema = $imported;
         }
 
-        return self::$schema;
+        return self::$topLevelSchema;
+    }
+
+    /**
+     * Strip the schema file's absolute filesystem path out of a validation-failure message before
+     * it reaches the client.
+     *
+     * `swaggest/json-schema` embeds the path a schema document was imported from inside `$ref[...]`
+     * trace segments of its own failure text. An unauthenticated WebSocket client — this validator
+     * runs ahead of any auth check, by design — has no business learning where on disk the server
+     * keeps its files. Scoping validation to one arm (see the class docblock) already removes most
+     * of the irrelevant trace text this could appear in; this removes what is left.
+     */
+    private function sanitize(string $message): string
+    {
+        return str_replace($this->schemaPath, basename($this->schemaPath), $message);
     }
 
     /**
@@ -144,18 +243,22 @@ final class WebSocketMessageValidator
      */
     public static function reset(): void
     {
-        self::$schema        = null;
-        self::$propertyNames = null;
+        self::$topLevelSchema = null;
+        self::$shapeSchemas   = [];
+        self::$propertyNames  = null;
+        self::$rawDocument    = null;
     }
 
     /**
-     * Import the schema now rather than on the first message. A server that cannot validate is
-     * misconfigured, and should fail where an operator sees it rather than answering every message
-     * with an internal error.
+     * Import every published shape now rather than on the first message that claims it. A server
+     * that cannot validate is misconfigured, and should fail where an operator sees it rather than
+     * answering every message with an internal error.
      */
     public function warm(): void
     {
-        $this->schema();
+        foreach (self::KNOWN_SHAPES as $shape) {
+            $this->schemaFor($shape);
+        }
         $this->propertyNamesFor('validateSource');
     }
 }

--- a/src/Services/WebSocketMessageValidator.php
+++ b/src/Services/WebSocketMessageValidator.php
@@ -31,6 +31,14 @@ use Swaggest\JsonSchema\Schema;
  * — a `runTest` with a bad `year` was, before this, told it was missing `executeValidation`'s
  * `sourceFolder`. Scoping the validated schema to the claimed arm means the failure text can only
  * ever be about that arm.
+ *
+ * **The failure text itself is rewritten before it reaches a client**, by {@see self::humanize()}:
+ * `swaggest/json-schema`'s own wording is kept — "Integer expected", "Enum failed" and so on are
+ * not reworded, which would put this class back in the business of maintaining a second vocabulary
+ * — but the internal `$ref`/`allOf`/`anyOf` trail that names *where* in the schema document the
+ * failure occurred is replaced with a dotted path built from the client's own vocabulary: the
+ * action it sent, plus the property names on its own message. `runTest.year: Integer expected, …`,
+ * not `… at #->allOf[0]->$ref[#/definitions/runTest]->properties:year`.
  */
 final class WebSocketMessageValidator
 {
@@ -91,7 +99,11 @@ final class WebSocketMessageValidator
                 $this->schema()->in($message);
             }
         } catch (\Throwable $e) {
-            return $this->sanitize($e->getMessage());
+            $action = ( null !== $shape && property_exists($message, 'action') && is_string($message->action) )
+                ? $message->action
+                : 'message';
+
+            return $this->humanize($this->sanitize($e->getMessage()), $action);
         }
 
         if (null === $shape || false === property_exists($message, 'requestId')) {
@@ -230,11 +242,71 @@ final class WebSocketMessageValidator
      * trace segments of its own failure text. An unauthenticated WebSocket client — this validator
      * runs ahead of any auth check, by design — has no business learning where on disk the server
      * keeps its files. Scoping validation to one arm (see the class docblock) already removes most
-     * of the irrelevant trace text this could appear in; this removes what is left.
+     * of the irrelevant trace text this could appear in, and {@see self::humanize()} removes the
+     * trace text itself; this stays as the backstop that guards the *class* of leak — a schema path
+     * reaching a client — rather than relying on either of those removing every route to it.
      */
     private function sanitize(string $message): string
     {
         return str_replace($this->schemaPath, basename($this->schemaPath), $message);
+    }
+
+    /**
+     * Turn a `swaggest/json-schema` failure into `<path>: <expectation>` — the client's own
+     * vocabulary, not the schema's internals.
+     *
+     * Two rules:
+     *
+     *  - **The path is prefixed with the action the client actually sent, never the internal
+     *    definition name.** A client that sent `action: "validateCalendar"` has no way to look up
+     *    `validateCalendarTyped` in the published schema's `oneOf` — that name exists only inside
+     *    this codebase and `WebSocketMessage.json`'s `definitions`, never on the wire.
+     *  - **Every `properties:<name>` segment of a trail becomes one dotted path component, in
+     *    order; `allOf`, `$ref` and `anyOf[n]` segments are dropped.** They describe how the schema
+     *    is assembled, not what is wrong with the client's data. A trail with no `properties:`
+     *    segment at all — a whole-message failure such as a missing required property — humanizes
+     *    to the action alone.
+     *
+     * A message may carry more than one trail (`oneOf`/`anyOf` failures report one per candidate
+     * branch); every trail is stripped, and the *last* one — always the outermost, closing one, by
+     * where `swaggest/json-schema` places it — supplies the path. A `data: {...}` clause whose value
+     * is a JSON *object* is also dropped: it is the library restating a chunk of the message the
+     * property path already names, most visibly for a root-level failure where it restates the
+     * entire message. A scalar `data: "widerregion"` clause is the offending value itself, and is
+     * kept — it is exactly what a client needs to see.
+     */
+    private function humanize(string $message, string $action): string
+    {
+        // `data: {…}` — braces may nest (e.g. the value is itself an object with its own object
+        // properties) — but never `data: [...]` or `data: "…"`/`data: 42`, which are the useful,
+        // short cases and are left alone.
+        $balancedObject = '(?P<bal>\{(?:[^{}]|(?P>bal))*\})';
+        $withoutEchoes  = (string) preg_replace('/,?\s*data:\s*' . $balancedObject . '/', '', $message);
+
+        $trailPattern = '/ at (#(?:->\S+)*)/';
+        preg_match_all($trailPattern, $withoutEchoes, $trails);
+        /** @var list<non-falsy-string> $trailList */
+        $trailList = $trails[1];
+        $path      = [] === $trailList ? $action : $this->pathFromTrail((string) end($trailList), $action);
+
+        $withoutTrails = (string) preg_replace($trailPattern, '', $withoutEchoes);
+
+        return $path . ': ' . trim($withoutTrails);
+    }
+
+    /**
+     * The dotted client-facing path a single trail names. See {@see self::humanize()}.
+     */
+    private function pathFromTrail(string $trail, string $action): string
+    {
+        $properties = [];
+        foreach (explode('->', $trail) as $segment) {
+            if (str_starts_with($segment, 'properties:')) {
+                $properties[] = substr($segment, strlen('properties:'));
+            }
+        }
+
+        return [] === $properties ? $action : $action . '.' . implode('.', $properties);
     }
 
     /**


### PR DESCRIPTION
Before this branch, several malformed WebSocket messages **terminated the `Health` process for every connected client** — on an endpoint with no authentication in front of it.

`validateMessageProperties()` checked that required keys *existed* and never what they were, and the dispatch unpacked them straight into typed parameters:

```php
$this->validateCalendar($m->calendar, $m->year, $m->category, $m->responsetype, ...);
//                       string        int       string        string
```

Ratchet's `IoServer::handleData` catches `\Exception`. `TypeError`, `ValueError` and `Error` are not `\Exception`, so they escaped and killed the daemon. Measured against `c38dbb97`:

| message                                                       | before                                     |
|---------------------------------------------------------------|--------------------------------------------|
| `validateCalendar` with `"year": "not-a-year"`                | `TypeError` — process dies                 |
| `validateCalendar` with `"category": []`                      | `TypeError` — process dies                 |
| `validateCalendar` with `"responsetype": "NOT_A_FORMAT"`      | `ValueError` — process dies                |
| `executeUnitTest` with `"test": {…}`                          | `TypeError` — process dies                 |
| `executeValidation` with `"category": {…}`                    | `Error` (the `(string)` cast) — dies       |
| `validateCalendar` with `"year": 1e30`                        | `TypeError` — process dies                 |
| `executeValidation` with a NUL byte in `sourceFile`           | `ValueError` — process dies                |

The split was not accidental: the three v1 actions crashed and the three v2 actions did not, because the v2 handlers were written after the hazard was understood. This branch applies that lesson everywhere instead of door by door.

## What it does

- **`jsondata/schemas/WebSocketMessage.json`** is now the published contract, transcribed from the `@phpstan-type` annotations PHPStan already enforces against the implementation — so annotation, code and contract agree by construction. `ACTION_PROPERTIES` and `validateMessageProperties()` are deleted rather than kept beside it.
- **Every inbound message is validated** against the single definition it claims to be, resolved by the discriminator the dispatch already used.
- **Refusals are typed:** `{"type":"protocolError","errorCode":"…","text":"…"}`. Nine codes, each existing only where a client would *act* differently — `INVALID_MESSAGE` deliberately covers every schema violation, because "wrong type", "unknown enum value" and "undeclared property" all mean *fix the message*.
- **Unknown-property rejection is gated on `requestId`**, the same v2 opt-in the terminal `complete` frame uses. The shipped client sends `runToken` on every message and spreads `rite` onto an `executeValidation` that never reads it — a uniform rule would have taken the test interface down on day one.
- **A `\Throwable` backstop** around the dispatch, because a process-wide crash must not depend on a schema file being correct.

## Compatibility

**No message the shipped UnitTestInterface sends stops working**, verified against that client's source at `9126ad9` rather than against this branch's own fixtures. Run tokens are `crypto.randomUUID()` and match the correlation pattern; every `category` and `responsetype` it sends is inside the enums; all ~20 `executeValidation` sites pair `category` with `sourceFile`/`sourceFolder` the way the schema requires. The client sends no `requestId` anywhere, so the strict gate is entirely dormant for it.

Two deliberate tightenings, both refusing things that already failed: `year` must be a JSON number (the client sends numbers), and `category` must be a known value. The one `executeValidation` combination now refused — `universalcalendar` + `sourceFolder` — is the one `wsProtocol.js`'s own docblock records as closing the connection today.

## Evidence

The final review fuzzed **4000 mutated messages** and 75 targeted vectors through `onMessage()`: **0 escapes**. Then it neutered the schema gate and re-ran 800 of them — **92 hit the `\Throwable` backstop**, proving both layers are load-bearing rather than one guard wearing two hats.

Every guard was mutation-checked: remove it, watch the named tests fail, restore.

Three defects were found by *probing the running code* rather than reading diffs, and all are fixed here:

- validation against the whole `oneOf` reported an **irrelevant arm** — a `runTest` was told it was missing `sourceFolder`;
- rejection text **leaked the server's absolute filesystem path** to unauthenticated clients;
- `humanize()` silently dropped the entire reason on messages over ~13 KB (PCRE JIT stack limit).

Rejection text is now `<action>.<property.path>: <expectation>`, built from the action the client sent rather than the internal definition name, with no path, no stack trace and no internal vocabulary. A test asserts no rejection text ever contains the project root.

## Not in scope

- **#823** — throws inside promise callbacks, after `onMessage()` has returned, which no `try` around the dispatch can see. Documented in the spec.
- **#827** — `Health`'s *success* frames still quote absolute schema paths. Same class of leak, byte-identical to before this branch, filed separately rather than mixed into a security fix.
- **#826** — a draft-2019-09+ validator would let the unknown-property gate move into the schema; the spec records why it is in PHP.

## Verification

`composer analyse` (PHPStan level 10) clean, `composer lint`, `composer lint:md`, `composer lint:openapi` clean. The eight directly affected suites are 203/203. Remaining `composer test:quick` failures in the worktree are the known environmental ones (`ApiTestCase` resolves the production host without `.env.local`; the WS suite talks to a container serving the main checkout) — CI runs `composer ws:start` from the branch, so those assertions meet their own server there.

Closes #806 (section G)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added strict validation for incoming WebSocket messages, including required fields, supported actions, value types, and message structure.
  * Added structured `protocolError` responses with machine-readable error codes and explanatory messages.
  * Preserved request and run identifiers in relevant responses.
  * Added clearer handling for invalid JSON, retired properties, unknown targets, malformed requests, and unexpected server errors.

* **Bug Fixes**
  * Prevented malformed or oversized messages from terminating processing.
  * Improved protection against exposing internal file paths or schema details in error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->