### PR TITLE
fix(health): the WebSocket server cannot start on development

### DIFF
--- a/phpunit_tests/HealthConstructionOrderTest.php
+++ b/phpunit_tests/HealthConstructionOrderTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `new Health()` must work with nothing initialised first, because that is what the entry point does.
+ *
+ * **This test exists because the suite could not see the bug it guards.** `Health::__construct()`
+ * builds a `WebSocketMessageValidator`, whose constructor resolves the message schema's path through
+ * `Router::$apiFilePath` — a *typed* static, so reading it before assignment is a fatal `Error`, not
+ * a null. `public/LitCalTestServer.php` calls `new Health()` without calling `Router::getApiPaths()`
+ * first; `Health::onOpen()` was where paths got initialised, on the first client connection. So the
+ * WebSocket server died at startup, every time, on a code path 447 in-process tests never touched.
+ *
+ * They never touched it because `phpunit_tests/bootstrap.php` initialises the paths before any test
+ * runs. Every test therefore constructs a `Health` in an order production never uses. A test written
+ * inside this process — however carefully — would assert against that initialised state and pass.
+ *
+ * Hence the subprocess. The fixture requires nothing but the autoloader, exactly as the entry point
+ * does, and this asserts it survives. It is the cheapest thing that could have caught the failure.
+ */
+#[CoversClass(Health::class)]
+final class HealthConstructionOrderTest extends TestCase
+{
+    public function testAHealthCanBeConstructedWithNothingInitialisedFirst(): void
+    {
+        $projectRoot = dirname(__DIR__);
+        $fixture     = $projectRoot . '/phpunit_tests/fixtures/construct-health-bare.php';
+        self::assertFileExists($fixture);
+
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process     = proc_open(
+            [PHP_BINARY, $fixture],
+            $descriptors,
+            $pipes,
+            $projectRoot
+        );
+        self::assertIsResource($process, 'could not start the subprocess');
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+        $exitCode = proc_close($process);
+
+        self::assertSame(
+            0,
+            $exitCode,
+            "constructing a Health in a bare process failed — this is what the WebSocket server does at startup:\n{$stderr}"
+        );
+        self::assertStringContainsString('CONSTRUCTED', $stdout);
+        self::assertStringNotContainsString(
+            'must not be accessed before initialization',
+            $stderr,
+            'a typed static was read before it was assigned; Health::__construct() resolves a path, so it must initialise the paths first'
+        );
+    }
+}

--- a/phpunit_tests/fixtures/construct-health-bare.php
+++ b/phpunit_tests/fixtures/construct-health-bare.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * Construct a Health the way the real entry point does: with nothing initialised beforehand.
+ *
+ * `public/LitCalTestServer.php` requires the autoloader and calls `new Health()` — it does not call
+ * `Router::getApiPaths()` first, and never did. PHPUnit's bootstrap *does*, long before any test
+ * builds a Health, so the two orders differ and only this one matches production.
+ *
+ * Run as its own process by {@see \LiturgicalCalendar\Tests\HealthConstructionOrderTest}. It lives
+ * under the project root rather than in a temp directory because `Router::getApiPaths()` locates the
+ * project by walking up from `$_SERVER['argv'][0]` looking for composer.json.
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+new \LiturgicalCalendar\Api\Health();
+
+echo 'CONSTRUCTED';

--- a/src/Health.php
+++ b/src/Health.php
@@ -295,6 +295,22 @@ class Health implements MessageComponentInterface
     {
         $this->clients = new \SplObjectStorage();
 
+        // Before anything that resolves a path. `Router::$apiFilePath` is a *typed* static, so
+        // reading it before assignment is a fatal `Error`, not a null — and the validator below
+        // resolves the message schema's path as it is constructed. `public/LitCalTestServer.php`
+        // calls `new Health()` with nothing initialised, so without this the WebSocket server dies
+        // at startup. No test caught it: PHPUnit's bootstrap initialises the paths long before any
+        // test builds a Health, so every test ran an order production never uses.
+        //
+        // **Guarded, and the guard is load-bearing.** Calling `getApiPaths()` unconditionally
+        // *overwrites* the path, and several tests deliberately point it at a fixture tree before
+        // building a Health — see `BrokenInventoryTrait`. Stomping that override made a passing
+        // suite fail. `isset()` on an uninitialised typed static is false and does not throw, which
+        // is exactly the "initialise only if nobody has" test needed here.
+        if (false === isset(Router::$apiFilePath)) {
+            Router::getApiPaths();
+        }
+
         // A server that cannot validate is misconfigured, and should fail here — where an operator
         // sees it, before a client ever connects — rather than answering every message with an
         // internal error. See {@see WebSocketMessageValidator::warm()}.


### PR DESCRIPTION
**`development` is broken right now: `public/LitCalTestServer.php` dies on startup, every time.**

```text
PHP Fatal error: Uncaught Error: Typed static property
LiturgicalCalendar\Api\Router::$apiFilePath must not be accessed before initialization
  in src/Enum/JsonData.php:476
#0 src/Enum/LitSchema.php(33):        JsonData->path()
#1 src/Services/WebSocketMessageValidator.php(82): LitSchema->path()
#2 src/Health.php(301):               WebSocketMessageValidator->__construct()
#3 public/LitCalTestServer.php(139):  Health->__construct()
```

`Health::__construct()` now builds a `WebSocketMessageValidator`, whose constructor resolves the message schema's path. `Router::$apiFilePath` is a **typed** static, so reading it before assignment is a fatal `Error` rather than a null. The entry point calls `new Health()` with nothing initialised — `Router::getApiPaths()` ran in `onOpen()`, on the first client *connection*, which is far too late.

Introduced by #828, which merged green.

## Why the whole suite missed it

`phpunit_tests/bootstrap.php` initialises the paths before any test runs. So all 447 in-process tests construct a `Health` in an order production never uses, and **no test written inside that process could have failed** — however carefully written. The failure lives in the gap between the harness's setup and the entry point's.

That is what `HealthConstructionOrderTest` addresses: it runs a fixture in a **subprocess** that requires nothing but the autoloader, exactly as the entry point does, and asserts it survives. Verified to reproduce the fatal with this fix reverted.

## The guard is load-bearing

The obvious fix — call `Router::getApiPaths()` in the constructor — **turned a green suite red.** `getApiPaths()` *overwrites* the path, and several tests deliberately point it at a fixture tree before building a `Health` (`BrokenInventoryTrait` is the documented case). `HealthValidateSourceTest` went from 18/18 to a failure.

So it is guarded:

```php
if (false === isset(Router::$apiFilePath)) {
    Router::getApiPaths();
}
```

`isset()` on an uninitialised typed static is `false` and does not throw — precisely the "initialise only if nobody has" test needed, and it leaves deliberate overrides alone. I found this by running the suite after the first attempt, not by reading the diff.

## Verification

- `HealthConstructionOrderTest` passes with the fix, **fails with it reverted** (the exact production fatal).
- `HealthValidateSourceTest` back to 18/18.
- `composer test:quick`: 2904 tests, **0 failures**. The 16 remaining errors are all `WebSocket/*` suites, which need a live server on `:8082` — currently down, because this bug is what prevents it starting. They pass in CI, which starts the server from the branch.
- `composer analyse` (PHPStan level 10) and `composer lint` clean.

## How it was found

By restarting the API container after merging #828, to pick up the new code — the WebSocket server is a long-running ReactPHP process, so unlike the `php -S` workers it does not re-read source on its own. It never came back up. That restart is the only reason this surfaced today rather than at the next deploy.

Refs #806, #828

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved health-check initialization when the application starts without prior setup.
  * Preserved existing configuration overrides while ensuring required routing information is available.
* **Tests**
  * Added coverage confirming health checks can be constructed in a clean process.
  * Added validation that startup completes successfully without initialization errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->