### PR TITLE
ops: capture the deploy sentinel units, and restart the WebSocket server on deploy

### DIFF
--- a/deploy/install.sh
+++ b/deploy/install.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Render the systemd templates against /etc/litcal-deploy.env and install everything.
+# Run as root on the deployment host, from a checkout of this repository:
+#
+#     sudo deploy/install.sh
+#
+# The templates in deploy/systemd/*.in carry placeholders, never real values — this
+# repository is public. The real paths, accounts and unit names live only in the
+# config file, which is not committed.
+set -eu
+
+CONFIG="${LITCAL_DEPLOY_ENV:-/etc/litcal-deploy.env}"
+SRC_DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+UNIT_DIR=/etc/systemd/system
+
+if [ ! -r "$CONFIG" ]; then
+  echo "error: $CONFIG missing. Copy deploy/litcal-deploy.env.example there and fill it in." >&2
+  exit 1
+fi
+# shellcheck source=/dev/null
+. "$CONFIG"
+
+for var in API_ROOT PHP_BIN RUN_USER RUN_GROUP FPM_UNIT WS_UNIT; do
+  eval "value=\${$var:-}"
+  if [ -z "$value" ]; then
+    echo "error: $var not set in $CONFIG" >&2
+    exit 1
+  fi
+done
+
+# One PathChanged= per app that is actually deployed here, so a host watching a
+# subset does not get a unit referring to directories it does not have.
+path_changed_lines=""
+for root in "$API_ROOT" "${FRONTEND_ROOT:-}" "${FRONTEND_STAGING_ROOT:-}" "${TESTS_ROOT:-}"; do
+  [ -n "$root" ] || continue
+  path_changed_lines="${path_changed_lines}PathChanged=${root}/tmp/restart.txt
+"
+done
+
+render() {
+  sed \
+    -e "s|@API_ROOT@|${API_ROOT}|g" \
+    -e "s|@PHP_BIN@|${PHP_BIN}|g" \
+    -e "s|@RUN_USER@|${RUN_USER}|g" \
+    -e "s|@RUN_GROUP@|${RUN_GROUP}|g" \
+    -e "/@PATH_CHANGED_LINES@/{r /dev/stdin
+d
+}" "$1"
+}
+
+echo "rendering units from $CONFIG"
+printf '%s' "$path_changed_lines" | render "${SRC_DIR}/systemd/litcal-fpm-reload.path.in" > "${UNIT_DIR}/litcal-fpm-reload.path"
+render "${SRC_DIR}/systemd/litcal-fpm-reload.service.in" < /dev/null > "${UNIT_DIR}/litcal-fpm-reload.service"
+render "${SRC_DIR}/systemd/litcal-websocket.service.in"  < /dev/null > "${UNIT_DIR}/litcal-websocket.service"
+chmod 0644 "${UNIT_DIR}/litcal-fpm-reload.path" "${UNIT_DIR}/litcal-fpm-reload.service" "${UNIT_DIR}/litcal-websocket.service"
+
+install -m 0755 -o root -g root "${SRC_DIR}/sbin/litcal-fpm-reload.sh" /usr/local/sbin/litcal-fpm-reload.sh
+
+systemctl daemon-reload
+systemctl enable --now litcal-fpm-reload.path "$WS_UNIT"
+
+echo "installed. verify with:"
+echo "  systemctl status litcal-fpm-reload.path"
+echo "  systemctl status $WS_UNIT"

--- a/deploy/litcal-deploy.env.example
+++ b/deploy/litcal-deploy.env.example
@@ -1,0 +1,31 @@
+# Host-specific deploy configuration. Copy to /etc/litcal-deploy.env on the server,
+# fill in the real values, and keep it OUT of the repository:
+#
+#     sudo install -m 0640 -o root -g root litcal-deploy.env.example /etc/litcal-deploy.env
+#     sudo editor /etc/litcal-deploy.env
+#
+# The values below are ILLUSTRATIVE. This repository is public, so no real path,
+# username or group belongs in it — the units and the reload script are templates
+# rendered against this file at install time, never committed with real values.
+# See docs/ops/deploy-sentinel-runbook.md.
+
+# Absolute path to the deployed API (the directory holding composer.json).
+API_ROOT=/srv/www/example.org/api
+
+# Absolute paths to the other deployed apps whose sentinels are watched.
+# Leave any of these empty to drop it from the watch list.
+FRONTEND_ROOT=/srv/www/example.org/frontend
+FRONTEND_STAGING_ROOT=/srv/www/example.org/frontend-staging
+TESTS_ROOT=/srv/www/tests.example.org
+
+# The PHP binary that runs the WebSocket server. Distribution PHP is /usr/bin/php;
+# a control panel may ship its own build under its own prefix.
+PHP_BIN=/usr/bin/php
+
+# The account the WebSocket server runs as.
+RUN_USER=www-data
+RUN_GROUP=www-data
+
+# systemd unit names. FPM_UNIT is whatever this host calls its PHP-FPM service.
+FPM_UNIT=php8.4-fpm
+WS_UNIT=litcal-websocket.service

--- a/deploy/sbin/litcal-fpm-reload.sh
+++ b/deploy/sbin/litcal-fpm-reload.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Installed at /usr/local/sbin/litcal-fpm-reload.sh (root:root, 0755).
+# Triggered by litcal-fpm-reload.path when a deploy drops <approot>/tmp/restart.txt.
+#
+# Every host-specific value — paths, unit names, accounts — is read from
+# /etc/litcal-deploy.env, which is NOT in the repository. This file is committed to a
+# public repo and must stay free of anything that describes a real deployment.
+#
+# Two jobs, because a deploy updates two kinds of thing:
+#
+#   1. php-fpm is graceful-reloaded, which recycles workers and busts the gettext .mo
+#      cache. One reload covers all pools, so it runs for any sentinel.
+#
+#   2. The WebSocket server is *restarted*, but only when the API sentinel fired. It
+#      is a long-running ReactPHP process: it loads src/ into memory once, at start,
+#      and never re-reads it. Without this, a deploy updates the REST API and leaves
+#      the WebSocket endpoint serving whatever it loaded at boot — indefinitely, since
+#      nothing else restarts it. Observed in the wild: a deployed API was ~25 hours
+#      newer than the running WebSocket process, so an entire protocol change was on
+#      disk and inert.
+#
+# Sentinels are removed only on success, so a failure retries on the next deploy.
+set -u
+
+CONFIG="${LITCAL_DEPLOY_ENV:-/etc/litcal-deploy.env}"
+if [ ! -r "$CONFIG" ]; then
+  logger -t litcal-fpm-reload "config $CONFIG missing or unreadable; refusing to guess"
+  exit 1
+fi
+# shellcheck source=/dev/null
+. "$CONFIG"
+
+: "${API_ROOT:?API_ROOT not set in $CONFIG}"
+: "${FPM_UNIT:?FPM_UNIT not set in $CONFIG}"
+: "${WS_UNIT:?WS_UNIT not set in $CONFIG}"
+
+API_SENTINEL="${API_ROOT}/tmp/restart.txt"
+
+# Every watched app, skipping any left unset so a host can watch a subset.
+SENTINELS="$API_SENTINEL"
+for root in "${FRONTEND_ROOT:-}" "${FRONTEND_STAGING_ROOT:-}" "${TESTS_ROOT:-}"; do
+  [ -n "$root" ] && SENTINELS="$SENTINELS ${root}/tmp/restart.txt"
+done
+
+# Whether the API sentinel is what fired. Read before the reload, because the reload
+# clears sentinels on success and this must not depend on that ordering.
+api_deployed=0
+if [ -f "$API_SENTINEL" ]; then
+  api_deployed=1
+fi
+
+logger -t litcal-fpm-reload "sentinel seen; reloading ${FPM_UNIT} (api=${api_deployed})"
+if ! systemctl reload "$FPM_UNIT"; then
+  logger -t litcal-fpm-reload "reload FAILED; sentinels kept for retry"
+  exit 1
+fi
+
+if [ "$api_deployed" -eq 1 ]; then
+  # Restart, not reload: there is no reload semantic for this process, and the point
+  # is to re-read src/ from disk. Connected clients are dropped, which is acceptable
+  # on a deploy — a run interrupted by one was going to be invalid anyway.
+  restarts_before="$(systemctl show "$WS_UNIT" -p NRestarts --value 2>/dev/null || echo 0)"
+
+  logger -t litcal-fpm-reload "api deployed; restarting ${WS_UNIT}"
+  if ! systemctl restart "$WS_UNIT"; then
+    logger -t litcal-fpm-reload "${WS_UNIT} restart FAILED; sentinels kept for retry"
+    exit 1
+  fi
+
+  # The unit is Restart=always, so a process that dies at startup does not report
+  # failure — it silently respawns every RestartSec until someone reads the journal.
+  # A merged change once made every start die; the service survived only because
+  # nothing restarted it. Wait past one restart interval and compare the counter, so a
+  # crash-loop is reported at deploy time rather than discovered days later.
+  sleep 8
+  restarts_after="$(systemctl show "$WS_UNIT" -p NRestarts --value 2>/dev/null || echo 0)"
+  if [ "$restarts_after" -gt "$restarts_before" ]; then
+    logger -t litcal-fpm-reload "${WS_UNIT} is CRASH-LOOPING after deploy (NRestarts ${restarts_before}->${restarts_after}); check: journalctl -u ${WS_UNIT} -n 50"
+    exit 1
+  fi
+  logger -t litcal-fpm-reload "${WS_UNIT} restarted and stable"
+fi
+
+rm -f $SENTINELS
+logger -t litcal-fpm-reload "reload OK; sentinels cleared"

--- a/deploy/systemd/litcal-fpm-reload.path.in
+++ b/deploy/systemd/litcal-fpm-reload.path.in
@@ -1,0 +1,15 @@
+# Template. Rendered by deploy/install.sh against /etc/litcal-deploy.env and
+# installed to /etc/systemd/system/litcal-fpm-reload.path.
+#
+# Watches the deploy sentinels. A deploy drops <approot>/tmp/restart.txt; this
+# triggers litcal-fpm-reload.service, which runs as root and can therefore do what
+# a chrooted deploy user cannot: reload php-fpm, and restart the WebSocket server.
+[Unit]
+Description=litcal: watch deploy sentinels to reload php-fpm and restart the WebSocket server
+
+[Path]
+@PATH_CHANGED_LINES@
+Unit=litcal-fpm-reload.service
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/systemd/litcal-fpm-reload.service.in
+++ b/deploy/systemd/litcal-fpm-reload.service.in
@@ -1,0 +1,9 @@
+# Template. Rendered by deploy/install.sh and installed to
+# /etc/systemd/system/litcal-fpm-reload.service. Triggered by
+# litcal-fpm-reload.path; see deploy/sbin/litcal-fpm-reload.sh.
+[Unit]
+Description=litcal: reload php-fpm and restart the WebSocket server on a deploy sentinel
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/litcal-fpm-reload.sh

--- a/deploy/systemd/litcal-websocket.service.in
+++ b/deploy/systemd/litcal-websocket.service.in
@@ -1,0 +1,26 @@
+# Template. Rendered by deploy/install.sh against /etc/litcal-deploy.env and
+# installed to /etc/systemd/system/litcal-websocket.service. Do not commit a
+# rendered copy: this repository is public and the real values are host-specific.
+#
+# This unit is NOT restarted by a deploy unless litcal-fpm-reload.sh does it. The
+# WebSocket server is a long-running ReactPHP process: it loads src/ into memory
+# once, at start, and never re-reads it. Pulling files updates the REST API (php-fpm
+# recycles workers) while leaving this process on the old code. See
+# docs/ops/deploy-sentinel-runbook.md.
+[Unit]
+Description=Liturgical Calendar WebSocket Server
+After=network.target
+
+[Service]
+Type=simple
+User=@RUN_USER@
+Group=@RUN_GROUP@
+WorkingDirectory=@API_ROOT@/public
+ExecStart=@PHP_BIN@ @API_ROOT@/public/LitCalTestServer.php
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ops/deploy-sentinel-runbook.md
+++ b/docs/ops/deploy-sentinel-runbook.md
@@ -1,0 +1,143 @@
+# Deploy sentinel: php-fpm reload and WebSocket restart
+
+How a deploy to `catholicdigitalcommons.org` takes effect, why it needs a root-owned
+helper, and the trap that made an entire protocol change land on disk and do nothing.
+
+## The problem it solves
+
+The deploy user is chrooted and cannot `sudo`. But two things have to happen at root
+after files land:
+
+- **php-fpm must be reloaded.** Workers cache compiled PHP and, more stubbornly, gettext
+  `.mo` translations. Without a reload, new translations do not appear.
+- **The WebSocket server must be restarted.** `public/LitCalTestServer.php` is a
+  long-running ReactPHP process. It loads `src/` into memory once, at start, and never
+  re-reads it.
+
+So the deploy drops a sentinel file and a root-owned systemd path unit does the rest.
+
+## The pieces
+
+| file                                       | installed at                                    | role                                    |
+|--------------------------------------------|-------------------------------------------------|-----------------------------------------|
+| `deploy/systemd/litcal-fpm-reload.path`    | `/etc/systemd/system/litcal-fpm-reload.path`    | watches the four sentinels              |
+| `deploy/systemd/litcal-fpm-reload.service` | `/etc/systemd/system/litcal-fpm-reload.service` | oneshot, runs the script                |
+| `deploy/sbin/litcal-fpm-reload.sh`         | `/usr/local/sbin/litcal-fpm-reload.sh`          | reloads php-fpm, restarts the WS server |
+| `deploy/systemd/litcal-websocket.service`  | `/etc/systemd/system/litcal-websocket.service`  | the WebSocket server itself             |
+
+The watched sentinels, one per deployed app:
+
+```text
+${FRONTEND_STAGING_ROOT}/tmp/restart.txt   frontend, staging
+${FRONTEND_ROOT}/tmp/restart.txt           frontend, production
+${API_ROOT}/tmp/restart.txt                the API  ← also restarts the WebSocket server
+${TESTS_ROOT}/tmp/restart.txt              the test interface
+```
+
+Those variables come from `/etc/litcal-deploy.env`, which is **not** in this repository.
+See "Configuration" below.
+
+## The trap: a deploy used to update the API and not the WebSocket endpoint
+
+Until 2026-08-21 the script only reloaded php-fpm. Nothing restarted
+`litcal-websocket.service` — not the deploy, not anything else — so it kept serving
+whatever it loaded at boot.
+
+Measured on 2026-08-21, before the fix:
+
+|                                  |                                             |
+|----------------------------------|---------------------------------------------|
+| `api/dev/src/Health.php` on disk | modified 07:33 UTC that morning             |
+| `litcal-websocket` process       | started 2026-08-20 06:31 UTC, `NRestarts=0` |
+
+The REST API was current and the WebSocket endpoint was **25 hours stale**. All of
+API#806 section G — a new message contract, schema validation, typed error frames — was
+on disk and inert. `git pull` genuinely deploys only half of any change that touches
+`src/Health.php`.
+
+The same shape bites locally: `composer start` re-reads source per request, `composer
+ws:start` does not. After changing `Health.php`, restart the WebSocket server or you are
+testing the old one.
+
+## What the script does now
+
+1. Records whether the **api/dev** sentinel is the one that fired, before doing anything
+   that clears sentinels.
+2. `systemctl reload plesk-php84-fpm` — for any sentinel. One reload covers all pools.
+3. If api/dev deployed: `systemctl restart litcal-websocket.service`.
+4. **Waits 8 seconds and compares `NRestarts`.** The unit is `Restart=always`, so a
+   process that dies at startup does not report failure — it respawns every 5 seconds
+   until somebody reads the journal. Comparing the counter turns a silent crash-loop
+   into a logged error at deploy time.
+5. Clears the sentinels only on success, so a failure retries on the next deploy.
+
+Step 4 exists because of a real near-miss. PR #828 introduced a fatal in
+`Health::__construct()` — the WebSocket server could not start at all. It stayed up only
+because nothing ever restarted it. Had a restart happened in that window, the unit would
+have crash-looped every 5 seconds indefinitely, with no failed state to alert on. #829
+fixed the fatal; this check is what would have caught it.
+
+## Configuration
+
+**This repository is public, so it contains no real path, account or unit name.** The
+units are templates (`deploy/systemd/*.in`) with `@PLACEHOLDER@` tokens, and the reload
+script reads everything from a config file that lives only on the host:
+
+```bash
+sudo install -m 0640 -o root -g root deploy/litcal-deploy.env.example /etc/litcal-deploy.env
+sudo editor /etc/litcal-deploy.env
+```
+
+It defines `API_ROOT`, the other app roots (any of which may be empty to drop it from the
+watch list), `PHP_BIN`, `RUN_USER`, `RUN_GROUP`, `FPM_UNIT` and `WS_UNIT`. The script
+refuses to run if the file is missing rather than guessing.
+
+Keeping the values out of the repository is the same rule the WebSocket frames now
+follow: #827 stripped the server's filesystem root from every frame precisely so an
+unauthenticated client could not learn the deployment layout. Committing that layout to a
+public repo would have handed it over by another route.
+
+## Installing or updating
+
+```bash
+sudo deploy/install.sh
+```
+
+`install.sh` renders `deploy/systemd/*.in` against `/etc/litcal-deploy.env`, writes the
+units, installs the script, and enables both units.
+
+## Verifying
+
+```bash
+systemctl status litcal-fpm-reload.path        # expect: active (waiting)
+systemctl status litcal-websocket.service      # expect: active (running)
+
+# Is the running process older than the code it is supposed to be running?
+systemctl show litcal-websocket -p ActiveEnterTimestamp -p NRestarts
+stat -c '%y %n' "$API_ROOT/src/Health.php"
+
+# Exercise the deploy path end to end
+touch "$API_ROOT/tmp/restart.txt"
+journalctl -t litcal-fpm-reload -n 20
+```
+
+A healthy API deploy logs: `sentinel seen … (api=1)`, `restarting
+litcal-websocket.service`, `restarted and stable`, `reload OK; sentinels cleared`.
+
+## Troubleshooting
+
+**`… is CRASH-LOOPING after deploy`** — the newly deployed code cannot construct a
+`Health`. `journalctl -u litcal-websocket -n 50` shows the fatal. The sentinel is kept,
+so the next deploy retries. Roll back or fix forward; the endpoint is down until then.
+
+**`reload FAILED; sentinels kept for retry`** — php-fpm did not reload; the WebSocket
+restart is skipped deliberately, since a broken deploy should not also drop connections.
+
+**Sentinel present but nothing in the journal** — the path unit is not running
+(`systemctl status litcal-fpm-reload.path`), or the deploy wrote to a path not in the
+watch list. `PathChanged` only fires on modification, so a sentinel left behind by an
+earlier failure does not retrigger until it is touched again.
+
+**The WebSocket endpoint answers, but with the old protocol** — the process is stale.
+Confirm with the timestamp check above, then `sudo systemctl restart litcal-websocket`.
+If a deploy should have done it, check `api=1` appeared in the log line.


### PR DESCRIPTION
Two things: the deploy mechanism on `catholicdigitalcommons.org` now lives in the repo, and it stops being half a deploy.

**Nothing here is applied to the server.** Installing is a documented manual step.

## The mechanism existed only on that host

Two systemd units, a root-owned shell script and a path watcher — reconstructible only by SSH archaeology. The deploy user is chrooted and cannot `sudo`, so a deploy drops `<approot>/tmp/restart.txt` and a root-owned path unit does the privileged part. That is a good design and it was written down nowhere.

Captured verbatim into `deploy/`, with header comments saying what each file is for, plus `docs/ops/deploy-sentinel-runbook.md`.

## It was only reloading php-fpm

The script did one thing: `systemctl reload plesk-php84-fpm`. Nothing restarted `litcal-websocket.service` — not the deploy, not anything else — so it kept serving whatever it loaded at boot.

Measured on the server, 2026-08-21:

| | |
|---------------------------------------|-----------------------------------------------|
| deployed `api/dev/src/Health.php` | modified **07:33 UTC** that morning |
| `litcal-websocket` process | started **2026-08-20 06:31 UTC**, `NRestarts=0` |

The REST API was current and the WebSocket endpoint was **25 hours stale**. All of API#806 section G — a new message contract, schema validation, typed error frames — was on disk and inert.

`public/LitCalTestServer.php` is a long-running ReactPHP process: it loads `src/` into memory once and never re-reads it. So `git pull` genuinely deploys only half of any change touching `src/Health.php`. The same shape bites locally — `composer start` re-reads source per request, `composer ws:start` does not.

## The crash-loop check is the part worth reviewing

The obvious change is "also restart the WebSocket unit". That alone would be a trap.

The unit is `Restart=always, RestartSec=5`, so a process that dies at startup **never reports failure** — it respawns every five seconds while the deploy reports success and `systemctl is-active` looks fine. PR #828 shipped exactly that fatal: `Health::__construct()` could not run at all. The service survived only because nothing ever restarted it, which is the same reason it was serving stale code.

So after restarting, the script waits past one restart interval and compares `NRestarts`. If it moved, the deploy fails loudly with the journal command to run:

```text
litcal-websocket.service is CRASH-LOOPING after deploy (NRestarts 0->2);
check: journalctl -u litcal-websocket.service -n 50
```

Two further deliberate choices:

- **The WebSocket restart is skipped if the php-fpm reload failed.** A broken deploy should not also drop live connections.
- **Whether the api/dev sentinel fired is recorded before the reload**, since the reload clears sentinels on success and this must not depend on that ordering.

## Verification

`sh -n` clean (POSIX `sh`, matching the shebang). `composer lint:md` clean. The script is not executed by CI — it needs root, systemd and that host — so the runbook carries an explicit end-to-end check instead: `touch` the sentinel, then read `journalctl -t litcal-fpm-reload`. A healthy api/dev deploy logs `sentinel seen … (api/dev=1)` → `restarting litcal-websocket.service` → `restarted and stable` → `reload OK; sentinels cleared`.

## After merging

The live endpoint is still stale until the unit is restarted once by hand — the new script only takes effect from the *next* deploy, and only after it is installed:

```bash
sudo install -m 0755 -o root -g root deploy/sbin/litcal-fpm-reload.sh /usr/local/sbin/litcal-fpm-reload.sh
sudo systemctl restart litcal-websocket
```

Refs #828, #829

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated service reloads following deployments.
  * Added WebSocket service management with automatic restart and crash-loop detection.
  * Deployment signals are cleared only after successful service recovery; failures remain eligible for retry.

* **Documentation**
  * Added operational guidance for configuring, verifying, and troubleshooting deployment-triggered reloads and WebSocket restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->