### PR TITLE
fix(health): stop WebSocket frames leaking the server's filesystem path

### DIFF
--- a/phpunit_tests/HealthFolderStepResultTest.php
+++ b/phpunit_tests/HealthFolderStepResultTest.php
@@ -248,7 +248,11 @@ final class HealthFolderStepResultTest extends TestCase
     {
         Router::getApiPaths();
 
-        $derived = strtr(JsonData::NATIONAL_CALENDAR_I18N_FOLDER->path(), ['{nation}' => 'ZZ']);
+        $derivedAbsolute = strtr(JsonData::NATIONAL_CALENDAR_I18N_FOLDER->path(), ['{nation}' => 'ZZ']);
+        // #827: a frame quotes the server-derived folder project-relative, never with the server's
+        // absolute filesystem root, so the assertion below has to match what actually reaches the
+        // wire rather than the raw JsonData::*->path() this is derived from.
+        $derived = substr($derivedAbsolute, strlen(Router::$apiFilePath));
 
         $conn   = self::createStubConnection(4);
         $health = $this->newHealth();
@@ -277,6 +281,11 @@ final class HealthFolderStepResultTest extends TestCase
                 $derived,
                 (string) $frame->text,
                 'and must report on the folder the server derived from the slug and actually read'
+            );
+            self::assertStringNotContainsString(
+                rtrim(Router::$apiFilePath, '/'),
+                (string) $frame->text,
+                'the frame must not leak the server filesystem root while reporting the derived folder (#827)'
             );
         }
     }

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
-use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
@@ -362,23 +361,25 @@ final class HealthProtocolValidationTest extends TestCase
      * Widens the guarantee above from *rejections* to **every** frame `Health` emits, success and
      * error alike (#827).
      *
-     * `Router::$apiFilePath` itself is not the right needle here: a `validateSource`/
-     * `executeValidation` frame legitimately quotes the *data* file path a client asked about (e.g.
-     * `jsondata/sourcedata/rite/roman/calendars/nations/IT/IT.json`, resolved against
-     * `Router::$apiFilePath` before it is read), and that is not a leak — it is the identity of the
-     * artifact the client asked to have checked, not an internal implementation detail. What must
-     * never appear is the **schema's** absolute path: the server picks the schema, the client never
-     * names it, and disclosing it serves only to map the deployment's directory layout. Every schema
-     * lives under `JsonData::SCHEMAS_FOLDER->path()`, so that prefix is the honest thing to assert
-     * against — it catches all four site shapes fixed by #827 (`LitSchema::*->name()`, `basename()`
-     * on a resolved `$schema`/`$pathForSchema` variable, and the `swaggest/json-schema` `$ref` trace
-     * sanitised in {@see Health::validateDataAgainstSchema()}) without being tripped up by the
-     * unrelated, in-scope data-path text.
+     * The needle is `rtrim(Router::$apiFilePath, '/')` — the same one the rejection test above
+     * uses — not a narrower prefix such as the schemas folder. A first pass at this test asserted
+     * only against `JsonData::SCHEMAS_FOLDER->path()`, which is exactly why it missed
+     * `validateSource`'s data-path frames: a v2 client sends only an opaque id
+     * (`{"target":{"id":"temporale:roman"}}`), never a path, so `runValidationSteps()` /
+     * `processValidationData()` quoting the server-resolved *absolute* path back at it is as much a
+     * leak as the schema paths this issue started from — nothing here is "the identity of the
+     * artifact the client asked to have checked" once the client never supplied a path at all. The
+     * fix ({@see Health::stripProjectRoot()}) makes every data path project-relative before a frame
+     * leaves the process, which is also correct for a v1 client that *did* supply a relative path
+     * (`jsondata/x.json`): the substitution is simply never found in it, so it passes through
+     * unchanged, and a v1 `resourceFile` URL is left alone the same way.
      *
-     * Four sites are driven for real, matching the four shapes #827 identified as interpolating a
-     * schema path into frame text:
+     * Five sites are driven for real:
      *
      *  - a successful source-file validation (`validateSource` on a single file);
+     *  - the exact fixture that regressed — `validateSource` on `temporale:roman` — pinned on its
+     *    own, since it is what caught this the first time and the general assertion below would not
+     *    by itself explain why this particular id matters;
      *  - a successful folder validation (`validateSource` on an i18n folder — a different branch of
      *    `runValidationSteps()` than the file case, and the one with two schema mentions per frame);
      *  - a schema-failure frame (`validateCalendar` against data that decodes but fails the LitCal
@@ -387,17 +388,17 @@ final class HealthProtocolValidationTest extends TestCase
      *  - a calendar validation that actually passes (`validateCalendar` against a fully schema-valid
      *    LitCal payload).
      */
-    public function testNoFrameEverLeaksTheSchemasAbsolutePath(): void
+    public function testNoFrameEverLeaksTheServerFilesystemPath(): void
     {
-        $schemasFolder = JsonData::SCHEMAS_FOLDER->path();
+        $root = rtrim(Router::$apiFilePath, '/');
 
-        $assertNoLeak = static function (array $frames, string $context) use ($schemasFolder): void {
+        $assertNoLeak = static function (array $frames, string $context) use ($root): void {
             self::assertNotEmpty($frames, "{$context}: expected at least one frame");
             foreach ($frames as $i => $frame) {
                 self::assertStringNotContainsString(
-                    $schemasFolder,
+                    $root,
                     (string) ( $frame->text ?? '' ),
-                    "{$context} frame #{$i} leaked the server's schemas folder path: {$frame->text}"
+                    "{$context} frame #{$i} leaked the server filesystem path: {$frame->text}"
                 );
             }
         };
@@ -409,6 +410,14 @@ final class HealthProtocolValidationTest extends TestCase
         ]));
         self::assertSame('success', $sourceFileFrames[2]->type, 'precondition: the source file is actually schema-valid');
         $assertNoLeak($sourceFileFrames, 'source-file validation');
+
+        // --- the exact regression fixture: an opaque id, no path anywhere in the message ------
+        $temporaleFrames = $this->frames((string) json_encode([
+            'action' => 'validateSource',
+            'target' => ['id' => 'temporale:roman'],
+        ]));
+        self::assertSame('success', $temporaleFrames[2]->type, 'precondition: the temporale source is actually schema-valid');
+        $assertNoLeak($temporaleFrames, 'validateSource temporale:roman (the id-only regression fixture)');
 
         // --- a successful folder validation --------------------------------------------------
         $folderFrames = $this->frames((string) json_encode([

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +33,15 @@ final class HealthProtocolValidationTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         Router::getApiPaths();
+        // Only the new tests below reach the inventory (via validateSource), but resetting it here
+        // keeps this class independent of whatever an earlier test class left memoized, the same
+        // reasoning HealthValidateSourceTest applies to itself.
+        CheckableInventory::reset();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        CheckableInventory::reset();
     }
 
     private static function createStubConnection(int $resourceId = 1)
@@ -344,6 +356,154 @@ final class HealthProtocolValidationTest extends TestCase
                 'a rejection leaked the server filesystem path'
             );
         }
+    }
+
+    /**
+     * Widens the guarantee above from *rejections* to **every** frame `Health` emits, success and
+     * error alike (#827).
+     *
+     * `Router::$apiFilePath` itself is not the right needle here: a `validateSource`/
+     * `executeValidation` frame legitimately quotes the *data* file path a client asked about (e.g.
+     * `jsondata/sourcedata/rite/roman/calendars/nations/IT/IT.json`, resolved against
+     * `Router::$apiFilePath` before it is read), and that is not a leak — it is the identity of the
+     * artifact the client asked to have checked, not an internal implementation detail. What must
+     * never appear is the **schema's** absolute path: the server picks the schema, the client never
+     * names it, and disclosing it serves only to map the deployment's directory layout. Every schema
+     * lives under `JsonData::SCHEMAS_FOLDER->path()`, so that prefix is the honest thing to assert
+     * against — it catches all four site shapes fixed by #827 (`LitSchema::*->name()`, `basename()`
+     * on a resolved `$schema`/`$pathForSchema` variable, and the `swaggest/json-schema` `$ref` trace
+     * sanitised in {@see Health::validateDataAgainstSchema()}) without being tripped up by the
+     * unrelated, in-scope data-path text.
+     *
+     * Four sites are driven for real, matching the four shapes #827 identified as interpolating a
+     * schema path into frame text:
+     *
+     *  - a successful source-file validation (`validateSource` on a single file);
+     *  - a successful folder validation (`validateSource` on an i18n folder — a different branch of
+     *    `runValidationSteps()` than the file case, and the one with two schema mentions per frame);
+     *  - a schema-failure frame (`validateCalendar` against data that decodes but fails the LitCal
+     *    schema, exercising the `swaggest/json-schema` error text rather than the hand-written
+     *    success sentence); and
+     *  - a calendar validation that actually passes (`validateCalendar` against a fully schema-valid
+     *    LitCal payload).
+     */
+    public function testNoFrameEverLeaksTheSchemasAbsolutePath(): void
+    {
+        $schemasFolder = JsonData::SCHEMAS_FOLDER->path();
+
+        $assertNoLeak = static function (array $frames, string $context) use ($schemasFolder): void {
+            self::assertNotEmpty($frames, "{$context}: expected at least one frame");
+            foreach ($frames as $i => $frame) {
+                self::assertStringNotContainsString(
+                    $schemasFolder,
+                    (string) ( $frame->text ?? '' ),
+                    "{$context} frame #{$i} leaked the server's schemas folder path: {$frame->text}"
+                );
+            }
+        };
+
+        // --- a successful source-file validation --------------------------------------------
+        $sourceFileFrames = $this->frames((string) json_encode([
+            'action' => 'validateSource',
+            'target' => ['id' => 'nation:roman:IT'],
+        ]));
+        self::assertSame('success', $sourceFileFrames[2]->type, 'precondition: the source file is actually schema-valid');
+        $assertNoLeak($sourceFileFrames, 'source-file validation');
+
+        // --- a successful folder validation --------------------------------------------------
+        $folderFrames = $this->frames((string) json_encode([
+            'action' => 'validateSource',
+            'target' => ['id' => 'nation:roman:US:i18n'],
+        ]));
+        self::assertSame('success', $folderFrames[2]->type, 'precondition: the i18n folder is actually schema-valid');
+        $assertNoLeak($folderFrames, 'folder validation');
+
+        // --- a schema-failure frame -------------------------------------------------------------
+        // A decodable-but-invalid LitCal body: passes the exists/parses steps, then fails schema
+        // validation and returns the swaggest/json-schema error text this issue also had to sanitise.
+        $failConn = self::createStubConnection();
+        $health   = $this->newHealth();
+        $health->onMessage($failConn, (string) json_encode([
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON',
+        ]));
+        $queued = ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+        self::assertCount(1, $queued, 'precondition: one calendar fetch queued');
+        /** @var array{resolve: \Closure(\Psr\Http\Message\ResponseInterface):void} $entry */
+        $entry = $queued[0];
+        ( $entry['resolve'] )(new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            (string) json_encode(['litcal' => [], 'settings' => [], 'metadata' => [], 'messages' => []])
+        ));
+        $failFrames      = array_map(
+            static fn (string $raw): \stdClass => json_decode($raw),
+            $failConn->sent
+        );
+        $schemaFailFrame = array_values(array_filter($failFrames, static fn (\stdClass $f): bool => 'error' === $f->type))[0] ?? null;
+        self::assertNotNull($schemaFailFrame, 'precondition: the empty settings/metadata objects actually fail schema validation');
+        $assertNoLeak($failFrames, 'calendar schema-failure');
+
+        // --- a calendar validation that passes -------------------------------------------------
+        $passConn = self::createStubConnection();
+        $health2  = $this->newHealth();
+        $health2->onMessage($passConn, (string) json_encode([
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON',
+        ]));
+        $queued2 = ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health2);
+        self::assertCount(1, $queued2, 'precondition: one calendar fetch queued');
+        /** @var array{resolve: \Closure(\Psr\Http\Message\ResponseInterface):void} $entry2 */
+        $entry2 = $queued2[0];
+        ( $entry2['resolve'] )(new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            (string) json_encode([
+                'litcal'   => [],
+                'settings' => [
+                    'year'                   => 2026,
+                    'year_type'              => 'CIVIL',
+                    'epiphany'               => 'JAN6',
+                    'ascension'              => 'THURSDAY',
+                    'corpus_christi'         => 'THURSDAY',
+                    'locale'                 => 'en_US',
+                    'return_type'            => 'JSON',
+                    'eternal_high_priest'    => true,
+                    'holydays_of_obligation' => new \stdClass(),
+                    'rite'                   => 'roman',
+                ],
+                'metadata' => [
+                    'version'                   => '1.0',
+                    'request_headers'           => new \stdClass(),
+                    'solemnities_lord_bvm'      => [],
+                    'solemnities_lord_bvm_keys' => [],
+                    'solemnities'               => [],
+                    'solemnities_keys'          => [],
+                    'feasts_lord'               => [],
+                    'feasts_lord_keys'          => [],
+                    'feasts'                    => [],
+                    'feasts_keys'               => [],
+                    'memorials'                 => [],
+                    'memorials_keys'            => [],
+                ],
+                'messages' => [],
+            ])
+        ));
+        $passFrames         = array_map(
+            static fn (string $raw): \stdClass => json_decode($raw),
+            $passConn->sent
+        );
+        $validatesPassFrame = array_values(array_filter(
+            $passFrames,
+            static fn (\stdClass $f): bool => 'success' === $f->type
+                && str_contains((string) ( $f->text ?? '' ), 'successfully validated against the Schema')
+        ))[0] ?? null;
+        self::assertNotNull($validatesPassFrame, 'precondition: the fully-populated payload actually passes schema validation');
+        $assertNoLeak($passFrames, 'calendar validation success');
     }
 
     /**

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -29,6 +29,12 @@ final class HealthProtocolValidationTest extends TestCase
 {
     use HealthQueueIsolationTrait;
 
+    /**
+     * A folder created under the project root for the leak probe, so the path the read failure
+     * reports actually begins with `Router::$apiFilePath` and the stripping has something to do.
+     */
+    private const LEAK_PROBE_FOLDER = 'jsondata/sourcedata/.leak-probe';
+
     public static function setUpBeforeClass(): void
     {
         Router::getApiPaths();
@@ -392,14 +398,31 @@ final class HealthProtocolValidationTest extends TestCase
     {
         $root = rtrim(Router::$apiFilePath, '/');
 
+        // Both halves of the frame, because `stripProjectRoot()` sanitises both. Checking only
+        // `text` would leave the `details` half of the fix unfalsifiable — remove it from
+        // production and this test would still pass — and `details` is where a path is most
+        // likely to appear: a folder check puts one per offending file there, and a schema
+        // failure carries the validator's own message.
         $assertNoLeak = static function (array $frames, string $context) use ($root): void {
             self::assertNotEmpty($frames, "{$context}: expected at least one frame");
             foreach ($frames as $i => $frame) {
                 self::assertStringNotContainsString(
                     $root,
                     (string) ( $frame->text ?? '' ),
-                    "{$context} frame #{$i} leaked the server filesystem path: {$frame->text}"
+                    "{$context} frame #{$i} leaked the server filesystem path in text: {$frame->text}"
                 );
+
+                $details = $frame->details ?? [];
+                if (false === is_array($details)) {
+                    continue;
+                }
+                foreach ($details as $j => $detail) {
+                    self::assertStringNotContainsString(
+                        $root,
+                        (string) $detail,
+                        "{$context} frame #{$i} leaked the server filesystem path in details[{$j}]: " . ( (string) $detail )
+                    );
+                }
             }
         };
 
@@ -410,6 +433,31 @@ final class HealthProtocolValidationTest extends TestCase
         ]));
         self::assertSame('success', $sourceFileFrames[2]->type, 'precondition: the source file is actually schema-valid');
         $assertNoLeak($sourceFileFrames, 'source-file validation');
+
+        // --- a folder check whose file cannot be read: the one path that puts an absolute
+        // --- path into `details` rather than `text`, and therefore the only thing that makes
+        // --- the details half of the assertion above capable of failing.
+        //
+        // `runValidationSteps()`'s folder branch collects "unreadable i18n json file {name}: "
+        // followed by the read's own message, which is "Unable to read file: {absolute path}".
+        // A *directory* named like an i18n file is matched by the `*.json` glob and refused by
+        // the `is_file()` check added for #822, so this reproduces it without depending on
+        // permissions — `chmod 000` is a no-op when the suite runs as root, as it does in CI.
+        $probeDir = Router::$apiFilePath . self::LEAK_PROBE_FOLDER;
+        self::assertTrue(mkdir($probeDir . '/it.json', 0777, true), 'could not build the unreadable-file fixture');
+        try {
+            $unreadableFrames = $this->frames((string) json_encode([
+                'action'       => 'executeValidation',
+                'category'     => 'sourceDataCheck',
+                'validate'     => 'leak-probe',
+                'sourceFolder' => self::LEAK_PROBE_FOLDER,
+            ]));
+            self::assertNotEmpty($unreadableFrames[0]->details ?? [], 'precondition: this arm must put the read failure in details');
+            $assertNoLeak($unreadableFrames, 'folder check with an unreadable file (details carries the path)');
+        } finally {
+            @rmdir($probeDir . '/it.json');
+            @rmdir($probeDir);
+        }
 
         // --- the exact regression fixture: an opaque id, no path anywhere in the message ------
         $temporaleFrames = $this->frames((string) json_encode([

--- a/phpunit_tests/HealthRiteSourcePathTest.php
+++ b/phpunit_tests/HealthRiteSourcePathTest.php
@@ -220,25 +220,32 @@ final class HealthRiteSourcePathTest extends TestCase
      */
     public function testAnAmbrosianDioceseDerivesItsI18nFolderFromTheAmbrosianTemplate(): void
     {
-        $expected = strtr(JsonData::AMBROSIAN_DIOCESAN_CALENDAR_I18N_FOLDER->path(), [
+        $expectedAbsolute = strtr(JsonData::AMBROSIAN_DIOCESAN_CALENDAR_I18N_FOLDER->path(), [
             '{nation}'  => 'ZZ',
             '{diocese}' => 'nowher_zz'
         ]);
+        // #827: the frame quotes the derived folder project-relative, never with the server's
+        // absolute filesystem root.
+        $expected = substr($expectedAbsolute, strlen(Router::$apiFilePath));
 
         $conn = self::runI18nFolderCheck([self::diocese('nowher_zz', 'Nowhere', 'ZZ', Rite::AMBROSIAN)], 'nowher_zz');
 
         self::assertCount(3, $conn->sent);
         foreach (self::decode($conn) as $frame) {
             self::assertStringContainsString($expected, (string) $frame->text);
+            self::assertStringNotContainsString(rtrim(Router::$apiFilePath, '/'), (string) $frame->text);
         }
     }
 
     public function testARomanDioceseDerivesItsI18nFolderFromTheRomanTemplate(): void
     {
-        $expected = strtr(JsonData::DIOCESAN_CALENDAR_I18N_FOLDER->path(), [
+        $expectedAbsolute = strtr(JsonData::DIOCESAN_CALENDAR_I18N_FOLDER->path(), [
             '{nation}'  => 'ZZ',
             '{diocese}' => 'nowher_zz'
         ]);
+        // #827: the frame quotes the derived folder project-relative, never with the server's
+        // absolute filesystem root.
+        $expected = substr($expectedAbsolute, strlen(Router::$apiFilePath));
 
         $conn = self::runI18nFolderCheck([self::diocese('nowher_zz', 'Nowhere', 'ZZ', Rite::ROMAN)], 'nowher_zz');
 
@@ -246,6 +253,7 @@ final class HealthRiteSourcePathTest extends TestCase
         foreach (self::decode($conn) as $frame) {
             self::assertStringContainsString($expected, (string) $frame->text);
             self::assertStringNotContainsString(JsonData::AMBROSIAN_DIOCESAN_CALENDARS_FOLDER->value, (string) $frame->text);
+            self::assertStringNotContainsString(rtrim(Router::$apiFilePath, '/'), (string) $frame->text);
         }
     }
 

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -283,8 +283,6 @@ final class HealthValidateSourceTest extends TestCase
         self::assertIsString($legacySchema, "the legacy slug {$slug} resolves to no schema at all");
         // The frame quotes the schema's file name, never the server's absolute filesystem path
         // (#827): compare against basename(), and assert the resolved schema path itself is absent.
-        // (The data-file path is a separate, out-of-scope concern — see HealthProtocolValidationTest
-        // ::testNoFrameLeaksAnAbsoluteSchemaPath for the file-agnostic version of this guarantee.)
         self::assertStringContainsString(
             basename($legacySchema),
             (string) $frames[2]->text,
@@ -295,6 +293,17 @@ final class HealthValidateSourceTest extends TestCase
             (string) $frames[2]->text,
             "{$id}'s schema-valid frame leaked the server's absolute schema path"
         );
+        // Nor does any frame leak the server's filesystem root through the *data* path it quotes —
+        // see HealthProtocolValidationTest::testNoFrameEverLeaksTheServerFilesystemPath for the
+        // dedicated regression coverage (this id resolves through CheckableInventory to an absolute
+        // path, so it is exercised for real here too, not just asserted in the abstract).
+        foreach ($frames as $frame) {
+            self::assertStringNotContainsString(
+                rtrim(Router::$apiFilePath, '/'),
+                (string) $frame->text,
+                "{$id}'s frame leaked the server filesystem path: {$frame->text}"
+            );
+        }
     }
 
     // ---------------------------------------------------------------- rejections

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -281,10 +281,19 @@ final class HealthValidateSourceTest extends TestCase
 
         $legacySchema = self::retrieveSchemaForCategory('sourceDataCheck', $slug);
         self::assertIsString($legacySchema, "the legacy slug {$slug} resolves to no schema at all");
+        // The frame quotes the schema's file name, never the server's absolute filesystem path
+        // (#827): compare against basename(), and assert the resolved schema path itself is absent.
+        // (The data-file path is a separate, out-of-scope concern — see HealthProtocolValidationTest
+        // ::testNoFrameLeaksAnAbsoluteSchemaPath for the file-agnostic version of this guarantee.)
         self::assertStringContainsString(
-            $legacySchema,
+            basename($legacySchema),
             (string) $frames[2]->text,
             "{$id} was validated against a different schema than {$slug} resolves to"
+        );
+        self::assertStringNotContainsString(
+            $legacySchema,
+            (string) $frames[2]->text,
+            "{$id}'s schema-valid frame leaked the server's absolute schema path"
         );
     }
 

--- a/src/Enum/LitSchema.php
+++ b/src/Enum/LitSchema.php
@@ -33,6 +33,18 @@ enum LitSchema: string
         return JsonData::SCHEMAS_FOLDER->path() . $this->value;
     }
 
+    /**
+     * The schema's file name, e.g. `LitCal.json`, without the server's absolute
+     * filesystem path. Use this (rather than {@see self::path()}) anywhere the schema
+     * is named in text that reaches an unauthenticated client, such as a WebSocket
+     * validation frame — {@see self::path()} would otherwise leak the deployment's
+     * directory layout.
+     */
+    public function name(): string
+    {
+        return ltrim($this->value, '/');
+    }
+
     public function error(): string
     {
         $ERRMSG = 'Schema validation error: ';

--- a/src/Health.php
+++ b/src/Health.php
@@ -835,11 +835,49 @@ class Health implements MessageComponentInterface
         if ($msg instanceof \stdClass && null !== $requestId) {
             $msg->requestId = $requestId;
         }
+        if ($msg instanceof \stdClass) {
+            self::stripProjectRoot($msg);
+        }
         if (gettype($msg) !== 'string') {
             $msg = json_encode($msg, JSON_PRETTY_PRINT);
         }
         /** @var string $msg */
         $from->send($msg);
+    }
+
+    /**
+     * Make an absolute filesystem path project-relative, wherever one appears in a frame's `text`
+     * or `details`, immediately before the frame leaves the process (#827).
+     *
+     * Every frame funnels through {@see Health::sendMessage()} — the 5 direct callers cover every
+     * `send*StepResult()`/`sendComplete()`/`rejectMessage()` in the class — so this is the one place
+     * the substitution needs to happen, rather than at each of the ~30 sites that build frame text. A
+     * per-site fix is exactly what let this leak reappear: #806 section G sanitised the same class of
+     * leak on the rejection path, and it resurfaced, unrelated, on `validateSource`'s result frames.
+     * A choke point cannot be bypassed by a new frame added elsewhere in this class.
+     *
+     * A v1 client-supplied data path (`jsondata/x.json`) is already project-relative, so the
+     * replacement is never found in it and it passes through unchanged. A v2 server-resolved
+     * absolute path (from `CheckableInventory`, `JsonData::*->path()`, or `LitSchema::*->path()`)
+     * becomes project-relative the same way: meaningful and stable across deployments, without
+     * disclosing where this one keeps its files. A URL is untouched for the same reason a relative
+     * path is: `Router::$apiFilePath` is not a substring of either.
+     */
+    private static function stripProjectRoot(\stdClass $msg): void
+    {
+        $root = Router::$apiFilePath;
+        if ('' === $root) {
+            return;
+        }
+        if (property_exists($msg, 'text') && is_string($msg->text)) {
+            $msg->text = str_replace($root, '', $msg->text);
+        }
+        if (property_exists($msg, 'details') && is_array($msg->details)) {
+            $msg->details = array_map(
+                static fn (mixed $detail): mixed => is_string($detail) ? str_replace($root, '', $detail) : $detail,
+                $msg->details
+            );
+        }
     }
 
     /**

--- a/src/Health.php
+++ b/src/Health.php
@@ -1595,6 +1595,9 @@ class Health implements MessageComponentInterface
                     // Exactly one frame per step, pass or fail. A folder check is a statement
                     // about the folder, so a failure names the offending files inside a single
                     // frame instead of emitting one frame each.
+                    // $schema is the server-resolved absolute path to the schema file; only its
+                    // name is fit to reach the client (see LitSchema::name()).
+                    $schemaName = null !== $schema ? basename($schema) : $schema;
                     $this->sendFolderStepResult(
                         $to,
                         $classFragment,
@@ -1625,8 +1628,8 @@ class Health implements MessageComponentInterface
                         $target,
                         Step::VALIDATES,
                         $schemaErrors,
-                        "The i18n json files in Data folder $sourceFolder were successfully validated against the Schema $schema",
-                        "The i18n json files in Data folder $sourceFolder were not all valid against the Schema $schema",
+                        "The i18n json files in Data folder $sourceFolder were successfully validated against the Schema $schemaName",
+                        "The i18n json files in Data folder $sourceFolder were not all valid against the Schema $schemaName",
                         $runToken,
                         requestId: $requestId
                     );
@@ -1937,7 +1940,7 @@ class Health implements MessageComponentInterface
                         $target,
                         Step::VALIDATES,
                         Status::PASS,
-                        "The Data file $dataPath was successfully validated against the Schema $schema",
+                        "The Data file $dataPath was successfully validated against the Schema " . basename($schema),
                         null,
                         $runToken,
                         requestId: $requestId
@@ -1971,7 +1974,7 @@ class Health implements MessageComponentInterface
                     $target,
                     Step::VALIDATES,
                     Status::FAIL,
-                    "executeValidation validation->sourceFile (JSON): Unable to detect schema for dataPath {$dataPath} and category {$category} (path for schema: $pathForSchema, Route::CALENDARS->path(): " . Route::CALENDARS->path() . ', LitSchema::METADATA->path(): ' . LitSchema::METADATA->path() . ')',
+                    "executeValidation validation->sourceFile (JSON): Unable to detect schema for dataPath {$dataPath} and category {$category} (path for schema: $pathForSchema, Route::CALENDARS->path(): " . Route::CALENDARS->path() . ', LitSchema::METADATA->name(): ' . LitSchema::METADATA->name() . ')',
                     null,
                     $runToken,
                     requestId: $requestId
@@ -2601,7 +2604,8 @@ class Health implements MessageComponentInterface
                             );
 
                             // Always validate against schema (even for cached responses) since this is a test endpoint
-                            $validationResult = $xml->schemaValidate(JsonData::SCHEMAS_FOLDER->path() . '/LiturgicalCalendar.xsd');
+                            $xsdPath          = JsonData::SCHEMAS_FOLDER->path() . '/LiturgicalCalendar.xsd';
+                            $validationResult = $xml->schemaValidate($xsdPath);
                             if ($validationResult) {
                                 $this->sendCalendarStepResult(
                                     $to,
@@ -2611,7 +2615,7 @@ class Health implements MessageComponentInterface
                                     Status::PASS,
                                     sprintf(
                                         "The $category of $calendar for the year $year was successfully validated against the Schema %s%s",
-                                        JsonData::SCHEMAS_FOLDER->path() . '/LiturgicalCalendar.xsd',
+                                        basename($xsdPath),
                                         $fromCache ? ' (cached)' : ''
                                     ),
                                     runToken: $runToken,
@@ -2734,7 +2738,7 @@ class Health implements MessageComponentInterface
                                     $year,
                                     Step::VALIDATES,
                                     Status::PASS,
-                                    "The $category of $calendar for the year $year was successfully validated against the Schema " . LitSchema::LITCAL->path() . $cachedNote,
+                                    "The $category of $calendar for the year $year was successfully validated against the Schema " . LitSchema::LITCAL->name() . $cachedNote,
                                     runToken: $runToken,
                                     requestId: $requestId
                                 );
@@ -2823,7 +2827,7 @@ class Health implements MessageComponentInterface
                                 $year,
                                 Step::VALIDATES,
                                 Status::PASS,
-                                "The $category of $calendar for the year $year was successfully validated against the Schema " . LitSchema::LITCAL->path() . $cachedNote,
+                                "The $category of $calendar for the year $year was successfully validated against the Schema " . LitSchema::LITCAL->name() . $cachedNote,
                                 runToken: $runToken,
                                 requestId: $requestId
                             );
@@ -3109,7 +3113,13 @@ class Health implements MessageComponentInterface
             $litSchema     = LitSchema::fromURL($schemaUrl);
             $message       = new \stdClass();
             $message->type = 'error';
-            $message->text = $litSchema->error() . PHP_EOL . $e->getMessage();
+            // `swaggest/json-schema` embeds the absolute path it imported $schemaUrl from inside
+            // every `$ref[...]` trace segment for the top-level schema (nested `$ref`s to other
+            // schema files stay relative, e.g. `./CommonDef.json`, so this one substitution is
+            // sufficient). An unauthenticated client has no business learning the server's
+            // filesystem layout, hence the same backstop {@see WebSocketMessageValidator::sanitize()}
+            // applies on the rejection path (#806 section G) — see #827.
+            $message->text = $litSchema->error() . PHP_EOL . str_replace($schemaUrl, basename($schemaUrl), $e->getMessage());
             return $message;
         }
         return $res;


### PR DESCRIPTION
Closes #827.

`Health`'s frames sent the server's absolute filesystem path to any client on an unauthenticated WebSocket:

```text
… was successfully validated against the Schema /home/…/jsondata/schemas/LitCal.json
```

## Two layers, because there were two sources

**1. Schema paths → schema names** (`d3e579be`). Eight interpolation sites, one of them found empirically while building the required schema-failure test: `validateDataAgainstSchema()`'s `swaggest/json-schema` error text embeds the schema's absolute import path in its `$ref[...]` trace. That is the same leak API#806 section G already closed on the *rejection* path — it was still open on the success path.

**2. Data paths → project-relative** (`f709b734`). The first layer was not enough, and the residual is the interesting part. A v2 `validateSource` sends **only an opaque id** and got back three frames carrying the absolute root, because the *data* path was resolved by the server from the inventory:

```text
{"action":"validateSource","target":{"id":"temporale:roman"}}
→ The Data file /home/…/LCAPI-827/jsondata/sourcedata/rite/roman/…/propriumdetempore.json exists
```

The rule that separates a leak from a useful diagnostic: **echo what the client gave you, not what you resolved.** A v1 `executeValidation` that sent `sourceFile: "jsondata/x.json"` should still see it. So rather than tracking provenance, `stripProjectRoot()` removes `Router::$apiFilePath` from `text` and from every string in `details` — correct for both cases with one transform. The result is *better* than a redaction:

```text
The Data file jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json exists
```

Stable across hosts, meaningful to a client, disclosing nothing.

## One choke point, not eight patches

`stripProjectRoot()` lives in `Health::sendMessage()`. Review verified that claim rather than accepting it: `grep -n '\->send(' src/Health.php` returns exactly one hit, inside `sendMessage()` itself, and every emitter funnels through it. This leak has now surfaced twice in different frame families, so the fix belongs where a future frame type cannot bypass it.

## Three tests were asserting the leak as correct behaviour

That is why section G's narrower guard did not catch this. `HealthFolderStepResultTest` and two `HealthRiteSourcePathTest` cases each asserted an absolute path was present verbatim. All three now assert the project-relative form **and** add `assertStringNotContainsString(rtrim(Router::$apiFilePath, '/'), …)` — strictly more assertions over strictly more behaviour, not a failing test made to pass.

The section G guard is widened accordingly: from "no *rejection* text contains the root" to **no frame `Health` emits, of any kind, contains it** — renamed `testNoFrameEverLeaksTheServerFilesystemPath`, with the `temporale:roman` regression fixture pinned explicitly.

## Verification

Independent review probed 6 end-to-end scenarios and 7 direct edge cases: client-supplied relative paths echoed verbatim, `resourceDataCheck` URLs byte-identical, non-path `details` untouched, terminal frames and malformed shapes handled without error. `Route::*->path()` was confirmed to be a **URL**, never a filesystem path, so those interpolations are correctly untouched — which also corrects #827's text, where I wrote that one site leaked two absolute paths; it leaks one, alongside a URL.

Cost measured at **1.37 µs per frame** (200k calls in 274 ms) — negligible against WebSocket I/O.

459 tests / 2654 assertions in the Health and schema suites, PHPStan level 10 clean, phpcs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed server filesystem paths from health and validation messages.
  * Validation results now display safe, project-relative filenames instead of absolute paths.
  * Improved protection across source, calendar, folder, file, and schema validation responses.

* **Tests**
  * Added coverage confirming outgoing frames never expose the server’s filesystem location.
  * Updated path assertions to match the safer relative-path format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->