### PR TITLE
fix(health): a URL check must not report `exists` for a 4xx or 5xx

### DIFF
--- a/phpunit_tests/HealthHelpersTest.php
+++ b/phpunit_tests/HealthHelpersTest.php
@@ -14,13 +14,15 @@ use Psr\Http\Message\ResponseInterface;
 use React\Promise\Deferred;
 
 /**
- * Targeted coverage for two pure static helpers on the WebSocket Health component:
+ * Targeted coverage for pure static helpers on the WebSocket Health component:
  *  - isInternalApiUrl(): the host check that keeps the first-party WS_API_KEY from leaking to an
  *    arbitrary absolute URL validated via executeValidation.
- *  - isUpstreamFailureStatus(): which upstream HTTP statuses (429, 5xx) are rejected versus flowed
- *    through to per-format validation (e.g. a 404 for an unknown calendar).
+ *  - isUpstreamFailureStatus(): which upstream HTTP statuses (429, 5xx) are kept out of the cache
+ *    (#834) versus eligible for it (e.g. a 400 or 404, cached like any other response). All statuses
+ *    resolve and are reported through the same `exists` gate — this helper no longer decides who
+ *    rejects, only who gets cached.
  *
- * Both are dependency-free of the Ratchet/Guzzle machinery, so they are exercised directly via
+ * All are dependency-free of the Ratchet/Guzzle machinery, so they are exercised directly via
  * reflection without standing up the WebSocket server.
  */
 #[CoversClass(Health::class)]
@@ -135,7 +137,7 @@ final class HealthHelpersTest extends TestCase
      */
     private static function runHandleHttpResponse(ResponseInterface $response): array
     {
-        /** @var Deferred<array{data: string, status: int, fromCache: bool}> $deferred */
+        /** @var Deferred<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $deferred */
         $deferred = new Deferred();
         $resolved = null;
         $rejected = null;
@@ -159,31 +161,40 @@ final class HealthHelpersTest extends TestCase
         return ['resolved' => $resolved, 'rejected' => $rejected];
     }
 
-    public function testHandleHttpResponseRejectsRateLimited(): void
+    /**
+     * #834 revised this: a 429 used to be rejected on its own, separately from every other non-2xx.
+     * That carve-out existed because a 429's problem+json body "decodes fine but lacks the calendar
+     * keys," which the JSON-shape branch would otherwise mislabel as "response data was perhaps
+     * truncated?" — but every consumer now gates on {@see Health::isHttpSuccessStatus()} *before* any
+     * JSON-shape check runs, so that mislabelling can no longer happen regardless of how this method
+     * settles. A 429 now resolves like any other refusal, with its status on the resolved value and
+     * its `Retry-After` hint carried alongside it rather than only visible on a rejection's message.
+     */
+    public function testHandleHttpResponseResolvesRateLimitedWithStatusAndRetryAfter(): void
     {
         $response = new Response(429, ['Retry-After' => '30'], '{"status":429}', '1.1', 'Too Many Requests');
         $result   = self::runHandleHttpResponse($response);
 
-        $this->assertNull($result['resolved']);
-        $rejected = $result['rejected'];
-        if (!$rejected instanceof \RuntimeException) {
-            self::fail('Expected a RuntimeException rejection.');
-        }
-        $this->assertStringContainsString('HTTP 429', $rejected->getMessage());
-        $this->assertStringContainsString('Retry-After: 30', $rejected->getMessage());
+        $this->assertNull($result['rejected'], 'a 429 must resolve, not reject, like every other non-2xx');
+        $this->assertSame(
+            ['data' => '{"status":429}', 'status' => 429, 'fromCache' => false, 'retryAfter' => '30'],
+            $result['resolved']
+        );
     }
 
-    public function testHandleHttpResponseRejectsServerError(): void
+    /**
+     * A 5xx resolves the same way, with no `Retry-After` when the response carried none.
+     */
+    public function testHandleHttpResponseResolvesServerErrorWithStatus(): void
     {
         $response = new Response(503, [], 'service unavailable', '1.1', 'Service Unavailable');
         $result   = self::runHandleHttpResponse($response);
 
-        $this->assertNull($result['resolved']);
-        $rejected = $result['rejected'];
-        if (!$rejected instanceof \RuntimeException) {
-            self::fail('Expected a RuntimeException rejection.');
-        }
-        $this->assertStringContainsString('HTTP 503', $rejected->getMessage());
+        $this->assertNull($result['rejected']);
+        $this->assertSame(
+            ['data' => 'service unavailable', 'status' => 503, 'fromCache' => false, 'retryAfter' => null],
+            $result['resolved']
+        );
     }
 
     public function testHandleHttpResponseResolvesSuccessBody(): void
@@ -192,7 +203,7 @@ final class HealthHelpersTest extends TestCase
         $result = self::runHandleHttpResponse(new Response(200, [], $body));
 
         $this->assertNull($result['rejected']);
-        $this->assertSame(['data' => $body, 'status' => 200, 'fromCache' => false], $result['resolved']);
+        $this->assertSame(['data' => $body, 'status' => 200, 'fromCache' => false, 'retryAfter' => null], $result['resolved']);
     }
 
     /**
@@ -209,13 +220,13 @@ final class HealthHelpersTest extends TestCase
         $result = self::runHandleHttpResponse(new Response(404, [], $body, '1.1', 'Not Found'));
 
         $this->assertNull($result['rejected']);
-        $this->assertSame(['data' => $body, 'status' => 404, 'fromCache' => false], $result['resolved']);
+        $this->assertSame(['data' => $body, 'status' => 404, 'fromCache' => false, 'retryAfter' => null], $result['resolved']);
     }
 
     /**
      * The RFC 9110 rite-boundary refusal #833 was filed about: a 400 whose body is a problem
-     * document. It is not an upstream failure (only 429/5xx are), so it resolves rather than rejects
-     * — and the whole point of #833 is that the status on that resolution must be the real one.
+     * document. It is not an upstream failure (only 429/5xx are), so its body is still eligible for
+     * caching — and the whole point of #833 is that the status on that resolution must be the real one.
      */
     public function testHandleHttpResponseResolvesBadRequestWithItsStatus(): void
     {
@@ -223,7 +234,7 @@ final class HealthHelpersTest extends TestCase
         $result = self::runHandleHttpResponse(new Response(400, [], $body, '1.1', 'Bad Request'));
 
         $this->assertNull($result['rejected']);
-        $this->assertSame(['data' => $body, 'status' => 400, 'fromCache' => false], $result['resolved']);
+        $this->assertSame(['data' => $body, 'status' => 400, 'fromCache' => false, 'retryAfter' => null], $result['resolved']);
     }
 
     // ---------------------------------------------------------------- the cached-path trap (#833)

--- a/phpunit_tests/HealthHelpersTest.php
+++ b/phpunit_tests/HealthHelpersTest.php
@@ -135,7 +135,7 @@ final class HealthHelpersTest extends TestCase
      */
     private static function runHandleHttpResponse(ResponseInterface $response): array
     {
-        /** @var Deferred<array{data: string, fromCache: bool}> $deferred */
+        /** @var Deferred<array{data: string, status: int, fromCache: bool}> $deferred */
         $deferred = new Deferred();
         $resolved = null;
         $rejected = null;
@@ -192,9 +192,15 @@ final class HealthHelpersTest extends TestCase
         $result = self::runHandleHttpResponse(new Response(200, [], $body));
 
         $this->assertNull($result['rejected']);
-        $this->assertSame(['data' => $body, 'fromCache' => false], $result['resolved']);
+        $this->assertSame(['data' => $body, 'status' => 200, 'fromCache' => false], $result['resolved']);
     }
 
+    /**
+     * The status is on the resolved value, not just in a log line (#833): `'http_errors' => false` on
+     * the Guzzle client means a 4xx/5xx resolves this promise rather than rejecting it, so a consumer
+     * gating `exists` on success has nothing else to look at. Before #833, this resolved value carried
+     * only `data` and `fromCache` — a 404's body flowed through indistinguishably from a 200's.
+     */
     public function testHandleHttpResponseResolvesNonFailureErrorBody(): void
     {
         // A 404 (unknown calendar) is not an upstream failure: its body flows through so the
@@ -203,7 +209,84 @@ final class HealthHelpersTest extends TestCase
         $result = self::runHandleHttpResponse(new Response(404, [], $body, '1.1', 'Not Found'));
 
         $this->assertNull($result['rejected']);
-        $this->assertSame(['data' => $body, 'fromCache' => false], $result['resolved']);
+        $this->assertSame(['data' => $body, 'status' => 404, 'fromCache' => false], $result['resolved']);
+    }
+
+    /**
+     * The RFC 9110 rite-boundary refusal #833 was filed about: a 400 whose body is a problem
+     * document. It is not an upstream failure (only 429/5xx are), so it resolves rather than rejects
+     * — and the whole point of #833 is that the status on that resolution must be the real one.
+     */
+    public function testHandleHttpResponseResolvesBadRequestWithItsStatus(): void
+    {
+        $body   = '{"type":"…rfc9110#name-400-bad-request","title":"Bad Request","status":400,"detail":"The Ambrosian rite is only available from 1976 onward (the first reformed Ambrosian Missal); requested year 1970."}';
+        $result = self::runHandleHttpResponse(new Response(400, [], $body, '1.1', 'Bad Request'));
+
+        $this->assertNull($result['rejected']);
+        $this->assertSame(['data' => $body, 'status' => 400, 'fromCache' => false], $result['resolved']);
+    }
+
+    // ---------------------------------------------------------------- the cached-path trap (#833)
+
+    /**
+     * `cachedGet()`'s cache-hit branch resolves from whatever {@see Health::decodeHttpCacheEntry()}
+     * hands back, which is whatever {@see Health::encodeHttpCacheEntry()} wrote — extracted out of
+     * `handleHttpResponse()` and `cachedGet()` respectively so this round trip is testable without a
+     * real cache backend and without driving the ReactPHP loop `cachedGet()` schedules resolution
+     * through.
+     *
+     * This is the trap the issue is about: a 400 that survives to a *second* request only if the
+     * status written to the cache is the status read back from it. Before #833 there was no status in
+     * the cached entry at all — a cache hit always meant `fromCache: true` and nothing else, so a
+     * refused request that got cached (as 4xx already were, per the comment on the non-upstream-failure
+     * branch below `isUpstreamFailureStatus()`) would replay as a pass on every request after the first.
+     */
+    public function testCacheEntryRoundTripsTheRealStatusNotJustTheBody(): void
+    {
+        $body = '{"status":400,"detail":"The Ambrosian rite is only available from 1976 onward; requested year 1970."}';
+
+        $encodeMethod = new \ReflectionMethod(Health::class, 'encodeHttpCacheEntry');
+        $encoded      = $encodeMethod->invoke(null, 400, $body);
+        self::assertIsString($encoded, 'precondition: a JSON-safe body encodes');
+
+        $decodeMethod = new \ReflectionMethod(Health::class, 'decodeHttpCacheEntry');
+        /** @var array{status: int, body: string}|null $decoded */
+        $decoded = $decodeMethod->invoke(null, $encoded);
+
+        self::assertSame(['status' => 400, 'body' => $body], $decoded, 'the second resolution must see the same status the first one did, not a silent 200');
+    }
+
+    /**
+     * A 200 round-trips too — the codec is not special-cased to success or failure, only to the shape.
+     */
+    public function testCacheEntryRoundTripsA200Status(): void
+    {
+        $body = '{"litcal":[],"settings":{},"metadata":{},"messages":[]}';
+
+        $encodeMethod = new \ReflectionMethod(Health::class, 'encodeHttpCacheEntry');
+        $encoded      = $encodeMethod->invoke(null, 200, $body);
+        self::assertIsString($encoded);
+
+        $decodeMethod = new \ReflectionMethod(Health::class, 'decodeHttpCacheEntry');
+        /** @var array{status: int, body: string}|null $decoded */
+        $decoded = $decodeMethod->invoke(null, $encoded);
+
+        self::assertSame(['status' => 200, 'body' => $body], $decoded);
+    }
+
+    /**
+     * A cache entry that is not the `{"status":…,"body":…}` envelope — the shape every entry had
+     * *before* #833 — must not be guessed at. Defaulting a bare body to status 200 would silently
+     * reintroduce the exact bug #833 fixed, the moment a pre-fix cache entry outlived a deploy: decode
+     * treats it as absent instead, which sends the caller back to `reject()` and a real re-fetch.
+     */
+    public function testDecodeRejectsAPreFixBareBodyCacheEntryRatherThanGuessingAStatus(): void
+    {
+        $decodeMethod = new \ReflectionMethod(Health::class, 'decodeHttpCacheEntry');
+
+        self::assertNull($decodeMethod->invoke(null, '{"litcal":[],"settings":{},"metadata":{},"messages":[]}'), 'a bare JSON body, with no envelope, must not decode to a guessed status');
+        self::assertNull($decodeMethod->invoke(null, 'not json at all'), 'garbage must not decode either');
+        self::assertNull($decodeMethod->invoke(null, '{"status":"400","body":"x"}'), 'a non-integer status must not decode');
     }
 
     /**

--- a/phpunit_tests/HealthHttpStatusExistsTest.php
+++ b/phpunit_tests/HealthHttpStatusExistsTest.php
@@ -332,4 +332,115 @@ final class HealthHttpStatusExistsTest extends TestCase
             $frames[0]->text
         );
     }
+
+    // ---------------------------------------------------------------- #834 review round 1
+
+    /**
+     * F2: a 429 is no longer rejected on its own — it reaches the same `exists` gate as every other
+     * non-2xx, and its `Retry-After` hint is folded into the failure text rather than only visible on
+     * a rejection's exception message (which nothing downstream of `cachedGet()` ever saw again).
+     */
+    public function testARateLimitedCalendarFailsExistsAndCarriesTheRetryAfterHint(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON',
+            'requestId'      => 'req-alpha'
+        ]);
+
+        $queued = self::queuedRequests($health);
+        self::assertCount(1, $queued);
+        /** @var \Closure(ResponseInterface):void $resolve */
+        $resolve = $queued[0]['resolve'];
+        ob_start();
+        $resolve(new Response(429, ['Retry-After' => '30'], '{"type":"about:blank","status":429,"title":"Too Many Requests"}', '1.1', 'Too Many Requests'));
+        ob_end_clean();
+
+        $frames = self::framesOf($conn);
+        self::assertSame('fail', $frames[0]->status, 'a 429 must not pass exists, same as any other non-2xx');
+        self::assertStringContainsString('HTTP 429', $frames[0]->text);
+        self::assertStringContainsString('Retry-After: 30', $frames[0]->text, 'the hint must survive the move off the rejection path');
+    }
+
+    /**
+     * F1: `cachedGet()`'s cache-hit branch must treat an entry it cannot decode as a miss, not as a
+     * rejection. A rejection there would fail every check whose cache entry predates a deploy — the
+     * bare-body shape every entry had before #833 is exactly that shape — for the whole of its TTL,
+     * which is the false-failure mirror of the bug #833 fixes, introduced by the fix itself.
+     *
+     * Driven through the real `cachedGet()` against a real (if minimal) APCu-shaped backend — see
+     * `phpunit_tests/Support/ApcuShim.php` — rather than reasoning about the control flow, because
+     * "it falls through" is exactly the kind of claim that is easy to get wrong by inspection alone.
+     */
+    public function testAMalformedLegacyCacheEntryFallsThroughToALiveRequestRatherThanFailing(): void
+    {
+        require_once __DIR__ . '/Support/ApcuShim.php';
+
+        $health  = $this->newHealth();
+        $url     = 'https://example.test/calendar/nation/IT/2026';
+        $options = [];
+
+        $cacheEnabledProp = new \ReflectionProperty(Health::class, 'cacheEnabled');
+        $cacheBackendProp = new \ReflectionProperty(Health::class, 'cacheBackend');
+        $enabledBefore    = $cacheEnabledProp->getValue();
+        $backendBefore    = $cacheBackendProp->getValue();
+        $cacheEnabledProp->setValue(null, true);
+        $cacheBackendProp->setValue(null, 'apcu');
+
+        $key = 'http_' . md5($url . serialize($options));
+
+        try {
+            // The bare-body shape every entry had before #833: no {"status":…,"body":…} envelope.
+            apcu_store($key, '{"litcal":[],"settings":{},"metadata":{},"messages":[]}', 300);
+            self::assertTrue(apcu_exists($key), 'precondition: the stale entry is actually in the cache');
+
+            $cachedGet = new \ReflectionMethod(Health::class, 'cachedGet');
+            ob_start();
+            /** @var \React\Promise\PromiseInterface<array<string, mixed>> $promise */
+            $promise = $cachedGet->invoke($health, $url, $options, 300, null);
+            ob_end_clean();
+
+            $resolved = null;
+            $rejected = null;
+            $promise->then(
+                function (mixed $value) use (&$resolved): void {
+                    $resolved = $value;
+                },
+                function (\Throwable $e) use (&$rejected): void {
+                    $rejected = $e;
+                }
+            );
+
+            self::assertNull($rejected, 'F1: a malformed cache entry must not surface as a rejection');
+            self::assertNull($resolved, 'nothing has answered yet — a live request should have been queued instead of a synchronous answer');
+
+            $queue = ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+            self::assertCount(1, $queue, 'the malformed entry must fall through to a live request being queued, not dead-end at rejection');
+            self::assertSame($url, $queue[0]['url']);
+
+            self::assertFalse(apcu_exists($key), 'the stale entry must be deleted, not left to reject the next request too');
+
+            // Prove the round trip actually completes: fulfilling the queued request resolves the
+            // very promise cachedGet() returned, exactly as an uncached first request would.
+            /** @var \Closure(ResponseInterface):void $resolve */
+            $resolve = $queue[0]['resolve'];
+            ob_start();
+            $resolve(new Response(200, [], '{"litcal":[]}'));
+            ob_end_clean();
+
+            self::assertNull($rejected);
+            self::assertIsArray($resolved);
+            self::assertSame(200, $resolved['status'] ?? null, 'the check must succeed on the live re-fetch, not stay broken');
+            self::assertFalse($resolved['fromCache'] ?? null);
+        } finally {
+            $cacheEnabledProp->setValue(null, $enabledBefore);
+            $cacheBackendProp->setValue(null, $backendBefore);
+            apcu_delete($key);
+        }
+    }
 }

--- a/phpunit_tests/HealthHttpStatusExistsTest.php
+++ b/phpunit_tests/HealthHttpStatusExistsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\ApcuShimStore;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
@@ -396,8 +397,8 @@ final class HealthHttpStatusExistsTest extends TestCase
 
         try {
             // The bare-body shape every entry had before #833: no {"status":…,"body":…} envelope.
-            apcu_store($key, '{"litcal":[],"settings":{},"metadata":{},"messages":[]}', 300);
-            self::assertTrue(apcu_exists($key), 'precondition: the stale entry is actually in the cache');
+            ApcuShimStore::store($key, '{"litcal":[],"settings":{},"metadata":{},"messages":[]}', 300);
+            self::assertTrue(ApcuShimStore::exists($key), 'precondition: the stale entry is actually in the cache');
 
             $cachedGet = new \ReflectionMethod(Health::class, 'cachedGet');
             ob_start();
@@ -423,7 +424,7 @@ final class HealthHttpStatusExistsTest extends TestCase
             self::assertCount(1, $queue, 'the malformed entry must fall through to a live request being queued, not dead-end at rejection');
             self::assertSame($url, $queue[0]['url']);
 
-            self::assertFalse(apcu_exists($key), 'the stale entry must be deleted, not left to reject the next request too');
+            self::assertFalse(ApcuShimStore::exists($key), 'the stale entry must be deleted, not left to reject the next request too');
 
             // Prove the round trip actually completes: fulfilling the queued request resolves the
             // very promise cachedGet() returned, exactly as an uncached first request would.
@@ -440,7 +441,7 @@ final class HealthHttpStatusExistsTest extends TestCase
         } finally {
             $cacheEnabledProp->setValue(null, $enabledBefore);
             $cacheBackendProp->setValue(null, $backendBefore);
-            apcu_delete($key);
+            ApcuShimStore::delete($key);
         }
     }
 
@@ -471,8 +472,8 @@ final class HealthHttpStatusExistsTest extends TestCase
 
         try {
             // Well-formed envelope, impossible status.
-            apcu_store($key, (string) json_encode(['status' => 0, 'body' => '{"litcal":[]}']), 300);
-            self::assertTrue(apcu_exists($key), 'precondition: the corrupt entry is actually in the cache');
+            ApcuShimStore::store($key, (string) json_encode(['status' => 0, 'body' => '{"litcal":[]}']), 300);
+            self::assertTrue(ApcuShimStore::exists($key), 'precondition: the corrupt entry is actually in the cache');
 
             $cachedGet = new \ReflectionMethod(Health::class, 'cachedGet');
             ob_start();
@@ -497,9 +498,9 @@ final class HealthHttpStatusExistsTest extends TestCase
             $queue = ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
             self::assertCount(1, $queue, 'an out-of-range status must fall through to a live request');
             self::assertSame($url, $queue[0]['url']);
-            self::assertFalse(apcu_exists($key), 'the corrupt entry must be deleted, not left to be re-read');
+            self::assertFalse(ApcuShimStore::exists($key), 'the corrupt entry must be deleted, not left to be re-read');
         } finally {
-            apcu_delete($key);
+            ApcuShimStore::delete($key);
             $cacheEnabledProp->setValue(null, $enabledBefore);
             $cacheBackendProp->setValue(null, $backendBefore);
         }

--- a/phpunit_tests/HealthHttpStatusExistsTest.php
+++ b/phpunit_tests/HealthHttpStatusExistsTest.php
@@ -443,4 +443,65 @@ final class HealthHttpStatusExistsTest extends TestCase
             apcu_delete($key);
         }
     }
+
+    /**
+     * A cached status outside the range HTTP defines is a corrupt entry, not a refusal.
+     *
+     * `is_int()` alone accepts `0`, `-1` and `99999`, and any of those would reach the `exists`
+     * gate as "not a 2xx" and fail a check that may be perfectly healthy — the same false failure
+     * the malformed-entry fall-through exists to prevent, arriving through a weaker type check
+     * rather than a missing one. Range-validating turns it back into a miss.
+     */
+    public function testACachedStatusOutsideTheHttpRangeIsAMissRatherThanARefusal(): void
+    {
+        require_once __DIR__ . '/Support/ApcuShim.php';
+
+        $health  = $this->newHealth();
+        $url     = 'https://example.test/calendar/nation/IT/2027';
+        $options = [];
+
+        $cacheEnabledProp = new \ReflectionProperty(Health::class, 'cacheEnabled');
+        $cacheBackendProp = new \ReflectionProperty(Health::class, 'cacheBackend');
+        $enabledBefore    = $cacheEnabledProp->getValue();
+        $backendBefore    = $cacheBackendProp->getValue();
+        $cacheEnabledProp->setValue(null, true);
+        $cacheBackendProp->setValue(null, 'apcu');
+
+        $key = 'http_' . md5($url . serialize($options));
+
+        try {
+            // Well-formed envelope, impossible status.
+            apcu_store($key, (string) json_encode(['status' => 0, 'body' => '{"litcal":[]}']), 300);
+            self::assertTrue(apcu_exists($key), 'precondition: the corrupt entry is actually in the cache');
+
+            $cachedGet = new \ReflectionMethod(Health::class, 'cachedGet');
+            ob_start();
+            /** @var \React\Promise\PromiseInterface<array<string, mixed>> $promise */
+            $promise = $cachedGet->invoke($health, $url, $options, 300, null);
+            ob_end_clean();
+
+            $rejected = null;
+            $resolved = null;
+            $promise->then(
+                function (mixed $value) use (&$resolved): void {
+                    $resolved = $value;
+                },
+                function (\Throwable $e) use (&$rejected): void {
+                    $rejected = $e;
+                }
+            );
+
+            self::assertNull($rejected, 'a corrupt cached status must not surface as a rejection');
+            self::assertNull($resolved, 'nor as a synchronous answer carrying the impossible status');
+
+            $queue = ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+            self::assertCount(1, $queue, 'an out-of-range status must fall through to a live request');
+            self::assertSame($url, $queue[0]['url']);
+            self::assertFalse(apcu_exists($key), 'the corrupt entry must be deleted, not left to be re-read');
+        } finally {
+            apcu_delete($key);
+            $cacheEnabledProp->setValue(null, $enabledBefore);
+            $cacheBackendProp->setValue(null, $backendBefore);
+        }
+    }
 }

--- a/phpunit_tests/HealthHttpStatusExistsTest.php
+++ b/phpunit_tests/HealthHttpStatusExistsTest.php
@@ -1,0 +1,335 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * #833: a URL-based check must not report `exists = success` for a non-2xx HTTP status.
+ *
+ * `Health`'s Guzzle client is built with `'http_errors' => false`, so a 4xx or 5xx resolves
+ * {@see Health::cachedGet()}'s promise instead of rejecting it, and before this fix the status was
+ * discarded entirely: every consumer's fulfil handler had nothing to check and reported `exists` as
+ * passed unconditionally. Observed live on Ambrosian years 1970-1975, which the API correctly refuses
+ * with a 400 whose body is an RFC 9457 problem document explaining exactly why — none of it reached
+ * the client.
+ *
+ * Every arm here drives {@see Health::onMessage()} end-to-end and settles the queued HTTP request by
+ * hand, exactly as {@see HealthTerminalFrameTest} does — nothing here drives the ReactPHP loop.
+ *
+ * @see HealthHelpersTest for the codec-level coverage of the cached-path trap (point 2 of the issue):
+ *      {@see Health::encodeHttpCacheEntry()} and {@see Health::decodeHttpCacheEntry()} are unit-tested
+ *      there without a real cache backend, since the status only survives a second run if the value
+ *      written to the cache on the first one can be decoded back correctly.
+ */
+#[CoversClass(Health::class)]
+final class HealthHttpStatusExistsTest extends TestCase
+{
+    use HealthQueueIsolationTrait;
+
+    /** The exact 400 the issue quotes, refusing an Ambrosian year before the rite's lower bound. */
+    private const AMBROSIAN_400_BODY = '{"type":"https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request","title":"Bad Request","status":400,"detail":"The Ambrosian rite is only available from 1976 onward (the first reformed Ambrosian Missal); requested year 1970."}';
+
+    /** A 404 with no problem-document `detail`, so the fallback-to-bare-status wording is exercised too. */
+    private const PLAIN_404_BODY = '{"type":"about:blank","status":404}';
+
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+        CheckableInventory::reset();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        CheckableInventory::reset();
+    }
+
+    private ?string $appEnvBackup = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Keeps handleHttpResponse() out of its development-only debug-logging branch.
+        $this->appEnvBackup = isset($_ENV['APP_ENV']) && is_string($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : null;
+        $_ENV['APP_ENV']    = 'test';
+    }
+
+    protected function tearDown(): void
+    {
+        if (null === $this->appEnvBackup) {
+            unset($_ENV['APP_ENV']);
+        } else {
+            $_ENV['APP_ENV'] = $this->appEnvBackup;
+        }
+        parent::tearDown();
+    }
+
+    // ---------------------------------------------------------------- harness
+
+    /**
+     * A minimal Ratchet connection that records every outbound frame, matching the stub convention
+     * used across the Health suite rather than a PHPUnit mock, which would trigger a
+     * dynamic-property deprecation over `resourceId`.
+     */
+    private static function stubConnection(int $resourceId = 1)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function send(Health $health, ConnectionInterface $conn, array $payload): void
+    {
+        $health->onMessage($conn, (string) json_encode($payload));
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    private static function framesOf(ConnectionInterface $conn): array
+    {
+        /** @var object{sent: list<string>} $conn */
+        return array_map(
+            static fn (string $raw): \stdClass => json_decode($raw),
+            $conn->sent
+        );
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function queuedRequests(Health $health): array
+    {
+        /** @var list<array<string, mixed>> */
+        return ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+    }
+
+    /**
+     * Settle one outstanding request with the given status and body — the shape a real upstream
+     * refusal takes, since `'http_errors' => false` means Guzzle resolves rather than rejects for
+     * every status this test drives.
+     */
+    private static function fulfilQueuedRequestWithStatus(Health $health, int $index, int $status, string $body): void
+    {
+        $queued = self::queuedRequests($health);
+        self::assertArrayHasKey($index, $queued, "expected a queued request at index {$index}");
+        /** @var \Closure(ResponseInterface):void $resolve */
+        $resolve = $queued[$index]['resolve'];
+
+        ob_start();
+        $resolve(new Response($status, ['Content-Type' => 'application/problem+json'], $body));
+        ob_end_clean();
+    }
+
+    // ---------------------------------------------------------------- validateCalendar
+
+    /**
+     * The arm the issue is named after: a calendar year the API refuses with a 400. `exists` must
+     * fail, quoting the problem document's `detail` verbatim, and `parses`/`validates` must still be
+     * reported — failed, not skipped — per #821's one-frame-per-step contract.
+     */
+    public function testACalendarRefusedWithA400FailsExistsAndQuotesTheProblemDetail(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'rite', 'id' => 'ambrosian', 'rite' => 'ambrosian'],
+            'year'           => 1970,
+            'responseFormat' => 'JSON',
+            'requestId'      => 'req-alpha'
+        ]);
+        self::fulfilQueuedRequestWithStatus($health, 0, 400, self::AMBROSIAN_400_BODY);
+
+        $frames = self::framesOf($conn);
+        self::assertSame(
+            ['exists', 'parses', 'validates', 'complete'],
+            array_map(static fn (\stdClass $f): ?string => property_exists($f, 'step') && is_string($f->step) ? $f->step : null, $frames),
+            'a refused calendar still reports every published step, then terminates'
+        );
+
+        [$exists, $parses, $validates, $complete] = $frames;
+
+        self::assertSame('fail', $exists->status, 'the defect: exists must not pass for a 400');
+        self::assertStringContainsString('HTTP 400', $exists->text);
+        self::assertStringContainsString(
+            'The Ambrosian rite is only available from 1976 onward (the first reformed Ambrosian Missal); requested year 1970.',
+            $exists->text,
+            'the API\'s own problem-document detail must reach the client verbatim'
+        );
+
+        self::assertSame('fail', $parses->status, 'a refused request was never parsed, so this must not be a silent skip');
+        self::assertSame('fail', $validates->status, 'a refused request was never schema-checked either');
+
+        self::assertSame('req-alpha', $complete->requestId);
+    }
+
+    /**
+     * A 404 with no `detail` in its body still fails `exists`, falling back to the bare status rather
+     * than fabricating an explanation the response never gave.
+     */
+    public function testACalendarRefusedWithA404WithNoDetailFallsBackToTheBareStatus(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'ZZ', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON',
+            'requestId'      => 'req-beta'
+        ]);
+        self::fulfilQueuedRequestWithStatus($health, 0, 404, self::PLAIN_404_BODY);
+
+        $frames = self::framesOf($conn);
+        self::assertSame('fail', $frames[0]->status);
+        self::assertStringContainsString('HTTP 404', $frames[0]->text);
+        self::assertStringNotContainsString(': ', explode('HTTP 404', $frames[0]->text)[1] ?? '', 'no detail was available, so none is invented');
+    }
+
+    /**
+     * A 200 is unaffected: the happy path this fix must not have broken.
+     */
+    public function testACalendarThatExistsStillPassesOnA200(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON',
+            'requestId'      => 'req-gamma'
+        ]);
+        self::fulfilQueuedRequestWithStatus($health, 0, 200, '{"litcal":[],"settings":{},"metadata":{},"messages":[]}');
+
+        $frames = self::framesOf($conn);
+        self::assertSame('pass', $frames[0]->status, 'precondition: a 200 must still be reported as existing');
+    }
+
+    // ---------------------------------------------------------------- resourceDataCheck (executeValidation)
+
+    /**
+     * The scope the issue calls out explicitly: `executeValidation` with `category: "resourceDataCheck"`,
+     * whose `sourceFile` is a URL. It reaches {@see \LiturgicalCalendar\Api\Health::processValidationData()}
+     * on a 2xx and {@see \LiturgicalCalendar\Api\Health::handleValidationHttpFailure()} otherwise — the
+     * URL-based sibling of the unreadable-file arm {@see HealthValidationDataErrorTest} pins.
+     */
+    public function testAResourceUrlRefusedWithA400FailsAllThreePublishedSteps(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, [
+            'action'     => 'executeValidation',
+            'category'   => 'resourceDataCheck',
+            'validate'   => 'calendar-ambrosian-IT',
+            'sourceFile' => 'https://example.test/calendar/ambrosian/IT/1970',
+            'requestId'  => 'req-alpha'
+        ]);
+        self::fulfilQueuedRequestWithStatus($health, 0, 400, self::AMBROSIAN_400_BODY);
+
+        $frames = self::framesOf($conn);
+        self::assertSame(
+            ['exists', 'parses', 'validates', 'complete'],
+            array_map(static fn (\stdClass $f): ?string => property_exists($f, 'step') && is_string($f->step) ? $f->step : null, $frames)
+        );
+
+        [$exists, $parses, $validates] = $frames;
+        self::assertSame('fail', $exists->status);
+        self::assertStringContainsString('HTTP 400', $exists->text);
+        self::assertStringContainsString(
+            'The Ambrosian rite is only available from 1976 onward (the first reformed Ambrosian Missal); requested year 1970.',
+            $exists->text
+        );
+        self::assertSame('fail', $parses->status, 'not attempted must be reported the same as failed, per #821');
+        self::assertSame('fail', $validates->status);
+    }
+
+    /**
+     * A 2xx resource is unaffected and still reaches `processValidationData()`, which is what
+     * actually reports `exists` as passed for it.
+     */
+    public function testAResourceUrlThatExistsStillPassesOnA200(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, [
+            'action'     => 'executeValidation',
+            'category'   => 'resourceDataCheck',
+            'validate'   => 'calendar-roman-IT',
+            'sourceFile' => 'https://example.test/calendar/nation/IT/2026',
+            'requestId'  => 'req-beta'
+        ]);
+        self::fulfilQueuedRequestWithStatus($health, 0, 200, '{"litcal":[]}');
+
+        $frames = self::framesOf($conn);
+        self::assertSame('pass', $frames[0]->status);
+    }
+
+    // ---------------------------------------------------------------- runTest
+
+    /**
+     * A test run carries one step (`validates`), not three — but a refused calendar must still fail
+     * it rather than be handed to `LitTestRunner` as if the problem document were calendar data.
+     */
+    public function testARunTestAgainstARefusedCalendarFailsRatherThanRunningOverAProblemDocument(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, [
+            'action'    => 'runTest',
+            'test'      => 'SomeAmbrosianTest',
+            'calendar'  => ['kind' => 'rite', 'id' => 'ambrosian', 'rite' => 'ambrosian'],
+            'year'      => 1970,
+            'requestId' => 'req-alpha'
+        ]);
+        self::fulfilQueuedRequestWithStatus($health, 0, 400, self::AMBROSIAN_400_BODY);
+
+        $frames = self::framesOf($conn);
+        self::assertSame(
+            ['validates', 'complete'],
+            array_map(static fn (\stdClass $f): ?string => property_exists($f, 'step') && is_string($f->step) ? $f->step : null, $frames)
+        );
+        self::assertSame('fail', $frames[0]->status);
+        self::assertStringContainsString('HTTP 400', $frames[0]->text);
+        self::assertStringContainsString(
+            'The Ambrosian rite is only available from 1976 onward (the first reformed Ambrosian Missal); requested year 1970.',
+            $frames[0]->text
+        );
+    }
+}

--- a/phpunit_tests/Support/ApcuShim.php
+++ b/phpunit_tests/Support/ApcuShim.php
@@ -2,35 +2,65 @@
 
 declare(strict_types=1);
 
-// A minimal in-memory stand-in for the four APCu functions `Health` calls (apcu_store/apcu_fetch/
-// apcu_exists/apcu_delete/apcu_sma_info), active only when the real ext-apcu is not loaded — guarded
-// per function below, and never redeclared when the real extension is present (as in this project's
-// Docker image), where it runs untouched.
+namespace LiturgicalCalendar\Api;
+
+// A minimal in-memory stand-in for the APCu functions `Health` calls (apcu_store/apcu_fetch/
+// apcu_exists/apcu_delete/apcu_sma_info).
+//
+// Declared in the `LiturgicalCalendar\Api` namespace — the namespace `Health.php` itself lives in —
+// rather than the global one, and unconditionally rather than guarded by `function_exists()`. PHP
+// resolves an unqualified function call to the *current* namespace before falling back to the global
+// one, so once this file is loaded, every unqualified `apcu_*` call `Health.php` makes resolves to
+// the functions below regardless of whether the real ext-apcu is installed, and regardless of
+// whether it is enabled for the CLI SAPI.
+//
+// That last clause is not hypothetical: CI installs the real extension, but the workflow's
+// `apcu.enable_cli=1` ini setting is a no-op — APCu's actual setting is `apc.enable_cli` (inherited
+// from APC's naming), not `apcu.`. So in CI the extension is loaded but silently disabled under the
+// CLI SAPI: `apcu_store()` returns without storing anything and `apcu_exists()` always reports false.
+// A global-namespace shim guarded by `function_exists('apcu_store')` — this file's first version —
+// never activated there, because the real (if inert) function already existed. Namespace-first
+// resolution sidesteps that runtime-configuration question entirely: it does not matter whether real
+// APCu exists, is loaded, or is CLI-enabled, because `LiturgicalCalendar\Api\apcu_store` is found
+// before PHP ever looks for the global one.
 //
 // This exists so a test can drive `Health::cachedGet()`'s actual cache-hit branch — including the
-// malformed/legacy-entry fall-through #834 fixed — through the real code path, instead of
-// re-implementing that branch's logic in the test and only reasoning about whether the real one
-// matches it. Deliberately not a mock of `Health`'s cache methods: those stay untouched, and only the
-// backend three layers below them is stood in for.
+// malformed/legacy-entry and out-of-range-status fall-throughs #834 fixed — through the real code
+// path, instead of re-implementing that branch's logic in the test and only reasoning about whether
+// the real one matches it. Deliberately not a mock of `Health`'s cache methods: those stay untouched,
+// and only the backend three layers below them is stood in for.
 //
-// Declared in the global namespace on purpose: `Health.php` is in `LiturgicalCalendar\Api` and calls
-// these functions unqualified, so PHP resolves them against the global namespace exactly as it would
-// the real extension's functions.
-if (!function_exists('apcu_store')) {
-    function apcu_store(string $key, mixed $value, int $ttl = 0): bool
+// Tests must never call `apcu_store()`/`apcu_fetch()`/`apcu_exists()`/`apcu_delete()` directly: a
+// test lives in `LiturgicalCalendar\Tests`, so an unqualified call from there resolves to
+// `LiturgicalCalendar\Tests\apcu_*` (undefined), then falls back to the *global* — real — function,
+// not this shim. That would have the test writing to one store and `Health` reading from another,
+// failing the test's own precondition for a reason that has nothing to do with the code under test.
+// {@see ApcuShimStore} is the accessor tests use instead, backed by the same array these functions
+// read and write.
+
+/**
+ * The backing store shared between the namespaced `apcu_*` shim functions below (which `Health.php`
+ * calls unqualified) and the tests that seed or inspect it directly. A single shared store is the
+ * whole point: it is what makes "the test wrote this entry" and "Health read this entry" the same
+ * claim, rather than two stores that happen to have similar names.
+ */
+final class ApcuShimStore
+{
+    /** @var array<string, array{value: string, expires: int}> */
+    private static array $store = [];
+
+    public static function store(string $key, mixed $value, int $ttl = 0): bool
     {
-        $GLOBALS['__apcuShimStore']     ??= [];
-        $GLOBALS['__apcuShimStore'][$key] = [
+        self::$store[$key] = [
             'value'   => $value,
             'expires' => $ttl > 0 ? time() + $ttl : 0,
         ];
         return true;
     }
 
-    function apcu_fetch(string $key, ?bool &$success = null): mixed
+    public static function fetch(string $key, ?bool &$success = null): mixed
     {
-        $GLOBALS['__apcuShimStore'] ??= [];
-        $entry                        = $GLOBALS['__apcuShimStore'][$key] ?? null;
+        $entry = self::$store[$key] ?? null;
         if (null === $entry || ( $entry['expires'] > 0 && $entry['expires'] < time() )) {
             $success = false;
             return false;
@@ -39,33 +69,51 @@ if (!function_exists('apcu_store')) {
         return $entry['value'];
     }
 
-    function apcu_exists(string $key): bool
+    public static function exists(string $key): bool
     {
-        $GLOBALS['__apcuShimStore'] ??= [];
-        $entry                        = $GLOBALS['__apcuShimStore'][$key] ?? null;
+        $entry = self::$store[$key] ?? null;
         if (null === $entry) {
             return false;
         }
         if ($entry['expires'] > 0 && $entry['expires'] < time()) {
-            unset($GLOBALS['__apcuShimStore'][$key]);
+            unset(self::$store[$key]);
             return false;
         }
         return true;
     }
 
-    function apcu_delete(string $key): bool
+    public static function delete(string $key): bool
     {
-        $GLOBALS['__apcuShimStore'] ??= [];
-        $existed                      = isset($GLOBALS['__apcuShimStore'][$key]);
-        unset($GLOBALS['__apcuShimStore'][$key]);
+        $existed = isset(self::$store[$key]);
+        unset(self::$store[$key]);
         return $existed;
     }
+}
 
-    /**
-     * @return array{seg_size: int, avail_mem: int}
-     */
-    function apcu_sma_info(bool $limited = false): array
-    {
-        return ['seg_size' => 0, 'avail_mem' => 0];
-    }
+function apcu_store(string $key, mixed $value, int $ttl = 0): bool
+{
+    return ApcuShimStore::store($key, $value, $ttl);
+}
+
+function apcu_fetch(string $key, ?bool &$success = null): mixed
+{
+    return ApcuShimStore::fetch($key, $success);
+}
+
+function apcu_exists(string $key): bool
+{
+    return ApcuShimStore::exists($key);
+}
+
+function apcu_delete(string $key): bool
+{
+    return ApcuShimStore::delete($key);
+}
+
+/**
+ * @return array{seg_size: int, avail_mem: int}
+ */
+function apcu_sma_info(bool $limited = false): array
+{
+    return ['seg_size' => 0, 'avail_mem' => 0];
 }

--- a/phpunit_tests/Support/ApcuShim.php
+++ b/phpunit_tests/Support/ApcuShim.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+// A minimal in-memory stand-in for the four APCu functions `Health` calls (apcu_store/apcu_fetch/
+// apcu_exists/apcu_delete/apcu_sma_info), active only when the real ext-apcu is not loaded — guarded
+// per function below, and never redeclared when the real extension is present (as in this project's
+// Docker image), where it runs untouched.
+//
+// This exists so a test can drive `Health::cachedGet()`'s actual cache-hit branch — including the
+// malformed/legacy-entry fall-through #834 fixed — through the real code path, instead of
+// re-implementing that branch's logic in the test and only reasoning about whether the real one
+// matches it. Deliberately not a mock of `Health`'s cache methods: those stay untouched, and only the
+// backend three layers below them is stood in for.
+//
+// Declared in the global namespace on purpose: `Health.php` is in `LiturgicalCalendar\Api` and calls
+// these functions unqualified, so PHP resolves them against the global namespace exactly as it would
+// the real extension's functions.
+if (!function_exists('apcu_store')) {
+    function apcu_store(string $key, mixed $value, int $ttl = 0): bool
+    {
+        $GLOBALS['__apcuShimStore']     ??= [];
+        $GLOBALS['__apcuShimStore'][$key] = [
+            'value'   => $value,
+            'expires' => $ttl > 0 ? time() + $ttl : 0,
+        ];
+        return true;
+    }
+
+    function apcu_fetch(string $key, ?bool &$success = null): mixed
+    {
+        $GLOBALS['__apcuShimStore'] ??= [];
+        $entry                        = $GLOBALS['__apcuShimStore'][$key] ?? null;
+        if (null === $entry || ( $entry['expires'] > 0 && $entry['expires'] < time() )) {
+            $success = false;
+            return false;
+        }
+        $success = true;
+        return $entry['value'];
+    }
+
+    function apcu_exists(string $key): bool
+    {
+        $GLOBALS['__apcuShimStore'] ??= [];
+        $entry                        = $GLOBALS['__apcuShimStore'][$key] ?? null;
+        if (null === $entry) {
+            return false;
+        }
+        if ($entry['expires'] > 0 && $entry['expires'] < time()) {
+            unset($GLOBALS['__apcuShimStore'][$key]);
+            return false;
+        }
+        return true;
+    }
+
+    function apcu_delete(string $key): bool
+    {
+        $GLOBALS['__apcuShimStore'] ??= [];
+        $existed                      = isset($GLOBALS['__apcuShimStore'][$key]);
+        unset($GLOBALS['__apcuShimStore'][$key]);
+        return $existed;
+    }
+
+    /**
+     * @return array{seg_size: int, avail_mem: int}
+     */
+    function apcu_sma_info(bool $limited = false): array
+    {
+        return ['seg_size' => 0, 'avail_mem' => 0];
+    }
+}

--- a/phpunit_tests/WebSocket/ValidateCalendarTest.php
+++ b/phpunit_tests/WebSocket/ValidateCalendarTest.php
@@ -174,14 +174,15 @@ final class ValidateCalendarTest extends TestCase
     }
 
     /**
-     * An unknown calendar 404s. This test's name and body used to state the defect issue #833 was
-     * filed about as its expectation: it asserted a `file-exists` **success** — reasoning that the WS
-     * handler "reports any non-error HTTP response... as a 'file' that exists" — followed by a
-     * `json-valid` failure, because the 404 page's body isn't a valid LitCal document. That is exactly
-     * the bug: `'http_errors' => false` on the Guzzle client means a 404 resolves rather than rejects,
-     * and before #833 nothing checked the status it resolved with, so `exists` passed unconditionally
-     * and the reader was pointed at the wrong step — "the schema is wrong" instead of "the endpoint
-     * refused the request".
+     * An unknown calendar is refused with **400** — the API validates the nation against a known list
+     * and rejects the *value*, rather than routing to a missing resource. This test's name and body
+     * used to state the defect issue #833 was filed about as its expectation: it asserted a
+     * `file-exists` **success** — reasoning that the WS handler "reports any non-error HTTP
+     * response... as a 'file' that exists" — followed by a `json-valid` failure, because the refusal
+     * body isn't a valid LitCal document. That is exactly the bug: `'http_errors' => false` on the
+     * Guzzle client means a 400 resolves rather than rejects, and before #833 nothing checked the
+     * status it resolved with, so `exists` passed unconditionally and the reader was pointed at the
+     * wrong step — "the schema is wrong" instead of "the endpoint refused the request".
      *
      * Now `exists` fails, quoting the status, and — per #821's one-frame-per-step contract — so do
      * `parses` and `validates`: a refusal establishes none of the three, so none of them may report a
@@ -199,13 +200,15 @@ final class ValidateCalendarTest extends TestCase
 
         $this->assertSame('error', $frames[0]->type);
         $this->assertSame('.calendar-NONEXISTENT_NATION_589.file-exists.year-2020', $frames[0]->classes);
-        // 400, not 404: the API validates the nation against a known list and refuses the *value*,
-        // rather than routing to a missing resource. Asserted as a literal because surfacing the
-        // real status is the point of #833 — a test that accepted any status would pass against the
-        // bug it guards. The `detail` it quotes is the API's own explanation, which is why the
-        // failure text names the valid values without this test having to know them.
+        // The status is asserted as a literal because surfacing the *real* one is the point of #833:
+        // a test that accepted any status would pass against the bug it guards.
         $this->assertStringContainsString('was refused with HTTP 400', $frames[0]->text);
-        $this->assertStringContainsString('valid values are', $frames[0]->text);
+        // Endpoint-specific, not merely "some explanation came back": `valid values are` would match
+        // any parameter-validation message from any route. This pins that the detail quoted belongs
+        // to *this* refusal. The list of nations it goes on to name is deliberately not asserted —
+        // that grows as calendars are added, and pinning it would make an unrelated addition fail here.
+        $this->assertStringContainsString('Invalid value', $frames[0]->text);
+        $this->assertStringContainsString('national_calendar', $frames[0]->text);
 
         $this->assertSame('error', $frames[1]->type);
         $this->assertSame('.calendar-NONEXISTENT_NATION_589.json-valid.year-2020', $frames[1]->classes);

--- a/phpunit_tests/WebSocket/ValidateCalendarTest.php
+++ b/phpunit_tests/WebSocket/ValidateCalendarTest.php
@@ -199,7 +199,13 @@ final class ValidateCalendarTest extends TestCase
 
         $this->assertSame('error', $frames[0]->type);
         $this->assertSame('.calendar-NONEXISTENT_NATION_589.file-exists.year-2020', $frames[0]->classes);
-        $this->assertStringContainsString('HTTP 404', $frames[0]->text);
+        // 400, not 404: the API validates the nation against a known list and refuses the *value*,
+        // rather than routing to a missing resource. Asserted as a literal because surfacing the
+        // real status is the point of #833 — a test that accepted any status would pass against the
+        // bug it guards. The `detail` it quotes is the API's own explanation, which is why the
+        // failure text names the valid values without this test having to know them.
+        $this->assertStringContainsString('was refused with HTTP 400', $frames[0]->text);
+        $this->assertStringContainsString('valid values are', $frames[0]->text);
 
         $this->assertSame('error', $frames[1]->type);
         $this->assertSame('.calendar-NONEXISTENT_NATION_589.json-valid.year-2020', $frames[1]->classes);

--- a/phpunit_tests/WebSocket/ValidateCalendarTest.php
+++ b/phpunit_tests/WebSocket/ValidateCalendarTest.php
@@ -173,25 +173,40 @@ final class ValidateCalendarTest extends TestCase
         $this->assertPhase($frames[2], 'schema-valid', 2020);
     }
 
-    public function testUnknownCalendarFailsAtJsonValidPhase(): void
+    /**
+     * An unknown calendar 404s. This test's name and body used to state the defect issue #833 was
+     * filed about as its expectation: it asserted a `file-exists` **success** — reasoning that the WS
+     * handler "reports any non-error HTTP response... as a 'file' that exists" — followed by a
+     * `json-valid` failure, because the 404 page's body isn't a valid LitCal document. That is exactly
+     * the bug: `'http_errors' => false` on the Guzzle client means a 404 resolves rather than rejects,
+     * and before #833 nothing checked the status it resolved with, so `exists` passed unconditionally
+     * and the reader was pointed at the wrong step — "the schema is wrong" instead of "the endpoint
+     * refused the request".
+     *
+     * Now `exists` fails, quoting the status, and — per #821's one-frame-per-step contract — so do
+     * `parses` and `validates`: a refusal establishes none of the three, so none of them may report a
+     * pass just because nothing tried to check them.
+     */
+    public function testUnknownCalendarFailsAtTheExistsPhase(): void
     {
-        // The first message is always the "file-exists" success because
-        // the WS handler reports any non-error HTTP response (the 404
-        // page) as a "file" that exists. The body, however, isn't a
-        // valid LitCal JSON document, so the json-valid phase fails.
         $frames = $this->validateCalendar([
             'action'       => 'validateCalendar',
             'calendar'     => 'NONEXISTENT_NATION_589',
             'year'         => 2020,
             'category'     => 'nationalcalendar',
             'responsetype' => 'JSON',
-        ], 2);
+        ], 3);
 
-        $this->assertSame('success', $frames[0]->type);
+        $this->assertSame('error', $frames[0]->type);
         $this->assertSame('.calendar-NONEXISTENT_NATION_589.file-exists.year-2020', $frames[0]->classes);
+        $this->assertStringContainsString('HTTP 404', $frames[0]->text);
+
         $this->assertSame('error', $frames[1]->type);
         $this->assertSame('.calendar-NONEXISTENT_NATION_589.json-valid.year-2020', $frames[1]->classes);
         $this->assertObjectHasProperty('responsetype', $frames[1]);
         $this->assertSame('JSON', $frames[1]->responsetype);
+
+        $this->assertSame('error', $frames[2]->type);
+        $this->assertSame('.calendar-NONEXISTENT_NATION_589.schema-valid.year-2020', $frames[2]->classes);
     }
 }

--- a/src/Health.php
+++ b/src/Health.php
@@ -3807,6 +3807,8 @@ class Health implements MessageComponentInterface
             is_array($decoded)
             && isset($decoded['status'], $decoded['body'])
             && is_int($decoded['status'])
+            && $decoded['status'] >= 100
+            && $decoded['status'] <= 599
             && is_string($decoded['body'])
         ) {
             /** @var array{status: int, body: string} $decoded */

--- a/src/Health.php
+++ b/src/Health.php
@@ -482,13 +482,13 @@ class Health implements MessageComponentInterface
             // which is exactly what a problem-document body would produce, as "not loaded yet": self::
             // $metadata is simply left unset and the next request retries. Nothing here claims success
             // for a refusal, so there is no false "exists" for #833 to fix.
-            /** @var PromiseInterface<array{data: string, status: int, fromCache: bool}> $metadataPromise */
+            /** @var PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $metadataPromise */
             $metadataPromise = $this->cachedGet(Route::CALENDARS->path(), $opts, 300, $conn);
             //self::$metadataPromise = $metadataPromise;
 
             $metadataPromise->then(
                 function (array $result) {
-                    /** @var array{data: string, status: int, fromCache: bool} $result */
+                    /** @var array{data: string, status: int, fromCache: bool, retryAfter: ?string} $result */
                     $rawData = $result['data'];
                     echo 'Fetched metadata: got ' . strlen($rawData) . " bytes\n";
 
@@ -1689,23 +1689,25 @@ class Health implements MessageComponentInterface
             if (str_starts_with($dataPath, 'http://') || str_starts_with($dataPath, 'https://')) {
                 // $dataPath is an API path in this case
                 echo 'Retrieving data from URL ' . $dataPath . "\n";
-                /** @var PromiseInterface<array{data: string, status: int, fromCache: bool}> $httpPromise */
+                /** @var PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $httpPromise */
                 $httpPromise = $this->cachedGet($dataPath, [], 300, $to);
                 $httpPromise->then(
                     function (array $result) use ($to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $requestId, $target) {
-                        /** @var array{data: string, status: int, fromCache: bool} $result */
-                        $data   = $result['data'];
-                        $status = $result['status'];
+                        /** @var array{data: string, status: int, fromCache: bool, retryAfter: ?string} $result */
+                        $data       = $result['data'];
+                        $status     = $result['status'];
+                        $retryAfter = $result['retryAfter'];
                         echo 'Fetched data for ' . $dataPath . ': got ' . strlen($data) . " bytes, HTTP $status\n";
                         // #833: `'http_errors' => false` on the Guzzle client means a 4xx/5xx resolves
                         // this promise instead of rejecting it, so `processValidationData()` — which
                         // unconditionally reports `exists` as passed, correctly so for the filesystem
                         // arm that only ever reaches it once #822's stat has already proven the file is
-                        // there — must not be reached at all for a resource the API refused.
+                        // there — must not be reached at all for a resource the API refused. 429/5xx
+                        // are included (#834), reported the same way as any other refusal.
                         if (self::isHttpSuccessStatus($status)) {
                             $this->processValidationData($data, $to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $target, requestId: $requestId);
                         } else {
-                            $this->handleValidationHttpFailure($status, $data, $to, $validationForMessages, $dataPath, $runToken, $target, requestId: $requestId);
+                            $this->handleValidationHttpFailure($status, $data, $retryAfter, $to, $validationForMessages, $dataPath, $runToken, $target, requestId: $requestId);
                         }
                         // Terminates whether the steps passed or failed. Every arm now emits one
                         // frame per published step — the decode arm's missing third was #821 — but
@@ -1829,10 +1831,12 @@ class Health implements MessageComponentInterface
      *
      * The `exists` text quotes the API's own RFC 9457 `detail` when the body decodes to one — it
      * already explains precisely what is wrong (e.g. a rite's year boundary) — and falls back to the
-     * bare status when it does not.
+     * bare status when it does not. A `Retry-After` hint, when the response carried one (429/5xx,
+     * which reach here the same way as any other refusal since #834), is folded into the same text.
      *
      * @param int $status The non-2xx HTTP status the request resolved with.
      * @param string $body The response body, inspected only for a problem-document `detail`.
+     * @param ?string $retryAfter The `Retry-After` header value, or null when the response carried none.
      * @param ConnectionInterface $to The WebSocket connection to send errors to.
      * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource $validation The validation object.
      * @param string $dataPath The URL that was requested.
@@ -1843,15 +1847,16 @@ class Health implements MessageComponentInterface
      *        {@see Health::onMessage()} for why that distinction is load-bearing.
      * @return void
      */
-    private function handleValidationHttpFailure(int $status, string $body, ConnectionInterface $to, \stdClass $validation, string $dataPath, ?string $runToken = null, ?\stdClass $target = null, ?string $requestId = null): void
+    private function handleValidationHttpFailure(int $status, string $body, ?string $retryAfter, ConnectionInterface $to, \stdClass $validation, string $dataPath, ?string $runToken = null, ?\stdClass $target = null, ?string $requestId = null): void
     {
         // `validate` carries the class fragment: see the note where $validationForMessages is built.
         $validate = (string) $validation->validate;
         $category = (string) $validation->category;
         echo "Refused: HTTP $status received from $dataPath\n";
 
-        $detail = self::problemDetailFromBody($body);
-        $suffix = $detail !== null ? ": $detail" : '';
+        $detail  = self::problemDetailFromBody($body);
+        $suffix  = $detail !== null ? ": $detail" : '';
+        $suffix .= $retryAfter !== null ? " (Retry-After: $retryAfter)" : '';
 
         $this->sendStepResult(
             $to,
@@ -2656,20 +2661,25 @@ class Health implements MessageComponentInterface
         $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
         $promise->then(
             function (array $result) use ($to, $calendar, $year, $category, $req, $responseType, $runToken, $requestId) {
-                /** @var array{data: string, status: int, fromCache: bool} $result */
-                $data      = $result['data'];
-                $status    = $result['status'];
-                $fromCache = $result['fromCache'];
+                /** @var array{data: string, status: int, fromCache: bool, retryAfter: ?string} $result */
+                $data       = $result['data'];
+                $status     = $result['status'];
+                $fromCache  = $result['fromCache'];
+                $retryAfter = $result['retryAfter'];
                 echo 'Fetched data for ' . Route::CALENDAR->path() . $req . ': got ' . strlen($data) . " bytes, HTTP $status" . ( $fromCache ? ' (from cache)' : '' ) . "\n";
 
                 // #833: `'http_errors' => false` means a 4xx/5xx resolves this promise rather than
                 // rejecting it, so `exists` must not be reported as passed without checking the status
                 // that resolved it. A refusal means none of the three published steps were established
                 // — not just the first — so all three are reported failed here rather than skipping
-                // straight to `complete`, per #821's one-frame-per-step contract.
+                // straight to `complete`, per #821's one-frame-per-step contract. 429/5xx reach this
+                // gate too (#834): they used to be rejected separately, but nothing left downstream of
+                // this gate can be misled by their body any more, so they are reported the same way as
+                // any other refusal — including the `Retry-After` hint, when the response carried one.
                 if (false === self::isHttpSuccessStatus($status)) {
-                    $detail = self::problemDetailFromBody($data);
-                    $suffix = $detail !== null ? ": $detail" : '';
+                    $detail  = self::problemDetailFromBody($data);
+                    $suffix  = $detail !== null ? ": $detail" : '';
+                    $suffix .= $retryAfter !== null ? " (Retry-After: $retryAfter)" : '';
                     $this->sendCalendarStepResult(
                         $to,
                         $calendar,
@@ -3190,18 +3200,22 @@ class Health implements MessageComponentInterface
         $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
         $promise->then(
             function (array $result) use ($to, $test, $calendar, $year, $category, $req, $runToken, $requestId, $rite) {
-                /** @var array{data: string, status: int, fromCache: bool} $result */
-                $data   = $result['data'];
-                $status = $result['status'];
+                /** @var array{data: string, status: int, fromCache: bool, retryAfter: ?string} $result */
+                $data       = $result['data'];
+                $status     = $result['status'];
+                $retryAfter = $result['retryAfter'];
 
                 // #833: a refused calendar (e.g. a rite's year boundary) is valid JSON — a problem
                 // document — so without this check it would decode cleanly and be handed to
                 // LitTestRunner as if it were calendar data, which is worse than a plain failure: the
                 // run would go on to answer whatever the test asserts, over data that never existed. A
                 // test run carries one step, so the refusal is reported there rather than skipped.
+                // 429/5xx reach this the same way as any other refusal (#834); their `Retry-After`
+                // hint, when present, is folded into the same text rather than lost.
                 if (false === self::isHttpSuccessStatus($status)) {
-                    $detail = self::problemDetailFromBody($data);
-                    $suffix = $detail !== null ? ": $detail" : '';
+                    $detail  = self::problemDetailFromBody($data);
+                    $suffix  = $detail !== null ? ": $detail" : '';
+                    $suffix .= $retryAfter !== null ? " (Retry-After: $retryAfter)" : '';
                     $this->sendTestResult(
                         $to,
                         $test,
@@ -3405,6 +3419,37 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * Delete a key from the cache.
+     *
+     * Used when a stored entry cannot be decoded back into a usable value (#834): a malformed entry
+     * — including the bare-body shape every entry had before #833 — must not be left in place to be
+     * hit again on the very next request. Removing it lets the following request treat this key as a
+     * plain miss instead of standing rejection for the rest of the TTL window.
+     */
+    private static function cacheDelete(string $key): void
+    {
+        if (!self::$cacheEnabled) {
+            return;
+        }
+        if (self::$cacheBackend === 'redis' && self::$redis !== null) {
+            try {
+                self::$redis->del($key);
+                return;
+            } catch (\RedisException $e) {
+                self::handleRedisFailure($e);
+                // Retry with APCu if now available
+                if (self::$cacheBackend === 'apcu') {
+                    apcu_delete($key);
+                }
+                return;
+            }
+        }
+        if (self::$cacheBackend === 'apcu') {
+            apcu_delete($key);
+        }
+    }
+
+    /**
      * Get cache memory info string for logging.
      */
     private static function cacheInfo(): string
@@ -3533,13 +3578,13 @@ class Health implements MessageComponentInterface
     /**
      * @param array{headers?:array<string, string>,stream?:bool} $options
      *
-     * @return PromiseInterface<array{data: string, status: int, fromCache: bool}>
+     * @return PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}>
      */
     private function cachedGet(string $url, array $options = [], int $ttl = 300, ?ConnectionInterface $conn = null): PromiseInterface
     {
         $key = 'http_' . md5($url . serialize($options));
 
-        /** @var Deferred<array{data: string, status: int, fromCache: bool}> $deferred */
+        /** @var Deferred<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $deferred */
         $deferred = new Deferred();
 
         // Return from cache if available - stagger resolutions to stream results back gradually
@@ -3568,20 +3613,31 @@ class Health implements MessageComponentInterface
                     if ($conn !== null && !$this->clients->contains($conn)) {
                         return;
                     }
-                    $deferred->resolve(['data' => $data, 'status' => $status, 'fromCache' => true]);
+                    // A cached entry is never a 429/5xx (handleHttpResponse() excludes those from the
+                    // cache), so there is no Retry-After to carry forward here.
+                    $deferred->resolve(['data' => $data, 'status' => $status, 'fromCache' => true, 'retryAfter' => null]);
                 };
                 if ($delay > 0) {
                     Loop::addTimer($delay, $resolveIfOpen);
                 } else {
                     Loop::futureTick($resolveIfOpen);
                 }
-            } else {
-                $deferred->reject(new \RuntimeException("Cache fetch for URL $url failed or returned malformed cache payload"));
+
+                /** @var PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $deferredPromise */
+                $deferredPromise = $deferred->promise();
+                return $deferredPromise;
             }
 
-            /** @var PromiseInterface<array{data: string, status: int, fromCache: bool}> $deferredPromise */
-            $deferredPromise = $deferred->promise();
-            return $deferredPromise;
+            // A cache hit whose entry cannot be decoded — malformed, or written in the bare-body
+            // shape a pre-#833 process left behind — is not a hit at all: it must not be answered
+            // with a rejection, which is what this arm did until a review of #834 caught it. Doing so
+            // fails every check whose entry predates this fix (all three published steps, via
+            // handleValidationDataError() and friends) for the entire TTL window, which is exactly
+            // the false-failure mirror of the bug this file fixes, landing right at the moment of
+            // deploy. The stale bytes are removed and control falls through to the live-request path
+            // below, exactly as a plain cache miss would.
+            echo "Cache entry for $url could not be decoded, treating as a miss and re-fetching\n";
+            self::cacheDelete($key);
         }
 
         if (self::$cacheEnabled) {
@@ -3615,24 +3671,44 @@ class Health implements MessageComponentInterface
             'runToken'   => $queuedRunToken
         ];
 
-        /** @var PromiseInterface<array{data: string, status: int, fromCache: bool}> $deferredPromise */
+        /** @var PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $deferredPromise */
         $deferredPromise = $deferred->promise();
         $this->ensureTicking();
         return $deferredPromise;
     }
 
     /**
-     * Handle a fulfilled HTTP response for a queued {@see cachedGet} request: surface rate-limit
-     * (429) and server-error (5xx) responses as a rejection, otherwise cache the body (when caching
-     * is enabled) and resolve the deferred with it. Extracted from the cachedGet fulfillment closure
-     * so the status/cache branching is unit-testable without the Ratchet/Guzzle event loop; the
-     * caller is responsible for the inFlight bookkeeping.
+     * Handle a fulfilled HTTP response for a queued {@see cachedGet} request: resolve the deferred
+     * with the real status and body, caching them (when caching is enabled) unless the status is a
+     * rate-limit (429) or server error (5xx). Extracted from the cachedGet fulfillment closure so the
+     * status/cache branching is unit-testable without the Ratchet/Guzzle event loop; the caller is
+     * responsible for the inFlight bookkeeping.
      *
-     * The resolved value always carries the real HTTP status (#833): `'http_errors' => false` on the
-     * Guzzle client means a 4xx or 5xx never rejects this promise on its own, so a consumer that wants
-     * to tell "the resource exists" from "the resource was refused" has nothing else to look at.
+     * **Every status resolves; none reject (#833, revised by #834's review).** `'http_errors' =>
+     * false` on the Guzzle client already means a 4xx or 5xx never rejects this promise on its own —
+     * this method used to carve out 429/5xx as an exception and reject those specifically, reasoning
+     * that a 429's RFC 9457 problem+json body "decodes fine but lacks the calendar keys, which the
+     * JSON branch would otherwise mislabel as 'response data was perhaps truncated?'". That reasoning
+     * no longer holds: every consumer of `cachedGet()` now gates on {@see Health::isHttpSuccessStatus()}
+     * *before* any JSON-shape check runs, for exactly this reason, so the mislabelling the rejection
+     * was written to prevent cannot happen regardless of whether this method resolves or rejects. With
+     * the original reason gone, rejecting 429/5xx separately is pure inconsistency: it makes those two
+     * statuses arrive through a different frame-emission path (an exception message assembled here)
+     * than every other non-2xx (the uniform `exists`/`parses`/`validates` gate), for no remaining
+     * benefit — and it is why they were still missing the problem document's `detail` that #833 gives
+     * every other refusal. They are resolved uniformly here instead, so the gate reports them exactly
+     * like a 400 or 404.
      *
-     * @param Deferred<array{data: string, status: int, fromCache: bool}> $deferred
+     * **`Retry-After` is still carried, not dropped.** It is genuinely useful and was previously only
+     * visible on the rejection's exception message; it now rides on the resolved value's `retryAfter`
+     * key so a consumer can fold it into the `exists` failure text it already builds.
+     *
+     * **429/5xx are still excluded from the cache.** That part of the original decision stands on its
+     * own merit, independent of the rejection question: a rate limit or a server outage is transient
+     * information about *this moment*, not a fact about the resource, and caching it would have a
+     * request made one second after the outage ended keep reporting the outage for the rest of the TTL.
+     *
+     * @param Deferred<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $deferred
      */
     private static function handleHttpResponse(
         ResponseInterface $response,
@@ -3659,31 +3735,17 @@ class Health implements MessageComponentInterface
             file_put_contents(Router::$apiFilePath . 'logs' . DIRECTORY_SEPARATOR . "websocket_response_{$date}.log", $debugMessage);
         }
 
-        // Surface rate-limit (429) and server-error (5xx) responses honestly instead of passing
-        // an error body downstream: a 429 returns an RFC 9457 problem+json object that decodes
-        // fine but lacks the calendar keys, which the JSON branch would otherwise mislabel as
-        // "response data was perhaps truncated?". Reject with the real status; don't cache it.
-        // Other statuses (e.g. a 404 for an unknown calendar) still flow through so the
-        // per-format validation can report them at the json-valid phase as before.
-        $statusCode = $response->getStatusCode();
-        if (self::isUpstreamFailureStatus($statusCode)) {
-            $retryAfter = $response->getHeaderLine('Retry-After');
-            $suffix     = $retryAfter !== '' ? " (Retry-After: {$retryAfter})" : '';
-            $deferred->reject(new \RuntimeException(
-                "HTTP {$statusCode} {$response->getReasonPhrase()} received from {$url}{$suffix}"
-            ));
-            return;
-        }
+        $statusCode      = $response->getStatusCode();
+        $retryAfterValue = $response->getHeaderLine('Retry-After');
+        $retryAfter      = '' !== $retryAfterValue ? $retryAfterValue : null;
 
         // The status is cached alongside the body, not just resolved alongside it: a consumer that
-        // asked for this URL before is entitled to the same answer a live request would give it. Every
-        // other status this method reaches (i.e. everything that isn't 429/5xx, rejected above and
-        // never cached) was already being cached before #833 — a 400 or 404 flows through "so the
-        // per-format validation can report them at the json-valid phase as before" per the comment
-        // below. That design is kept: what changes is that the cached entry can now be decoded back
-        // into a real status instead of always being replayed as a silent 200 (`cachedGet()`'s
-        // cache-hit branch decodes this JSON envelope; see the note there for why that trap mattered).
-        if (self::$cacheEnabled) {
+        // asked for this URL before is entitled to the same answer a live request would give it.
+        // 429/5xx are excluded — see the docblock above for why that exclusion still stands even
+        // though these statuses are no longer rejected. Every other status was already being cached
+        // before #833 — a 400 or 404 flows through so the per-format validation can report it at the
+        // json-valid phase, now gated behind the `exists` check the resolved status makes possible.
+        if (self::$cacheEnabled && !self::isUpstreamFailureStatus($statusCode)) {
             $cachePayload = self::encodeHttpCacheEntry($statusCode, $body);
             if (null !== $cachePayload) {
                 $stored = self::cacheSet($key, $cachePayload, $ttl);
@@ -3693,14 +3755,15 @@ class Health implements MessageComponentInterface
                 echo "Failed to encode response body for caching (not valid UTF-8?), skipping cache write\n";
             }
         }
-        $deferred->resolve(['data' => $body, 'status' => $statusCode, 'fromCache' => false]);
+        $deferred->resolve(['data' => $body, 'status' => $statusCode, 'fromCache' => false, 'retryAfter' => $retryAfter]);
     }
 
     /**
-     * Whether an upstream HTTP status should be surfaced as a hard failure (reject) instead of
-     * being passed to per-format validation. Rate limiting (429) and server errors (5xx) mean the
-     * API could not serve the resource, so their bodies must not be validated as calendar content;
-     * other statuses (e.g. 404 for an unknown calendar) flow through to the validation phases.
+     * Whether an upstream HTTP status must be kept out of the cache. Rate limiting (429) and server
+     * errors (5xx) are transient facts about *this moment*, not about the resource, so caching one
+     * would have a request made the instant an outage ends keep reporting the outage for the rest of
+     * the TTL. Both statuses still resolve rather than reject (#834) and are reported through the same
+     * `exists` gate as every other non-2xx — this only controls what gets written to the cache.
      */
     private static function isUpstreamFailureStatus(int $statusCode): bool
     {
@@ -3756,9 +3819,9 @@ class Health implements MessageComponentInterface
      * Whether an HTTP status is a plain success. Consumers of {@see Health::cachedGet()} gate the
      * `exists` step on this (#833): `'http_errors' => false` on the Guzzle client means a 4xx/5xx
      * resolves rather than rejects, so without this check `exists` would pass for a request the API
-     * refused. 429 and 5xx never reach this check — {@see Health::handleHttpResponse()} rejects those
-     * before the promise resolves — but every other non-2xx (e.g. a 400 rite-boundary refusal, or a
-     * 404 for an unknown calendar) does, and must be caught here.
+     * refused. Every non-2xx reaches this check uniformly, 429 and 5xx included (#834) —
+     * {@see Health::handleHttpResponse()} resolves every status rather than rejecting any of it, so
+     * the gate is the only place any of them is told apart from a success.
      */
     private static function isHttpSuccessStatus(int $statusCode): bool
     {

--- a/src/Health.php
+++ b/src/Health.php
@@ -2697,6 +2697,10 @@ class Health implements MessageComponentInterface
                         Step::PARSES,
                         Status::FAIL,
                         "Could not decode the $category of $calendar for the year $year as $responseType because the request for it returned HTTP $status",
+                        // Every sibling `parses`-fail frame in the switch below carries `responsetype`
+                        // (JSON/XML/ICS/YAML decode failures all do) — this gate short-circuits before
+                        // the switch, but it is reporting the very same phase, so it must match.
+                        responseType: $responseType,
                         runToken: $runToken,
                         requestId: $requestId
                     );

--- a/src/Health.php
+++ b/src/Health.php
@@ -475,13 +475,20 @@ class Health implements MessageComponentInterface
                 ]
             ];
 
-            /** @var PromiseInterface<array{data: string, fromCache: bool}> $metadataPromise */
+            // #833 note: this internal /calendars fetch is deliberately left ungated on status. It
+            // never emits a step frame — it is metadata bootstrapping, not a check reported to a
+            // client — and the shape guards below (instanceof \stdClass, then the litcal_metadata
+            // property) already treat a body that doesn't decode into the expected metadata shape,
+            // which is exactly what a problem-document body would produce, as "not loaded yet": self::
+            // $metadata is simply left unset and the next request retries. Nothing here claims success
+            // for a refusal, so there is no false "exists" for #833 to fix.
+            /** @var PromiseInterface<array{data: string, status: int, fromCache: bool}> $metadataPromise */
             $metadataPromise = $this->cachedGet(Route::CALENDARS->path(), $opts, 300, $conn);
             //self::$metadataPromise = $metadataPromise;
 
             $metadataPromise->then(
                 function (array $result) {
-                    /** @var array{data: string, fromCache: bool} $result */
+                    /** @var array{data: string, status: int, fromCache: bool} $result */
                     $rawData = $result['data'];
                     echo 'Fetched metadata: got ' . strlen($rawData) . " bytes\n";
 
@@ -1682,14 +1689,24 @@ class Health implements MessageComponentInterface
             if (str_starts_with($dataPath, 'http://') || str_starts_with($dataPath, 'https://')) {
                 // $dataPath is an API path in this case
                 echo 'Retrieving data from URL ' . $dataPath . "\n";
-                /** @var PromiseInterface<array{data: string, fromCache: bool}> $httpPromise */
+                /** @var PromiseInterface<array{data: string, status: int, fromCache: bool}> $httpPromise */
                 $httpPromise = $this->cachedGet($dataPath, [], 300, $to);
                 $httpPromise->then(
                     function (array $result) use ($to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $requestId, $target) {
-                        /** @var array{data: string, fromCache: bool} $result */
-                        $data = $result['data'];
-                        echo 'Fetched data for ' . $dataPath . ': got ' . strlen($data) . " bytes\n";
-                        $this->processValidationData($data, $to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $target, requestId: $requestId);
+                        /** @var array{data: string, status: int, fromCache: bool} $result */
+                        $data   = $result['data'];
+                        $status = $result['status'];
+                        echo 'Fetched data for ' . $dataPath . ': got ' . strlen($data) . " bytes, HTTP $status\n";
+                        // #833: `'http_errors' => false` on the Guzzle client means a 4xx/5xx resolves
+                        // this promise instead of rejecting it, so `processValidationData()` — which
+                        // unconditionally reports `exists` as passed, correctly so for the filesystem
+                        // arm that only ever reaches it once #822's stat has already proven the file is
+                        // there — must not be reached at all for a resource the API refused.
+                        if (self::isHttpSuccessStatus($status)) {
+                            $this->processValidationData($data, $to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $target, requestId: $requestId);
+                        } else {
+                            $this->handleValidationHttpFailure($status, $data, $to, $validationForMessages, $dataPath, $runToken, $target, requestId: $requestId);
+                        }
                         // Terminates whether the steps passed or failed. Every arm now emits one
                         // frame per published step — the decode arm's missing third was #821 — but
                         // what a client stops on is still this frame, never a count.
@@ -1791,6 +1808,82 @@ class Health implements MessageComponentInterface
             Step::VALIDATES,
             Status::FAIL,
             "Unable to verify schema for dataPath {$dataPath} and category {$category} since Data file $dataPath does not exist or is not readable",
+            null,
+            $runToken,
+            requestId: $requestId
+        );
+    }
+
+    /**
+     * Handle a non-2xx HTTP response for a `resourceDataCheck` (#833): the URL-based sibling of
+     * {@see Health::handleValidationDataError()}'s unreadable-file arm, and built to match it frame
+     * for frame. `Health`'s Guzzle client is built with `'http_errors' => false`, so a 4xx or 5xx
+     * resolves {@see Health::cachedGet()}'s promise rather than rejecting it — this is the check that
+     * would otherwise be skipped, leaving `runValidationSteps()` to hand a problem document to
+     * {@see Health::processValidationData()} as if it were the checked resource, which reports
+     * `exists` as passed unconditionally.
+     *
+     * All three published steps fail, not just `exists`: a refusal means `parses` and `validates`
+     * were never attempted either, and per #821 "not attempted" is reported the same as "failed",
+     * never left unsent.
+     *
+     * The `exists` text quotes the API's own RFC 9457 `detail` when the body decodes to one — it
+     * already explains precisely what is wrong (e.g. a rite's year boundary) — and falls back to the
+     * bare status when it does not.
+     *
+     * @param int $status The non-2xx HTTP status the request resolved with.
+     * @param string $body The response body, inspected only for a problem-document `detail`.
+     * @param ConnectionInterface $to The WebSocket connection to send errors to.
+     * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource $validation The validation object.
+     * @param string $dataPath The URL that was requested.
+     * @param ?string $runToken The originating run token to echo back on responses, or null to use the per-connection fallback.
+     * @param ?\stdClass $target What the frames are about, per {@see Health::frameTarget()}, or null for a v1 message, which names none.
+     * @param ?string $requestId The correlation id of the request that caused this frame, captured by the handler when
+     *        the request arrived and passed explicitly rather than read from any per-connection store; see
+     *        {@see Health::onMessage()} for why that distinction is load-bearing.
+     * @return void
+     */
+    private function handleValidationHttpFailure(int $status, string $body, ConnectionInterface $to, \stdClass $validation, string $dataPath, ?string $runToken = null, ?\stdClass $target = null, ?string $requestId = null): void
+    {
+        // `validate` carries the class fragment: see the note where $validationForMessages is built.
+        $validate = (string) $validation->validate;
+        $category = (string) $validation->category;
+        echo "Refused: HTTP $status received from $dataPath\n";
+
+        $detail = self::problemDetailFromBody($body);
+        $suffix = $detail !== null ? ": $detail" : '';
+
+        $this->sendStepResult(
+            $to,
+            $validate,
+            $target,
+            Step::EXISTS,
+            Status::FAIL,
+            "The Data file $dataPath was refused with HTTP $status$suffix",
+            null,
+            $runToken,
+            requestId: $requestId
+        );
+
+        $this->sendStepResult(
+            $to,
+            $validate,
+            $target,
+            Step::PARSES,
+            Status::FAIL,
+            "Could not decode the Data file $dataPath as JSON because the request for it returned HTTP $status",
+            null,
+            $runToken,
+            requestId: $requestId
+        );
+
+        $this->sendStepResult(
+            $to,
+            $validate,
+            $target,
+            Step::VALIDATES,
+            Status::FAIL,
+            "Unable to verify schema for dataPath {$dataPath} and category {$category} since the request for it returned HTTP $status",
             null,
             $runToken,
             requestId: $requestId
@@ -2563,10 +2656,53 @@ class Health implements MessageComponentInterface
         $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
         $promise->then(
             function (array $result) use ($to, $calendar, $year, $category, $req, $responseType, $runToken, $requestId) {
-                /** @var array{data: string, fromCache: bool} $result */
+                /** @var array{data: string, status: int, fromCache: bool} $result */
                 $data      = $result['data'];
+                $status    = $result['status'];
                 $fromCache = $result['fromCache'];
-                echo 'Fetched data for ' . Route::CALENDAR->path() . $req . ': got ' . strlen($data) . ' bytes' . ( $fromCache ? ' (from cache)' : '' ) . "\n";
+                echo 'Fetched data for ' . Route::CALENDAR->path() . $req . ': got ' . strlen($data) . " bytes, HTTP $status" . ( $fromCache ? ' (from cache)' : '' ) . "\n";
+
+                // #833: `'http_errors' => false` means a 4xx/5xx resolves this promise rather than
+                // rejecting it, so `exists` must not be reported as passed without checking the status
+                // that resolved it. A refusal means none of the three published steps were established
+                // — not just the first — so all three are reported failed here rather than skipping
+                // straight to `complete`, per #821's one-frame-per-step contract.
+                if (false === self::isHttpSuccessStatus($status)) {
+                    $detail = self::problemDetailFromBody($data);
+                    $suffix = $detail !== null ? ": $detail" : '';
+                    $this->sendCalendarStepResult(
+                        $to,
+                        $calendar,
+                        $year,
+                        Step::EXISTS,
+                        Status::FAIL,
+                        "The $category of $calendar for the year $year was refused with HTTP $status$suffix",
+                        runToken: $runToken,
+                        requestId: $requestId
+                    );
+                    $this->sendCalendarStepResult(
+                        $to,
+                        $calendar,
+                        $year,
+                        Step::PARSES,
+                        Status::FAIL,
+                        "Could not decode the $category of $calendar for the year $year as $responseType because the request for it returned HTTP $status",
+                        runToken: $runToken,
+                        requestId: $requestId
+                    );
+                    $this->sendCalendarStepResult(
+                        $to,
+                        $calendar,
+                        $year,
+                        Step::VALIDATES,
+                        Status::FAIL,
+                        "Unable to verify schema for the $category of $calendar for the year $year since the request for it returned HTTP $status",
+                        runToken: $runToken,
+                        requestId: $requestId
+                    );
+                    $this->sendComplete($to, target: self::frameTarget($calendar, ['year' => $year]), runToken: $runToken, requestId: $requestId);
+                    return;
+                }
 
                 $this->sendCalendarStepResult(
                     $to,
@@ -3053,9 +3189,33 @@ class Health implements MessageComponentInterface
         $req     = $this->buildCalendarRequestPath($calendar, $year, $category, $rite);
         $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
         $promise->then(
-            function (array $result) use ($to, $test, $calendar, $year, $runToken, $requestId, $rite) {
-                /** @var array{data: string, fromCache: bool} $result */
-                $data = $result['data'];
+            function (array $result) use ($to, $test, $calendar, $year, $category, $req, $runToken, $requestId, $rite) {
+                /** @var array{data: string, status: int, fromCache: bool} $result */
+                $data   = $result['data'];
+                $status = $result['status'];
+
+                // #833: a refused calendar (e.g. a rite's year boundary) is valid JSON — a problem
+                // document — so without this check it would decode cleanly and be handed to
+                // LitTestRunner as if it were calendar data, which is worse than a plain failure: the
+                // run would go on to answer whatever the test asserts, over data that never existed. A
+                // test run carries one step, so the refusal is reported there rather than skipped.
+                if (false === self::isHttpSuccessStatus($status)) {
+                    $detail = self::problemDetailFromBody($data);
+                    $suffix = $detail !== null ? ": $detail" : '';
+                    $this->sendTestResult(
+                        $to,
+                        $test,
+                        $calendar,
+                        $year,
+                        Status::FAIL,
+                        "The $category of $calendar for the year $year was refused with HTTP $status$suffix at the URL " . Route::CALENDAR->path() . $req,
+                        runToken: $runToken,
+                        requestId: $requestId
+                    );
+                    $this->sendComplete($to, target: self::frameTarget($test, ['calendar' => $calendar, 'year' => $year]), runToken: $runToken, requestId: $requestId);
+                    return;
+                }
+
                 /** @var \stdClass&object{settings:object{year:int,national_calendar?:string,diocesan_calendar?:string},litcal:LiturgicalEvent[]} $jsonData */
                 $jsonData = json_decode($data);
                 if (json_last_error() === JSON_ERROR_NONE) {
@@ -3373,32 +3533,42 @@ class Health implements MessageComponentInterface
     /**
      * @param array{headers?:array<string, string>,stream?:bool} $options
      *
-     * @return PromiseInterface<array{data: string, fromCache: bool}>
+     * @return PromiseInterface<array{data: string, status: int, fromCache: bool}>
      */
     private function cachedGet(string $url, array $options = [], int $ttl = 300, ?ConnectionInterface $conn = null): PromiseInterface
     {
         $key = 'http_' . md5($url . serialize($options));
 
-        /** @var Deferred<array{data: string, fromCache: bool}> $deferred */
+        /** @var Deferred<array{data: string, status: int, fromCache: bool}> $deferred */
         $deferred = new Deferred();
 
         // Return from cache if available - stagger resolutions to stream results back gradually
         if (self::$cacheEnabled && self::cacheExists($key)) {
             echo "Cache hit for $url\n";
-            [$success, $data] = self::cacheGet($key);
-            if ($success && is_string($data)) {
+            [$success, $raw] = self::cacheGet($key);
+            // The cache stores `{"status":…,"body":…}` (see handleHttpResponse()), not the bare body,
+            // precisely so a cache hit can answer the same question a live fetch just did: #833 was a
+            // 400 that resolved as a pass on the *first* run because the status was never propagated at
+            // all, and it would have resolved as a pass again on the *second* run — from cache — had the
+            // status not been stored alongside the body it is decoded from here. Decoding is extracted
+            // to {@see Health::decodeHttpCacheEntry()} so this contract is unit-testable on its own,
+            // without a real cache backend or the ReactPHP loop {@see HealthHelpersTest} covers it.
+            $decoded = ( $success && is_string($raw) ) ? self::decodeHttpCacheEntry($raw) : null;
+            if (null !== $decoded) {
+                $data   = $decoded['body'];
+                $status = $decoded['status'];
                 // Stagger cached responses: resolve in small batches using incremental delays
                 // This prevents all cache hits from resolving in a single tick
                 $connId                          = $conn !== null && is_int($conn->resourceId) ? $conn->resourceId : 0;
                 $counter                         = $this->cacheHitCounters[$connId] ?? 0;
                 $delay                           = floor($counter / max(1, $this->maxConcurrency)) * $this->staggerInterval;
                 $this->cacheHitCounters[$connId] = $counter + 1;
-                $resolveIfOpen                   = function () use ($deferred, $data, $conn) {
+                $resolveIfOpen                   = function () use ($deferred, $data, $status, $conn) {
                     // Skip resolving if the client has disconnected while waiting
                     if ($conn !== null && !$this->clients->contains($conn)) {
                         return;
                     }
-                    $deferred->resolve(['data' => $data, 'fromCache' => true]);
+                    $deferred->resolve(['data' => $data, 'status' => $status, 'fromCache' => true]);
                 };
                 if ($delay > 0) {
                     Loop::addTimer($delay, $resolveIfOpen);
@@ -3406,10 +3576,10 @@ class Health implements MessageComponentInterface
                     Loop::futureTick($resolveIfOpen);
                 }
             } else {
-                $deferred->reject(new \RuntimeException("Cache fetch for URL $url failed or returned non-string data"));
+                $deferred->reject(new \RuntimeException("Cache fetch for URL $url failed or returned malformed cache payload"));
             }
 
-            /** @var PromiseInterface<array{data: string, fromCache: bool}> $deferredPromise */
+            /** @var PromiseInterface<array{data: string, status: int, fromCache: bool}> $deferredPromise */
             $deferredPromise = $deferred->promise();
             return $deferredPromise;
         }
@@ -3445,7 +3615,7 @@ class Health implements MessageComponentInterface
             'runToken'   => $queuedRunToken
         ];
 
-        /** @var PromiseInterface<array{data: string, fromCache: bool}> $deferredPromise */
+        /** @var PromiseInterface<array{data: string, status: int, fromCache: bool}> $deferredPromise */
         $deferredPromise = $deferred->promise();
         $this->ensureTicking();
         return $deferredPromise;
@@ -3458,7 +3628,11 @@ class Health implements MessageComponentInterface
      * so the status/cache branching is unit-testable without the Ratchet/Guzzle event loop; the
      * caller is responsible for the inFlight bookkeeping.
      *
-     * @param Deferred<array{data: string, fromCache: bool}> $deferred
+     * The resolved value always carries the real HTTP status (#833): `'http_errors' => false` on the
+     * Guzzle client means a 4xx or 5xx never rejects this promise on its own, so a consumer that wants
+     * to tell "the resource exists" from "the resource was refused" has nothing else to look at.
+     *
+     * @param Deferred<array{data: string, status: int, fromCache: bool}> $deferred
      */
     private static function handleHttpResponse(
         ResponseInterface $response,
@@ -3501,12 +3675,25 @@ class Health implements MessageComponentInterface
             return;
         }
 
+        // The status is cached alongside the body, not just resolved alongside it: a consumer that
+        // asked for this URL before is entitled to the same answer a live request would give it. Every
+        // other status this method reaches (i.e. everything that isn't 429/5xx, rejected above and
+        // never cached) was already being cached before #833 — a 400 or 404 flows through "so the
+        // per-format validation can report them at the json-valid phase as before" per the comment
+        // below. That design is kept: what changes is that the cached entry can now be decoded back
+        // into a real status instead of always being replayed as a silent 200 (`cachedGet()`'s
+        // cache-hit branch decodes this JSON envelope; see the note there for why that trap mattered).
         if (self::$cacheEnabled) {
-            $stored = self::cacheSet($key, $body, $ttl);
-            echo ( $stored ? "Stored response body in cache\n" : "Failed to store response body in cache\n" );
-            echo self::cacheInfo() . "\n";
+            $cachePayload = self::encodeHttpCacheEntry($statusCode, $body);
+            if (null !== $cachePayload) {
+                $stored = self::cacheSet($key, $cachePayload, $ttl);
+                echo ( $stored ? "Stored response body in cache\n" : "Failed to store response body in cache\n" );
+                echo self::cacheInfo() . "\n";
+            } else {
+                echo "Failed to encode response body for caching (not valid UTF-8?), skipping cache write\n";
+            }
         }
-        $deferred->resolve(['data' => $body, 'fromCache' => false]);
+        $deferred->resolve(['data' => $body, 'status' => $statusCode, 'fromCache' => false]);
     }
 
     /**
@@ -3518,6 +3705,82 @@ class Health implements MessageComponentInterface
     private static function isUpstreamFailureStatus(int $statusCode): bool
     {
         return $statusCode === 429 || $statusCode >= 500;
+    }
+
+    /**
+     * Encode a fetched HTTP response for the cache: the status alongside the body, in one string, so
+     * that a cache hit can answer #833's "does it exist" question exactly as a live fetch would.
+     *
+     * Extracted from {@see Health::handleHttpResponse()}, and paired with {@see Health::decodeHttpCacheEntry()}
+     * below it, so the round trip is unit-testable on its own — without a real cache backend and
+     * without the ReactPHP loop that `cachedGet()`'s cache-hit branch schedules its resolution through.
+     *
+     * Returns null when the body cannot be represented as JSON (e.g. invalid UTF-8) rather than
+     * falling back to caching the bare body: a caller that cannot cache the status safely must not
+     * cache at all, since a bare-body entry is exactly the pre-#833 shape that read back as an
+     * unconditional pass.
+     */
+    private static function encodeHttpCacheEntry(int $status, string $body): ?string
+    {
+        $encoded = json_encode(['status' => $status, 'body' => $body]);
+        return false !== $encoded ? $encoded : null;
+    }
+
+    /**
+     * The inverse of {@see Health::encodeHttpCacheEntry()}.
+     *
+     * Returns null for anything that is not a well-formed `{"status":…,"body":…}` envelope —
+     * including a bare body, which is what a cache entry written before #833 (or by anything else
+     * that ever wrote to this key) would be. Guessing a status for that shape, e.g. defaulting to 200,
+     * would silently reintroduce the exact bug #833 fixed the moment an old entry outlived a deploy;
+     * treating it as absent instead makes the caller reject and re-fetch, which is always correct.
+     *
+     * @return array{status: int, body: string}|null
+     */
+    private static function decodeHttpCacheEntry(string $raw): ?array
+    {
+        $decoded = json_decode($raw, true);
+        if (
+            is_array($decoded)
+            && isset($decoded['status'], $decoded['body'])
+            && is_int($decoded['status'])
+            && is_string($decoded['body'])
+        ) {
+            /** @var array{status: int, body: string} $decoded */
+            return $decoded;
+        }
+        return null;
+    }
+
+    /**
+     * Whether an HTTP status is a plain success. Consumers of {@see Health::cachedGet()} gate the
+     * `exists` step on this (#833): `'http_errors' => false` on the Guzzle client means a 4xx/5xx
+     * resolves rather than rejects, so without this check `exists` would pass for a request the API
+     * refused. 429 and 5xx never reach this check — {@see Health::handleHttpResponse()} rejects those
+     * before the promise resolves — but every other non-2xx (e.g. a 400 rite-boundary refusal, or a
+     * 404 for an unknown calendar) does, and must be caught here.
+     */
+    private static function isHttpSuccessStatus(int $statusCode): bool
+    {
+        return $statusCode >= 200 && $statusCode < 300;
+    }
+
+    /**
+     * The `detail` of an RFC 9457 problem-document body, when the body decodes to one.
+     *
+     * The API's own explanation of a refusal is quoted verbatim in an `exists` failure text (#833)
+     * rather than left for a client to go and re-fetch: `detail` already says precisely what is wrong
+     * — e.g. a rite's year boundary — better than any text manufactured here. `null` covers both "the
+     * body is not JSON" and "it is JSON but not a problem document", so every call site falls back to
+     * reporting the bare status.
+     */
+    private static function problemDetailFromBody(string $body): ?string
+    {
+        $decoded = json_decode($body);
+        if ($decoded instanceof \stdClass && isset($decoded->detail) && is_string($decoded->detail)) {
+            return $decoded->detail;
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
Closes #833.

Reported from the live test interface: Ambrosian years **1970–1975** showed a green **"data exists"** while the API was correctly returning 400 with a problem document explaining the rite's lower bound.

## Two facts composed into it

1. `Health`'s Guzzle client is built with **`'http_errors' => false`**, so a 400 resolves as a *success*.
2. `cachedGet()` resolved with `{data, fromCache}` — **the status was never propagated**, so no consumer could check it even in principle.

`validateCalendar()`'s fulfil handler therefore emitted `Step::EXISTS, Status::PASS` unconditionally.

What a user saw was worse than a plain failure: `exists` passed, `json-valid` **also** passed — a problem document is perfectly valid JSON — and `schema-valid` failed. So the interface said *"the schema is wrong"* when the truth was *"the endpoint refused the request"*.

## The fix

`cachedGet()` now resolves with `{data, status, fromCache}`; the `exists` frame is gated on a 2xx at each consumer; and a non-2xx **fails the remaining steps** rather than skipping them, per the one-frame-per-published-step contract from #821. The failure quotes the problem document's own `detail`, which explains the cause better than anything we would write:

```text
ambrosian 1970 was refused with HTTP 400: The Ambrosian rite is only available
from 1976 onward (the first reformed Ambrosian Missal); requested year 1970.
```

## The cache was the trap

A cached 4xx replaying without its status would reopen the bug on the **second** run of the same check — exactly what a user hits re-running the interface. Entries now carry `{status, body}`.

Beyond that: entries written by the *old* code are bare bodies with no status. They decode to `null` and are treated as a miss, so the URL is re-fetched, rather than being assumed 200 — which would have silently reopened the bug for precisely the checks already cached.

## Relationship to #822

This is the same defect — a check asserting existence it never established — in the half #822's fix structurally could not reach. #822 stat-ed before reading, which works for a **file**. For a **URL** there is nothing to stat: the HTTP status is the only existence signal there is, and it was being discarded.

## Deliberately unchanged

The internal `/calendars` metadata fetch. It emits no step frame to any client, and its existing shape guards already treat a refused or malformed body as "not loaded yet", so there is no false `exists` there. A comment records that rather than leaving the omission to look accidental.

## Verification

Six new tests drive `onMessage()` through the reported scenario and its siblings — Ambrosian 1970 via `validateCalendar`, an unknown nation, a `resourceDataCheck` URL, and `runTest` — with no real network I/O.

Mutation-checked: replacing the 2xx gate with `return true` fails **4 of 6**; restored, all pass. The suite had no case where a URL check receives a 4xx, which is why this survived alongside #822's fix.

469 tests / 2648 assertions in the Health and schema suites, PHPStan level 10 clean, phpcs clean.

Refs #822, #821, UnitTestInterface#52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation now consistently reports HTTP status codes for calendar, resource, and test requests.
  * Failure responses include problem details and preserve `Retry-After` guidance when available.
  * Rate-limited and server-error responses are handled consistently without losing response information.
  * Cached responses retain validated status data, while malformed or out-of-range entries are discarded and refreshed automatically.
  * Unknown calendars now report clear 400 validation errors with valid-value guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->