### PR TITLE
fix(health): verify APCu with a store/fetch round trip, and fix the CI ini typo (#835)

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -59,7 +59,16 @@ jobs:
         with:
           php-version: ${{ env.PHP_VERSION }}
           extensions: yaml, intl, zip, calendar, gettext, apcu, opcache, pdo_pgsql, pdo_sqlite
-          ini-values: apcu.enable_cli=1, opcache.enable=1, opcache.enable_cli=1
+          # APCu is installed but deliberately left OFF under the CLI SAPI (#835), which mirrors the
+          # deployment host: production selects Redis and never takes the APCu path, so a real APCu
+          # here would exercise a configuration nothing runs — and, because APCu state persists for
+          # the life of the PHP process, one test's cache entry would change what a later test sees
+          # across the whole suite. The cache logic is covered deterministically by
+          # phpunit_tests/Support/ApcuShim.php instead.
+          # Mind the prefix: APCu inherited APC's, so the setting is `apc.enable_cli`. This line read
+          # `apcu.enable_cli=1` until #835 — a no-op, leaving the extension loaded but CLI-disabled,
+          # i.e. the value below by accident rather than by decision.
+          ini-values: apc.enable_cli=0, opcache.enable=1, opcache.enable_cli=1
           coverage: pcov
 
       - name: Cache Composer dependencies

--- a/phpunit_tests/HealthApcuDetectionTest.php
+++ b/phpunit_tests/HealthApcuDetectionTest.php
@@ -55,6 +55,7 @@ final class HealthApcuDetectionTest extends TestCase
     protected function tearDown(): void
     {
         ApcuShimStore::simulateDisabledStore(false);
+        ApcuShimStore::simulateThrowingStore(false);
         ( new \ReflectionProperty(Health::class, 'cacheEnabled') )->setValue(null, $this->cacheEnabledBefore);
         ( new \ReflectionProperty(Health::class, 'cacheBackend') )->setValue(null, $this->cacheBackendBefore);
         parent::tearDown();
@@ -165,6 +166,48 @@ final class HealthApcuDetectionTest extends TestCase
             [false, 'none'],
             self::backendState(),
             'an inert APCu must fall to `none` with caching off, exactly as an absent one does'
+        );
+    }
+
+    /**
+     * A backend that *raises* rather than answering dishonestly. The probe owes its callers a bool
+     * either way: a throw escaping here would propagate out of `handleRedisFailure()`, i.e. during
+     * the Redis outage the APCu fallback exists to cover, turning a degraded cache into a broken
+     * connection handler.
+     */
+    public function testAnApcuWhoseStoreThrowsIsNotUsableRatherThanPropagating(): void
+    {
+        ApcuShimStore::simulateThrowingStore(true);
+
+        ob_start();
+        $usable = self::apcuUsable();
+        $output = ob_get_clean();
+
+        self::assertFalse($usable, 'a store that throws must read as unusable, not escape as an exception');
+        self::assertIsString($output);
+        self::assertStringContainsString(
+            'simulated APCu store failure',
+            $output,
+            'the throw must be reported, not silently swallowed — an exception here is by definition unanticipated'
+        );
+    }
+
+    /**
+     * And the same at the site that matters: a throwing APCu must leave the backend at `none` with
+     * caching off, exactly as an inert or absent one does.
+     */
+    public function testTheRedisFallbackDisablesCachingWhenApcuThrows(): void
+    {
+        ( new \ReflectionProperty(Health::class, 'cacheEnabled') )->setValue(null, true);
+        ( new \ReflectionProperty(Health::class, 'cacheBackend') )->setValue(null, 'redis');
+        ApcuShimStore::simulateThrowingStore(true);
+
+        self::handleRedisFailure();
+
+        self::assertSame(
+            [false, 'none'],
+            self::backendState(),
+            'a throwing APCu must fall to `none`, not abort the Redis-failure path with an exception'
         );
     }
 

--- a/phpunit_tests/HealthApcuDetectionTest.php
+++ b/phpunit_tests/HealthApcuDetectionTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\ApcuShimStore;
+use LiturgicalCalendar\Api\Health;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #835: an APCu that is present but inert must not be selected as the cache backend.
+ *
+ * The predicate this replaces was `extension_loaded('apcu') && function_exists('apcu_exists'|'apcu_store'|'apcu_fetch')`,
+ * and on the deployment host all four are true while `apc.enable_cli=0` leaves APCu doing nothing under
+ * the CLI SAPI the WebSocket server runs in. Selecting that backend produces a cache that stores
+ * nothing: every `cacheSet()` reports success, every `cacheGet()` misses, and the only symptom is quiet
+ * slowness — reached only on the Redis-outage fallback, i.e. exactly when the fallback is what is being
+ * relied on. Nothing exercised either detection site, which is how the gap survived.
+ *
+ * Both directions are asserted deliberately: a probe that always fails would satisfy the negative case
+ * on its own while disabling caching everywhere. Read as a pair, they say that flipping *only* the
+ * round trip — same extension, same functions, same everything else — is what flips the decision.
+ *
+ * The backend is driven through {@see \LiturgicalCalendar\Api\Health::apcuUsable()} and through the
+ * real Redis-failure fallback ({@see \LiturgicalCalendar\Api\Health::handleRedisFailure()}), not by
+ * setting `cacheBackend` by reflection the way the cache-*behaviour* tests do — the selection decision
+ * is the thing under test here.
+ *
+ * `apcu_*` calls inside `Health` resolve to `phpunit_tests/Support/ApcuShim.php`'s namespaced
+ * stand-ins (see that file's header for why namespace-first resolution is load-bearing in CI), so
+ * `ApcuShimStore::simulateDisabledStore()` can make a store silently drop what it is given while still
+ * reporting success — the inert-APCu behaviour, reproduced without needing an inert APCu.
+ */
+#[CoversClass(Health::class)]
+final class HealthApcuDetectionTest extends TestCase
+{
+    private const PROBE_KEY_PREFIX = 'health_apcu_probe_';
+
+    private bool $cacheEnabledBefore;
+    private string $cacheBackendBefore;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/Support/ApcuShim.php';
+
+        $enabled                  = ( new \ReflectionProperty(Health::class, 'cacheEnabled') )->getValue();
+        $backend                  = ( new \ReflectionProperty(Health::class, 'cacheBackend') )->getValue();
+        $this->cacheEnabledBefore = is_bool($enabled) ? $enabled : false;
+        $this->cacheBackendBefore = is_string($backend) ? $backend : 'none';
+    }
+
+    protected function tearDown(): void
+    {
+        ApcuShimStore::simulateDisabledStore(false);
+        ( new \ReflectionProperty(Health::class, 'cacheEnabled') )->setValue(null, $this->cacheEnabledBefore);
+        ( new \ReflectionProperty(Health::class, 'cacheBackend') )->setValue(null, $this->cacheBackendBefore);
+        parent::tearDown();
+    }
+
+    // ---------------------------------------------------------------- harness
+
+    private static function apcuUsable(): bool
+    {
+        $usable = ( new \ReflectionMethod(Health::class, 'apcuUsable') )->invoke(null);
+        self::assertIsBool($usable);
+
+        return $usable;
+    }
+
+    /**
+     * Drive the real Redis-connection-lost fallback, which is one of the two sites that has to make
+     * this decision (the other being initial selection in `onOpen()`).
+     */
+    private static function handleRedisFailure(): void
+    {
+        ob_start();
+        ( new \ReflectionMethod(Health::class, 'handleRedisFailure') )->invoke(null, new \RedisException('connection lost'));
+        ob_end_clean();
+    }
+
+    /**
+     * @return array{0: bool, 1: string} [cacheEnabled, cacheBackend]
+     */
+    private static function backendState(): array
+    {
+        $enabled = ( new \ReflectionProperty(Health::class, 'cacheEnabled') )->getValue();
+        $backend = ( new \ReflectionProperty(Health::class, 'cacheBackend') )->getValue();
+        self::assertIsBool($enabled);
+        self::assertIsString($backend);
+
+        return [$enabled, $backend];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function probeKeysLeftBehind(): array
+    {
+        return array_values(array_filter(
+            ApcuShimStore::keys(),
+            static fn (string $key): bool => str_starts_with($key, self::PROBE_KEY_PREFIX)
+        ));
+    }
+
+    // ---------------------------------------------------------------- the probe itself
+
+    /**
+     * The defect, reduced to its smallest statement: functions all present, store reports success,
+     * nothing comes back. That must read as unusable.
+     */
+    public function testAnApcuThatReportsSuccessButStoresNothingIsNotUsable(): void
+    {
+        ApcuShimStore::simulateDisabledStore(true);
+
+        self::assertFalse(
+            self::apcuUsable(),
+            'an APCu whose writes silently vanish must not be reported as usable, however present its functions are'
+        );
+    }
+
+    /**
+     * The other half of the pair: a backend that does round-trip is still selected, so the probe is
+     * not simply always-false — which would "fix" the issue by disabling caching outright.
+     */
+    public function testAnApcuThatRoundTripsIsUsable(): void
+    {
+        self::assertTrue(
+            self::apcuUsable(),
+            'a store/fetch round trip that works must be reported as usable'
+        );
+    }
+
+    /**
+     * A probe key is a write into a live cache and must not outlive the question it answers.
+     */
+    public function testTheProbeCleansUpAfterItself(): void
+    {
+        self::assertTrue(self::apcuUsable(), 'precondition: the probe took the store/fetch path');
+
+        self::assertSame(
+            [],
+            self::probeKeysLeftBehind(),
+            'the probe key must be deleted, not left sitting in the cache it was only testing'
+        );
+    }
+
+    // ---------------------------------------------------------------- the Redis-outage fallback site
+
+    /**
+     * The path the issue is actually about: Redis drops, and the fallback must refuse an APCu that
+     * stores nothing rather than switching to it and quietly caching into the void.
+     */
+    public function testTheRedisFallbackDisablesCachingWhenApcuStoresNothing(): void
+    {
+        ( new \ReflectionProperty(Health::class, 'cacheEnabled') )->setValue(null, true);
+        ( new \ReflectionProperty(Health::class, 'cacheBackend') )->setValue(null, 'redis');
+        ApcuShimStore::simulateDisabledStore(true);
+
+        self::handleRedisFailure();
+
+        self::assertSame(
+            [false, 'none'],
+            self::backendState(),
+            'an inert APCu must fall to `none` with caching off, exactly as an absent one does'
+        );
+    }
+
+    /**
+     * And the fallback still works when there is something to fall back to.
+     */
+    public function testTheRedisFallbackSelectsApcuWhenTheRoundTripSucceeds(): void
+    {
+        ( new \ReflectionProperty(Health::class, 'cacheEnabled') )->setValue(null, true);
+        ( new \ReflectionProperty(Health::class, 'cacheBackend') )->setValue(null, 'redis');
+
+        self::handleRedisFailure();
+
+        self::assertSame(
+            [true, 'apcu'],
+            self::backendState(),
+            'a working APCu is still the fallback — this fix must not amount to switching the fallback off'
+        );
+    }
+}

--- a/phpunit_tests/Support/ApcuShim.php
+++ b/phpunit_tests/Support/ApcuShim.php
@@ -61,6 +61,16 @@ final class ApcuShimStore
     private static bool $storeIsNoOp = false;
 
     /**
+     * Fault injection for #835: when true, `store()` raises instead of returning.
+     *
+     * A separate failure mode from {@see self::$storeIsNoOp}: that one models a backend that answers
+     * dishonestly, this one models one that blows up. `Health::apcuUsable()` owes its callers a bool
+     * in both cases — a raised exception would propagate out of `handleRedisFailure()` during the
+     * Redis outage the APCu fallback exists to cover.
+     */
+    private static bool $storeThrows = false;
+
+    /**
      * Make every subsequent `store()` a reported-success no-op (or stop doing so).
      *
      * Process-wide state, so a test that turns it on must turn it off again in a `finally`/`tearDown`.
@@ -68,6 +78,16 @@ final class ApcuShimStore
     public static function simulateDisabledStore(bool $noOp): void
     {
         self::$storeIsNoOp = $noOp;
+    }
+
+    /**
+     * Make every subsequent `store()` throw a \RuntimeException (or stop doing so).
+     *
+     * Process-wide state, so a test that turns it on must turn it off again in a `finally`/`tearDown`.
+     */
+    public static function simulateThrowingStore(bool $throws): void
+    {
+        self::$storeThrows = $throws;
     }
 
     /**
@@ -83,6 +103,9 @@ final class ApcuShimStore
 
     public static function store(string $key, mixed $value, int $ttl = 0): bool
     {
+        if (self::$storeThrows) {
+            throw new \RuntimeException('simulated APCu store failure');
+        }
         if (self::$storeIsNoOp) {
             return true;
         }

--- a/phpunit_tests/Support/ApcuShim.php
+++ b/phpunit_tests/Support/ApcuShim.php
@@ -49,8 +49,43 @@ final class ApcuShimStore
     /** @var array<string, array{value: string, expires: int}> */
     private static array $store = [];
 
+    /**
+     * Fault injection for #835: when true, `store()` reports success and stores nothing.
+     *
+     * That is exactly the shape of the defect the round-trip probe exists to catch — an APCu that is
+     * loaded and whose functions all exist, but which is inert (CLI-disabled, or a full/broken shared
+     * memory segment), so every write is silently dropped while reporting success. Reporting success
+     * is the harsher of the two possible behaviours and the one that defeats any check that trusts
+     * `apcu_store()`'s return value, which is why the shim simulates it that way round.
+     */
+    private static bool $storeIsNoOp = false;
+
+    /**
+     * Make every subsequent `store()` a reported-success no-op (or stop doing so).
+     *
+     * Process-wide state, so a test that turns it on must turn it off again in a `finally`/`tearDown`.
+     */
+    public static function simulateDisabledStore(bool $noOp): void
+    {
+        self::$storeIsNoOp = $noOp;
+    }
+
+    /**
+     * The keys currently held, expired entries included — for asserting that a probe cleaned up after
+     * itself rather than leaving a key behind in the cache it was only meant to test.
+     *
+     * @return list<string>
+     */
+    public static function keys(): array
+    {
+        return array_keys(self::$store);
+    }
+
     public static function store(string $key, mixed $value, int $ttl = 0): bool
     {
+        if (self::$storeIsNoOp) {
+            return true;
+        }
         self::$store[$key] = [
             'value'   => $value,
             'expires' => $ttl > 0 ? time() + $ttl : 0,

--- a/src/Health.php
+++ b/src/Health.php
@@ -448,20 +448,17 @@ class Health implements MessageComponentInterface
                 }
             }
 
-            // Fall back to APCu if Redis not available
+            // Fall back to APCu if Redis not available — but only to an APCu that demonstrably stores
+            // what it is given. See {@see Health::apcuUsable()} for why loaded is not the same as usable.
             if (self::$cacheBackend === 'none') {
-                $apcuAvailable = extension_loaded('apcu')
-                    && function_exists('apcu_exists')
-                    && function_exists('apcu_store')
-                    && function_exists('apcu_fetch');
-                if ($apcuAvailable) {
+                if (self::apcuUsable()) {
                     self::$cacheEnabled = true;
                     self::$cacheBackend = 'apcu';
-                    echo "APCu extension loaded, will use for caching\n";
-                    $logger->info('APCu extension loaded, will use for caching');
+                    echo "APCu verified by store/fetch round trip, will use for caching\n";
+                    $logger->info('APCu verified by store/fetch round trip, will use for caching');
                 } else {
-                    echo "No cache backend available (Redis and APCu both unavailable)\n";
-                    $logger->warning('No cache backend available (Redis and APCu both unavailable)');
+                    echo "No cache backend available (Redis unavailable; APCu missing or not storing)\n";
+                    $logger->warning('No cache backend available (Redis unavailable; APCu missing or not storing)');
                 }
             }
         }
@@ -3358,20 +3355,76 @@ class Health implements MessageComponentInterface
     }
 
     /**
-     * Handle Redis connection failure by falling back to APCu if available.
+     * Whether the APCu that this file's unqualified `apcu_*` calls actually reach is usable as a
+     * cache — established by storing a probe key and reading it back, not by asking whether the
+     * extension happens to be present.
+     *
+     * #835: the predicate this replaces was `extension_loaded('apcu')` plus `function_exists()` on
+     * three of the `apcu_*` functions. All four are true on the deployment host, where `apc.enable_cli`
+     * is `0` and APCu is therefore inert under the CLI SAPI the WebSocket server runs in: `apcu_store()`
+     * stores nothing and `apcu_exists()` always answers false. Selecting that as the backend yields a
+     * cache that silently swallows everything — every `cacheSet()` reports success, every `cacheGet()`
+     * misses — and the only symptom is quiet slowness. It is latent rather than live only because
+     * Redis is up; the path that reaches it is the Redis-outage fallback, i.e. precisely when the
+     * fallback is what is being relied on.
+     *
+     * A round trip answers the question that actually matters, and unlike `apcu_enabled()` it also
+     * catches a full or otherwise broken shared-memory segment, which no configuration flag reports.
+     *
+     * Two details of the checks below are deliberate:
+     *
+     * - The existence check looks in **this namespace before the global one**, because that is the
+     *   order PHP itself resolves the unqualified `apcu_*` calls in this file. It is what makes the
+     *   answer here describe the functions that will really be called — including under
+     *   `phpunit_tests/Support/ApcuShim.php`, which stands in for the backend precisely so this
+     *   decision can be tested in both directions (see that file's header).
+     * - `extension_loaded('apcu')` is **not** consulted: it is subsumed. An unloaded extension defines
+     *   no functions, so the existence check already stands down, and a loaded one proves nothing that
+     *   the round trip does not prove better.
+     */
+    private static function apcuUsable(): bool
+    {
+        // Every `apcu_*` function this class calls, not only the three the old predicate named:
+        // `cacheDelete()` calls `apcu_delete()` and `cacheInfo()` calls `apcu_sma_info()`, and an
+        // undefined function is a fatal, not a miss.
+        foreach (['apcu_store', 'apcu_fetch', 'apcu_exists', 'apcu_delete', 'apcu_sma_info'] as $function) {
+            if (!function_exists(__NAMESPACE__ . '\\' . $function) && !function_exists($function)) {
+                return false;
+            }
+        }
+
+        // Random per call: a fixed key could collide with a concurrent process probing the same
+        // shared segment, and a probe must never answer using another writer's value.
+        $probeKey   = 'health_apcu_probe_' . bin2hex(random_bytes(8));
+        $probeValue = 'probe';
+
+        try {
+            if (true !== apcu_store($probeKey, $probeValue, 10)) {
+                return false;
+            }
+            // The store's own return value is not trusted on its own — reporting success while
+            // storing nothing is the exact failure being ruled out here.
+            $fetched = apcu_fetch($probeKey, $success);
+
+            return true === $success && $fetched === $probeValue;
+        } finally {
+            apcu_delete($probeKey);
+        }
+    }
+
+    /**
+     * Handle Redis connection failure by falling back to APCu if it is actually usable.
      */
     private static function handleRedisFailure(\RedisException $e): void
     {
         echo "Redis connection lost: {$e->getMessage()}, falling back to APCu\n";
         self::$redis = null;
-        // Use the same comprehensive APCu check as initialization
-        $apcuAvailable = extension_loaded('apcu')
-            && function_exists('apcu_exists')
-            && function_exists('apcu_store')
-            && function_exists('apcu_fetch');
-        if ($apcuAvailable) {
+        // Use the same round-trip verification as initialization: a loaded-but-inert APCu would
+        // otherwise be selected here, during an outage, and cache nothing at all (#835).
+        if (self::apcuUsable()) {
             self::$cacheBackend = 'apcu';
-            echo "APCu fallback enabled\n";
+            self::$cacheEnabled = true;
+            echo "APCu fallback enabled (store/fetch round trip verified)\n";
         } else {
             self::$cacheBackend = 'none';
             self::$cacheEnabled = false;

--- a/src/Health.php
+++ b/src/Health.php
@@ -3371,6 +3371,11 @@ class Health implements MessageComponentInterface
      * A round trip answers the question that actually matters, and unlike `apcu_enabled()` it also
      * catches a full or otherwise broken shared-memory segment, which no configuration flag reports.
      *
+     * **It never throws.** Every caller reads the answer as a yes/no about whether to select the
+     * backend, so any failure at all — including one raised by `random_bytes()` or by the `apcu_*`
+     * functions themselves — is reported and answered `false`, which is what makes the backend fall
+     * to `none` rather than propagating out of a connection handler or a Redis-failure path.
+     *
      * Two details of the checks below are deliberate:
      *
      * - The existence check looks in **this namespace before the global one**, because that is the
@@ -3393,12 +3398,16 @@ class Health implements MessageComponentInterface
             }
         }
 
-        // Random per call: a fixed key could collide with a concurrent process probing the same
-        // shared segment, and a probe must never answer using another writer's value.
-        $probeKey   = 'health_apcu_probe_' . bin2hex(random_bytes(8));
-        $probeValue = 'probe';
+        $probeKey = null;
 
         try {
+            // Random per call: a fixed key could collide with a concurrent process probing the same
+            // shared segment, and a probe must never answer using another writer's value. Generated
+            // inside the `try` because `random_bytes()` can itself throw, and a caller of this method
+            // is owed a bool rather than an exception.
+            $probeKey   = 'health_apcu_probe_' . bin2hex(random_bytes(8));
+            $probeValue = 'probe';
+
             if (true !== apcu_store($probeKey, $probeValue, 10)) {
                 return false;
             }
@@ -3407,8 +3416,25 @@ class Health implements MessageComponentInterface
             $fetched = apcu_fetch($probeKey, $success);
 
             return true === $success && $fetched === $probeValue;
+        } catch (\Throwable $e) {
+            // Any failure whatsoever means "do not select this backend". A throw would instead
+            // propagate out of onOpen(), or — worse — out of handleRedisFailure(), which runs during
+            // the very Redis outage this fallback exists to cover. Reported rather than swallowed:
+            // an exception reaching here is by definition one nobody anticipated.
+            echo 'APCu probe failed: ' . $e::class . ': ' . $e->getMessage() . "\n";
+
+            return false;
         } finally {
-            apcu_delete($probeKey);
+            // Best effort, and deliberately not allowed to change the answer: an exception raised in
+            // a `finally` *replaces* whatever the `try` or `catch` was returning, so an unlucky
+            // cleanup could otherwise mask an answer that was already correctly decided.
+            if (null !== $probeKey) {
+                try {
+                    apcu_delete($probeKey);
+                } catch (\Throwable) {
+                    // Nothing to do: the answer is settled and the probe key carries a TTL.
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Closes #835.

Two related APCu problems, fixed as two commits because the workflow change has suite-wide blast radius and deserves to be revertable on its own.

## 1. The CI ini setting was a no-op (typo)

`.github/workflows/phpunit.yml` set `apcu.enable_cli=1`. APCu inherited APC's prefix, so the real name is `apc.enable_cli` — the line did nothing. It is now `apc.enable_cli=0`, **not** `1`, with a comment recording why: production selects Redis and never takes the APCu path, and APCu state persists for the life of the PHP process, so a real APCu would leak one test's cache entry into what a later test sees across the whole suite. The cache logic is covered deterministically by `phpunit_tests/Support/ApcuShim.php` instead.

The resulting behaviour is unchanged — it was already correct *by accident*. This turns it into a recorded decision.

## 2. The availability check would have selected a cache that stores nothing

The old predicate — `extension_loaded('apcu')` plus `function_exists()` on three `apcu_*` functions — is true on the deployment host while `apc.enable_cli=0`. Selecting that backend yields a cache that silently swallows everything: every `cacheSet()` reports success, every `cacheGet()` misses, and the only symptom is quiet slowness. It is latent rather than live only because Redis is up — the path that reaches it is the **Redis-outage fallback**, i.e. precisely when the fallback is what you are relying on.

Both detection sites (initial selection in `onOpen()`, and `handleRedisFailure()`) now call a new `Health::apcuUsable()`, which stores a random probe key and reads it back. A round trip was chosen over `apcu_enabled()` because it also catches a full or broken shared-memory segment, which no configuration flag reports. On failure the backend falls to `none` with `cacheEnabled = false`, exactly as when the extension is absent.

Three deviations from the issue text, each reasoned in the docblock:

- **The existence check resolves namespace-first** (`LiturgicalCalendar\Api\apcu_store` before global), mirroring how PHP resolves the unqualified `apcu_*` calls in that file. This is also what makes the decision testable, via the same mechanism #834's shim uses.
- **`extension_loaded('apcu')` is dropped** as subsumed: an unloaded extension defines no functions, so the existence loop already stands down.
- **The function list grew from three to five.** `cacheDelete()` calls `apcu_delete()` and `cacheInfo()` calls `apcu_sma_info()`; neither was checked, and an undefined function is a fatal, not a miss.

## Tests

New `phpunit_tests/HealthApcuDetectionTest.php` (5 tests): probe-level negative and positive, probe cleanup, and both directions through the real `handleRedisFailure()` site. `ApcuShim` gained `simulateDisabledStore()` (store reports success, stores nothing) and `keys()` — the round trip needs no `apcu_enabled` stub, but *simulating* an inert APCu does need a fault switch.

Pre-fix the new suite reported `Errors: 3, Failures: 1`; post-fix `OK (5 tests, 13 assertions)`.

Honest limitation, also stated in the test docblock: on a host without ext-apcu the *negative* test would pass pre-fix for the wrong reason. It is the positive/negative pair that makes it a real differential.

## Verification

- `composer lint` (phpcs): clean
- `composer analyse` (PHPStan level 10): `[OK] No errors`, 322 files
- `composer test:quick`: exit 0 — `Tests: 2923, Assertions: 177760, Skipped: 11`

## Follow-up

The identical predicate survives in six other places (`src/Utilities.php` ×5, `src/Models/MissalsPath/MissalMetadataMap.php` ×1). Those are on the FPM request path rather than the WebSocket CLI process, so they are not a live defect — filed separately as #836.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache reliability by verifying that APCu can store and retrieve data before enabling it.
  * Updated Redis-failure fallback behavior to disable caching when APCu is unavailable, nonfunctional, or encounters errors.
  * Corrected CLI test configuration to disable APCu as intended.

* **Tests**
  * Added coverage for APCu detection, fallback selection, probe cleanup, error handling, and nonpersisting cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->