### PR TITLE
fix(health): terminate a request whose fulfil handler threw (#823)

### DIFF
--- a/docs/superpowers/specs/2026-08-20-structured-responses-design.md
+++ b/docs/superpowers/specs/2026-08-20-structured-responses-design.md
@@ -371,7 +371,7 @@ A client stops on `complete` and never counts frames.
 > and the terminal frame is not thereby redundant: `complete` stays correct for an arm a later change makes shorter,
 > which is the property that made it worth adding while the counts disagreed.
 
-### A known limit: a throw inside a fulfil handler skips `complete` (#823)
+### A closed hole, and the shape that would reopen it: a throw inside a fulfil handler (#823)
 
 > **Amended: this hole is closed.** Each of the five `then(fulfil, reject)` pairs named below now carries a tail
 > handler — `->then(null, $this->terminateOnHandlerThrow(...))` — attached to the *derived* promise, which is where
@@ -387,23 +387,29 @@ A client stops on `complete` and never counts frames.
 > end of this subsection — a queued request dropped by `dropSupersededQueuedRequests()` — is untouched by that fix
 > and remains open.**
 
-The guarantee above is "every path that starts work terminates." It has two known holes — the fulfil-handler shape
-this subsection is named for, and a second, unrelated one recorded at the end of it — and it is honest to state them
-next to the guarantee rather than let a reader discover them independently.
+The guarantee above is "every path that starts work terminates." It had two known holes. The fulfil-handler shape
+this subsection is named for is **closed** — see the amendment above. The second, unrelated one recorded at the end of
+this subsection — a queued request dropped by `dropSupersededQueuedRequests()` — **remains open**, tracked as
+[#837](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/837). Both are stated next to the guarantee
+rather than left for a reader to discover independently.
 
-**The identifying shape:** `sendComplete()` is the last statement of a promise's `onFulfilled` handler, paired with
-a sibling `onRejected` that never runs to cover it. If anything *above* that last statement throws, `sendComplete()`
-never runs, and the request goes silent after whatever step frames it had already managed to emit. This is not a
-case the code declines to handle — it is a case the code cannot reach: React's promise implementation does not
-invoke the sibling `onRejected` when `onFulfilled` throws; the rejection propagates to the *next* promise in the
-chain, and there is no next promise here. A v2 client that stops on `complete`, exactly as this design tells it to,
-wedges on this path — the precise failure the terminal frame exists to prevent. Stated as a shape rather than a
-fixed list on purpose: a future `then(fulfil, reject)` pair added to `Health` inherits this description
-automatically, where a hardcoded list would need remembering to update and would silently go stale otherwise.
+**The identifying shape** — recorded as the rule that keeps this closed, because a `then(fulfil, reject)` pair added
+later *without* a tail handler reintroduces it exactly: `sendComplete()` as the last statement of a promise's
+`onFulfilled` handler, paired with a sibling `onRejected` that never runs to cover it. Absent the tail handler, anything
+throwing *above* that last statement means `sendComplete()` never runs and the request goes silent after whatever step
+frames it had already managed to emit. That was never a case the code declined to handle — it is one the pair alone
+cannot reach: React's promise implementation does not invoke the sibling `onRejected` when `onFulfilled` throws; the
+rejection propagates to the *next* promise in the chain, and there was no next promise here. Attaching one is precisely
+what the fix does. A v2 client that stops on `complete`, exactly as this design tells it to, would wedge on such a path
+— the precise failure the terminal frame exists to prevent. Stated as a shape rather than a fixed list on purpose: a
+future `then(fulfil, reject)` pair added to `Health` inherits this description automatically, where a hardcoded list
+would need remembering to update and would silently go stale otherwise.
 
-Checked against `src/Health.php` at `74c01d84`, the shape matches **five** sites today, all of them worth naming
-because "worth checking against the code" is exactly what an enumerated claim buys a reader — a hardcoded count
-this document once got wrong by one, so state it as an audit result, not received wisdom:
+Checked against `src/Health.php` at `74c01d84`, the shape matched **five** sites, all of them worth naming because
+"worth checking against the code" is exactly what an enumerated claim buys a reader — a hardcoded count this document
+once got wrong by one, so it is stated as an audit result, not received wisdom. **This is the historical audit that
+produced the fix, not a live list:** all five now carry a tail handler, and the line numbers below are those of
+`74c01d84` and have since drifted.
 
 - the i18n folder-check fulfil (line 1546, `runValidationSteps()`'s `Promise\all` branch)
 - the URL-check fulfil (line 1592, `runValidationSteps()`'s HTTP branch)
@@ -417,13 +423,13 @@ its remaining step frames nor a `complete`. It is reached by `cancelRun` and, le
 change. Also pre-existing, also out of scope here — the terminal frame does not make a discarded request terminate, it
 only makes the silence easier to notice.
 
-Exposure is narrow rather than nil, and pre-existing rather than introduced by this work: `validateDataAgainstSchema()`
+Exposure was narrow rather than nil, and pre-existing rather than introduced by this work: `validateDataAgainstSchema()`
 already catches `\Throwable` internally and is the principal throw source inside these handlers, and the `then(fulfil,
 reject)` pair with no tail handler is the shape these five call sites had before this design. A client that used to
-count `checks * 3` wedged on the same paths for the same reason; making `complete` explicit did not create the gap,
-it just gave the gap a name. **Deliberately not fixed here** — wrapping five error paths is not a change to make
-late in a branch whose own review is about the terminal frame's happy paths, not its exception plumbing. Filed as
-[#823](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/823).
+count `checks * 3` wedged on the same paths for the same reason; making `complete` explicit did not create the gap, it
+just gave the gap a name. It was **deliberately not fixed in this branch** — wrapping five error paths is not a change
+to make late in a branch whose own review is about the terminal frame's happy paths, not its exception plumbing — and
+was filed as [#823](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/823), then fixed there.
 
 ## Error handling
 

--- a/docs/superpowers/specs/2026-08-20-structured-responses-design.md
+++ b/docs/superpowers/specs/2026-08-20-structured-responses-design.md
@@ -373,6 +373,20 @@ A client stops on `complete` and never counts frames.
 
 ### A known limit: a throw inside a fulfil handler skips `complete` (#823)
 
+> **Amended: this hole is closed.** Each of the five `then(fulfil, reject)` pairs named below now carries a tail
+> handler — `->then(null, $this->terminateOnHandlerThrow(...))` — attached to the *derived* promise, which is where
+> React delivers a throw raised inside either of the two handlers. It logs the failure to the server's stdout and
+> emits `complete`, still gated on `requestId`, so a v2 client terminates and a v1 stream is byte-for-byte what it
+> was. Nothing else is reported to the client: an extra frame partway through a stream a v1 client sizes as
+> `checks * 3` is the miscount the gate exists to prevent, and unlike `complete` an error frame has no gate.
+> The **shape** below is what still matters, and the enumeration is kept as the audit that produced the fix rather
+> than as a live list: a `then(fulfil, reject)` pair added later without a tail handler reintroduces the hole
+> exactly as described. `phpunit_tests/HealthFulfilHandlerThrowTest.php` drives a throw from inside each of the five
+> fulfil handlers — settling each request *successfully* and throwing afterwards, which is what makes it a different
+> test from the rejection-driven ones in `HealthTerminalFrameTest`. **The second, unrelated shape recorded at the
+> end of this subsection — a queued request dropped by `dropSupersededQueuedRequests()` — is untouched by that fix
+> and remains open.**
+
 The guarantee above is "every path that starts work terminates." It has two known holes — the fulfil-handler shape
 this subsection is named for, and a second, unrelated one recorded at the end of it — and it is honest to state them
 next to the guarantee rather than let a reader discover them independently.
@@ -421,7 +435,9 @@ late in a branch whose own review is about the terminal frame's happy paths, not
 | Target never resolves (unknown id) | `echobot` rejection, no `complete` — no work was started           |
 
 "A step throws" assumes the throw is caught where the frame is composed. It is not, on the five fulfil-handler paths
-described above (#823): there, a throw skips both the error frame and `complete`, rather than producing them.
+described above (#823): there, a throw still skips the error frame, since nothing on those paths composes one for it.
+It no longer skips `complete` — the tail handler each of those `then()` pairs now carries emits the terminal frame —
+so the row reads "no error frame, then `complete`" on those paths rather than silence.
 
 No new response `type` is introduced. Since UnitTestInterface PR #46 an unrecognised `type` is painted as a visible
 failed check, so a `protocolError` type would make every rejection look like a failing test. That belongs to section

--- a/phpunit_tests/HealthFulfilHandlerThrowTest.php
+++ b/phpunit_tests/HealthFulfilHandlerThrowTest.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * A throw raised *inside* a fulfil handler still terminates the request (#823).
+ *
+ * ReactPHP does not invoke a `then()`'s sibling `onRejected` when its own `onFulfilled` throws: it
+ * rejects the promise *derived* from that `then()` instead. So an exception raised inside a
+ * fulfilment handler skipped the `sendComplete()` that followed it in the same handler, and a v2
+ * client that stops on the terminal frame waited forever — the very wedge the frame exists to
+ * prevent, arrived at from inside rather than outside.
+ *
+ * **This file is not {@see HealthTerminalFrameTest} with different names.** Every arm driven there
+ * is settled by *rejecting* the outstanding request, which takes the sibling `onRejected` — the path
+ * that has always worked. What is driven here is the other one: the request is settled
+ * **successfully**, and the throw happens afterwards, in the handler that was invoked to report the
+ * success. Copying a rejection test would have asserted nothing new.
+ *
+ * **How the throw is injected.** Everything a fulfil handler does with the outside world, it does
+ * through the connection — the step emitters all funnel into `Health::sendMessage()`, which calls
+ * `ConnectionInterface::send()`. So a connection that throws on one nominated frame puts the
+ * exception exactly where the issue describes: partway through the fulfil handler, after some of
+ * its frames have gone out and before it reaches its `sendComplete()`. It throws **once** and then
+ * behaves normally, so the terminal frame that the recovery arm sends is observable rather than
+ * lost to a second throw.
+ *
+ * The assertion in each case is the same and is deliberately about the *stream*, not a count: the
+ * last frame the client receives says `complete`, and it says it once.
+ *
+ * Nothing here drives the ReactPHP loop. Queued HTTP requests are settled by hand exactly as
+ * {@see HealthTerminalFrameTest} settles them, and the filesystem reads resolve synchronously
+ * through `react/filesystem`'s Fallback adapter.
+ */
+#[CoversClass(Health::class)]
+final class HealthFulfilHandlerThrowTest extends TestCase
+{
+    use HealthQueueIsolationTrait;
+
+    /** A calendar body that decodes but lacks the four keys the JSON branch requires. */
+    private const TRUNCATED_CALENDAR_BODY = '{"litcal":[]}';
+
+    /** A calendar body complete enough for {@see \LiturgicalCalendar\Api\Test\LitTestRunner} to report on. */
+    private const CALENDAR_BODY = '{"settings":{"year":2026,"national_calendar":"IT"},"litcal":[]}';
+
+    private ?string $appEnvBackup = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+        CheckableInventory::reset();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        CheckableInventory::reset();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Keeps handleHttpResponse() out of its development-only debug-logging branch.
+        $this->appEnvBackup = isset($_ENV['APP_ENV']) && is_string($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : null;
+        $_ENV['APP_ENV']    = 'test';
+    }
+
+    protected function tearDown(): void
+    {
+        if (null === $this->appEnvBackup) {
+            unset($_ENV['APP_ENV']);
+        } else {
+            $_ENV['APP_ENV'] = $this->appEnvBackup;
+        }
+        parent::tearDown();
+    }
+
+    // ---------------------------------------------------------------- the five fulfil handlers
+
+    /**
+     * `runValidationSteps()`, the URL arm: a resource the API answered, whose reporting then threw.
+     *
+     * The fetch succeeded — this is the arm that reports a 200 — so the sibling `onRejected` is not
+     * reachable from here at all, which is precisely why the terminal frame had nowhere else to come
+     * from.
+     */
+    public function testAThrowInsideTheUrlFulfilHandlerStillTerminates(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createThrowingConnection(1);
+
+        self::send($health, $conn, [
+            'action'     => 'executeValidation',
+            'category'   => 'resourceDataCheck',
+            'validate'   => 'national-calendar-IT',
+            'sourceFile' => 'https://example.test/data/nation/IT',
+            'requestId'  => 'req-alpha'
+        ]);
+        self::fulfilQueuedRequest($health, 0, self::CALENDAR_BODY);
+
+        self::assertTerminated($conn, 'req-alpha');
+    }
+
+    /**
+     * `runValidationSteps()`, the filesystem arm: a source file that was read, whose reporting then
+     * threw. The read resolves synchronously, so the throw lands in the fulfil handler while the
+     * message that started the work is still on the stack.
+     */
+    public function testAThrowInsideTheFilesystemFulfilHandlerStillTerminates(): void
+    {
+        $conn = self::createThrowingConnection(1);
+
+        self::send($this->newHealth(), $conn, [
+            'action'    => 'validateSource',
+            'target'    => ['id' => 'temporale:roman'],
+            'requestId' => 'req-alpha'
+        ]);
+
+        self::assertTerminated($conn, 'req-alpha');
+    }
+
+    /**
+     * `runValidationSteps()`, the i18n folder arm: the handler that runs once `Promise\all()` has
+     * resolved every per-file read.
+     *
+     * This is the site the original report of #823 missed. Its per-file promises each handle their
+     * own rejection, so the folder's own `onRejected` is reached only by something nothing
+     * anticipated — and a throw in the summarising handler is not it: React rejects the derived
+     * promise, not this one.
+     */
+    public function testAThrowInsideTheI18nFolderFulfilHandlerStillTerminates(): void
+    {
+        $conn = self::createThrowingConnection(1);
+
+        self::send($this->newHealth(), $conn, [
+            'action'    => 'validateSource',
+            'target'    => ['id' => 'nation:roman:US:i18n'],
+            'requestId' => 'req-alpha'
+        ]);
+
+        self::assertTerminated($conn, 'req-alpha');
+    }
+
+    /**
+     * `validateCalendar()`: the largest cluster in `Health`, whose fulfil handler reaches its end
+     * through a `switch` with an arm per response format. A throw anywhere in it — here in the
+     * middle, after `exists` has been reported — skipped the terminal frame that sits after the
+     * switch for exactly the opposite reason.
+     */
+    public function testAThrowInsideTheCalendarFulfilHandlerStillTerminates(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createThrowingConnection(1);
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON',
+            'requestId'      => 'req-alpha'
+        ]);
+        self::fulfilQueuedRequest($health, 0, self::TRUNCATED_CALENDAR_BODY);
+
+        self::assertTerminated($conn, 'req-alpha');
+    }
+
+    /**
+     * `executeUnitTest()`: a test run carries one result frame rather than three steps, so a throw
+     * while emitting that one frame leaves the client with nothing at all — no result and, before
+     * this fix, no terminal frame either.
+     */
+    public function testAThrowInsideTheTestRunFulfilHandlerStillTerminates(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createThrowingConnection(0);
+
+        self::send($health, $conn, [
+            'action'    => 'runTest',
+            'test'      => 'TerminalHarnessAlpha',
+            'calendar'  => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'      => 2026,
+            'requestId' => 'req-alpha'
+        ]);
+        self::fulfilQueuedRequest($health, 0, self::CALENDAR_BODY);
+
+        self::assertTerminated($conn, 'req-alpha');
+    }
+
+    // ---------------------------------------------------------------- and what the recovery is not
+
+    /**
+     * **The gate still holds on the recovery arm.** A client that did not correlate receives no
+     * terminal frame when a handler throws, exactly as it receives none when one does not.
+     *
+     * The recovery would otherwise be a way for the frame to reach a v1 client after all — and a v1
+     * `resources.js` sizes a phase as `checks * 3` and advances on `>=`, so a stray terminal frame
+     * is counted toward whichever phase happens to be active: a cascading miscount with nothing
+     * visibly failing. Asserted as an absence rather than as a count, because a count that happens
+     * to be unchanged would also pass if the frame were arriving somewhere unexpected.
+     */
+    public function testNoTerminalFrameReachesAClientThatDidNotCorrelateEvenWhenAHandlerThrows(): void
+    {
+        $conn = self::createThrowingConnection(1);
+
+        self::send($this->newHealth(), $conn, [
+            'action' => 'validateSource',
+            'target' => ['id' => 'temporale:roman']
+        ]);
+
+        $frames = self::framesOf($conn);
+        self::assertNotEmpty($frames, 'precondition: the request was answered, so the absence below means something');
+        self::assertNotContains('complete', self::stepsOf($frames), 'a v1 stream must be exactly what it was');
+    }
+
+    // ---------------------------------------------------------------- harness
+
+    /**
+     * The stream ends with exactly one terminal frame, carrying the id of the request that threw.
+     *
+     * "Exactly one" is asserted rather than "at least one": the recovery arm must not re-terminate a
+     * request whose handler had already terminated it, and `sendComplete()` has no idempotency guard
+     * of its own — by design, since one added in the wrong place is what would double-complete.
+     */
+    private static function assertTerminated(ConnectionInterface $conn, string $requestId): void
+    {
+        $frames = self::framesOf($conn);
+        $steps  = self::stepsOf($frames);
+
+        self::assertSame(
+            1,
+            count(array_filter($steps, static fn (?string $step): bool => 'complete' === $step)),
+            'a request terminates once, and the stream it terminates was: ['
+                . implode(', ', array_map(static fn (?string $s): string => $s ?? 'null', $steps)) . ']'
+        );
+        self::assertSame('complete', $steps[array_key_last($steps)], 'the terminal frame is the last thing the client hears');
+        self::assertSame($requestId, $frames[array_key_last($frames)]->requestId);
+    }
+
+    /**
+     * A Ratchet connection that records every outbound frame and throws on one nominated `send()`.
+     *
+     * `resourceId` is a dynamic public property Ratchet assigns and is not part of
+     * `ConnectionInterface`, so this mirrors the stub convention the other Health tests use rather
+     * than a PHPUnit mock, which would trigger a dynamic-property deprecation.
+     *
+     * @param int $throwOnSend The zero-based index of the `send()` call that throws. The frame it
+     *        was given is *not* recorded, since it never reached the wire.
+     */
+    private static function createThrowingConnection(int $throwOnSend, int $resourceId = 1)
+    {
+        return new class ($throwOnSend, $resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            private int $sends = 0;
+
+            public function __construct(private int $throwOnSend, public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                if ($this->sends++ === $this->throwOnSend) {
+                    throw new \RuntimeException('a frame emitter threw inside the fulfil handler');
+                }
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function send(Health $health, ConnectionInterface $conn, array $payload): void
+    {
+        ob_start();
+        try {
+            $health->onMessage($conn, (string) json_encode($payload));
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    private static function framesOf(ConnectionInterface $conn): array
+    {
+        /** @var object{sent: list<string>} $conn */
+        return array_map(
+            /** @return \stdClass */
+            static fn (string $raw): object => (object) json_decode($raw),
+            $conn->sent
+        );
+    }
+
+    /**
+     * The `step` of each frame in order, with a frame that carries none reported as `null` rather
+     * than dropped, so a stream is compared as a whole.
+     *
+     * @param list<\stdClass> $frames
+     * @return list<string|null>
+     */
+    private static function stepsOf(array $frames): array
+    {
+        return array_map(
+            static fn (\stdClass $frame): ?string => property_exists($frame, 'step') && is_string($frame->step) ? $frame->step : null,
+            $frames
+        );
+    }
+
+    /**
+     * Settle one outstanding request with a 200 carrying the given body, without dispatching it. The
+     * queued entry holds the very `resolve` closure `cachedGet()` built for it, so calling it does
+     * what the event loop would have done later.
+     */
+    private static function fulfilQueuedRequest(Health $health, int $index, string $body): void
+    {
+        /** @var list<array<string, mixed>> $queued */
+        $queued = ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+        self::assertArrayHasKey($index, $queued, "expected a queued request at index {$index}");
+        /** @var \Closure(\Psr\Http\Message\ResponseInterface):void $resolve */
+        $resolve = $queued[$index]['resolve'];
+
+        ob_start();
+        try {
+            $resolve(new Response(200, ['Content-Type' => 'application/json'], $body));
+        } finally {
+            ob_end_clean();
+        }
+    }
+}

--- a/src/Health.php
+++ b/src/Health.php
@@ -1005,8 +1005,10 @@ class Health implements MessageComponentInterface
      * then, finishing the *following* phase early too. A cascading miscount with nothing visibly
      * failing, which is worse than a crash. `requestId` is already the v2 opt-in signal and a client
      * adopting `complete` is adopting correlation anyway, so the gate costs a v2 client nothing and
-     * keeps the byte-identity guarantee whole. The gate lives here rather than at the twelve call
-     * sites so that it cannot be forgotten at a thirteenth.
+     * keeps the byte-identity guarantee whole. The gate lives here rather than at its call sites so
+     * that it cannot be forgotten at a new one — including the recovery arm in
+     * {@see Health::terminateOnHandlerThrow()}, which terminates a request whose handler threw and is
+     * gated by the same `null === $requestId` return as every other path.
      *
      * **No `status`.** The frame reports that the work finished, not that it passed; a run whose every
      * step failed still completes. The outcome is on the step frames, which is where a client reads it.
@@ -1042,6 +1044,65 @@ class Health implements MessageComponentInterface
         $message->target = $target;
         $message->step   = Step::COMPLETE->value;
         $this->sendMessage($to, $message, $runToken, requestId: $requestId);
+    }
+
+    /**
+     * The last resort behind a `then()`: terminate the request when one of its own handlers threw (#823).
+     *
+     * **React does not invoke a `then()`'s sibling `onRejected` when its own `onFulfilled` throws.** It
+     * rejects the promise *derived* from that `then()` instead. So every fulfil handler in this class
+     * that ends with {@see Health::sendComplete()} had one uncovered exit: an exception raised partway
+     * through it skipped the terminal frame, and a v2 client that stops on `complete` waited forever —
+     * the wedge the frame exists to prevent, arrived at from inside rather than from outside.
+     *
+     * The closure this returns is attached to the *derived* promise, as `->then(null, ...)`, rather than
+     * wrapped around the handler body in a `try`. That is deliberate on three counts: it is where React
+     * actually delivers the failure, so nothing has to be re-derived from the handler's shape; it leaves
+     * the handler bodies untouched, which matters for arms this class cannot easily re-test; and it covers
+     * a throw from the sibling `onRejected` too, which wedges a client the same way and by the same
+     * mechanism.
+     *
+     * **It logs and does not rethrow.** Every call site discards the promise it builds, so a rethrow would
+     * reach no handler at all — only `react/promise`'s unhandled-rejection reporter, which `error_log`s a
+     * message with no idea which check it belonged to. `echo` is how this class reports to the WebSocket
+     * server's stdout, and it is what the sibling `onRejected` arms already do with the reasons they are
+     * handed. Nothing is reported to the *client* beyond the terminal frame: the failure arrived partway
+     * through a stream whose frames a v1 client counts as `checks * 3`, and an extra one — unlike
+     * `complete`, which is gated on `requestId` — would be counted toward whatever phase was active.
+     *
+     * **On double-completion.** `sendComplete()` has no idempotency guard, by design, so this must not be
+     * reachable after a request has already terminated. It is not: in every handler it is attached to,
+     * `sendComplete()` is either the last statement or is followed immediately by `return`, so a throw
+     * that reaches here happened *before* the terminal frame — or it *was* the terminal frame failing to
+     * send, in which case the connection is already gone and a second attempt reaches nobody. A handler
+     * that completes and then keeps working would break that, which is why the terminal frame stays last.
+     *
+     * @param ConnectionInterface $to The connection that asked for the work.
+     * @param ?\stdClass $target What was checked, per {@see Health::frameTarget()} — the same target the
+     *        handler's own terminal frame would have carried.
+     * @param ?string $runToken The originating run token to echo back, or null to use the per-connection fallback.
+     * @param ?string $requestId The correlation id of the request that has finished. Null means the client never
+     *        opted in, and {@see Health::sendComplete()} sends nothing at all — the gate holds here too.
+     * @param string $context What was being reported when the handler threw, for the log line.
+     *
+     * @return \Closure(\Throwable): void
+     */
+    private function terminateOnHandlerThrow(
+        ConnectionInterface $to,
+        ?\stdClass $target,
+        ?string $runToken,
+        ?string $requestId,
+        string $context
+    ): \Closure {
+        return function (\Throwable $e) use ($to, $target, $runToken, $requestId, $context): void {
+            // Class and origin as well as message: a throw that reaches here is by definition one nobody
+            // anticipated, and until now it was reported by `react/promise`'s unhandled-rejection reporter,
+            // which at least said where it came from. Handling the rejection silences that reporter, so
+            // what it used to say has to be said here instead.
+            echo 'Error while reporting on ' . $context . ': ' . $e::class . ': ' . $e->getMessage()
+                . ' (' . $e->getFile() . ':' . $e->getLine() . ")\n";
+            $this->sendComplete($to, target: $target, runToken: $runToken, requestId: $requestId);
+        };
     }
 
     /**
@@ -1705,7 +1766,7 @@ class Health implements MessageComponentInterface
                     // never arrive.
                     $this->sendComplete($to, target: $target, runToken: $runToken, requestId: $requestId);
                 }
-            );
+            )->then(null, $this->terminateOnHandlerThrow($to, $target, $runToken, $requestId, "the i18n folder check for $label ($dataPath)"));
         } else {
             // {@see Health::processValidationData()} and {@see Health::handleValidationDataError()} take a
             // whole v1 message and read exactly two properties off it: `validate` and `category`. Both are
@@ -1759,7 +1820,7 @@ class Health implements MessageComponentInterface
                         $this->handleValidationDataError($e, $to, $validationForMessages, $dataPath, $runToken, $target, requestId: $requestId);
                         $this->sendComplete($to, target: $target, runToken: $runToken, requestId: $requestId);
                     }
-                );
+                )->then(null, $this->terminateOnHandlerThrow($to, $target, $runToken, $requestId, "the resource check for $dataPath"));
             } else {
                 // $dataPath is probably a source file in the filesystem in this case
                 // Resolve relative paths against the project root
@@ -1786,7 +1847,7 @@ class Health implements MessageComponentInterface
                         $this->handleValidationDataError($e, $to, $validationForMessages, $dataPath, $runToken, $target, requestId: $requestId);
                         $this->sendComplete($to, target: $target, runToken: $runToken, requestId: $requestId);
                     }
-                );
+                )->then(null, $this->terminateOnHandlerThrow($to, $target, $runToken, $requestId, "the source file check for $dataPath"));
             }
         }
     }
@@ -3059,7 +3120,13 @@ class Health implements MessageComponentInterface
 
                 $this->sendComplete($to, target: self::frameTarget($calendar, ['year' => $year]), runToken: $runToken, requestId: $requestId);
             }
-        );
+        )->then(null, $this->terminateOnHandlerThrow(
+            $to,
+            self::frameTarget($calendar, ['year' => $year]),
+            $runToken,
+            $requestId,
+            "the $category of $calendar for the year $year"
+        ));
     }
 
     /**
@@ -3323,7 +3390,13 @@ class Health implements MessageComponentInterface
 
                 $this->sendComplete($to, target: self::frameTarget($test, ['calendar' => $calendar, 'year' => $year]), runToken: $runToken, requestId: $requestId);
             }
-        );
+        )->then(null, $this->terminateOnHandlerThrow(
+            $to,
+            self::frameTarget($test, ['calendar' => $calendar, 'year' => $year]),
+            $runToken,
+            $requestId,
+            "the test $test against the $category of $calendar for the year $year"
+        ));
     }
 
     /**


### PR DESCRIPTION
Closes #823.

React does not invoke a `then()`'s sibling `onRejected` when its own `onFulfilled` throws — it rejects the promise *derived* from that `then()` instead. So every fulfil handler ending in `sendComplete()` had one uncovered exit: an exception raised partway through it skipped the terminal frame, and a v2 client that stops on `complete` waited forever. That is the wedge the frame exists to prevent, arrived at from inside rather than from outside.

## The approach

Rather than wrapping five handler bodies in `try`, this attaches one `->then(null, $this->terminateOnHandlerThrow(...))` to the promise derived from each `then(fulfil, reject)` pair — which is where React actually delivers the failure. One line per site, no re-indentation of the 250-line `validateCalendar()` switch, and it additionally covers a throw from the sibling `onRejected`, which wedges a client the same way.

**It logs rather than rethrows**, at all five sites, for a reason that is per-site rather than blanket: at every one of them the promise `then()` builds is **discarded**, so a rethrow reaches no handler at all — only react/promise's unhandled-rejection reporter, which `error_log`s a message naming no check. Handling the rejection silences that reporter, so the log line carries the throw's class, message and `file:line`; nothing diagnostic is lost.

It deliberately does **not** emit a client-facing error frame. The throw lands partway through a stream whose frames a v1 client counts as `checks * 3` and advances on `>=`, and unlike `complete` an error frame has no `requestId` gate — the extra frame would be exactly the cascading miscount the gate exists to prevent.

**Double-completion cannot occur.** In every handler the tail is attached to, `sendComplete()` is either the last statement or is immediately followed by `return`, so a throw reaching the tail happened *before* the terminal frame — or it *was* the terminal frame failing to send, in which case the connection is gone and a second attempt reaches nobody. (`$from->send($msg)` is the last statement of `sendMessage()`, which is the last statement of `sendComplete()`; there is no post-send work that could throw after a frame was delivered.) `sendComplete()` keeps having no idempotency guard. Each test asserts the `complete` count is exactly **1**, not "at least 1".

## A correction to the issue's accounting

The issue recorded 12 `sendComplete()` call sites in three groups against `b172889f`. There are now **14**, and the three-group taxonomy is no longer exhaustive: #833/#834 added two calls that sit *mid-body* in an `onFulfilled` as early-return refusal gates — neither last-statement nor synchronous. They are not separately wedged (they `return` immediately and live inside closures this fix covers), but they mean the double-completion argument must be stated as "last statement **or** immediately followed by `return`".

The affected count is unchanged at **five**, as the issue's first comment established.

## Tests

New `phpunit_tests/HealthFulfilHandlerThrowTest.php` (6 tests). Injection is a Ratchet stub connection that throws on one nominated `send()` and behaves normally afterwards; every fulfil handler reaches the outside world only through `sendMessage()` → `send()`, so this puts the exception mid-handler. Crucially each request is settled **successfully** and the throw happens afterward — unlike the existing `HealthTerminalFrameTest`, whose arms are all settled by *rejecting*, which takes the sibling handler and is therefore the path that already worked.

Pre-fix: 5 of 6 failed with `Failed asserting that 0 is identical to 1` — the client never received `complete`. Post-fix: `OK (6 tests, 20 assertions)`. The sixth test pins that the recovery arm respects the `requestId` gate, so a v1 client gets no terminal frame even when a handler throws.

## Verification

- `composer lint` (phpcs): clean
- `composer analyse` (PHPStan level 10): `[OK] No errors`
- `vendor/bin/phpunit --filter Health`: `OK (450 tests, 2747 assertions)`
- `composer test:quick`: exit 0 — `Tests: 2924, Assertions: 177767, Skipped: 11`

Note that the `WebSocket/*` tests passed but are not evidence about this branch: they talk to the shared `:8082` server, a long-running process still executing the main checkout's `src/`. That server picks up `Health.php` changes only on restart.

## Docs

`docs/superpowers/specs/2026-08-20-structured-responses-design.md` section C: added an "Amended: this hole is closed" note in the file's existing amendment style, kept the shape statement and the five-site enumeration as the audit that produced the fix, and explicitly restated that the **second, unrelated** shape recorded there — `dropSupersededQueuedRequests()` dropping queued entries without rejecting them — is untouched and remains open. That one is now filed as #837.

Also fixed a stale hardcoded count in `sendComplete()`'s own docblock ("the twelve call sites … a thirteenth"), rephrased shape-first — the same failure mode the issue's second comment complains about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Requests now receive a final completion notification when certain asynchronous processing steps fail unexpectedly.
  * Completion notifications remain limited to the relevant request, preventing unrelated clients from receiving terminal frames.
  * Improved handling for URL, filesystem, translation-folder, calendar, and test-run processing failures.

* **Tests**
  * Added coverage for failure scenarios across supported fulfilment handlers and request-correlation behavior.

* **Documentation**
  * Updated error-handling guidance to reflect completion behavior after handler failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->