### PR TITLE
fix(schemas): admit the Ambrosian diocesan /events settings shape, discriminated on rite (#817)

### DIFF
--- a/jsondata/schemas/CommonDef.json
+++ b/jsondata/schemas/CommonDef.json
@@ -487,6 +487,14 @@
                 "ambrosian"
             ]
         },
+        "RiteWithoutNationalCalendars": {
+            "type": "string",
+            "title": "Rite without national calendars",
+            "description": "the subset of `Rite` whose calendars have no national tier, so that a diocese under such a rite reports a `diocesan_calendar` with a `null` `national_calendar`. Only the Ambrosian rite qualifies: `EventsParams::validateRiteCompatibility()` and `CalendarParams::validateRiteCompatibility()` reject a `national_calendar` combined with the Ambrosian rite, and the Ambrosian diocesan loaders deliberately leave the national calendar null rather than deriving it from the diocese's `nation` metadata. Under the Roman rite a diocese always sits on top of a national calendar, so `roman` must never appear here. Keep in sync with `Rite`: whenever a rite is added, decide explicitly whether it has a national tier. See issue #817.",
+            "enum": [
+                "ambrosian"
+            ]
+        },
         "Epiphany": {
             "type": "string",
             "title": "Epiphany",

--- a/jsondata/schemas/LitCalEventsPath.json
+++ b/jsondata/schemas/LitCalEventsPath.json
@@ -67,6 +67,27 @@
                 },
                 "additionalProperties": false,
                 "required": [ "locale", "national_calendar", "diocesan_calendar", "rite" ]
+              },
+              {
+                "properties": {
+                  "locale": {
+                    "$ref": "./CommonDef.json#/definitions/Locale"
+                  },
+                  "national_calendar": {
+                    "type": "null",
+                    "description": "always `null` here: this branch describes a diocesan request under a rite that has no national tier, so the diocese is not built on top of a national calendar"
+                  },
+                  "diocesan_calendar": {
+                    "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId",
+                    "description": "indicates the Diocesan Calendar used to produce the data in `litcal_events`"
+                  },
+                  "rite": {
+                    "$ref": "./CommonDef.json#/definitions/RiteWithoutNationalCalendars",
+                    "description": "narrowed to the rites that have no national calendars, so that a *Roman* diocesan response with a `null` `national_calendar` — an impossible shape under the Roman rite, where a diocese always inherits from a national calendar — is still rejected by this branch and by every other one"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [ "locale", "national_calendar", "diocesan_calendar", "rite" ]
               }
             ]
         }

--- a/phpunit_tests/Schemas/EventsPathSettingsSchemaTest.php
+++ b/phpunit_tests/Schemas/EventsPathSettingsSchemaTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * Unit tests for the `settings` property of the `LitCalEventsPath.json` response schema (issue #817).
+ *
+ * `settings` is a `oneOf` over the four combinations of `national_calendar`/`diocesan_calendar` that
+ * `EventsHandler` can actually emit:
+ *
+ * | # | `national_calendar` | `diocesan_calendar` | `rite`         | produced by                        |
+ * |---|---------------------|---------------------|----------------|------------------------------------|
+ * | 0 | `"IT"` (2 letters)  | diocesan id         | any            | `/events/diocese/{id}` (Roman)     |
+ * | 1 | `"IT"` (2 letters)  | `null`              | any            | `/events/nation/{nation}`          |
+ * | 2 | `null`              | `null`              | any            | `/events`, `/events/ambrosian`     |
+ * | 3 | `null`              | diocesan id         | **ambrosian**  | `/events/ambrosian/diocese/{id}`   |
+ *
+ * Branch 3 is the one issue #817 added. The Ambrosian rite has no national layer
+ * ({@see \LiturgicalCalendar\Api\Params\EventsParams::validateRiteCompatibility()} rejects a
+ * `national_calendar` under the Ambrosian rite, and
+ * {@see \LiturgicalCalendar\Api\Handlers\EventsHandler::loadAmbrosianDiocesanData()} deliberately
+ * leaves `NationalCalendar` null), so an Ambrosian diocesan request reports a diocesan calendar with
+ * no national calendar — a shape the original three branches did not admit, producing 8 red
+ * `schema-valid` cards (2 locales x 4 Ambrosian dioceses) in the UnitTestInterface resources runner.
+ *
+ * Branch 3 is deliberately NOT open to every rite: its `rite` is narrowed to
+ * `CommonDef.json#/definitions/RiteWithoutNationalCalendars`. Under the Roman rite a diocese always
+ * inherits from a national calendar, so a Roman `{national_calendar: null, diocesan_calendar: <id>}`
+ * payload is invalid and must keep being rejected — widening the schema for the Ambrosian rite must
+ * not quietly legalise it for the Roman one. That is what
+ * {@see self::testRomanDiocesanWithNullNationalCalendarIsRejected()} pins down.
+ *
+ * Branch 2 stays open to both rites on purpose: `/events` and `/events/ambrosian` both emit
+ * `{null, null}`, so pinning it to `roman` would break a live 200 response.
+ *
+ * Because this is a `oneOf` and not an `anyOf`, the tests below assert not only that each shape
+ * validates but that it matches EXACTLY ONE branch: a fourth branch that overlapped an existing one
+ * would turn a previously-passing payload into a failure.
+ */
+final class EventsPathSettingsSchemaTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // LitSchema::path() depends on Router::$apiFilePath; initialize it.
+        Router::getApiPaths();
+    }
+
+    private static function settingsSchema(): Schema
+    {
+        return Schema::import(LitSchema::EVENTS->path() . '#/properties/settings');
+    }
+
+    /**
+     * The number of `oneOf` branches under `settings` that the given payload matches.
+     *
+     * Used to prove branch exclusivity: a valid payload must match exactly 1.
+     */
+    private static function matchingBranchCount(\stdClass $settings): int
+    {
+        $schemaFile = LitSchema::EVENTS->path();
+        /** @var array{properties:array{settings:array{oneOf:list<array<string,mixed>>}}} $raw */
+        $raw         = json_decode(file_get_contents($schemaFile) ?: '', true, 512, JSON_THROW_ON_ERROR);
+        $branchCount = count($raw['properties']['settings']['oneOf']);
+        $matches     = 0;
+        for ($idx = 0; $idx < $branchCount; ++$idx) {
+            try {
+                Schema::import($schemaFile . '#/properties/settings/oneOf/' . $idx)->in($settings);
+                ++$matches;
+            } catch (\Swaggest\JsonSchema\Exception) {
+                // branch does not match; nothing to do
+            }
+        }
+
+        return $matches;
+    }
+
+    private static function decode(string $json): \stdClass
+    {
+        $obj = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+        self::assertInstanceOf(\stdClass::class, $obj);
+        return $obj;
+    }
+
+    /**
+     * Every `settings` shape the `/events` endpoint can emit, keyed by the request that produces it.
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function validSettingsProvider(): array
+    {
+        return [
+            '/events'                             => ['{"locale":"en","national_calendar":null,"diocesan_calendar":null,"rite":"roman"}'],
+            '/events/nation/IT'                   => ['{"locale":"it_IT","national_calendar":"IT","diocesan_calendar":null,"rite":"roman"}'],
+            '/events/diocese/romamo_it'           => ['{"locale":"it_IT","national_calendar":"IT","diocesan_calendar":"romamo_it","rite":"roman"}'],
+            '/events/ambrosian'                   => ['{"locale":"it","national_calendar":null,"diocesan_calendar":null,"rite":"ambrosian"}'],
+            '/events/ambrosian/diocese/milano_it' => ['{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"milano_it","rite":"ambrosian"}'],
+            '/events/ambrosian/diocese/bergam_it' => ['{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"bergam_it","rite":"ambrosian"}'],
+            '/events/ambrosian/diocese/novara_it' => ['{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"novara_it","rite":"ambrosian"}'],
+            '/events/ambrosian/diocese/lugano_ch' => ['{"locale":"la_VA","national_calendar":null,"diocesan_calendar":"lugano_ch","rite":"ambrosian"}'],
+        ];
+    }
+
+    #[DataProvider('validSettingsProvider')]
+    public function testEmittedSettingsShapeIsValid(string $json): void
+    {
+        $settings = self::decode($json);
+        self::settingsSchema()->in($settings);
+        $this->addToAssertionCount(1);
+    }
+
+    /**
+     * `oneOf` exclusivity: every emitted shape must match one and only one branch.
+     */
+    #[DataProvider('validSettingsProvider')]
+    public function testEmittedSettingsShapeMatchesExactlyOneBranch(string $json): void
+    {
+        $this->assertSame(1, self::matchingBranchCount(self::decode($json)));
+    }
+
+    /**
+     * Shapes that must stay rejected after the fourth branch was added.
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function invalidSettingsProvider(): array
+    {
+        return [
+            // The Roman paradigm: a Roman diocese always sits on top of a national calendar.
+            'Roman diocese, null nation'  => ['{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"romamo_it","rite":"roman"}'],
+            'unknown diocesan id'         => ['{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"nowhere_xx","rite":"ambrosian"}'],
+            'unknown rite'                => ['{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"milano_it","rite":"mozarabic"}'],
+            'missing rite'                => ['{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"milano_it"}'],
+            'missing national_calendar'   => ['{"locale":"it_IT","diocesan_calendar":"milano_it","rite":"ambrosian"}'],
+            'additional property'         => ['{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"milano_it","rite":"ambrosian","totally_new":true}'],
+            'lowercase national_calendar' => ['{"locale":"it_IT","national_calendar":"it","diocesan_calendar":"milano_it","rite":"roman"}'],
+            'diocesan id as null-ish ""'  => ['{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"","rite":"ambrosian"}'],
+        ];
+    }
+
+    #[DataProvider('invalidSettingsProvider')]
+    public function testInvalidSettingsShapeIsRejected(string $json): void
+    {
+        $this->expectException(\Swaggest\JsonSchema\Exception::class);
+        self::settingsSchema()->in(self::decode($json));
+    }
+
+    /**
+     * The single assertion that proves the Roman paradigm survived issue #817.
+     *
+     * The fourth `oneOf` branch legalises `{national_calendar: null, diocesan_calendar: <id>}` for the
+     * Ambrosian rite ONLY. The very same shape under `rite: "roman"` describes a Roman diocese with no
+     * national calendar, which the Roman calendar hierarchy cannot produce, and must therefore still
+     * match no branch at all.
+     */
+    public function testRomanDiocesanWithNullNationalCalendarIsRejected(): void
+    {
+        $settings = self::decode('{"locale":"it_IT","national_calendar":null,"diocesan_calendar":"romamo_it","rite":"roman"}');
+
+        $this->assertSame(0, self::matchingBranchCount($settings), 'no branch may admit a Roman diocese without a national calendar');
+
+        $this->expectException(\Swaggest\JsonSchema\Exception::class);
+        self::settingsSchema()->in($settings);
+    }
+
+    /**
+     * `RiteWithoutNationalCalendars` must stay a non-empty proper subset of `Rite` that excludes
+     * `roman`. Mirrors the `RomanLitColor`/`AmbrosianLitColor` parity guard in
+     * {@see ColorEnumParityTest}: the two lists are spelled out separately in `CommonDef.json` and
+     * would otherwise drift the first time a rite is added.
+     */
+    public function testRiteWithoutNationalCalendarsIsAProperSubsetOfRite(): void
+    {
+        $commonDef = dirname(__DIR__, 2) . '/jsondata/schemas/CommonDef.json';
+        /** @var array{definitions:array<string,array{enum?:list<string>}>} $decoded */
+        $decoded = json_decode((string) file_get_contents($commonDef), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertArrayHasKey('RiteWithoutNationalCalendars', $decoded['definitions']);
+
+        $allRites = $decoded['definitions']['Rite']['enum'] ?? [];
+        $tierless = $decoded['definitions']['RiteWithoutNationalCalendars']['enum'] ?? [];
+
+        $this->assertNotEmpty($tierless);
+        $this->assertNotContains('roman', $tierless, 'the Roman rite has national calendars');
+        $this->assertSame([], array_diff($tierless, $allRites), 'RiteWithoutNationalCalendars has drifted from Rite');
+        $this->assertNotSame([], array_diff($allRites, $tierless), 'RiteWithoutNationalCalendars must stay a *proper* subset');
+    }
+
+    /**
+     * Draft-07 trap guard.
+     *
+     * In draft-07 a `$ref` REPLACES its containing schema object: sibling validation keywords are
+     * silently ignored. Verified against swaggest/json-schema — both
+     * `{"$ref": ".../Rite", "not": {"const": "roman"}}` and `{"$ref": ".../Rite", "enum": ["ambrosian"]}`
+     * accept `"roman"` without complaint. The narrowing on branch 3 therefore has to be a `$ref` to a
+     * definition that is already narrow (`RiteWithoutNationalCalendars`), never a `$ref` plus a
+     * sibling constraint. This test fails if anyone later "tightens" a branch that way, because the
+     * tightening would be a no-op.
+     *
+     * `description` is exempt: it is an annotation, not a validation keyword.
+     */
+    public function testNoRefInTheSettingsBranchesCarriesSiblingValidationKeywords(): void
+    {
+        /** @var array{properties:array{settings:array{oneOf:list<array<string,mixed>>}}} $decoded */
+        $decoded = json_decode((string) file_get_contents(LitSchema::EVENTS->path()), true, 512, JSON_THROW_ON_ERROR);
+
+        foreach ($decoded['properties']['settings']['oneOf'] as $idx => $branch) {
+            self::assertIsArray($branch['properties']);
+            foreach ($branch['properties'] as $property => $subSchema) {
+                self::assertIsArray($subSchema);
+                if (false === array_key_exists('$ref', $subSchema)) {
+                    continue;
+                }
+                $siblings = array_diff(array_keys($subSchema), ['$ref', 'description']);
+                $this->assertSame(
+                    [],
+                    array_values($siblings),
+                    "oneOf[{$idx}].properties.{$property} pairs a \$ref with " . implode(', ', $siblings)
+                        . ' — under draft-07 those siblings are ignored, so the constraint would silently do nothing.'
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #817.

`GET /events/ambrosian/diocese/milano_it` returns HTTP 200 with `{national_calendar: null, diocesan_calendar: "milano_it", rite: "ambrosian"}`, a shape none of `LitCalEventsPath.json`'s three `oneOf` branches admitted. The response is correct; the schema was incomplete. Symptom: 8 red `events-path-diocese-*` `schema-valid` cards on every Ambrosian resources run in the UnitTestInterface runner (2 locales × 4 dioceses).

## Discriminated on `rite`, so the Roman paradigm stays intact

The issue proposed simply adding a fourth branch. That would also have admitted a **Roman** diocesan response with a `null` `national_calendar` — an impossible shape under the Roman rite, where a diocese always sits on top of a national calendar. So the widening is conditioned on `rite`, which was already a declared, `required` property in all three branches under `additionalProperties: false`.

New `CommonDef.json#/definitions/RiteWithoutNationalCalendars` (`enum: ["ambrosian"]`), `$ref`'d from the new branch only. This follows the established house pattern of `RomanLitColor`/`AmbrosianLitColor` — rite-partitioned subsets in `CommonDef.json`. Net effect on the accepted set: it grows by exactly `{null, <diocesan id>, "ambrosian"}` and nothing else. Branches 0–2 are untouched.

## The draft-07 trap, measured rather than assumed

Two of the obvious spellings are **silent no-ops** — in draft-07 `$ref` replaces the schema object and sibling keywords are ignored:

| spelling | on `rite: "roman"` | message |
|---|---|---|
| `{"$ref": Rite, "not": {"const":"roman"}}` | **VALID — no-op** | — |
| `{"$ref": Rite, "enum": ["ambrosian"]}` | **VALID — no-op** | — |
| `{"allOf":[{"$ref":Rite},{"not":{"const":"roman"}}]}` | rejected | `Not {"const":"roman"} expected …` |
| `{"const":"ambrosian"}` | rejected | `Const failed` — carries neither expected nor received value |
| `$ref` → narrow definition | rejected | `Enum failed, enum: ["ambrosian"], data: "roman"` |

Error-message quality is a real criterion here, not a matter of taste: `Health::validateDataAgainstSchema()` puts the validator's message into a client-visible frame whose `details` is built by splitting it on newlines (#824). The narrow-`$ref` spelling gives the most legible failure and a self-documenting name. A committed guard asserts that no `$ref` in these branches carries sibling validation keywords, so neither no-op can creep back in.

## Branches 0 and 1 are deliberately *not* pinned to `roman`

`/events/ambrosian/nation/IT` returns 400, so pinning would break no live response — but it would *remove* payloads the schema already accepted (a pre-existing looseness unrelated to this bug), and it would encode "no non-Roman rite ever has a national tier", which is true today only because of a refusal in the routing/params layer. The same looseness exists in `LitCal.json`, so fixing it here alone would be half a fix. Recommended as a separate follow-up spanning both schemas.

Stated plainly: `{national_calendar:"IT", diocesan_calendar:"milano_it", rite:"ambrosian"}` still validates. The API cannot emit it (400).

## `oneOf` exclusivity

Branch selection is fully determined by the two discriminators, which are pairwise disjoint by **type** (`string`+`pattern` vs `null`; `DiocesanCalendarId` — a flat 2934-entry string enum — vs `null`). Measured, not just argued: the test asserts exactly one matching branch for all emitted shapes, and zero for the Roman `{null, <id>}` payload.

## Validation matrix — real captured 200 responses

All 8 Ambrosian cases (`milano_it`, `bergam_it`, `novara_it`, `lugano_ch` × `it`, `la`): **before**, all 8 failed with 0 branches matched; **after**, all 8 pass with exactly 1.

| regression check | result |
|---|---|
| `/events` (`null/null/roman`) | pass, 1 branch |
| `/events/nation/IT` (`IT/null/roman`) | pass, 1 branch |
| `/events/diocese/romamo_it` (`IT/romamo_it/roman`) | pass, 1 branch |
| `/events/ambrosian` (`null/null/**ambrosian**`) | pass, 1 branch |
| synthetic Roman `null` nation + `romamo_it` + `roman` | **correctly rejected**, 0 branches |

That fourth row is the one a naive "pin everything to roman" fix would have broken: the rite-level Ambrosian request legitimately reaches the `null`/`null` branch.

## Tests

New `phpunit_tests/Schemas/EventsPathSettingsSchemaTest.php` (27 tests, 86 assertions), following the `AmbrosianLitCalSchemaTest` pattern. Covers all emitted shapes, per-shape branch exclusivity, a dedicated `testRomanDiocesanWithNullNationalCalendarIsRejected`, 7 invalid shapes, a parity test keeping the new definition a non-empty proper subset of `Rite` excluding `roman`, and the draft-07 sibling-keyword guard. Both new guards were mutation-checked.

Against the unedited schema: `Errors: 4, Failures: 4`. After: `OK (27 tests, 86 assertions)`.

## Verification

- `composer lint` (phpcs): clean
- `composer analyse` (PHPStan level 10): `[OK] No errors`
- `composer lint:openapi`: valid (run because `CommonDef.json` is externally `$ref`'d; `openapi.json` untouched)
- `composer test:quick`: baseline `Tests: 2918` → final `Tests: 2945`, exit 0 both

## Two sibling defects found and left out of scope

- **`/calendar` has the same gap, spelled differently.** `GET /calendar/ambrosian/diocese/milano_it/2026` returns 200 with `national_calendar` **absent entirely** (not `null`) and fails all three `LitCal.json` branches.
- **A silent locale fallback.** `?locale=la` on `/events/ambrosian/diocese/milano_it` returns `it_IT` with no error, while `la_VA`, `la-VA` and the rite-level `/events/ambrosian?locale=la` all resolve correctly — the short tag is not canonicalised before the membership check in the diocesan branch. Consequence: the UTI runner's "2 locales" validate the same `it_IT` payload twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for diocesan calendar requests under rites without national calendars.
  * Ambrosian diocesan requests can now specify a null national calendar alongside their diocesan calendar.

* **Bug Fixes**
  * Improved validation to reject unsupported calendar and rite combinations, including Roman diocesan requests without a national calendar.

* **Tests**
  * Added comprehensive validation coverage for valid and invalid calendar request formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->