### PR TITLE
docs(openapi): document the rite segment on /data (#818)

### DIFF
--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -5471,7 +5471,7 @@
           {}
         ],
         "summary": "Retrieve a national calendar data resource",
-        "description": "There is no rite-qualified variant of this path other than the explicit synonym `/data/roman/nation/{key}`: only the diocesan tier exists under more than one rite, so `/data/ambrosian/nation/{key}` returns `400 Bad Request` (\"The ambrosian rite has no national calendars; request a diocesan calendar of that rite instead.\").",
+        "description": "`/data/roman/nation/{key}` states the same rite explicitly and is the canonical form of this path. There is no other rite-qualified variant: only the diocesan tier exists under more than one rite, so `/data/ambrosian/nation/{key}` returns `400 Bad Request` (\"The ambrosian rite has no national calendars; request a diocesan calendar of that rite instead.\").",
         "operationId": "nationalDataGET",
         "parameters": [
           {
@@ -5747,6 +5747,291 @@
         }
       }
     },
+    "/data/roman/nation/{key}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve a national calendar data resource",
+        "description": "This is the canonical form of this route: the rite is stated explicitly. The bare `/data/nation/{key}` form is equivalent and resolves here. Only the diocesan tier exists under more than one rite, so there is no `/data/ambrosian/nation/{key}`: that path returns `400 Bad Request` (\"The ambrosian rite has no national calendars; request a diocesan calendar of that rite instead.\").",
+        "operationId": "romanNationalDataGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/Nation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: National calendar data resource retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./NationalCalendar.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a national calendar data resource",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.\n\nThis is the canonical, explicit-rite form of `/data/nation/{key}`.",
+        "operationId": "romanNationalCalendarDataPUT",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/Nation"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./NationalCalendar.json"
+              },
+              "examples": {
+                "ItalyNationalCalendar": {
+                  "$ref": "#/components/examples/NationalCalendarRequestBody"
+                },
+                "USANationalCalendar": {
+                  "$ref": "#/components/examples/NationalCalendarUSRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "examples": [
+                        "National calendar created for nation {NATION}"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict409"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve a national calendar data resource",
+        "operationId": "romanNationalDataPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/Nation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./NationalCalendar.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Update a national calendar data resource",
+        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.\n\nThis is the canonical, explicit-rite form of `/data/nation/{key}`.",
+        "operationId": "romanNationalDataPATCH",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{2,45}$"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./NationalCalendar.json"
+              },
+              "examples": {
+                "ItalyNationalCalendar": {
+                  "$ref": "#/components/examples/NationalCalendarRequestBody"
+                },
+                "USANationalCalendar": {
+                  "$ref": "#/components/examples/NationalCalendarUSRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "example": "National calendar updated for nation {NATION}"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete a national calendar data resource",
+        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`.\n\nThis is the canonical, explicit-rite form of `/data/nation/{key}`.",
+        "operationId": "romanNationalDataDELETE",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{2}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DeleteSuccess200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      }
+    },
     "/data/diocese/{key}": {
       "get": {
         "tags": [
@@ -5756,7 +6041,7 @@
           {}
         ],
         "summary": "Retrieve a diocesan calendar data resource",
-        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` is an accepted explicit synonym of this path.",
+        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` states the same rite explicitly and is the canonical form of this path.",
         "operationId": "diocesanDataGET",
         "parameters": [
           {
@@ -5881,7 +6166,7 @@
           {}
         ],
         "summary": "Retrieve a diocesan calendar data resource",
-        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` is an accepted explicit synonym of this path.",
+        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` states the same rite explicitly and is the canonical form of this path.",
         "operationId": "diocesanDataPOST",
         "parameters": [
           {
@@ -6040,6 +6325,299 @@
         }
       }
     },
+    "/data/roman/diocese/{key}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve a diocesan calendar data resource",
+        "description": "This is the canonical form of this route: the rite is stated explicitly, symmetric with `/data/ambrosian/diocese/{key}`. The bare `/data/diocese/{key}` form is equivalent and resolves here. A diocese defined under another rite must be addressed through its own rite-qualified path; asking for one here returns `422 Unprocessable Content`.",
+        "operationId": "romanDiocesanDataGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./DiocesanCalendar.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a diocesan calendar data resource",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.\n\nThis is the canonical, explicit-rite form of `/data/diocese/{key}`.",
+        "operationId": "romanDiocesanDataPUT",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./DiocesanCalendar.json"
+              },
+              "examples": {
+                "BostonDiocesan": {
+                  "$ref": "#/components/examples/DiocesanCalendarRequestBody"
+                },
+                "RomeDiocesan": {
+                  "$ref": "#/components/examples/DiocesanCalendarRomeRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "examples": [
+                        "Diocesan calendar created for diocese {DIOCESE}"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict409"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve a diocesan calendar data resource",
+        "description": "This is the canonical form of this route: the rite is stated explicitly, symmetric with `/data/ambrosian/diocese/{key}`. The bare `/data/diocese/{key}` form is equivalent and resolves here. A diocese defined under another rite must be addressed through its own rite-qualified path; asking for one here returns `422 Unprocessable Content`.",
+        "operationId": "romanDiocesanDataPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./DiocesanCalendar.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Update a diocesan calendar data resource",
+        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.\n\nThis is the canonical, explicit-rite form of `/data/diocese/{key}`.",
+        "operationId": "romanDiocesanDataPATCH",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./DiocesanCalendar.json"
+              },
+              "examples": {
+                "BostonDiocesan": {
+                  "$ref": "#/components/examples/DiocesanCalendarRequestBody"
+                },
+                "RomeDiocesan": {
+                  "$ref": "#/components/examples/DiocesanCalendarRomeRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "example": "Diocesan calendar updated for diocese {DIOCESE}"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete a diocesan calendar data resource",
+        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.\n\nThis is the canonical, explicit-rite form of `/data/diocese/{key}`.",
+        "operationId": "romanDiocesanDataDELETE",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DeleteSuccess200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      }
+    },
     "/data/widerregion/{key}": {
       "get": {
         "tags": [
@@ -6049,7 +6627,7 @@
           {}
         ],
         "summary": "Retrieve a wider region calendar data resource",
-        "description": "There is no rite-qualified variant of this path other than the explicit synonym `/data/roman/widerregion/{key}`: wider regions are a layer over national calendars, which exist only in the Roman rite, so `/data/ambrosian/widerregion/{key}` returns `400 Bad Request`.",
+        "description": "`/data/roman/widerregion/{key}` states the same rite explicitly and is the canonical form of this path. There is no other rite-qualified variant: wider regions are a layer over national calendars, which exist only in the Roman rite, so `/data/ambrosian/widerregion/{key}` returns `400 Bad Request`.",
         "operationId": "widerregionDataGET",
         "parameters": [
           {
@@ -6294,6 +6872,289 @@
         "summary": "Delete a wider region calendar data resource",
         "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`.",
         "operationId": "widerregionDataDELETE",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DeleteSuccess200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      }
+    },
+    "/data/roman/widerregion/{key}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve a wider region calendar data resource",
+        "description": "This is the canonical form of this route: the rite is stated explicitly. The bare `/data/widerregion/{key}` form is equivalent and resolves here. Wider regions are a layer over national calendars, which exist only in the Roman rite, so `/data/ambrosian/widerregion/{key}` returns `400 Bad Request`.",
+        "operationId": "romanWiderregionDataGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./WiderRegionCalendar.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a wider region data resource",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.\n\nThis is the canonical, explicit-rite form of `/data/widerregion/{key}`.",
+        "operationId": "romanWiderregionDataPUT",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./WiderRegionCalendar.json"
+              },
+              "examples": {
+                "EuropeWiderRegion": {
+                  "$ref": "#/components/examples/WiderRegionCalendarRequestBody"
+                },
+                "AsiaWiderRegion": {
+                  "$ref": "#/components/examples/WiderRegionCalendarAsiaRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "examples": [
+                        "Wider region calendar created for region {REGION}"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict409"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve a wider region calendar data resource",
+        "operationId": "romanWiderregionDataPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./WiderRegionCalendar.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Update a wider region calendar data resource",
+        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.\n\nThis is the canonical, explicit-rite form of `/data/widerregion/{key}`.",
+        "operationId": "romanWiderregionDataPATCH",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./WiderRegionCalendar.json"
+              },
+              "examples": {
+                "EuropeWiderRegion": {
+                  "$ref": "#/components/examples/WiderRegionCalendarRequestBody"
+                },
+                "AsiaWiderRegion": {
+                  "$ref": "#/components/examples/WiderRegionCalendarAsiaRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "example": "Wider region calendar updated for region {REGION}"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete a wider region calendar data resource",
+        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`.\n\nThis is the canonical, explicit-rite form of `/data/widerregion/{key}`.",
+        "operationId": "romanWiderregionDataDELETE",
         "parameters": [
           {
             "name": "key",

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -5471,6 +5471,7 @@
           {}
         ],
         "summary": "Retrieve a national calendar data resource",
+        "description": "There is no rite-qualified variant of this path other than the explicit synonym `/data/roman/nation/{key}`: only the diocesan tier exists under more than one rite, so `/data/ambrosian/nation/{key}` returns `400 Bad Request` (\"The ambrosian rite has no national calendars; request a diocesan calendar of that rite instead.\").",
         "operationId": "nationalDataGET",
         "parameters": [
           {
@@ -5755,6 +5756,7 @@
           {}
         ],
         "summary": "Retrieve a diocesan calendar data resource",
+        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` is an accepted explicit synonym of this path.",
         "operationId": "diocesanDataGET",
         "parameters": [
           {
@@ -5782,6 +5784,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -5798,7 +5803,7 @@
           }
         ],
         "summary": "Create a diocesan calendar data resource",
-        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.",
         "operationId": "diocesanDataPUT",
         "parameters": [
           {
@@ -5876,6 +5881,7 @@
           {}
         ],
         "summary": "Retrieve a diocesan calendar data resource",
+        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` is an accepted explicit synonym of this path.",
         "operationId": "diocesanDataPOST",
         "parameters": [
           {
@@ -5903,6 +5909,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -5919,7 +5928,7 @@
           }
         ],
         "summary": "Update a diocesan calendar data resource",
-        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.",
+        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.",
         "operationId": "diocesanDataPATCH",
         "parameters": [
           {
@@ -5997,7 +6006,7 @@
           }
         ],
         "summary": "Delete a diocesan calendar data resource",
-        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`.",
+        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.",
         "operationId": "diocesanDataDELETE",
         "parameters": [
           {
@@ -6024,6 +6033,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       }
@@ -6037,6 +6049,7 @@
           {}
         ],
         "summary": "Retrieve a wider region calendar data resource",
+        "description": "There is no rite-qualified variant of this path other than the explicit synonym `/data/roman/widerregion/{key}`: wider regions are a layer over national calendars, which exist only in the Roman rite, so `/data/ambrosian/widerregion/{key}` returns `400 Bad Request`.",
         "operationId": "widerregionDataGET",
         "parameters": [
           {
@@ -6306,6 +6319,293 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      }
+    },
+    "/data/ambrosian/diocese/{key}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve an Ambrosian diocesan calendar data resource",
+        "description": "Retrieve the source definition of a diocesan calendar defined under the Ambrosian rite.\n\n**The `ambrosian` rite segment is required here, not decorative.** The bare `/data/diocese/{key}` form resolves to the Roman rite, so addressing an Ambrosian diocese through it returns `422 Unprocessable Content` (`Diocesan calendar ... belongs to the ambrosian rite, not the requested roman rite.`); the same `422` is returned on this path for a diocese that is not Ambrosian. The Ambrosian dioceses are Milano (`milano_it`), Bergamo (`bergam_it`), Novara (`novara_it`) and Lugano (`lugano_ch`) \u2014 every other diocese is Roman. On any `/data` path `roman` is accepted as an explicit synonym of the bare form.\n\nOnly the diocesan tier exists under more than one rite, so there is deliberately no `/data/ambrosian/nation/{key}` and no `/data/ambrosian/widerregion/{key}`: the Ambrosian rite is proper to the Archdiocese of Milan and a handful of neighbouring dioceses rather than to any nation or region, and the source tree has no Ambrosian national or wider-region partition to read or write. Either of those requests returns `400 Bad Request`.\n\nUnlike `/calendar` and `/events`, `/data` advertises no canonical URL: the bare form returns no RFC 6596 `Link: <...>; rel=\"canonical\"` response header.\n\nThe Ambrosian rite has approved liturgical books only in Italian and Latin, so `diocesan_calendars[].locales` on `/calendars` declares `it_IT` and `la_VA` for these dioceses; a `locale` naming any other language returns `422 Unprocessable Content`.",
+        "operationId": "ambrosianDiocesanDataGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./DiocesanCalendar.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create an Ambrosian diocesan calendar data resource",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.\n\nThe method surface is identical to `/data/diocese/{key}`: the `ambrosian` segment only selects which rite partition of the source tree is written. It is required for an Ambrosian diocese \u2014 see `GET /data/ambrosian/diocese/{key}` for the full rite grammar and for why no rite-qualified national or wider-region path exists.",
+        "operationId": "ambrosianDiocesanDataPUT",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./DiocesanCalendar.json"
+              },
+              "examples": {
+                "MilanDiocesan": {
+                  "$ref": "#/components/examples/DiocesanCalendarMilanRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "examples": [
+                        "Diocesan calendar created for diocese {DIOCESE}"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "409": {
+            "$ref": "#/components/responses/Conflict409"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve an Ambrosian diocesan calendar data resource",
+        "description": "Retrieve the source definition of a diocesan calendar defined under the Ambrosian rite.\n\n**The `ambrosian` rite segment is required here, not decorative.** The bare `/data/diocese/{key}` form resolves to the Roman rite, so addressing an Ambrosian diocese through it returns `422 Unprocessable Content` (`Diocesan calendar ... belongs to the ambrosian rite, not the requested roman rite.`); the same `422` is returned on this path for a diocese that is not Ambrosian. The Ambrosian dioceses are Milano (`milano_it`), Bergamo (`bergam_it`), Novara (`novara_it`) and Lugano (`lugano_ch`) \u2014 every other diocese is Roman. On any `/data` path `roman` is accepted as an explicit synonym of the bare form.\n\nOnly the diocesan tier exists under more than one rite, so there is deliberately no `/data/ambrosian/nation/{key}` and no `/data/ambrosian/widerregion/{key}`: the Ambrosian rite is proper to the Archdiocese of Milan and a handful of neighbouring dioceses rather than to any nation or region, and the source tree has no Ambrosian national or wider-region partition to read or write. Either of those requests returns `400 Bad Request`.\n\nUnlike `/calendar` and `/events`, `/data` advertises no canonical URL: the bare form returns no RFC 6596 `Link: <...>; rel=\"canonical\"` response header.\n\nThe Ambrosian rite has approved liturgical books only in Italian and Latin, so `diocesan_calendars[].locales` on `/calendars` declares `it_IT` and `la_VA` for these dioceses; a `locale` naming any other language returns `422 Unprocessable Content`.",
+        "operationId": "ambrosianDiocesanDataPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./DiocesanCalendar.json"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Update an Ambrosian diocesan calendar data resource",
+        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.\n\nThe method surface is identical to `/data/diocese/{key}`: the `ambrosian` segment only selects which rite partition of the source tree is written. It is required for an Ambrosian diocese \u2014 see `GET /data/ambrosian/diocese/{key}` for the full rite grammar and for why no rite-qualified national or wider-region path exists.",
+        "operationId": "ambrosianDiocesanDataPATCH",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "./DiocesanCalendar.json"
+              },
+              "examples": {
+                "MilanDiocesan": {
+                  "$ref": "#/components/examples/DiocesanCalendarMilanRequestBody"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "201 Created. Even when updating an existing resource, we will still get the same 201 Created because we are basically overwriting the previous resource",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "success": {
+                      "type": "string",
+                      "example": "Diocesan calendar updated for diocese {DIOCESE}"
+                    }
+                  },
+                  "required": [
+                    "success"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete an Ambrosian diocesan calendar data resource",
+        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`.\n\nThe method surface is identical to `/data/diocese/{key}`: the `ambrosian` segment only selects which rite partition of the source tree is written. It is required for an Ambrosian diocese \u2014 see `GET /data/ambrosian/diocese/{key}` for the full rite grammar and for why no rite-qualified national or wider-region path exists.",
+        "operationId": "ambrosianDiocesanDataDELETE",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/DeleteSuccess200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       }
@@ -11070,6 +11370,51 @@
           "i18n": {
             "it_IT": {
               "DedicationoftheBasilicaofStJohnLateran": "Dedicazione della Basilica Lateranense"
+            }
+          }
+        }
+      },
+      "DiocesanCalendarMilanRequestBody": {
+        "summary": "Diocesan Calendar for the Archdiocese of Milan (Ambrosian rite)",
+        "description": "Example of a diocesan calendar definition for a diocese of the Ambrosian rite. `metadata.rite` names the rite the calendar belongs to and agrees with the `ambrosian` segment of the path. Ambrosian dioceses declare no `settings`: the movable-feast settings of the rite are fixed and are announced on `/calendars` as `ambrosian_calendars[].settings`.",
+        "value": {
+          "litcal": [
+            {
+              "liturgical_event": {
+                "event_key": "BeatoManfredoSettala",
+                "color": [
+                  "white"
+                ],
+                "grade": 3,
+                "common": [
+                  "Proper"
+                ],
+                "day": 27,
+                "month": 1
+              },
+              "metadata": {
+                "since_year": 2024,
+                "form_rownum": 0
+              }
+            }
+          ],
+          "metadata": {
+            "nation": "IT",
+            "diocese_id": "milano_it",
+            "diocese_name": "Arcidiocesi di Milano",
+            "locales": [
+              "it_IT",
+              "la_VA"
+            ],
+            "timezone": "Europe/Rome",
+            "rite": "ambrosian"
+          },
+          "i18n": {
+            "it_IT": {
+              "BeatoManfredoSettala": "B. Manfredo Settala, presbitero"
+            },
+            "la_VA": {
+              "BeatoManfredoSettala": "Beatus Manfredus Settala, presbyter"
             }
           }
         }

--- a/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
@@ -106,6 +106,18 @@ final class OpenApiDataRiteSegmentTest extends TestCase
                 'the bare form of every tier must stay documented'
             );
 
+            // The exclusion described in this method's docblock, asserted rather than merely stated.
+            // Without this the decision lived only in prose, and a `/data/roman/...` duplicate could be
+            // added without anything noticing that the contract had grown a second spelling of a path
+            // it already documents. Should that duplication ever become the intent — mirroring how
+            // `/calendar` enumerates both rites at every tier — this is the assertion to revisit, which
+            // is the point: the change would be a deliberate one rather than a drift.
+            self::assertArrayNotHasKey(
+                "/data/{$rite->value}/{$category->value}/{key}",
+                self::paths(),
+                'the Roman rite is expressed through the bare path, not through a /data/roman/... duplicate'
+            );
+
             return;
         }
 

--- a/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
@@ -144,15 +144,23 @@ final class OpenApiDataRiteSegmentTest extends TestCase
         /** @var array<string,array<string,mixed>> $riteQualified */
         $riteQualified = $paths['/data/ambrosian/diocese/{key}'];
 
+        // Compare the *sets* of documented methods. Ordering inside a path item carries no meaning in
+        // OpenAPI, and a path item may legally hold non-method keys (`parameters`, `summary`, `servers`),
+        // so an ordered comparison of raw keys would fail on a cosmetic reshuffle and would drag a
+        // hoisted `parameters` array into the security loop below, where it would compare null to null
+        // and pass for the wrong reason.
+        $bareMethods          = self::operationMethods($bare);
+        $riteQualifiedMethods = self::operationMethods($riteQualified);
+
         self::assertSame(
-            array_keys($bare),
-            array_keys($riteQualified),
-            'the rite-qualified path must document the same methods, in the same order, as the bare form'
+            $bareMethods,
+            $riteQualifiedMethods,
+            'the rite-qualified path must document the same methods as the bare form'
         );
 
-        foreach ($bare as $method => $operation) {
+        foreach ($bareMethods as $method) {
             self::assertSame(
-                $operation['security'] ?? null,
+                $bare[$method]['security'] ?? null,
                 $riteQualified[$method]['security'] ?? null,
                 "{$method} /data/ambrosian/diocese/{key} must be protected exactly like the bare form"
             );
@@ -198,5 +206,25 @@ final class OpenApiDataRiteSegmentTest extends TestCase
             $pathItem[$method]['responses'],
             strtoupper($method) . " {$path} can refuse a diocese of the wrong rite with 422, which it does not declare"
         );
+    }
+
+    /**
+     * The HTTP methods a path item documents, sorted, with any non-method key (`parameters`,
+     * `summary`, `description`, `servers`) filtered out — those are legal siblings of the operations
+     * in an OpenAPI path item and are not operations themselves.
+     *
+     * @param array<string,mixed> $pathItem
+     *
+     * @return list<string>
+     */
+    private static function operationMethods(array $pathItem): array
+    {
+        $methods = array_values(array_intersect(
+            array_keys($pathItem),
+            ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
+        ));
+        sort($methods);
+
+        return $methods;
     }
 }

--- a/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\PathCategory;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Params\RegionalDataParams;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `Router::extractRiteSegment()` accepts an optional leading rite segment on `data`, exactly as
+ * it does on `calendar` and `events`, but openapi.json documented only the bare forms — so a
+ * client reading the contract could not discover `/data/ambrosian/diocese/{key}` at all (#818).
+ *
+ * The rite × tier matrix is deliberately not full: only the diocesan tier exists under more than
+ * one rite, so `/data/ambrosian/nation/{key}` and `/data/ambrosian/widerregion/{key}` are refused
+ * by {@see RegionalDataParams::validateRiteCompatibility()}. A contract that advertised them would
+ * be worse than one that omits the rite segment entirely.
+ *
+ * Both halves are asserted against that runtime rule rather than against a second hardcoded list,
+ * so the document cannot quietly drift away from the routing grammar: adding a rite, or giving a
+ * rite a national tier, fails here until the contract says so too.
+ */
+final class OpenApiDataRiteSegmentTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private static array $openapi;
+
+    public static function setUpBeforeClass(): void
+    {
+        $raw = file_get_contents(dirname(__DIR__, 2) . '/jsondata/schemas/openapi.json');
+        self::assertIsString($raw, 'Could not read openapi.json');
+
+        /** @var array<string,mixed> $decoded */
+        $decoded       = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        self::$openapi = $decoded;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private static function paths(): array
+    {
+        /** @var array<string,array<string,mixed>> $paths */
+        $paths = self::$openapi['paths'];
+
+        return $paths;
+    }
+
+    /**
+     * Whether the handler's parameter object accepts this rite for this tier. This is the same
+     * check the running API performs before any file path is built.
+     */
+    private static function combinationIsAccepted(Rite $rite, PathCategory $category): bool
+    {
+        try {
+            new RegionalDataParams([
+                'category' => $category,
+                'key'      => 'milano_it',
+                'rite'     => $rite,
+            ]);
+        } catch (ValidationException) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string,array{0:Rite,1:PathCategory}>
+     */
+    public static function riteAndCategoryCombinations(): array
+    {
+        $combinations = [];
+
+        foreach (Rite::cases() as $rite) {
+            foreach (PathCategory::cases() as $category) {
+                $combinations[$rite->value . ' / ' . $category->value] = [$rite, $category];
+            }
+        }
+
+        return $combinations;
+    }
+
+    /**
+     * A non-default rite is addressed by naming it in the path, so the contract must list exactly
+     * the rite-qualified paths the API accepts — no more (a documented 400 is a lie a generated
+     * client will act on) and no fewer (the omission is what #818 reports).
+     *
+     * The Roman rite is deliberately excluded: it is the rite an absent segment resolves to, and
+     * the contract expresses it through the bare path rather than through a `/data/roman/...`
+     * duplicate of every operation. `/data/roman/{category}/{key}` is still accepted at runtime as
+     * an explicit synonym, and the bare paths' descriptions say so.
+     */
+    #[DataProvider('riteAndCategoryCombinations')]
+    public function testRiteQualifiedPathIsDocumentedExactlyWhenItIsAccepted(Rite $rite, PathCategory $category): void
+    {
+        if ($rite === Rite::default()) {
+            self::assertArrayHasKey(
+                "/data/{$category->value}/{key}",
+                self::paths(),
+                'the bare form of every tier must stay documented'
+            );
+
+            return;
+        }
+
+        $path     = "/data/{$rite->value}/{$category->value}/{key}";
+        $accepted = self::combinationIsAccepted($rite, $category);
+
+        if ($accepted) {
+            self::assertArrayHasKey(
+                $path,
+                self::paths(),
+                "the API accepts {$path} but openapi.json does not document it"
+            );
+        } else {
+            self::assertArrayNotHasKey(
+                $path,
+                self::paths(),
+                "openapi.json documents {$path}, which the API refuses with 400 Bad Request"
+            );
+        }
+    }
+
+    /**
+     * The rite segment selects a partition of the source tree; it does not change what may be done
+     * to it. `/data` is wired for GET, POST, PUT, PATCH and DELETE alike on both forms (Router's
+     * `data` case keys the allowed methods off the path-part count, which the rite segment does not
+     * alter), and the write methods are JWT-protected on both. A rite-qualified path that quietly
+     * documented a narrower — or wider — surface would misdescribe the authorization boundary.
+     */
+    public function testTheRiteQualifiedPathMirrorsTheBareFormsOperationSurface(): void
+    {
+        $paths = self::paths();
+        self::assertArrayHasKey('/data/ambrosian/diocese/{key}', $paths);
+
+        /** @var array<string,array<string,mixed>> $bare */
+        $bare = $paths['/data/diocese/{key}'];
+        /** @var array<string,array<string,mixed>> $riteQualified */
+        $riteQualified = $paths['/data/ambrosian/diocese/{key}'];
+
+        self::assertSame(
+            array_keys($bare),
+            array_keys($riteQualified),
+            'the rite-qualified path must document the same methods, in the same order, as the bare form'
+        );
+
+        foreach ($bare as $method => $operation) {
+            self::assertSame(
+                $operation['security'] ?? null,
+                $riteQualified[$method]['security'] ?? null,
+                "{$method} /data/ambrosian/diocese/{key} must be protected exactly like the bare form"
+            );
+        }
+    }
+
+    /**
+     * The refusal of an Ambrosian diocese on the bare path is a `422`, not a `404` or a `400`
+     * (`RegionalDataHandler::checkDiocesanCalendarConditions()`), which means the rite segment is
+     * *required* for those dioceses rather than an optional decoration. Every operation of both
+     * diocesan paths that can produce that refusal has to declare it, or a client generated from
+     * this document has no branch to handle the one status it will actually meet.
+     *
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function diocesanOperationsThatCanRefuseOnRite(): array
+    {
+        $operations = [];
+
+        // PUT is excluded: it creates a calendar that does not exist yet, so there is no stored
+        // rite to disagree with — the conditions check skips the comparison for PUT.
+        foreach (['get', 'post', 'patch', 'delete'] as $method) {
+            foreach (['/data/diocese/{key}', '/data/ambrosian/diocese/{key}'] as $path) {
+                $operations[strtoupper($method) . ' ' . $path] = [$path, $method];
+            }
+        }
+
+        return $operations;
+    }
+
+    #[DataProvider('diocesanOperationsThatCanRefuseOnRite')]
+    public function testTheRiteMismatchRefusalIsDeclared(string $path, string $method): void
+    {
+        $paths = self::paths();
+        self::assertArrayHasKey($path, $paths);
+
+        /** @var array<string,array<string,array<string,mixed>>> $pathItem */
+        $pathItem = $paths[$path];
+        self::assertArrayHasKey($method, $pathItem);
+
+        self::assertArrayHasKey(
+            '422',
+            $pathItem[$method]['responses'],
+            strtoupper($method) . " {$path} can refuse a diocese of the wrong rite with 422, which it does not declare"
+        );
+    }
+}

--- a/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
@@ -91,10 +91,9 @@ final class OpenApiDataRiteSegmentTest extends TestCase
      * the rite-qualified paths the API accepts — no more (a documented 400 is a lie a generated
      * client will act on) and no fewer (the omission is what #818 reports).
      *
-     * The Roman rite is deliberately excluded: it is the rite an absent segment resolves to, and
-     * the contract expresses it through the bare path rather than through a `/data/roman/...`
-     * duplicate of every operation. `/data/roman/{category}/{key}` is still accepted at runtime as
-     * an explicit synonym, and the bare paths' descriptions say so.
+     * The Roman rite is enumerated too, mirroring how `/calendar` documents both rites at every
+     * tier: of the two equivalent spellings the explicit one is canonical, so the contract names it
+     * rather than leaving a client to infer it from the bare path's prose.
      */
     #[DataProvider('riteAndCategoryCombinations')]
     public function testRiteQualifiedPathIsDocumentedExactlyWhenItIsAccepted(Rite $rite, PathCategory $category): void
@@ -106,16 +105,13 @@ final class OpenApiDataRiteSegmentTest extends TestCase
                 'the bare form of every tier must stay documented'
             );
 
-            // The exclusion described in this method's docblock, asserted rather than merely stated.
-            // Without this the decision lived only in prose, and a `/data/roman/...` duplicate could be
-            // added without anything noticing that the contract had grown a second spelling of a path
-            // it already documents. Should that duplication ever become the intent — mirroring how
-            // `/calendar` enumerates both rites at every tier — this is the assertion to revisit, which
-            // is the point: the change would be a deliberate one rather than a drift.
-            self::assertArrayNotHasKey(
+            // Both spellings are documented, and the explicit one is canonical. Asserted rather than
+            // left to prose: the bare and rite-qualified forms are equivalent at runtime, so nothing
+            // else would notice if the canonical spelling of a tier quietly stopped being documented.
+            self::assertArrayHasKey(
                 "/data/{$rite->value}/{$category->value}/{key}",
                 self::paths(),
-                'the Roman rite is expressed through the bare path, not through a /data/roman/... duplicate'
+                'the canonical explicit-rite form of every tier must be documented alongside the bare form'
             );
 
             return;


### PR DESCRIPTION
Closes #818.

`Router::extractRiteSegment()` accepts a leading rite segment on `data` exactly as it does on `calendar` and `events`, but `openapi.json` documented no rite-qualified `/data` variants. A client reading the schema could not discover `/data/ambrosian/diocese/{key}`.

## The issue's framing was wrong in one important way

The issue calls the rite segment "optional". It is optional **only for Roman dioceses**, where it is an exact synonym. For the four Ambrosian dioceses it is **required** — the bare path is a 422, not a synonym. Documenting it as an optional decoration would have misdescribed the API, so the spec says "required here, not decorative" in bold.

Grammar established from source and confirmed live:

| request | result | proof |
|---|---|---|
| `/data/{cat}/{key}` | rite resolves to `roman` | `Router::extractRiteSegment()` returns `Rite::default()`; `'data'` is in the accepting list (`src/Router.php:133-144`) |
| `/data/roman/{cat}/{key}` | exact synonym, all three tiers | byte-identical responses (md5 match) vs the bare form |
| `/data/ambrosian/diocese/{key}` | 200 | `JsonData::diocesanCalendarFileFor($this->rite)` |
| `/data/ambrosian/diocese/{roman diocese}` | **422** | `RegionalDataHandler::checkDiocesanCalendarConditions()` |
| `/data/diocese/{ambrosian diocese}` | **422** | same check, both directions |
| `/data/ambrosian/nation/{key}` | **400** | `RegionalDataParams::validateRiteCompatibility()` |
| `/data/ambrosian/widerregion/{key}` | **400** | same |
| `/data/latin/…` | 400 "Unexpected path param latin" | unknown segment is not a rite; falls through as a category |

PUT is the one exception to the requirement — no stored rite to disagree with, so the comparison is skipped. The test's data provider excludes it and says why.

## What was added

- **`/data/ambrosian/diocese/{key}`**, full GET/POST/PUT/PATCH/DELETE, cloned from `/data/diocese/{key}` so tags, `security` blocks, parameter and response `$ref`s and operation ordering are identical. operationIds follow the `/data` family convention.
- **A Milan request-body example** (`DiocesanCalendarMilanRequestBody`) rather than reusing the Boston/Rome ones — those are Roman dioceses, and copying them onto an Ambrosian path would document a payload the path cannot legitimately take. Built from the real source file plus its `it_IT`/`la_VA` i18n entries; Redocly's `no-invalid-media-type-examples` validates it against `DiocesanCalendar.json`.
- **The `422` declared** on `/data/diocese/{key}` GET/POST/DELETE as well as the new path. This was a **pre-existing hole beyond the issue's scope**: the rite-mismatch refusal was undeclared on every diocesan read.
- **The asymmetry documented where a reader will find it** — the new path's descriptions state it in full, and `/data/nation/{key}` and `/data/widerregion/{key}` GET each gained a one-sentence note quoting the actual 400 text.

## No `/data/roman/…` duplicate paths — a judgement call worth reviewing

Two precedents exist in this file: `/calendar` enumerates both rites at every tier, `/events` documents only the Ambrosian variant. This follows `/events`, reasoning that `/calendar`'s roman paths exist to name the **canonical** form, and `Router::canonicalRiteUrl()` (`src/Router.php:199`) explicitly excludes `data` — `/data` emits no `Link: rel="canonical"` header, so there is no canonical form for such duplicates to name. The synonym is documented in prose on the bare paths instead.

(A templated `{rite}` parameter, as `/tests` uses, would over-promise here: the rite × tier matrix is not full.)

Happy to switch to the `/calendar` style if you'd prefer `/data` mirrored it.

## Tests

New `phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php` (15 tests, 37 assertions), pure-logic per the CLAUDE.md layering table. It asserts the documented set **against `validateRiteCompatibility()` itself** rather than a second hardcoded list — matching the house style of `OpenApiAmbrosianLocaleParamTest`, which asserts against `riteSupportsLocale()`. Negative control: renaming the path key produces 6 failures, so the assertions bite.

No existing test asserted the set of documented paths.

## Verification

- `composer lint:openapi`: *"Woohoo! Your API description is valid. 🎉"* — 11 problems explicitly ignored, **identical to the pre-change baseline**; no new suppressions in `.redocly.lint-ignore.yaml`
- `composer lint` (phpcs): clean
- `composer analyse` (PHPStan level 10): `[OK] No errors`
- `composer test:quick`: exit 0 — `Tests: 2933, Assertions: 177784, Skipped: 11`; delta is exactly the 15 new tests

## Follow-ups filed

Two further gaps on the same family, deliberately out of scope: #838 (the `/data/{category}/{key}/{locale}` i18n sub-resource is undocumented entirely) and #839 (the `locale` parameter is undocumented across the whole family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added documented Ambrosian diocesan data operations for retrieving, creating, updating, and deleting records.
  - Added validation and authorisation details for Ambrosian diocesan requests.
  - Added an example request for Milan’s Ambrosian diocesan data.

- **Bug Fixes**
  - Clarified Roman-rite resolution for national, regional, and diocesan data paths.
  - Documented `422` responses when diocesan requests use an incompatible rite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->