### PR TITLE
docs: stop the guidance that reads as "always add #[Group('slow')]", and add .coderabbit.yaml

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,67 @@
+# CodeRabbit configuration.
+#
+# The path instructions below encode repo rules that a general-purpose reviewer
+# reliably gets wrong, because the correct answer is the opposite of the usual
+# convention. Each one describes a suggestion that has actually been made and
+# was actively harmful, not merely unnecessary.
+#
+# Reference: https://docs.coderabbit.ai/reference/yaml-template
+#
+# Note: .coderabbit.yaml has no top-level `version` key. Adding one risks the
+# whole file being rejected, taking these instructions with it.
+
+language: en-GB
+
+reviews:
+  path_instructions:
+    - path: "phpunit_tests/**"
+      instructions: |
+        PHPUnit `slow` group — do NOT suggest adding `#[Group('slow')]` to a test.
+
+        In this repository the `slow` group is an EXCLUSION mechanism, not a
+        descriptive label. `composer test:quick` runs `--exclude-group slow`, so
+        anything in the group disappears from the command developers actually
+        run. Adding a fast test to the group silently removes the regression
+        guard it was written to provide.
+
+        The group is reserved for tests with MEASURED runtime cost — multi-year
+        calendar calculations, rate-limit window waits, full-schema-corpus
+        validation. Integration tests are not automatically slow: most
+        `Routes/*` tests run in under 200 ms and are deliberately NOT grouped.
+
+        CLAUDE.md's rule "always use the `#[Group('slow')]` ATTRIBUTE, never a
+        legacy `@group slow` docblock" is about the SPELLING of the group for
+        tests that already belong in it. It is not an instruction to apply the
+        group. Do not cite it as a reason to add the attribute to a new test.
+
+        Only raise the group at all if a test's own measured runtime is large
+        and it is NOT already grouped, or if a test uses the legacy `@group slow`
+        docblock — PHPUnit 12 ignores the docblock, which makes both
+        `--exclude-group` and `--group` misbehave.
+
+        Also do NOT suggest passing `--exclude-group` on the phpunit CLI. A CLI
+        `--exclude-group` overrides the XML config and un-fences a
+        golden-master-generate group that silently rewrites the fixtures it is
+        checked against. Use `composer test:quick`.
+
+    - path: "jsondata/schemas/**"
+      instructions: |
+        These schemas declare JSON Schema draft-07 and are validated with
+        `swaggest/json-schema`, which implements draft-07 only.
+
+        In draft-07 a `$ref` REPLACES the schema object and sibling keywords are
+        ignored. So `{"$ref": "...", "not": {...}}` and `{"$ref": "...", "enum":
+        [...]}` are SILENT NO-OPS — they validate everything, including the
+        values they appear to forbid. Never suggest that shape. To narrow a
+        `$ref`, use `allOf: [{$ref: ...}, {...}]`, or `$ref` a definition that is
+        already narrow.
+
+        Do not suggest draft 2019-09 / 2020-12 keywords such as
+        `unevaluatedProperties` or `$dynamicRef`: the validator cannot evaluate
+        them, so they fail open rather than erroring. Migration is tracked
+        separately.
+
+        `settings` schemas use `oneOf`, where EXACTLY ONE branch must match. When
+        reviewing a new or widened branch, check that it does not also make a
+        previously single-matching payload match two branches — that turns a
+        passing response into a failure just as surely as matching none.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -449,11 +449,16 @@ Other notable test infrastructure:
   window waits (`Services/RateLimiterTest`), or full-schema-corpus validation (`Schemas/SchemaValidationTest`). Integration tests are NOT automatically slow:
   most `Routes/*` tests run in < 200 ms and are excluded from the `slow` group.
 
-> **Always use the `#[Group('slow')]` ATTRIBUTE, never a legacy `@group slow` docblock.** PHPUnit 12 honours only the attribute. Several existing suites
+> **Most tests do not belong in the `slow` group, and adding them to it is a mistake.** The group is an *exclusion* mechanism, not a label: anything in it
+> disappears from `composer test:quick`, the command developers actually run. A millisecond-scale test placed in the group silently stops guarding what it
+> was written to guard. Default to leaving a new test out of the group; put it in only when you have **measured** a runtime cost worth excluding.
+>
+> **When — and only when — a test does belong in the group, mark it with the `#[Group('slow')]` ATTRIBUTE, never a legacy `@group slow` docblock.** That
+> sentence is about the *spelling*, not about whether to apply the group at all. PHPUnit 12 honours only the attribute. Several existing suites
 > (`Schemas/SchemaValidationTest`, `Routes/Readonly/TemporaleTest`) still use docblocks, with two consequences: `--exclude-group slow` does not exclude
 > them, so `composer test:quick` runs them anyway; and `--group slow <path>` on those files selects **zero tests and exits successfully** — a false green.
-> If you use `--group` for anything, confirm with `--list-tests` that it actually selected something. Migrating the remaining docblocks to attributes is
-> open work.
+> If you use `--group` for anything, confirm with `--list-tests` that it actually selected something. Migrating those existing docblocks to attributes is
+> open work — that migration means changing the *spelling* of groups already applied, not adding the group to further tests.
 
 **Engine cache (`engineCache/`) — a trap when comparing revisions:**
 


### PR DESCRIPTION
CodeRabbit has repeatedly suggested adding `#[Group('slow')]` to new, millisecond-scale tests — most recently on #840, for a class whose whole runtime is **7 ms**.

The suggestion is not merely unnecessary, it is harmful. The `slow` group is an **exclusion** mechanism: `composer test:quick` runs `--exclude-group slow`, so anything in the group disappears from the command developers actually run. Putting a fast test there silently removes the regression guard it was written to provide.

## Why it keeps happening

Our own `CLAUDE.md` is the likely cause. The rule was written as a bolded, standalone blockquote:

> **Always use the `#[Group('slow')]` ATTRIBUTE, never a legacy `@group slow` docblock.**

The subject of that sentence is the *spelling* of the group — attribute vs. docblock, because PHPUnit 12 honours only the attribute. The condition governing *whether the group applies at all* lived in a separate list item further up. Read on its own — which is how a chunked retrieval reads it — it is an unconditional instruction to apply the attribute. The formatting that made the rule prominent also made it more likely to be retrieved standalone, stripped of its scope.

A secondary contributor: "Migrating the remaining docblocks to attributes is open work" reads as encouragement to add attributes, when it means changing the spelling of groups **already applied**.

## Changes

**`CLAUDE.md`** — reworded so the default comes first ("most tests do not belong in the `slow` group, and adding them to it is a mistake"), the conditional sits inside the imperative sentence ("when — and only when — a test does belong in the group…"), the sentence says outright that it is about spelling rather than application, and the migration note is scoped to groups already applied.

**`.coderabbit.yaml`** (new) — the channel the reviewer reads directly rather than inferring from prose. Two path instructions, each covering a rule where the correct answer is the *opposite* of the usual convention:

- **`phpunit_tests/**`** — the slow-group rule, stated as "do NOT suggest adding `#[Group('slow')]`", with the narrow cases where raising it *is* right (a measured-slow test that is ungrouped; a test using the legacy docblock). Plus: do not suggest passing `--exclude-group` on the phpunit CLI, since a CLI `--exclude-group` overrides the XML config and un-fences a golden-master-generate group that silently rewrites the fixtures it is checked against.
- **`jsondata/schemas/**`** — in draft-07 a `$ref` **replaces** the schema object and sibling keywords are ignored, so `{"$ref": …, "not": {…}}` and `{"$ref": …, "enum": […]}` are **silent no-ops** that validate everything they appear to forbid. This was measured while implementing #817, where both spellings let `rite: "roman"` sail through. A reviewer suggesting either shape would be recommending a change that looks correct and enforces nothing. Also covers draft-2019-09/2020-12 keywords (the validator fails open on them) and `oneOf` exclusivity.

## Validation

- `.coderabbit.yaml` parses, and every top-level key is checked against the documented set (`language`, `tone_instructions`, `early_access`, `enable_free_tier`, `reviews`, `chat`, `knowledge_base`, `code_generation`, `issue_enrichment`).
- **There is no top-level `version` key.** One was nearly added out of habit; the comment at the top of the file records this, because an unknown key risks the file being rejected and taking these instructions with it.
- `path_instructions` entries use the documented `path` / `instructions` fields, at 1443 and 982 characters against a 20,000-character limit.
- `composer lint:md` clean (via the pre-commit hook).

No source or test files are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
