### PR TITLE
fix(cache): answer the APCu question with a round trip at the six surviving sites (#836)

### DIFF
--- a/phpunit_tests/ApcuCacheDetectionTest.php
+++ b/phpunit_tests/ApcuCacheDetectionTest.php
@@ -66,6 +66,8 @@ final class ApcuCacheDetectionTest extends TestCase
         $this->usableBefore = is_bool($usable) ? $usable : null;
         self::forgetProbeResult();
 
+        self::assertShimIsTheBoundBackend();
+
         $this->tmpFile = sys_get_temp_dir() . '/litcal_apcu_cache_test_' . uniqid() . '.json';
     }
 
@@ -97,6 +99,48 @@ final class ApcuCacheDetectionTest extends TestCase
     private static function forgetProbeResult(): void
     {
         ( new \ReflectionProperty(ApcuCache::class, 'usable') )->setValue(null, null);
+    }
+
+    /**
+     * Fail loudly if `ApcuCache`'s calls are not reaching the shim.
+     *
+     * PHP's `INIT_NS_FCALL_BY_NAME` caches the function it resolved in the opline's run-time cache,
+     * so a call site that once executed while the shim was not loaded stays bound to the *global*
+     * `apcu_*` for the life of the process. Nothing in this class can undo that, and the failure is
+     * silent in the worst way: the fault switches below would simply have no effect, and the
+     * positive cases would pass against a real backend while the negative ones passed for the wrong
+     * reason.
+     *
+     * `phpunit_tests/bootstrap.php` is what keeps this from happening — by pinning the memo it stops
+     * `Utilities` reaching an `apcu_*` opline at all on hosts where the answer is `false`. But that
+     * argument does not hold on a host where the probe genuinely answers `true` (a real APCu with
+     * `apc.enable_cli=1`), where an earlier test *can* bind these sites first. Rather than load the
+     * shim from the bootstrap — which would also bind `Health`'s call sites to it and change what
+     * `Health::apcuUsable()` measures on such a host — the coupling is asserted here, where it is
+     * cheap and where a violation is a test failure rather than a wrong answer.
+     */
+    private static function assertShimIsTheBoundBackend(): void
+    {
+        ApcuShimStore::simulateDisabledStore(false);
+        ApcuShimStore::simulateThrowingStore(false);
+
+        $sentinel = self::PROBE_KEY_PREFIX . 'binding_' . uniqid();
+        ApcuShimStore::store($sentinel, 'bound', 10);
+
+        ( new \ReflectionProperty(ApcuCache::class, 'usable') )->setValue(null, true);
+
+        try {
+            $value = ApcuCache::fetch($sentinel, $found);
+            self::assertTrue(
+                $found && 'bound' === $value,
+                'ApcuCache is not reaching phpunit_tests/Support/ApcuShim.php: its apcu_* call sites were '
+                . 'bound to the global functions before the shim was loaded, so the fault switches this '
+                . 'class relies on cannot take effect. See assertShimIsTheBoundBackend().'
+            );
+        } finally {
+            ApcuShimStore::delete($sentinel);
+            self::forgetProbeResult();
+        }
     }
 
     /**

--- a/phpunit_tests/ApcuCacheDetectionTest.php
+++ b/phpunit_tests/ApcuCacheDetectionTest.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\ApcuCache;
+use LiturgicalCalendar\Api\ApcuShimStore;
+use LiturgicalCalendar\Api\Models\MissalsPath\MissalMetadataMap;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Utilities;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #836: an APCu that is present but inert must not be selected as the JSON-file cache either.
+ *
+ * The same predicate #835 replaced in `Health` — `extension_loaded('apcu')` plus `function_exists()`
+ * on three of the `apcu_*` names — survived in six further places: the four `Utilities::jsonFileTo*()`
+ * / `jsonUrlToObject()` readers, `Utilities::invalidateJsonFileCache()` (a narrower variant), and
+ * `MissalMetadataMap::__construct()`. All of them now consult {@see ApcuCache}, whose answer comes
+ * from a store→fetch round trip.
+ *
+ * Both directions are asserted, as in {@see HealthApcuDetectionTest}: a probe that always answered
+ * "no" would satisfy every negative case here while silently disabling caching outright, so the
+ * positive cases are what make the negative ones mean something.
+ *
+ * **Why the sites are tested and not only the probe.** `ApcuCache` exists in the
+ * `LiturgicalCalendar\Api` namespace on purpose. PHP resolves an unqualified `apcu_store()` against
+ * the *calling* namespace before the global one, so a probe run inside `LiturgicalCalendar\Api` only
+ * describes the functions a caller in `LiturgicalCalendar\Api` will really reach.
+ * `MissalMetadataMap` lives in `LiturgicalCalendar\Api\Models\MissalsPath`, where the very same
+ * unqualified call resolves somewhere else entirely — which is why it no longer calls `apcu_*` at all
+ * and goes through `ApcuCache` instead. `testMissalMetadataMapCachesThroughTheSharedHelper()` is what
+ * holds that property down: before #836 it failed, because the map's own unqualified calls bypassed
+ * `phpunit_tests/Support/ApcuShim.php` and landed on the global (real, and under the CLI SAPI inert)
+ * functions.
+ */
+#[CoversClass(ApcuCache::class)]
+final class ApcuCacheDetectionTest extends TestCase
+{
+    private const PROBE_KEY_PREFIX  = 'litcal_apcu_probe_';
+    private const MISSALS_INDEX_KEY = 'litcal_missals_index';
+
+    private ?string $tmpFile    = null;
+    private ?bool $usableBefore = null;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        // MissalMetadataMap::buildIndex() resolves JsonData paths through Router::$apiFilePath and
+        // composes api_path values from Router::$apiPath, both uninitialized typed statics.
+        Router::getApiPaths();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/Support/ApcuShim.php';
+
+        // The memoised answer is process-wide state, and this class deliberately flips what the
+        // answer would be. Capture it so tearDown can put the process back exactly as it was found:
+        // the shim's functions cannot be un-declared once loaded, so a memo left unresolved here
+        // would let this class retroactively switch Utilities caching on for every later test.
+        $usable             = ( new \ReflectionProperty(ApcuCache::class, 'usable') )->getValue();
+        $this->usableBefore = is_bool($usable) ? $usable : null;
+        self::forgetProbeResult();
+
+        $this->tmpFile = sys_get_temp_dir() . '/litcal_apcu_cache_test_' . uniqid() . '.json';
+    }
+
+    protected function tearDown(): void
+    {
+        ApcuShimStore::simulateDisabledStore(false);
+        ApcuShimStore::simulateThrowingStore(false);
+
+        if (null !== $this->tmpFile) {
+            Utilities::invalidateJsonFileCache($this->tmpFile);
+            if (file_exists($this->tmpFile)) {
+                unlink($this->tmpFile);
+            }
+        }
+        ApcuShimStore::delete(self::MISSALS_INDEX_KEY);
+
+        ( new \ReflectionProperty(ApcuCache::class, 'usable') )->setValue(null, $this->usableBefore);
+        parent::tearDown();
+    }
+
+    // ---------------------------------------------------------------- harness
+
+    /**
+     * Drop the memoised probe result so the next question is answered against the fault switches the
+     * calling test has just set. Memoisation is what keeps a store/fetch/delete off the hot path of
+     * every JSON file read; it is also what would otherwise freeze the first test's answer for all
+     * the rest.
+     */
+    private static function forgetProbeResult(): void
+    {
+        ( new \ReflectionProperty(ApcuCache::class, 'usable') )->setValue(null, null);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function probeKeysLeftBehind(): array
+    {
+        return array_values(array_filter(
+            ApcuShimStore::keys(),
+            static fn (string $key): bool => str_starts_with($key, self::PROBE_KEY_PREFIX)
+        ));
+    }
+
+    private function writeTmpFile(mixed $contents): string
+    {
+        self::assertIsString($this->tmpFile);
+        file_put_contents($this->tmpFile, json_encode($contents, JSON_THROW_ON_ERROR));
+
+        return $this->tmpFile;
+    }
+
+    // ---------------------------------------------------------------- the probe itself
+
+    /**
+     * The defect, reduced to its smallest statement: the functions are all present, the store reports
+     * success, and nothing comes back. That must read as unusable.
+     */
+    public function testAnApcuThatReportsSuccessButStoresNothingIsNotUsable(): void
+    {
+        ApcuShimStore::simulateDisabledStore(true);
+
+        self::assertFalse(
+            ApcuCache::isUsable(),
+            'an APCu whose writes silently vanish must not be reported as usable, however present its functions are'
+        );
+    }
+
+    /**
+     * The other half of the pair: a backend that does round-trip is still used, so the probe is not
+     * simply always-false — which would "fix" the issue by disabling caching everywhere.
+     */
+    public function testAnApcuThatRoundTripsIsUsable(): void
+    {
+        self::assertTrue(
+            ApcuCache::isUsable(),
+            'a store/fetch round trip that works must be reported as usable'
+        );
+    }
+
+    /**
+     * A probe key is a write into a live cache and must not outlive the question it answers.
+     */
+    public function testTheProbeCleansUpAfterItself(): void
+    {
+        self::assertTrue(ApcuCache::isUsable(), 'precondition: the probe took the store/fetch path');
+
+        self::assertSame(
+            [],
+            self::probeKeysLeftBehind(),
+            'the probe key must be deleted, not left sitting in the cache it was only testing'
+        );
+    }
+
+    /**
+     * The probe owes its callers a bool even when the backend raises. Unlike `Health`, these callers
+     * sit on the HTTP request path: an escaping exception would turn a degraded cache into a failed
+     * `/calendar` response.
+     */
+    public function testAnApcuWhoseStoreThrowsIsNotUsableRatherThanPropagating(): void
+    {
+        ApcuShimStore::simulateThrowingStore(true);
+
+        self::assertFalse(
+            ApcuCache::isUsable(),
+            'a store that throws must read as unusable, not escape as an exception'
+        );
+    }
+
+    /**
+     * Nothing may be written to stdout on the way to that answer. `Health` reports its probe failures
+     * with `echo` because it is a CLI process; the same line from `Utilities` would be prepended to a
+     * PSR-7 response body.
+     */
+    public function testTheProbeNeverWritesToOutput(): void
+    {
+        ApcuShimStore::simulateThrowingStore(true);
+
+        ob_start();
+        ApcuCache::isUsable();
+        $output = ob_get_clean();
+
+        self::assertSame('', $output, 'a probe failure must not be echoed into an HTTP response body');
+    }
+
+    // ---------------------------------------------------------------- Utilities::jsonFileTo*()
+
+    /**
+     * A usable backend is still used: prime, rewrite the file underneath, and the stale value must
+     * come back. Before #836 this failed wherever `extension_loaded('apcu')` was false — the operand
+     * is not merely subsumed by the round trip, it actively contradicts it whenever the functions
+     * that will really be called are not the extension's.
+     */
+    public function testJsonFileToArrayServesFromCacheWhenApcuRoundTrips(): void
+    {
+        $file = $this->writeTmpFile(['greeting' => 'hello']);
+
+        self::assertSame('hello', Utilities::jsonFileToArray($file)['greeting']);
+
+        $this->writeTmpFile(['greeting' => 'world']);
+
+        self::assertSame(
+            'hello',
+            Utilities::jsonFileToArray($file)['greeting'],
+            'a working APCu must actually be used — otherwise the fix amounts to switching caching off'
+        );
+    }
+
+    /**
+     * And an inert one is not: every read goes back to disk, so a rewrite is visible immediately.
+     */
+    public function testJsonFileToArrayDoesNotCacheWhenApcuStoresNothing(): void
+    {
+        $file = $this->writeTmpFile(['greeting' => 'hello']);
+        ApcuShimStore::simulateDisabledStore(true);
+
+        self::assertSame('hello', Utilities::jsonFileToArray($file)['greeting']);
+
+        $this->writeTmpFile(['greeting' => 'world']);
+
+        self::assertSame(
+            'world',
+            Utilities::jsonFileToArray($file)['greeting'],
+            'an inert APCu must leave the reader going to disk, not pretending it has a cache'
+        );
+    }
+
+    /**
+     * `jsonFileToObject()` and `jsonUrlToObject()` share a cache-key prefix, and the object readers
+     * take a different branch from the array one; assert the same pair for the object reader.
+     */
+    public function testJsonFileToObjectServesFromCacheWhenApcuRoundTrips(): void
+    {
+        $file = $this->writeTmpFile(['status' => 'initial']);
+
+        self::assertSame('initial', Utilities::jsonFileToObject($file)->status);
+
+        $this->writeTmpFile(['status' => 'refreshed']);
+
+        self::assertSame('initial', Utilities::jsonFileToObject($file)->status);
+
+        Utilities::invalidateJsonFileCache($file);
+
+        self::assertSame(
+            'refreshed',
+            Utilities::jsonFileToObject($file)->status,
+            'invalidation must reach the same backend the reader used'
+        );
+    }
+
+    /**
+     * The object-array reader has its own key prefix and its own fetch branch.
+     */
+    public function testJsonFileToObjectArrayServesFromCacheWhenApcuRoundTrips(): void
+    {
+        $file = $this->writeTmpFile([['key' => 'original_value']]);
+
+        self::assertSame('original_value', Utilities::jsonFileToObjectArray($file)[0]->key);
+
+        $this->writeTmpFile([['key' => 'updated_value']]);
+
+        self::assertSame('original_value', Utilities::jsonFileToObjectArray($file)[0]->key);
+
+        Utilities::invalidateJsonFileCache($file);
+
+        self::assertSame(
+            'updated_value',
+            Utilities::jsonFileToObjectArray($file)[0]->key,
+            'invalidation must clear the object-array key too'
+        );
+    }
+
+    /**
+     * A backend that raises must not take the request down with it. Before #836 the reader called
+     * `apcu_store()` on the strength of `function_exists()` alone, so a throwing backend threw
+     * straight out of `jsonFileToArray()` — a JSON file read that had already succeeded.
+     */
+    public function testJsonFileToArraySurvivesAThrowingApcu(): void
+    {
+        $file = $this->writeTmpFile(['greeting' => 'hello']);
+        ApcuShimStore::simulateThrowingStore(true);
+
+        self::assertSame(
+            'hello',
+            Utilities::jsonFileToArray($file)['greeting'],
+            'a throwing cache backend must degrade to no cache, not to a failed read'
+        );
+    }
+
+    /**
+     * `invalidateJsonFileCache()` carried the narrow variant of the predicate,
+     * `!extension_loaded('apcu') || !function_exists('apcu_delete')`. Its `extension_loaded()` operand
+     * is wrong for the same reason the full predicate's is: it asks about the extension rather than
+     * about the functions the unqualified calls actually reach.
+     */
+    public function testInvalidationReachesTheBackendTheReaderWroteTo(): void
+    {
+        $file = $this->writeTmpFile(['greeting' => 'hello']);
+
+        Utilities::jsonFileToArray($file);
+        $this->writeTmpFile(['greeting' => 'world']);
+        Utilities::invalidateJsonFileCache($file);
+
+        self::assertSame(
+            'world',
+            Utilities::jsonFileToArray($file)['greeting'],
+            'invalidation must not be gated on an extension the reader never consulted'
+        );
+    }
+
+    // ---------------------------------------------------------------- MissalMetadataMap
+
+    /**
+     * The namespace question, made observable.
+     *
+     * `MissalMetadataMap` lives in `LiturgicalCalendar\Api\Models\MissalsPath`, so its own unqualified
+     * `apcu_store()` resolved to the global function — never to the shim, which declares its
+     * stand-ins in `LiturgicalCalendar\Api`. It therefore decided usability from one set of functions
+     * while writing through another. Routing it through `ApcuCache` collapses that into one question
+     * with one answer, and this assertion is what proves the write really lands where the decision
+     * was made.
+     */
+    public function testMissalMetadataMapCachesThroughTheSharedHelper(): void
+    {
+        ApcuShimStore::delete(self::MISSALS_INDEX_KEY);
+
+        ( new MissalMetadataMap() )->buildIndex();
+
+        self::assertTrue(
+            ApcuShimStore::exists(self::MISSALS_INDEX_KEY),
+            'the missals index must be written to the same backend the usability decision was made against'
+        );
+    }
+
+    /**
+     * And an inert backend leaves nothing behind, rather than a decision that says otherwise.
+     */
+    public function testMissalMetadataMapWritesNothingWhenApcuStoresNothing(): void
+    {
+        ApcuShimStore::delete(self::MISSALS_INDEX_KEY);
+        ApcuShimStore::simulateDisabledStore(true);
+
+        ( new MissalMetadataMap() )->buildIndex();
+
+        self::assertFalse(
+            ApcuShimStore::exists(self::MISSALS_INDEX_KEY),
+            'an inert APCu must not be selected as the missals-index cache'
+        );
+    }
+
+    /**
+     * The map builds its index on the HTTP request path for `/missals`; a throwing backend must cost
+     * the cache, not the response.
+     */
+    public function testMissalMetadataMapSurvivesAThrowingApcu(): void
+    {
+        ApcuShimStore::simulateThrowingStore(true);
+
+        $map = new MissalMetadataMap();
+        $map->buildIndex();
+
+        self::assertFalse($map->isEmpty(), 'the index must still be built when the cache backend raises');
+    }
+}

--- a/phpunit_tests/ApcuCacheDetectionTest.php
+++ b/phpunit_tests/ApcuCacheDetectionTest.php
@@ -75,6 +75,8 @@ final class ApcuCacheDetectionTest extends TestCase
     {
         ApcuShimStore::simulateDisabledStore(false);
         ApcuShimStore::simulateThrowingStore(false);
+        ApcuShimStore::simulateThrowingReads(false);
+        ApcuShimStore::simulateRefusingStore(false);
 
         if (null !== $this->tmpFile) {
             Utilities::invalidateJsonFileCache($this->tmpFile);
@@ -412,5 +414,98 @@ final class ApcuCacheDetectionTest extends TestCase
         $map->buildIndex();
 
         self::assertFalse($map->isEmpty(), 'the index must still be built when the cache backend raises');
+    }
+
+    // ------------------------------------------------- a backend that throws is an unusable one
+
+    /**
+     * `ApcuCache` promises callers a cache answer, not an exception — and the promise has to hold for
+     * a backend that *raises* as much as for one that silently drops writes. These drive each public
+     * method against a throwing backend and require the documented value back, which is also what
+     * covers the `catch` arms that would otherwise never execute.
+     */
+    public function testAThrowingBackendReadsAsAMissRatherThanEscaping(): void
+    {
+        ( new \ReflectionProperty(ApcuCache::class, 'usable') )->setValue(null, true);
+        ApcuShimStore::simulateThrowingReads(true);
+
+        ob_start();
+        $exists = ApcuCache::exists('litcal_throwing_probe');
+        $value  = ApcuCache::fetch('litcal_throwing_probe', $found);
+        $output = ob_get_clean();
+
+        self::assertFalse($exists, 'exists() must answer false when the backend throws, not propagate');
+        self::assertFalse($found, 'fetch() must report a miss when the backend throws');
+        self::assertFalse($value, 'fetch() must return false when the backend throws');
+        self::assertSame('', $output, 'the failure is logged, never echoed into a PSR-7 body');
+    }
+
+    public function testAThrowingStoreIsReportedAsARefusalRatherThanEscaping(): void
+    {
+        ( new \ReflectionProperty(ApcuCache::class, 'usable') )->setValue(null, true);
+        ApcuShimStore::simulateThrowingStore(true);
+
+        ob_start();
+        $stored = ApcuCache::store('litcal_throwing_probe', 'value', 10);
+        $output = ob_get_clean();
+
+        self::assertFalse($stored, 'store() must answer false when the backend throws, not propagate');
+        self::assertSame('', $output);
+    }
+
+    public function testAThrowingDeleteIsContainedToo(): void
+    {
+        ApcuShimStore::simulateThrowingReads(true);
+
+        ob_start();
+        $deleted = ApcuCache::delete('litcal_throwing_probe');
+        $output  = ob_get_clean();
+
+        self::assertFalse($deleted, 'delete() must answer false when the backend throws, not propagate');
+        self::assertSame('', $output);
+    }
+
+    /**
+     * And the probe itself: a store that throws must leave the backend unusable rather than let the
+     * exception out of whatever request happened to trigger the first cache read.
+     */
+    public function testAProbeAgainstAThrowingBackendAnswersUnusable(): void
+    {
+        self::forgetProbeResult();
+        ApcuShimStore::simulateThrowingStore(true);
+
+        ob_start();
+        $usable = ApcuCache::isUsable();
+        ob_end_clean();
+
+        self::assertFalse($usable, 'a backend whose store throws is not usable');
+    }
+
+    /**
+     * A backend that honestly refuses the write is unusable too — the probe must not read the
+     * refusal as anything other than "do not select this".
+     */
+    public function testAProbeAgainstARefusingStoreAnswersUnusable(): void
+    {
+        self::forgetProbeResult();
+        ApcuShimStore::simulateRefusingStore(true);
+
+        self::assertFalse(ApcuCache::isUsable(), 'a store that returns false must not be selected');
+    }
+
+    /**
+     * And when the *read* throws mid-probe, the cleanup in the probe's `finally` throws too. That
+     * arm must not be allowed to replace the answer the probe had already reached.
+     */
+    public function testAProbeSurvivesCleanupThrowingAfterAFailedRead(): void
+    {
+        self::forgetProbeResult();
+        ApcuShimStore::simulateThrowingReads(true);
+
+        ob_start();
+        $usable = ApcuCache::isUsable();
+        ob_end_clean();
+
+        self::assertFalse($usable, 'a probe whose read and cleanup both throw still answers unusable');
     }
 }

--- a/phpunit_tests/Support/ApcuShim.php
+++ b/phpunit_tests/Support/ApcuShim.php
@@ -70,6 +70,12 @@ final class ApcuShimStore
      */
     private static bool $storeThrows = false;
 
+    /** Fault injection for #836: when true, `exists()`, `fetch()` and `delete()` raise. */
+    private static bool $readsThrow = false;
+
+    /** Fault injection for #836: when true, `store()` returns false instead of accepting the value. */
+    private static bool $storeRefuses = false;
+
     /**
      * Make every subsequent `store()` a reported-success no-op (or stop doing so).
      *
@@ -91,6 +97,31 @@ final class ApcuShimStore
     }
 
     /**
+     * Fault injection for #836: when true, `exists()`, `fetch()` and `delete()` raise.
+     *
+     * A store is not the only call that can blow up, and `ApcuCache` promises a cache answer rather
+     * than an exception on every one of them. Kept separate from {@see self::$storeThrows} so a test
+     * can break exactly one operation and leave the others honest.
+     *
+     * Process-wide state, so a test that turns it on must turn it off again in a `finally`/`tearDown`.
+     */
+    public static function simulateThrowingReads(bool $throws): void
+    {
+        self::$readsThrow = $throws;
+    }
+
+    /**
+     * Fault injection for #836: when true, `store()` refuses the value by returning false.
+     *
+     * Distinct from {@see self::$storeIsNoOp}, which returns *true* while dropping the value: this
+     * models a backend that is at least honest about refusing (a full segment, typically).
+     */
+    public static function simulateRefusingStore(bool $refuses): void
+    {
+        self::$storeRefuses = $refuses;
+    }
+
+    /**
      * The keys currently held, expired entries included — for asserting that a probe cleaned up after
      * itself rather than leaving a key behind in the cache it was only meant to test.
      *
@@ -106,6 +137,9 @@ final class ApcuShimStore
         if (self::$storeThrows) {
             throw new \RuntimeException('simulated APCu store failure');
         }
+        if (self::$storeRefuses) {
+            return false;
+        }
         if (self::$storeIsNoOp) {
             return true;
         }
@@ -118,6 +152,9 @@ final class ApcuShimStore
 
     public static function fetch(string $key, ?bool &$success = null): mixed
     {
+        if (self::$readsThrow) {
+            throw new \RuntimeException('simulated APCu fetch failure');
+        }
         $entry = self::$store[$key] ?? null;
         if (null === $entry || ( $entry['expires'] > 0 && $entry['expires'] < time() )) {
             $success = false;
@@ -129,6 +166,9 @@ final class ApcuShimStore
 
     public static function exists(string $key): bool
     {
+        if (self::$readsThrow) {
+            throw new \RuntimeException('simulated APCu exists failure');
+        }
         $entry = self::$store[$key] ?? null;
         if (null === $entry) {
             return false;
@@ -142,6 +182,9 @@ final class ApcuShimStore
 
     public static function delete(string $key): bool
     {
+        if (self::$readsThrow) {
+            throw new \RuntimeException('simulated APCu delete failure');
+        }
         $existed = isset(self::$store[$key]);
         unset(self::$store[$key]);
         return $existed;

--- a/phpunit_tests/bootstrap.php
+++ b/phpunit_tests/bootstrap.php
@@ -43,6 +43,49 @@ if (!extension_loaded('redis')) {
 }
 
 use Dotenv\Dotenv;
+use LiturgicalCalendar\Api\ApcuCache;
 
 $dotenv = Dotenv::createMutable($projectFolder, ['.env', '.env.local', '.env.development', '.env.staging', '.env.production'], false);
 $dotenv->safeLoad();
+
+// Settle the APCu question once, here, before any test can change the answer (#836).
+//
+// `ApcuCache::isUsable()` memoises a store/fetch round trip, and it resolves the `apcu_*` names
+// against `LiturgicalCalendar\Api` before the global ones. `phpunit_tests/Support/ApcuShim.php`
+// declares stand-ins in exactly that namespace, and once any test has required it the declarations
+// cannot be undone — so a suite that left the answer unresolved would hand `Utilities` a real,
+// working cache from whichever test happened to load the shim first onwards, with a 300-second TTL
+// spanning the rest of the run. That is precisely the cross-test coupling the CI workflow's
+// `apc.enable_cli=0` exists to prevent ("one test's cache entry would change what a later test
+// sees across the whole suite", .github/workflows/phpunit.yml).
+//
+// The answer pinned here is the one this process would genuinely give with no shim loaded, probed
+// through the *global* `apcu_*` functions: false on a host without ext-apcu, false in CI where it is
+// loaded but inert, true only where APCu really works under the CLI SAPI (`php -d apc.enable_cli=1`,
+// the documented way to run UtilitiesJsonFileCacheTest). `ApcuCacheDetectionTest` resets and restores
+// the memo around its own cases, which is the only place the shim is meant to reach these sites.
+//
+// Deliberately NOT written as a call to `ApcuCache::isUsable()`, however much shorter that would be.
+// PHP's `INIT_NS_FCALL_BY_NAME` caches the function it resolved in the opline's run-time cache, so
+// executing `ApcuCache`'s unqualified `apcu_store()` here — while the extension is loaded and the shim
+// is not — binds that call site to the real function for the life of the process. A shim required
+// later would then be ignored at exactly the sites it exists to stand in for, which is not a
+// hypothetical: it turned every positive case in `ApcuCacheDetectionTest` red under a loaded ext-apcu
+// while leaving them green on a host without one.
+$litcalApcuUsable = false;
+if (
+    function_exists('apcu_store')
+    && function_exists('apcu_fetch')
+    && function_exists('apcu_exists')
+    && function_exists('apcu_delete')
+) {
+    $litcalApcuProbeKey = 'litcal_bootstrap_apcu_probe_' . bin2hex(random_bytes(8));
+    try {
+        $litcalApcuUsable = true === apcu_store($litcalApcuProbeKey, 'probe', 10)
+            && 'probe' === apcu_fetch($litcalApcuProbeKey);
+        apcu_delete($litcalApcuProbeKey);
+    } catch (\Throwable) {
+        $litcalApcuUsable = false;
+    }
+}
+( new ReflectionProperty(ApcuCache::class, 'usable') )->setValue(null, $litcalApcuUsable);

--- a/src/ApcuCache.php
+++ b/src/ApcuCache.php
@@ -1,0 +1,265 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api;
+
+/**
+ * The one place in the request path that decides whether APCu is usable, and the one place that calls
+ * `apcu_*`.
+ *
+ * ## Why this class exists at all (#836)
+ *
+ * Six sites used to answer "is there a cache?" with
+ * `extension_loaded('apcu') && function_exists('apcu_exists') && function_exists('apcu_store') && function_exists('apcu_fetch')`.
+ * Every operand can be true while APCu stores nothing: on the deployment host `apc.enable_cli=0`
+ * leaves the extension loaded, its functions defined, and the store inert under the CLI SAPI — every
+ * write reports success, every read misses. #835 established the shape of the defect and replaced the
+ * predicate in `Health` with a store→fetch round trip; #836 is the same replacement for the other six.
+ *
+ * A round trip also answers questions no configuration flag does: a full or corrupted shared-memory
+ * segment reports nothing at all, and `apcu_enabled()` would still say yes.
+ *
+ * ## Why it lives in `LiturgicalCalendar\Api` and not in a `Cache\` sub-namespace
+ *
+ * This is the subtle part, and it is a correctness constraint rather than a matter of taste.
+ *
+ * PHP resolves an *unqualified* function call against the current namespace first and only then the
+ * global one. A probe therefore describes the functions reachable **from the namespace the probe's own
+ * calls are written in** — nothing more. That is exactly what makes
+ * `phpunit_tests/Support/ApcuShim.php` able to stand in for the backend: it declares
+ * `LiturgicalCalendar\Api\apcu_store()` and friends, so unqualified calls from that namespace reach
+ * the shim whether or not ext-apcu is installed, loaded, or CLI-enabled.
+ *
+ * The consequence for a *shared* helper is that a probe cannot answer on behalf of a caller in a
+ * different namespace. `Utilities` is in `LiturgicalCalendar\Api`; `MissalMetadataMap` is in
+ * `LiturgicalCalendar\Api\Models\MissalsPath`, where the identical unqualified `apcu_store()` resolves
+ * to a different function. Before #836 the map decided usability from one set of functions and wrote
+ * through another — a divergence invisible in production, where only one set exists, and precisely
+ * the thing the test shim is meant to be able to reproduce.
+ *
+ * Two ways out were available. The helper could take the caller's `__NAMESPACE__` as an argument and
+ * dispatch through variable function names — which spreads the resolution rule across every call site
+ * and makes it something each new caller has to remember. Or every `apcu_*` call in the request path
+ * could be moved into one namespace, so that "where the decision is made" and "where the writes
+ * happen" are the same place by construction. This class is the second: it is the only code outside
+ * `Health` that calls `apcu_*`, it sits in the namespace the shim already covers, and callers in any
+ * namespace get an answer that is true of the calls that will actually be made — because those calls
+ * are made here.
+ *
+ * ## Which entry points reach this, and under which SAPI
+ *
+ * #836 asked for this to be established rather than assumed, because `apc.enable_cli` is what makes
+ * the difference between a cache and a hole in the ground.
+ *
+ * - **php-fpm** (`public/index.php` in production) — APCu live. Every `Utilities::jsonFileTo*()` /
+ *   `jsonUrlToObject()` caller is here: `CalendarHandler`, `EventsHandler`, `MissalsHandler`,
+ *   `DecreesHandler`, `RegionalDataHandler`, `TemporaleHandler`, `CalendarMetadataProvider`,
+ *   `CalendarParams`, `LocaleConfigurator`, `AmbrosianSanctoraleLoader`.
+ * - **cli-server** (`composer start`, i.e. `php -S`) — APCu **live**, which is the opposite of what
+ *   the issue suspected. APCu disables itself by comparing `sapi_module.name` against the literal
+ *   `"cli"`; the built-in server reports `"cli-server"`, so `apc.enable_cli=0` does not touch it.
+ *   Measured on the project image: under `php -S` with `apc.enable_cli=0`, `apcu_enabled()` is true
+ *   and a store/fetch round trip succeeds. The dev server gets a real cache, not an inert one.
+ * - **cli** — the WebSocket server (`public/LitCalTestServer.php`) runs here, but reaches calendar
+ *   data only by issuing HTTP requests to the API, which execute in one of the two SAPIs above; it
+ *   calls none of these helpers itself, and `Health` carries its own probe (#835). That leaves
+ *   PHPUnit as the one routine CLI executor, via the in-process handler tests.
+ *
+ * So the six predicates this class replaces were latent rather than live — but latent only for as
+ * long as that list holds, and nothing was asserting it. The round trip makes the question
+ * self-answering wherever the code runs, which is the point.
+ *
+ * ## Memoisation
+ *
+ * The answer is cached for the life of the process. `Health` probes on connection open and on Redis
+ * failure — rare events; these callers run per JSON file load, many times per request, and an extra
+ * store/fetch/delete on each would be a real cost on the hot path of every handler. APCu's usability
+ * does not change under a process: `apc.enable_cli` and `apc.enabled` are startup settings, and a
+ * segment that fills later degrades safely on its own (`store()` returns false, the next `fetch()`
+ * misses, and callers already treat a miss as "read from disk").
+ *
+ * Tests flip the answer by resetting `self::$usable` to null via reflection — see
+ * `phpunit_tests/ApcuCacheDetectionTest.php`. Deliberately not a public reset method: nothing in the
+ * request path has any business un-deciding this.
+ *
+ * ## One trap worth knowing, for tests only
+ *
+ * PHP's `INIT_NS_FCALL_BY_NAME` remembers, in each opline's run-time cache, which function the
+ * namespace-then-global lookup resolved to. So the *first execution* of an unqualified `apcu_*` call
+ * below binds that call site for the life of the process: if it runs while ext-apcu is loaded and the
+ * shim is not, a shim required afterwards is ignored at precisely the sites it exists to stand in
+ * for. Production never notices — there is only ever one candidate there — but anything that wants to
+ * pin this answer before the tests start (`phpunit_tests/bootstrap.php` does) must do so *without*
+ * calling through this class.
+ */
+final class ApcuCache
+{
+    /**
+     * Every `apcu_*` function this class calls. An undefined function is a fatal, not a miss, so the
+     * probe must not proceed to a round trip until all of them are known to resolve.
+     *
+     * `extension_loaded('apcu')` is deliberately absent, and not merely because it is subsumed: it
+     * asks about the extension, while what is called is whatever the unqualified name resolves to.
+     * An unloaded extension defines no functions, so the callability check below already stands down;
+     * a loaded one proves nothing the round trip does not prove better.
+     *
+     * @var list<string>
+     */
+    private const array REQUIRED_FUNCTIONS = ['apcu_exists', 'apcu_fetch', 'apcu_store', 'apcu_delete'];
+
+    private const string PROBE_KEY_PREFIX = 'litcal_apcu_probe_';
+
+    /**
+     * The memoised answer, or null before it has been established.
+     *
+     * Reset via reflection by tests; see the class docblock.
+     */
+    private static ?bool $usable = null;
+
+    /**
+     * Whether the APCu that this file's unqualified `apcu_*` calls actually reach can hold a value —
+     * established by storing a probe key and reading it back, not by asking whether an extension
+     * happens to be present.
+     *
+     * **Never throws.** Every caller reads the answer as a yes/no about whether to use a cache, and
+     * these callers sit on the HTTP request path: an exception escaping here would turn a degraded
+     * cache into a failed `/calendar`, `/events` or `/missals` response.
+     */
+    public static function isUsable(): bool
+    {
+        return self::$usable ??= self::probe();
+    }
+
+    /**
+     * Whether an unqualified call to $function from this namespace will resolve to something.
+     *
+     * This namespace before the global one, because that is the order PHP itself resolves the calls
+     * below in. Checking only the global name would describe functions this class may never call.
+     */
+    private static function callable(string $function): bool
+    {
+        return function_exists(__NAMESPACE__ . '\\' . $function) || function_exists($function);
+    }
+
+    /**
+     * The store→fetch round trip, run once per process.
+     */
+    private static function probe(): bool
+    {
+        foreach (self::REQUIRED_FUNCTIONS as $function) {
+            if (false === self::callable($function)) {
+                return false;
+            }
+        }
+
+        $probeKey = null;
+
+        try {
+            // Random per call: a fixed key could collide with a concurrent process probing the same
+            // shared segment, and a probe must never answer using another writer's value. Generated
+            // inside the `try` because `random_bytes()` can itself throw, and a caller of this method
+            // is owed a bool rather than an exception.
+            $probeKey   = self::PROBE_KEY_PREFIX . bin2hex(random_bytes(8));
+            $probeValue = 'probe';
+
+            if (true !== apcu_store($probeKey, $probeValue, 10)) {
+                return false;
+            }
+
+            // The store's own return value is not trusted on its own — reporting success while
+            // storing nothing is the exact failure being ruled out here.
+            $success = false;
+            $fetched = apcu_fetch($probeKey, $success);
+
+            return true === $success && $fetched === $probeValue;
+        } catch (\Throwable $e) {
+            // Any failure whatsoever means "do not use this backend". Reported rather than swallowed —
+            // an exception reaching here is by definition one nobody anticipated — but through
+            // `error_log()` and never `echo`, unlike `Health::apcuUsable()`: `Health` is a CLI process
+            // whose stdout is a log, whereas anything written here would be prepended to a PSR-7
+            // response body.
+            error_log('APCu probe failed, caching disabled for this process: ' . $e::class . ': ' . $e->getMessage());
+
+            return false;
+        } finally {
+            // Best effort, and deliberately not allowed to change the answer: an exception raised in a
+            // `finally` *replaces* whatever the `try` or `catch` was returning, so an unlucky cleanup
+            // could otherwise mask an answer that was already correctly decided.
+            if (null !== $probeKey) {
+                try {
+                    apcu_delete($probeKey);
+                } catch (\Throwable) {
+                    // Nothing to do: the answer is settled and the probe key carries a TTL.
+                }
+            }
+        }
+    }
+
+    /**
+     * Whether $key is currently held. False whenever the backend is unusable — there is nothing to
+     * find in a cache that cannot hold anything.
+     */
+    public static function exists(string $key): bool
+    {
+        return self::isUsable() && true === apcu_exists($key);
+    }
+
+    /**
+     * Read $key, reporting through $success whether anything was found.
+     *
+     * An unusable backend is reported as a miss rather than as an error: callers of a cache read
+     * already have a path for "not cached", and it is the correct one here.
+     *
+     * @param bool|null $success Set to true only when a stored value was returned.
+     * @param-out bool $success
+     */
+    public static function fetch(string $key, ?bool &$success = null): mixed
+    {
+        if (false === self::isUsable()) {
+            $success = false;
+            return false;
+        }
+
+        // `apcu_fetch()` declares its out-parameter as `mixed`; narrow it here rather than passing
+        // `$success` straight in, so callers get the strict bool this method's signature promises.
+        $found   = false;
+        $value   = apcu_fetch($key, $found);
+        $success = true === $found;
+
+        return $value;
+    }
+
+    /**
+     * Write $key, returning whether the backend accepted it.
+     *
+     * @param int $ttl Seconds; 0 means no expiry.
+     */
+    public static function store(string $key, mixed $value, int $ttl = 0): bool
+    {
+        return self::isUsable() && true === apcu_store($key, $value, $ttl);
+    }
+
+    /**
+     * Remove $key.
+     *
+     * Gated on callability alone rather than on {@see self::isUsable()}, and the asymmetry is
+     * deliberate. A store that cannot happen costs a cache hit; a delete that does not happen leaves
+     * stale data being served, so the weaker precondition is the safer one. Against an inert backend
+     * the call is a harmless no-op, which is all "unusable" would have bought.
+     */
+    public static function delete(string $key): bool
+    {
+        if (false === self::callable('apcu_delete')) {
+            return false;
+        }
+
+        try {
+            return true === apcu_delete($key);
+        } catch (\Throwable $e) {
+            error_log('APCu delete failed for key ' . $key . ': ' . $e::class . ': ' . $e->getMessage());
+
+            return false;
+        }
+    }
+}

--- a/src/ApcuCache.php
+++ b/src/ApcuCache.php
@@ -199,10 +199,25 @@ final class ApcuCache
     /**
      * Whether $key is currently held. False whenever the backend is unusable — there is nothing to
      * find in a cache that cannot hold anything.
+     *
+     * Like every other method here, a backend that *throws* is treated as one that is unusable: the
+     * class promises callers a cache answer, not an exception, and a caller of a cache read already
+     * has a "not cached" path. Without this the promise held for an inert backend but not for a
+     * broken one, which is the harder failure to reason about, not the easier.
      */
     public static function exists(string $key): bool
     {
-        return self::isUsable() && true === apcu_exists($key);
+        if (false === self::isUsable()) {
+            return false;
+        }
+
+        try {
+            return true === apcu_exists($key);
+        } catch (\Throwable $e) {
+            error_log('APCu exists failed for key ' . $key . ': ' . $e::class . ': ' . $e->getMessage());
+
+            return false;
+        }
     }
 
     /**
@@ -223,8 +238,17 @@ final class ApcuCache
 
         // `apcu_fetch()` declares its out-parameter as `mixed`; narrow it here rather than passing
         // `$success` straight in, so callers get the strict bool this method's signature promises.
-        $found   = false;
-        $value   = apcu_fetch($key, $found);
+        $found = false;
+
+        try {
+            $value = apcu_fetch($key, $found);
+        } catch (\Throwable $e) {
+            error_log('APCu fetch failed for key ' . $key . ': ' . $e::class . ': ' . $e->getMessage());
+            $success = false;
+
+            return false;
+        }
+
         $success = true === $found;
 
         return $value;
@@ -237,7 +261,17 @@ final class ApcuCache
      */
     public static function store(string $key, mixed $value, int $ttl = 0): bool
     {
-        return self::isUsable() && true === apcu_store($key, $value, $ttl);
+        if (false === self::isUsable()) {
+            return false;
+        }
+
+        try {
+            return true === apcu_store($key, $value, $ttl);
+        } catch (\Throwable $e) {
+            error_log('APCu store failed for key ' . $key . ': ' . $e::class . ': ' . $e->getMessage());
+
+            return false;
+        }
     }
 
     /**

--- a/src/Models/MissalsPath/MissalMetadataMap.php
+++ b/src/Models/MissalsPath/MissalMetadataMap.php
@@ -2,6 +2,7 @@
 
 namespace LiturgicalCalendar\Api\Models\MissalsPath;
 
+use LiturgicalCalendar\Api\ApcuCache;
 use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\RomanMissal;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
@@ -15,6 +16,8 @@ use LiturgicalCalendar\Api\Router;
  */
 final class MissalMetadataMap implements \IteratorAggregate, \JsonSerializable
 {
+    private const string CACHE_KEY = 'litcal_missals_index';
+
     /** @var array<string,MissalMetadata> */
     private array $missals;
     /** @var array<string,MissalMetadata> */
@@ -23,13 +26,11 @@ final class MissalMetadataMap implements \IteratorAggregate, \JsonSerializable
     private string $regionFilter;
     private int $yearFilter;
     private bool $includeEmpty = false;
-    private bool $cacheEnabled = false;
 
     public function __construct()
     {
-        $this->missals      = [];
-        $this->allMissals   = [];
-        $this->cacheEnabled = ( extension_loaded('apcu') && function_exists('apcu_exists') && function_exists('apcu_store') && function_exists('apcu_fetch') );
+        $this->missals    = [];
+        $this->allMissals = [];
     }
 
     /**
@@ -180,8 +181,12 @@ final class MissalMetadataMap implements \IteratorAggregate, \JsonSerializable
 
     public function buildIndex(): void
     {
-        if ($this->cacheEnabled && apcu_exists('litcal_missals_index')) {
-            $cached = apcu_fetch('litcal_missals_index', $success);
+        // #836: both the decision and the calls belong to ApcuCache, which lives in
+        // `LiturgicalCalendar\Api`. An unqualified `apcu_store()` written *here* would resolve against
+        // `LiturgicalCalendar\Api\Models\MissalsPath` first and so could reach a different function
+        // than any usability check made elsewhere — which is exactly what used to happen.
+        if (ApcuCache::exists(self::CACHE_KEY)) {
+            $cached = ApcuCache::fetch(self::CACHE_KEY, $success);
             if (
                 $success
                 && is_array($cached)
@@ -258,11 +263,9 @@ final class MissalMetadataMap implements \IteratorAggregate, \JsonSerializable
         $allMissals       = RomanMissal::produceMetadata();
         $this->allMissals = $allMissals;
 
-        if ($this->cacheEnabled) {
-            apcu_store('litcal_missals_index', [
-                'missals'    => $this->missals,
-                'allMissals' => $this->allMissals
-            ], 600);
-        }
+        ApcuCache::store(self::CACHE_KEY, [
+            'missals'    => $this->missals,
+            'allMissals' => $this->allMissals
+        ], 600);
     }
 }

--- a/src/Models/MissalsPath/MissalMetadataMap.php
+++ b/src/Models/MissalsPath/MissalMetadataMap.php
@@ -185,27 +185,27 @@ final class MissalMetadataMap implements \IteratorAggregate, \JsonSerializable
         // `LiturgicalCalendar\Api`. An unqualified `apcu_store()` written *here* would resolve against
         // `LiturgicalCalendar\Api\Models\MissalsPath` first and so could reach a different function
         // than any usability check made elsewhere — which is exactly what used to happen.
-        if (ApcuCache::exists(self::CACHE_KEY)) {
-            $cached = ApcuCache::fetch(self::CACHE_KEY, $success);
-            if (
-                $success
-                && is_array($cached)
-                && isset($cached['missals'])
-                && is_array($cached['missals'])
-                && array_all($cached['missals'], fn ($item, $key): bool => is_string($key) && $item instanceof MissalMetadata)
-                && isset($cached['allMissals'])
-                && is_array($cached['allMissals'])
-                && array_all($cached['allMissals'], fn ($item, $key): bool => is_string($key) && $item instanceof MissalMetadata)
-            ) {
-                /** @var array<string,MissalMetadata> $missals */
-                $missals = $cached['missals'];
-                /** @var array<string,MissalMetadata> $allMissals */
-                $allMissals = $cached['allMissals'];
+        // `fetch()` reports both a miss and an unusable backend through `$success`, so an
+        // `exists()` first would only add a second round trip (#836).
+        $cached = ApcuCache::fetch(self::CACHE_KEY, $success);
+        if (
+            $success
+            && is_array($cached)
+            && isset($cached['missals'])
+            && is_array($cached['missals'])
+            && array_all($cached['missals'], fn ($item, $key): bool => is_string($key) && $item instanceof MissalMetadata)
+            && isset($cached['allMissals'])
+            && is_array($cached['allMissals'])
+            && array_all($cached['allMissals'], fn ($item, $key): bool => is_string($key) && $item instanceof MissalMetadata)
+        ) {
+            /** @var array<string,MissalMetadata> $missals */
+            $missals = $cached['missals'];
+            /** @var array<string,MissalMetadata> $allMissals */
+            $allMissals = $cached['allMissals'];
 
-                $this->missals    = $missals;
-                $this->allMissals = $allMissals;
-                return;
-            }
+            $this->missals    = $missals;
+            $this->allMissals = $allMissals;
+            return;
         }
 
         if (false === is_readable(JsonData::MISSALS_FOLDER->path())) {

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -574,13 +574,13 @@ class Utilities
 
         // Try cache first. ApcuCache answers "is there a cache?" with a store/fetch round trip rather
         // than with extension_loaded() plus function_exists(), which are all true of an APCu that
-        // stores nothing (#836).
-        if (ApcuCache::exists($cacheKey)) {
-            $data = ApcuCache::fetch($cacheKey, $success);
-            if ($success && is_array($data)) {
-                /** @var array<string|int,mixed> $data */
-                return $data;
-            }
+        // stores nothing (#836). `fetch()` reports a miss — and an unusable backend — through
+        // `$success`, so an `exists()` first would only add a second round trip and a window for the
+        // entry to expire between the two calls.
+        $data = ApcuCache::fetch($cacheKey, $success);
+        if ($success && is_array($data)) {
+            /** @var array<string|int,mixed> $data */
+            return $data;
         }
 
         $rawContents = self::rawContentsFromFile($filename);
@@ -605,12 +605,11 @@ class Utilities
     {
         $cacheKey = 'jsoncache_object_' . md5($filename);
 
-        // Try cache first — see jsonFileToArray() for why the decision is ApcuCache's (#836).
-        if (ApcuCache::exists($cacheKey)) {
-            $data = ApcuCache::fetch($cacheKey, $success);
-            if ($success && $data instanceof \stdClass) {
-                return $data;
-            }
+        // Try cache first — see jsonFileToArray() for why the decision is ApcuCache's, and why the
+        // read is a single `fetch()` rather than `exists()` then `fetch()` (#836).
+        $data = ApcuCache::fetch($cacheKey, $success);
+        if ($success && $data instanceof \stdClass) {
+            return $data;
         }
 
         $rawContents = self::rawContentsFromFile($filename);

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -570,12 +570,13 @@ class Utilities
      */
     public static function jsonFileToArray(string $filename): array
     {
-        $cacheEnabled = ( extension_loaded('apcu') && function_exists('apcu_exists') && function_exists('apcu_store') && function_exists('apcu_fetch') );
-        $cacheKey     = 'jsoncache_array_' . md5($filename);
+        $cacheKey = 'jsoncache_array_' . md5($filename);
 
-        // Try cache first
-        if ($cacheEnabled && apcu_exists($cacheKey)) {
-            $data = apcu_fetch($cacheKey, $success);
+        // Try cache first. ApcuCache answers "is there a cache?" with a store/fetch round trip rather
+        // than with extension_loaded() plus function_exists(), which are all true of an APCu that
+        // stores nothing (#836).
+        if (ApcuCache::exists($cacheKey)) {
+            $data = ApcuCache::fetch($cacheKey, $success);
             if ($success && is_array($data)) {
                 /** @var array<string|int,mixed> $data */
                 return $data;
@@ -586,9 +587,7 @@ class Utilities
         $jsonArr     = json_decode($rawContents, true, 512, JSON_THROW_ON_ERROR);
 
         // Store in cache
-        if ($cacheEnabled) {
-            apcu_store($cacheKey, $jsonArr, 300);
-        }
+        ApcuCache::store($cacheKey, $jsonArr, 300);
 
         /** @var array<string|int,mixed> $jsonArr */
         return $jsonArr;
@@ -604,12 +603,11 @@ class Utilities
      */
     public static function jsonFileToObject(string $filename): \stdClass
     {
-        $cacheEnabled = ( extension_loaded('apcu') && function_exists('apcu_exists') && function_exists('apcu_store') && function_exists('apcu_fetch') );
-        $cacheKey     = 'jsoncache_object_' . md5($filename);
+        $cacheKey = 'jsoncache_object_' . md5($filename);
 
-        // Try cache first
-        if ($cacheEnabled && apcu_exists($cacheKey)) {
-            $data = apcu_fetch($cacheKey, $success);
+        // Try cache first — see jsonFileToArray() for why the decision is ApcuCache's (#836).
+        if (ApcuCache::exists($cacheKey)) {
+            $data = ApcuCache::fetch($cacheKey, $success);
             if ($success && $data instanceof \stdClass) {
                 return $data;
             }
@@ -622,9 +620,7 @@ class Utilities
         }
 
         // Store in cache
-        if ($cacheEnabled) {
-            apcu_store($cacheKey, $jsonObj, 300);
-        }
+        ApcuCache::store($cacheKey, $jsonObj, 300);
 
         return $jsonObj;
     }
@@ -639,18 +635,20 @@ class Utilities
      */
     public static function invalidateJsonFileCache(string $filename): void
     {
-        if (!extension_loaded('apcu') || !function_exists('apcu_delete')) {
-            return;
-        }
-
         $fileHash            = md5($filename);
         $objectCacheKey      = 'jsoncache_object_' . $fileHash;
         $objectArrayCacheKey = 'jsoncache_objectarray_' . $fileHash;
         $arrayCacheKey       = 'jsoncache_array_' . $fileHash;
 
-        apcu_delete($objectCacheKey);
-        apcu_delete($objectArrayCacheKey);
-        apcu_delete($arrayCacheKey);
+        // #836: the guard removed here was `!extension_loaded('apcu') || !function_exists('apcu_delete')`.
+        // Its extension_loaded() operand was wrong for the same reason the readers' was — it asks about
+        // the extension rather than about the function an unqualified call actually reaches, so it could
+        // skip an invalidation whose matching store had gone through. ApcuCache::delete() gates on
+        // callability alone, deliberately weaker than the readers' round-trip gate: a delete that does
+        // not happen leaves stale data being served.
+        ApcuCache::delete($objectCacheKey);
+        ApcuCache::delete($objectArrayCacheKey);
+        ApcuCache::delete($arrayCacheKey);
     }
 
     /**
@@ -662,16 +660,13 @@ class Utilities
      */
     public static function jsonFileToObjectArray(string $filename): array
     {
-        $cacheEnabled = ( extension_loaded('apcu') && function_exists('apcu_exists') && function_exists('apcu_store') && function_exists('apcu_fetch') );
-        $cacheKey     = 'jsoncache_objectarray_' . md5($filename);
+        $cacheKey = 'jsoncache_objectarray_' . md5($filename);
 
-        // Try cache first
-        if ($cacheEnabled) {
-            $data = apcu_fetch($cacheKey, $success);
-            if ($success && is_array($data)) {
-                /** @var \stdClass[] $data */
-                return $data;
-            }
+        // Try cache first — see jsonFileToArray() for why the decision is ApcuCache's (#836).
+        $data = ApcuCache::fetch($cacheKey, $success);
+        if ($success && is_array($data)) {
+            /** @var \stdClass[] $data */
+            return $data;
         }
 
         $rawContents = self::rawContentsFromFile($filename);
@@ -686,9 +681,7 @@ class Utilities
         }
 
         // Store in cache
-        if ($cacheEnabled) {
-            apcu_store($cacheKey, $jsonArr, 300);
-        }
+        ApcuCache::store($cacheKey, $jsonArr, 300);
 
         /** @var \stdClass[] $jsonArr */
         return $jsonArr;
@@ -705,15 +698,12 @@ class Utilities
      */
     public static function jsonUrlToObject(string $url): \stdClass
     {
-        $cacheEnabled = ( extension_loaded('apcu') && function_exists('apcu_exists') && function_exists('apcu_store') && function_exists('apcu_fetch') );
-        $cacheKey     = 'jsoncache_object_' . md5($url);
+        $cacheKey = 'jsoncache_object_' . md5($url);
 
-        // Try cache first
-        if ($cacheEnabled) {
-            $data = apcu_fetch($cacheKey, $success);
-            if ($success && $data instanceof \stdClass) {
-                return $data;
-            }
+        // Try cache first — see jsonFileToArray() for why the decision is ApcuCache's (#836).
+        $data = ApcuCache::fetch($cacheKey, $success);
+        if ($success && $data instanceof \stdClass) {
+            return $data;
         }
 
         $rawContents = self::rawContentsFromUrl($url);
@@ -723,9 +713,7 @@ class Utilities
         }
 
         // Store in cache
-        if ($cacheEnabled) {
-            apcu_store($cacheKey, $jsonObj, 300);
-        }
+        ApcuCache::store($cacheKey, $jsonObj, 300);
 
         return $jsonObj;
     }


### PR DESCRIPTION
Closes #836.

The four-operand predicate `extension_loaded('apcu') && function_exists('apcu_exists'|'apcu_store'|'apcu_fetch')` answers the wrong question: all four are true on a host where `apc.enable_cli=0`, so under the CLI SAPI it selects an APCu that silently stores nothing. #835 fixed the two copies in `Health`; six survived.

## The issue's open question, answered — and the answer is reassuring

The issue explicitly recorded that `php -S` (`cli-server` SAPI) had **not** been checked. Measured in the project's own `litcal-api` image, which has real ext-apcu:

| SAPI | `apc.enable_cli` | `apcu_enabled()` | old predicate | round trip |
|---|---|---|---|---|
| `cli` | 0 | **false** | true | **fails** |
| `cli` | 1 | true | true | ok |
| `cli-server` (`php -S`) | 0 | **true** | true | **ok** |

APCu disables itself by comparing `sapi_module.name` against the literal `"cli"`; `php -S` reports `"cli-server"`, so `apc.enable_cli=0` never reaches it. **`composer start` gets a genuinely working cache.** All `src/` callers of these helpers are on the HTTP path (php-fpm or cli-server); the WebSocket server reaches this data only via internal HTTP requests, which execute in the HTTP process. That leaves **PHPUnit as the only routine `cli`-SAPI executor** — so these six were latent, but latent only as long as that list holds, and nothing asserted it.

## Placement: a new `src/ApcuCache.php`, not a helper function

A probe only describes the functions reachable *from the namespace its own calls are written in*. `MissalMetadataMap` lives in `…\Models\MissalsPath`, where the same unqualified `apcu_store()` resolves differently — it was deciding usability from one set of functions and writing through another. Rather than thread `__NAMESPACE__` through every call site and dispatch via variable function names, every `apcu_*` call outside `Health` now lives in one class in the namespace the shim already covers. **Decision-point and write-point are the same place by construction**, and `MissalMetadataMap` no longer calls `apcu_*` at all.

Other decisions:

- **Memoised.** These helpers are on the hot path of every handler (per JSON file load), unlike `Health`'s twice-per-connection probe, and `apc.enabled`/`apc.enable_cli` are startup settings. Tests reset the private static by reflection, the repo idiom (cf. `HealthApcuDetectionTest`); no public reset exists in the request path.
- **`delete()` is deliberately weaker** — gated on callability, not on the round trip. A store that cannot happen costs a cache hit; a delete that does not happen serves stale data.
- **`error_log()`, not `echo`.** `Health` is a CLI process; the same line from `Utilities` would be prepended to a PSR-7 body. Asserted by `testTheProbeNeverWritesToOutput`.

## The one surprise, and why `phpunit_tests/bootstrap.php` changed

Making the six sites shim-reachable turned the shim into a live, process-wide cache for the rest of the suite: **328 errors / 53 failures**. The shim stores objects *by reference* where real APCu serializes, so cached `stdClass` instances were mutated across tests.

The fix pins the answer in `bootstrap.php` before any test can load the shim — the same coupling CI's `apc.enable_cli=0` exists to prevent. The pinned value is what this process would genuinely answer with no shim loaded.

**It is deliberately not written as a call to `ApcuCache::isUsable()`**, however much shorter that would be. PHP's `INIT_NS_FCALL_BY_NAME` caches the resolved function in the opline's run-time cache, so executing `ApcuCache`'s unqualified `apcu_store()` while the extension is loaded and the shim is not **permanently binds that call site to the real function**. A shim required later is then ignored at exactly the sites it exists to stand in for. This is not hypothetical — it turned every positive case red under a loaded ext-apcu while staying green on a host without one. Documented in both files.

This is the change in this PR most worth a human eye.

## Tests

`phpunit_tests/ApcuCacheDetectionTest.php`, 14 cases. Pre-fix, against unmodified code in the CI-like container (`apcu` loaded, `apc.enable_cli=0`), the sharpest failure was a throwing backend propagating **straight out of a JSON read that had already succeeded**. Post-fix all 14 pass in three environments: dev host (no apcu), container with `apc.enable_cli=0`, and container with `apc.enable_cli=1` — where the previously-always-skipped `UtilitiesJsonFileCacheTest` actually runs, and stays green.

## Verification

- `composer lint` clean; `composer analyse` (PHPStan level 10) `[OK] No errors`
- `composer test:quick`: baseline `Tests: 2973` → `Tests: 2987` (+14), no new skips

One pre-existing failure appears in full runs, `Routes/Readonly/CalendarEtagStabilityTest`. It is **not from this branch** — it fails 3/3 on pristine `development` too, and it is a `Routes/*` test hitting `:8000`, which serves the *main* checkout. Filed as #849.

## Follow-ups, deliberately not done here

- **`phpunit_tests/Support/ApcuShim.php` is not a faithful APCu**: it preserves object identity where real APCu serializes. Harmless while only `Health` (scalars/arrays) uses it, but it is now one call away from biting someone. Recommend `serialize()`/`unserialize()` in the shim.
- `Health::apcuUsable()` left untouched as instructed. It could eventually delegate to `ApcuCache`, but note it additionally requires `apcu_sma_info`, which `ApcuCache` does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable APCu cache detection with safe handling for unavailable or failing cache backends.
  - Centralised cache operations for JSON data and missal metadata.
  - Cache reads, writes, expiry and invalidation now work consistently across supported data sources.

- **Bug Fixes**
  - Prevented cache failures from interrupting normal data loading.
  - Ensured temporary detection data is cleaned up and cache invalidation reaches the correct backend.

- **Tests**
  - Added comprehensive coverage for cache usability, failures, cleanup, expiry and integration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->