### PR TITLE
fix(health): terminate a superseded queued request instead of discarding it (#837)

### DIFF
--- a/docs/superpowers/specs/2026-08-20-structured-responses-design.md
+++ b/docs/superpowers/specs/2026-08-20-structured-responses-design.md
@@ -358,6 +358,7 @@ happy path        exists(pass) → parses(pass) → validates(pass) → complete
 JSON decode fails exists(pass) → parses(fail) → validates(fail) → complete
 file missing      exists(fail) → parses(fail) → validates(fail) → complete
 test run          validates(pass|fail) → complete
+cancelled run     complete(cancelled) — the queued work was dropped before it ran, so no step frame precedes it
 unknown target    echobot rejection only — no complete, nothing was started
 ```
 
@@ -370,6 +371,14 @@ A client stops on `complete` and never counts frames.
 > `steps` is now an exact frame count and safe to render one card per step against. The stopping rule is unchanged
 > and the terminal frame is not thereby redundant: `complete` stays correct for an arm a later change makes shorter,
 > which is the property that made it worth adding while the counts disagreed.
+>
+> **Amended after #837 landed: the `cancelled run` row, and the one key that goes with it.** A request whose queued
+> work is dropped because its run was cancelled or superseded terminates like any other — but it emits **no step
+> frames at all**, because none of its steps ran, and its terminal frame carries `"cancelled": true` so a client can
+> tell a run it abandoned from one that failed. That key is the only addition to this frame, `type` stays `'success'`,
+> and it is omitted rather than sent as `false` on every other path, so an ordinary terminal frame is unchanged. The
+> full reasoning — including why a dropped request is *not* rejected into the existing failure arms — is in the
+> known-holes subsection below.
 
 ### A closed hole, and the shape that would reopen it: a throw inside a fulfil handler (#823)
 
@@ -384,14 +393,17 @@ A client stops on `complete` and never counts frames.
 > exactly as described. `phpunit_tests/HealthFulfilHandlerThrowTest.php` drives a throw from inside each of the five
 > fulfil handlers — settling each request *successfully* and throwing afterwards, which is what makes it a different
 > test from the rejection-driven ones in `HealthTerminalFrameTest`. **The second, unrelated shape recorded at the
-> end of this subsection — a queued request dropped by `dropSupersededQueuedRequests()` — is untouched by that fix
-> and remains open.**
+> end of this subsection — a queued request dropped by `dropSupersededQueuedRequests()` — is untouched by that fix,
+> and was closed separately by [#837](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/837); the
+> amendment at the end of this subsection records how.**
 
-The guarantee above is "every path that starts work terminates." It had two known holes. The fulfil-handler shape
-this subsection is named for is **closed** — see the amendment above. The second, unrelated one recorded at the end of
-this subsection — a queued request dropped by `dropSupersededQueuedRequests()` — **remains open**, tracked as
-[#837](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/837). Both are stated next to the guarantee
-rather than left for a reader to discover independently.
+The guarantee above is "every path that starts work terminates." It had two known holes, and **both are now closed**.
+The fulfil-handler shape this subsection is named for was closed by
+[#823](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/823) — see the amendment above. The second,
+unrelated one recorded at the end of this subsection — a queued request dropped by `dropSupersededQueuedRequests()` —
+was closed by [#837](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/837). Both are stated next to
+the guarantee rather than left for a reader to discover independently, and both are kept on record as *shapes* rather
+than deleted once fixed: each describes a way a later change reopens the hole.
 
 **The identifying shape** — recorded as the rule that keeps this closed, because a `then(fulfil, reject)` pair added
 later *without* a tail handler reintroduces it exactly: `sendComplete()` as the last statement of a promise's
@@ -422,6 +434,40 @@ filters superseded entries out of the request queue without calling their `rejec
 its remaining step frames nor a `complete`. It is reached by `cancelRun` and, less obviously, by an ordinary run-token
 change. Also pre-existing, also out of scope here — the terminal frame does not make a discarded request terminate, it
 only makes the silence easier to notice.
+
+> **Amended: this hole is closed too (#837).** A queue entry now carries an `onSuperseded` terminator alongside its
+> `resolve`/`reject` pair — supplied by whichever caller of `cachedGet()` queued the work, since the HTTP layer knows a
+> connection and a run token but not the `target` or the `requestId` a terminal frame needs — and the drop site calls it
+> instead of discarding the entry silently. Each of the three callers that report to a client passes one; the
+> connect-time metadata fetch passes none and needs none, since it carries no run token and is therefore never dropped.
+> An entry dropped with no terminator is reported on the server's stdout rather than passed over, so a caller added
+> later that forgets one is visible from the server instead of only from the wedged client.
+>
+> **A superseded request emits its terminal frame and nothing else.** The obvious fix — rejecting the dropped entry so
+> the existing `onRejected` arms run — was **rejected on purpose**: those arms report a *failed check*, and
+> `validateCalendar()`'s says the calendar "does not exist at the URL", which is a claim about the API rather than
+> about a run the client stopped. A cancelled run and a failed one must not look identical to a client; saying a check
+> failed when it never ran is the same "reports something that did not happen" family as #822/#833/#834/#835. So the
+> promise is deliberately left unsettled, neither of the caller's handlers ever runs, and the only frame the request
+> emits from here is `complete`.
+>
+> Two further reasons the entry's own `reject` closure is the wrong thing to call, recorded because it is the first
+> thing anyone tries: it decrements `inFlight`, which a *queued* entry never incremented — dispatch does — so calling
+> it drives the counter below zero and quietly raises the concurrency cap for the rest of the process; and it has to
+> stay reachable exactly once, which it stops being if both the drop and a dispatch can call it.
+>
+> **Distinguishable without adding a frame:** the terminal frame carries `cancelled: true` and a `text` that says the
+> request never ran. A new *frame* is the one thing the additive envelope cannot absorb — a v1 client sizes a phase as
+> `checks * 3` and would count it — while a new *key* on a frame the client was going to receive anyway costs nothing,
+> the same reasoning `rejectMessage()` records for its `type`. `type` stays `'success'`, because since
+> UnitTestInterface#46 an unrecognised `type` is painted as a visible failed check, which is precisely what an
+> abandoned run must not look like. The key is omitted rather than sent as `false`, so an ordinary terminal frame is
+> byte-identical to what it was before. The `requestId` gate is unchanged and still the only gate: a v1 client's stream
+> is exactly what it was, cancelled or otherwise.
+>
+> `phpunit_tests/HealthSupersededRequestTest.php` drives both call sites — an explicit `cancelRun` and an ordinary
+> run-token change through `processQueue()` — and asserts that the queued request terminates, terminates *once*, and
+> reports no step outcome while doing so.
 
 Exposure was narrow rather than nil, and pre-existing rather than introduced by this work: `validateDataAgainstSchema()`
 already catches `\Throwable` internally and is the principal throw source inside these handlers, and the `then(fulfil,

--- a/phpunit_tests/HealthCancelRunTest.php
+++ b/phpunit_tests/HealthCancelRunTest.php
@@ -68,19 +68,31 @@ final class HealthCancelRunTest extends TestCase
      * A queue entry shaped like the ones `cachedGet()` enqueues. The promise callbacks are never
      * invoked here — these tests only ever inspect which entries survive the filter.
      *
+     * `onSuperseded` is the terminator a dropped entry is ended by (#837) and is a no-op here for the
+     * same reason the other two callbacks are: what these tests assert is which entries survive, not
+     * what a dropped one says. That it is present at all still matters — an entry without the key is
+     * one `cachedGet()` cannot produce, and the drop site reports such an entry on stdout as a caller
+     * that forgot to supply one. The one test in this file that asserts on the frames a cancel
+     * produces ({@see testCancellingTheCurrentRunDropsItsQueuedRequestsAndSaysNothing()}) is asserting
+     * that `cancelRun` itself acknowledges nothing; the terminal frames a real dropped request emits
+     * are covered by `HealthSupersededRequestTest`, which queues through `cachedGet()` rather than by
+     * hand.
+     *
      * @return array<string, mixed>
      */
     private static function queueEntry(string $url, ?int $resourceId, ?string $runToken): array
     {
         return [
-            'url'        => $url,
-            'options'    => [],
-            'resolve'    => static function (): void {
+            'url'          => $url,
+            'options'      => [],
+            'resolve'      => static function (): void {
             },
-            'reject'     => static function (): void {
+            'reject'       => static function (): void {
             },
-            'resourceId' => $resourceId,
-            'runToken'   => $runToken
+            'resourceId'   => $resourceId,
+            'runToken'     => $runToken,
+            'onSuperseded' => static function (): void {
+            }
         ];
     }
 

--- a/phpunit_tests/HealthSupersededRequestTest.php
+++ b/phpunit_tests/HealthSupersededRequestTest.php
@@ -1,0 +1,402 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * A queued request whose run is abandoned still terminates — and says it was cancelled (#837).
+ *
+ * `dropSupersededQueuedRequests()` used to filter superseded entries out of the queue with
+ * `array_filter`, discarding each entry's deferred along with it. The promise handed to the caller
+ * was then never settled — not resolved, not rejected — so neither the fulfil handler nor the
+ * sibling `onRejected` ever ran, and a v2 client that stops on the terminal frame, exactly as the
+ * design tells it to, waited forever.
+ *
+ * **This is not {@see HealthFulfilHandlerThrowTest} with different names, nor
+ * {@see HealthTerminalFrameTest}.** Those two drive requests that *were* settled — successfully and
+ * then thrown from, or rejected outright. Nothing is settled here at all: the work is taken off the
+ * queue before it is ever dispatched, which is why neither of the tail handlers #823 attached can
+ * reach it.
+ *
+ * **The two call sites are driven separately, because they are reached differently.** `cancelRun()`
+ * is the explicit one — the client says stop. `processQueue()` is the one that is easy to miss: it
+ * drops superseded entries on *every* queue pass, so an ordinary run-token change supersedes queued
+ * work with no cancellation anywhere in sight.
+ *
+ * **What termination looks like here, and why it is not an error frame.** A cancelled request emits
+ * its terminal frame and nothing else: no `exists(fail)`, no error text. The check never ran, so a
+ * step frame reporting its outcome would be an untruth of exactly the kind #822/#833/#834/#835 were
+ * filed to remove — and `validateCalendar()`'s rejection arm would have said the calendar "does not
+ * exist at the URL", which is a statement about the API, not about a run the client stopped. The
+ * terminal frame carries `cancelled: true` instead, so a client can tell a run it abandoned from one
+ * that failed without a new frame being added to a stream a v1 client sizes as `checks * 3`.
+ *
+ * Nothing here drives the ReactPHP loop: a queued entry is an inert record until something settles
+ * it, which is what makes it assertable.
+ */
+#[CoversClass(Health::class)]
+final class HealthSupersededRequestTest extends TestCase
+{
+    use HealthQueueIsolationTrait;
+
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+        CheckableInventory::reset();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        CheckableInventory::reset();
+    }
+
+    // ---------------------------------------------------------------- call site 1: cancelRun()
+
+    /**
+     * The explicit cancellation: `cancelRun()` clears the connection's stored token and drops the
+     * backlog that belonged to it. The resource check queued below had emitted nothing yet — it was
+     * still waiting for its turn — so the terminal frame is the only frame this request ever sends,
+     * and the client stops on it instead of waiting for a fetch that will never happen.
+     */
+    public function testAnExplicitCancelTerminatesItsQueuedRequest(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'     => 'executeValidation',
+            'category'   => 'resourceDataCheck',
+            'validate'   => 'national-calendar-IT',
+            'sourceFile' => 'https://example.test/data/nation/IT',
+            'runToken'   => 'run-a',
+            'requestId'  => 'req-alpha'
+        ]);
+        self::assertCount(1, self::queuedRequests($health), 'precondition: the request is queued, not yet dispatched');
+        self::assertSame([], $conn->sent, 'precondition: a queued request has emitted nothing, so what follows is all of it');
+
+        self::send($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertSame([], self::queuedRequests($health), 'the cancelled run keeps no queued work');
+        self::assertCancelled($conn, 'req-alpha', 'run-a');
+    }
+
+    // ---------------------------------------------------------------- call site 2: processQueue()
+
+    /**
+     * The unobvious one: no cancellation is sent at all. The client simply starts a new run, the
+     * connection's stored token advances, and the next queue pass finds the previous run's queued
+     * work superseded. `processQueue()` runs that pass on every tick, so this is the common path, not
+     * the exotic one.
+     *
+     * The second message is a `validateCalendar` missing every property but `runToken`: it stores the
+     * new token and is then refused by `WebSocketMessageValidator`, so it advances the run without
+     * queueing work of its own — the same technique `HealthCancelRunTest` uses to drive a token change
+     * through the real entry point.
+     */
+    public function testARunTokenChangeTerminatesTheSupersededQueuedRequest(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON',
+            'runToken'       => 'run-a',
+            'requestId'      => 'req-alpha'
+        ]);
+        self::assertCount(1, self::queuedRequests($health), 'precondition: the calendar fetch is queued');
+
+        // The run advances: same connection, new token, no cancelRun anywhere.
+        self::send($health, $conn, ['action' => 'validateCalendar', 'runToken' => 'run-b']);
+        self::processQueue($health);
+
+        self::assertSame([], self::queuedRequests($health), 'the superseded run keeps no queued work');
+        self::assertCancelled($conn, 'req-alpha', 'run-a');
+    }
+
+    /**
+     * The third and last consumer of `cachedGet()` that reports to a client: a test run. It carries
+     * one result frame rather than three steps, so a dropped one leaves the client with nothing at
+     * all unless the terminal frame is sent.
+     */
+    public function testASupersededTestRunTerminatesToo(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'    => 'runTest',
+            'test'      => 'TerminalHarnessAlpha',
+            'calendar'  => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'      => 2026,
+            'runToken'  => 'run-a',
+            'requestId' => 'req-alpha'
+        ]);
+        self::assertCount(1, self::queuedRequests($health), 'precondition: the test run\'s calendar fetch is queued');
+
+        self::send($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertCancelled($conn, 'req-alpha', 'run-a');
+    }
+
+    // ---------------------------------------------------------------- and what termination is not
+
+    /**
+     * **A cancelled request does not report a failed check.** The queued work never ran, so nothing
+     * can be said about whether the resource exists, parses or validates — and the rejection arm this
+     * fix deliberately does not route through would have said the calendar "does not exist at the
+     * URL", a statement about the API rather than about a run the client stopped.
+     *
+     * Asserted as the absence of any `status`-bearing frame rather than by matching text, so it keeps
+     * holding if the wording of those frames changes.
+     */
+    public function testACancelledRequestReportsNoStepOutcomeAtAll(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'national', 'id' => 'IT', 'rite' => 'roman'],
+            'year'           => 2026,
+            'responseFormat' => 'JSON',
+            'runToken'       => 'run-a',
+            'requestId'      => 'req-alpha'
+        ]);
+        self::send($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        $frames = self::framesOf($conn);
+        self::assertNotEmpty($frames, 'precondition: the request was answered, so what is asserted below is not vacuous');
+        foreach ($frames as $frame) {
+            self::assertFalse(property_exists($frame, 'status'), 'a request that never ran reports no step outcome');
+            self::assertNotSame('error', $frame->type ?? null, 'a cancelled run is not a failed one');
+        }
+    }
+
+    /**
+     * **The `requestId` gate holds here too.** A client that did not correlate receives nothing when
+     * its queued work is dropped, exactly as it receives nothing when a handler throws (#823) and
+     * nothing when a request completes normally.
+     *
+     * This is the one thing a fix here could break that nothing else would catch: `resources.js`
+     * sizes a phase as `checks * 3` and advances on `>=`, so a terminal frame reaching a v1 client
+     * finishes the *following* phase early too — a cascading miscount with nothing visibly failing.
+     */
+    public function testAClientThatDidNotCorrelateHearsNothingWhenItsWorkIsDropped(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        self::send($health, $conn, [
+            'action'     => 'executeValidation',
+            'category'   => 'resourceDataCheck',
+            'validate'   => 'national-calendar-IT',
+            'sourceFile' => 'https://example.test/data/nation/IT',
+            'runToken'   => 'run-a'
+        ]);
+        self::assertCount(1, self::queuedRequests($health), 'precondition: the request was started, so the silence below means something');
+
+        self::send($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertSame([], self::queuedRequests($health), 'precondition: the queued work really was dropped');
+        self::assertSame([], $conn->sent, 'a v1 stream is exactly what it was: no terminal frame, cancelled or otherwise');
+    }
+
+    /**
+     * **One request's termination must not take the rest of the batch with it.** A terminator sends a
+     * frame, and a frame's journey out ends in Ratchet and then in a socket — a `send()` on a
+     * connection that has just gone away throws, and it would otherwise do so partway through a queue
+     * pass, leaving the remaining superseded requests unterminated and taking `processQueue()` down
+     * with it.
+     *
+     * The queue is seeded directly here rather than through `cachedGet()`: what is under test is the
+     * drop site's own containment, and a terminator that throws on demand is the whole point.
+     */
+    public function testATerminatorThatThrowsDoesNotStopTheRestOfTheBatch(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection();
+
+        $terminated = [];
+        self::setRunTokens($health, [1 => 'run-a', 2 => 'run-b']);
+        self::setQueue($health, [
+            self::queueEntry('https://example.test/throws', 1, 'run-a', static function (): void {
+                throw new \RuntimeException('the client went away mid-cancellation');
+            }),
+            self::queueEntry('https://example.test/after', 1, 'run-a', static function () use (&$terminated): void {
+                $terminated[] = 'after';
+            }),
+            self::queueEntry('https://example.test/other-connection', 2, 'run-b', static function () use (&$terminated): void {
+                $terminated[] = 'other-connection';
+            })
+        ]);
+
+        self::send($health, $conn, ['action' => 'cancelRun', 'runToken' => 'run-a']);
+
+        self::assertSame(['after'], $terminated, 'the entry behind the throwing one is still terminated, and no surviving entry is');
+        self::assertSame(
+            ['https://example.test/other-connection'],
+            array_column(self::queuedRequests($health), 'url'),
+            'the other connection keeps the work it is still running'
+        );
+    }
+
+    // ---------------------------------------------------------------- harness
+
+    /**
+     * The client heard exactly one frame about this request, it was the terminal one, and it says the
+     * request was cancelled rather than finished.
+     *
+     * "Exactly one" is the point of the assertion, not a bonus: `sendComplete()` has no idempotency
+     * guard, by design, so a fix that both terminated the dropped entry *and* let its promise arms
+     * run would double-complete and a client counting nothing would still be told twice.
+     */
+    private static function assertCancelled(ConnectionInterface $conn, string $requestId, string $runToken): void
+    {
+        $frames    = self::framesOf($conn);
+        $terminals = array_values(array_filter(
+            $frames,
+            static fn (\stdClass $frame): bool => 'complete' === ( $frame->step ?? null ) && $requestId === ( $frame->requestId ?? null )
+        ));
+
+        self::assertCount(
+            1,
+            $terminals,
+            'a superseded request terminates exactly once; the stream was: [' . implode(', ', array_map(
+                static fn (\stdClass $f): string => is_string($f->step ?? null) ? $f->step : ( is_string($f->type ?? null) ? $f->type : '?' ),
+                $frames
+            )) . ']'
+        );
+
+        $terminal = $terminals[0];
+        self::assertTrue(property_exists($terminal, 'cancelled'), 'the terminal frame of a cancelled request says so');
+        self::assertTrue($terminal->cancelled, 'a cancelled request is marked cancelled, not merely complete');
+        self::assertSame($runToken, $terminal->runToken, 'the frame belongs to the run that was abandoned, not to whatever replaced it');
+        self::assertSame('complete', $terminal->step);
+    }
+
+    /**
+     * A minimal Ratchet connection that records every outbound frame. `resourceId` is a dynamic
+     * public property Ratchet assigns and is not part of `ConnectionInterface`, so this mirrors the
+     * stub convention the other Health tests use rather than a PHPUnit mock, which would trigger a
+     * dynamic-property deprecation.
+     */
+    private static function createStubConnection(int $resourceId = 1)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function send(Health $health, ConnectionInterface $conn, array $payload): void
+    {
+        ob_start();
+        try {
+            $health->onMessage($conn, (string) json_encode($payload));
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    /**
+     * Run one queue pass, which is what the event loop does on every tick. Nothing is dispatched: the
+     * only queued entry belongs to a superseded run and is dropped before the dispatch loop is
+     * reached, so no HTTP request leaves this test.
+     */
+    private static function processQueue(Health $health): void
+    {
+        $method = new \ReflectionMethod(Health::class, 'processQueue');
+        ob_start();
+        try {
+            $method->invoke($health);
+        } finally {
+            ob_end_clean();
+        }
+    }
+
+    /**
+     * A queue entry shaped like the ones `cachedGet()` enqueues, for the one test that seeds the
+     * queue by hand rather than by sending a message. `resolve` and `reject` are never reached: a
+     * dropped entry's promise is deliberately left unsettled.
+     *
+     * @return array<string, mixed>
+     */
+    private static function queueEntry(string $url, ?int $resourceId, ?string $runToken, \Closure $onSuperseded): array
+    {
+        return [
+            'url'          => $url,
+            'options'      => [],
+            'resolve'      => static function (): void {
+            },
+            'reject'       => static function (): void {
+            },
+            'resourceId'   => $resourceId,
+            'runToken'     => $runToken,
+            'onSuperseded' => $onSuperseded
+        ];
+    }
+
+    /** @param list<array<string, mixed>> $queue */
+    private static function setQueue(Health $health, array $queue): void
+    {
+        ( new \ReflectionProperty(Health::class, 'queue') )->setValue($health, $queue);
+    }
+
+    /** @param array<int, string> $tokens */
+    private static function setRunTokens(Health $health, array $tokens): void
+    {
+        ( new \ReflectionProperty(Health::class, 'runTokens') )->setValue($health, $tokens);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function queuedRequests(Health $health): array
+    {
+        /** @var list<array<string, mixed>> */
+        return ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    private static function framesOf(ConnectionInterface $conn): array
+    {
+        /** @var object{sent: list<string>} $conn */
+        return array_map(
+            /** @return \stdClass */
+            static fn (string $raw): object => (object) json_decode($raw),
+            $conn->sent
+        );
+    }
+}

--- a/src/Health.php
+++ b/src/Health.php
@@ -260,7 +260,7 @@ class Health implements MessageComponentInterface
     private float $staggerInterval;
     private int $maxConcurrency;
     private int $inFlight = 0;
-    /** @var list<array{url:string,options:array{headers?:array<string, string>,stream?:bool},resolve:\Closure(ResponseInterface):void,reject:\Closure(\Throwable):void,resourceId:int|null,runToken:string|null}> */
+    /** @var list<array{url:string,options:array{headers?:array<string, string>,stream?:bool},resolve:\Closure(ResponseInterface):void,reject:\Closure(\Throwable):void,resourceId:int|null,runToken:string|null,onSuperseded:(\Closure():void)|null}> */
     private array $queue  = [];
     private bool $ticking = false;
 
@@ -479,6 +479,9 @@ class Health implements MessageComponentInterface
             // which is exactly what a problem-document body would produce, as "not loaded yet": self::
             // $metadata is simply left unset and the next request retries. Nothing here claims success
             // for a refusal, so there is no false "exists" for #833 to fix.
+            // #837 note: no `onSuperseded` terminator, and none is needed. This fetch is made on connect,
+            // before the connection is on any run, so the queued entry carries no run token and is never
+            // dropped; and it emits no frames at all, so there is no client request to terminate.
             /** @var PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $metadataPromise */
             $metadataPromise = $this->cachedGet(Route::CALENDARS->path(), $opts, 300, $conn);
             //self::$metadataPromise = $metadataPromise;
@@ -1024,12 +1027,34 @@ class Health implements MessageComponentInterface
      * @param ?string $runToken The originating run token to echo back, or null to use the per-connection fallback.
      * @param ?string $requestId The correlation id of the request that has finished. Null means the client never opted
      *        in, and nothing is sent at all — see above.
+     * @param bool $cancelled Whether the request is ending because the run it belonged to was abandoned rather than
+     *        because its work finished; see {@see Health::dropSupersededQueuedRequests()}, which is the only caller
+     *        that passes `true`. It adds a `cancelled` key and changes `text`; everything else about the frame,
+     *        including `type`, is unchanged.
+     *
+     *        **Why a key on this frame rather than a frame of its own.** A cancelled run and a failed one must not
+     *        look identical to a client — `cancelRun` is a request to stop, and an error frame reading like a check
+     *        failure would be its own untruth, of exactly the kind #822/#833/#834/#835 were filed to remove. But a
+     *        *new frame* is the one thing the additive envelope cannot absorb: a v1 client sizes a phase as
+     *        `checks * 3` and would count it. A new key on a frame the client was going to receive anyway carries
+     *        the distinction at no such cost — the same reasoning {@see Health::rejectMessage()} records for its
+     *        `type` — and this frame is gated on `requestId`, so a v1 client never sees the key at all.
+     *
+     *        **Why `type` stays `'success'`.** It is the legacy pass/fail projection, and since UnitTestInterface#46
+     *        an unrecognised `type` is painted as a visible failed check: a `'cancelled'` type would make an
+     *        abandoned run look like a failing one in the very client this distinction exists for. The frame already
+     *        says `'success'` for a request whose every step failed — it reports that the work finished, not that it
+     *        passed — so a cancellation is no more of an exception to that than a failure is.
+     *
+     *        **Omitted rather than sent as `false`.** A normal terminal frame is byte-identical to what it was
+     *        before this key existed, so nothing has to tell "not cancelled" from "an older server".
      */
     private function sendComplete(
         ConnectionInterface $to,
         ?\stdClass $target,
         ?string $runToken = null,
-        ?string $requestId = null
+        ?string $requestId = null,
+        bool $cancelled = false
     ): void {
         if (null === $requestId) {
             return;
@@ -1037,9 +1062,14 @@ class Health implements MessageComponentInterface
 
         $message         = new \stdClass();
         $message->type   = 'success';
-        $message->text   = 'All checks for this request are complete';
+        $message->text   = $cancelled
+            ? 'This request did not run: the run it belonged to was cancelled or superseded before the work started'
+            : 'All checks for this request are complete';
         $message->target = $target;
         $message->step   = Step::COMPLETE->value;
+        if ($cancelled) {
+            $message->cancelled = true;
+        }
         $this->sendMessage($to, $message, $runToken, requestId: $requestId);
     }
 
@@ -1789,7 +1819,17 @@ class Health implements MessageComponentInterface
                 // $dataPath is an API path in this case
                 echo 'Retrieving data from URL ' . $dataPath . "\n";
                 /** @var PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $httpPromise */
-                $httpPromise = $this->cachedGet($dataPath, [], 300, $to);
+                $httpPromise = $this->cachedGet(
+                    $dataPath,
+                    [],
+                    300,
+                    $to,
+                    // If this fetch is dropped because its run was abandoned, the request ends here
+                    // instead of going silent; see cachedGet()'s $onSuperseded.
+                    function () use ($to, $target, $runToken, $requestId): void {
+                        $this->sendComplete($to, target: $target, runToken: $runToken, requestId: $requestId, cancelled: true);
+                    }
+                );
                 $httpPromise->then(
                     function (array $result) use ($to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $requestId, $target) {
                         /** @var array{data: string, status: int, fromCache: bool, retryAfter: ?string} $result */
@@ -2757,7 +2797,18 @@ class Health implements MessageComponentInterface
         ];
 
         $req     = $this->buildCalendarRequestPath($calendar, $year, $category, $this->resolveRite($calendar, $category, $riteHint));
-        $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
+        $promise = $this->cachedGet(
+            Route::CALENDAR->path() . $req,
+            $opts,
+            300,
+            $to,
+            // A run abandoned while this fetch is still queued ends the request here. It must not go
+            // through the rejection arm below, which would report that the calendar "does not exist at
+            // the URL" — a statement about the API, not about a run the client stopped.
+            function () use ($to, $calendar, $year, $runToken, $requestId): void {
+                $this->sendComplete($to, target: self::frameTarget($calendar, ['year' => $year]), runToken: $runToken, requestId: $requestId, cancelled: true);
+            }
+        );
         $promise->then(
             function (array $result) use ($to, $calendar, $year, $category, $req, $responseType, $runToken, $requestId) {
                 /** @var array{data: string, status: int, fromCache: bool, retryAfter: ?string} $result */
@@ -3307,7 +3358,23 @@ class Health implements MessageComponentInterface
 
         $rite    = $this->resolveRite($calendar, $category, $riteHint);
         $req     = $this->buildCalendarRequestPath($calendar, $year, $category, $rite);
-        $promise = $this->cachedGet(Route::CALENDAR->path() . $req, $opts, 300, $to);
+        $promise = $this->cachedGet(
+            Route::CALENDAR->path() . $req,
+            $opts,
+            300,
+            $to,
+            // A test run carries one result frame rather than three steps, so a dropped fetch leaves the
+            // client with nothing at all unless the terminal frame is sent; see cachedGet()'s $onSuperseded.
+            function () use ($to, $test, $calendar, $year, $runToken, $requestId): void {
+                $this->sendComplete(
+                    $to,
+                    target: self::frameTarget($test, ['calendar' => $calendar, 'year' => $year]),
+                    runToken: $runToken,
+                    requestId: $requestId,
+                    cancelled: true
+                );
+            }
+        );
         $promise->then(
             function (array $result) use ($to, $test, $calendar, $year, $category, $req, $runToken, $requestId, $rite) {
                 /** @var array{data: string, status: int, fromCache: bool, retryAfter: ?string} $result */
@@ -3781,10 +3848,25 @@ class Health implements MessageComponentInterface
 
     /**
      * @param array{headers?:array<string, string>,stream?:bool} $options
+     * @param ?ConnectionInterface $conn The connection whose run this request belongs to, or null for a request that
+     *        belongs to no run. It is read for its `resourceId` only, to tag the queued entry; see
+     *        {@see Health::dropSupersededQueuedRequests()}.
+     * @param ?\Closure():void $onSuperseded How to end the request this fetch belongs to, if the fetch is dropped from
+     *        the queue before it is ever dispatched because its run was abandoned (#837).
+     *
+     *        **Every caller that reports to a client must pass one.** A dropped entry's promise is never settled, so
+     *        neither of the caller's `then()` handlers ever runs and the request would otherwise go silent — no step
+     *        frames, no terminal frame, and a v2 client that stops on `complete` waiting forever. The closure is what
+     *        the drop site calls instead, and in practice it is a single `sendComplete(..., cancelled: true)`: this
+     *        method knows a connection and a run token, but not the `target` or the `requestId` a terminal frame needs,
+     *        and threading those through the HTTP layer would make it a frame emitter. Null is right only for a fetch
+     *        no client is waiting on — the connect-time metadata bootstrap, which carries no run token and is therefore
+     *        never dropped anyway. Omitting it where a client *is* waiting reintroduces #837 for that call site, which
+     *        the drop site says so on stdout rather than leaving to be discovered.
      *
      * @return PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}>
      */
-    private function cachedGet(string $url, array $options = [], int $ttl = 300, ?ConnectionInterface $conn = null): PromiseInterface
+    private function cachedGet(string $url, array $options = [], int $ttl = 300, ?ConnectionInterface $conn = null, ?\Closure $onSuperseded = null): PromiseInterface
     {
         $key = 'http_' . md5($url . serialize($options));
 
@@ -3867,12 +3949,13 @@ class Health implements MessageComponentInterface
         $queuedRunToken   = $queuedResourceId !== null ? ( $this->runTokens[$queuedResourceId] ?? null ) : null;
 
         $this->queue[] = [
-            'url'        => $url,
-            'options'    => $options,
-            'resolve'    => $resolve,
-            'reject'     => $reject,
-            'resourceId' => $queuedResourceId,
-            'runToken'   => $queuedRunToken
+            'url'          => $url,
+            'options'      => $options,
+            'resolve'      => $resolve,
+            'reject'       => $reject,
+            'resourceId'   => $queuedResourceId,
+            'runToken'     => $queuedRunToken,
+            'onSuperseded' => $onSuperseded
         ];
 
         /** @var PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $deferredPromise */
@@ -4106,18 +4189,80 @@ class Health implements MessageComponentInterface
      * instead of first draining the abandoned run's backlog. Untagged requests (e.g. the metadata fetch
      * on connect) carry no token and are always kept. In-flight requests are not affected (they are few —
      * capped at maxConcurrency — and their responses are discarded client-side).
+     *
+     * **A dropped entry is terminated, not merely discarded (#837).** Until this fix the filter took the
+     * entry and with it the only reference to the deferred behind it, so the promise `cachedGet()` handed
+     * the caller was never settled — not resolved, not rejected. Neither of the caller's `then()` handlers
+     * ever ran, and neither did the tail handler #823 attached to the promise derived from them, since
+     * nothing was ever delivered to derive from. The request simply stopped, after whatever step frames it
+     * had already emitted, and a v2 client that stops on `complete` waited forever. Each entry's
+     * `onSuperseded` closure is called instead: see {@see Health::cachedGet()} for why the termination is
+     * supplied by the caller rather than composed here.
+     *
+     * **A cancellation is not a failure, so the promise is deliberately left unsettled.** Rejecting it —
+     * the obvious fix, and the one #837 sketches — would run each caller's sibling `onRejected`, and those
+     * arms report a *failed check*: `validateCalendar()`'s says the calendar "does not exist at the URL",
+     * which is a claim about the API rather than about a run the client stopped. That is the same
+     * "reports something that did not happen" family as #822/#833/#834/#835. So a superseded request emits
+     * its terminal frame and nothing else, marked `cancelled` (see {@see Health::sendComplete()}), and the
+     * unsettled promise is collected along with the entry that held its callbacks.
+     *
+     * Two further reasons rejecting the entry's own `reject` closure would be wrong, recorded because it
+     * is the first thing anyone will try: that closure decrements `inFlight`, which a *queued* entry never
+     * incremented (dispatch does, in {@see Health::processQueue()}), so calling it would drive the counter
+     * below zero and quietly raise the concurrency cap for the rest of the process; and it also has to be
+     * reachable exactly once, which it stops being if it is called both here and by a dispatch.
+     *
+     * **Exactly one terminal frame per dropped request.** `sendComplete()` has no idempotency guard, by
+     * design. Nothing double-completes here: an entry is removed from the queue before any terminator runs
+     * (so a re-entrant pass cannot see it again), a queued entry has by definition not been dispatched, so
+     * none of its caller's frame-emitting handlers has run, and the promise stays unsettled so none of them
+     * ever will.
      */
     private function dropSupersededQueuedRequests(): void
     {
         if (empty($this->queue)) {
             return;
         }
-        $this->queue = array_values(array_filter(
-            $this->queue,
-            fn (array $item): bool => null === $item['resourceId']
+
+        $kept    = [];
+        $dropped = [];
+        foreach ($this->queue as $item) {
+            $stillCurrent = null === $item['resourceId']
                 || null === $item['runToken']
-                || ( $this->runTokens[$item['resourceId']] ?? null ) === $item['runToken']
-        ));
+                || ( $this->runTokens[$item['resourceId']] ?? null ) === $item['runToken'];
+            if ($stillCurrent) {
+                $kept[] = $item;
+            } else {
+                $dropped[] = $item;
+            }
+        }
+
+        // Reassigned before a single terminator runs. A terminator sends a frame, which ends up in
+        // Ratchet and then in code this class does not control; anything that re-entered this method
+        // from there would otherwise find the dropped entries still queued and terminate them twice.
+        $this->queue = $kept;
+
+        foreach ($dropped as $item) {
+            $terminate = $item['onSuperseded'] ?? null;
+            if (null === $terminate) {
+                // Said out loud rather than passed over: a caller that reports to a client and forgets
+                // this closure reintroduces #837 for its own path, and the symptom — one client, one
+                // request, waiting forever — is invisible from the server unless the drop says so.
+                echo 'Dropped a superseded queued request for ' . $item['url'] . " that has no way to terminate: its caller passed no onSuperseded to cachedGet()\n";
+                continue;
+            }
+            try {
+                $terminate();
+            } catch (\Throwable $e) {
+                // One request's termination must not take the rest of the batch — or the queue pass
+                // this runs inside — down with it. Reported the way `terminateOnHandlerThrow()` reports
+                // its own last-resort catch: to the server's stdout, and not to the client, whose frame
+                // stream must not gain one it cannot account for.
+                echo 'Error terminating the superseded request for ' . $item['url'] . ': ' . $e::class . ': ' . $e->getMessage()
+                    . ' (' . $e->getFile() . ':' . $e->getLine() . ")\n";
+            }
+        }
     }
 
     private function processQueue(): void


### PR DESCRIPTION
Closes #837.

`dropSupersededQueuedRequests()` filtered superseded entries out of the queue with `array_filter`, discarding each entry's callbacks without settling the promise. Neither the fulfil handler nor the sibling `onRejected` ever ran, so the request went silent after whatever step frames it had already emitted, and a v2 client stopping on `complete` waited forever.

This was the last of the two known holes in the "every path that starts work terminates" guarantee; #823 closed the other.

## Both call sites

| call site | line | trigger |
|---|---|---|
| `cancelRun()` | `Health.php:1172` (right after `unset($this->runTokens[$resourceId])`) | explicit client cancellation |
| `processQueue()` | `Health.php:4125` (first statement) | **every** queue pass — an ordinary run-token change supersedes queued work with no cancellation |

Droppable entries come from exactly three client-facing `cachedGet()` callers, each 1:1 with one request and one `sendComplete()`. The fourth caller — the connect-time `/calendars` metadata fetch — is queued before any run token exists, is therefore never dropped, and needs no terminator.

## The issue's literal fix is a trap

#837 said "call their `reject`". Doing so would corrupt the concurrency accounting: `++$this->inFlight` happens at **dispatch** (`Health.php:4162`, inside `processQueue()`'s loop), while `cachedGet()`'s `reject` closure decrements it. A **queued** entry never incremented the counter, so rejecting it drives `inFlight` negative and silently raises the concurrency cap for the life of the process.

This already has a footprint in the existing suite: `HealthTerminalFrameTest` settles queued entries by hand and its drain log prints `inFlight: -1` and `inFlight: -2`. Hence a separate `onSuperseded` terminator on the entry rather than reuse of `reject`.

## Cancellation must not be reported as failure

The second reason not to reject into the existing arms is honesty. Those arms report a *failed check*: `validateCalendar()`'s says the calendar "does not exist at the URL", `executeUnitTest()`'s says it "was not retrieved", the resource arm runs `handleValidationDataError()` and emits three FAIL frames. **None of that happened** — the fetch never left the queue. Reporting it would be the same "reports something that did not happen" family as #822/#833/#834/#835.

**A superseded request now emits its terminal frame and nothing else: `complete` carrying `cancelled: true`.**

- Distinguishability rides on a frame the client was already going to receive, never a new one — a v1 client sizes a phase as `checks * 3`, so an extra frame is a cascading miscount.
- `type` stays `'success'`: since UnitTestInterface#46 an unrecognised `type` is painted as a visible failed check, which is exactly what an abandoned run must not look like.
- `cancelled` is **omitted** rather than sent as `false`, so an ordinary terminal frame stays byte-identical.
- The `requestId` gate is untouched, so a v1 client still sees nothing at all.

**Completes exactly once**: the promise is deliberately left unsettled, so neither `then()` handler nor #823's tail handler can run; a queued entry has by definition not been dispatched, so no frame of that request has been emitted yet; and `$this->queue` is reassigned to the survivors *before* any terminator runs, so a re-entrant pass cannot see a dropped entry twice. Asserted directly — the tests count terminal frames as exactly 1.

## Tests

`phpunit_tests/HealthSupersededRequestTest.php`, 6 cases: both call sites, the test-run site, "no step outcome", the v1 gate, and a throwing terminator not taking the batch down. Pre-fix, 3 failed with exactly the reported silence (`the stream was: []`), plus one risky test with no frames to assert on. Post-fix `OK (6 tests, 29 assertions)`; full `--filter Health` `OK (463 tests, 2796 assertions)`.

## Verification

- `composer lint`, `composer lint:md` clean; `composer analyse` (PHPStan level 10) `[OK] No errors`
- `composer test:quick`: `Tests: 2979, Assertions: 177957, Skipped: 11`, exit 0

## Protocol note

`cancelled` is a **new key on the terminal frame** — a v2 addition behind the existing `requestId` gate. UnitTestInterface#42 will want to know about it when the v2 contract lands.

Section C of `docs/superpowers/specs/2026-08-20-structured-responses-design.md` now records the guarantee as having both holes closed, with an amendment covering the fix, the rejected alternative, the `inFlight` trap and the `cancelled` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cancelled or superseded queued requests now receive a clear terminal completion frame.
  * Cancelled requests no longer produce misleading step or error frames.
  * HTTP response statuses and retry guidance are handled consistently, including cached responses.

* **Bug Fixes**
  * Improved validation failure reporting for refused responses, malformed data and decoding errors.
  * Fixed dropped queued requests that previously ended without a completion notification.
  * Improved calendar, diocesan path and schema matching.
  * APCu availability checks now verify stored and retrieved values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->