### PR TITLE
fix(locale): negotiate Accept-Language against the calendar's own locales (#845)

### DIFF
--- a/phpunit_tests/Handlers/AmbrosianLocaleEnforcementTest.php
+++ b/phpunit_tests/Handlers/AmbrosianLocaleEnforcementTest.php
@@ -226,11 +226,15 @@ final class AmbrosianLocaleEnforcementTest extends AbstractHandlerTestCase
 
     /**
      * Narrowing negotiation to the rite's languages must not narrow the *shape* of the
-     * tag it returns. The rite-level metadata declares bare languages (`it`, `la`), but
-     * the diocesan layer matches the negotiated locale against its own full identifiers
-     * (`it_IT`, `la_VA`) with a strict `in_array()` — so a negotiator that answered `la`
-     * instead of `la_VA` would fail that membership test and get silently downgraded to
-     * the diocese's first locale, turning a request for Latin into Italian.
+     * tag it returns: the rite's candidate set is all the negotiator has to answer with on
+     * the rite-level routes, so offering it only the bare `it`/`la` the rite metadata
+     * declares would report a coarser `settings.locale` than the client asked for.
+     *
+     * (This also used to be what kept the diocesan layer honest, since that layer
+     * string-compared the negotiated tag against its own `it_IT`/`la_VA`. It no longer
+     * does — #845 made it re-negotiate the original header against its own declared
+     * locales — so the diocesan rows below are now a straightforward regression guard
+     * rather than a proof of that coupling. See CalendarScopedLocaleNegotiationTest.)
      *
      * These cases pin the exact `settings.locale` each header produced before locale
      * enforcement existed; the only behavior this feature is allowed to change is what

--- a/phpunit_tests/Handlers/CalendarScopedLocaleNegotiationTest.php
+++ b/phpunit_tests/Handlers/CalendarScopedLocaleNegotiationTest.php
@@ -1,0 +1,347 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Handlers\EventsHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Http\Enum\StatusCode;
+use LiturgicalCalendar\Api\Http\Exception\ApiException;
+use LiturgicalCalendar\Api\Http\Negotiator;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Issue #845: an `Accept-Language` **range** must be negotiated against the requested
+ * calendar's own declared `metadata->locales`, not matched against them for literal
+ * equality after having been negotiated against something else.
+ *
+ * Canada declares `["en_CA", "fr_CA"]`. Under RFC 4647 §3.3.1 basic filtering the range
+ * `fr` matches the tag `fr-CA`, so a French-speaking client sending the plain `fr` range
+ * must be served `fr_CA`. Before this fix it was served `en_CA` — a different *language*,
+ * not merely a different region of the same one — because the two halves of the decision
+ * ran in the wrong order:
+ *
+ * 1. `handle()` negotiated the header against the *rite's* candidate set, which is empty
+ *    for the Roman rite and therefore means "the API-wide locale list". `fr` exists there
+ *    as a tag in its own right, and an exact match beats a prefix match, so the header
+ *    correctly resolved to `fr`. The requested calendar was not yet known at that point.
+ * 2. Once the calendar JSON loaded, the resolved locale was tested for literal membership
+ *    in `["en_CA", "fr_CA"]` — which `fr` fails — and silently replaced by `locales[0]`.
+ *
+ * So the right matching ran against the wrong candidate set, and the right candidate set
+ * was applied with the wrong matching. The fix re-runs the *original header* through
+ * `Negotiator::pickLanguage()` once the calendar's own locales are known.
+ *
+ * The re-negotiation is deliberately narrow: it only re-opens the question when the locale
+ * already in hand is *not* one of the calendar's declared locales — i.e. exactly where the
+ * old code would have thrown it away for `locales[0]`. A locale the calendar does declare is
+ * left alone, so the #761 "unacceptable header degrades to the API-wide Latin default"
+ * behaviour survives wherever Latin is among the calendar's own locales.
+ *
+ * The header/parameter asymmetry established by #761 is preserved and asserted here: a
+ * header states a *preference* and is negotiated, while an explicit `locale` parameter is
+ * an *exact selector* naming a dataset, so `?locale=fr` is NOT widened to `fr_CA`.
+ */
+final class CalendarScopedLocaleNegotiationTest extends AbstractHandlerTestCase
+{
+    private ?string $savedServerName = null;
+
+    /**
+     * Pin `SERVER_NAME` to localhost so `Router::isLocalhost()` is true and `CalendarHandler`
+     * takes its "never touch `engineCache/`" path. The engine cache is keyed on the calendar
+     * params (locale included) but is written to a path relative to the process working
+     * directory and is blind to PHP source changes, so a cached body from an earlier revision
+     * could otherwise answer for the code under test. Mirrors
+     * {@see AmbrosianLocaleEnforcementTest::setUp()}.
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->savedServerName  = $_SERVER['SERVER_NAME'] ?? null;
+        $_SERVER['SERVER_NAME'] = 'localhost';
+    }
+
+    /**
+     * `EventsHandler::setLocale()` calls `setlocale(LC_ALL, ...)`, which persists for the
+     * lifetime of the PHPUnit process; later suites rely on gettext falling through to the
+     * untranslated (Latin) msgid rather than being left pinned to a translated catalog.
+     */
+    protected function tearDown(): void
+    {
+        if (null === $this->savedServerName) {
+            unset($_SERVER['SERVER_NAME']);
+        } else {
+            $_SERVER['SERVER_NAME'] = $this->savedServerName;
+        }
+        setlocale(LC_ALL, 'C');
+        parent::tearDown();
+    }
+
+    /**
+     * In-process handler tests call `handle()` directly, bypassing the PSR-15
+     * ErrorHandlingMiddleware that turns an ApiException into a problem+json response, so
+     * catch it here and read its status the way the middleware would.
+     *
+     * @param string[]             $pathParts
+     * @param array<string,string> $queryParams
+     * @param array<string,string> $headers
+     * @return array{status:int,locale:?string}
+     */
+    private function events(array $pathParts, Rite $rite, string $uri, array $queryParams = [], array $headers = []): array
+    {
+        $handler = new EventsHandler($pathParts, $rite);
+        $request = $this->requestFor('GET', $uri, $headers)->withQueryParams($queryParams);
+
+        try {
+            $response = $handler->handle($request);
+        } catch (ApiException $e) {
+            return ['status' => $e->getStatus(), 'locale' => null];
+        }
+
+        $body = $this->decodeJsonBody($response);
+        /** @var array{locale?:string} $settings */
+        $settings = is_array($body['settings'] ?? null) ? $body['settings'] : [];
+
+        return ['status' => $response->getStatusCode(), 'locale' => $settings['locale'] ?? null];
+    }
+
+    /**
+     * @param string[]             $pathParts
+     * @param array<string,string> $queryParams
+     * @param array<string,string> $headers
+     * @return array{status:int,locale:?string}
+     */
+    private function calendar(array $pathParts, Rite $rite, string $uri, array $queryParams = [], array $headers = []): array
+    {
+        $handler = new CalendarHandler($pathParts, $rite);
+        $handler->setAllowedReturnTypes([ReturnTypeParam::JSON]);
+        $request = $this->requestFor('GET', $uri, $headers)->withQueryParams($queryParams);
+
+        try {
+            $response = $handler->handle($request);
+        } catch (ApiException $e) {
+            return ['status' => $e->getStatus(), 'locale' => null];
+        }
+
+        $body = $this->decodeJsonBody($response);
+        /** @var array{locale?:string} $settings */
+        $settings = is_array($body['settings'] ?? null) ? $body['settings'] : [];
+
+        return ['status' => $response->getStatusCode(), 'locale' => $settings['locale'] ?? null];
+    }
+
+    /**
+     * Every `Accept-Language` shape a Canadian client plausibly sends, with the locale the
+     * bilingual Canadian national calendar (`["en_CA", "fr_CA"]`) must resolve it to.
+     *
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function canadianAcceptLanguageHeaders(): array
+    {
+        return [
+            // The bug: a bare range matches `fr_CA` under RFC 4647 basic filtering.
+            'bare French range'           => ['fr', 'fr_CA'],
+            // Regression guard: the fully-qualified tag already worked.
+            'French (Canada), hyphen'     => ['fr-CA', 'fr_CA'],
+            'French (Canada), underscore' => ['fr_CA', 'fr_CA'],
+            'bare English range'          => ['en', 'en_CA'],
+            'English (Canada)'            => ['en-CA', 'en_CA'],
+            // What a real French browser sends: `fr-FR` matches nothing Canada declares,
+            // but the `fr` range behind it does.
+            'French (France) then French' => ['fr-FR,fr;q=0.9', 'fr_CA'],
+            // Quality still governs which range is tried first.
+            'French outranked by English' => ['fr;q=0.5,en;q=0.9', 'en_CA'],
+            // A wildcard takes the calendar's first declared locale.
+            'wildcard'                    => ['*', 'en_CA'],
+            // Matching nothing the calendar declares lands on the documented default,
+            // i.e. `metadata->locales[0]`. `fr-FR` is the sharp case: French, but not a
+            // French *range* — RFC 4647 basic filtering does not match it to `fr-CA`.
+            'unrelated language'          => ['de', 'en_CA'],
+            'French (France) alone'       => ['fr-FR', 'en_CA'],
+        ];
+    }
+
+    #[DataProvider('canadianAcceptLanguageHeaders')]
+    public function testEventsNegotiatesAcceptLanguageAgainstTheNationalCalendarsOwnLocales(string $header, string $expected): void
+    {
+        $result = $this->events(['nation', 'CA'], Rite::ROMAN, '/events/nation/CA', [], ['Accept-Language' => $header]);
+
+        self::assertSame(StatusCode::OK->value, $result['status']);
+        self::assertSame($expected, $result['locale']);
+    }
+
+    #[DataProvider('canadianAcceptLanguageHeaders')]
+    public function testCalendarNegotiatesAcceptLanguageAgainstTheNationalCalendarsOwnLocales(string $header, string $expected): void
+    {
+        $result = $this->calendar(
+            ['nation', 'CA', '2026'],
+            Rite::ROMAN,
+            '/calendar/nation/CA/2026',
+            [],
+            ['Accept-Language' => $header]
+        );
+
+        self::assertSame(StatusCode::OK->value, $result['status']);
+        self::assertSame($expected, $result['locale']);
+    }
+
+    /**
+     * The case `CalendarMetadataProvider::negotiableLocalesForRite()`'s workaround was built
+     * for, now asserted directly against the diocesan layer instead of indirectly through the
+     * shape of the rite-level candidate set.
+     *
+     * The Ambrosian dioceses declare `["it_IT", "la_VA"]`. `la-VA` already worked, because the
+     * rite-level negotiation happened to emit that exact identifier. `la` did not: it is a tag
+     * in its own right in the API-wide list, so the rite-level negotiation answered `la`, which
+     * then failed the diocesan literal-membership test and silently came back in Italian —
+     * exactly the failure mode the workaround's docblock describes, reachable through a
+     * different door.
+     *
+     * @return array<string,array{0:string,1:string,2:string}> Accept-Language, /events locale, /calendar locale
+     */
+    public static function ambrosianAcceptLanguageHeaders(): array
+    {
+        return [
+            // `/calendar` collapses Latin to its runtime primary language, `/events` does not.
+            'bare Latin range'     => ['la', 'la_VA', 'la'],
+            'Latin (Vatican)'      => ['la-VA', 'la_VA', 'la'],
+            'bare Italian range'   => ['it', 'it_IT', 'it_IT'],
+            'Italian (Italy)'      => ['it-IT', 'it_IT', 'it_IT'],
+            // The rite has no books for Dutch, so nothing in the header is negotiable at the
+            // rite level and the request falls through to the API-wide Latin default (#761).
+            // The diocese declares Latin, so that default is already one of its own locales
+            // and survives untouched — calendar-scoped negotiation only re-opens the question
+            // when the locale in hand is *not* one the calendar declares.
+            'unsupported language' => ['nl', 'la_VA', 'la'],
+        ];
+    }
+
+    #[DataProvider('ambrosianAcceptLanguageHeaders')]
+    public function testEventsNegotiatesAcceptLanguageAgainstTheDiocesesOwnLocales(string $header, string $expectedEventsLocale, string $expectedCalendarLocale): void
+    {
+        $result = $this->events(
+            ['diocese', 'milano_it'],
+            Rite::AMBROSIAN,
+            '/events/ambrosian/diocese/milano_it',
+            [],
+            ['Accept-Language' => $header]
+        );
+
+        self::assertSame(StatusCode::OK->value, $result['status']);
+        self::assertSame($expectedEventsLocale, $result['locale']);
+    }
+
+    #[DataProvider('ambrosianAcceptLanguageHeaders')]
+    public function testCalendarNegotiatesAcceptLanguageAgainstTheDiocesesOwnLocales(string $header, string $expectedEventsLocale, string $expectedCalendarLocale): void
+    {
+        $result = $this->calendar(
+            ['diocese', 'milano_it', '2025'],
+            Rite::AMBROSIAN,
+            '/calendar/ambrosian/diocese/milano_it/2025',
+            [],
+            ['Accept-Language' => $header]
+        );
+
+        self::assertSame(StatusCode::OK->value, $result['status']);
+        self::assertSame($expectedCalendarLocale, $result['locale']);
+    }
+
+    /**
+     * The header/parameter asymmetry from #761, in the direction #845 must not disturb.
+     *
+     * An explicit `locale` parameter is a client assertion naming a dataset, and regional
+     * calendars store their data under specific regional variants, so `fr` on its own does
+     * not name one of Canada's datasets. It therefore keeps its existing exact-match
+     * treatment and lands on the calendar's default rather than being widened to `fr_CA` —
+     * even though the identical string arriving as an `Accept-Language` *range* now does
+     * resolve to `fr_CA`. The two are the same characters and deliberately different things.
+     */
+    public function testExplicitLocaleParamIsNotWidenedToARegionalVariant(): void
+    {
+        $events = $this->events(['nation', 'CA'], Rite::ROMAN, '/events/nation/CA', ['locale' => 'fr']);
+        self::assertSame(StatusCode::OK->value, $events['status']);
+        self::assertSame('en_CA', $events['locale'], 'an explicit `locale` param is an exact selector, not a range');
+
+        $calendar = $this->calendar(['nation', 'CA', '2026'], Rite::ROMAN, '/calendar/nation/CA/2026', ['locale' => 'fr']);
+        self::assertSame(StatusCode::OK->value, $calendar['status']);
+        self::assertSame('en_CA', $calendar['locale'], 'an explicit `locale` param is an exact selector, not a range');
+    }
+
+    /**
+     * An explicit parameter must win over the header, and must not be silently re-negotiated
+     * back into something the header would have preferred: `?locale=en_CA` alongside
+     * `Accept-Language: fr` is English, not French.
+     */
+    public function testExplicitLocaleParamOverridesTheHeader(): void
+    {
+        $events = $this->events(
+            ['nation', 'CA'],
+            Rite::ROMAN,
+            '/events/nation/CA',
+            ['locale' => 'en_CA'],
+            ['Accept-Language' => 'fr']
+        );
+        self::assertSame(StatusCode::OK->value, $events['status']);
+        self::assertSame('en_CA', $events['locale']);
+
+        $calendar = $this->calendar(
+            ['nation', 'CA', '2026'],
+            Rite::ROMAN,
+            '/calendar/nation/CA/2026',
+            ['locale' => 'fr_CA'],
+            ['Accept-Language' => 'en']
+        );
+        self::assertSame(StatusCode::OK->value, $calendar['status']);
+        self::assertSame('fr_CA', $calendar['locale']);
+    }
+
+    /**
+     * The ambiguity rule, pinned rather than left emergent (#845 point 5).
+     *
+     * When a range matches more than one declared locale at the same quality — `fr` against
+     * `["fr_CA", "fr_FR"]` — every candidate scores identically (same q, same match
+     * specificity, same header index), and `Negotiator::pickLanguage()` keeps the first
+     * candidate to reach that score because it replaces its running best only on a strictly
+     * greater score. Since it iterates the supported list in the order it was handed, the
+     * winner is **the calendar's first declared locale among those that match** — the same
+     * declaration order that already decides the `metadata->locales[0]` default. Reversing
+     * the declared order reverses the answer.
+     *
+     * An exact match still outranks any prefix match regardless of order, so a calendar that
+     * declared both `fr` and `fr_CA` would serve `fr` for the range `fr`.
+     */
+    public function testAmbiguousRangeResolvesToTheFirstDeclaredMatchingLocale(): void
+    {
+        self::assertSame('fr_CA', self::negotiate('fr', ['fr_CA', 'fr_FR']));
+        self::assertSame('fr_FR', self::negotiate('fr', ['fr_FR', 'fr_CA']));
+
+        // Exact beats prefix, whichever way round they are declared.
+        self::assertSame('fr', self::negotiate('fr', ['fr_CA', 'fr']));
+        self::assertSame('fr', self::negotiate('fr', ['fr', 'fr_CA']));
+    }
+
+    /**
+     * `pickLanguage()` returns null — not the fallback — when a non-empty header matches
+     * nothing supported; the fallback argument only covers a *missing* header. Both callers
+     * of the new calendar-scoped negotiation therefore have to coalesce, so pin the contract.
+     */
+    public function testNegotiatorReturnsNullWhenNothingMatchesButFallsBackOnAMissingHeader(): void
+    {
+        self::assertNull(self::negotiate('de', ['en_CA', 'fr_CA']));
+        self::assertSame('en_CA', self::negotiate(null, ['en_CA', 'fr_CA']));
+    }
+
+    /**
+     * @param string[] $supported
+     */
+    private static function negotiate(?string $header, array $supported): ?string
+    {
+        $request = new ServerRequest('GET', '/', null === $header ? [] : ['Accept-Language' => $header]);
+
+        return Negotiator::pickLanguage($request, $supported, $supported[0]);
+    }
+}

--- a/phpunit_tests/Services/CalendarMetadataProviderTest.php
+++ b/phpunit_tests/Services/CalendarMetadataProviderTest.php
@@ -123,9 +123,17 @@ final class CalendarMetadataProviderTest extends TestCase
     /**
      * The negotiable set narrows *which languages* are acceptable without narrowing the
      * *shape* of the identifiers offered: it must still carry the region-qualified tags
-     * (`it_IT`, `la_VA`) that the Ambrosian diocesan layer matches against exactly. A set
-     * of bare languages alone would make `Accept-Language: la-VA` negotiate to `la`, miss
-     * that diocesan membership test, and silently come back in Italian.
+     * (`it_IT`, `la_VA`), because this list is the entire candidate set for the rite-level
+     * routes and the negotiator can only answer with something it was offered. A set of
+     * bare languages alone would make `Accept-Language: it-IT` on `/events/ambrosian`
+     * negotiate down to `it`, reporting a coarser `settings.locale` than was asked for.
+     *
+     * It used to matter for a second, heavier reason, retired in #845: the Ambrosian
+     * diocesan layer string-compared the negotiated tag against its own `it_IT`/`la_VA`,
+     * so a bare `la` here turned a request for Latin into Italian one layer down. That
+     * layer now re-negotiates the original header against its own declared locales — see
+     * {@see \LiturgicalCalendar\Tests\Handlers\CalendarScopedLocaleNegotiationTest} — and
+     * no longer depends on the shape produced here.
      */
     public function testNegotiableLocalesKeepRegionQualifiedTagsForTheRitesLanguages(): void
     {

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -117,6 +117,23 @@ final class CalendarHandler extends AbstractHandler
     private static CatholicDiocesesMap $worldDiocesesLatinRite; // can only be set once, after which it will be read-only
     private CalendarParams $CalendarParams;
     private Rite $rite = Rite::ROMAN;
+
+    /**
+     * The request being handled, kept so the locale decision can be re-taken against the
+     * requested calendar's own declared locales once that calendar is known — which happens
+     * well after {@see self::handle()}'s first, calendar-agnostic negotiation. Only the
+     * original `Accept-Language` header carries enough information to do that (#845);
+     * see {@see self::resolveCalendarLocale()}.
+     */
+    private ?ServerRequestInterface $request = null;
+
+    /**
+     * True when this request carried an explicit `locale` parameter (query string or body),
+     * as opposed to having its locale derived from the `Accept-Language` header. The two are
+     * deliberately treated differently (#761): a header states a preference and is
+     * negotiated, a parameter names a dataset and is matched exactly.
+     */
+    private bool $localeExplicitlyRequested = false;
     private \NumberFormatter $formatter;
     private \NumberFormatter $formatterFem;
     private \IntlDateFormatter $dayOfTheWeek;
@@ -415,6 +432,51 @@ final class CalendarHandler extends AbstractHandler
     }
 
     /**
+     * The locale to serve for a calendar that declares its own `metadata->locales`.
+     *
+     * Returns the locale already in hand whenever the calendar declares it. Otherwise the
+     * request has asked for something this calendar has no dataset under, and what happens
+     * next depends on *how* it asked (#845, and the #761 asymmetry the negotiation block in
+     * {@see self::handle()} describes):
+     *
+     * - An explicit `locale` **parameter** is an exact selector naming a dataset. Regional
+     *   calendars store their data under regional variants, so `fr` on its own does not name
+     *   one of Canada's; it keeps its historical treatment and lands on the calendar's first
+     *   declared locale.
+     * - An **`Accept-Language` header** is a language *range*, and RFC 4647 §3.3.1 basic
+     *   filtering applies: the range `fr` matches the tag `fr-CA`. The *original header* is
+     *   re-negotiated here — not the tag it was already negotiated down to — because that
+     *   earlier negotiation ran before the calendar was known, against the rite's candidate
+     *   set (empty, i.e. the API-wide set, for the Roman rite), and widening its answer after
+     *   the fact cannot recover the quality ordering or the alternatives it discarded.
+     *
+     * `Negotiator::pickLanguage()` answers null (rather than the fallback) when a non-empty
+     * header matches nothing supported, so the coalesce below is what actually implements
+     * "a range matching nothing the calendar declares lands on `locales[0]`".
+     *
+     * When a range matches several declared locales at equal quality — `fr` against
+     * `['fr_CA', 'fr_FR']` — the negotiator keeps the first candidate to reach the winning
+     * score, so the calendar's declaration order decides, the same order that supplies the
+     * `locales[0]` default. An exact match still outranks any prefix match.
+     *
+     * @param string[] $declaredLocales The calendar's `metadata->locales`, in declaration order.
+     * @return string One of `$declaredLocales`.
+     */
+    private function resolveCalendarLocale(array $declaredLocales): string
+    {
+        if (in_array($this->CalendarParams->Locale, $declaredLocales, true)) {
+            return $this->CalendarParams->Locale;
+        }
+
+        if ($this->localeExplicitlyRequested || null === $this->request) {
+            return $declaredLocales[0];
+        }
+
+        return Negotiator::pickLanguage($this->request, $declaredLocales, $declaredLocales[0])
+            ?? $declaredLocales[0];
+    }
+
+    /**
      * If a Diocesan calendar is specified, we need to check if any of the settings for Epiphany, Ascension, Corpus Christi
      * have been overridden. If so, we update the CalendarParams object with the new values.
      *
@@ -452,11 +514,10 @@ final class CalendarHandler extends AbstractHandler
         } else {
             // If multiple locales are available for the diocesan calendar,
             // the desired locale should be set in the Accept-Language header.
-            // We should however check that this is an available locale for the current Diocesan Calendar,
-            // and if not use the first valid value.
-            if (false === in_array($this->CalendarParams->Locale, $this->DiocesanData->metadata->locales)) {
-                $this->CalendarParams->Locale = $this->DiocesanData->metadata->locales[0];
-            }
+            // That header is negotiated against this diocese's own declared locales
+            // here — see self::resolveCalendarLocale() — rather than merely tested for
+            // literal membership in them (#845).
+            $this->CalendarParams->Locale = $this->resolveCalendarLocale($this->DiocesanData->metadata->locales);
         }
     }
 
@@ -3489,11 +3550,11 @@ final class CalendarHandler extends AbstractHandler
         } else {
             // If multiple locales are available for the national calendar,
             // the desired locale should be set in the Accept-Language header.
-            // We should however check that this is an available locale for the current National Calendar,
-            // and if not use the first valid value.
-            if (false === in_array($this->CalendarParams->Locale, $this->NationalData->metadata->locales)) {
-                $this->CalendarParams->Locale = $this->NationalData->metadata->locales[0];
-            }
+            // That header is negotiated against this nation's own declared locales
+            // here — see self::resolveCalendarLocale() — rather than merely tested for
+            // literal membership in them: Canada declares ['en_CA', 'fr_CA'], and the
+            // range `fr` matches `fr_CA` under RFC 4647 basic filtering (#845).
+            $this->CalendarParams->Locale = $this->resolveCalendarLocale($this->NationalData->metadata->locales);
         }
 
         if ($this->NationalData->hasWiderRegion()) {
@@ -5491,10 +5552,12 @@ final class CalendarHandler extends AbstractHandler
         // the API-wide Latin default, exactly as if no header had been sent. An explicit
         // `locale` parameter, merged in below, still overrides — and is still rejected
         // when the rite has no books for it.
-        // TODO: Future enhancement - narrow this further to the requested national or
-        // diocesan calendar's own declared locales (requires reordering to parse the
-        // calendar param first); those are currently applied as a silent downgrade in
-        // updateSettingsBasedOnDiocesanCalendar().
+        // This is a calendar-agnostic first pass: the requested national or diocesan
+        // calendar is not known yet, so the header is re-negotiated against that
+        // calendar's own declared locales once it loads (#845). The request is kept on
+        // the handler for that second pass — see self::resolveCalendarLocale(), reached
+        // from loadNationalCalendarData() and updateSettingsBasedOnDiocesanCalendar().
+        $this->request = $request;
         if ($request->getHeaderLine('Accept-Language') !== '') {
             $locale = Negotiator::pickLanguage($request, CalendarMetadataProvider::negotiableLocalesForRite($this->rite), null);
             if ($locale && LitLocale::isValid($locale)) {
@@ -5502,19 +5565,28 @@ final class CalendarHandler extends AbstractHandler
             }
         }
 
+        /** @var array<string,scalar|null> $requestParams */
+        $requestParams = [];
         switch ($method) {
             case RequestMethod::GET:
-                /** @var CalendarParamsData $params */
-                $params = array_merge($params, $this->getScalarQueryParams($request));
+                $requestParams = $this->getScalarQueryParams($request);
                 break;
             default:
                 $parsedBodyParams = $this->parseBodyParams($request, false);
 
                 if (null !== $parsedBodyParams) {
-                    /** @var CalendarParamsData $params */
-                    $params = array_merge($params, $parsedBodyParams);
+                    /** @var array<string,scalar|null> $requestParams */
+                    $requestParams = $parsedBodyParams;
                 }
         }
+
+        // Whether the locale about to be applied came from the client's own words or from
+        // the header negotiation above, which decides how it is treated when the requested
+        // calendar turns out not to declare it (#845/#761).
+        $this->localeExplicitlyRequested = array_key_exists('locale', $requestParams);
+
+        /** @var CalendarParamsData $params */
+        $params = array_merge($params, $requestParams);
 
         $this->CalendarParams = new CalendarParams();
         $this->CalendarParams->setAllowedReturnTypes($this->allowedReturnTypes);

--- a/src/Handlers/EventsHandler.php
+++ b/src/Handlers/EventsHandler.php
@@ -69,6 +69,23 @@ final class EventsHandler extends AbstractHandler
     private Rite $rite = Rite::ROMAN;
 
     /**
+     * The request being handled, kept so the locale decision can be re-taken against the
+     * requested calendar's own declared locales once that calendar is known — which happens
+     * well after {@see self::handle()}'s first, calendar-agnostic negotiation. Only the
+     * original `Accept-Language` header carries enough information to do that (#845);
+     * see {@see self::resolveCalendarLocale()}.
+     */
+    private ?ServerRequestInterface $request = null;
+
+    /**
+     * True when this request carried an explicit `locale` parameter (query string or body),
+     * as opposed to having its locale derived from the `Accept-Language` header. The two are
+     * deliberately treated differently (#761): a header states a preference and is
+     * negotiated, a parameter names a dataset and is matched exactly.
+     */
+    private bool $localeExplicitlyRequested = false;
+
+    /**
      * Initializes the EventsHandler.
      *
      * Calls the parent constructor and initializes an empty LiturgicalEventMap
@@ -158,10 +175,9 @@ final class EventsHandler extends AbstractHandler
 
                 $diocesanDataJson   = Utilities::jsonFileToObject($diocesanDataFile);
                 self::$DiocesanData = DiocesanData::fromObject($diocesanDataJson);
-                if (
-                    !in_array($this->EventsParams->Locale, self::$DiocesanData->metadata->locales)
-                ) {
-                    $this->EventsParams->Locale = self::$DiocesanData->metadata->locales[0];
+                $resolvedLocale     = $this->resolveCalendarLocale(self::$DiocesanData->metadata->locales);
+                if ($resolvedLocale !== $this->EventsParams->Locale) {
+                    $this->EventsParams->Locale = $resolvedLocale;
                     $baseLocale                 = \Locale::getPrimaryLanguage($this->EventsParams->Locale);
                     if (null === $baseLocale) {
                         throw new ValidationException(
@@ -214,8 +230,9 @@ final class EventsHandler extends AbstractHandler
         $diocesanDataJson   = Utilities::jsonFileToObject($diocesanDataFile);
         self::$DiocesanData = DiocesanData::fromObject($diocesanDataJson);
 
-        if (false === in_array($this->EventsParams->Locale, self::$DiocesanData->metadata->locales, true)) {
-            $this->EventsParams->Locale = self::$DiocesanData->metadata->locales[0];
+        $resolvedLocale = $this->resolveCalendarLocale(self::$DiocesanData->metadata->locales);
+        if ($resolvedLocale !== $this->EventsParams->Locale) {
+            $this->EventsParams->Locale = $resolvedLocale;
             $baseLocale                 = \Locale::getPrimaryLanguage($this->EventsParams->Locale);
             if (null === $baseLocale) {
                 throw new ValidationException(
@@ -252,10 +269,9 @@ final class EventsHandler extends AbstractHandler
             $nationalDataJson   = Utilities::jsonFileToObject($NationalDataFile);
             self::$NationalData = NationalData::fromObject($nationalDataJson);
 
-            if (
-                !in_array($this->EventsParams->Locale, self::$NationalData->metadata->locales)
-            ) {
-                $this->EventsParams->Locale = self::$NationalData->metadata->locales[0];
+            $resolvedLocale = $this->resolveCalendarLocale(self::$NationalData->metadata->locales);
+            if ($resolvedLocale !== $this->EventsParams->Locale) {
+                $this->EventsParams->Locale = $resolvedLocale;
                 $baseLocale                 = \Locale::getPrimaryLanguage($this->EventsParams->Locale);
                 if (null === $baseLocale) {
                     throw new \RuntimeException(
@@ -298,6 +314,51 @@ final class EventsHandler extends AbstractHandler
                 }
             }
         }
+    }
+
+    /**
+     * The locale to serve for a calendar that declares its own `metadata->locales`.
+     *
+     * Returns the locale already in hand whenever the calendar declares it. Otherwise the
+     * request has asked for something this calendar has no dataset under, and what happens
+     * next depends on *how* it asked (#845, and the #761 asymmetry the negotiation block in
+     * {@see self::handle()} describes):
+     *
+     * - An explicit `locale` **parameter** is an exact selector naming a dataset. Regional
+     *   calendars store their data under regional variants, so `fr` on its own does not name
+     *   one of Canada's; it keeps its historical treatment and lands on the calendar's first
+     *   declared locale.
+     * - An **`Accept-Language` header** is a language *range*, and RFC 4647 §3.3.1 basic
+     *   filtering applies: the range `fr` matches the tag `fr-CA`. The *original header* is
+     *   re-negotiated here — not the tag it was already negotiated down to — because that
+     *   earlier negotiation ran before the calendar was known, against the rite's candidate
+     *   set (empty, i.e. the API-wide set, for the Roman rite), and widening its answer after
+     *   the fact cannot recover the quality ordering or the alternatives it discarded.
+     *
+     * `Negotiator::pickLanguage()` answers null (rather than the fallback) when a non-empty
+     * header matches nothing supported, so the coalesce below is what actually implements
+     * "a range matching nothing the calendar declares lands on `locales[0]`".
+     *
+     * When a range matches several declared locales at equal quality — `fr` against
+     * `['fr_CA', 'fr_FR']` — the negotiator keeps the first candidate to reach the winning
+     * score, so the calendar's declaration order decides, the same order that supplies the
+     * `locales[0]` default. An exact match still outranks any prefix match.
+     *
+     * @param string[] $declaredLocales The calendar's `metadata->locales`, in declaration order.
+     * @return string One of `$declaredLocales`.
+     */
+    private function resolveCalendarLocale(array $declaredLocales): string
+    {
+        if (in_array($this->EventsParams->Locale, $declaredLocales, true)) {
+            return $this->EventsParams->Locale;
+        }
+
+        if ($this->localeExplicitlyRequested || null === $this->request) {
+            return $declaredLocales[0];
+        }
+
+        return Negotiator::pickLanguage($this->request, $declaredLocales, $declaredLocales[0])
+            ?? $declaredLocales[0];
     }
 
     /**
@@ -827,24 +888,38 @@ final class EventsHandler extends AbstractHandler
         // preference degrades to Latin rather than tripping the rejection in
         // EventsParams::validateRiteCompatibility() — see the equivalent block in
         // CalendarHandler::handle() for why headers and explicit params differ (#761).
-        $locale = Negotiator::pickLanguage($request, CalendarMetadataProvider::negotiableLocalesForRite($this->rite), LitLocale::LATIN);
+        // This is a calendar-agnostic first pass: the requested national or diocesan
+        // calendar is not known yet, so the header is re-negotiated against that
+        // calendar's own declared locales once it loads (#845). The request is kept on
+        // the handler for that second pass — see self::resolveCalendarLocale().
+        $this->request = $request;
+        $locale        = Negotiator::pickLanguage($request, CalendarMetadataProvider::negotiableLocalesForRite($this->rite), LitLocale::LATIN);
         if ($locale && LitLocale::isValid($locale)) {
             $params['locale'] = $locale;
         } else {
             $params['locale'] = LitLocale::LATIN;
         }
 
+        /** @var array<string,scalar|null> $requestParams */
+        $requestParams = [];
         if ($method === RequestMethod::GET) {
-            /** @var array{locale?:string,national_calendar?:string,diocesan_calendar?:string,eternal_high_priest?:bool} $params */
-            $params = array_merge($params, $this->getScalarQueryParams($request));
+            $requestParams = $this->getScalarQueryParams($request);
         } elseif ($method === RequestMethod::POST) {
             $parsedBodyParams = $this->parseBodyParams($request, false);
 
             if (null !== $parsedBodyParams) {
-                /** @var array{locale?:string,national_calendar?:string,diocesan_calendar?:string,eternal_high_priest?:bool} $params */
-                $params = array_merge($params, $parsedBodyParams);
+                /** @var array<string,scalar|null> $requestParams */
+                $requestParams = $parsedBodyParams;
             }
         }
+
+        // Whether the locale about to be applied came from the client's own words or from
+        // the header negotiation above, which decides how it is treated when the requested
+        // calendar turns out not to declare it (#845/#761).
+        $this->localeExplicitlyRequested = array_key_exists('locale', $requestParams);
+
+        /** @var array{locale?:string,national_calendar?:string,diocesan_calendar?:string,eternal_high_priest?:bool} $params */
+        $params = array_merge($params, $requestParams);
 
         $this->EventsParams = new EventsParams($params);
         $this->EventsParams->setRite($this->rite);

--- a/src/Services/CalendarMetadataProvider.php
+++ b/src/Services/CalendarMetadataProvider.php
@@ -397,15 +397,23 @@ final class CalendarMetadataProvider
      * its full default list.
      *
      * This *filters* the negotiator's candidate list rather than replacing it with the
-     * bare languages {@see self::localesForRite()} returns, and that distinction is load-
-     * bearing. The rite-level metadata declares `it`/`la`, but the Ambrosian diocesan
-     * layer matches the negotiated locale against its own full identifiers
-     * (`it_IT`/`la_VA`) with a strict `in_array()`, falling back to its first locale on a
-     * miss. Handing the negotiator only bare languages made it answer `la` where it used
-     * to answer `la_VA`, which failed that membership test — so `Accept-Language: la-VA`
-     * on `/events/ambrosian/diocese/milano_it` silently came back in Italian. Narrowing
-     * the *set* of acceptable languages must not narrow the *shape* of the tag returned
-     * for one that is acceptable.
+     * bare languages {@see self::localesForRite()} returns, so that narrowing the *set* of
+     * acceptable languages does not narrow the *shape* of the tag returned for one that is
+     * acceptable: offered only `['it', 'la']`, the negotiator answers `it` for
+     * `Accept-Language: it-IT`, and the rite-level routes would then report a coarser
+     * `settings.locale` than the client asked for (`it` for `/events/ambrosian`, where the
+     * whole candidate list is this one). Keeping the region-qualified tags keeps that
+     * answer faithful to the request.
+     *
+     * This function used to carry a second, heavier responsibility, retired in #845: the
+     * Ambrosian diocesan layer matched the negotiated locale against its own full
+     * identifiers (`it_IT`/`la_VA`) with a strict `in_array()` and fell back to its first
+     * locale on a miss, so the shape of the tag produced *here* decided whether a request
+     * for Latin came back in Latin or silently in Italian one layer down. That layer now
+     * re-negotiates the original `Accept-Language` header against its own declared locales
+     * instead of string-comparing an already-negotiated tag, so it no longer depends on
+     * anything this function does — `Accept-Language: la` reaches `la_VA` there even though
+     * the tag negotiated here is the bare `la`.
      *
      * @return string[]
      */


### PR DESCRIPTION
Closes #845.

`Accept-Language: fr` on `GET /events/nation/CA` returned **`en_CA`**, although Canada declares `["en_CA", "fr_CA"]`. Under RFC 4647 §3.3.1 basic filtering the range `fr` matches the tag `fr-CA`, so a French-speaking client was getting English with a 200 and no indication anything had been refused. `/calendar` behaved identically.

**Scope:** this is the `Accept-Language` **header**, not the `?locale=` query parameter. An explicit `?locale=fr` demanding an exact dataset identifier remains intended behaviour and is unchanged.

## No new negotiator was needed

`Negotiator::pickLanguage()` already implements the required semantics. The bug was **ordering and candidate set**:

1. `EventsHandler::handle():830` negotiated the header against the *rite's* candidate set. For the Roman rite that is `[]`, which `pickLanguage()` reads as "use my full default list" — so `fr` matched against every ICU locale, where `fr` is a tag in its own right, and exact-beats-prefix correctly returned `fr`. The requested calendar was not yet known.
2. After the calendar JSON loaded, `EventsHandler:161-164`/`:217`/`:255-258` and `CalendarHandler:457-458`/`:3494-3495` did `in_array($locale, $data->metadata->locales)` and fell back to `locales[0]`.

So the right matching ran against the wrong candidate set, and the right candidate set was applied with the wrong matching. `CalendarHandler:5494` carried a TODO asking for exactly this fix; it is now removed.

Both handlers retain the `ServerRequestInterface` and call a new `resolveCalendarLocale(array $declaredLocales)` at each filter site, **re-negotiating the original header** against the calendar's declared locales — re-negotiated rather than widened, because the first pass has already discarded the quality ordering and the alternatives.

## One deviation from the issue's proposed one-liner, and it matters

The issue suggested `pickLanguage($request, $locales, $locales[0])`. But `pickLanguage()` returns **`null`, not `$fallback`**, when a *non-empty* header matches nothing supported — the fallback argument only covers an *absent* header. Applying that literally would have turned `Accept-Language: nl` on an Ambrosian diocese from `la_VA` into `it_IT`, silently reversing #761's "an unacceptable header degrades to Latin".

So the helper only fires when the locale in hand is **not** declared — exactly where the old code discarded it anyway — and coalesces `?? $declaredLocales[0]`. A locale the calendar declares is left untouched. This is pinned as a test data row.

## Header vs. explicit parameter

`localeExplicitlyRequested` is set from `array_key_exists('locale', $requestParams)` (query for GET, parsed body for POST) before the merge. Explicit params take the unchanged exact-match + `locales[0]` branch. Asserted by `testExplicitLocaleParamIsNotWidenedToARegionalVariant` (`?locale=fr` → `en_CA` on both endpoints) and `testExplicitLocaleParamOverridesTheHeader`.

## `negotiableLocalesForRite()` kept, its warning retired

The dependency its docblock recorded is genuinely gone — the diocesan layer no longer string-compares an already-negotiated tag, and `Accept-Language: la` now reaches `la_VA` even though the rite-level pass answers bare `la`.

But its region-qualified shape remains load-bearing for an **independent** reason, verified empirically: that list is the *entire* candidate set on the rite-level routes, so returning bare `['it','la']` makes `pickLanguage` answer `it` for `it-IT` and `la` for `la-VA`, changing `settings.locale` on `/events/ambrosian` and breaking `AmbrosianLocaleEnforcementTest`. Simplifying it would be an observable contract change, so it was not simplified. Stale justifications in `CalendarMetadataProviderTest` and `AmbrosianLocaleEnforcementTest` are updated.

## Ambiguity rule, established empirically and now asserted

`fr` against `['fr_CA','fr_FR']` → `fr_CA`; against `['fr_FR','fr_CA']` → `fr_FR`. Every candidate scores identically and `pickLanguage` replaces its running best only on a *strictly* greater score, so **the calendar's declaration order wins** — the same order that supplies the `locales[0]` default. Exact still beats prefix either way: `fr` against `['fr_CA','fr']` → `fr`.

## Tests

`phpunit_tests/Handlers/CalendarScopedLocaleNegotiationTest.php`, 34 cases. Pre-fix **7 failures**: `fr` → `en_CA` instead of `fr_CA` on both endpoints (including `fr-FR,fr;q=0.9`), and `la` → `it_IT` instead of `la_VA` on `/events/ambrosian/diocese/milano_it`. Post-fix `OK (34 tests, 108 assertions)`; full `--filter Locale` `OK (205 tests, 2649 assertions)`.

In-process handler tests deliberately, not `Routes/*` — those hit `:8000`, which serves the main checkout, so a green there would say nothing about this branch.

## Verification

- `composer lint` clean; `composer analyse` (PHPStan level 10) `[OK] No errors`
- `composer test:quick`: baseline `Tests: 2973` → `Tests: 3007`

One unrelated failure appears in full runs (`Handlers/Auth/NotificationsHandlerTest`). Confirmed environmental: it fails **3/3 on pristine `development`** and passes intermittently on this branch — shared-Postgres contention while several branches were being tested concurrently. Nothing here touches DB, auth or notifications.

## Out of scope

Refuse-vs-substitute for a valid-but-unavailable explicit locale (`?locale=de_DE` → 200 `en_CA` while `?locale=zz_ZZ` → 400) is unchanged: the explicit-parameter branch is behaviourally identical to before, so both outcomes stand as #845 describes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar and event locales now negotiate `Accept-Language` headers against the locales available for the selected national or diocesan calendar.
  * Supports language-range matching, quality preferences, wildcards and sensible fallback behaviour.
  * Explicit `locale` parameters take precedence over request headers and fall back to the calendar’s first declared locale when unmatched.
  * Ambiguous language ranges resolve consistently using the first declared matching locale.

* **Tests**
  * Added comprehensive coverage for national, diocesan and Ambrosian locale negotiation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->