### PR TITLE
docs(openapi): document the /data i18n sub-resource and locale parameter (#838, #839)

### DIFF
--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -7471,6 +7471,552 @@
         }
       }
     },
+    "/data/nation/{key}/{i18n_locale}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a national calendar",
+        "description": "Retrieve the stored translations of a national calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/nation/{key}`, which the path hangs off: that returns the calendar definition, this returns the translation file behind it.\n\nOnly `GET` and `POST` exist at this depth. `RegionalDataHandler::validateRequestPath()` accepts two or three path segments for those two methods and exactly two for the others, and the router narrows the allowed methods to `GET` and `POST` for any three-segment `/data` path, so a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). `POST` is a read alias of `GET`.\n\nThe third segment binds to `i18nRequest`. It is not the `locale` parameter that `/data/nation/{key}` accepts, and the two are documented separately for that reason.\n\nAn unknown nation is refused with `422 Unprocessable Content`; a nation that exists but has no translation file for the requested locale gives `404 Not Found`. `/data/roman/nation/{key}/{i18n_locale}` states the same rite explicitly and is the canonical form of this path.",
+        "operationId": "nationalDataI18nGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/Nation"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a national calendar",
+        "description": "Read alias of `GET /data/nation/{key}/{i18n_locale}`, returning the same translation map. See that operation for how the third path segment differs from the `locale` parameter.",
+        "operationId": "nationalDataI18nPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/Nation"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      }
+    },
+    "/data/roman/nation/{key}/{i18n_locale}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a national calendar",
+        "description": "This is the canonical form of this route: the rite is stated explicitly. The bare `/data/nation/{key}/{i18n_locale}` form is equivalent and resolves here.\n\nRetrieve the stored translations of a national calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/roman/nation/{key}`, which returns the calendar definition itself.\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request`. The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path.\n\nOnly the diocesan tier exists under more than one rite, so there is no `/data/ambrosian/nation/{key}/{i18n_locale}`.",
+        "operationId": "romanNationalDataI18nGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/Nation"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a national calendar",
+        "description": "Read alias of `GET /data/roman/nation/{key}/{i18n_locale}`, returning the same translation map.",
+        "operationId": "romanNationalDataI18nPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/Nation"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      }
+    },
+    "/data/diocese/{key}/{i18n_locale}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a diocesan calendar",
+        "description": "Retrieve the stored translations of a diocesan calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/diocese/{key}`, which returns the calendar definition itself.\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path.\n\nThis path resolves to the Roman rite. An unknown diocese, or a diocese defined under another rite, is refused with `422 Unprocessable Content` (`Diocesan calendar ... belongs to the ambrosian rite, not the requested roman rite.`); such a diocese must be addressed through `/data/ambrosian/diocese/{key}/{i18n_locale}`. A diocese that exists but has no translation file for the requested locale gives `404 Not Found`. `/data/roman/diocese/{key}/{i18n_locale}` states the same rite explicitly and is the canonical form of this path.",
+        "operationId": "diocesanDataI18nGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a diocesan calendar",
+        "description": "Read alias of `GET /data/diocese/{key}/{i18n_locale}`, returning the same translation map. This path resolves to the Roman rite; a diocese defined under another rite is refused with `422 Unprocessable Content`.",
+        "operationId": "diocesanDataI18nPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      }
+    },
+    "/data/roman/diocese/{key}/{i18n_locale}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a diocesan calendar",
+        "description": "This is the canonical form of this route: the rite is stated explicitly, symmetric with `/data/ambrosian/diocese/{key}/{i18n_locale}`. The bare `/data/diocese/{key}/{i18n_locale}` form is equivalent and resolves here.\n\nRetrieve the stored translations of a diocesan calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/roman/diocese/{key}`, which returns the calendar definition itself.\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request`. The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path. A diocese defined under another rite is refused with `422 Unprocessable Content`.",
+        "operationId": "romanDiocesanDataI18nGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a diocesan calendar",
+        "description": "Read alias of `GET /data/roman/diocese/{key}/{i18n_locale}`, returning the same translation map.",
+        "operationId": "romanDiocesanDataI18nPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      }
+    },
+    "/data/widerregion/{key}/{i18n_locale}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a wider region calendar",
+        "description": "Retrieve the stored translations of a wider region calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/widerregion/{key}`, which returns the calendar definition itself.\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path.\n\nAn unknown wider region is refused with `422 Unprocessable Content`; a wider region that exists but has no translation file for the requested locale gives `404 Not Found`. `/data/roman/widerregion/{key}/{i18n_locale}` states the same rite explicitly and is the canonical form of this path.",
+        "operationId": "widerregionDataI18nGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a wider region calendar",
+        "description": "Read alias of `GET /data/widerregion/{key}/{i18n_locale}`, returning the same translation map.",
+        "operationId": "widerregionDataI18nPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      }
+    },
+    "/data/roman/widerregion/{key}/{i18n_locale}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a wider region calendar",
+        "description": "This is the canonical form of this route: the rite is stated explicitly. The bare `/data/widerregion/{key}/{i18n_locale}` form is equivalent and resolves here.\n\nRetrieve the stored translations of a wider region calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/roman/widerregion/{key}`, which returns the calendar definition itself.\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request`. The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path.\n\nWider regions are a layer over national calendars, which exist only in the Roman rite, so there is no `/data/ambrosian/widerregion/{key}/{i18n_locale}`.",
+        "operationId": "romanWiderregionDataI18nGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of a wider region calendar",
+        "description": "Read alias of `GET /data/roman/widerregion/{key}/{i18n_locale}`, returning the same translation map.",
+        "operationId": "romanWiderregionDataI18nPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/WiderRegionNames"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      }
+    },
+    "/data/ambrosian/diocese/{key}/{i18n_locale}": {
+      "get": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of an Ambrosian diocesan calendar",
+        "description": "Retrieve the stored translations of an Ambrosian diocesan calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/ambrosian/diocese/{key}`, which returns the calendar definition itself.\n\n**The `ambrosian` rite segment is required here, not decorative.** The bare `/data/diocese/{key}/{i18n_locale}` form resolves to the Roman rite, so addressing an Ambrosian diocese through it returns `422 Unprocessable Content`; the same `422` is returned on this path for a diocese that is not Ambrosian. The Ambrosian dioceses are Milano (`milano_it`), Bergamo (`bergam_it`), Novara (`novara_it`) and Lugano (`lugano_ch`).\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path.\n\nThe Ambrosian rite has approved liturgical books only in Italian and Latin, so these dioceses store translation files for `it_IT` and `la_VA` only; any other locale gives `404 Not Found`.",
+        "operationId": "ambrosianDiocesanDataI18nGET",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Calendar Source Data"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve the stored translations of an Ambrosian diocesan calendar",
+        "description": "Read alias of `GET /data/ambrosian/diocese/{key}/{i18n_locale}`, returning the same translation map. The `ambrosian` rite segment is required: a diocese that is not Ambrosian is refused with `422 Unprocessable Content`.",
+        "operationId": "ambrosianDiocesanDataI18nPOST",
+        "parameters": [
+          {
+            "name": "key",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataI18nLocalePathParam"
+          }
+        ],
+        "responses": {
+          "200": {
+            "$ref": "#/components/responses/RegionalDataI18n200"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
+          }
+        }
+      }
+    },
     "/easter": {
       "get": {
         "tags": [
@@ -11961,6 +12507,15 @@
           "minimum": 0,
           "default": 0
         }
+      },
+      "RegionalDataI18nLocalePathParam": {
+        "in": "path",
+        "name": "i18n_locale",
+        "required": true,
+        "description": "Names the stored translation file to return, normally one of the locales the addressed calendar declares in its `metadata.locales` (mirrored by `/calendars`). A locale for which the calendar has no file is answered with `404 Not Found` rather than by falling back to another language.\n\nThe segment is spelled `i18n_locale` rather than `locale` deliberately. `RegionalDataHandler` binds this third path segment to `i18nRequest`, which selects a different resource, and not to the `locale` parameter that the two-segment `/data` paths accept to choose the language of a calendar definition. The two are independent: a `locale` supplied alongside this segment is still validated, and can still be refused with `400 Bad Request`, but it has no effect on the response.",
+        "schema": {
+          "$ref": "./CommonDef.json#/definitions/Locale"
+        }
       }
     },
     "examples": {
@@ -12435,6 +12990,20 @@
               "required": [
                 "success"
               ]
+            }
+          }
+        }
+      },
+      "RegionalDataI18n200": {
+        "description": "OK: the stored translation map for the requested calendar and locale.\n\nThis is a different payload shape from the calendar definition that the two-segment path returns. It is a flat object whose keys are the `event_key` identifiers of that calendar's own liturgical events and whose values are the translated names, served verbatim from the calendar's `i18n/{i18n_locale}.json` source file. Only the events the calendar itself defines appear here: events inherited from the General Roman Calendar, or from a wider region, are translated elsewhere.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "./LitCalTranslation.json"
+            },
+            "example": {
+              "StCatherineSiena": "Santa Caterina da Siena, vergine e dottore della Chiesa, patrona d'Italia",
+              "StFrancisAssisi": "San Francesco d'Assisi, patrono d'Italia"
             }
           }
         }

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -5475,6 +5475,12 @@
         "operationId": "nationalDataGET",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataLocaleQueryParam"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -5499,6 +5505,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -5596,6 +5605,9 @@
         "operationId": "nationalDataPOST",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -5604,6 +5616,21 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
@@ -5620,6 +5647,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -5639,6 +5669,9 @@
         "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.",
         "operationId": "nationalDataPATCH",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
           {
             "name": "key",
             "in": "path",
@@ -5760,6 +5793,12 @@
         "operationId": "romanNationalDataGET",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataLocaleQueryParam"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -5784,6 +5823,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -5881,6 +5923,9 @@
         "operationId": "romanNationalDataPOST",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -5889,6 +5934,21 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
@@ -5905,6 +5965,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -5924,6 +5987,9 @@
         "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.\n\nThis is the canonical, explicit-rite form of `/data/nation/{key}`.",
         "operationId": "romanNationalDataPATCH",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
           {
             "name": "key",
             "in": "path",
@@ -6044,6 +6110,12 @@
         "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` states the same rite explicitly and is the canonical form of this path.",
         "operationId": "diocesanDataGET",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataLocaleQueryParam"
+          },
           {
             "name": "key",
             "in": "path",
@@ -6170,6 +6242,9 @@
         "operationId": "diocesanDataPOST",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -6178,6 +6253,21 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
@@ -6216,6 +6306,9 @@
         "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.",
         "operationId": "diocesanDataPATCH",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
           {
             "name": "key",
             "in": "path",
@@ -6337,6 +6430,12 @@
         "description": "This is the canonical form of this route: the rite is stated explicitly, symmetric with `/data/ambrosian/diocese/{key}`. The bare `/data/diocese/{key}` form is equivalent and resolves here. A diocese defined under another rite must be addressed through its own rite-qualified path; asking for one here returns `422 Unprocessable Content`.",
         "operationId": "romanDiocesanDataGET",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataLocaleQueryParam"
+          },
           {
             "name": "key",
             "in": "path",
@@ -6463,6 +6562,9 @@
         "operationId": "romanDiocesanDataPOST",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -6471,6 +6573,21 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
@@ -6509,6 +6626,9 @@
         "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.\n\nThis is the canonical, explicit-rite form of `/data/diocese/{key}`.",
         "operationId": "romanDiocesanDataPATCH",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
           {
             "name": "key",
             "in": "path",
@@ -6631,6 +6751,12 @@
         "operationId": "widerregionDataGET",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataLocaleQueryParam"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -6655,6 +6781,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -6752,6 +6881,9 @@
         "operationId": "widerregionDataPOST",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -6760,6 +6892,21 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
@@ -6776,6 +6923,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -6795,6 +6945,9 @@
         "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.",
         "operationId": "widerregionDataPATCH",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
           {
             "name": "key",
             "in": "path",
@@ -6914,6 +7067,12 @@
         "operationId": "romanWiderregionDataGET",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataLocaleQueryParam"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -6938,6 +7097,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -7035,6 +7197,9 @@
         "operationId": "romanWiderregionDataPOST",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -7043,6 +7208,21 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
@@ -7059,6 +7239,9 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity422"
           }
         }
       },
@@ -7078,6 +7261,9 @@
         "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.\n\nThis is the canonical, explicit-rite form of `/data/widerregion/{key}`.",
         "operationId": "romanWiderregionDataPATCH",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
           {
             "name": "key",
             "in": "path",
@@ -7196,6 +7382,12 @@
         "description": "Retrieve the source definition of a diocesan calendar defined under the Ambrosian rite.\n\n**The `ambrosian` rite segment is required here, not decorative.** The bare `/data/diocese/{key}` form resolves to the Roman rite, so addressing an Ambrosian diocese through it returns `422 Unprocessable Content` (`Diocesan calendar ... belongs to the ambrosian rite, not the requested roman rite.`); the same `422` is returned on this path for a diocese that is not Ambrosian. The Ambrosian dioceses are Milano (`milano_it`), Bergamo (`bergam_it`), Novara (`novara_it`) and Lugano (`lugano_ch`) \u2014 every other diocese is Roman. On any `/data` path `roman` is accepted as an explicit synonym of the bare form.\n\nOnly the diocesan tier exists under more than one rite, so there is deliberately no `/data/ambrosian/nation/{key}` and no `/data/ambrosian/widerregion/{key}`: the Ambrosian rite is proper to the Archdiocese of Milan and a handful of neighbouring dioceses rather than to any nation or region, and the source tree has no Ambrosian national or wider-region partition to read or write. Either of those requests returns `400 Bad Request`.\n\nUnlike `/calendar` and `/events`, `/data` advertises no canonical URL: the bare form returns no RFC 6596 `Link: <...>; rel=\"canonical\"` response header.\n\nThe Ambrosian rite has approved liturgical books only in Italian and Latin, so `diocesan_calendars[].locales` on `/calendars` declares `it_IT` and `la_VA` for these dioceses; a `locale` naming any other language returns `422 Unprocessable Content`.",
         "operationId": "ambrosianDiocesanDataGET",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "$ref": "#/components/parameters/RegionalDataLocaleQueryParam"
+          },
           {
             "name": "key",
             "in": "path",
@@ -7319,6 +7511,9 @@
         "operationId": "ambrosianDiocesanDataPOST",
         "parameters": [
           {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
             "name": "key",
             "in": "path",
             "required": true,
@@ -7327,6 +7522,21 @@
             }
           }
         ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegionalDataRequestBody"
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
@@ -7365,6 +7575,9 @@
         "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.\n\nThe method surface is identical to `/data/diocese/{key}`: the `ambrosian` segment only selects which rite partition of the source tree is written. It is required for an Ambrosian diocese \u2014 see `GET /data/ambrosian/diocese/{key}` for the full rite grammar and for why no rite-qualified national or wider-region path exists.",
         "operationId": "ambrosianDiocesanDataPATCH",
         "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
           {
             "name": "key",
             "in": "path",
@@ -10212,6 +10425,16 @@
           }
         }
       },
+      "RegionalDataRequestBody": {
+        "type": "object",
+        "title": "Calendar source data request body",
+        "description": "The `/data` POST operations are read aliases of the corresponding GET, but they read their parameters from the request body rather than from the query string: `RegionalDataHandler` merges `parseBodyParams()` into the parameter array for POST and `getScalarQueryParams()` for GET, never both. A `locale` supplied in the query string of a POST is therefore ignored, and the operation falls back to whatever the `Accept-Language` header negotiated. The same set of locales is accepted as on GET, and refused the same way; see the `locale` query parameter of the GET operation.",
+        "properties": {
+          "locale": {
+            "$ref": "./CommonDef.json#/definitions/Locale"
+          }
+        }
+      },
       "CivilOrLiturgicalYear": {
         "type": "object",
         "title": "Liturgical or Civil year",
@@ -12506,6 +12729,25 @@
           "type": "integer",
           "minimum": 0,
           "default": 0
+        }
+      },
+      "RegionalDataLocaleQueryParam": {
+        "in": "query",
+        "name": "locale",
+        "required": false,
+        "description": "Selects the language of the `name` of every liturgical event in the returned calendar definition, overriding the `Accept-Language` header.\n\nWhere the value is read from depends on the method. GET reads it from the query string. POST reads it from the request body instead (see that operation's `requestBody`) and ignores a query string `locale`, because `RegionalDataHandler` merges `getScalarQueryParams()` for GET and `parseBodyParams()` for POST, never both. PUT, PATCH and DELETE accept no `locale` parameter at all: PATCH still resolves one, but only from `Accept-Language`, so a PATCH that sends no such header is negotiated to `la_VA` and refused with `422 Unprocessable Content` by any calendar that does not declare Latin, while PUT and DELETE ignore the locale entirely.\n\nValidation happens in two stages. `RegionalDataParams::setParams()` canonicalises the value and refuses anything that is not a locale this server ships, with `400 Bad Request`. A well-formed locale that the addressed calendar does not itself declare, per the `locales` of its entry on `/calendars`, is then refused with `422 Unprocessable Content`. That second set is data-driven and cannot be enumerated here: `IT` declares only `it_IT`, and the Ambrosian dioceses only `it_IT` and `la_VA`.\n\nThis is not the `{i18n_locale}` path segment of `/data/.../{key}/{i18n_locale}`. That segment addresses a different resource, the stored translation map, and binds to a different internal parameter (`i18nRequest`); supplied alongside it, this parameter is still validated, and can still produce the `400` above, but has no effect on the response.",
+        "schema": {
+          "$ref": "./CommonDef.json#/definitions/Locale"
+        },
+        "examples": {
+          "italian": {
+            "value": "it_IT",
+            "summary": "Italian (Italy)"
+          },
+          "latin": {
+            "value": "la_VA",
+            "summary": "Latin (Vatican)"
+          }
         }
       },
       "RegionalDataI18nLocalePathParam": {

--- a/phpunit_tests/Schemas/OpenApiDataI18nSubResourceTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataI18nSubResourceTest.php
@@ -129,6 +129,20 @@ final class OpenApiDataI18nSubResourceTest extends TestCase
         $paths = self::paths();
 
         if ($rite === Rite::default()) {
+            // Gated exactly as the non-default branch below is. Every current PathCategory is accepted
+            // under the default rite, so this changes nothing today — but a category the default rite
+            // refused would otherwise have its documentation *demanded* here, which is the inverse of
+            // what this test claims to check.
+            if (false === self::combinationIsAccepted($rite, $category)) {
+                self::assertArrayNotHasKey(
+                    "/data/{$category->value}/{key}/{i18n_locale}",
+                    $paths,
+                    "openapi.json documents a {$category->value} i18n sub-resource that the default rite refuses"
+                );
+
+                return;
+            }
+
             self::assertArrayHasKey(
                 "/data/{$category->value}/{key}/{i18n_locale}",
                 $paths,
@@ -212,7 +226,12 @@ final class OpenApiDataI18nSubResourceTest extends TestCase
     {
         $accepted = self::thirdSegmentIsAcceptedFor(strtoupper($method));
 
-        foreach (self::i18nPathKeys() as $path) {
+        // Without this the loop body never runs if the sub-resource paths are ever removed, and the
+        // test passes having asserted nothing — the precise regression it exists to catch.
+        $i18nPaths = self::i18nPathKeys();
+        self::assertNotEmpty($i18nPaths, 'openapi.json documents no {i18n_locale} sub-resource path at all');
+
+        foreach ($i18nPaths as $path) {
             /** @var array<string,mixed> $pathItem */
             $pathItem = self::paths()[$path];
 
@@ -297,9 +316,18 @@ final class OpenApiDataI18nSubResourceTest extends TestCase
         $payload = json_decode($contents, false, 512, JSON_THROW_ON_ERROR);
 
         $schema = Schema::import(LitSchema::I18N->path());
-        $schema->in($payload);
-
         self::assertIsObject($payload, 'the translation map is a JSON object of event_key to translated name');
+
+        // The validation is the claim; asserting only that json_decode returned an object would be
+        // near-tautological and would report success even when the schema rejected the payload.
+        try {
+            $schema->in($payload);
+        } catch (\Throwable $invalid) {
+            self::fail(
+                'a stored translation file does not validate against the documented response schema: '
+                . $invalid->getMessage()
+            );
+        }
     }
 
     /**

--- a/phpunit_tests/Schemas/OpenApiDataI18nSubResourceTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataI18nSubResourceTest.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\PathCategory;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Params\RegionalDataParams;
+use LiturgicalCalendar\Api\Router;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * `/data/{category}/{key}/{i18n_locale}` is a working sub-resource that returns a *different*
+ * payload shape from the two-segment path it hangs off: `RegionalDataHandler` binds the third
+ * path segment to `i18nRequest` and answers with the stored translation map rather than with a
+ * calendar definition. openapi.json documented none of it (#838), so a client reading the
+ * contract could not discover the resource, and could not learn what it returns.
+ *
+ * Everything here is asserted against the handler and its parameter object rather than against a
+ * second hardcoded list, so the document cannot quietly drift away from the routing grammar:
+ *
+ * - which tiers the sub-resource exists on comes from {@see RegionalDataParams::validateRiteCompatibility()},
+ *   exactly as {@see OpenApiDataRiteSegmentTest} derives the two-segment matrix;
+ * - which methods it exists for comes from `RegionalDataHandler::validateRequestPath()`, the same
+ *   guard the running API applies before any file path is built;
+ * - what it returns comes from {@see LitSchema::I18N}, the schema the API itself validates stored
+ *   translation files against.
+ *
+ * The `{i18n_locale}` path segment is deliberately *not* spelled `{locale}`: the `locale` parameter
+ * of the two-segment paths (#839) is a different thing, and a contract that gave them one name
+ * would be worse than one that documented neither.
+ */
+final class OpenApiDataI18nSubResourceTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private static array $openapi;
+
+    public static function setUpBeforeClass(): void
+    {
+        // Required for JsonData::path() and LitSchema::path() to resolve.
+        Router::getApiPaths();
+    }
+
+    /**
+     * The parsed document. Loaded lazily rather than in `setUpBeforeClass()` because the data
+     * providers below derive their cases from it, and PHPUnit resolves providers first.
+     *
+     * @return array<string,mixed>
+     */
+    private static function openapi(): array
+    {
+        if (false === isset(self::$openapi)) {
+            $raw = file_get_contents(dirname(__DIR__, 2) . '/jsondata/schemas/openapi.json');
+
+            if (false === is_string($raw)) {
+                throw new \RuntimeException('Could not read openapi.json');
+            }
+
+            /** @var array<string,mixed> $decoded */
+            $decoded       = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            self::$openapi = $decoded;
+        }
+
+        return self::$openapi;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private static function paths(): array
+    {
+        /** @var array<string,array<string,mixed>> $paths */
+        $paths = self::openapi()['paths'];
+
+        return $paths;
+    }
+
+    /**
+     * Whether the handler's parameter object accepts this rite for this tier. Same check the
+     * running API performs, and the same one the two-segment matrix is asserted against.
+     */
+    private static function combinationIsAccepted(Rite $rite, PathCategory $category): bool
+    {
+        try {
+            new RegionalDataParams([
+                'category' => $category,
+                'key'      => 'milano_it',
+                'rite'     => $rite,
+            ]);
+        } catch (ValidationException) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string,array{0:Rite,1:PathCategory}>
+     */
+    public static function riteAndCategoryCombinations(): array
+    {
+        $combinations = [];
+
+        foreach (Rite::cases() as $rite) {
+            foreach (PathCategory::cases() as $category) {
+                $combinations[$rite->value . ' / ' . $category->value] = [$rite, $category];
+            }
+        }
+
+        return $combinations;
+    }
+
+    /**
+     * The sub-resource hangs off every `/data` tier the API accepts, and off no other: the rite
+     * segment narrows which tiers exist, not which sub-resources they carry. A documented path
+     * the API refuses is a lie a generated client will act on; an undocumented one is #838.
+     */
+    #[DataProvider('riteAndCategoryCombinations')]
+    public function testTheI18nSubResourceIsDocumentedExactlyWhereItsTierExists(Rite $rite, PathCategory $category): void
+    {
+        $paths = self::paths();
+
+        if ($rite === Rite::default()) {
+            self::assertArrayHasKey(
+                "/data/{$category->value}/{key}/{i18n_locale}",
+                $paths,
+                "the bare {$category->value} tier accepts a third path segment but openapi.json does not document it"
+            );
+
+            self::assertArrayHasKey(
+                "/data/{$rite->value}/{$category->value}/{key}/{i18n_locale}",
+                $paths,
+                'the canonical explicit-rite form must be documented alongside the bare form, as the two-segment paths are'
+            );
+
+            return;
+        }
+
+        $path = "/data/{$rite->value}/{$category->value}/{key}/{i18n_locale}";
+
+        if (self::combinationIsAccepted($rite, $category)) {
+            self::assertArrayHasKey(
+                $path,
+                $paths,
+                "the API accepts {$path} but openapi.json does not document it"
+            );
+        } else {
+            self::assertArrayNotHasKey(
+                $path,
+                $paths,
+                "openapi.json documents {$path}, which the API refuses with 400 Bad Request"
+            );
+        }
+    }
+
+    /**
+     * Whether `RegionalDataHandler` tolerates a three-segment `/data` path for this method. This
+     * is `validateRequestPath()`, the first thing the handler does with a request and the guard
+     * that decides whether the third segment is a sub-resource address or a malformed request.
+     */
+    private static function thirdSegmentIsAcceptedFor(string $method): bool
+    {
+        $pathParams = ['diocese', 'romamo_it', 'it_IT'];
+        $handler    = new RegionalDataHandler($pathParams);
+        $request    = new ServerRequest($method, '/data/' . implode('/', $pathParams));
+
+        $validate = new \ReflectionMethod(RegionalDataHandler::class, 'validateRequestPath');
+
+        try {
+            $validate->invoke($handler, $request);
+        } catch (ValidationException) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string,array{0:string}>
+     */
+    public static function requestMethods(): array
+    {
+        $methods = [];
+
+        foreach (['get', 'post', 'put', 'patch', 'delete'] as $method) {
+            $methods[strtoupper($method)] = [$method];
+        }
+
+        return $methods;
+    }
+
+    /**
+     * The sub-resource exists for `GET` and `POST` only. `validateRequestPath()` allows two or
+     * three path segments for those and exactly two for the write methods, so a `PUT`, `PATCH` or
+     * `DELETE` carrying a third segment never reaches the resource at all: it is refused with
+     * `400 Bad Request` before authorization is even considered on the path count alone.
+     *
+     * #838 asked for this to be established rather than assumed, so it is asserted against the
+     * guard instead of being restated: wiring a write method for three segments fails here until
+     * the contract documents it.
+     */
+    #[DataProvider('requestMethods')]
+    public function testOnlyTheMethodsThatAcceptAThirdSegmentAreDocumented(string $method): void
+    {
+        $accepted = self::thirdSegmentIsAcceptedFor(strtoupper($method));
+
+        foreach (self::i18nPathKeys() as $path) {
+            /** @var array<string,mixed> $pathItem */
+            $pathItem = self::paths()[$path];
+
+            if ($accepted) {
+                self::assertArrayHasKey(
+                    $method,
+                    $pathItem,
+                    strtoupper($method) . " {$path} is accepted by the handler but is not documented"
+                );
+            } else {
+                self::assertArrayNotHasKey(
+                    $method,
+                    $pathItem,
+                    'openapi.json documents ' . strtoupper($method) . " {$path}, which the handler refuses with 400 Bad Request on the path segment count"
+                );
+            }
+        }
+    }
+
+    /**
+     * The whole point of #838 is that this sub-resource does not return a calendar. Its `200` must
+     * therefore name the schema the API itself validates stored translation files against, and not
+     * one of the calendar schemas the two-segment paths return.
+     *
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function i18nOperations(): array
+    {
+        $operations = [];
+
+        foreach (self::i18nPathKeys() as $path) {
+            foreach (['get', 'post'] as $method) {
+                $operations[strtoupper($method) . ' ' . $path] = [$path, $method];
+            }
+        }
+
+        return $operations;
+    }
+
+    #[DataProvider('i18nOperations')]
+    public function testTheTranslationMapIsDocumentedWithTheStoredTranslationSchema(string $path, string $method): void
+    {
+        /** @var array<string,array<string,mixed>> $pathItem */
+        $pathItem = self::paths()[$path];
+        self::assertArrayHasKey($method, $pathItem);
+
+        /** @var array<string,mixed> $responses */
+        $responses = $pathItem[$method]['responses'];
+        self::assertArrayHasKey('200', $responses, strtoupper($method) . " {$path} must document a success response");
+
+        $ref = self::resolveResponseSchemaRef($responses['200']);
+
+        self::assertNotNull(
+            $ref,
+            strtoupper($method) . " {$path} must name a response schema for the translation map"
+        );
+        self::assertStringEndsWith(
+            LitSchema::I18N->value,
+            $ref,
+            strtoupper($method) . " {$path} must return the stored translation schema (" . LitSchema::I18N->value . '), not a calendar schema'
+        );
+    }
+
+    /**
+     * The documented response schema has to actually describe what the handler serves.
+     * `getI18nData()` streams the stored `i18n/{locale}.json` file back verbatim, so a real one of
+     * those files is the response body, and validating it against the schema the contract names
+     * closes the loop between the two.
+     */
+    public function testAStoredTranslationFileValidatesAgainstTheDocumentedResponseSchema(): void
+    {
+        $file = strtr(JsonData::NATIONAL_CALENDAR_I18N_FILE->path(), [
+            '{nation}' => 'IT',
+            '{locale}' => 'it_IT',
+        ]);
+
+        self::assertFileExists($file, 'the fixture this assertion is built on has moved');
+
+        $contents = file_get_contents($file);
+        self::assertIsString($contents);
+
+        $payload = json_decode($contents, false, 512, JSON_THROW_ON_ERROR);
+
+        $schema = Schema::import(LitSchema::I18N->path());
+        $schema->in($payload);
+
+        self::assertIsObject($payload, 'the translation map is a JSON object of event_key to translated name');
+    }
+
+    /**
+     * `i18n` and `locale` must stay two names for two things. The third path segment binds to
+     * `i18nRequest` and selects a stored file; the `locale` parameter of the two-segment paths
+     * (#839) selects the language of a calendar definition and has no effect here. Spelling the
+     * segment `{locale}` would collapse the distinction that both issues insist on, and would put
+     * two differently-behaving parameters called `locale` on one operation.
+     */
+    #[DataProvider('i18nOperations')]
+    public function testTheI18nSegmentIsNotSpelledLikeTheLocaleParameter(string $path, string $method): void
+    {
+        self::assertStringContainsString('{i18n_locale}', $path);
+
+        /** @var array<string,array<string,mixed>> $pathItem */
+        $pathItem = self::paths()[$path];
+
+        /** @var list<array<string,mixed>> $parameters */
+        $parameters = $pathItem[$method]['parameters'];
+
+        foreach ($parameters as $parameter) {
+            $name = $parameter['name'] ?? self::componentParameterName($parameter);
+
+            self::assertNotSame(
+                'locale',
+                $name,
+                strtoupper($method) . " {$path} declares a parameter named `locale`; the sub-resource segment binds to i18nRequest and the two must not share a name"
+            );
+        }
+    }
+
+    /**
+     * The i18n sub-resource paths documented in openapi.json.
+     *
+     * @return list<string>
+     */
+    private static function i18nPathKeys(): array
+    {
+        return array_values(array_filter(
+            array_keys(self::paths()),
+            static fn (string $path): bool => str_starts_with($path, '/data/') && str_ends_with($path, '/{i18n_locale}')
+        ));
+    }
+
+    /**
+     * The `$ref` of the `application/json` schema of a response, following one level of
+     * `#/components/responses` indirection.
+     *
+     * @param array<string,mixed> $response
+     */
+    private static function resolveResponseSchemaRef(array $response): ?string
+    {
+        if (isset($response['$ref']) && is_string($response['$ref'])) {
+            $name = substr($response['$ref'], strrpos($response['$ref'], '/') + 1);
+            /** @var array<string,array<string,mixed>> $components */
+            $components = self::openapi()['components']['responses'];
+            self::assertArrayHasKey($name, $components, "unknown response component {$name}");
+            $response = $components[$name];
+        }
+
+        $ref = $response['content']['application/json']['schema']['$ref'] ?? null;
+
+        return is_string($ref) ? $ref : null;
+    }
+
+    /**
+     * The `name` of a parameter given as a `#/components/parameters` reference.
+     *
+     * @param array<string,mixed> $parameter
+     */
+    private static function componentParameterName(array $parameter): ?string
+    {
+        if (false === isset($parameter['$ref']) || false === is_string($parameter['$ref'])) {
+            return null;
+        }
+
+        $key = substr($parameter['$ref'], strrpos($parameter['$ref'], '/') + 1);
+        /** @var array<string,array<string,mixed>> $components */
+        $components = self::openapi()['components']['parameters'];
+        self::assertArrayHasKey($key, $components, "unknown parameter component {$key}");
+
+        $name = $components[$key]['name'] ?? null;
+
+        return is_string($name) ? $name : null;
+    }
+}

--- a/phpunit_tests/Schemas/OpenApiDataLocaleParamTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataLocaleParamTest.php
@@ -1,0 +1,479 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\PathCategory;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Params\RegionalDataParams;
+use LiturgicalCalendar\Api\Router;
+use Nyholm\Psr7\ServerRequest;
+use Nyholm\Psr7\Stream;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `RegionalDataParams` canonicalises and validates a `locale` parameter across the whole `/data`
+ * family, and openapi.json documented it on none of the paths (#839): a client could not discover
+ * the parameter, could not learn its accepted values, and could not learn that a bad one is a
+ * refusal rather than a fallback.
+ *
+ * Two things have to stay true and are asserted here against the running code rather than against
+ * a restatement of it:
+ *
+ * - *where* the parameter is read from, which is not uniform. `RegionalDataHandler` merges
+ *   `getScalarQueryParams()` into the parameter array for GET and `parseBodyParams()` for POST,
+ *   never both, and neither for the write methods. The contract therefore has to declare `locale`
+ *   as a query parameter on GET, as a request body field on POST, and not at all elsewhere. Each
+ *   of those claims is probed against the handler in process below.
+ * - *which values* it accepts, which is the full locale set the server ships and not the narrowed
+ *   Ambrosian set that `/calendar/ambrosian` and `/events/ambrosian` document. `/data` narrows per
+ *   calendar instead, and does it with a `422` rather than the `400` that an out-of-set value
+ *   earns, so reusing `AmbrosianLocaleParam` on `/data/ambrosian/...` would misdescribe both the
+ *   accepted set and the status code.
+ *
+ * The `locale` parameter is not the `{i18n_locale}` path segment of #838; that is a different
+ * resource with a different binding, asserted in {@see OpenApiDataI18nSubResourceTest}.
+ */
+final class OpenApiDataLocaleParamTest extends TestCase
+{
+    private const string PARAM_NAME = 'RegionalDataLocaleQueryParam';
+    private const string BODY_NAME  = 'RegionalDataRequestBody';
+
+    /** @var array<string,mixed> */
+    private static array $openapi;
+
+    public static function setUpBeforeClass(): void
+    {
+        // The in-process probes read source data through JsonData paths.
+        Router::getApiPaths();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private static function openapi(): array
+    {
+        if (false === isset(self::$openapi)) {
+            $raw = file_get_contents(dirname(__DIR__, 2) . '/jsondata/schemas/openapi.json');
+
+            if (false === is_string($raw)) {
+                throw new \RuntimeException('Could not read openapi.json');
+            }
+
+            /** @var array<string,mixed> $decoded */
+            $decoded       = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            self::$openapi = $decoded;
+        }
+
+        return self::$openapi;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private static function paths(): array
+    {
+        /** @var array<string,array<string,mixed>> $paths */
+        $paths = self::openapi()['paths'];
+
+        return $paths;
+    }
+
+    /**
+     * The `/data` paths that address a calendar definition, which are the ones that take a
+     * `locale`. Derived from the document rather than listed, so a tier added later (as #843
+     * added the rite-qualified forms) is covered without editing this file. The `{i18n_locale}`
+     * sub-resource paths are excluded: they address the stored translation map, where a `locale`
+     * is validated but inert.
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function calendarDataPaths(): array
+    {
+        $paths = [];
+
+        foreach (array_keys(self::paths()) as $path) {
+            if (false === str_starts_with($path, '/data/') || str_ends_with($path, '/{i18n_locale}')) {
+                continue;
+            }
+
+            $paths[$path] = [$path];
+        }
+
+        return $paths;
+    }
+
+    /**
+     * GET reads `locale` from the query string, so every calendar-data GET has to declare it, and
+     * has to declare it by reference so that all seven tiers cannot drift apart.
+     */
+    #[DataProvider('calendarDataPaths')]
+    public function testEveryCalendarDataGetDeclaresTheSharedLocaleQueryParameter(string $path): void
+    {
+        /** @var array<string,array<string,mixed>> $pathItem */
+        $pathItem = self::paths()[$path];
+        self::assertArrayHasKey('get', $pathItem);
+
+        /** @var list<array<string,string>> $parameters */
+        $parameters = $pathItem['get']['parameters'];
+
+        self::assertContains(
+            '#/components/parameters/' . self::PARAM_NAME,
+            array_column($parameters, '$ref'),
+            "GET {$path} accepts a `locale` query parameter but does not declare it"
+        );
+    }
+
+    /**
+     * POST is a read alias of GET but reads its parameters from the body, so the same `locale` has
+     * to appear there as a body field and must *not* appear as a query parameter: a query `locale`
+     * on POST is silently ignored, and declaring it would document behaviour that does not exist.
+     */
+    #[DataProvider('calendarDataPaths')]
+    public function testEveryCalendarDataPostDocumentsTheLocaleBodyFieldAndNoQueryParameter(string $path): void
+    {
+        /** @var array<string,array<string,mixed>> $pathItem */
+        $pathItem = self::paths()[$path];
+        self::assertArrayHasKey('post', $pathItem);
+
+        /** @var array<string,mixed> $operation */
+        $operation = $pathItem['post'];
+
+        /** @var list<array<string,string>> $parameters */
+        $parameters = $operation['parameters'];
+        self::assertNotContains(
+            '#/components/parameters/' . self::PARAM_NAME,
+            array_column($parameters, '$ref'),
+            "POST {$path} ignores a query string `locale`; declaring it would document behaviour that does not exist"
+        );
+
+        self::assertArrayHasKey('requestBody', $operation, "POST {$path} must document its body parameters");
+
+        /** @var array<string,array{schema:array<string,string>}> $content */
+        $content = $operation['requestBody']['content'];
+        self::assertNotEmpty($content);
+
+        foreach ($content as $mediaType => $definition) {
+            self::assertSame(
+                '#/components/schemas/' . self::BODY_NAME,
+                $definition['schema']['$ref'] ?? null,
+                "POST {$path} ({$mediaType}) must reference the shared calendar source data body"
+            );
+        }
+    }
+
+    /**
+     * The write methods read no client-supplied `locale` at all, so none of them may declare one.
+     */
+    #[DataProvider('calendarDataPaths')]
+    public function testTheWriteMethodsDeclareNoLocaleParameter(string $path): void
+    {
+        /** @var array<string,array<string,mixed>> $pathItem */
+        $pathItem = self::paths()[$path];
+
+        foreach (['put', 'patch', 'delete'] as $method) {
+            self::assertArrayHasKey($method, $pathItem);
+
+            /** @var list<array<string,mixed>> $parameters */
+            $parameters = $pathItem[$method]['parameters'];
+
+            foreach ($parameters as $parameter) {
+                $name = $parameter['name'] ?? self::componentParameterName($parameter);
+
+                self::assertNotSame(
+                    'locale',
+                    $name,
+                    strtoupper($method) . " {$path} does not read a client-supplied `locale`; only Accept-Language reaches it"
+                );
+            }
+        }
+    }
+
+    /**
+     * The parameter must point at the same shared locale definition the rest of the document uses
+     * for an unrestricted `locale`, rather than carrying its own copy of a 900-entry enum. The
+     * reference is compared against `/temporale`'s `locale` query parameter rather than to a
+     * literal, so the two cannot drift apart: they describe the same accepted set.
+     */
+    public function testTheLocaleParameterReusesTheSharedLocaleDefinition(): void
+    {
+        /** @var array<string,array<string,mixed>> $params */
+        $params = self::openapi()['components']['parameters'];
+        self::assertArrayHasKey(self::PARAM_NAME, $params);
+
+        /** @var array{schema:array<string,string>} $param */
+        $param = $params[self::PARAM_NAME];
+
+        self::assertSame(
+            self::temporaleLocaleSchemaRef(),
+            $param['schema']['$ref'] ?? null,
+            'the /data locale parameter must reuse the shared unrestricted locale definition'
+        );
+
+        /** @var array<string,array<string,mixed>> $schemas */
+        $schemas = self::openapi()['components']['schemas'];
+        self::assertArrayHasKey(self::BODY_NAME, $schemas);
+
+        /** @var array{properties:array<string,array<string,string>>} $body */
+        $body = $schemas[self::BODY_NAME];
+        self::assertSame(
+            $param['schema']['$ref'],
+            $body['properties']['locale']['$ref'] ?? null,
+            'the POST body locale field must reuse the same set as the GET query parameter, not restate it'
+        );
+    }
+
+    /**
+     * `/data` is not narrowed to the Ambrosian liturgical languages the way `/calendar/ambrosian`
+     * and `/events/ambrosian` are. `RegionalDataParams` accepts any locale the server ships, on
+     * every tier and rite alike; the per-calendar narrowing happens later in the handler and is a
+     * `422`, not the `400` an out-of-set value earns. Reusing `AmbrosianLocaleParam` here would
+     * therefore advertise both the wrong set and the wrong status.
+     */
+    public function testTheAmbrosianTierIsNotNarrowedToTheAmbrosianLocaleSet(): void
+    {
+        $params = new RegionalDataParams([
+            'category' => PathCategory::DIOCESE,
+            'key'      => 'milano_it',
+            'rite'     => Rite::AMBROSIAN,
+            'locale'   => 'fr_FR',
+        ]);
+
+        self::assertSame(
+            'fr_FR',
+            $params->locale,
+            'RegionalDataParams accepts any locale the server ships, including for an Ambrosian diocese'
+        );
+
+        /** @var array<string,array<string,mixed>> $schemas */
+        $schemas = self::openapi()['components']['schemas'];
+
+        /** @var array{enum:list<string>} $ambrosian */
+        $ambrosian = $schemas['AmbrosianLocale'];
+        self::assertNotContains(
+            'fr_FR',
+            $ambrosian['enum'],
+            'the fixture this assertion rests on has changed: fr_FR is no longer outside the Ambrosian set'
+        );
+
+        foreach (array_keys(self::calendarDataPaths()) as $path) {
+            /** @var array<string,array<string,mixed>> $pathItem */
+            $pathItem = self::paths()[$path];
+
+            foreach ($pathItem as $method => $operation) {
+                if (false === is_array($operation) || false === isset($operation['parameters'])) {
+                    continue;
+                }
+
+                /** @var list<array<string,string>> $parameters */
+                $parameters = $operation['parameters'];
+                self::assertNotContains(
+                    '#/components/parameters/AmbrosianLocaleParam',
+                    array_column($parameters, '$ref'),
+                    "{$method} {$path} must not restrict its locales to the Ambrosian set; /data narrows per calendar with a 422"
+                );
+            }
+        }
+    }
+
+    /**
+     * Every place a client could put a `locale`, for each method whose binding can be settled
+     * without writing anything, paired with whether the handler is expected to read it from there.
+     * Both halves of the grid matter: the positive cases prove the parameter is declared where it
+     * is read, and the negative ones prove it is not declared where it would be silently dropped.
+     *
+     * PUT and PATCH are absent on purpose. Their branch parses and schema-validates the calendar
+     * payload *before* `RegionalDataParams` ever looks at a locale, so a probe carrying a bad
+     * locale always fails on the payload first and can prove nothing; reaching the locale check
+     * would require a payload valid enough to be written to disk. DELETE shares the same
+     * "merges neither" branch and is probed below, which settles the family.
+     *
+     * @return array<string,array{0:string,1:string,2:bool}>
+     */
+    public static function bindingProbes(): array
+    {
+        return [
+            'GET reads the query string'      => ['GET', 'query', true],
+            'GET ignores the request body'    => ['GET', 'body', false],
+            'POST reads the request body'     => ['POST', 'body', true],
+            'POST ignores the query string'   => ['POST', 'query', false],
+            'DELETE ignores the query string' => ['DELETE', 'query', false],
+            'DELETE ignores the request body' => ['DELETE', 'body', false],
+        ];
+    }
+
+    /**
+     * Send a deliberately invalid locale in one specific place and require the handler to notice
+     * it exactly when the contract says it will. A locale the server does not ship is refused by
+     * `RegionalDataParams::setParams()` with a message naming the parameter, which is an
+     * unmistakable signal that the value was bound; anything else means it was not.
+     */
+    #[DataProvider('bindingProbes')]
+    public function testTheHandlerBindsLocaleWhereTheContractSaysItDoes(string $method, string $sentIn, bool $isRead): void
+    {
+        // A non-existent nation for DELETE, so that the probe can never reach a real deletion:
+        // the key is refused first, and a locale refusal would still precede it if one were bound.
+        $key   = $method === 'DELETE' ? 'ZZ' : 'IT';
+        $query = $sentIn === 'query' ? ['locale' => 'zz_ZZ'] : [];
+        $body  = $sentIn === 'body' ? '{"locale":"zz_ZZ"}' : '';
+
+        $refusal = self::probe($method, ['nation', $key], $query, $body);
+
+        self::assertSame(
+            $isRead,
+            self::isLocaleRefusal($refusal),
+            $isRead
+                ? "{$method} /data/nation/{$key} did not refuse an unsupported locale sent in the {$sentIn}, so the contract declares it in the wrong place"
+                : "{$method} /data/nation/{$key} refused a locale sent in the {$sentIn}, so it does bind one there and the contract must say so"
+        );
+    }
+
+    /**
+     * A well-formed locale the calendar does not declare is a different refusal from a locale the
+     * server does not ship: `422 Unprocessable Content`, not `400 Bad Request`. Both are reachable
+     * on every calendar-data read, so both have to be declared, or a generated client has no
+     * branch for the one status it will actually meet. This is the omission #843 fixed for the
+     * rite-mismatch `422`; the locale narrowing produces the same status on the national and
+     * wider-region tiers, where it was undeclared.
+     */
+    #[DataProvider('calendarDataPaths')]
+    public function testBothLocaleRefusalsAreDeclaredOnTheReadOperations(string $path): void
+    {
+        /** @var array<string,array<string,mixed>> $pathItem */
+        $pathItem = self::paths()[$path];
+
+        foreach (['get', 'post'] as $method) {
+            /** @var array<string,mixed> $responses */
+            $responses = $pathItem[$method]['responses'];
+
+            self::assertArrayHasKey(
+                '400',
+                $responses,
+                strtoupper($method) . " {$path} refuses a locale the server does not ship with 400, which it does not declare"
+            );
+            self::assertArrayHasKey(
+                '422',
+                $responses,
+                strtoupper($method) . " {$path} refuses a locale the calendar does not declare with 422, which it does not declare"
+            );
+        }
+    }
+
+    /**
+     * The `422` above is not hypothetical: assert the handler really produces it for a locale that
+     * is perfectly valid but foreign to the addressed calendar, so the response declared on every
+     * read operation is anchored to behaviour and not to this test's opinion.
+     */
+    public function testTheCalendarScopedLocaleRefusalIsReachable(): void
+    {
+        $refusal = self::probe('GET', ['nation', 'IT'], ['locale' => 'en_US'], '');
+
+        self::assertNotNull($refusal, 'GET /data/nation/IT?locale=en_US must be refused: IT declares only it_IT');
+        self::assertStringContainsString('for param `locale`', $refusal->getMessage());
+        self::assertSame(
+            422,
+            $refusal->getCode(),
+            'a valid locale the calendar does not declare is a 422, not the 400 an unshipped locale earns'
+        );
+    }
+
+    /**
+     * Drive the handler in process for one request and hand back whatever it refused with.
+     *
+     * @param list<string>         $pathParams
+     * @param array<string,string> $query
+     */
+    private static function probe(string $method, array $pathParams, array $query, string $body): ?\Throwable
+    {
+        $handler = new RegionalDataHandler($pathParams);
+        $handler->setAllowedRequestMethods([
+            RequestMethod::GET,
+            RequestMethod::POST,
+            RequestMethod::PUT,
+            RequestMethod::PATCH,
+            RequestMethod::DELETE,
+        ]);
+
+        $request = ( new ServerRequest($method, '/data/' . implode('/', $pathParams), [
+            'Accept'          => 'application/json',
+            'Accept-Language' => 'it-IT',
+            'Content-Type'    => 'application/json',
+        ]) )->withQueryParams($query);
+
+        if ($body !== '') {
+            $request = $request->withBody(Stream::create($body));
+        }
+
+        try {
+            $handler->handle($request);
+        } catch (\Throwable $refusal) {
+            return $refusal;
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether a refusal is the parameter-level locale refusal, as opposed to no refusal at all or
+     * a refusal about something else entirely (an unknown key, a malformed payload).
+     */
+    private static function isLocaleRefusal(?\Throwable $refusal): bool
+    {
+        return $refusal instanceof ValidationException
+            && str_contains($refusal->getMessage(), 'for param `locale`');
+    }
+
+    /**
+     * The `$ref` of `/temporale`'s `locale` query parameter, which is the document's existing
+     * unrestricted locale surface.
+     */
+    private static function temporaleLocaleSchemaRef(): string
+    {
+        /** @var array<string,array<string,mixed>> $paths */
+        $paths = self::paths();
+        self::assertArrayHasKey('/temporale', $paths, 'the precedent this assertion compares against has moved');
+
+        /** @var list<array<string,mixed>> $parameters */
+        $parameters = $paths['/temporale']['get']['parameters'];
+
+        foreach ($parameters as $parameter) {
+            if (( $parameter['name'] ?? null ) !== 'locale') {
+                continue;
+            }
+
+            /** @var array{schema:array<string,string>} $parameter */
+            $ref = $parameter['schema']['$ref'] ?? null;
+            self::assertIsString($ref);
+
+            return $ref;
+        }
+
+        self::fail('/temporale no longer documents a locale query parameter');
+    }
+
+    /**
+     * The `name` of a parameter given as a `#/components/parameters` reference.
+     *
+     * @param array<string,mixed> $parameter
+     */
+    private static function componentParameterName(array $parameter): ?string
+    {
+        if (false === isset($parameter['$ref']) || false === is_string($parameter['$ref'])) {
+            return null;
+        }
+
+        $key = substr($parameter['$ref'], strrpos($parameter['$ref'], '/') + 1);
+        /** @var array<string,array<string,mixed>> $components */
+        $components = self::openapi()['components']['parameters'];
+        self::assertArrayHasKey($key, $components, "unknown parameter component {$key}");
+
+        $name = $components[$key]['name'] ?? null;
+
+        return is_string($name) ? $name : null;
+    }
+}

--- a/phpunit_tests/Schemas/OpenApiDataLocaleParamTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataLocaleParamTest.php
@@ -177,7 +177,12 @@ final class OpenApiDataLocaleParamTest extends TestCase
         $pathItem = self::paths()[$path];
 
         foreach (['put', 'patch', 'delete'] as $method) {
-            self::assertArrayHasKey($method, $pathItem);
+            // Only the locale claim belongs to this test. Requiring every write method to exist here
+            // would make a future read-only /data tier fail a *locale* test with a message about a
+            // missing locale parameter; the route-surface test is where that claim lives.
+            if (false === array_key_exists($method, $pathItem)) {
+                continue;
+            }
 
             /** @var list<array<string,mixed>> $parameters */
             $parameters = $pathItem[$method]['parameters'];

--- a/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
@@ -217,6 +217,37 @@ final class OpenApiDataRiteSegmentTest extends TestCase
     }
 
     /**
+     * Every calendar-definition path documents the full method surface the handler accepts.
+     *
+     * This claim used to ride along inside the locale test, which meant a future read-only `/data`
+     * tier would have failed a *locale* test with a message about a missing locale parameter. It
+     * belongs here, with the route surface. `Router`'s `data` case wires GET, POST, PUT, PATCH and
+     * DELETE for a two-part path; the i18n sub-resource paths are excluded because that same case
+     * wires only GET and POST for a three-part path (#838).
+     */
+    public function testEveryCalendarDefinitionPathDocumentsTheFullMethodSurface(): void
+    {
+        $paths = self::paths();
+        $seen  = 0;
+
+        foreach ($paths as $path => $pathItem) {
+            if (false === str_starts_with((string) $path, '/data/') || str_contains((string) $path, '{i18n_locale}')) {
+                continue;
+            }
+
+            /** @var array<string,mixed> $pathItem */
+            self::assertSame(
+                ['delete', 'get', 'patch', 'post', 'put'],
+                self::operationMethods($pathItem),
+                "{$path} must document the full method surface Router wires for a two-part /data path"
+            );
+            ++$seen;
+        }
+
+        self::assertGreaterThan(0, $seen, 'openapi.json documents no /data calendar-definition path at all');
+    }
+
+    /**
      * The HTTP methods a path item documents, sorted, with any non-method key (`parameters`,
      * `summary`, `description`, `servers`) filtered out — those are legal siblings of the operations
      * in an OpenAPI path item and are not operations themselves.


### PR DESCRIPTION
Closes #838. Closes #839.

Two companion issues on the same file and the same operations, so they land together — one commit each.

## The `/data` surface, established live rather than assumed

Probed against a running server (read-only, plus authenticated write probes against the non-existent key `ZZ` so nothing could be written), then re-derived from the handler.

**`{locale}` third path segment** — works on **all seven** documented tiers, GET and POST, all 200:

```
GET/POST  /data/{nation|diocese|widerregion}/{key}/it_IT        200  translation map
GET/POST  /data/roman/{...}/{key}/it_IT                          200  translation map
GET/POST  /data/ambrosian/diocese/milano_it/it_IT                200  translation map
PUT/PATCH/DELETE  .../{key}/it_IT                                400  "Expected two path params …, received 3"
```

The write-method 400 was **established, not assumed**: unauthenticated those return 401 because auth middleware precedes the handler, so it took a login to see the real answer. `Router`'s `data` case independently wires `[GET, POST]` for a three-part path. Error surface: `404` for a locale with no stored file, `422` for an unknown key or a rite mismatch.

**`locale` parameter — #839's stated guess was wrong.** It is read from the **body on POST**, not on PUT/PATCH; PUT, PATCH and DELETE read no client-supplied locale at all:

| method | query | body |
|---|---|---|
| GET | **read** (400 on `zz_ZZ`) | ignored |
| POST | ignored | **read** (JSON, YAML, form-urlencoded) |
| PUT / PATCH / DELETE | ignored | ignored |

Two-stage validation: `400` for a locale the server does not ship, `422` for a well-formed locale the calendar does not declare (`?locale=en_US` on `IT` → "valid values for calendar IT are: it_IT").

## Keeping the two apart

The path segment is spelled **`{i18n_locale}`**, not `{locale}`, and both components state explicitly that the other is a different thing — the segment selects a stored translation map, the parameter selects the language of a calendar definition. Verified inert in combination: `/data/nation/IT/it_IT?locale=en_US` returns 200 (the calendar-locales check short-circuits for i18n requests) while `?locale=zz_ZZ` still 400s. A test fails if anyone collapses the two names.

## Schema and `$ref` choices

- **Translation map:** `LitCalTranslation.json` already described the shape exactly and is what `LitSchema::I18N` validates stored i18n files against. `$ref`'d externally via a new shared `RegionalDataI18n200` response component. A test loads a real stored file and validates it against that schema, closing the loop.
- **`locale`:** `CommonDef.json#/definitions/Locale` — the same definition `/temporale`'s `locale` parameter uses; the test compares against `/temporale`'s `$ref` rather than a literal. Deliberately **not** `AmbrosianLocale` even on the Ambrosian path, because `RegionalDataParams` accepts `fr_FR` there and the rite narrowing is a later `422`, not the `400` that `AmbrosianLocaleParam` documents.
- **`422` was missing** from the national and wider-region reads even though `?locale=en_US` produces it there — the same class of omission #843 fixed for the rite `422`.

## The diff is surgical

`openapi.json` grew 12733 → 13544 lines, **+811 insertions, zero deletions**. No reformat: this file is inconsistently escaped, so it was edited by text-level splice rather than re-serialisation. The seven new path items sit as one contiguous block before `/easter`, and the #839 edits are confined to `parameters`/`requestBody`/`responses` of existing operations, to keep #848's rebase tractable.

## Tests and mutation checks

`OpenApiDataI18nSubResourceTest` and `OpenApiDataLocaleParamTest` — 77 tests, 365 assertions — asserting the documented surface against `RegionalDataParams`/`RegionalDataHandler` rather than a second hardcoded list, in the house style of `OpenApiDataRiteSegmentTest`.

Every assertion was mutation-checked and restored: removing the ambrosian i18n path, documenting `put` on an i18n path, pointing the 200 at the wrong schema, renaming the segment to `{locale}`, dropping the param from a GET, adding it to a POST or DELETE, narrowing to `AmbrosianLocale`, dropping the 422 — each fails with a specific message.

Worth noting: the behavioural probes' **first version was vacuous** — a `null` expectation sent no locale at all, so flipping GET's expectation still passed. Restructured into an explicit where-sent × is-read grid; flipping any cell now fails.

## Verification

- `composer lint:openapi` → valid, **11 problems ignored — unchanged**, no new `.redocly.lint-ignore.yaml` entries
- `composer lint` clean; `composer analyse` (PHPStan level 10) `[OK] No errors`
- `composer test:quick` → `Tests: 3050, Assertions: 178305, Skipped: 11`

The single failure in full runs is `Routes/Readonly/CalendarEtagStabilityTest`, reproduced with bare `curl` and **not from this branch** — it is an `ApiTestCase` hitting `:8000`, which serves the main checkout. Filed as #849.

## Found, deliberately not fixed — reported instead

1. **An undocumented accidental alias.** `POST /data/nation/IT` with body `{"i18nRequest":"it_IT"}` returns the translation map with no third path segment — the internal `i18nRequest` name leaks through `array_merge($params, $parsedBodyParams)`. Not documented, because enshrining an internal name as public API would be worse than the omission. Deserves its own issue, probably closed off in the handler.
2. **`CommonDef.json#/definitions/Locale` has drifted from `LitLocale`** (ICU version skew): the schema enum carries 957 entries including uppercase forms and `ks_IN`/`sd_PK`/`yi_001` which the server rejects with 400, while `LitLocale` ships ~100 the schema lacks. The `$ref` was reused anyway — it is the intended set — but `CommonDef.json` belongs to #844's branch, so it was left alone. Worth a regeneration issue.
3. `DELETE /data/nation/{key}` and `/data/widerregion/{key}` can return 422 on an unknown key but declare only `200,400,401,403,404`.
4. The 404 detail on a missing translation file leaks a server path (`The requested resource ../jsondata/sourcedata/…/i18n/bogus.json was not found`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added locale-aware retrieval for regional calendar data across GET and POST requests.
  * Added documented validation responses for unsupported and unavailable locales.
  * Expanded Ambrosian diocesan data coverage to include all standard operations.
  * Added translation-resource endpoints for national, diocesan, regional, Roman and Ambrosian calendars.
  * Translation resources are available by locale and return structured translation maps.

* **Documentation**
  * Updated the OpenAPI specification with locale parameters, request formats, response schemas and newly supported endpoints.

* **Tests**
  * Added coverage to verify locale handling, translation-resource documentation and response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->