### PR TITLE
fix(deploy): stop shipping dev-only files, and assert the deploy payload in CI

### DIFF
--- a/.github/deploy/check-deploy-payload.sh
+++ b/.github/deploy/check-deploy-payload.sh
@@ -3,11 +3,19 @@
 # Fail if a deploy would ship a tracked file that is not part of the runtime
 # payload (#deploy-hygiene).
 #
-# Why this exists: the vhost docroot is the *application root*, not public/,
-# so every deployed file is readable over HTTP. rsync-exclude.txt is a
-# denylist, which means each new dev-only file at the repo root has to be
-# remembered — and twice it was not (phpstan-baseline.neon, .coderabbit.yaml),
-# both of which ended up publicly fetchable.
+# Why this exists: the API is served as a folder under the *frontend* docroot,
+# and the nginx location for it resolves `try_files $uri ...` — so any file
+# physically present under /api/{dev,vN}/ is served straight off disk before the
+# front controller sees the request. rsync-exclude.txt is a denylist, which means
+# each new dev-only file at the repo root has to be remembered — and twice it was
+# not (phpstan-baseline.neon, .coderabbit.yaml), both of which ended up publicly
+# fetchable.
+#
+# The nginx side has since been narrowed to map into public/ rather than the app
+# root, which makes the whole class unreachable over HTTP. This check is still
+# worth keeping: it stops the files reaching the server at all, which matters for
+# anything reading the deployed tree outside nginx (backups, an operator grepping
+# around), and it is the half that lives in this repo.
 #
 # This flips the guarantee: the payload is checked against an ALLOWlist of
 # top-level entries. A new dev-only file fails CI instead of reaching the web.

--- a/.github/deploy/check-deploy-payload.sh
+++ b/.github/deploy/check-deploy-payload.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Fail if a deploy would ship a tracked file that is not part of the runtime
+# payload (#deploy-hygiene).
+#
+# Why this exists: the vhost docroot is the *application root*, not public/,
+# so every deployed file is readable over HTTP. rsync-exclude.txt is a
+# denylist, which means each new dev-only file at the repo root has to be
+# remembered — and twice it was not (phpstan-baseline.neon, .coderabbit.yaml),
+# both of which ended up publicly fetchable.
+#
+# This flips the guarantee: the payload is checked against an ALLOWlist of
+# top-level entries. A new dev-only file fails CI instead of reaching the web.
+# Adding a genuinely new runtime path is a deliberate one-line edit here.
+#
+# Only git-tracked files are considered: a deploy runs from a fresh checkout,
+# so untracked local scratch files are never on the runner.
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+# Top-level entries that legitimately ship. Keep the justification with each.
+ALLOWED=(
+  "src"                     # the application
+  "jsondata"                # calendar source data + schemas
+  "i18n"                    # compiled translations
+  "public"                  # front controller + assets
+  "scripts"                 # operational scripts run ON the server (RBAC runbook)
+  "bin"                     # reconcile-outbox: systemd/cron server-side CLI
+  "composer.json"           # Router::findProjectRoot() uses it as a root marker
+  "doctrine-migrations.php" # read by MigrateHandler via PhpFile
+  ".env.example"            # deliberately shipped so admins can diff against .env.production
+)
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+git ls-files | sort -u > "$tmp/tracked"
+rsync -a --dry-run --out-format='%n' \
+  --exclude-from=.github/deploy/rsync-exclude.txt \
+  ./ "$tmp/dest/" 2>/dev/null | sed 's:/$::' | awk 'NF' | sort -u > "$tmp/shipped"
+
+# Tracked ∩ shipped, reduced to top-level entry.
+comm -12 "$tmp/tracked" "$tmp/shipped" | cut -d/ -f1 | sort -u > "$tmp/top"
+
+status=0
+while IFS= read -r entry; do
+  [ -n "$entry" ] || continue
+  for allowed in "${ALLOWED[@]}"; do
+    [ "$entry" = "$allowed" ] && continue 2
+  done
+  if [ "$status" -eq 0 ]; then
+    echo "::error::Deploy payload contains tracked entries that are not runtime files."
+    echo "The vhost serves the application root, so anything below would be publicly readable."
+    echo
+  fi
+  echo "  unexpected: $entry"
+  comm -12 "$tmp/tracked" "$tmp/shipped" | grep -E "^${entry}(/|$)" | sed 's/^/      /'
+  status=1
+done < "$tmp/top"
+
+if [ "$status" -ne 0 ]; then
+  echo
+  echo "Either add it to .github/deploy/rsync-exclude.txt (dev-only), or add the"
+  echo "top-level entry to ALLOWED in this script (genuinely needed at runtime)."
+  echo
+  echo "NOTE: excluding a file does NOT remove copies already on the server —"
+  echo "excluded paths are also protected from --delete. Delete them there by hand."
+  exit 1
+fi
+
+echo "Deploy payload OK: only runtime entries would ship."

--- a/.github/deploy/rsync-exclude.txt
+++ b/.github/deploy/rsync-exclude.txt
@@ -43,10 +43,19 @@ phpcs.xml
 phpcs.xml.dist
 phpstan.neon
 phpstan.neon.dist
+# The baseline is a third phpstan file and was missed when the two above were
+# listed; it shipped, and the vhost serves the app root, so it was publicly
+# readable at /api/dev/phpstan-baseline.neon (it names internal paths and the
+# text of every suppressed error).
+phpstan-baseline.neon
 phpunit.xml
 phpunit.xml.dist
 captainhook.json
 redocly.yaml
+# Lint-suppression lists for the OpenAPI document, and the code-review bot's
+# path instructions. Both are dev-only and both shipped.
+.redocly.lint-ignore.yaml
+.coderabbit.yaml
 .markdownlint.yml
 .markdownlint-wiki.yml
 .php-version
@@ -76,6 +85,10 @@ parseOpenAPI.js
 deploy/
 infrastructure/
 /migrations/
+# authz/openfga-expectations.json is read only by
+# phpunit_tests/Services/OpenFgaModelTest.php; nothing under src/ touches it.
+# The authorization model itself lives in cdcf-infra, not here.
+authz/
 
 # --- Dev-only entries inside scripts/ ---
 # scripts/ itself MUST ship: the operational scripts (mint-official-key,

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -124,6 +124,14 @@ jobs:
             echo "skip=false" >> "${GITHUB_OUTPUT}"
           fi
 
+      # Pre-flight: refuse to deploy a payload carrying non-runtime files. CI
+      # already asserts this on every PR, but a deploy can run from a tag or a
+      # hand-picked branch that never went through it, and the docroot is the
+      # application root — so the last gate before the wire checks too.
+      - name: Verify deploy payload contains only runtime files
+        if: steps.shape.outputs.skip != 'true'
+        run: ./.github/deploy/check-deploy-payload.sh
+
       - name: Set up PHP
         if: steps.shape.outputs.skip != 'true'
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,13 +134,22 @@ jobs:
 
   deploy_payload:
     runs-on: ubuntu-latest
+    # Least privilege, as jsondata_lint above: this job only reads the tree and
+    # enumerates what rsync would transfer. It writes nothing and calls no API.
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Nothing here pushes; don't leave the token in .git/config for later steps.
+          persist-credentials: false
 
-      # The vhost docroot is the application root, not public/, so anything the
-      # deploy transfers is readable over HTTP. rsync-exclude.txt is a denylist;
-      # this asserts the resulting payload against an allowlist instead, so a new
-      # dev-only file fails here rather than becoming publicly fetchable.
+      # The API is served as a folder under the frontend docroot, and the nginx
+      # location for it does `try_files $uri ...` — so any file physically present
+      # under /api/{dev,vN}/ is served straight off disk, before the front
+      # controller sees the request. rsync-exclude.txt is a denylist; this asserts
+      # the resulting payload against an allowlist instead, so a new dev-only file
+      # fails here rather than becoming publicly fetchable.
       - name: Deploy payload contains only runtime files
         run: ./.github/deploy/check-deploy-payload.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,18 @@ jobs:
       - name: Markdown lint
         run: npx --yes markdownlint-cli2 "**/*.md" "#node_modules" "#vendor" "#.aider*"
 
+  deploy_payload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The vhost docroot is the application root, not public/, so anything the
+      # deploy transfers is readable over HTTP. rsync-exclude.txt is a denylist;
+      # this asserts the resulting payload against an allowlist instead, so a new
+      # dev-only file fails here rather than becoming publicly fetchable.
+      - name: Deploy payload contains only runtime files
+        run: ./.github/deploy/check-deploy-payload.sh
+
   gettext_update:
     runs-on: ubuntu-latest
     needs: [codesniffer, static_analysis]


### PR DESCRIPTION
Four tracked dev-only files were being deployed, and all four were publicly readable:

| URL | status |
|---|---|
| `/api/dev/phpstan-baseline.neon` | 200, 9337 b |
| `/api/dev/.coderabbit.yaml` | 200, 3422 b |
| `/api/dev/.redocly.lint-ignore.yaml` | 200, 1834 b |
| `/api/dev/authz/openfga-expectations.json` | 200, 883 b |

**Nothing sensitive is exposed.** `.env`, `.git/config` and `logs/` all correctly return 404, and no credentials are involved — `admin.pat`/`login-client.pat` are untracked, so they never reach the runner. The baseline is the most informative of the four, naming internal file paths and the text of every suppressed error.

## Why it happened

`rsync-exclude.txt` already listed `phpstan.neon` and `phpstan.neon.dist` — but not `phpstan-baseline.neon`, a third file in the same family. `authz/` was never listed at all. The other two are recent additions that post-date the last review of the list; `.coderabbit.yaml` shipped **within hours** of being committed in #847.

That pattern is the actual defect. The exclude list is a **denylist**, so every new dev-only file has to be remembered, and the docroot layout means forgetting one publishes it. Adding four lines fixes today's leak and leaves the next one to chance.

## The fix

**1. The four exclusions**, each with its reason recorded inline.

**2. `.github/deploy/check-deploy-payload.sh`** — enumerates what rsync would transfer, intersects it with `git ls-files` (a deploy runs from a fresh checkout, so untracked scratch files are irrelevant), and asserts the top-level entries against an **allowlist** of runtime paths:

```
src  jsondata  i18n  public  scripts  bin
composer.json  doctrine-migrations.php  .env.example
```

Each carries its justification — e.g. `composer.json` because `Router::findProjectRoot()` uses it as a root marker, `bin/` because `reconcile-outbox` is invoked server-side by systemd/cron. A new dev-only file now fails CI instead of reaching the web; adding a genuinely new runtime path is a deliberate one-line edit.

**3. Wired in twice** — a `deploy_payload` job in `main.yml` gating every PR, and a pre-flight in `deploy.yaml` before rsync, because a deploy can run from a tag or a hand-picked branch that never went through CI.

## Verification

Mutation-tested in both directions. With the exclusions reverted, the guard names all four:

```
::error::Deploy payload contains tracked entries that are not runtime files.
  unexpected: .coderabbit.yaml
  unexpected: .redocly.lint-ignore.yaml
  unexpected: authz
      authz/openfga-expectations.json
  unexpected: phpstan-baseline.neon
```

Removing only `phpstan-baseline.neon` from the list makes it name that one. With the fix applied: `Deploy payload OK: only runtime entries would ship.` Both workflow files re-parse as valid YAML.

## ⚠️ Manual cleanup still required

**Merging this does not remove the files already on the server.** Excluded paths are also protected from `--delete` — the gotcha documented at the top of `rsync-exclude.txt` — so this stops them being re-sent but fossilizes the existing copies.

They must be deleted by hand on both deploy paths:

```
rm -f  <app>/dev/phpstan-baseline.neon <app>/dev/.coderabbit.yaml <app>/dev/.redocly.lint-ignore.yaml
rm -rf <app>/dev/authz
# and the same under the production vN/ path for any that are present there
```

**Do not use `--delete-excluded`** to do this: it would wipe `.env.production`, `logs/` and `cache/`.

## The mechanism (corrected)

An earlier revision of this description said the vhost docroot is the application root. **That is wrong.** The API is served as a folder under the *frontend* docroot, via this nginx directive on the frontend domain:

```nginx
location ~ ^/api/(dev|v[3-9])(/.*)?$ {
    # If the requested file exists, serve it
    # Otherwise, route everything to the front controller
    try_files $uri /api/$1/public/index.php$is_args$args;
}
```

`try_files $uri` is the exposure: **any file physically present under `/api/{dev,vN}/` is matched by `$uri` and served straight off disk, before the front controller ever sees the request.** That is precisely why `phpstan-baseline.neon` was fetchable — it existed, so nginx served it.

PHP is not disclosed: `vendor/autoload.php` returns 200 with an empty body and `public/LitCalTestServer.php` returns 500, so `.php` under the API dir is executed rather than dumped as source. Non-PHP files are served raw.

## The durable fix is one line of nginx

Map requests into `public/` instead of the application root:

```nginx
location ~ ^/api/(dev|v[3-9])(/.*)?$ {
    try_files /api/$1/public$2 /api/$1/public/index.php$is_args$args;
}
```

With that, `/api/dev/phpstan-baseline.neon` resolves against `/api/dev/public/phpstan-baseline.neon`, which does not exist, and falls through to the front controller — the API's own 404. **The entire class of leak becomes impossible regardless of what the deploy ships**, and arbitrary non-entrypoint PHP under the app root (`vendor/autoload.php` and friends) stops being directly executable.

Only `index.php` and `LitCalTestServer.php` ship into `public/`, so nothing legitimate is lost; `LitCalTestServer.php` simply moves from `/api/dev/public/LitCalTestServer.php` to `/api/dev/LitCalTestServer.php`.

One consequence worth deciding on: `public/engineCache/` would become reachable as `/api/dev/engineCache/...`. It is already directly servable today at its longer path, so this is not new exposure — and the contents are computed calendars that the API serves publicly anyway — but if you would rather it were not addressable at all, add a `location ~ ^/api/(dev|v[3-9])/engineCache/ { return 404; }` alongside.

**This PR is still worth merging with that change**, not instead of it: the guard keeps dev-only files off the server in the first place, which matters for anything that reads the deployed directory outside nginx (backups, greps, an operator browsing the tree), and it is the only half that lives in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment validation to detect unexpected files before release.
  * Prevented development, testing, and authorisation-related files from being included in deployed packages.

* **Chores**
  * Added automated checks to confirm deployment payloads contain only approved runtime files.
  * Deployment now reports invalid payload contents and stops safely when issues are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->