### PR TITLE
fix(ics): keep LAST-MODIFIED and CREATED out of the ETag (#849)

### DIFF
--- a/phpunit_tests/Handlers/CalendarIcsValidatorSourceTest.php
+++ b/phpunit_tests/Handlers/CalendarIcsValidatorSourceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The ICS validator source must neutralise every provenance stamp the representation embeds
+ * about itself, not only `DTSTAMP`.
+ *
+ * {@see CalendarHandler::produceIcal()} emits three of them, and all three can carry a
+ * per-request value:
+ *
+ * - `DTSTAMP` is always generation time.
+ * - `LAST-MODIFIED` is the engine-cache directory's mtime, and falls back to generation time
+ *   whenever that directory cannot be resolved — which is ordinary rather than exceptional,
+ *   since localhost deliberately bypasses the cache and never calls `ensureCachePathExists()`,
+ *   leaving `CachePath` a relative path resolved against the server's working directory.
+ * - `CREATED` is the GitHub release date, and falls back to generation time when that lookup
+ *   fails.
+ *
+ * None of the three describes the calendar; they describe when and whence this body was
+ * produced. Leaving any of them in the hash hands an unchanged calendar a fresh validator, so a
+ * conditional request re-transfers the whole body for nothing — precisely the defect the
+ * validator exists to prevent. The validator is weak (`W/`) exactly so that bodies differing
+ * only in these stamps may share it (RFC 9110 §8.8.1).
+ *
+ * This is a unit test rather than a live-HTTP one on purpose: whether `LAST-MODIFIED` takes its
+ * mtime value or its generation-time fallback depends on whether `engineCache/<version>/` happens
+ * to exist relative to the server's working directory, so an integration test would guard the bug
+ * only in whichever environment it happened to run.
+ */
+#[CoversClass(CalendarHandler::class)]
+final class CalendarIcsValidatorSourceTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        // CalendarParams resolves source-data paths through Router::$apiFilePath on construction,
+        // which is a typed static left uninitialised outside a served request.
+        Router::getApiPaths();
+    }
+
+    /**
+     * A minimal but structurally faithful ICS body carrying all three provenance stamps.
+     */
+    private static function icsBody(string $dtstamp, string $created, string $lastModified): string
+    {
+        return implode("\r\n", [
+            'BEGIN:VCALENDAR',
+            'VERSION:2.0',
+            'METHOD:PUBLISH',
+            'BEGIN:VEVENT',
+            'UID:litcal-2026-easter',
+            'DTSTAMP:' . $dtstamp,
+            'DTSTART;VALUE=DATE:20260405',
+            'SUMMARY:Easter Sunday',
+            'CREATED:' . $created,
+            'LAST-MODIFIED:' . $lastModified,
+            'END:VEVENT',
+            'END:VCALENDAR',
+            ''
+        ]);
+    }
+
+    private static function validatorSourceForIcs(string $body): string
+    {
+        $handler = new CalendarHandler([]);
+
+        $params             = new CalendarParams();
+        $params->ReturnType = ReturnTypeParam::ICS;
+
+        $property = new \ReflectionProperty(CalendarHandler::class, 'CalendarParams');
+        $property->setValue($handler, $params);
+
+        $method = new \ReflectionMethod(CalendarHandler::class, 'validatorSource');
+        $result = $method->invoke($handler, $body);
+
+        self::assertIsString($result);
+
+        return $result;
+    }
+
+    public function testBodiesDifferingOnlyInTheirProvenanceStampsShareOneValidatorSource(): void
+    {
+        // The same calendar generated twice: a later second, a newer release, and a rebuilt
+        // cache directory. Every difference is provenance; none of it is the calendar.
+        $first  = self::icsBody('20260822T100031Z', '20251216T151718Z', '20260822T100031Z');
+        $second = self::icsBody('20260822T100033Z', '20260101T090000Z', '20260822T100706Z');
+
+        self::assertNotSame($first, $second, 'the fixture must actually differ, or this proves nothing');
+        self::assertSame(
+            md5(self::validatorSourceForIcs($first)),
+            md5(self::validatorSourceForIcs($second)),
+            'DTSTAMP, CREATED and LAST-MODIFIED must all be neutralised before hashing'
+        );
+    }
+
+    public function testAGenuineContentDifferenceStillChangesTheValidatorSource(): void
+    {
+        // The converse guard: neutralising the stamps must not flatten the calendar itself, or
+        // every calendar would share one validator and a 304 would be answered for the wrong body.
+        $easter    = self::icsBody('20260822T100031Z', '20251216T151718Z', '20260822T100031Z');
+        $pentecost = str_replace('SUMMARY:Easter Sunday', 'SUMMARY:Pentecost', $easter);
+
+        self::assertNotSame(
+            md5(self::validatorSourceForIcs($easter)),
+            md5(self::validatorSourceForIcs($pentecost))
+        );
+    }
+}

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -4935,11 +4935,20 @@ final class CalendarHandler extends AbstractHandler
      * identifies the calendar rather than the moment it was serialized.
      *
      * Every representation carries the same stamp under a different spelling: `timestamp` /
-     * `date_time` in JSON and YML, `<Timestamp>` / `<DateTime>` in XML, and `DTSTAMP` in ICS. All
-     * of them change on every generation while saying nothing about the calendar. Hashing the raw
-     * body therefore handed an unchanged calendar a fresh validator on every regeneration — every
-     * request where the server cache is bypassed, and every cache rebuild otherwise — so a
-     * conditional request re-sent the whole body for nothing.
+     * `date_time` in JSON and YML, and `<Timestamp>` / `<DateTime>` in XML. All of them change on
+     * every generation while saying nothing about the calendar. Hashing the raw body therefore
+     * handed an unchanged calendar a fresh validator on every regeneration — every request where
+     * the server cache is bypassed, and every cache rebuild otherwise — so a conditional request
+     * re-sent the whole body for nothing.
+     *
+     * ICS carries three such stamps rather than one, and all three must go. `DTSTAMP` is always
+     * generation time; `CREATED` is the release date but falls back to generation time when the
+     * release lookup fails; `LAST-MODIFIED` is the engine-cache directory's mtime but falls back
+     * to generation time whenever that directory cannot be resolved — which is the ordinary case
+     * on localhost, where the cache is deliberately bypassed so `ensureCachePathExists()` never
+     * runs and `CachePath` stays a relative path resolved against the server's working directory.
+     * Neutralising only `DTSTAMP` therefore left the ICS validator changing on every request in
+     * exactly the deployments the stable validator was introduced for ({@see self::produceIcal()}).
      *
      * Two bodies reduced to the same source may still differ in those stamps, which is exactly why
      * the resulting validator is weak at the call sites (RFC 9110 §8.8.1).
@@ -4951,7 +4960,11 @@ final class CalendarHandler extends AbstractHandler
                 '#<Timestamp>[^<]*</Timestamp>#' => '<Timestamp></Timestamp>',
                 '#<DateTime>[^<]*</DateTime>#'   => '<DateTime></DateTime>'
             ],
-            ReturnTypeParam::ICS => ['/DTSTAMP:\d{8}T\d{6}Z/' => 'DTSTAMP:'],
+            ReturnTypeParam::ICS => [
+                '/DTSTAMP:\d{8}T\d{6}Z/'       => 'DTSTAMP:',
+                '/CREATED:\d{8}T\d{6}Z/'       => 'CREATED:',
+                '/LAST-MODIFIED:\d{8}T\d{6}Z/' => 'LAST-MODIFIED:'
+            ],
             ReturnTypeParam::YAML => [
                 '/^(\s*)timestamp:\s*\d+$/m'     => '$1timestamp:',
                 "/^(\s*)date_time:\s*'[^']*'$/m" => '$1date_time:'


### PR DESCRIPTION
Follow-up to #858. The ICS validator neutralised `DTSTAMP` and nothing else, so the two other provenance stamps `produceIcal()` emits went into the hash raw.

## The symptom

A dev server returned a different ICS ETag on **every** request:

```
Etag: W/"9bc3d9f02a78478213282dcb8930c13a"
Etag: W/"1e2ea55ac0e163f4ac10fb70628c5d86"
Etag: W/"5e5a14dcc076b2ac42ef38b1c0209219"
```

JSON, XML and YML were all perfectly stable, which is why this read as an ICS-only flake rather than a defect.

Diffing two ICS bodies 1.2 s apart — 371,662 bytes each — they differ in exactly two properties:

| property | occurrences | in the validator? |
|---|---|---|
| `DTSTAMP` | 1096 | neutralised |
| `LAST-MODIFIED` | 1096 | **hashed raw** |

## Why `LAST-MODIFIED` moves

`LAST-MODIFIED` is the engine-cache directory's mtime, falling back to generation time when that directory cannot be resolved. That fallback is the ordinary case, not an edge one:

- localhost deliberately bypasses the cache, so `ensureCachePathExists()` never runs;
- that method is the only thing that resolves `CachePath` from the relative `engineCache/v<ver>-<digest>/` into an absolute path;
- the relative path is then resolved against the **server's** working directory.

Where that directory does not exist, `is_dir()` is false and `LAST-MODIFIED` becomes generation time, advancing every second. In the dev container:

```
WorkingDir: /var/www/html
is_dir("engineCache/v5_7-55f2f89352e2") => bool(false)
```

So a conditional request re-transferred the whole ~370 KB body for nothing — the exact defect the stable validator was introduced to remove.

`CREATED` has the same shape: normally the GitHub release date, but it falls back to generation time when that lookup fails. Dormant today, identical failure mode. Fixed here too.

## Why it looked intermittent

Same relative path. The existing live-HTTP test passes wherever `engineCache/<version>/` happens to exist relative to the server's cwd and fails where it does not — green on CI, where earlier in-process tests create that directory before `Routes/*` runs; red against a container whose docroot has none. The outcome was an accident of working directory.

That is why the new test is a **unit** test on `validatorSource()` rather than a live-HTTP one: it guards the neutralisation in every environment instead of whichever one it happens to run in. It asserts the converse as well — a genuine content difference must still move the validator, so the neutralisation cannot quietly become too broad.

## Verification

Reproduced the failing condition end-to-end (cache dir made unresolvable, so `LAST-MODIFIED` takes its generation-time fallback), then confirmed the fix against those same bodies:

```
body 1:  DTSTAMP:20260822T101400Z   LAST-MODIFIED:20260822T101400Z
body 2:  DTSTAMP:20260822T101401Z   LAST-MODIFIED:20260822T101401Z

old rule (DTSTAMP only):  e232854ce65890dae2da17d8df67bc63
                          df93dacb10a1e2e5a51068f81cc91911   <- two validators
new rule:                 one stable ETag across both
```

- `CalendarIcsValidatorSourceTest` — red before, green after
- `CalendarEtagStabilityTest` — `OK (9 tests, 18 assertions)`
- `composer lint` — clean
- `composer analyse` (PHPStan level 10) — `[OK] No errors`
- `composer test:quick` — `Tests: 3166, Failures: 1`; the single failure is `WebSocket\ExecuteValidationTest`, confirmed pre-existing by re-running it with these changes stashed (a worktree-environment failure: the containerised WebSocket server cannot reach an API on a spare port)

## Note on semantics

Neutralising all three stamps is what the weak validator already licenses. Bodies differing only in when and whence they were produced are semantically equivalent, which is precisely what `W/` asserts (RFC 9110 §8.8.1). The events themselves are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar response validation so unchanged calendars retain the same validator, even when generation timestamps change.
  * Prevented unnecessary cache refreshes and downloads caused by regenerated ICS timestamp values.

* **Tests**
  * Added coverage confirming that provenance timestamp changes do not alter validation.
  * Added coverage confirming genuine calendar content changes still produce a new validator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->