### PR TITLE
feat(router): scope the canonical rite Link by method and extend it to /data (#848)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,15 @@ Some characteristics of this API:
   One deliberate exception: on read endpoints this API uses `POST` as a body-parameterized synonym of `GET` (not as collection-create),
   pending possible adoption of the [`QUERY` method](https://datatracker.ietf.org/doc/draft-ietf-httpbis-safe-method-w-body/) when it becomes standard.
 * **The explicit rite segment is the canonical URL form**: `/calendar/roman/{year}` states the rite outright, symmetric with `/calendar/ambrosian/{year}`, and
-  the explicit Roman form is accepted everywhere the bare form is — `/calendar/roman`, `/calendar/roman/nation/{calendar_id}`,
-  `/calendar/roman/diocese/{calendar_id}`, and `/events/roman`. The bare paths (`/calendar/{year}`, `/events`, …) are retained for backwards compatibility and
-  return an identical response. They are deliberately **not** redirected: these routes accept `POST`, so a redirect would both downgrade `POST` to `GET`
+  the explicit Roman form is accepted everywhere the bare form is, across all three route families that take the segment — `/calendar/roman/nation/{calendar_id}`,
+  `/events/roman/diocese/{calendar_id}`, `/data/roman/widerregion/{key}`, and so on. The bare paths (`/calendar/{year}`, `/events`, `/data/nation/{key}`, …) are
+  retained for backwards compatibility and return an identical response; they are marked `deprecated` in the OpenAPI description wherever the explicit form is
+  documented. They are deliberately **not** redirected: these routes accept `POST`, so a redirect would both downgrade `POST` to `GET`
   (dropping the request body) and, per the [Fetch standard](https://fetch.spec.whatwg.org/#http-redirect-fetch), turn any preflighted cross-origin request into
   a network error. Instead, responses to the bare form carry an [RFC 6596](https://www.rfc-editor.org/rfc/rfc6596) `Link: <...>; rel="canonical"` header naming
-  the canonical URL (query string preserved), exposed to browser clients via `Access-Control-Expose-Headers`.
+  the canonical URL (query string preserved), exposed to browser clients via `Access-Control-Expose-Headers`. The header is emitted on read methods only —
+  `GET` and `POST` — so a `/data` write (`PUT`, `PATCH`, `DELETE`) carries none: it names a canonical representation of the resource, and a write request is
+  not one.
 * **Response headers are readable by cross-origin browser clients**: only the CORS-safelisted headers are visible to JavaScript by default, so the API names
   its own in `Access-Control-Expose-Headers` — always `X-Request-Id` (so a browser client can quote it in a bug report), plus `ETag` (so a client can echo it
   back as `If-None-Match`) and the canonical `Link`, each named only on the responses that actually carry them.

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -145,7 +145,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -222,7 +227,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -414,7 +424,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -502,7 +517,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -696,7 +716,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -784,7 +809,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -969,7 +999,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1067,7 +1102,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1262,7 +1302,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1341,7 +1386,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1517,7 +1567,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -1607,7 +1662,12 @@
             "$ref": "#/components/responses/LitCal200"
           },
           "304": {
-            "description": "Not Modified: client should use cached results seeing that the response has not changed"
+            "description": "Not Modified: client should use cached results seeing that the response has not changed",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "400": {
             "$ref": "#/components/responses/BadRequest400"
@@ -4914,6 +4974,11 @@
         "responses": {
           "200": {
             "description": "OK: A collection of all possible liturgical events that can be found in a liturgical calendar produced by the LitCal API",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -4923,7 +4988,12 @@
             }
           },
           "304": {
-            "description": "304 Not Modified"
+            "description": "304 Not Modified",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
@@ -4952,6 +5022,11 @@
         "responses": {
           "200": {
             "description": "OK: A collection of all possible liturgical events that can be found in a liturgical calendar produced by the LitCal API",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -4961,7 +5036,12 @@
             }
           },
           "304": {
-            "description": "304 Not Modified"
+            "description": "304 Not Modified",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
@@ -5276,6 +5356,137 @@
         ],
         "summary": "Retrieve all possible liturgical events from the given national calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
         "operationId": "retrieveEventsForNationalCalendarGET",
+        "deprecated": true,
+        "description": "**Deprecated in favour of the explicit-rite form `/events/roman/nation/{calendar_id}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "CA",
+                "HR",
+                "IT",
+                "NL",
+                "US",
+                "VA"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in a liturgical calendar produced by the LitCal API",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the given national calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "operationId": "retrieveEventsForNationalCalendarPOST",
+        "deprecated": true,
+        "description": "**Deprecated in favour of the explicit-rite form `/events/roman/nation/{calendar_id}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "CA",
+                "HR",
+                "IT",
+                "NL",
+                "US",
+                "VA"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in a liturgical calendar produced by the LitCal API",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      }
+    },
+    "/events/roman/nation/{calendar_id}": {
+      "get": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the given national calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "operationId": "retrieveRomanRiteEventsForNationalCalendarGET",
+        "description": "This is the canonical form of this route: the rite is stated explicitly. The equivalent bare path (`/events/nation/{calendar_id}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header. There is no Ambrosian counterpart: the Ambrosian rite has no national calendars, so `/events/ambrosian/nation/{calendar_id}` returns 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -5327,7 +5538,8 @@
           {}
         ],
         "summary": "Retrieve all possible liturgical events from the given national calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
-        "operationId": "retrieveEventsForNationalCalendarPOST",
+        "operationId": "retrieveRomanRiteEventsForNationalCalendarPOST",
+        "description": "This is the canonical form of this route: the rite is stated explicitly. The equivalent bare path (`/events/nation/{calendar_id}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header. There is no Ambrosian counterpart: the Ambrosian rite has no national calendars, so `/events/ambrosian/nation/{calendar_id}` returns 400 Bad Request.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -5382,6 +5594,8 @@
         ],
         "summary": "Retrieve all possible liturgical events from the given diocesan calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
         "operationId": "retrieveEventsForDiocesanCalendarGET",
+        "deprecated": true,
+        "description": "**Deprecated in favour of the explicit-rite form `/events/roman/diocese/{calendar_id}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -5398,6 +5612,11 @@
         "responses": {
           "200": {
             "description": "OK: A collection of all possible liturgical events that can be found in a liturgical calendar produced by the LitCal API",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -5407,7 +5626,15 @@
             }
           },
           "304": {
-            "description": "304 Not Modified"
+            "description": "304 Not Modified",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
@@ -5426,6 +5653,68 @@
         ],
         "summary": "Retrieve all possible liturgical events from the given diocesan calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
         "operationId": "retrieveEventsForDiocesanCalendarPOST",
+        "deprecated": true,
+        "description": "**Deprecated in favour of the explicit-rite form `/events/roman/diocese/{calendar_id}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in a liturgical calendar produced by the LitCal API",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      }
+    },
+    "/events/roman/diocese/{calendar_id}": {
+      "get": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the given diocesan calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "operationId": "retrieveRomanRiteEventsForDiocesanCalendarGET",
+        "description": "This is the canonical form of this route: the rite is stated explicitly, symmetric with the `/events/ambrosian/diocese/{calendar_id}` variant. The equivalent bare path (`/events/diocese/{calendar_id}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header. Only Roman-rite dioceses are valid here: an Ambrosian diocese (milano_it, bergam_it, novara_it, lugano_ch) combined with the roman rite segment returns 400 Bad Request, as does a Roman diocese combined with the ambrosian one.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -5452,6 +5741,57 @@
           },
           "304": {
             "description": "304 Not Modified"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          },
+          "503": {
+            "$ref": "#/components/responses/ServiceUnavailable503"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Liturgical events"
+        ],
+        "security": [
+          {}
+        ],
+        "summary": "Retrieve all possible liturgical events from the given diocesan calendar even if they won't appear in the Liturgical Calendar one year or the other; useful mostly for frontend select inputs to choose an `event_key` that corresponds with an actual liturgical event",
+        "operationId": "retrieveRomanRiteEventsForDiocesanCalendarPOST",
+        "description": "This is the canonical form of this route: the rite is stated explicitly, symmetric with the `/events/ambrosian/diocese/{calendar_id}` variant. The equivalent bare path (`/events/diocese/{calendar_id}`) is retained for backwards compatibility and returns an identical response, advertising this URL through an RFC 6596 `Link: <...>; rel=\"canonical\"` response header. Only Roman-rite dioceses are valid here: an Ambrosian diocese (milano_it, bergam_it, novara_it, lugano_ch) combined with the roman rite segment returns 400 Bad Request, as does a Roman diocese combined with the ambrosian one.",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AcceptLanguageHeader"
+          },
+          {
+            "in": "path",
+            "name": "calendar_id",
+            "required": true,
+            "schema": {
+              "$ref": "./CommonDef.json#/definitions/DiocesanCalendarId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A collection of all possible liturgical events that can be found in a liturgical calendar produced by the LitCal API",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LitCalAllFestivitiesResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "304 Not Modified"
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest400"
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
@@ -5471,8 +5811,9 @@
           {}
         ],
         "summary": "Retrieve a national calendar data resource",
-        "description": "`/data/roman/nation/{key}` states the same rite explicitly and is the canonical form of this path. There is no other rite-qualified variant: only the diocesan tier exists under more than one rite, so `/data/ambrosian/nation/{key}` returns `400 Bad Request` (\"The ambrosian rite has no national calendars; request a diocesan calendar of that rite instead.\").",
+        "description": "`/data/roman/nation/{key}` states the same rite explicitly and is the canonical form of this path. There is no other rite-qualified variant: only the diocesan tier exists under more than one rite, so `/data/ambrosian/nation/{key}` returns `400 Bad Request` (\"The ambrosian rite has no national calendars; request a diocesan calendar of that rite instead.\").\n\n**Deprecated in favour of the explicit-rite form `/data/roman/nation/{key}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "nationalDataGET",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -5492,6 +5833,11 @@
         "responses": {
           "200": {
             "description": "OK: National calendar data resource retrieved successfully",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -5524,8 +5870,9 @@
           }
         ],
         "summary": "Create a national calendar data resource",
-        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/nation/{key}`,** which is canonical. This path keeps working unchanged and behaves identically; it is deliberately not redirected, since a redirect would downgrade the method and drop the request body. Unlike the read methods it carries no `Link: <...>; rel=\"canonical\"` header: that header names a canonical representation of the resource, which a write request is not.",
         "operationId": "nationalCalendarDataPUT",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -5603,6 +5950,8 @@
         ],
         "summary": "Retrieve a national calendar data resource",
         "operationId": "nationalDataPOST",
+        "deprecated": true,
+        "description": "**Deprecated in favour of the explicit-rite form `/data/roman/nation/{key}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -5634,6 +5983,11 @@
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -5666,8 +6020,9 @@
           }
         ],
         "summary": "Update a national calendar data resource",
-        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.",
+        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/nation/{key}`,** which is canonical. This path keeps working unchanged and behaves identically; it is deliberately not redirected, since a redirect would downgrade the method and drop the request body. Unlike the read methods it carries no `Link: <...>; rel=\"canonical\"` header: that header names a canonical representation of the resource, which a write request is not.",
         "operationId": "nationalDataPATCH",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -5748,8 +6103,9 @@
           }
         ],
         "summary": "Delete a national calendar data resource",
-        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`.",
+        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/nation/{key}`,** which is canonical. This path keeps working unchanged and behaves identically; it is deliberately not redirected, since a redirect would downgrade the method and drop the request body. Unlike the read methods it carries no `Link: <...>; rel=\"canonical\"` header: that header names a canonical representation of the resource, which a write request is not.",
         "operationId": "nationalDataDELETE",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -6107,8 +6463,9 @@
           {}
         ],
         "summary": "Retrieve a diocesan calendar data resource",
-        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` states the same rite explicitly and is the canonical form of this path.",
+        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` states the same rite explicitly and is the canonical form of this path.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/diocese/{key}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "diocesanDataGET",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -6128,6 +6485,11 @@
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -6160,8 +6522,9 @@
           }
         ],
         "summary": "Create a diocesan calendar data resource",
-        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/diocese/{key}`,** which is canonical. This path keeps working unchanged and behaves identically; it is deliberately not redirected, since a redirect would downgrade the method and drop the request body. Unlike the read methods it carries no `Link: <...>; rel=\"canonical\"` header: that header names a canonical representation of the resource, which a write request is not.",
         "operationId": "diocesanDataPUT",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -6238,8 +6601,9 @@
           {}
         ],
         "summary": "Retrieve a diocesan calendar data resource",
-        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` states the same rite explicitly and is the canonical form of this path.",
+        "description": "This path resolves to the Roman rite. A diocese defined under another rite must be addressed through its rite-qualified path (`/data/ambrosian/diocese/{key}`); asking for one here returns `422 Unprocessable Content`. `/data/roman/diocese/{key}` states the same rite explicitly and is the canonical form of this path.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/diocese/{key}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "diocesanDataPOST",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -6271,6 +6635,11 @@
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -6303,8 +6672,9 @@
           }
         ],
         "summary": "Update a diocesan calendar data resource",
-        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.",
+        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/diocese/{key}`,** which is canonical. This path keeps working unchanged and behaves identically; it is deliberately not redirected, since a redirect would downgrade the method and drop the request body. Unlike the read methods it carries no `Link: <...>; rel=\"canonical\"` header: that header names a canonical representation of the resource, which a write request is not.",
         "operationId": "diocesanDataPATCH",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -6384,8 +6754,9 @@
           }
         ],
         "summary": "Delete a diocesan calendar data resource",
-        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.",
+        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`. This path resolves to the Roman rite; an Ambrosian diocese must be addressed through `/data/ambrosian/diocese/{key}`.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/diocese/{key}`,** which is canonical. This path keeps working unchanged and behaves identically; it is deliberately not redirected, since a redirect would downgrade the method and drop the request body. Unlike the read methods it carries no `Link: <...>; rel=\"canonical\"` header: that header names a canonical representation of the resource, which a write request is not.",
         "operationId": "diocesanDataDELETE",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -6747,8 +7118,9 @@
           {}
         ],
         "summary": "Retrieve a wider region calendar data resource",
-        "description": "`/data/roman/widerregion/{key}` states the same rite explicitly and is the canonical form of this path. There is no other rite-qualified variant: wider regions are a layer over national calendars, which exist only in the Roman rite, so `/data/ambrosian/widerregion/{key}` returns `400 Bad Request`.",
+        "description": "`/data/roman/widerregion/{key}` states the same rite explicitly and is the canonical form of this path. There is no other rite-qualified variant: wider regions are a layer over national calendars, which exist only in the Roman rite, so `/data/ambrosian/widerregion/{key}` returns `400 Bad Request`.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/widerregion/{key}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "widerregionDataGET",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -6768,6 +7140,11 @@
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -6800,8 +7177,9 @@
           }
         ],
         "summary": "Create a wider region data resource",
-        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.",
+        "description": "Create (`PUT`) requires the `admin` relation. `admin` implies `editor` and `viewer`. The `{key}` in the path is authoritative; the corresponding identifier in the request body must match it.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/widerregion/{key}`,** which is canonical. This path keeps working unchanged and behaves identically; it is deliberately not redirected, since a redirect would downgrade the method and drop the request body. Unlike the read methods it carries no `Link: <...>; rel=\"canonical\"` header: that header names a canonical representation of the resource, which a write request is not.",
         "operationId": "widerregionDataPUT",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -6879,6 +7257,8 @@
         ],
         "summary": "Retrieve a wider region calendar data resource",
         "operationId": "widerregionDataPOST",
+        "deprecated": true,
+        "description": "**Deprecated in favour of the explicit-rite form `/data/roman/widerregion/{key}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -6910,6 +7290,11 @@
         "responses": {
           "200": {
             "description": "OK: Regional calendar data resource (whether national, or diocesan, or wider region) retrieved successfully",
+            "headers": {
+              "Link": {
+                "$ref": "#/components/headers/CanonicalRiteLink"
+              }
+            },
             "content": {
               "application/json": {
                 "schema": {
@@ -6942,8 +7327,9 @@
           }
         ],
         "summary": "Update a wider region calendar data resource",
-        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.",
+        "description": "Edit (`PATCH`) requires the `editor` relation; `DELETE` requires `admin`. `admin` implies `editor` and `viewer`.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/widerregion/{key}`,** which is canonical. This path keeps working unchanged and behaves identically; it is deliberately not redirected, since a redirect would downgrade the method and drop the request body. Unlike the read methods it carries no `Link: <...>; rel=\"canonical\"` header: that header names a canonical representation of the resource, which a write request is not.",
         "operationId": "widerregionDataPATCH",
+        "deprecated": true,
         "parameters": [
           {
             "$ref": "#/components/parameters/AcceptLanguageHeader"
@@ -7023,8 +7409,9 @@
           }
         ],
         "summary": "Delete a wider region calendar data resource",
-        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`.",
+        "description": "`DELETE` requires the `admin` relation. `admin` implies `editor` and `viewer`.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/widerregion/{key}`,** which is canonical. This path keeps working unchanged and behaves identically; it is deliberately not redirected, since a redirect would downgrade the method and drop the request body. Unlike the read methods it carries no `Link: <...>; rel=\"canonical\"` header: that header names a canonical representation of the resource, which a write request is not.",
         "operationId": "widerregionDataDELETE",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -7693,8 +8080,9 @@
           {}
         ],
         "summary": "Retrieve the stored translations of a national calendar",
-        "description": "Retrieve the stored translations of a national calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/nation/{key}`, which the path hangs off: that returns the calendar definition, this returns the translation file behind it.\n\nOnly `GET` and `POST` exist at this depth. `RegionalDataHandler::validateRequestPath()` accepts two or three path segments for those two methods and exactly two for the others, and the router narrows the allowed methods to `GET` and `POST` for any three-segment `/data` path, so a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). `POST` is a read alias of `GET`.\n\nThe third segment binds to `i18nRequest`. It is not the `locale` parameter that `/data/nation/{key}` accepts, and the two are documented separately for that reason.\n\nAn unknown nation is refused with `422 Unprocessable Content`; a nation that exists but has no translation file for the requested locale gives `404 Not Found`. `/data/roman/nation/{key}/{i18n_locale}` states the same rite explicitly and is the canonical form of this path.",
+        "description": "Retrieve the stored translations of a national calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/nation/{key}`, which the path hangs off: that returns the calendar definition, this returns the translation file behind it.\n\nOnly `GET` and `POST` exist at this depth. `RegionalDataHandler::validateRequestPath()` accepts two or three path segments for those two methods and exactly two for the others, and the router narrows the allowed methods to `GET` and `POST` for any three-segment `/data` path, so a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). `POST` is a read alias of `GET`.\n\nThe third segment binds to `i18nRequest`. It is not the `locale` parameter that `/data/nation/{key}` accepts, and the two are documented separately for that reason.\n\nAn unknown nation is refused with `422 Unprocessable Content`; a nation that exists but has no translation file for the requested locale gives `404 Not Found`. `/data/roman/nation/{key}/{i18n_locale}` states the same rite explicitly and is the canonical form of this path.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/nation/{key}/{i18n_locale}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "nationalDataI18nGET",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -7731,8 +8119,9 @@
           {}
         ],
         "summary": "Retrieve the stored translations of a national calendar",
-        "description": "Read alias of `GET /data/nation/{key}/{i18n_locale}`, returning the same translation map. See that operation for how the third path segment differs from the `locale` parameter.",
+        "description": "Read alias of `GET /data/nation/{key}/{i18n_locale}`, returning the same translation map. See that operation for how the third path segment differs from the `locale` parameter.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/nation/{key}/{i18n_locale}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "nationalDataI18nPOST",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -7849,8 +8238,9 @@
           {}
         ],
         "summary": "Retrieve the stored translations of a diocesan calendar",
-        "description": "Retrieve the stored translations of a diocesan calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/diocese/{key}`, which returns the calendar definition itself.\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path.\n\nThis path resolves to the Roman rite. An unknown diocese, or a diocese defined under another rite, is refused with `422 Unprocessable Content` (`Diocesan calendar ... belongs to the ambrosian rite, not the requested roman rite.`); such a diocese must be addressed through `/data/ambrosian/diocese/{key}/{i18n_locale}`. A diocese that exists but has no translation file for the requested locale gives `404 Not Found`. `/data/roman/diocese/{key}/{i18n_locale}` states the same rite explicitly and is the canonical form of this path.",
+        "description": "Retrieve the stored translations of a diocesan calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/diocese/{key}`, which returns the calendar definition itself.\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path.\n\nThis path resolves to the Roman rite. An unknown diocese, or a diocese defined under another rite, is refused with `422 Unprocessable Content` (`Diocesan calendar ... belongs to the ambrosian rite, not the requested roman rite.`); such a diocese must be addressed through `/data/ambrosian/diocese/{key}/{i18n_locale}`. A diocese that exists but has no translation file for the requested locale gives `404 Not Found`. `/data/roman/diocese/{key}/{i18n_locale}` states the same rite explicitly and is the canonical form of this path.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/diocese/{key}/{i18n_locale}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "diocesanDataI18nGET",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -7887,8 +8277,9 @@
           {}
         ],
         "summary": "Retrieve the stored translations of a diocesan calendar",
-        "description": "Read alias of `GET /data/diocese/{key}/{i18n_locale}`, returning the same translation map. This path resolves to the Roman rite; a diocese defined under another rite is refused with `422 Unprocessable Content`.",
+        "description": "Read alias of `GET /data/diocese/{key}/{i18n_locale}`, returning the same translation map. This path resolves to the Roman rite; a diocese defined under another rite is refused with `422 Unprocessable Content`.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/diocese/{key}/{i18n_locale}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "diocesanDataI18nPOST",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -8005,8 +8396,9 @@
           {}
         ],
         "summary": "Retrieve the stored translations of a wider region calendar",
-        "description": "Retrieve the stored translations of a wider region calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/widerregion/{key}`, which returns the calendar definition itself.\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path.\n\nAn unknown wider region is refused with `422 Unprocessable Content`; a wider region that exists but has no translation file for the requested locale gives `404 Not Found`. `/data/roman/widerregion/{key}/{i18n_locale}` states the same rite explicitly and is the canonical form of this path.",
+        "description": "Retrieve the stored translations of a wider region calendar's own liturgical events, as a map of `event_key` to translated name. This is a different resource from `/data/widerregion/{key}`, which returns the calendar definition itself.\n\nOnly `GET` and `POST` exist at this depth; a `PUT`, `PATCH` or `DELETE` carrying a third segment is refused with `400 Bad Request` (`Expected two path params for PUT, PATCH and DELETE requests, received 3`). The third segment binds to `i18nRequest` and is not the `locale` parameter of the two-segment path.\n\nAn unknown wider region is refused with `422 Unprocessable Content`; a wider region that exists but has no translation file for the requested locale gives `404 Not Found`. `/data/roman/widerregion/{key}/{i18n_locale}` states the same rite explicitly and is the canonical form of this path.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/widerregion/{key}/{i18n_locale}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "widerregionDataI18nGET",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -8043,8 +8435,9 @@
           {}
         ],
         "summary": "Retrieve the stored translations of a wider region calendar",
-        "description": "Read alias of `GET /data/widerregion/{key}/{i18n_locale}`, returning the same translation map.",
+        "description": "Read alias of `GET /data/widerregion/{key}/{i18n_locale}`, returning the same translation map.\n\n**Deprecated in favour of the explicit-rite form `/data/roman/widerregion/{key}/{i18n_locale}`,** which is canonical. This path keeps working unchanged and returns an identical response \u2014 it is deliberately not redirected, because these routes accept POST and a redirect would both downgrade POST to GET and break preflighted cross-origin requests. Responses carry a `Link: <...>; rel=\"canonical\"` header naming the canonical URL.",
         "operationId": "widerregionDataI18nPOST",
+        "deprecated": true,
         "parameters": [
           {
             "name": "key",
@@ -13238,6 +13631,11 @@
       },
       "RegionalDataI18n200": {
         "description": "OK: the stored translation map for the requested calendar and locale.\n\nThis is a different payload shape from the calendar definition that the two-segment path returns. It is a flat object whose keys are the `event_key` identifiers of that calendar's own liturgical events and whose values are the translated names, served verbatim from the calendar's `i18n/{i18n_locale}.json` source file. Only the events the calendar itself defines appear here: events inherited from the General Roman Calendar, or from a wider region, are translated elsewhere.",
+        "headers": {
+          "Link": {
+            "$ref": "#/components/headers/CanonicalRiteLink"
+          }
+        },
         "content": {
           "application/json": {
             "schema": {
@@ -13499,6 +13897,9 @@
               ]
             },
             "description": "Indicates whether the current response was produced from: a fresh calculation since the response to the given request had not yet been calculated, or from client cache since the response has not changed since last request, or from server cache since the client had not yet made this same request but the calculation had already been done formerly on the server"
+          },
+          "Link": {
+            "$ref": "#/components/headers/CanonicalRiteLink"
           }
         },
         "content": {
@@ -13524,6 +13925,15 @@
             }
           }
         }
+      }
+    },
+    "headers": {
+      "CanonicalRiteLink": {
+        "description": "RFC 6596 link to the canonical explicit-rite spelling of this route, emitted when the request omitted the optional rite segment: `GET /events/nation/IT` answers `</events/roman/nation/IT>; rel=\"canonical\"`, preserving the query string. A request that already names its rite is itself canonical and carries no `Link`. Read methods only \u2014 `GET` and `POST` carry it, a `/data` write does not, since the header names a canonical representation of the resource and a write request is not one. The bare spelling keeps working and is deliberately not redirected: these routes accept POST, a redirect would both downgrade POST to GET and drop the body, and per the Fetch standard a browser treats any redirect response to a preflighted cross-origin request as a network error. `Link` is not a CORS-safelisted response header, so it is also named in `Access-Control-Expose-Headers`.",
+        "schema": {
+          "type": "string"
+        },
+        "example": "<https://litcal.johnromanodorazio.com/api/dev/events/roman/nation/IT>; rel=\"canonical\""
       }
     },
     "securitySchemes": {

--- a/phpunit_tests/RouterCanonicalRiteLinkTest.php
+++ b/phpunit_tests/RouterCanonicalRiteLinkTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests;
 
 use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -17,6 +19,11 @@ use PHPUnit\Framework\TestCase;
  * A redirect is not usable here: the calendar routes accept POST, a 301/302 would downgrade
  * POST to GET and drop the body, and per the Fetch standard a browser treats any redirect
  * response to a preflighted cross-origin request as a network error.
+ *
+ * The header is scoped to the read methods (`GET` and `POST`). `/data` is the route that
+ * makes the distinction matter — it is a mixed read/write surface, and `rel="canonical"` on
+ * a `PUT` describes nothing the request is doing (#848). The same rule covers `OPTIONS`:
+ * a CORS preflight is a control response rather than a representation of the resource.
  */
 #[CoversMethod(Router::class, 'canonicalRiteUrl')]
 final class RouterCanonicalRiteLinkTest extends TestCase
@@ -46,7 +53,7 @@ final class RouterCanonicalRiteLinkTest extends TestCase
     {
         self::assertSame(
             'https://example.test/api/dev/calendar/roman/2026',
-            Router::canonicalRiteUrl('calendar', false, Rite::ROMAN, ['2026'])
+            Router::canonicalRiteUrl('calendar', 'GET', false, Rite::ROMAN, ['2026'])
         );
     }
 
@@ -54,7 +61,7 @@ final class RouterCanonicalRiteLinkTest extends TestCase
     {
         self::assertSame(
             'https://example.test/api/dev/calendar/roman',
-            Router::canonicalRiteUrl('calendar', false, Rite::ROMAN, [])
+            Router::canonicalRiteUrl('calendar', 'GET', false, Rite::ROMAN, [])
         );
     }
 
@@ -62,7 +69,7 @@ final class RouterCanonicalRiteLinkTest extends TestCase
     {
         self::assertSame(
             'https://example.test/api/dev/calendar/roman/nation/IT/2026',
-            Router::canonicalRiteUrl('calendar', false, Rite::ROMAN, ['nation', 'IT', '2026'])
+            Router::canonicalRiteUrl('calendar', 'GET', false, Rite::ROMAN, ['nation', 'IT', '2026'])
         );
     }
 
@@ -70,35 +77,94 @@ final class RouterCanonicalRiteLinkTest extends TestCase
     {
         self::assertSame(
             'https://example.test/api/dev/events/roman',
-            Router::canonicalRiteUrl('events', false, Rite::ROMAN, [])
+            Router::canonicalRiteUrl('events', 'GET', false, Rite::ROMAN, [])
         );
+    }
+
+    /**
+     * `/data` reads the source definition of a calendar, and that read wants the same
+     * discoverability the other two route families have (#848).
+     */
+    public function testBareDataRouteAdvertisesTheExplicitRomanForm(): void
+    {
+        self::assertSame(
+            'https://example.test/api/dev/data/roman/nation/IT',
+            Router::canonicalRiteUrl('data', 'GET', false, Rite::ROMAN, ['nation', 'IT'])
+        );
+    }
+
+    /**
+     * On `/data`, `POST` is a read verb — the "retrieve with parameters in a request body"
+     * spelling of `GET` — which is why the read surface is `GET`+`POST` rather than `GET` alone.
+     */
+    public function testBareDataRouteAdvertisesTheCanonicalFormOnAPostRead(): void
+    {
+        self::assertSame(
+            'https://example.test/api/dev/data/roman/diocese/romamo_it',
+            Router::canonicalRiteUrl('data', 'POST', false, Rite::ROMAN, ['diocese', 'romamo_it'])
+        );
+    }
+
+    /**
+     * @return array<string,array{0:string}>
+     */
+    public static function writeMethods(): array
+    {
+        return [
+            'PUT'    => [RequestMethod::PUT->value],
+            'PATCH'  => [RequestMethod::PATCH->value],
+            'DELETE' => [RequestMethod::DELETE->value],
+        ];
+    }
+
+    /**
+     * A write request is not a representation of the resource it is addressed to, so naming a
+     * canonical URL for it is noise. This is the objection the `data` route was originally
+     * excluded over; scoping by method preserves it exactly.
+     */
+    #[DataProvider('writeMethods')]
+    public function testAWriteRequestAdvertisesNoCanonicalForm(string $method): void
+    {
+        self::assertNull(Router::canonicalRiteUrl('data', $method, false, Rite::ROMAN, ['nation', 'IT']));
+    }
+
+    /**
+     * A CORS preflight is a control response rather than a representation of the resource.
+     * It needs no separate guard: `OPTIONS` is not a read method.
+     */
+    public function testAPreflightAdvertisesNoCanonicalForm(): void
+    {
+        self::assertNull(Router::canonicalRiteUrl('calendar', 'OPTIONS', false, Rite::ROMAN, ['2026']));
+        self::assertNull(Router::canonicalRiteUrl('events', 'OPTIONS', false, Rite::ROMAN, []));
+        self::assertNull(Router::canonicalRiteUrl('data', 'OPTIONS', false, Rite::ROMAN, ['nation', 'IT']));
     }
 
     public function testQueryStringIsPreservedOnTheCanonicalUrl(): void
     {
         self::assertSame(
             'https://example.test/api/dev/calendar/roman/2026?year_type=CIVIL&locale=it',
-            Router::canonicalRiteUrl('calendar', false, Rite::ROMAN, ['2026'], 'year_type=CIVIL&locale=it')
+            Router::canonicalRiteUrl('calendar', 'GET', false, Rite::ROMAN, ['2026'], 'year_type=CIVIL&locale=it')
         );
     }
 
     public function testAnExplicitRiteRequestIsAlreadyCanonicalSoNoLinkIsAdvertised(): void
     {
-        self::assertNull(Router::canonicalRiteUrl('calendar', true, Rite::ROMAN, ['2026']));
-        self::assertNull(Router::canonicalRiteUrl('calendar', true, Rite::AMBROSIAN, ['diocese', 'milano_it']));
+        self::assertNull(Router::canonicalRiteUrl('calendar', 'GET', true, Rite::ROMAN, ['2026']));
+        self::assertNull(Router::canonicalRiteUrl('calendar', 'GET', true, Rite::AMBROSIAN, ['diocese', 'milano_it']));
+        self::assertNull(Router::canonicalRiteUrl('data', 'GET', true, Rite::ROMAN, ['nation', 'IT']));
     }
 
     public function testRoutesWithoutARiteSegmentAdvertiseNoCanonicalForm(): void
     {
-        // Only the calendar and events routes carry a rite segment (see extractRiteSegment()).
-        self::assertNull(Router::canonicalRiteUrl('metadata', false, Rite::ROMAN, []));
-        self::assertNull(Router::canonicalRiteUrl('missals', false, Rite::ROMAN, ['EDITIO_TYPICA_1970']));
+        // Only the calendar, events and data routes carry a rite segment (see extractRiteSegment()).
+        self::assertNull(Router::canonicalRiteUrl('metadata', 'GET', false, Rite::ROMAN, []));
+        self::assertNull(Router::canonicalRiteUrl('missals', 'GET', false, Rite::ROMAN, ['EDITIO_TYPICA_1970']));
     }
 
     public function testTheRootRouteAdvertisesNoCanonicalForm(): void
     {
         // `/` resolves to the calendar handler, but canonicalising it to `/calendar/roman`
         // would rename the endpoint rather than merely make the rite explicit.
-        self::assertNull(Router::canonicalRiteUrl('', false, Rite::ROMAN, []));
+        self::assertNull(Router::canonicalRiteUrl('', 'GET', false, Rite::ROMAN, []));
     }
 }

--- a/phpunit_tests/Routes/Readonly/CanonicalRiteLinkHeaderTest.php
+++ b/phpunit_tests/Routes/Readonly/CanonicalRiteLinkHeaderTest.php
@@ -7,8 +7,8 @@ namespace LiturgicalCalendar\Tests\Routes\Readonly;
 use LiturgicalCalendar\Tests\ApiTestCase;
 
 /**
- * Live HTTP integration test for the RFC 6596 `Link: rel="canonical"` header on the calendar
- * and events routes.
+ * Live HTTP integration test for the RFC 6596 `Link: rel="canonical"` header on the calendar,
+ * events and data routes.
  *
  * The explicit rite form (`/calendar/roman/2026`) is the canonical form; the bare form
  * (`/calendar/2026`) is retained for backwards compatibility and points at the canonical form
@@ -19,6 +19,11 @@ use LiturgicalCalendar\Tests\ApiTestCase;
  *
  * `Link` is not a CORS-safelisted response header, so it is only readable by a cross-origin
  * browser client when the API also names it in `Access-Control-Expose-Headers`.
+ *
+ * `/data` carries the header on its read methods only (#848). The write half of that rule is
+ * asserted in {@see \LiturgicalCalendar\Tests\RouterCanonicalRiteLinkTest}: proving it here would
+ * mean driving an authenticated `PUT` all the way to a 2xx — creating and deleting a calendar
+ * definition — where the unit test states the same rule without the side effects.
  */
 final class CanonicalRiteLinkHeaderTest extends ApiTestCase
 {
@@ -157,6 +162,46 @@ final class CanonicalRiteLinkHeaderTest extends ApiTestCase
         $response = self::$http->get('/calendar/nation/XX/2026', ['http_errors' => false]);
 
         self::assertSame(400, $response->getStatusCode());
+        self::assertSame('', $response->getHeaderLine('Link'));
+    }
+
+    /**
+     * `/data` reads a calendar's source definition, and that read wants the same discoverability
+     * the other two families have. The header was previously withheld from the whole route on the
+     * grounds that it is an admin write surface; scoping it to the read methods keeps that
+     * objection intact while serving the reads (#848).
+     */
+    public function testBareNationalDataReadAdvertisesTheExplicitRomanForm(): void
+    {
+        $response = self::$http->get('/data/nation/IT', ['headers' => ['Accept-Language' => 'it-IT']]);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '#^<' . self::originPattern() . '/data/roman/nation/IT>; rel="canonical"$#',
+            $response->getHeaderLine('Link')
+        );
+    }
+
+    /**
+     * On `/data`, `POST` is a read verb — the "retrieve with parameters in a request body" form of
+     * `GET` — which is why the read surface is `GET`+`POST` rather than `GET` alone.
+     */
+    public function testBareDiocesanDataPostReadAdvertisesTheExplicitRomanForm(): void
+    {
+        $response = self::$http->post('/data/diocese/romamo_it', ['headers' => ['Accept-Language' => 'it-IT']]);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertMatchesRegularExpression(
+            '#^<' . self::originPattern() . '/data/roman/diocese/romamo_it>; rel="canonical"$#',
+            $response->getHeaderLine('Link')
+        );
+    }
+
+    public function testAnExplicitRomanDataReadIsAlreadyCanonicalSoCarriesNoLink(): void
+    {
+        $response = self::$http->get('/data/roman/nation/IT', ['headers' => ['Accept-Language' => 'it-IT']]);
+
+        self::assertSame(200, $response->getStatusCode());
         self::assertSame('', $response->getHeaderLine('Link'));
     }
 }

--- a/phpunit_tests/Schemas/OpenApiCanonicalFormTest.php
+++ b/phpunit_tests/Schemas/OpenApiCanonicalFormTest.php
@@ -1,0 +1,414 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * How openapi.json describes the relationship between the two equivalent spellings of a
+ * rite-qualified route: the bare one (`/events/nation/IT`) and the canonical explicit one
+ * (`/events/roman/nation/IT`).
+ *
+ * Two claims, both previously undocumented (#848):
+ *
+ * 1. **The canonical `Link` header.** `Router::canonicalRiteUrl()` answers a bare read request
+ *    with an RFC 6596 `Link: <...>; rel="canonical"` naming the explicit form. Not one response
+ *    in the document declared that header, so a generated client had no idea it existed. It is
+ *    declared on the responses that actually carry it: the `200` (and the `304` that stands in
+ *    for it) of the bare read operations. A request that already named the rite is itself
+ *    canonical and carries no header — asserted wherever the explicit form has a response object
+ *    of its own. `/calendar` and the `/data` i18n sub-resource share one response component
+ *    between both spellings, so there the header rides on the shared component and its
+ *    description carries the condition; those are the paths this test cannot assert negatively.
+ *
+ * 2. **Deprecation of the bare spellings.** The established rule is: a roman variant exists ⇒ the
+ *    bare form is deprecated (`/calendar` has marked its bare operations so since the rite segment
+ *    landed). #848 decided to apply that rule uniformly rather than let it drift, which reaches
+ *    `/events`'s tiers and all of `/data`, write methods included: `deprecated` describes the
+ *    *spelling* of the path, not the safety of the operation, and the write methods have an
+ *    explicit spelling to move to just as the reads do.
+ */
+final class OpenApiCanonicalFormTest extends TestCase
+{
+    private const HEADER_REF = '#/components/headers/CanonicalRiteLink';
+
+    /** Route families whose first path segment takes an optional rite segment. */
+    private const RITE_ROUTES = ['calendar', 'events', 'data'];
+
+    /**
+     * Loaded lazily rather than in `setUpBeforeClass()`: the data providers below enumerate the
+     * document itself, and PHPUnit runs providers before any fixture method.
+     *
+     * @var array<string,mixed>|null
+     */
+    private static ?array $openapi = null;
+
+    /**
+     * @return array<string,mixed>
+     */
+    private static function openapi(): array
+    {
+        if (null === self::$openapi) {
+            $raw = file_get_contents(dirname(__DIR__, 2) . '/jsondata/schemas/openapi.json');
+
+            if (false === $raw) {
+                throw new \RuntimeException('Could not read openapi.json');
+            }
+
+            /** @var array<string,mixed> $decoded */
+            $decoded       = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            self::$openapi = $decoded;
+        }
+
+        return self::$openapi;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private static function paths(): array
+    {
+        /** @var array<string,array<string,mixed>> $paths */
+        $paths = self::openapi()['paths'];
+
+        return $paths;
+    }
+
+    /**
+     * The route family a path belongs to, or null when it is not one of the three that take a
+     * rite segment. Split on segments rather than matched as a prefix: `/calendars` is a different
+     * endpoint from `/calendar`, and a prefix match would sweep it in.
+     */
+    private static function riteRouteOf(string $path): ?string
+    {
+        $segments = explode('/', ltrim($path, '/'));
+        $route    = $segments[0] ?? '';
+
+        return in_array($route, self::RITE_ROUTES, true) ? $route : null;
+    }
+
+    /**
+     * Whether the path states its rite explicitly (`/events/roman/...`, `/calendar/ambrosian/...`).
+     */
+    private static function isRiteQualified(string $path): bool
+    {
+        $segments = explode('/', ltrim($path, '/'));
+
+        return isset($segments[1]) && null !== Rite::tryFrom($segments[1]);
+    }
+
+    /**
+     * The canonical spelling of a bare path: the same path with the default rite named explicitly.
+     */
+    private static function canonicalTwinOf(string $path): string
+    {
+        $segments = explode('/', ltrim($path, '/'));
+        array_splice($segments, 1, 0, Rite::default()->value);
+
+        return '/' . implode('/', $segments);
+    }
+
+    /**
+     * @param array<string,mixed> $pathItem
+     *
+     * @return list<string>
+     */
+    private static function operationMethods(array $pathItem): array
+    {
+        $methods = array_values(array_intersect(
+            array_keys($pathItem),
+            ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
+        ));
+        sort($methods);
+
+        return $methods;
+    }
+
+    /**
+     * A response object with any `$ref` to a shared response component resolved, so a response
+     * declared once and reused by several operations is inspected the same way as an inline one.
+     *
+     * @param array<string,mixed> $response
+     *
+     * @return array{0:array<string,mixed>,1:bool} the resolved response, and whether it was shared
+     */
+    private static function resolveResponse(array $response): array
+    {
+        if (false === isset($response['$ref'])) {
+            return [$response, false];
+        }
+
+        $ref = $response['$ref'];
+        self::assertIsString($ref);
+        self::assertStringStartsWith('#/components/responses/', $ref);
+
+        /** @var array<string,array<string,array<string,mixed>>> $components */
+        $components = self::openapi()['components'];
+        $name       = substr($ref, strlen('#/components/responses/'));
+        self::assertArrayHasKey($name, $components['responses'], "unresolvable response {$ref}");
+
+        return [$components['responses'][$name], true];
+    }
+
+    /**
+     * @param array<string,mixed> $response
+     */
+    private static function declaresCanonicalLink(array $response): bool
+    {
+        $headers = $response['headers'] ?? [];
+
+        return is_array($headers)
+            && isset($headers['Link'])
+            && is_array($headers['Link'])
+            && ( $headers['Link']['$ref'] ?? null ) === self::HEADER_REF;
+    }
+
+    /**
+     * The read operations of every bare path in the three rite-taking families: exactly the
+     * operations `Router::canonicalRiteUrl()` emits the header on.
+     *
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function bareReadOperations(): array
+    {
+        $operations = [];
+
+        foreach (self::paths() as $path => $pathItem) {
+            $path = (string) $path;
+            if (null === self::riteRouteOf($path) || self::isRiteQualified($path)) {
+                continue;
+            }
+
+            /** @var array<string,mixed> $pathItem */
+            foreach (array_intersect(self::operationMethods($pathItem), ['get', 'post']) as $method) {
+                $operations[strtoupper($method) . ' ' . $path] = [$path, $method];
+            }
+        }
+
+        return $operations;
+    }
+
+    /**
+     * The header is declared on the `200`, and on the `304` wherever one is documented: a resolved
+     * conditional request stands in for the `200` it would otherwise have been and carries the same
+     * canonical URL, so a client driving its own conditional requests does not lose it.
+     */
+    #[DataProvider('bareReadOperations')]
+    public function testABareReadOperationDeclaresTheCanonicalLinkHeader(string $path, string $method): void
+    {
+        /** @var array<string,array<string,array<string,mixed>>> $pathItem */
+        $pathItem = self::paths()[$path];
+        /** @var array<string,array<string,mixed>> $responses */
+        $responses = $pathItem[$method]['responses'];
+
+        foreach (['200', '304'] as $status) {
+            if (false === isset($responses[$status])) {
+                continue;
+            }
+
+            [$response] = self::resolveResponse($responses[$status]);
+            self::assertTrue(
+                self::declaresCanonicalLink($response),
+                strtoupper($method) . " {$path} carries a Link: rel=\"canonical\" on its {$status}, which it does not declare"
+            );
+        }
+    }
+
+    /**
+     * The counterpart: a request that already names its rite is canonical, so it sends no header.
+     * Only assertable where the explicit form has a response object of its own — `/calendar` and
+     * the `/data` i18n sub-resource share one component between both spellings.
+     *
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function riteQualifiedReadOperations(): array
+    {
+        $operations = [];
+
+        foreach (self::paths() as $path => $pathItem) {
+            $path = (string) $path;
+            if (null === self::riteRouteOf($path) || false === self::isRiteQualified($path)) {
+                continue;
+            }
+
+            /** @var array<string,mixed> $pathItem */
+            foreach (array_intersect(self::operationMethods($pathItem), ['get', 'post']) as $method) {
+                $operations[strtoupper($method) . ' ' . $path] = [$path, $method];
+            }
+        }
+
+        return $operations;
+    }
+
+    #[DataProvider('riteQualifiedReadOperations')]
+    public function testARiteQualifiedReadOperationDeclaresNoCanonicalLinkHeader(string $path, string $method): void
+    {
+        /** @var array<string,array<string,array<string,mixed>>> $pathItem */
+        $pathItem = self::paths()[$path];
+        /** @var array<string,array<string,mixed>> $responses */
+        $responses = $pathItem[$method]['responses'];
+
+        foreach (['200', '304'] as $status) {
+            if (false === isset($responses[$status])) {
+                continue;
+            }
+
+            [$response, $shared] = self::resolveResponse($responses[$status]);
+            if ($shared) {
+                // Shared with the bare spelling, which does carry the header; the condition lives
+                // in the header's own description rather than in the operation.
+                continue;
+            }
+
+            self::assertFalse(
+                self::declaresCanonicalLink($response),
+                strtoupper($method) . " {$path} is already canonical, so its {$status} must not declare a canonical Link header"
+            );
+        }
+    }
+
+    /**
+     * `/data`'s write methods are the reason the header is scoped by method at all: a
+     * `rel="canonical"` on a `PUT` would describe nothing the request is doing.
+     *
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function writeOperations(): array
+    {
+        $operations = [];
+
+        foreach (self::paths() as $path => $pathItem) {
+            $path = (string) $path;
+            if (null === self::riteRouteOf($path)) {
+                continue;
+            }
+
+            /** @var array<string,mixed> $pathItem */
+            foreach (array_intersect(self::operationMethods($pathItem), ['put', 'patch', 'delete']) as $method) {
+                $operations[strtoupper($method) . ' ' . $path] = [$path, $method];
+            }
+        }
+
+        return $operations;
+    }
+
+    #[DataProvider('writeOperations')]
+    public function testAWriteOperationDeclaresNoCanonicalLinkHeader(string $path, string $method): void
+    {
+        /** @var array<string,array<string,array<string,mixed>>> $pathItem */
+        $pathItem = self::paths()[$path];
+        /** @var array<string,array<string,mixed>> $responses */
+        $responses = $pathItem[$method]['responses'];
+
+        foreach ($responses as $status => $response) {
+            [$resolved] = self::resolveResponse($response);
+            self::assertFalse(
+                self::declaresCanonicalLink($resolved),
+                strtoupper($method) . " {$path} emits no canonical Link header, so its {$status} must not declare one"
+            );
+        }
+    }
+
+    /**
+     * The header is declared once and referenced, so its description — the only place the
+     * "bare spelling, read methods, not a redirect" contract is written down — cannot drift
+     * between the responses that carry it.
+     */
+    public function testTheCanonicalLinkHeaderIsDefinedOnce(): void
+    {
+        /** @var array<string,array<string,array<string,mixed>>> $components */
+        $components = self::openapi()['components'];
+
+        self::assertArrayHasKey('headers', $components, 'openapi.json defines no reusable headers at all');
+        self::assertArrayHasKey('CanonicalRiteLink', $components['headers']);
+
+        $header = $components['headers']['CanonicalRiteLink'];
+        self::assertArrayHasKey('description', $header);
+        self::assertIsString($header['description']);
+        self::assertStringContainsString('rel="canonical"', $header['description']);
+        self::assertSame(['type' => 'string'], $header['schema'] ?? null);
+    }
+
+    /**
+     * Of the two equivalent spellings the explicit one is canonical, and the bare one is retained
+     * only for backwards compatibility — so wherever the canonical spelling is documented, the bare
+     * one is deprecated. Applied uniformly (#848): the rule was already in force on `/calendar`,
+     * and leaving `/events`'s tiers and `/data` outside it would have made the document state the
+     * rule in one family and contradict it in the next.
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function bareePathsWithACanonicalTwin(): array
+    {
+        $paths = [];
+
+        foreach (self::paths() as $path => $pathItem) {
+            $path = (string) $path;
+            if (null === self::riteRouteOf($path) || self::isRiteQualified($path)) {
+                continue;
+            }
+
+            if (isset(self::paths()[self::canonicalTwinOf($path)])) {
+                $paths[$path] = [$path];
+            }
+        }
+
+        return $paths;
+    }
+
+    #[DataProvider('bareePathsWithACanonicalTwin')]
+    public function testABarePathWithACanonicalTwinIsDeprecated(string $path): void
+    {
+        /** @var array<string,array<string,mixed>> $pathItem */
+        $pathItem = self::paths()[$path];
+
+        foreach (self::operationMethods($pathItem) as $method) {
+            /** @var array<string,mixed> $operation */
+            $operation = $pathItem[$method];
+            self::assertTrue(
+                $operation['deprecated'] ?? false,
+                strtoupper($method) . " {$path} has a canonical twin at " . self::canonicalTwinOf($path) . ', so it must be marked deprecated'
+            );
+        }
+    }
+
+    /**
+     * The other half of the rule: the canonical spelling is the one clients are being moved to, so
+     * nothing rite-qualified may carry the deprecation marker.
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function riteQualifiedPaths(): array
+    {
+        $paths = [];
+
+        foreach (self::paths() as $path => $pathItem) {
+            $path = (string) $path;
+            if (null !== self::riteRouteOf($path) && self::isRiteQualified($path)) {
+                $paths[$path] = [$path];
+            }
+        }
+
+        return $paths;
+    }
+
+    #[DataProvider('riteQualifiedPaths')]
+    public function testARiteQualifiedPathIsNotDeprecated(string $path): void
+    {
+        /** @var array<string,array<string,mixed>> $pathItem */
+        $pathItem = self::paths()[$path];
+
+        foreach (self::operationMethods($pathItem) as $method) {
+            /** @var array<string,mixed> $operation */
+            $operation = $pathItem[$method];
+            self::assertFalse(
+                $operation['deprecated'] ?? false,
+                strtoupper($method) . " {$path} is the canonical spelling, so it must not be marked deprecated"
+            );
+        }
+    }
+}

--- a/phpunit_tests/Schemas/OpenApiCanonicalFormTest.php
+++ b/phpunit_tests/Schemas/OpenApiCanonicalFormTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Schemas;
 
 use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Tests\Support\OpenApiPathItemTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -34,6 +35,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class OpenApiCanonicalFormTest extends TestCase
 {
+    use OpenApiPathItemTrait;
+
     private const HEADER_REF = '#/components/headers/CanonicalRiteLink';
 
     /** Route families whose first path segment takes an optional rite segment. */
@@ -110,22 +113,6 @@ final class OpenApiCanonicalFormTest extends TestCase
         array_splice($segments, 1, 0, Rite::default()->value);
 
         return '/' . implode('/', $segments);
-    }
-
-    /**
-     * @param array<string,mixed> $pathItem
-     *
-     * @return list<string>
-     */
-    private static function operationMethods(array $pathItem): array
-    {
-        $methods = array_values(array_intersect(
-            array_keys($pathItem),
-            ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
-        ));
-        sort($methods);
-
-        return $methods;
     }
 
     /**
@@ -342,11 +329,11 @@ final class OpenApiCanonicalFormTest extends TestCase
      *
      * @return array<string,array{0:string}>
      */
-    public static function bareePathsWithACanonicalTwin(): array
+    public static function barePathsWithACanonicalTwin(): array
     {
         $paths = [];
 
-        foreach (self::paths() as $path => $pathItem) {
+        foreach (array_keys(self::paths()) as $path) {
             $path = (string) $path;
             if (null === self::riteRouteOf($path) || self::isRiteQualified($path)) {
                 continue;
@@ -360,7 +347,7 @@ final class OpenApiCanonicalFormTest extends TestCase
         return $paths;
     }
 
-    #[DataProvider('bareePathsWithACanonicalTwin')]
+    #[DataProvider('barePathsWithACanonicalTwin')]
     public function testABarePathWithACanonicalTwinIsDeprecated(string $path): void
     {
         /** @var array<string,array<string,mixed>> $pathItem */
@@ -386,7 +373,7 @@ final class OpenApiCanonicalFormTest extends TestCase
     {
         $paths = [];
 
-        foreach (self::paths() as $path => $pathItem) {
+        foreach (array_keys(self::paths()) as $path) {
             $path = (string) $path;
             if (null !== self::riteRouteOf($path) && self::isRiteQualified($path)) {
                 $paths[$path] = [$path];

--- a/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
+++ b/phpunit_tests/Schemas/OpenApiDataRiteSegmentTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Enum\PathCategory;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Params\RegionalDataParams;
+use LiturgicalCalendar\Tests\Support\OpenApiPathItemTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
@@ -27,6 +28,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class OpenApiDataRiteSegmentTest extends TestCase
 {
+    use OpenApiPathItemTrait;
+
     /** @var array<string,mixed> */
     private static array $openapi;
 
@@ -245,25 +248,5 @@ final class OpenApiDataRiteSegmentTest extends TestCase
         }
 
         self::assertGreaterThan(0, $seen, 'openapi.json documents no /data calendar-definition path at all');
-    }
-
-    /**
-     * The HTTP methods a path item documents, sorted, with any non-method key (`parameters`,
-     * `summary`, `description`, `servers`) filtered out — those are legal siblings of the operations
-     * in an OpenAPI path item and are not operations themselves.
-     *
-     * @param array<string,mixed> $pathItem
-     *
-     * @return list<string>
-     */
-    private static function operationMethods(array $pathItem): array
-    {
-        $methods = array_values(array_intersect(
-            array_keys($pathItem),
-            ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
-        ));
-        sort($methods);
-
-        return $methods;
     }
 }

--- a/phpunit_tests/Schemas/OpenApiEventsRiteSegmentTest.php
+++ b/phpunit_tests/Schemas/OpenApiEventsRiteSegmentTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Http\Exception\ValidationException;
+use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
+use LiturgicalCalendar\Api\Params\EventsParams;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The `/events` sibling of {@see OpenApiDataRiteSegmentTest}.
+ *
+ * `Router::extractRiteSegment()` accepts an optional leading rite segment on `events` exactly as
+ * it does on `calendar` and `data`, and `Router::canonicalRiteUrl()` answers a bare request with a
+ * `Link: rel="canonical"` naming the explicit form — but openapi.json documented only
+ * `/events/roman`, leaving `/events/roman/nation/{calendar_id}` and
+ * `/events/roman/diocese/{calendar_id}` undescribed. The API therefore pointed clients at a
+ * canonical URL its own contract did not contain (#848, first reported in #818).
+ *
+ * As in the `/data` sibling, both halves are asserted against the runtime rule
+ * ({@see EventsParams::validateRiteCompatibility()}) rather than against a second hardcoded list,
+ * so the document cannot drift away from the routing grammar: the Ambrosian rite has no national
+ * layer, and a documented `/events/ambrosian/nation/{calendar_id}` would be a lie a generated
+ * client would act on.
+ */
+final class OpenApiEventsRiteSegmentTest extends TestCase
+{
+    /** @var array<string,mixed> */
+    private static array $openapi;
+
+    private static string $savedApiPath     = '';
+    private static string $savedApiFilePath = '';
+
+    public static function setUpBeforeClass(): void
+    {
+        $raw = file_get_contents(dirname(__DIR__, 2) . '/jsondata/schemas/openapi.json');
+        self::assertIsString($raw, 'Could not read openapi.json');
+
+        /** @var array<string,mixed> $decoded */
+        $decoded       = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        self::$openapi = $decoded;
+
+        // EventsParams builds the calendars metadata index in-process from local source data,
+        // so pin Router::$apiPath/$apiFilePath the way the production Router does (same setup
+        // as EventsParamsTest).
+        self::$savedApiPath     = isset(Router::$apiPath) ? Router::$apiPath : '';
+        self::$savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        Router::$apiPath        = '';
+        Router::$apiFilePath    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        Router::$apiPath     = self::$savedApiPath;
+        Router::$apiFilePath = self::$savedApiFilePath;
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private static function paths(): array
+    {
+        /** @var array<string,array<string,mixed>> $paths */
+        $paths = self::$openapi['paths'];
+
+        return $paths;
+    }
+
+    /**
+     * Whether the handler's parameter object accepts this rite for this tier, asked of the same
+     * object the running API asks. `null` for the tier means the bare rite root (`/events/roman`),
+     * which addresses the rite's own catalog and takes no calendar id.
+     */
+    private static function tierIsAccepted(Rite $rite, ?string $tier): bool
+    {
+        $params = [];
+
+        if ($tier === 'nation') {
+            $nations = ( new EventsParams() )->calendarsMetadata->national_calendars_keys;
+            self::assertNotEmpty($nations, 'precondition: at least one national calendar exists');
+            $params['national_calendar'] = $nations[0];
+        }
+
+        if ($tier === 'diocese') {
+            // Derived from the diocese metadata rather than named here: a diocese is addressable
+            // under exactly the rite it declares, so "does this rite have a diocesan tier" is the
+            // same question as "does any diocese declare this rite".
+            $diocese = array_find(
+                ( new EventsParams() )->calendarsMetadata->diocesan_calendars,
+                static fn (MetadataDiocesanCalendarItem $item): bool => $item->rite === $rite
+            );
+
+            if (null === $diocese) {
+                return false;
+            }
+
+            $params['diocesan_calendar'] = $diocese->calendar_id;
+        }
+
+        try {
+            $eventsParams = new EventsParams($params);
+            $eventsParams->setRite($rite);
+            $eventsParams->validateRiteCompatibility();
+        } catch (ValidationException) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array<string,array{0:Rite,1:?string}>
+     */
+    public static function riteAndTierCombinations(): array
+    {
+        $combinations = [];
+
+        foreach (Rite::cases() as $rite) {
+            foreach ([null, 'nation', 'diocese'] as $tier) {
+                $combinations[$rite->value . ' / ' . ( $tier ?? 'rite root' )] = [$rite, $tier];
+            }
+        }
+
+        return $combinations;
+    }
+
+    /**
+     * The contract must list exactly the rite-qualified `/events` paths the API accepts — no more
+     * (a documented 400 is a lie a generated client will act on) and no fewer (the omission is
+     * what #818 reports).
+     */
+    #[DataProvider('riteAndTierCombinations')]
+    public function testRiteQualifiedPathIsDocumentedExactlyWhenItIsAccepted(Rite $rite, ?string $tier): void
+    {
+        $suffix = null === $tier ? '' : "/{$tier}/{calendar_id}";
+        $path   = "/events/{$rite->value}{$suffix}";
+
+        if (self::tierIsAccepted($rite, $tier)) {
+            self::assertArrayHasKey(
+                $path,
+                self::paths(),
+                "the API accepts {$path} but openapi.json does not document it"
+            );
+        } else {
+            self::assertArrayNotHasKey(
+                $path,
+                self::paths(),
+                "openapi.json documents {$path}, which the API refuses"
+            );
+        }
+    }
+
+    /**
+     * The bare spelling stays documented alongside the canonical one: it is what the existing
+     * browser clients build, and it is the form the `Link: rel="canonical"` header is emitted on.
+     *
+     * @return array<string,array{0:string}>
+     */
+    public static function bareEventsPaths(): array
+    {
+        return [
+            '/events'                       => ['/events'],
+            '/events/nation/{calendar_id}'  => ['/events/nation/{calendar_id}'],
+            '/events/diocese/{calendar_id}' => ['/events/diocese/{calendar_id}']
+        ];
+    }
+
+    #[DataProvider('bareEventsPaths')]
+    public function testTheBareFormOfEveryTierStaysDocumented(string $path): void
+    {
+        self::assertArrayHasKey($path, self::paths(), 'the bare form of every tier must stay documented');
+    }
+
+    /**
+     * The rite segment selects which catalog is built; it does not change what may be done to it.
+     * `Router`'s `events` case wires GET and POST for both the rite root and a two-part tier path,
+     * and the rite segment does not alter the part count it keys off.
+     *
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function bareAndCanonicalPathPairs(): array
+    {
+        return [
+            'rite root' => ['/events', '/events/roman'],
+            'nation'    => ['/events/nation/{calendar_id}', '/events/roman/nation/{calendar_id}'],
+            'diocese'   => ['/events/diocese/{calendar_id}', '/events/roman/diocese/{calendar_id}']
+        ];
+    }
+
+    #[DataProvider('bareAndCanonicalPathPairs')]
+    public function testTheCanonicalFormMirrorsTheBareFormsOperationSurface(string $bare, string $canonical): void
+    {
+        $paths = self::paths();
+        self::assertArrayHasKey($bare, $paths);
+        self::assertArrayHasKey($canonical, $paths);
+
+        /** @var array<string,mixed> $barePathItem */
+        $barePathItem = $paths[$bare];
+        /** @var array<string,mixed> $canonicalPathItem */
+        $canonicalPathItem = $paths[$canonical];
+
+        self::assertSame(
+            self::operationMethods($barePathItem),
+            self::operationMethods($canonicalPathItem),
+            "{$canonical} must document the same methods as {$bare}"
+        );
+    }
+
+    /**
+     * A diocese is addressable under exactly the rite it declares: asking for an Ambrosian diocese
+     * under the Roman rite (or the reverse) is refused with a `400 Bad Request` by
+     * {@see EventsParams::validateRiteCompatibility()}. Both spellings of the diocesan path can
+     * produce that refusal — the bare one because it resolves to the Roman rite — so both have to
+     * declare it, or a client generated from this document has no branch for the one status it
+     * will actually meet on a wrong-rite diocese.
+     *
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function diocesanOperationsThatCanRefuseOnRite(): array
+    {
+        $operations = [];
+
+        foreach (['get', 'post'] as $method) {
+            foreach (['/events/diocese/{calendar_id}', '/events/roman/diocese/{calendar_id}', '/events/ambrosian/diocese/{calendar_id}'] as $path) {
+                $operations[strtoupper($method) . ' ' . $path] = [$path, $method];
+            }
+        }
+
+        return $operations;
+    }
+
+    #[DataProvider('diocesanOperationsThatCanRefuseOnRite')]
+    public function testTheRiteMismatchRefusalIsDeclared(string $path, string $method): void
+    {
+        $paths = self::paths();
+        self::assertArrayHasKey($path, $paths);
+
+        /** @var array<string,array<string,array<string,mixed>>> $pathItem */
+        $pathItem = $paths[$path];
+        self::assertArrayHasKey($method, $pathItem);
+
+        self::assertArrayHasKey(
+            '400',
+            $pathItem[$method]['responses'],
+            strtoupper($method) . " {$path} can refuse a diocese of the wrong rite with 400, which it does not declare"
+        );
+    }
+
+    /**
+     * The HTTP methods a path item documents, sorted, with any non-method key (`parameters`,
+     * `summary`, `description`, `servers`) filtered out — those are legal siblings of the
+     * operations in an OpenAPI path item and are not operations themselves.
+     *
+     * @param array<string,mixed> $pathItem
+     *
+     * @return list<string>
+     */
+    private static function operationMethods(array $pathItem): array
+    {
+        $methods = array_values(array_intersect(
+            array_keys($pathItem),
+            ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
+        ));
+        sort($methods);
+
+        return $methods;
+    }
+}

--- a/phpunit_tests/Schemas/OpenApiEventsRiteSegmentTest.php
+++ b/phpunit_tests/Schemas/OpenApiEventsRiteSegmentTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
 use LiturgicalCalendar\Api\Params\EventsParams;
+use LiturgicalCalendar\Tests\Support\OpenApiPathItemTrait;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -30,6 +31,8 @@ use PHPUnit\Framework\TestCase;
  */
 final class OpenApiEventsRiteSegmentTest extends TestCase
 {
+    use OpenApiPathItemTrait;
+
     /** @var array<string,mixed> */
     private static array $openapi;
 
@@ -249,25 +252,5 @@ final class OpenApiEventsRiteSegmentTest extends TestCase
             $pathItem[$method]['responses'],
             strtoupper($method) . " {$path} can refuse a diocese of the wrong rite with 400, which it does not declare"
         );
-    }
-
-    /**
-     * The HTTP methods a path item documents, sorted, with any non-method key (`parameters`,
-     * `summary`, `description`, `servers`) filtered out — those are legal siblings of the
-     * operations in an OpenAPI path item and are not operations themselves.
-     *
-     * @param array<string,mixed> $pathItem
-     *
-     * @return list<string>
-     */
-    private static function operationMethods(array $pathItem): array
-    {
-        $methods = array_values(array_intersect(
-            array_keys($pathItem),
-            ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
-        ));
-        sort($methods);
-
-        return $methods;
     }
 }

--- a/phpunit_tests/Support/OpenApiPathItemTrait.php
+++ b/phpunit_tests/Support/OpenApiPathItemTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+/**
+ * Shared reader for OpenAPI path items, used by the `phpunit_tests/Schemas/OpenApi*Test`
+ * classes that assert the routing grammar against `jsondata/schemas/openapi.json`.
+ *
+ * Three of those classes had grown their own identical copy of {@see operationMethods()},
+ * which meant the list of HTTP method keys — the one thing that decides what counts as an
+ * operation rather than a sibling property — had to be maintained in three places.
+ */
+trait OpenApiPathItemTrait
+{
+    /**
+     * The HTTP methods a path item documents, sorted, with any non-method key (`parameters`,
+     * `summary`, `description`, `servers`) filtered out — those are legal siblings of the
+     * operations in an OpenAPI path item and are not operations themselves.
+     *
+     * Sorted rather than in document order: ordering inside a path item carries no meaning in
+     * OpenAPI, so an ordered comparison would fail on a cosmetic reshuffle.
+     *
+     * @param array<string,mixed> $pathItem
+     *
+     * @return list<string>
+     */
+    private static function operationMethods(array $pathItem): array
+    {
+        $methods = array_values(array_intersect(
+            array_keys($pathItem),
+            ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace']
+        ));
+        sort($methods);
+
+        return $methods;
+    }
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -119,9 +119,10 @@ class Router
      * Absence of a rite segment defaults to Roman. No nation, diocese or path-category
      * identifier collides with a rite value, so this is unambiguous.
      *
-     * `data` takes the segment but is deliberately absent from {@see self::canonicalRiteUrl()}:
-     * that header advertises the explicit form for cacheable read routes, and `/data` is an
-     * admin write surface where a `Link: rel="canonical"` on a PUT is noise.
+     * `data` takes the segment on every method it accepts, but {@see self::canonicalRiteUrl()}
+     * advertises the explicit form only for its read methods (`GET` and `POST`). `/data` is also
+     * an admin write surface, and a `Link: rel="canonical"` on a `PUT` is noise: it would name a
+     * canonical representation of a request that is not a representation at all (#848).
      *
      * Of the two equivalent forms, the explicit one is canonical: a request that omits the
      * rite segment is answered with a `Link: rel="canonical"` header naming the explicit URL
@@ -184,19 +185,32 @@ class Router
      * break the browser clients that build the bare paths (liturgy-components-js `PathBuilder`).
      *
      * Returns null when no canonical form applies: the request already carried an explicit rite
-     * segment, or the route carries no rite segment at all.
+     * segment, the route carries no rite segment at all, or the request method is not a read
+     * method. Only `GET` and `POST` qualify, `POST` because all three route families accept it as
+     * the "retrieve with parameters in a request body" spelling of `GET`. That scoping is what
+     * lets `/data` take part: it is a mixed read/write surface, and `rel="canonical"` on a `PUT`
+     * would describe nothing the request is doing (#848). The same rule keeps the header off a
+     * CORS preflight, which is an `OPTIONS` control response rather than a representation of the
+     * resource, so no separate preflight guard is needed at the call site.
      *
      * @param string       $route               the first path segment (the endpoint), already shifted off
+     * @param string       $method              the request method; only the read methods advertise a canonical form
      * @param bool         $riteSegmentExplicit whether the request already carried a rite segment
      * @param Rite         $rite                the rite resolved for this request
      * @param list<string> $pathParts           the path segments following the route, rite segment already stripped
      * @param string       $query               the raw request query string, preserved on the canonical URL
      */
-    public static function canonicalRiteUrl(string $route, bool $riteSegmentExplicit, Rite $rite, array $pathParts, string $query = ''): ?string
+    public static function canonicalRiteUrl(string $route, string $method, bool $riteSegmentExplicit, Rite $rite, array $pathParts, string $query = ''): ?string
     {
         // The root route resolves to the calendar handler, but canonicalising `/` to
         // `/calendar/roman` would rename the endpoint rather than merely make the rite explicit.
-        if ($riteSegmentExplicit || false === in_array($route, ['calendar', 'events'], true)) {
+        if ($riteSegmentExplicit || false === in_array($route, ['calendar', 'events', 'data'], true)) {
+            return null;
+        }
+
+        // Read methods only, which is both what `/data`'s write surface requires and what keeps
+        // the header off a CORS preflight (see the note above).
+        if (false === in_array($method, [RequestMethod::GET->value, RequestMethod::POST->value], true)) {
             return null;
         }
 
@@ -796,19 +810,17 @@ class Router
             ->withHeader('X-Request-Id', $this->requestId);
 
         // A request that omitted the optional rite segment advertises the canonical explicit-rite
-        // form (RFC 6596). Only on success: pointing at a canonical URL for a request that did not
-        // resolve would just name an equally invalid URL. Never on a CORS preflight, which is a
-        // control response rather than a representation of the resource.
-        $isPreflight  = $this->request->getMethod() === RequestMethod::OPTIONS->value;
-        $canonicalUrl = $isPreflight
-            ? null
-            : self::canonicalRiteUrl(
-                $route,
-                $riteSegmentExplicit,
-                $rite,
-                $canonicalPathParts,
-                $this->request->getUri()->getQuery()
-            );
+        // form (RFC 6596), on read methods only — canonicalRiteUrl() applies that rule, which is
+        // also what keeps the header off a CORS preflight. Only on success: pointing at a
+        // canonical URL for a request that did not resolve would just name an equally invalid URL.
+        $canonicalUrl = self::canonicalRiteUrl(
+            $route,
+            $this->request->getMethod(),
+            $riteSegmentExplicit,
+            $rite,
+            $canonicalPathParts,
+            $this->request->getUri()->getQuery()
+        );
         // 304 is included alongside 2xx: a resolved conditional request stands in for the 200 it
         // would otherwise have been and describes the same resource, so a client driving its own
         // conditional requests should not lose the canonical URL merely because its cache was


### PR DESCRIPTION
Closes #848.

`/data` did not emit the RFC 6596 `Link: rel="canonical"` header that `/calendar` and `/events` do, `/events` was missing the rite-qualified paths clients were being pointed at, and no response in `openapi.json` declared the header at all.

## 1. The header is scoped by method, not withheld from the route

`Router::canonicalRiteUrl()` takes the request method and returns `null` unless it is a read method (`GET`/`POST`). That is what lets `data` join the route allow-list: the objection recorded at `src/Router.php:122-124` was to a `rel="canonical"` on a `PUT`, not to the route as a whole, and scoping preserves it exactly. On `/data`, `POST` is a read verb — the "retrieve with parameters in a request body" spelling of `GET` — so the read surface is `GET`+`POST` rather than `GET` alone.

The same rule covers a CORS preflight (`OPTIONS` is not a read method), so `route()`'s separate `$isPreflight` guard is gone; its rationale moved into the helper's docblock. `/calendar` and `/events` accept only read verbs, so nothing changes for them. The `extractRiteSegment()` docblock that recorded the old behaviour is rewritten in the same change.

## 2. `/events` Roman paths enumerated

`/events/roman/nation/{calendar_id}` and `/events/roman/diocese/{calendar_id}` are cloned from the bare forms as #843 did for `/data`, following the `/calendar` convention (`RomanRite` marker in the operationId, canonical-form prose in the description). Both diocesan spellings additionally declare the `400` they answer a wrong-rite diocese with — verified live: `GET /events/roman/diocese/milano_it` → `400 Bad Request`, "Diocesan calendar `milano_it` belongs to the ambrosian rite".

## 3. The `Link` header is documented

Defined once as `components/headers/CanonicalRiteLink` and referenced from the responses that actually carry it: the `200` and `304` of the 30 bare read operations across all three families, plus `LitCal200` and `RegionalDataI18n200` — the two response components that the bare and explicit spellings share, where the condition lives in the header's own description rather than in the operation. Explicit-rite operations with a response object of their own declare nothing.

## 4. Deprecation of bare paths — decided, not drifted into

Applied mechanically, as the issue asked to settle explicitly: 25 newly deprecated operations — bare `/events/nation`, `/events/diocese`, and all six `/data` tiers including `PUT`/`PATCH`/`DELETE`. `deprecated` describes the *spelling* of the path, not the safety of the operation, and the write methods have an explicit spelling to move to just as the reads do. Their deprecation note says plainly that a write carries no `Link` header.

## Tests

Written before the code, each watched fail first:

- `RouterCanonicalRiteLinkTest` — 14 cases including the write verbs and `OPTIONS`.
- `Routes/Readonly/CanonicalRiteLinkHeaderTest` — `/data` `GET` and `POST` carry the header, `/data/roman/...` carries none. The write half of the rule is asserted at unit level rather than driving an authenticated `PUT` to a 2xx.
- `Schemas/OpenApiEventsRiteSegmentTest` — the `/events` sibling of `OpenApiDataRiteSegmentTest`: the documented rite matrix is asserted against `EventsParams::validateRiteCompatibility()` and the diocese metadata, not a hand-maintained list, so the absent Ambrosian national tier is enforced by the router's own rule.
- `Schemas/OpenApiCanonicalFormTest` — 136 cases: the header is declared exactly where it is emitted, never on a write operation, and the deprecation rule holds in both directions.

## Verification

`composer analyse` (PHPStan level 10) clean · `composer lint` clean · `composer lint:md` clean · `composer lint:openapi` valid · `composer test:quick` → 3327 tests, **1 failure**, the documented worktree baseline (`ExecuteValidationTest`: the Docker WebSocket cannot reach a host-port server). Route-tier tests were run against a server booted from the worktree, not the shared `:8000` checkout.

## Notes on the issue text

- The canonical-Link behaviour was **not** unasserted: `RouterCanonicalRiteLinkTest` and `Routes/Readonly/CanonicalRiteLinkHeaderTest` already covered `/calendar` and `/events`, so that part of the test work was extension.
- Declaring the header "only on the bare operations" is not fully expressible: `/calendar`'s `200` is a component shared by 32 operations (as is the `/data` i18n `200`). There the header rides on the shared component and the negative assertion is skipped, by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit Roman rite routes for national and diocesan event calendars.
  * Added canonical `Link` headers to legacy read routes, including `/data`, while preserving query strings and exposing the header through CORS.
  * Canonical links now apply to `GET` and read-only `POST` requests only.

* **Documentation**
  * Updated the OpenAPI specification and README with canonical routes, deprecated aliases, rite resolution, and request-method behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->