### PR TITLE
feat(health): a versioned hello handshake — #806 section F

### DIFF
--- a/docs/superpowers/specs/2026-08-22-versioned-handshake-design.md
+++ b/docs/superpowers/specs/2026-08-22-versioned-handshake-design.md
@@ -1,0 +1,206 @@
+# A versioned handshake, and the client that consumes it
+
+**API#806 section F — the last one.** A, B, C, E, G and H are merged; D's server half is complete. F was deliberately
+held back: a handshake negotiates *between* protocol versions, and that is pointless until two exist and a client can
+choose. Everything before it was additive or gated on `requestId`, which is what made the sections landable one at a
+time while the shipped test interface kept working.
+
+This document covers both halves, because F is only half a handshake without a client that reads it:
+
+- **the API** sends `hello` on connect and accepts an inbound `protocol` — closes #806;
+- **UnitTestInterface** reworks `resources.php` onto the structured contract — the pilot half of UnitTestInterface#42.
+
+`index.php`, `types.js` regeneration, the `CLAUDE.md` protocol table and legacy removal are explicitly **not** in scope.
+
+## Why an unsolicited frame is safe
+
+The obvious objection to a server-initiated `hello` is that UnitTestInterface#46 made an unrecognised response `type`
+paint a visible failed check — so a new frame type would appear to break the shipped UI. It does not, and the reason is
+worth writing down rather than re-deriving.
+
+Both runners open their handler with the same two guards:
+
+```js
+if ( currentState === TestState.Stopped || currentRunToken === null ) { return; }
+// …parse…
+if ( null === responseData || 'object' !== typeof responseData || responseData.runToken !== currentRunToken ) { return; }
+```
+
+`hello` carries no `runToken`. Before a run there is no `currentRunToken`, so the first guard returns; during a run the
+second guard returns, because `undefined !== currentRunToken`. Neither path reaches the `type` dispatch, so neither
+reaches `countUnattributableFailure()`. The frame is invisible to a v1 client in both states.
+
+This is the same property every earlier section relied on, arrived at by a different route: C and E could add fields
+because a v1 client ignores unknown fields; D's terminal frame needed `requestId` gating because a v1 client *counts*
+frames. `hello` needs neither, because the run-token guard drops it before anything counts it.
+
+## The frame
+
+Sent once, from `Health::onOpen()`, through `sendMessage()` so it inherits `stripProjectRoot()` like every other frame:
+
+```jsonc
+{
+  "type": "hello",
+  "protocol": 1,
+  "capabilities": {
+    "rites":           ["roman", "ambrosian"],
+    "actions":         ["executeValidation", "validateCalendar", "executeUnitTest",
+                        "runTest", "cancelRun", "validateSource"],
+    "responseFormats": ["JSON", "XML", "ICS", "YML"],
+    "steps":           ["exists", "parses", "validates", "complete"],
+    "statuses":        ["pass", "fail"]
+  }
+}
+```
+
+**Nothing in `capabilities` is written down twice.** Each list is derived from the thing that already defines it:
+
+| key               | derived from                                                   |
+|-------------------|----------------------------------------------------------------|
+| `rites`           | `Rite::cases()`                                                |
+| `steps`           | `Step::cases()`                                                |
+| `statuses`        | `Status::cases()`                                              |
+| `responseFormats` | `Health::VALIDATABLE_RESPONSE_FORMATS`                         |
+| `actions`         | the `action.const` of every `WebSocketMessage.json` definition |
+
+That last one matters most. `actions` is the list a client uses to decide what it may send, and the authority on what
+the server accepts is the schema — so reading it from the schema means a definition added there cannot fail to be
+advertised. A hand-written list is precisely the "several places that must be edited in lockstep" #806 exists to
+remove; adding one inside the fix for it would be self-defeating.
+
+`protocol: 1` follows #806's own numbering: `1` is the new self-describing contract, an **absent** `protocol` is legacy.
+The value is the highest version the server supports, not a list — a client that needs to know the whole supported set
+learns it by being refused.
+
+## Inbound `protocol`
+
+`WebSocketMessageValidator` gains `SUPPORTED_PROTOCOL_VERSIONS = [1]`, and `Health::onMessage()` checks it **before**
+anything else interprets the message — before `UNKNOWN_ACTION`, before schema validation, before the action dispatch.
+The ordering is a claim about meaning, not a micro-optimisation: the protocol version says how the rest of the message
+is to be read, so "I do not speak your protocol" is a truer answer than "your action is unknown" for
+`{"action": "bogus", "protocol": 7}` — under protocol 7 that action might be perfectly well known.
+
+A violation answers a **tenth** `ProtocolErrorCode` case:
+
+```jsonc
+{ "type": "protocolError", "errorCode": "unsupported_protocol",
+  "text": "This server speaks protocol 1. …", "requestId": "…" }
+```
+
+Both a version the server does not implement (`7`) and a wrongly-typed one (`"1"`, `1.0`) land here. The wrong-type
+case is deliberately not left to the schema: `1.0` is a float that PHP's coercive typing would refuse deep inside a
+handler, which is the seventh crash shape section G found the hard way, and answering it at the door is the lesson that
+section already paid for.
+
+The schema declares `protocol` on all seven definitions as `{"type": "integer", "enum": [1]}`. Two reasons, neither of
+which is redundancy with the check above:
+
+1. **Without it, a v2 client is refused for being a v2 client.** The `requestId`-gated root strict check refuses any
+   property the shape does not declare, so the moment a client sends both `requestId` and `protocol` — which is
+   exactly what a v2 client sends — its message becomes `INVALID_MESSAGE`.
+2. The published schema is the contract clients read. A field the server requires but the schema omits is the
+   documentation drift #805 was filed for.
+
+**A drift test pins the two together**, asserting that the schema's `protocol` enum equals
+`SUPPORTED_PROTOCOL_VERSIONS` in every definition. This repo's recurring defect is a check that reports something it
+does not actually verify; two independent statements of the supported version set, with nothing comparing them, is
+how that starts.
+
+## What F deliberately does not do
+
+- **Shape selection does not move.** A message is still resolved by `action`, and for `validateCalendar` by whether
+  `calendar` is a string or an object. That mechanism works, is tested, and is what let the v1 and v2 shapes coexist;
+  routing by `protocol` instead would make version a second discriminator with nothing to gain.
+- **No per-connection protocol mode.** Declaring `protocol: 1` on one message does not make the connection refuse
+  legacy shapes on the next. A half-migrated client — which is precisely what the pilot produces, sending
+  `validateSource` for source data and `executeValidation` for routes on the same socket — must keep working.
+- **No capability *requests*.** The client does not send a `hello`. Negotiation here is one-directional advertisement
+  plus refusal of what the server cannot read, which is all either side needs while exactly one protocol exists.
+
+## `WebSocketFrame.json`
+
+`WebSocketMessage.json` publishes what a client may **send**. Nothing publishes what it will **receive** — and the
+client's typedefs are almost entirely about received frames, which is why UnitTestInterface#42 item 5 ("regenerate
+`types.js` from the published message schema") has no schema to regenerate from today.
+
+F is the section that makes the contract self-describing, so this is its natural home. A new schema publishes the three
+outbound frame shapes: `hello`, the step-result frame (`type` `success`/`error` with `runId`, `requestId`, `target`,
+`step`, `status`, `details`, plus the legacy `text`/`classes` projection), and `protocolError`.
+
+The legacy `classes` field is documented as **deprecated in the schema text**, not removed — removal is gated on
+UnitTestInterface#42 shipping, and this pilot is only half of that.
+
+This is an addition beyond #806's literal section-F text, and is called out as such.
+
+## Client half: the `resources.php` pilot
+
+Two commits, because they carry different risk and are separately revertible.
+
+### P1 — structured frames, no wire-shape change
+
+Since #824 the server already stamps `runId`, `requestId`, `target`, `step` and `status` on the frames answering
+**legacy** `executeValidation` messages, and gates the terminal `complete` frame on `requestId`. So the client gets the
+entire structured contract the moment it starts minting request ids — no action rename required, and the route checks
+benefit identically to the source checks.
+
+- mint a `requestId` per outbound message;
+- build a `requestId → {node, steps}` registry when the cards are rendered, and paint from `requestId` + `step` +
+  `status` rather than from `document.querySelectorAll(slugifySelector(responseData.classes))`;
+- finish each phase on its terminal `complete` frames, deleting `resourceDataChecks.length * 3` and
+  `sourceDataChecks.length * 3` — and with them the `>=`-tolerates-an-overshoot workaround, which exists only because
+  counting frames cannot tell a duplicate from a legitimate one.
+
+**The landmine.** Adding `requestId` *arms* the server's root unknown-property gate for these messages — that gate is
+`requestId`-gated precisely because the shipped client sends properties the shapes do not declare. `resources.js`
+spreads `...check` (`validate`, `category`, `sourceFile`/`sourceFolder`, and `rite` on the dynamically-pushed entries)
+plus `responsetype`, and `executeValidation` declares all of those. So it should pass — but "should" is not
+"verified", and the failure mode is every check in the run being refused. A test sends the real shapes, with a
+`requestId`, before anything relies on it.
+
+### P2 — opaque ids for source data
+
+`sourceDataChecks` stops coming from `wsProtocol.js`'s `UNIVERSAL_CHECKS` and starts coming from a `GET /validations`
+fetch, filtered by the selected rite through the existing `inRiteScope()`. Those checks send:
+
+```jsonc
+{ "action": "validateSource", "protocol": 1, "target": { "id": "…" }, "runToken": "…", "requestId": "…" }
+```
+
+Cards take their label and their step count from the inventory item, so `steps.length` drives the scaffolding — exact
+since #825, which is what makes rendering one card per step honest rather than an estimate. `UNIVERSAL_CHECKS`, the
+last hardcoded copy of the API's on-disk layout in this repo, is deleted.
+
+**Route checks stay on `executeValidation`.** `/validations` advertises source data only — 77 file and folder items —
+and the route family has no v2 shape to move to. That is a smaller problem than it sounds: a URL is not a filesystem
+path, and the per-nation and per-diocese route checks are already derived from `/calendars` metadata rather than
+hardcoded. A v2 shape for route checks gets its own issue; it would also close UnitTestInterface#50 (`/temporale` and
+`/validations` are not health-checked) by making the route list server-advertised instead of hand-listed.
+
+### Where the code goes
+
+All new protocol behaviour lands in `assets/js/wsProtocol.js` — `PROTOCOL_VERSION`, `newRequestId()`, `readHello()`,
+`createRequestRegistry()`, `fetchValidations()` — which is what that module was seeded for, and the alternative is a
+fourth copy of the protocol to keep in lockstep.
+
+`applyResultToDom()` lives in `assets/js/testResults.js` and is **shared with `index.js`**, which is not being migrated
+in this pass. It therefore gains a registry-based sibling rather than being rewritten in place; `index.js` keeps
+painting by `classes` until its own migration.
+
+## Testing
+
+**API.** `hello` is emitted on connect and shaped correctly; each capability list is genuinely derived, not
+transcribed — the actions test asserts against the schema document rather than a literal; `protocol: 1` is accepted on
+every shape; `protocol: 7`, `"1"` and `1.0` are refused with `unsupported_protocol`; an absent `protocol` leaves every
+legacy path byte-identical; the protocol check precedes `UNKNOWN_ACTION`; and the schema-to-constant drift test.
+
+**Client.** The e2e specs that assert card markup and dropdown contents are re-run — `e2e/rite-selection.spec.ts`
+pins the hand-built dropdown and may need revisiting once cards are inventory-rendered.
+
+**Known bound on the API test suite in a worktree:** `Routes/*` tests speak to `localhost:8000`, which is the *shared*
+checkout, so a green run there says nothing about this branch. The meaningful signals are the `Health*` and
+`WebSocket/*` suites, which drive `onMessage()` in-process, plus `composer analyse` and `composer lint`.
+
+## Order
+
+The API PR lands first. The client's `protocol: 1` messages need a server that accepts the field — sent to a server
+without it, and carrying a `requestId`, they are refused by the root strict gate as an undeclared property.

--- a/jsondata/schemas/WebSocketFrame.json
+++ b/jsondata/schemas/WebSocketFrame.json
@@ -1,0 +1,133 @@
+{
+    "$schema": "https://json-schema.org/draft-07/schema#",
+    "title": "Health WebSocket outbound frame",
+    "description": "Every frame the Health WebSocket endpoint sends to a client. Its inbound counterpart is WebSocketMessage.json; this document exists because a client's own types are almost entirely about what it receives, and until API issue #806 section F nothing published that half of the contract (see UnitTestInterface#42, item 5). Frames are discriminated by `type`, and a `success` frame additionally by whether it carries a `status`: a step result does, the terminal frame does not, because the terminal frame reports that the work finished rather than how it went.",
+    "oneOf": [
+        { "$ref": "#/definitions/hello" },
+        { "$ref": "#/definitions/stepResult" },
+        { "$ref": "#/definitions/complete" },
+        { "$ref": "#/definitions/protocolError" }
+    ],
+    "definitions": {
+        "correlationId": {
+            "type": "string",
+            "description": "An opaque client-minted handle echoed back exactly as it was sent. Same alphabet as its inbound counterpart.",
+            "pattern": "^[A-Za-z0-9_-]{1,64}$"
+        },
+        "runCorrelation": {
+            "type": "object",
+            "description": "The correlation properties any frame may carry. `runToken` and `runId` are the same value under two names — the protocol is moving to `runId`, and both are published so a client adopts the new spelling once rather than twice — and both are present only while the connection is on a run. `requestId` is present only when the request that caused the frame carried one; a client that sends no requestId opts out of per-request correlation, and of the terminal `complete` frame with it.",
+            "properties": {
+                "runToken": { "$ref": "#/definitions/correlationId" },
+                "runId": { "$ref": "#/definitions/correlationId" },
+                "requestId": { "$ref": "#/definitions/correlationId" }
+            }
+        },
+        "target": {
+            "type": ["object", "null"],
+            "description": "What the frame is about. An object rather than a bare id from the outset, because the things checked are not all identified by one value: a source check is its inventory id alone, a calendar validation is a calendar and a year, and a test run is a test, a calendar and a year. Null for a legacy `executeValidation` message, which names no id — nothing is fabricated for it. This says what was checked; `requestId` says which request asked, and the two are not interchangeable.",
+            "required": ["id"],
+            "properties": {
+                "id": { "type": "string" },
+                "year": { "type": "integer" },
+                "calendar": { "type": "string" }
+            }
+        },
+        "hello": {
+            "type": "object",
+            "description": "Sent once, unprompted, as soon as a client connects — API issue #806 section F. It carries no run correlation, and that is load-bearing rather than incidental: both shipped v1 runners guard their message handler on the frame's runToken matching the run they are on, so an untagged frame is dropped before it reaches their `type` dispatch, where an unrecognised type is painted as a failed check. A `hello` sent at any other moment — once the connection is on a run — would be stamped with a run token and would then be visible to a client that cannot read it.",
+            "required": ["type", "protocol", "capabilities"],
+            "properties": {
+                "type": { "const": "hello" },
+                "protocol": {
+                    "type": "integer",
+                    "description": "The highest protocol version this server reads, and the value a client should declare on its own messages. A client that declares one the server does not read is refused with errorCode `unsupported_protocol`, which names the versions that would have worked."
+                },
+                "capabilities": {
+                    "type": "object",
+                    "description": "What this server can be asked for. Every list is derived on the server from whatever already defines it — the Rite, Step and Status enums, the response formats the calendar validator actually has a branch for, and the actions this contract's inbound schema declares — so an advertisement cannot go stale against the behaviour it describes. `responseFormats` is deliberately narrower than the formats the REST API accepts: it lists only those the WebSocket calendar validation can act on.",
+                    "required": ["rites", "actions", "responseFormats", "steps", "statuses"],
+                    "properties": {
+                        "rites": { "type": "array", "items": { "type": "string" } },
+                        "actions": { "type": "array", "items": { "type": "string" } },
+                        "responseFormats": { "type": "array", "items": { "type": "string" } },
+                        "steps": { "type": "array", "items": { "type": "string" } },
+                        "statuses": { "type": "array", "items": { "type": "string" } }
+                    }
+                }
+            }
+        },
+        "stepResult": {
+            "type": "object",
+            "description": "The outcome of one step of one check. `target`, `step` and `status` are the structural statement; `type`, `text` and `classes` are a projection of it kept for clients that predate API issue #806 section C.",
+            "required": ["type", "text", "classes", "target", "step", "status"],
+            "allOf": [{ "$ref": "#/definitions/runCorrelation" }],
+            "properties": {
+                "type": {
+                    "enum": ["success", "error"],
+                    "description": "The legacy pass/fail projection of `status`. Branch on `status` instead: this exists so a v1 client keeps working, and it cannot express anything `status` does not."
+                },
+                "text": { "type": "string", "description": "The human-facing message. Never a path: the server's project root is stripped from every frame before it is sent." },
+                "classes": {
+                    "type": "string",
+                    "description": "DEPRECATED — a CSS selector the server composes and a browser client feeds to querySelectorAll(). It is what made this API's frames depend on one client's markup, and what made a selector matching nothing fail silently while the counters still advanced. Retained only until UnitTestInterface#42 ships; new clients address frames by `requestId` and `step` and must not parse this."
+                },
+                "responsetype": {
+                    "type": "string",
+                    "description": "DEPRECATED spelling, carried on calendar-validation failure frames alone, for the same reason `classes` is. The inbound contract's v2 shapes spell it `responseFormat`."
+                },
+                "target": { "$ref": "#/definitions/target" },
+                "step": { "enum": ["exists", "parses", "validates"] },
+                "status": { "enum": ["pass", "fail"] },
+                "details": {
+                    "type": "array",
+                    "description": "The individual failures behind a `text` that summarises them — a folder check's per-file errors, a schema failure's parts. Absent rather than empty when there are none, so a client need not tell 'no details' from 'none given'. Never manufactured for an emitter that has nothing to say.",
+                    "items": { "type": "string" }
+                }
+            }
+        },
+        "complete": {
+            "type": "object",
+            "description": "The terminal frame: the work this request started has finished. A client stops on this rather than counting the frames before it — an arm that stops early is a possibility the protocol should not need a client to predict. **Sent only to a request that carried a `requestId`**, because a new frame changes the stream a v1 client counts: a client sizing a phase as `checks * 3` reaches its threshold on the real frames and lets this one finish the *following* phase early. Pair stopping on it with a timeout, since a throw inside a fulfil handler can still skip it (API issue #823).",
+            "required": ["type", "text", "target", "step", "requestId"],
+            "allOf": [{ "$ref": "#/definitions/runCorrelation" }],
+            "properties": {
+                "type": {
+                    "const": "success",
+                    "description": "Always `success`, including for a request whose every step failed: this frame reports that the work finished, not that it passed. A distinct type would be painted as a failed check by the shipped clients."
+                },
+                "text": { "type": "string" },
+                "target": { "$ref": "#/definitions/target" },
+                "step": { "const": "complete" },
+                "cancelled": {
+                    "const": true,
+                    "description": "Present only when the request is ending because the run it belonged to was abandoned or superseded, rather than because its work finished. Omitted rather than sent as `false`, so a normal terminal frame is identical to what it was before this key existed and nothing has to tell 'not cancelled' from 'an older server'."
+                }
+            }
+        },
+        "protocolError": {
+            "type": "object",
+            "description": "The message could not be acted on, said in a form a client can branch on. Ungated, unlike the terminal frame: a new frame changes the stream a v1 client counts, but a new type on a frame it was going to receive anyway changes nothing for it. A code exists where a client would *act* differently; where it would only display the reason, the reason is prose in `text`.",
+            "required": ["type", "errorCode", "text"],
+            "allOf": [{ "$ref": "#/definitions/runCorrelation" }],
+            "properties": {
+                "type": { "const": "protocolError" },
+                "errorCode": {
+                    "enum": [
+                        "invalid_json",
+                        "not_an_object",
+                        "missing_action",
+                        "unknown_action",
+                        "invalid_request_id",
+                        "retired_property",
+                        "unknown_target_id",
+                        "invalid_message",
+                        "internal_error",
+                        "unsupported_protocol"
+                    ]
+                },
+                "text": { "type": "string", "description": "Why, phrased for the client that sent the message: the failure names the client's own action and property names, not this server's schema internals, and never its filesystem paths." }
+            }
+        }
+    }
+}

--- a/jsondata/schemas/WebSocketMessage.json
+++ b/jsondata/schemas/WebSocketMessage.json
@@ -17,6 +17,11 @@
             "pattern": "^[A-Za-z0-9_-]{1,64}$",
             "description": "An opaque client-minted handle the server echoes back. One alphabet for runToken and requestId alike."
         },
+        "protocolVersion": {
+            "type": "integer",
+            "enum": [1],
+            "description": "The self-describing contract this message is written in (API issue #806 section F). Absent means the legacy shapes, handled exactly as before; 1 is the contract the `hello` frame advertises on connect. Declared on every shape because the root unknown-property gate refuses anything a shape does not declare once a message carries a requestId, and a v2 client sends both fields together. The version the server accepts is enforced by WebSocketMessageValidator::SUPPORTED_PROTOCOL_VERSIONS before a message is interpreted at all — including its type, since a numerically-correct 1.0 is a float and a float reaching a typed parameter kills the process rather than failing the request. This enum and that constant are pinned to each other by a test."
+        },
         "calendarIdentity": {
             "type": "object",
             "description": "additionalProperties is unconditional here, unlike the root-level shapes above: unknown-property rejection at the root is gated on the message carrying a requestId (WebSocketMessageValidator, API issue #806 section G), because the shipped UnitTestInterface predates that field and sends other properties a strict root gate would refuse. This nested object is reachable only from validateCalendarTyped and runTest, both v2-only shapes the shipped client never sends, so there is no compatibility guarantee to protect here. Do not loosen this to match the root's gating — that would remove the only strictness these v2 nested objects have.",
@@ -54,6 +59,7 @@
                 "sourceFolder": { "type": "string", "pattern": "^[^\\x00]*$" },
                 "responsetype": { "type": "string" },
                 "rite": { "type": "string" },
+                "protocol": { "$ref": "#/definitions/protocolVersion" },
                 "runToken": { "$ref": "#/definitions/correlationId" },
                 "requestId": { "$ref": "#/definitions/correlationId" }
             }
@@ -68,6 +74,7 @@
                 "category": { "enum": ["nationalcalendar", "diocesancalendar", "ritecalendar"] },
                 "responsetype": { "enum": ["JSON", "XML", "ICS", "YML"] },
                 "rite": { "type": "string" },
+                "protocol": { "$ref": "#/definitions/protocolVersion" },
                 "runToken": { "$ref": "#/definitions/correlationId" },
                 "requestId": { "$ref": "#/definitions/correlationId" }
             }
@@ -80,6 +87,7 @@
                 "calendar": { "$ref": "#/definitions/calendarIdentity" },
                 "year": { "type": "integer" },
                 "responseFormat": { "enum": ["JSON", "XML", "ICS", "YML"] },
+                "protocol": { "$ref": "#/definitions/protocolVersion" },
                 "runToken": { "$ref": "#/definitions/correlationId" },
                 "requestId": { "$ref": "#/definitions/correlationId" }
             }
@@ -94,6 +102,7 @@
                 "category": { "enum": ["nationalcalendar", "diocesancalendar", "ritecalendar"] },
                 "test": { "type": "string" },
                 "rite": { "type": "string" },
+                "protocol": { "$ref": "#/definitions/protocolVersion" },
                 "runToken": { "$ref": "#/definitions/correlationId" },
                 "requestId": { "$ref": "#/definitions/correlationId" }
             }
@@ -106,6 +115,7 @@
                 "test": { "type": "string" },
                 "calendar": { "$ref": "#/definitions/calendarIdentity" },
                 "year": { "type": "integer" },
+                "protocol": { "$ref": "#/definitions/protocolVersion" },
                 "runToken": { "$ref": "#/definitions/correlationId" },
                 "requestId": { "$ref": "#/definitions/correlationId" }
             }
@@ -115,6 +125,7 @@
             "required": ["action", "runToken"],
             "properties": {
                 "action": { "const": "cancelRun" },
+                "protocol": { "$ref": "#/definitions/protocolVersion" },
                 "runToken": { "$ref": "#/definitions/correlationId" },
                 "requestId": { "$ref": "#/definitions/correlationId" }
             }
@@ -131,6 +142,7 @@
                     "properties": { "id": { "type": "string" } },
                     "additionalProperties": false
                 },
+                "protocol": { "$ref": "#/definitions/protocolVersion" },
                 "runToken": { "$ref": "#/definitions/correlationId" },
                 "requestId": { "$ref": "#/definitions/correlationId" }
             }

--- a/phpunit_tests/HealthHelloFrameTest.php
+++ b/phpunit_tests/HealthHelloFrameTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Enum\Status;
+use LiturgicalCalendar\Api\Enum\Step;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * The `hello` frame — #806 section F, the last section of that issue.
+ *
+ * Two things are being asserted here, and they pull in opposite directions.
+ *
+ * **That the frame says something true.** Every list in `capabilities` is derived from the thing that
+ * already defines it — the `Rite`, `Step` and `Status` enums, the response formats
+ * `Health::validateCalendar()` actually has a branch for, and the actions the *published schema*
+ * declares. A hand-written list here would be a second place to edit in lockstep, which is the defect
+ * #806 exists to remove; these tests are what stops one being introduced later by someone adding a
+ * case and not noticing the frame went stale.
+ *
+ * **That the frame is invisible to the client that cannot read it.** Both shipped runners open their
+ * message handler with `if (currentState === Stopped || currentRunToken === null) return;` and then
+ * `if (responseData.runToken !== currentRunToken) return;`. An unsolicited frame is dropped by the
+ * first guard before a run and by the second during one — but only for as long as it carries no run
+ * token. `Health::sendMessage()` stamps `runToken`/`runId` onto any frame whose connection is on a
+ * run, so "carries no run token" is a property of *when* the frame is sent, not of how it is built.
+ * {@see testTheHelloFrameCarriesNoRunTokenSoAV1ClientDropsIt()} pins that, because a later change
+ * that sent `hello` somewhere other than on connect would paint a failed check in the live UI —
+ * UnitTestInterface#46 made an unrecognised `type` a visible failure — and nothing else would notice.
+ */
+#[CoversClass(Health::class)]
+final class HealthHelloFrameTest extends TestCase
+{
+    // onOpen() queues the connect-time /calendars metadata fetch. Without this the process would
+    // dispatch it for real at PHPUnit shutdown. See the trait.
+    use HealthQueueIsolationTrait;
+
+    /**
+     * The `Health` statics `onOpen()` writes, saved so this file can put them back.
+     *
+     * @var array<string, mixed>
+     */
+    private array $cacheStateBackup = [];
+
+    /**
+     * The statics `onOpen()` initialises on its way past. Named here rather than inline so the
+     * save and the restore cannot drift apart.
+     *
+     * @var list<string>
+     */
+    private const CACHE_STATICS = ['cacheInitialized', 'cacheEnabled', 'cacheBackend', 'redis'];
+
+    /**
+     * **This file is the only one in the suite that calls `onOpen()` for real, and that is a
+     * process-wide event, not a per-test one.**
+     *
+     * `onOpen()` initialises `Health`'s cache backend — a set of *static* properties, guarded by
+     * `self::$cacheInitialized` so it happens once per process — and on a host with a reachable Redis
+     * or a working APCu it turns caching **on**. Every other Health suite relies on it being off:
+     * `HealthCorrelationTest` says so in as many words ("caching is off in this process (it is
+     * initialised in `onOpen()`, which no test calls), so every outbound request really is queued"),
+     * and their assertions are written against a queue that a cache hit empties. Measured: calling
+     * `onOpen()` without this guard turned 23 tests in six other Health suites red, all of them
+     * asserting on requests that were no longer queued — and none of them red for a reason a reader
+     * of those files could have traced back to here.
+     *
+     * So the cache-init block is skipped rather than exercised: `cacheInitialized` is set **before**
+     * `onOpen()` runs, which is the flag's own way of saying "already done", and the values are put
+     * back afterwards so a suite that ran before this one is not left looking at this one's state
+     * either. Nothing about the `hello` frame depends on the cache, so nothing is lost by skipping
+     * it — and `HealthApcuDetectionTest` is where that block is actually tested.
+     */
+    protected function setUp(): void
+    {
+        foreach (self::CACHE_STATICS as $name) {
+            $property                      = new \ReflectionProperty(Health::class, $name);
+            $this->cacheStateBackup[$name] = $property->getValue();
+        }
+
+        ( new \ReflectionProperty(Health::class, 'cacheInitialized') )->setValue(null, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cacheStateBackup as $name => $value) {
+            ( new \ReflectionProperty(Health::class, $name) )->setValue(null, $value);
+        }
+        $this->cacheStateBackup = [];
+    }
+
+    /**
+     * A Ratchet connection that records what was sent to it. `resourceId` is a dynamic public property
+     * Ratchet assigns and is not part of `ConnectionInterface`, so this is a stub rather than a PHPUnit
+     * mock, which would trigger a dynamic-property deprecation. Same convention as HealthCancelRunTest.
+     */
+    private static function createStubConnection(int $resourceId)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * Open a connection and return the `hello` frame it was sent.
+     *
+     * `onOpen()` also writes progress to stdout; it is captured and discarded so the frame assertions
+     * are not read through pages of connection logging.
+     */
+    private function helloFrameFor(ConnectionInterface $conn): \stdClass
+    {
+        $health = $this->newHealth();
+
+        ob_start();
+        $health->onOpen($conn);
+        ob_end_clean();
+
+        /** @var object{sent: list<string>} $conn */
+        self::assertNotEmpty($conn->sent, 'a connecting client was sent nothing at all');
+
+        $frame = json_decode($conn->sent[0]);
+        self::assertInstanceOf(\stdClass::class, $frame, 'the first frame is not a JSON object');
+
+        return $frame;
+    }
+
+    public function testAHelloFrameIsTheFirstThingAConnectingClientIsSent(): void
+    {
+        $frame = $this->helloFrameFor(self::createStubConnection(1));
+
+        self::assertSame('hello', $frame->type ?? null);
+        self::assertSame(1, $frame->protocol ?? null, 'the frame advertises the protocol version it speaks');
+        self::assertInstanceOf(\stdClass::class, $frame->capabilities ?? null);
+    }
+
+    public function testTheHelloFrameCarriesNoRunTokenSoAV1ClientDropsIt(): void
+    {
+        $frame = $this->helloFrameFor(self::createStubConnection(2));
+
+        self::assertObjectNotHasProperty('runToken', $frame);
+        self::assertObjectNotHasProperty('runId', $frame);
+        self::assertObjectNotHasProperty('requestId', $frame);
+    }
+
+    public function testEveryRiteIsAdvertised(): void
+    {
+        $frame = $this->helloFrameFor(self::createStubConnection(3));
+
+        self::assertSame(
+            array_column(Rite::cases(), 'value'),
+            $frame->capabilities->rites ?? null,
+            'a rite the API supports is not advertised — capabilities must be derived from Rite, not transcribed'
+        );
+    }
+
+    public function testTheFrameVocabularyIsAdvertised(): void
+    {
+        $frame = $this->helloFrameFor(self::createStubConnection(4));
+
+        self::assertSame(array_column(Step::cases(), 'value'), $frame->capabilities->steps ?? null);
+        self::assertSame(array_column(Status::cases(), 'value'), $frame->capabilities->statuses ?? null);
+    }
+
+    /**
+     * The response formats advertised are the ones `validateCalendar()` has a validation branch for —
+     * narrower than `ReturnTypeParam`, deliberately, because a format outside that list reaches
+     * `ReturnTypeParam::from()` and throws a `\ValueError`, which Ratchet does not catch. Advertising
+     * the wider list would invite a client to kill the server.
+     */
+    public function testOnlyTheValidatableResponseFormatsAreAdvertised(): void
+    {
+        $frame = $this->helloFrameFor(self::createStubConnection(5));
+
+        /** @var list<string> $validatable */
+        $validatable = ( new \ReflectionClassConstant(Health::class, 'VALIDATABLE_RESPONSE_FORMATS') )->getValue();
+
+        self::assertSame($validatable, $frame->capabilities->responseFormats ?? null);
+    }
+
+    /**
+     * `actions` is read from the published schema, not written down here or in `Health`.
+     *
+     * The schema is the authority on what the server accepts — `WebSocketMessageValidator` refuses
+     * anything whose action does not name one of its definitions — so deriving the advertisement from
+     * it makes "advertised" and "accepted" the same statement rather than two that must agree.
+     *
+     * `validateCalendar` has two definitions (a legacy and a typed shape) and must be advertised once:
+     * the wire carries actions, not definition names, and `validateCalendarTyped` is a name no client
+     * can send.
+     */
+    public function testTheAdvertisedActionsAreTheOnesTheSchemaDeclares(): void
+    {
+        $frame = $this->helloFrameFor(self::createStubConnection(6));
+
+        $schema = json_decode((string) file_get_contents(LitSchema::WEBSOCKET_MESSAGE->path()));
+        self::assertInstanceOf(\stdClass::class, $schema);
+
+        $declared = [];
+        foreach ((array) $schema->definitions as $definition) {
+            if ($definition instanceof \stdClass && isset($definition->properties->action->const)) {
+                $declared[] = (string) $definition->properties->action->const;
+            }
+        }
+        $declared = array_values(array_unique($declared));
+
+        self::assertNotEmpty($declared, 'the schema declares no actions at all — the test cannot mean anything');
+        self::assertEqualsCanonicalizing($declared, $frame->capabilities->actions ?? null);
+        self::assertSame(
+            count($declared),
+            count($frame->capabilities->actions ?? []),
+            'validateCalendar has two definitions but is one action; the advertisement must not list it twice'
+        );
+    }
+}

--- a/phpunit_tests/HealthProtocolVersionTest.php
+++ b/phpunit_tests/HealthProtocolVersionTest.php
@@ -178,6 +178,45 @@ final class HealthProtocolVersionTest extends TestCase
     }
 
     /**
+     * A message the server has just said it cannot read must not leave a mark on the run.
+     *
+     * The run-token block installs the connection's current run and, on a token change, rebuilds the
+     * checkable inventory. Both used to happen before the protocol was judged, so a message written
+     * in a protocol this server does not speak could still decide which run the connection was on —
+     * and every later frame would be tagged with a token that arrived in an unreadable message.
+     */
+    public function testAnUnsupportedProtocolLeavesTheConnectionOnNoRun(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection(1);
+
+        ob_start();
+        $health->onMessage($conn, (string) json_encode(self::cancelRun(['protocol' => 7, 'runToken' => 'run-a'])));
+        ob_end_clean();
+
+        /** @var array<int, string> $tokens */
+        $tokens = ( new \ReflectionProperty(Health::class, 'runTokens') )->getValue($health);
+        self::assertSame([], $tokens, 'a message refused for its protocol installed a run token anyway');
+    }
+
+    /**
+     * …and yet the refusal still names the run, or the client never sees it.
+     *
+     * Both shipped runners discard any frame whose `runToken` does not match the run they believe
+     * they are on. A refusal of a run's *first* message carries no stored token to fall back on — so
+     * without the message's own token on the frame, the one error the client most needs to see would
+     * be the one it silently drops.
+     */
+    public function testTheRefusalStillNamesTheRunTheMessageDeclared(): void
+    {
+        $frames = $this->framesFor(self::cancelRun(['protocol' => 7, 'runToken' => 'run-a']));
+
+        self::assertCount(1, $frames);
+        self::assertSame('run-a', $frames[0]->runToken ?? null);
+        self::assertSame('run-a', $frames[0]->runId ?? null);
+    }
+
+    /**
      * Every shape must accept it, not just the one this file probes with. A client does not send
      * `protocol` on some of its messages.
      */

--- a/phpunit_tests/HealthProtocolVersionTest.php
+++ b/phpunit_tests/HealthProtocolVersionTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * The inbound half of the handshake — #806 section F.
+ *
+ * A client that speaks the self-describing contract says so with `protocol: 1`; a client that predates
+ * it sends no `protocol` at all and is handled exactly as before. The interesting cases are neither of
+ * those: they are the version this server does not implement, and the version sent as the wrong type.
+ *
+ * **Why this is checked before anything else interprets the message.** The protocol version says how
+ * the rest of the message is to be *read*. Answering `{"action": "bogus", "protocol": 7}` with
+ * `unknown_action` would assert something the server cannot know — under protocol 7 that action might
+ * be perfectly well defined. `unsupported_protocol` is the only true answer, and
+ * {@see testAnUnsupportedProtocolIsAnsweredBeforeTheActionIsJudged()} pins the ordering so a later
+ * refactor cannot quietly reverse it.
+ *
+ * **Why the wrong type is refused here rather than by the schema.** `1.0` decodes to a PHP float, and
+ * a float reaching a typed parameter is refused by coercive typing as a `\TypeError` — an `\Error`,
+ * which Ratchet's `IoServer::handleData` does not catch, so it takes the WebSocket process down for
+ * every connected client. That is the seventh crash shape section G found by probing rather than by
+ * reading, and the lesson it paid for is that a value's *type* is checked at the door.
+ */
+#[CoversClass(Health::class)]
+#[CoversClass(WebSocketMessageValidator::class)]
+final class HealthProtocolVersionTest extends TestCase
+{
+    use HealthQueueIsolationTrait;
+
+    /** Same stub convention as HealthCancelRunTest; see the note there. */
+    private static function createStubConnection(int $resourceId)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * Drive one message through `onMessage()` and return the frames it produced.
+     *
+     * `onMessage()` echoes the message it received to stdout; captured and discarded so a failure
+     * report shows the assertion rather than the server's logging.
+     *
+     * @param array<string, mixed> $payload
+     * @return list<\stdClass>
+     */
+    private function framesFor(array $payload): array
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection(1);
+
+        // JSON_PRESERVE_ZERO_FRACTION, without which `1.0` is encoded as `1` and the float case below
+        // silently tests an integer instead — a green assertion about a message never sent.
+        ob_start();
+        $health->onMessage($conn, (string) json_encode($payload, JSON_PRESERVE_ZERO_FRACTION));
+        ob_end_clean();
+
+        return array_map(
+            static function (string $raw): \stdClass {
+                $frame = json_decode($raw);
+                self::assertInstanceOf(\stdClass::class, $frame);
+
+                return $frame;
+            },
+            $conn->sent
+        );
+    }
+
+    /**
+     * `cancelRun` is the probe throughout this file: it is the one action that touches no filesystem
+     * and issues no HTTP request, so a message that survives validation produces no frames at all.
+     * That makes "was it refused?" answerable by counting frames, with nothing else in the way.
+     *
+     * @param array<string, mixed> $extra
+     * @return array<string, mixed>
+     */
+    private static function cancelRun(array $extra = []): array
+    {
+        return array_merge(['action' => 'cancelRun', 'runToken' => 'run-a'], $extra);
+    }
+
+    public function testTheCurrentProtocolVersionIsAccepted(): void
+    {
+        $frames = $this->framesFor(self::cancelRun(['protocol' => 1]));
+
+        self::assertSame([], $frames, 'a message declaring the protocol this server speaks was refused');
+    }
+
+    public function testAMessageWithoutAProtocolIsStillLegacyAndUntouched(): void
+    {
+        $frames = $this->framesFor(self::cancelRun());
+
+        self::assertSame([], $frames, 'an absent protocol must mean legacy handling, exactly as before');
+    }
+
+    public function testAProtocolTheServerDoesNotImplementIsRefused(): void
+    {
+        $frames = $this->framesFor(self::cancelRun(['protocol' => 7]));
+
+        self::assertCount(1, $frames);
+        self::assertSame('protocolError', $frames[0]->type ?? null);
+        self::assertSame(ProtocolErrorCode::UNSUPPORTED_PROTOCOL->value, $frames[0]->errorCode ?? null);
+    }
+
+    /**
+     * A string, a float and a null are each a version this server cannot act on, and none of them may
+     * reach a typed parameter. `1.0` is the one worth naming: it is *numerically* the supported
+     * version, and accepting it on that basis is how a float reaches PHP's coercive typing.
+     */
+    public function testAProtocolOfTheWrongTypeIsRefused(): void
+    {
+        foreach (['1', 1.0, null, true, ['1']] as $version) {
+            $frames = $this->framesFor(self::cancelRun(['protocol' => $version]));
+
+            self::assertCount(1, $frames, sprintf('protocol %s was not refused', var_export($version, true)));
+            self::assertSame(
+                ProtocolErrorCode::UNSUPPORTED_PROTOCOL->value,
+                $frames[0]->errorCode ?? null,
+                sprintf('protocol %s was refused, but not as a protocol failure', var_export($version, true))
+            );
+        }
+    }
+
+    public function testAnUnsupportedProtocolIsAnsweredBeforeTheActionIsJudged(): void
+    {
+        $frames = $this->framesFor(['action' => 'notAnAction', 'protocol' => 7]);
+
+        self::assertCount(1, $frames);
+        self::assertSame(
+            ProtocolErrorCode::UNSUPPORTED_PROTOCOL->value,
+            $frames[0]->errorCode ?? null,
+            'the server cannot know an action is unknown under a protocol it does not read'
+        );
+    }
+
+    /**
+     * The strict unknown-property gate is armed by `requestId`, so a v2 client sends the two fields
+     * that could refuse each other: `protocol`, which the shapes must declare, and `requestId`, which
+     * makes any undeclared property fatal. Before the schema declared `protocol`, this exact pair —
+     * the ordinary shape of a v2 message — was answered with `INVALID_MESSAGE`.
+     */
+    public function testAProtocolFieldIsNotItselfAnUndeclaredProperty(): void
+    {
+        $frames = $this->framesFor(self::cancelRun(['protocol' => 1, 'requestId' => 'req-alpha']));
+
+        self::assertSame(
+            [],
+            $frames,
+            'a v2 message was refused for carrying the very field that marks it as v2'
+        );
+    }
+
+    /**
+     * Every shape must accept it, not just the one this file probes with. A client does not send
+     * `protocol` on some of its messages.
+     */
+    public function testEveryPublishedShapeDeclaresTheProtocolField(): void
+    {
+        $schema = json_decode((string) file_get_contents(
+            \LiturgicalCalendar\Api\Enum\LitSchema::WEBSOCKET_MESSAGE->path()
+        ));
+        self::assertInstanceOf(\stdClass::class, $schema);
+
+        $shapes = 0;
+        foreach ((array) $schema->definitions as $name => $definition) {
+            if (false === $definition instanceof \stdClass || false === isset($definition->properties->action)) {
+                continue;
+            }
+            ++$shapes;
+            self::assertTrue(
+                isset($definition->properties->protocol),
+                sprintf('%s does not declare protocol, so a v2 client sending it would be refused', (string) $name)
+            );
+        }
+
+        self::assertGreaterThan(0, $shapes, 'no message shapes were found to check');
+    }
+}

--- a/phpunit_tests/Schemas/WebSocketFrameSchemaTest.php
+++ b/phpunit_tests/Schemas/WebSocketFrameSchemaTest.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Schemas;
+
+use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Enum\Status;
+use LiturgicalCalendar\Api\Enum\Step;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+use Swaggest\JsonSchema\Schema;
+
+/**
+ * `WebSocketFrame.json` — the published contract for what the server *sends*.
+ *
+ * Its inbound counterpart has been published since #806 section G; this half arrived with section F,
+ * because a client's own types are almost entirely about received frames and there was nothing to
+ * check them against.
+ *
+ * **Every frame here is produced by the server, not transcribed into a fixture.** A published
+ * document that describes frames a test author wrote out by hand is exactly the drift this repo keeps
+ * filing bugs about — #805 (annotations that disagreed with the code), #822, #833, #834 (checks that
+ * reported something they had not verified). So `hello` and `protocolError` are captured by driving
+ * `onOpen()` and `onMessage()`, and the two result frames are captured by calling the private
+ * emitters that every real result frame goes through. If a frame's shape changes and this document
+ * does not, these fail.
+ */
+#[CoversClass(Health::class)]
+final class WebSocketFrameSchemaTest extends TestCase
+{
+    use HealthQueueIsolationTrait;
+
+    /** @var array<string, mixed> */
+    private array $cacheStateBackup = [];
+
+    /** @var list<string> */
+    private const CACHE_STATICS = ['cacheInitialized', 'cacheEnabled', 'cacheBackend', 'redis'];
+
+    /**
+     * Paths must exist before the schema can be located, and this class may be the first to run.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+    }
+
+    /**
+     * Skip `onOpen()`'s cache initialisation and put the statics back afterwards. The reasoning is
+     * recorded in full on `HealthHelloFrameTest::setUp()`: initialising the cache backend is a
+     * process-wide event that turns 23 tests in other Health suites red, none of them in a way a
+     * reader of those files could trace back to here.
+     */
+    protected function setUp(): void
+    {
+        foreach (self::CACHE_STATICS as $name) {
+            $this->cacheStateBackup[$name] = ( new \ReflectionProperty(Health::class, $name) )->getValue();
+        }
+        ( new \ReflectionProperty(Health::class, 'cacheInitialized') )->setValue(null, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cacheStateBackup as $name => $value) {
+            ( new \ReflectionProperty(Health::class, $name) )->setValue(null, $value);
+        }
+        $this->cacheStateBackup = [];
+    }
+
+    private static function schema(): Schema
+    {
+        $schema = Schema::import(LitSchema::WEBSOCKET_FRAME->path());
+        self::assertInstanceOf(Schema::class, $schema);
+
+        return $schema;
+    }
+
+    /** Same stub convention as the other Health suites; see HealthCancelRunTest. */
+    private static function createStubConnection(int $resourceId)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * Assert a frame the server really emitted validates, and say which frame if it does not.
+     */
+    private static function assertFrameValidates(string $raw, string $what): void
+    {
+        try {
+            self::schema()->in(json_decode($raw));
+        } catch (\Throwable $e) {
+            self::fail(sprintf("the %s frame the server emits does not match the published contract:\n%s\n%s", $what, $e->getMessage(), $raw));
+        }
+        self::assertTrue(true);
+    }
+
+    public function testTheHelloFrameMatchesThePublishedContract(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection(1);
+
+        ob_start();
+        $health->onOpen($conn);
+        ob_end_clean();
+
+        /** @var object{sent: list<string>} $conn */
+        self::assertFrameValidates($conn->sent[0], 'hello');
+    }
+
+    public function testAProtocolErrorFrameMatchesThePublishedContract(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection(2);
+
+        ob_start();
+        $health->onMessage($conn, (string) json_encode(['action' => 'cancelRun', 'runToken' => 'run-a', 'protocol' => 7]));
+        ob_end_clean();
+
+        /** @var object{sent: list<string>} $conn */
+        self::assertCount(1, $conn->sent);
+        self::assertFrameValidates($conn->sent[0], 'protocolError');
+    }
+
+    /**
+     * The step-result frame, taken from the emitter every real one passes through rather than written
+     * out here. Both outcomes are exercised, because `type` is projected from `status` and the two
+     * halves of that projection are different frames as far as the schema is concerned.
+     */
+    public function testAStepResultFrameMatchesThePublishedContract(): void
+    {
+        foreach ([Status::PASS, Status::FAIL] as $status) {
+            $health = $this->newHealth();
+            $conn   = self::createStubConnection(3);
+
+            $send = new \ReflectionMethod(Health::class, 'sendStepResult');
+            $send->invoke(
+                $health,
+                $conn,
+                'temporale-roman',
+                (object) ['id' => 'temporale:roman'],
+                Step::VALIDATES,
+                $status,
+                'a message a human reads',
+                Status::FAIL === $status ? ['one failure', 'another failure'] : null,
+                'run-a',
+                null,
+                \LiturgicalCalendar\Api\Enum\FrameFamily::CHECK,
+                null,
+                'req-alpha'
+            );
+
+            /** @var object{sent: list<string>} $conn */
+            self::assertFrameValidates($conn->sent[0], 'step result (' . $status->value . ')');
+        }
+    }
+
+    /**
+     * The terminal frame, both as it ends a finished request and as it ends a cancelled one — the
+     * `cancelled` key is the only difference and is omitted rather than sent as `false`.
+     */
+    public function testATerminalFrameMatchesThePublishedContract(): void
+    {
+        foreach ([false, true] as $cancelled) {
+            $health = $this->newHealth();
+            $conn   = self::createStubConnection(4);
+
+            $send = new \ReflectionMethod(Health::class, 'sendComplete');
+            $send->invoke($health, $conn, (object) ['id' => 'temporale:roman'], 'run-a', 'req-alpha', $cancelled);
+
+            /** @var object{sent: list<string>} $conn */
+            self::assertCount(1, $conn->sent, 'the terminal frame was not emitted at all');
+            self::assertFrameValidates($conn->sent[0], $cancelled ? 'complete (cancelled)' : 'complete');
+        }
+    }
+
+    /**
+     * The published error codes are the ones the server can actually send.
+     *
+     * A code the enum has and the schema lacks would make a real refusal fail its own contract; a code
+     * the schema has and the enum lacks would promise a client a branch that can never be taken.
+     */
+    public function testThePublishedErrorCodesAreTheOnesTheServerSends(): void
+    {
+        $raw = json_decode((string) file_get_contents(LitSchema::WEBSOCKET_FRAME->path()));
+        self::assertInstanceOf(\stdClass::class, $raw);
+
+        self::assertEqualsCanonicalizing(
+            array_column(\LiturgicalCalendar\Api\Enum\ProtocolErrorCode::cases(), 'value'),
+            array_map('strval', (array) $raw->definitions->protocolError->properties->errorCode->enum)
+        );
+    }
+
+    /**
+     * The steps a result frame may report are the ones the server has, minus the terminal one, which
+     * has a frame of its own.
+     */
+    public function testThePublishedStepsAreTheOnesTheServerSends(): void
+    {
+        $raw = json_decode((string) file_get_contents(LitSchema::WEBSOCKET_FRAME->path()));
+        self::assertInstanceOf(\stdClass::class, $raw);
+
+        $reportable = array_values(array_filter(
+            array_column(Step::cases(), 'value'),
+            static fn (string $step): bool => Step::COMPLETE->value !== $step
+        ));
+
+        self::assertEqualsCanonicalizing(
+            $reportable,
+            array_map('strval', (array) $raw->definitions->stepResult->properties->step->enum)
+        );
+        self::assertSame(
+            Step::COMPLETE->value,
+            $raw->definitions->complete->properties->step->const,
+            'the terminal frame must name the terminal step'
+        );
+    }
+}

--- a/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
+++ b/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Schemas;
 
 use LiturgicalCalendar\Api\Enum\LitSchema;
+use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Swaggest\JsonSchema\Schema;
@@ -203,6 +204,7 @@ final class WebSocketMessageSchemaTest extends TestCase
         self::assertEqualsCanonicalizing(
             [
                 'correlationId',
+                'protocolVersion',
                 'calendarIdentity',
                 'executeValidation',
                 'validateCalendarLegacy',
@@ -212,6 +214,30 @@ final class WebSocketMessageSchemaTest extends TestCase
                 'cancelRun', 'validateSource'
             ],
             array_keys((array) $raw->definitions)
+        );
+    }
+
+    /**
+     * The schema and the validator must name the same supported protocol versions.
+     *
+     * Two independent statements of the same set, with nothing comparing them, is how a published
+     * contract starts describing a server that no longer behaves that way — the drift #805 was filed
+     * for. Both spellings are load-bearing and neither can be dropped: the schema's `enum` is what a
+     * client reads, and `SUPPORTED_PROTOCOL_VERSIONS` is what the server enforces before a message is
+     * interpreted at all. So they are pinned to each other rather than one being derived from the
+     * other at runtime, which would make the published document unreadable on its own.
+     */
+    public function testTheSchemasProtocolEnumMatchesTheSupportedVersions(): void
+    {
+        $raw = json_decode((string) file_get_contents(LitSchema::WEBSOCKET_MESSAGE->path()));
+
+        /** @var list<int> $supported */
+        $supported = ( new \ReflectionClassConstant(WebSocketMessageValidator::class, 'SUPPORTED_PROTOCOL_VERSIONS') )->getValue();
+
+        self::assertSame(
+            $supported,
+            array_map('intval', (array) $raw->definitions->protocolVersion->enum),
+            'the published protocol versions are not the ones the server accepts'
         );
     }
 

--- a/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
+++ b/phpunit_tests/Schemas/WebSocketMessageSchemaTest.php
@@ -234,10 +234,14 @@ final class WebSocketMessageSchemaTest extends TestCase
         /** @var list<int> $supported */
         $supported = ( new \ReflectionClassConstant(WebSocketMessageValidator::class, 'SUPPORTED_PROTOCOL_VERSIONS') )->getValue();
 
+        // Compared without coercing: `array_map('intval', ...)` would make a schema declaring
+        // `["1"]` or `[1.0]` pass a test whose whole job is to notice that the published document
+        // and the server disagree — and a string or a float there is exactly the kind of drift
+        // `protocolViolation()` refuses at the door.
         self::assertSame(
             $supported,
-            array_map('intval', (array) $raw->definitions->protocolVersion->enum),
-            'the published protocol versions are not the ones the server accepts'
+            (array) $raw->definitions->protocolVersion->enum,
+            'the published protocol versions are not the ones the server accepts, in value or in type'
         );
     }
 

--- a/phpunit_tests/WebSocket/LitCalTestServerTest.php
+++ b/phpunit_tests/WebSocket/LitCalTestServerTest.php
@@ -53,6 +53,40 @@ final class LitCalTestServerTest extends TestCase
         fclose($probe);
     }
 
+    /**
+     * The `hello` frame, against a server that is actually running — #806 section F.
+     *
+     * The in-process suites assert what `Health::onOpen()` builds; this asserts what a client
+     * receives, which is not the same statement. Sixteen tests in this directory read `hello` where
+     * they expected their own answer when the frame was introduced, precisely because the frame is
+     * real on the wire and only the live suites see the wire. That the suite skips when no server
+     * is reachable is what let it reach CI.
+     */
+    public function testTheServerAdvertisesItsContractOnConnect(): void
+    {
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort);
+
+        $hello = $client->hello();
+        $this->assertNotNull($hello, 'a connecting client was not sent a hello frame');
+        $this->assertSame(1, $hello->protocol ?? null);
+
+        $capabilities = $hello->capabilities ?? null;
+        $this->assertIsObject($capabilities);
+        foreach (['rites', 'actions', 'responseFormats', 'steps', 'statuses'] as $capability) {
+            $this->assertIsArray($capabilities->{$capability} ?? null, "capabilities.{$capability} is missing");
+            $this->assertNotEmpty($capabilities->{$capability});
+        }
+        $this->assertContains('validateSource', $capabilities->actions);
+        $this->assertContains('complete', $capabilities->steps);
+
+        // No run correlation, which is what makes the frame invisible to a client that predates it:
+        // both shipped runners drop a frame whose runToken does not match the run they are on.
+        $this->assertObjectNotHasProperty('runToken', $hello);
+        $this->assertObjectNotHasProperty('runId', $hello);
+
+        $client->close();
+    }
+
     public function testHandshakeAndEcho(): void
     {
         $client = WsTestClient::connect($this->wsHost, $this->wsPort);

--- a/phpunit_tests/WebSocket/WsTestClient.php
+++ b/phpunit_tests/WebSocket/WsTestClient.php
@@ -27,6 +27,18 @@ final class WsTestClient
     /** @var resource */
     private $sock;
 
+    /** The connect-time `hello` frame, or null if the server sent something else first. */
+    private ?\stdClass $hello = null;
+
+    /**
+     * A frame read ahead of its consumer and put back.
+     *
+     * Only {@see self::readHelloFrame()} writes it, and only when the first frame was not a hello:
+     * the frame has already left the socket by then, so returning it to the next reader is the only
+     * way for that reader to see what the server really sent.
+     */
+    private ?string $pushedBack = null;
+
     private function __construct($sock)
     {
         $this->sock = $sock;
@@ -89,7 +101,46 @@ final class WsTestClient
             throw new \RuntimeException('WebSocket handshake failed: Sec-WebSocket-Accept did not match.');
         }
 
-        return new self($sock);
+        $client        = new self($sock);
+        $client->hello = $client->readHelloFrame();
+
+        return $client;
+    }
+
+    /**
+     * Read the `hello` frame the server sends on connect — #806 section F.
+     *
+     * **Consumed here, at the one place every WebSocket test connects**, because it is the first
+     * thing on the wire and every `receiveText()` in the suite is written expecting the answer to
+     * the message the test itself sent. Leaving it in the stream made sixteen tests read `hello`
+     * where they expected `success` or `protocolError` — and did so only in CI, since a suite with
+     * no reachable server skips instead of failing.
+     *
+     * Not swallowed silently: it is kept on {@see self::hello()} so a test can assert what the
+     * server advertised, and a first frame that is *not* a hello is left in the stream rather than
+     * discarded, so a server that stopped sending one fails the test that reads next instead of
+     * this method inventing a passing handshake.
+     */
+    private function readHelloFrame(): ?\stdClass
+    {
+        $frame   = $this->receiveText();
+        $decoded = json_decode($frame);
+
+        if ($decoded instanceof \stdClass && ( $decoded->type ?? null ) === 'hello') {
+            return $decoded;
+        }
+
+        $this->pushedBack = $frame;
+
+        return null;
+    }
+
+    /**
+     * What the server advertised on connect, or null if it sent no `hello`.
+     */
+    public function hello(): ?\stdClass
+    {
+        return $this->hello;
     }
 
     /**
@@ -129,6 +180,13 @@ final class WsTestClient
      */
     public function receiveText(): string
     {
+        if (null !== $this->pushedBack) {
+            $frame            = $this->pushedBack;
+            $this->pushedBack = null;
+
+            return $frame;
+        }
+
         $hdr = $this->readExact(2);
         $b0  = ord($hdr[0]);
         $b1  = ord($hdr[1]);

--- a/src/Enum/LitSchema.php
+++ b/src/Enum/LitSchema.php
@@ -27,6 +27,7 @@ enum LitSchema: string
     case SCHEMAS           = '/LitCalSchemasPath.json';
     case VALIDATIONS       = '/LitCalValidationsPath.json';
     case WEBSOCKET_MESSAGE = '/WebSocketMessage.json';
+    case WEBSOCKET_FRAME   = '/WebSocketFrame.json';
 
     public function path(): string
     {
@@ -68,7 +69,8 @@ enum LitSchema: string
             LitSchema::DATA     => $ERRMSG . 'Data path data not valid',
             LitSchema::SCHEMAS  => $ERRMSG . 'Schemas path data not valid',
             LitSchema::VALIDATIONS => $ERRMSG . 'Validations path data not valid',
-            LitSchema::WEBSOCKET_MESSAGE => $ERRMSG . 'WebSocket message not valid'
+            LitSchema::WEBSOCKET_MESSAGE => $ERRMSG . 'WebSocket message not valid',
+            LitSchema::WEBSOCKET_FRAME   => $ERRMSG . 'WebSocket frame not valid'
         };
     }
 
@@ -95,6 +97,7 @@ enum LitSchema: string
             LitSchema::SCHEMAS->path()           => LitSchema::SCHEMAS,
             LitSchema::VALIDATIONS->path()       => LitSchema::VALIDATIONS,
             LitSchema::WEBSOCKET_MESSAGE->path() => LitSchema::WEBSOCKET_MESSAGE,
+            LitSchema::WEBSOCKET_FRAME->path()   => LitSchema::WEBSOCKET_FRAME,
             default                              => throw new ValidationException('Invalid schema URL: ' . $url)
         };
     }

--- a/src/Enum/ProtocolErrorCode.php
+++ b/src/Enum/ProtocolErrorCode.php
@@ -22,4 +22,14 @@ enum ProtocolErrorCode: string
     case UNKNOWN_TARGET_ID  = 'unknown_target_id';
     case INVALID_MESSAGE    = 'invalid_message';
     case INTERNAL_ERROR     = 'internal_error';
+
+    /**
+     * The client declared a protocol version this server does not speak — #806 section F.
+     *
+     * Separate from `INVALID_MESSAGE` by the rule above, because a client acts on it differently:
+     * every other schema violation means "fix this message", while this one means "you are talking
+     * to a server of the wrong vintage" and the remedy is to fall back or to stop, not to correct a
+     * field. The `hello` frame names the version that would have worked.
+     */
+    case UNSUPPORTED_PROTOCOL = 'unsupported_protocol';
 }

--- a/src/Health.php
+++ b/src/Health.php
@@ -366,6 +366,11 @@ class Health implements MessageComponentInterface
             echo "New connection! ({$conn->resourceId}) and current working directory is " . getcwd() . "\n";
         }
 
+        // Announce the contract before anything is asked of the client — #806 section F. Sent here,
+        // ahead of the cache and metadata bootstrapping below, because those are this server's
+        // concerns and neither gates the client's ability to read this frame.
+        $this->sendMessage($conn, $this->helloFrame());
+
         // Initialize Router paths before creating logger (LoggerFactory needs Router::$apiFilePath)
         Router::getApiPaths();
 
@@ -528,6 +533,48 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * The frame announcing what this server speaks — #806 section F.
+     *
+     * **Nothing here is written down twice.** Every list is read from whatever already defines it:
+     * the `Rite`, `Step` and `Status` enums, the response formats {@see Health::validateCalendar()}
+     * actually has a branch for, and — through {@see WebSocketMessageValidator::supportedActions()} —
+     * the actions the published schema declares. #806 exists because the vocabulary and the layout
+     * lived in several places that had to be edited in lockstep; a hand-written capability list would
+     * be one more of them, and one that fails silently, since a stale advertisement misleads a client
+     * without breaking any test that does not compare it against the source.
+     *
+     * `responseFormats` advertises the narrow list on purpose. `ReturnTypeParam` knows more formats,
+     * but `ReturnTypeParam::from()` throws a `\ValueError` on the ones `validateCalendar()` has no
+     * branch for, and a `\ValueError` is an `\Error` that Ratchet does not catch — so advertising the
+     * wider set would invite a client to kill the server by taking the advertisement at its word.
+     *
+     * **This frame must stay unsolicited-safe.** It is sent on connect, before the connection is on
+     * any run, so `sendMessage()` stamps no `runToken` onto it — and that is exactly why the shipped
+     * v1 runners drop it: both guard their handler on `currentRunToken === null` and then on
+     * `responseData.runToken !== currentRunToken`, so an untagged frame never reaches the `type`
+     * dispatch that UnitTestInterface#46 made paint an unrecognised type as a failed check. Sending
+     * this frame at any other moment would break the live UI. Pinned by `HealthHelloFrameTest`.
+     */
+    private function helloFrame(): \stdClass
+    {
+        $capabilities                  = new \stdClass();
+        $capabilities->rites           = array_column(Rite::cases(), 'value');
+        $capabilities->actions         = $this->messageValidator->supportedActions();
+        $capabilities->responseFormats = self::VALIDATABLE_RESPONSE_FORMATS;
+        $capabilities->steps           = array_column(Step::cases(), 'value');
+        $capabilities->statuses        = array_column(Status::cases(), 'value');
+
+        $frame       = new \stdClass();
+        $frame->type = 'hello';
+        // The highest version understood, not the whole set: a client that needs to know what else
+        // would have been accepted learns it from the refusal, which names them.
+        $frame->protocol     = max(WebSocketMessageValidator::SUPPORTED_PROTOCOL_VERSIONS);
+        $frame->capabilities = $capabilities;
+
+        return $frame;
+    }
+
+    /**
      * Handle an incoming message.
      *
      * This function is called whenever a user sends a message to the WebSocket
@@ -609,6 +656,28 @@ class Health implements MessageComponentInterface
                 return;
             }
             $requestId = $candidateRequestId;
+        }
+
+        // The protocol version, settled before anything decides what the message *is* — #806 section F.
+        //
+        // Ahead of `UNKNOWN_ACTION` and of schema validation, and the ordering is a claim about
+        // meaning rather than a micro-optimisation: the version says how the rest of the message is to
+        // be read, so answering `{"action": "bogus", "protocol": 7}` with `unknown_action` would assert
+        // something this server cannot know — under protocol 7 that action might be perfectly well
+        // defined. `unsupported_protocol` is the only answer that is true.
+        //
+        // *Behind* the `requestId` read, though, so a refusal can be attributed: a client that
+        // declared an unreadable protocol is waiting on frames it means to match by request id, and a
+        // refusal carrying none would leave that request pending forever. The two orderings are not in
+        // tension — the first is about judging the message, the second only about being able to
+        // address the answer.
+        if ($messageReceived instanceof \stdClass) {
+            $protocolViolation = WebSocketMessageValidator::protocolViolation($messageReceived);
+            if (null !== $protocolViolation) {
+                echo sprintf('Unsupported protocol from connection %1$d: %2$s', $resourceId, $msg);
+                $this->rejectMessage($from, ProtocolErrorCode::UNSUPPORTED_PROTOCOL, $protocolViolation, requestId: $requestId);
+                return;
+            }
         }
 
         if (

--- a/src/Health.php
+++ b/src/Health.php
@@ -593,11 +593,30 @@ class Health implements MessageComponentInterface
         echo sprintf('Receiving message from connection %d: %s', $resourceId, $msg . "\n");
         /** @var ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource|ValidateCalendar|ValidateTypedCalendar|ExecuteUnitTest|RunTest|CancelRun|ValidateSource $messageReceived */
         $messageReceived = json_decode($msg);
+        // Settled before anything below mutates run state — #806 section F.
+        //
+        // The *answer* is sent further down, once `requestId` has been read, so a refusal can be
+        // correlated to the request the client is waiting on. But the **question** has to be asked
+        // here: the block immediately below installs a run token and can rebuild the checkable
+        // inventory, and a message this server has just said it cannot read must not be able to do
+        // either. Deciding early and answering late keeps both properties; deciding late kept only
+        // the second.
+        $protocolViolation = WebSocketMessageValidator::protocolViolation($messageReceived);
+
+        // The run token the message declares, as opposed to the one this connection is on. Needed
+        // because a message refused for its protocol never gets its token stored, and a rejection
+        // frame carrying no token is dropped by the shipped clients — they discard any frame whose
+        // `runToken` does not match the run they believe they are on, so an uncorrelated refusal of
+        // a run's *first* message would be invisible in the UI rather than merely uninformative.
+        $declaredRunToken = self::declaredCorrelationId($messageReceived, 'runToken');
+
         // Store optional run token for response correlation. `cancelRun` is exempt: it names the run it
         // wants abandoned rather than the run this connection is on, and storing it here would install
         // the very token cancelRun() is about to clear — making even a stale cancel match, and dropping
         // the queue of the run that replaced it.
         if (
+            null === $protocolViolation
+            &&
             $messageReceived instanceof \stdClass
             && property_exists($messageReceived, 'action')
             && $messageReceived->action !== 'cancelRun'
@@ -671,13 +690,16 @@ class Health implements MessageComponentInterface
         // refusal carrying none would leave that request pending forever. The two orderings are not in
         // tension — the first is about judging the message, the second only about being able to
         // address the answer.
-        if ($messageReceived instanceof \stdClass) {
-            $protocolViolation = WebSocketMessageValidator::protocolViolation($messageReceived);
-            if (null !== $protocolViolation) {
-                echo sprintf('Unsupported protocol from connection %1$d: %2$s', $resourceId, $msg);
-                $this->rejectMessage($from, ProtocolErrorCode::UNSUPPORTED_PROTOCOL, $protocolViolation, requestId: $requestId);
-                return;
-            }
+        if (null !== $protocolViolation) {
+            echo sprintf('Unsupported protocol from connection %1$d: %2$s', $resourceId, $msg);
+            $this->rejectMessage(
+                $from,
+                ProtocolErrorCode::UNSUPPORTED_PROTOCOL,
+                $protocolViolation,
+                requestId: $requestId,
+                runToken: $declaredRunToken
+            );
+            return;
         }
 
         if (
@@ -1212,14 +1234,19 @@ class Health implements MessageComponentInterface
      *
      * `text` carries the prose, as every other frame in this protocol does. #806's sketch spells it
      * `message`; a second name for an existing field is the duplication that issue exists to remove.
+     *
+     * @param ?string $runToken The run to tag the frame with, for a refusal issued *before* the message's
+     *        token was stored on the connection — which is every refusal that must not mutate run state,
+     *        `UNSUPPORTED_PROTOCOL` being the one today. Null everywhere else, where `sendMessage()`'s
+     *        per-connection fallback is already the right answer.
      */
-    private function rejectMessage(ConnectionInterface $to, ProtocolErrorCode $code, string $text, ?string $requestId = null): void
+    private function rejectMessage(ConnectionInterface $to, ProtocolErrorCode $code, string $text, ?string $requestId = null, ?string $runToken = null): void
     {
         $message            = new \stdClass();
         $message->type      = 'protocolError';
         $message->errorCode = $code->value;
         $message->text      = $text;
-        $this->sendMessage($to, $message, requestId: $requestId);
+        $this->sendMessage($to, $message, $runToken, requestId: $requestId);
     }
 
     /**
@@ -1228,6 +1255,28 @@ class Health implements MessageComponentInterface
      * request's token; that token is then threaded into the handler's async responses so they
      * are stamped correctly even after a later run overwrites the per-connection stored token.
      */
+    /**
+     * A well-formed correlation id a message declares, or null if it declares none.
+     *
+     * Takes `mixed` deliberately: the caller holds the raw `json_decode()` result, and a call site
+     * that narrowed it first would narrow it for everything after — which is how six later guards in
+     * {@see Health::onMessage()}, each one there on purpose, became statically dead. The type check
+     * belongs with the value check, in one place, for the same reason {@see Health::cancelRun()}
+     * takes `mixed`.
+     *
+     * @param string $property `runToken` or `requestId`; one alphabet governs both.
+     */
+    private static function declaredCorrelationId(mixed $message, string $property): ?string
+    {
+        if (false === $message instanceof \stdClass || false === property_exists($message, $property)) {
+            return null;
+        }
+
+        $value = $message->{$property};
+
+        return ( is_string($value) && 1 === preg_match(self::CORRELATION_ID_PATTERN, $value) ) ? $value : null;
+    }
+
     private function resolveRunToken(ConnectionInterface $conn): ?string
     {
         return is_int($conn->resourceId) ? ( $this->runTokens[$conn->resourceId] ?? null ) : null;

--- a/src/Services/WebSocketMessageValidator.php
+++ b/src/Services/WebSocketMessageValidator.php
@@ -180,9 +180,14 @@ final class WebSocketMessageValidator
      * client. Same hazard `Health::VALIDATABLE_RESPONSE_FORMATS` and `Health::cancelRun()` document,
      * reached through a third door.
      */
-    public static function protocolViolation(\stdClass $message): ?string
+    public static function protocolViolation(mixed $message): ?string
     {
-        if (false === property_exists($message, 'protocol')) {
+        // `mixed` rather than `\stdClass`, and the guard lives here rather than at the call site.
+        // Two reasons, one practical and one about where a rule belongs. `Health::onMessage()`
+        // hands this the raw `json_decode()` result, which is anything at all; and a call site that
+        // had to narrow first would narrow the variable for everything after it, which is how six
+        // later guards in that method — each one deliberate — became statically dead.
+        if (false === $message instanceof \stdClass || false === property_exists($message, 'protocol')) {
             return null;
         }
 

--- a/src/Services/WebSocketMessageValidator.php
+++ b/src/Services/WebSocketMessageValidator.php
@@ -60,6 +60,23 @@ final class WebSocketMessageValidator
     ];
 
     /**
+     * The protocol versions this server can read — #806 section F.
+     *
+     * An absent `protocol` is not in this list and is not meant to be: it means the legacy shapes,
+     * which predate versioning and are handled exactly as before. This list governs what a client
+     * may *declare*, and the highest entry is what {@see \LiturgicalCalendar\Api\Health::onOpen()}
+     * advertises in its `hello` frame.
+     *
+     * Kept here rather than on `Health` because this class is what refuses a message the server
+     * cannot read, and because the published schema's `protocolVersion` enum is pinned to this
+     * constant by a test — the two are one statement, and they belong next to the other place the
+     * schema is the authority.
+     *
+     * @var list<int>
+     */
+    public const SUPPORTED_PROTOCOL_VERSIONS = [1];
+
+    /**
      * The whole-document schema, used only when a message's shape cannot be determined at all.
      * Unreachable through {@see \LiturgicalCalendar\Api\Health::onMessage()}, which already refuses
      * an unrecognised action with `UNKNOWN_ACTION` before `validate()` ever runs — kept so a direct
@@ -145,6 +162,73 @@ final class WebSocketMessageValidator
     private static function article(string $word): string
     {
         return in_array($word[0] ?? '', ['a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U'], true) ? 'an' : 'a';
+    }
+
+    /**
+     * Why a message's declared protocol cannot be read, or null when it can — #806 section F.
+     *
+     * Deliberately **not** part of {@see self::validate()}, and the separation is the point. `validate()`
+     * answers "is this a well-formed message of a shape I know", which is a question that only makes
+     * sense once both ends agree on how to read it. The protocol version is that agreement, so it is
+     * settled first, by a caller that has not yet decided what the message even is — see the ordering
+     * note in {@see \LiturgicalCalendar\Api\Health::onMessage()}.
+     *
+     * **The type check is as load-bearing as the value check.** `1.0` decodes to a PHP float that is
+     * numerically the supported version; accepting it on that basis would let a float through to a
+     * typed parameter, and coercive typing refuses that with a `\TypeError` — an `\Error`, which
+     * Ratchet's `IoServer::handleData` does not catch, taking the process down for every connected
+     * client. Same hazard `Health::VALIDATABLE_RESPONSE_FORMATS` and `Health::cancelRun()` document,
+     * reached through a third door.
+     */
+    public static function protocolViolation(\stdClass $message): ?string
+    {
+        if (false === property_exists($message, 'protocol')) {
+            return null;
+        }
+
+        /** @var mixed $declared */
+        $declared = $message->protocol;
+
+        if (is_int($declared) && in_array($declared, self::SUPPORTED_PROTOCOL_VERSIONS, true)) {
+            return null;
+        }
+
+        return sprintf(
+            'This server speaks protocol %s. Send an integer protocol it supports, or omit the property entirely for the legacy contract; the hello frame sent on connect advertises what it accepts.',
+            implode(', ', array_map('strval', self::SUPPORTED_PROTOCOL_VERSIONS))
+        );
+    }
+
+    /**
+     * The action names the contract declares, read from the schema so that nothing carries a second
+     * list of them.
+     *
+     * `validateCalendar` has two definitions — a legacy and a typed shape — and appears once here: the
+     * wire carries actions, and `validateCalendarTyped` is an internal definition name no client can
+     * send. See {@see self::KNOWN_SHAPES}, which is the other list and counts the other way.
+     *
+     * @return list<string>
+     */
+    public function supportedActions(): array
+    {
+        $actions = [];
+        foreach ((array) $this->raw()->definitions as $definition) {
+            if (false === $definition instanceof \stdClass || false === isset($definition->properties)) {
+                continue;
+            }
+
+            $properties = $definition->properties;
+            if (false === $properties instanceof \stdClass || false === isset($properties->action)) {
+                continue;
+            }
+
+            $action = $properties->action;
+            if ($action instanceof \stdClass && isset($action->const) && is_string($action->const)) {
+                $actions[] = $action->const;
+            }
+        }
+
+        return array_values(array_unique($actions));
     }
 
     /**


### PR DESCRIPTION
Closes #806 — section F, the last one. A, B, C, E, G and H are merged and D's server half is complete, so this finishes the issue.

## What lands

**A `hello` frame on connect.**

```jsonc
{ "type": "hello", "protocol": 1,
  "capabilities": {
    "rites":           ["roman", "ambrosian"],
    "actions":         ["executeValidation", "validateCalendar", "executeUnitTest", "runTest", "cancelRun", "validateSource"],
    "responseFormats": ["JSON", "XML", "ICS", "YML"],
    "steps":           ["exists", "parses", "validates", "complete"],
    "statuses":        ["pass", "fail"] } }
```

Every list is **derived**, never transcribed: `Rite`/`Step`/`Status` cases, `VALIDATABLE_RESPONSE_FORMATS`, and the `action.const` of every `WebSocketMessage.json` definition. #806 exists because the vocabulary lived in several places that had to be edited in lockstep — a hand-written capability list would have been one more, and one that fails silently, since a stale advertisement misleads a client without breaking anything.

**Why it is safe to send unsolicited** — verified in the shipped clients, not assumed. Both runners open `onmessage` with `if (currentState === Stopped || currentRunToken === null) return;` and then `if (responseData.runToken !== currentRunToken) return;`. `hello` carries no `runToken`, so it is dropped by the first guard before a run and by the second during one, and never reaches the `type` dispatch that UnitTestInterface#46 made paint an unrecognised type as a visible failed check. That property depends on *when* the frame is sent, not how it is built, so a test pins it.

**An inbound `protocol`.** Checked before anything decides what the message is — ahead of `UNKNOWN_ACTION` and of schema validation. The ordering is a claim about meaning: the version says how the rest is to be read, so `{"action": "bogus", "protocol": 7}` cannot truthfully be answered with "unknown action". It sits *behind* the `requestId` read so a refusal can still be correlated to the request the client is waiting on.

A version the server does not implement, or one of the wrong type, answers a tenth `ProtocolErrorCode`:

```jsonc
{ "type": "protocolError", "errorCode": "unsupported_protocol", "text": "This server speaks protocol 1. …" }
```

The type check is as load-bearing as the value check. `1.0` is numerically the supported version and is a PHP float; a float reaching a typed parameter is refused as a `\TypeError` — an `\Error`, which Ratchet's `IoServer::handleData` does not catch, so it would take the process down for every connected client. Same hazard `VALIDATABLE_RESPONSE_FORMATS` and `cancelRun()` already document, through a third door.

**`protocol` declared on all seven shapes.** Not redundant with the check above: the root unknown-property gate is armed by `requestId`, and a v2 client sends `requestId` and `protocol` together — so without this the ordinary shape of a v2 message is refused for being one. A test pins the schema's enum to `SUPPORTED_PROTOCOL_VERSIONS`, because two independent statements of the same set with nothing comparing them is how #805 happened.

**`WebSocketFrame.json`** — the outbound half of the contract, published for the first time. `WebSocketMessage.json` says what a client may *send*; nothing said what it *receives*, which is what a client's own types are almost entirely about, so UnitTestInterface#42 item 5 ("regenerate `types.js` from the published schema") had no schema to regenerate from. It documents `hello`, step results, the terminal frame and `protocolError`, and marks `classes`/`responsetype` deprecated rather than removing them — removal is gated on #42 shipping.

This is an addition beyond section F's literal text, flagged as such.

## What this deliberately does not do

- **Shape selection does not move.** Still `action`, plus string-vs-object `calendar`. Routing by `protocol` would make version a second discriminator with nothing gained.
- **No per-connection protocol mode.** Declaring `protocol: 1` once does not make the connection refuse legacy shapes afterwards — the UnitTestInterface#42 pilot is deliberately half-migrated, sending `validateSource` for source data and `executeValidation` for route checks on one socket.
- **No client `hello`.** One-directional advertisement plus refusal of what cannot be read is all either side needs while exactly one protocol exists.

## Verification

`composer test:quick` — 3351 tests, 0 failures. `composer analyse` (PHPStan 10) clean. `composer lint` clean.

Every frame in `WebSocketFrameSchemaTest` is produced by the server rather than transcribed into a fixture, so the published document fails when the frames change.

Probed end to end against a live WebSocket server started from this branch: `hello` arrives on connect; `protocol: 7` is refused with `unsupported_protocol`; and a `validateSource` carrying `protocol: 1` **and** `requestId` runs to its terminal frame — which is the case the schema change exists for, since that pair is what arms the strict gate.

One finding worth recording from writing the tests: `HealthHelloFrameTest` is the only suite that calls `onOpen()` for real, and that initialises `Health`'s **static** cache backend for the whole process. Left unguarded it turned 23 tests in six other Health suites red — all asserting on requests a cache hit had stopped queueing, none of them traceable back to the new file. `HealthCorrelationTest` records the invariant in as many words: *"caching is off in this process (it is initialised in `onOpen()`, which no test calls)"*. The new suites set `cacheInitialized` before calling and restore the statics after.

## Next

UnitTestInterface#42's `resources.php` pilot, which is what consumes this. Design for both halves is in `docs/superpowers/specs/2026-08-22-versioned-handshake-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - WebSocket connections now receive an initial `hello` frame describing the supported protocol version and capabilities.
  - Added validation for WebSocket protocol versions, with clear errors for unsupported or incorrectly formatted values while preserving legacy messages.
  - Added a published schema for outbound handshake, result, completion, and protocol-error frames.

- **Documentation**
  - Added design documentation covering protocol negotiation, capabilities, compatibility, and client integration.

- **Tests**
  - Added coverage for handshake metadata, protocol handling, schema compliance, and capability consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->