### PR TITLE
refactor(locale): share one likelySubtags reader; normalize the /events model locale

### DIFF
--- a/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
+++ b/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
@@ -40,6 +40,12 @@ final class HandlerModelLocaleParityTest extends AbstractHandlerTestCase
         unset($_SERVER['SERVER_NAME']);
         setlocale(LC_ALL, 'C');
         putenv('LANGUAGE');
+        // These tests drive the handlers precisely in order to mutate the models'
+        // process-global locale statics, then read them back. Restore both class
+        // defaults so a later test constructing a model without setting a locale is
+        // not silently handed this test's Italian.
+        LiturgicalEvent::setLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
+        LiturgicalEventAbstract::setLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
         parent::tearDown();
     }
 

--- a/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
+++ b/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
@@ -25,27 +25,65 @@ use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventAbstract;
  */
 final class HandlerModelLocaleParityTest extends AbstractHandlerTestCase
 {
+    private string $savedLocale          = 'C';
+    private ?string $savedLanguageEnv    = null;
+    private string $savedIcuDefault      = 'en';
+    private string $savedPrimaryLanguage = LitLocale::LATIN_PRIMARY_LANGUAGE;
+    private string $savedRuntimeLocale   = 'en_US';
+    private bool $hadServerName          = false;
+    private ?string $savedServerName     = null;
+
     protected function setUp(): void
     {
+        // Snapshot every process-global bit of state this test (and the handlers it
+        // invokes) mutates, so tearDown() restores the world as it was found rather
+        // than imposing its own opinion of the baseline on later tests.
+        //
+        // Taken BEFORE parent::setUp() deliberately: that call can markTestSkipped()
+        // when JWT_SECRET is absent, and PHPUnit still runs tearDown() after a skip in
+        // setUp(). A snapshot taken after it would leave tearDown() restoring values it
+        // never captured.
+        $this->savedLocale          = setlocale(LC_ALL, 0) ?: 'C';
+        $languageEnv                = getenv('LANGUAGE');
+        $this->savedLanguageEnv     = false === $languageEnv ? null : $languageEnv;
+        $this->savedIcuDefault      = \Locale::getDefault();
+        $this->savedPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+        $this->savedRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
+        $this->hadServerName        = array_key_exists('SERVER_NAME', $_SERVER);
+        $this->savedServerName      = $this->hadServerName ? (string) $_SERVER['SERVER_NAME'] : null;
+
         parent::setUp();
+
         // Force Router::isLocalhost() true so CalendarHandler::handle() bypasses the
         // response cache and actually runs prepareL10N().
         $_SERVER['SERVER_NAME'] = 'localhost';
+
+        // Start from a known-clean process-global locale, whatever an earlier test in
+        // this process left behind.
         setlocale(LC_ALL, 'C');
         putenv('LANGUAGE');
     }
 
     protected function tearDown(): void
     {
-        unset($_SERVER['SERVER_NAME']);
-        setlocale(LC_ALL, 'C');
-        putenv('LANGUAGE');
+        if ($this->hadServerName) {
+            $_SERVER['SERVER_NAME'] = $this->savedServerName;
+        } else {
+            unset($_SERVER['SERVER_NAME']);
+        }
+        setlocale(LC_ALL, $this->savedLocale);
+        putenv(null === $this->savedLanguageEnv ? 'LANGUAGE' : 'LANGUAGE=' . $this->savedLanguageEnv);
+        \Locale::setDefault($this->savedIcuDefault);
+        LitLocale::$PRIMARY_LANGUAGE = $this->savedPrimaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = $this->savedRuntimeLocale;
+
         // These tests drive the handlers precisely in order to mutate the models'
         // process-global locale statics, then read them back. Restore both class
         // defaults so a later test constructing a model without setting a locale is
         // not silently handed this test's Italian.
         LiturgicalEvent::setLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
         LiturgicalEventAbstract::setLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
+
         parent::tearDown();
     }
 
@@ -95,14 +133,25 @@ final class HandlerModelLocaleParityTest extends AbstractHandlerTestCase
 
     public function testBothHandlersAgreeOnTheModelLocaleForATranslatedLocale(): void
     {
+        // Probe the precondition directly instead of inferring it from a status code.
+        // A missing Italian locale makes LocaleConfigurator::configure() THROW
+        // ServiceUnavailableException, and the middleware that would render that as a
+        // 503 is not in the in-process handler path — so the case this skip exists for
+        // never produces a status code at all, while "skip on any non-200" would
+        // silently swallow a genuine 404/500 regression. The candidates mirror the ones
+        // LocaleConfigurator itself tries for 'it'.
+        $italian = setlocale(LC_ALL, 'it_IT.utf8', 'it_IT.UTF-8', 'it_IT', 'it.utf8', 'it.UTF-8', 'it');
+        setlocale(LC_ALL, 'C');
+        if (false === $italian) {
+            self::markTestSkipped('No Italian system locale is installed on this host.');
+        }
+
         $calendar = new CalendarHandler(['nation', 'IT', '2024']);
         $calendar->setAllowedReturnTypes([ReturnTypeParam::JSON]);
         $calendarResponse = $calendar->handle(
             $this->requestFor('GET', '/calendar/nation/IT/2024', ['Accept' => 'application/json', 'Accept-Language' => 'it'])
         );
-        if (200 !== $calendarResponse->getStatusCode()) {
-            self::markTestSkipped('The Italian /calendar request failed (the it_IT system locale is likely not installed on this host).');
-        }
+        self::assertSame(200, $calendarResponse->getStatusCode());
         $calendarLocale = self::modelLocale(LiturgicalEvent::class);
 
         $eventsResponse = ( new EventsHandler() )->handle($this->requestFor('GET', '/events', [])->withQueryParams(['locale' => 'it']));

--- a/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
+++ b/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Handlers\CalendarHandler;
+use LiturgicalCalendar\Api\Handlers\EventsHandler;
+use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventAbstract;
+
+/**
+ * Regression for issue #749, item 2: CalendarHandler and EventsHandler must hand
+ * their liturgical-event models the SAME normalized locale.
+ *
+ * CalendarHandler::prepareL10N() has always passed the resolved runtime locale
+ * (LitLocale::$RUNTIME_LOCALE, e.g. 'it_IT', or 'la' for Latin). EventsHandler::setLocale()
+ * used to pass the raw EventsParams->Locale instead, which for Latin is 'la_VA'. The
+ * models branch on the strict primary-language form ('la') for the Masses for Various
+ * Needs commons, so the two handlers disagreed on that path.
+ *
+ * @see \LiturgicalCalendar\Tests\Models\EventsPath\MassVariousNeedsLatinLocaleTest
+ */
+final class HandlerModelLocaleParityTest extends AbstractHandlerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Force Router::isLocalhost() true so CalendarHandler::handle() bypasses the
+        // response cache and actually runs prepareL10N().
+        $_SERVER['SERVER_NAME'] = 'localhost';
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+    }
+
+    protected function tearDown(): void
+    {
+        unset($_SERVER['SERVER_NAME']);
+        setlocale(LC_ALL, 'C');
+        putenv('LANGUAGE');
+        parent::tearDown();
+    }
+
+    /**
+     * Read a model's process-global locale static, which both classes keep non-public.
+     *
+     * @param class-string $modelClass
+     */
+    private static function modelLocale(string $modelClass): string
+    {
+        $property = new \ReflectionProperty($modelClass, 'locale');
+        $value    = $property->getValue();
+        self::assertIsString($value);
+        return $value;
+    }
+
+    public function testLatinEventsRequestNormalizesTheModelLocaleToThePrimaryLanguage(): void
+    {
+        // 'la_VA' is the raw request form (and EventsParams' default). The model must
+        // still see 'la', the form its Latin branching tests for.
+        $response = ( new EventsHandler() )->handle($this->requestFor('GET', '/events', [])->withQueryParams(['locale' => 'la_VA']));
+        self::assertSame(200, $response->getStatusCode());
+
+        self::assertSame(
+            LitLocale::LATIN_PRIMARY_LANGUAGE,
+            self::modelLocale(LiturgicalEventAbstract::class),
+            'EventsHandler must pass the normalized runtime locale to the model, not the raw "la_VA" (#749).'
+        );
+    }
+
+    public function testBothHandlersAgreeOnTheModelLocaleForLatin(): void
+    {
+        $eventsResponse = ( new EventsHandler() )->handle($this->requestFor('GET', '/events', [])->withQueryParams(['locale' => 'la_VA']));
+        self::assertSame(200, $eventsResponse->getStatusCode());
+        $eventsLocale = self::modelLocale(LiturgicalEventAbstract::class);
+
+        $calendar = new CalendarHandler(['nation', 'VA', '2024']);
+        $calendar->setAllowedReturnTypes([ReturnTypeParam::JSON]);
+        $calendarResponse = $calendar->handle(
+            $this->requestFor('GET', '/calendar/nation/VA/2024', ['Accept' => 'application/json'])
+        );
+        self::assertSame(200, $calendarResponse->getStatusCode());
+        $calendarLocale = self::modelLocale(LiturgicalEvent::class);
+
+        self::assertSame($calendarLocale, $eventsLocale, 'The two handlers must configure their models with the same locale (#749).');
+    }
+
+    public function testBothHandlersAgreeOnTheModelLocaleForATranslatedLocale(): void
+    {
+        $calendar = new CalendarHandler(['nation', 'IT', '2024']);
+        $calendar->setAllowedReturnTypes([ReturnTypeParam::JSON]);
+        $calendarResponse = $calendar->handle(
+            $this->requestFor('GET', '/calendar/nation/IT/2024', ['Accept' => 'application/json', 'Accept-Language' => 'it'])
+        );
+        if (200 !== $calendarResponse->getStatusCode()) {
+            self::markTestSkipped('The Italian /calendar request failed (the it_IT system locale is likely not installed on this host).');
+        }
+        $calendarLocale = self::modelLocale(LiturgicalEvent::class);
+
+        $eventsResponse = ( new EventsHandler() )->handle($this->requestFor('GET', '/events', [])->withQueryParams(['locale' => 'it']));
+        self::assertSame(200, $eventsResponse->getStatusCode());
+        $eventsLocale = self::modelLocale(LiturgicalEventAbstract::class);
+
+        self::assertSame($calendarLocale, $eventsLocale, 'The two handlers must configure their models with the same locale (#749).');
+    }
+}

--- a/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
+++ b/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
@@ -25,13 +25,15 @@ use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventAbstract;
  */
 final class HandlerModelLocaleParityTest extends AbstractHandlerTestCase
 {
-    private string $savedLocale          = 'C';
-    private ?string $savedLanguageEnv    = null;
-    private string $savedIcuDefault      = 'en';
-    private string $savedPrimaryLanguage = LitLocale::LATIN_PRIMARY_LANGUAGE;
-    private string $savedRuntimeLocale   = 'en_US';
-    private bool $hadServerName          = false;
-    private ?string $savedServerName     = null;
+    private string $savedLocale              = 'C';
+    private ?string $savedLanguageEnv        = null;
+    private string $savedIcuDefault          = 'en';
+    private string $savedPrimaryLanguage     = LitLocale::LATIN_PRIMARY_LANGUAGE;
+    private string $savedRuntimeLocale       = 'en_US';
+    private bool $hadServerName              = false;
+    private ?string $savedServerName         = null;
+    private string $savedCalendarModelLocale = LitLocale::LATIN_PRIMARY_LANGUAGE;
+    private string $savedEventsModelLocale   = LitLocale::LATIN_PRIMARY_LANGUAGE;
 
     protected function setUp(): void
     {
@@ -51,6 +53,11 @@ final class HandlerModelLocaleParityTest extends AbstractHandlerTestCase
         $this->savedRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
         $this->hadServerName        = array_key_exists('SERVER_NAME', $_SERVER);
         $this->savedServerName      = $this->hadServerName ? (string) $_SERVER['SERVER_NAME'] : null;
+
+        // The models' locale statics too: these tests drive the handlers precisely in
+        // order to mutate them, then read them back.
+        $this->savedCalendarModelLocale = self::modelLocale(LiturgicalEvent::class);
+        $this->savedEventsModelLocale   = self::modelLocale(LiturgicalEventAbstract::class);
 
         parent::setUp();
 
@@ -77,12 +84,13 @@ final class HandlerModelLocaleParityTest extends AbstractHandlerTestCase
         LitLocale::$PRIMARY_LANGUAGE = $this->savedPrimaryLanguage;
         LitLocale::$RUNTIME_LOCALE   = $this->savedRuntimeLocale;
 
-        // These tests drive the handlers precisely in order to mutate the models'
-        // process-global locale statics, then read them back. Restore both class
-        // defaults so a later test constructing a model without setting a locale is
-        // not silently handed this test's Italian.
-        LiturgicalEvent::setLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
-        LiturgicalEventAbstract::setLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
+        // Restore the models' locale statics to what they held on entry, so a later
+        // test constructing a model without setting a locale is not silently handed
+        // this test's Italian. Restored via setLocale() rather than by writing the
+        // static directly: LiturgicalEvent derives four IntlDateFormatters from the
+        // locale, which must stay consistent with it.
+        LiturgicalEvent::setLocale($this->savedCalendarModelLocale);
+        LiturgicalEventAbstract::setLocale($this->savedEventsModelLocale);
 
         parent::tearDown();
     }

--- a/phpunit_tests/Models/EventsPath/MassVariousNeedsLatinLocaleTest.php
+++ b/phpunit_tests/Models/EventsPath/MassVariousNeedsLatinLocaleTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\EventsPath;
+
+use LiturgicalCalendar\Api\Enum\LitColor;
+use LiturgicalCalendar\Api\Enum\LitEventType;
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\LitMassVariousNeeds;
+use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventAbstract;
+use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventFixed;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Guards the Latin branch of the Masses for Various Needs commons in the /events
+ * models (#749).
+ *
+ * Unlike LitCommons::fullTranslate() and LitGrade::i18n() — which accept either
+ * Latin form via in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE])
+ * — LiturgicalEventAbstract branches on the strict primary-language form
+ * (self::$locale === 'la') for LitMassVariousNeeds commons. Before #749,
+ * EventsHandler::setLocale() passed the raw EventsParams->Locale, which defaults to
+ * 'la_VA'; that missed this branch and would have rendered these commons in English
+ * for a Latin request. No calendar in jsondata/sourcedata/ currently declares an MVN
+ * common, so no fixture or golden master exercises this path — hence this test.
+ *
+ * @see \LiturgicalCalendar\Api\Handlers\EventsHandler::setLocale()
+ */
+#[CoversClass(LiturgicalEventAbstract::class)]
+final class MassVariousNeedsLatinLocaleTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        // The model locale is process-global static state; restore the class default.
+        LiturgicalEventAbstract::setLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
+        parent::tearDown();
+    }
+
+    /**
+     * @param LitMassVariousNeeds|LitMassVariousNeeds[] $common
+     */
+    private function commonLclFor(LitMassVariousNeeds|array $common): string
+    {
+        $event = new LiturgicalEventFixed(
+            'TestMassVariousNeeds',
+            'Test Event',
+            1,
+            1,
+            LitColor::WHITE,
+            LitEventType::FIXED,
+            LitGrade::MEMORIAL_OPT,
+            $common
+        );
+
+        $commonLcl = $event->jsonSerialize()['common_lcl'];
+        self::assertIsString($commonLcl);
+        return $commonLcl;
+    }
+
+    public function testSingleMassVariousNeedsCommonRendersInLatin(): void
+    {
+        LiturgicalEventAbstract::setLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
+
+        self::assertSame(
+            'MISSÆ ET ORATIONES PRO VARIIS NECESSITATIBUS VEL AD DIVERSA: Pro Papa',
+            $this->commonLclFor(LitMassVariousNeeds::PRO_PAPA)
+        );
+    }
+
+    public function testMultipleMassVariousNeedsCommonsAreJoinedWithTheLatinGlue(): void
+    {
+        LiturgicalEventAbstract::setLocale(LitLocale::LATIN_PRIMARY_LANGUAGE);
+
+        $commonLcl = $this->commonLclFor([LitMassVariousNeeds::PRO_PAPA, LitMassVariousNeeds::PRO_ECCLESIA]);
+
+        self::assertSame(
+            'MISSÆ ET ORATIONES PRO VARIIS NECESSITATIBUS VEL AD DIVERSA: Pro Papa'
+                . '; vel MISSÆ ET ORATIONES PRO VARIIS NECESSITATIBUS VEL AD DIVERSA: Pro Ecclesia',
+            $commonLcl
+        );
+    }
+
+    /**
+     * The complement: a non-Latin locale must NOT take the Latin branch. This is what
+     * a Latin request wrongly produced while the handler passed the raw 'la_VA'.
+     */
+    public function testNonLatinLocaleDoesNotTakeTheLatinBranch(): void
+    {
+        LiturgicalEventAbstract::setLocale('en_US');
+
+        $commonLcl = $this->commonLclFor(LitMassVariousNeeds::PRO_PAPA);
+
+        self::assertStringNotContainsString('MISSÆ ET ORATIONES', $commonLcl);
+        self::assertStringContainsString('For the Pope', $commonLcl);
+    }
+}

--- a/phpunit_tests/Services/LikelySubtagsTest.php
+++ b/phpunit_tests/Services/LikelySubtagsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\LikelySubtags;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the shared CLDR likelySubtags reader extracted in #749 from
+ * CalendarParams::maximizeLocale() and LocaleConfigurator::likelyRegion().
+ *
+ * Both former readers had contracts the extraction must preserve exactly:
+ * maximize() returns the canonicalized full tag (script included) or the input
+ * unchanged on a miss; regionFor() returns the bare region subtag or '' on a miss.
+ */
+#[CoversClass(LikelySubtags::class)]
+final class LikelySubtagsTest extends TestCase
+{
+    private string $savedApiFilePath = '';
+
+    protected function setUp(): void
+    {
+        // JsonData::FOLDER->path() prefixes Router::$apiFilePath; point it at the repo root.
+        $this->savedApiFilePath = isset(Router::$apiFilePath) ? Router::$apiFilePath : '';
+        Router::$apiFilePath    = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+    }
+
+    protected function tearDown(): void
+    {
+        Router::$apiFilePath = $this->savedApiFilePath;
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function maximizedLanguages(): array
+    {
+        return [
+            'English maximizes to the US variant'        => ['en', 'en_Latn_US'],
+            'French maximizes to the FR variant'         => ['fr', 'fr_Latn_FR'],
+            'Portuguese maximizes to the Brazil variant' => ['pt', 'pt_Latn_BR'],
+        ];
+    }
+
+    #[DataProvider('maximizedLanguages')]
+    public function testMaximizeReturnsTheCanonicalizedFullTag(string $language, string $expected): void
+    {
+        self::assertSame($expected, LikelySubtags::maximize($language));
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string}>
+     */
+    public static function likelyRegions(): array
+    {
+        return [
+            'English → US'    => ['en', 'US'],
+            'French → FR'     => ['fr', 'FR'],
+            'Portuguese → BR' => ['pt', 'BR'],
+        ];
+    }
+
+    #[DataProvider('likelyRegions')]
+    public function testRegionForReturnsTheBareRegionSubtag(string $language, string $expected): void
+    {
+        self::assertSame($expected, LikelySubtags::regionFor($language));
+    }
+
+    public function testMaximizeReturnsTheInputUnchangedForAnUnknownLanguage(): void
+    {
+        self::assertSame('qqq', LikelySubtags::maximize('qqq'));
+    }
+
+    public function testRegionForReturnsAnEmptyStringForAnUnknownLanguage(): void
+    {
+        self::assertSame('', LikelySubtags::regionFor('qqq'));
+    }
+
+    /**
+     * The region subtag must never carry the script along: glibc rejects locale
+     * names such as "en_Latn_US", so LocaleConfigurator builds "en_US" from
+     * language + region and depends on regionFor() returning the region alone.
+     */
+    public function testRegionForStripsTheScriptSubtag(): void
+    {
+        $maximized = LikelySubtags::maximize('en');
+        self::assertStringContainsString('Latn', $maximized, 'Precondition: the maximized tag carries a script subtag.');
+        self::assertSame('US', LikelySubtags::regionFor('en'));
+    }
+
+    /**
+     * Both shapes are served from one cached map; repeated calls must be stable.
+     */
+    public function testRepeatedCallsAreStable(): void
+    {
+        self::assertSame(LikelySubtags::maximize('de'), LikelySubtags::maximize('de'));
+        self::assertSame(LikelySubtags::regionFor('de'), LikelySubtags::regionFor('de'));
+    }
+}

--- a/src/Handlers/EventsHandler.php
+++ b/src/Handlers/EventsHandler.php
@@ -365,13 +365,19 @@ final class EventsHandler extends AbstractHandler
      * Set up the process-global locale for this request via the shared
      * LocaleConfigurator (deterministic + leak-free, #745), then bind the gettext
      * text domain and configure the LiturgicalEventAbstract locale.
+     *
+     * The model receives the resolved `runtimeLocale`, not the raw request locale,
+     * so that it matches what CalendarHandler::prepareL10N() hands to
+     * LiturgicalEvent::setLocale() (#749). It matters for Latin: the model branches
+     * on the strict primary-language form 'la', so the raw 'la_VA' would miss the
+     * Latin branch of the Masses for Various Needs commons.
      */
     private function setLocale(): void
     {
-        LocaleConfigurator::configure($this->EventsParams->Locale);
+        $configured = LocaleConfigurator::configure($this->EventsParams->Locale);
         bindtextdomain('litcal', Router::$apiFilePath . 'i18n');
         textdomain('litcal');
-        LiturgicalEventAbstract::setLocale($this->EventsParams->Locale);
+        LiturgicalEventAbstract::setLocale($configured->runtimeLocale);
     }
 
     /**

--- a/src/Params/CalendarParams.php
+++ b/src/Params/CalendarParams.php
@@ -6,7 +6,6 @@ use LiturgicalCalendar\Api\Enum\YearType;
 use LiturgicalCalendar\Api\Enum\Epiphany;
 use LiturgicalCalendar\Api\Enum\Ascension;
 use LiturgicalCalendar\Api\Enum\CorpusChristi;
-use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitLocale;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
@@ -15,7 +14,7 @@ use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
 use LiturgicalCalendar\Api\Services\CalendarMetadataProvider;
-use LiturgicalCalendar\Api\Utilities;
+use LiturgicalCalendar\Api\Services\LikelySubtags;
 
 /**
  * This class is responsible for handling the parameters provided to the {@see \LiturgicalCalendar\Api\Handlers\CalendarHandler} class.
@@ -375,30 +374,10 @@ class CalendarParams implements ParamsInterface
         }
 
         if (!self::hasRegion($locale)) {
-            $locale = self::maximizeLocale($locale);
+            $locale = LikelySubtags::maximize($locale);
         }
 
         return $locale;
-    }
-
-    private static function maximizeLocale(string $language): string
-    {
-        /** @var array<string,string>|null $likely */
-        static $likely = null;
-
-        if ($likely === null) {
-            /** @var array{supplemental:array{likelySubtags:array<string,string>}} $data */
-            $data   = Utilities::jsonFileToArray(JsonData::FOLDER->path() . '/likelySubtags.json');
-            $likely = $data['supplemental']['likelySubtags'];
-        }
-
-        // Try direct hit (e.g. "en")
-        if (isset($likely[$language])) {
-            return \Locale::canonicalize($likely[$language]) ?? $language;
-        }
-
-        // Otherwise just return the original base language
-        return $language;
     }
 
     /**

--- a/src/Services/LikelySubtags.php
+++ b/src/Services/LikelySubtags.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Enum\JsonData;
+use LiturgicalCalendar\Api\Utilities;
+
+/**
+ * Single reader and cache for the CLDR `supplemental.likelySubtags` data
+ * (`jsondata/likelySubtags.json`), shared by the two consumers that need it in
+ * different shapes (#749):
+ *
+ * - {@see maximize()} returns the full maximized tag ('en' → 'en_Latn_US'), used by
+ *   CalendarParams to normalize a region-less request locale for the echoed
+ *   `settings.locale`.
+ * - {@see regionFor()} returns the region subtag only ('en' → 'US'), used by
+ *   LocaleConfigurator to build a glibc-acceptable `lang_REGION` candidate — glibc
+ *   rejects script-bearing names such as "en_Latn_US".
+ *
+ * The map is read from disk and cached once per process.
+ */
+final class LikelySubtags
+{
+    /** @var array<string,string>|null CLDR map: language subtag => maximized tag ("lang-Script-Region"). */
+    private static ?array $map = null;
+
+    /**
+     * Maximize a language subtag to its canonicalized likely tag
+     * (e.g. 'en' → 'en_Latn_US'). Returns $language unchanged when CLDR has no
+     * entry for it, or when the entry fails to canonicalize.
+     */
+    public static function maximize(string $language): string
+    {
+        $maximized = self::map()[$language] ?? null;
+        if ($maximized === null) {
+            return $language;
+        }
+
+        return \Locale::canonicalize($maximized) ?? $language;
+    }
+
+    /**
+     * Resolve the likely region subtag for a region-less language
+     * (e.g. 'en' → 'US', 'pt' → 'BR'). Returns '' when unknown.
+     */
+    public static function regionFor(string $language): string
+    {
+        $maximized = self::map()[$language] ?? null;
+        if ($maximized === null) {
+            return '';
+        }
+
+        $canonical = \Locale::canonicalize($maximized);
+        $region    = \Locale::getRegion(( $canonical === null || $canonical === '' ) ? $maximized : $canonical);
+        return ( $region === null ) ? '' : $region;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private static function map(): array
+    {
+        if (self::$map === null) {
+            /** @var array{supplemental:array{likelySubtags:array<string,string>}} $data */
+            $data      = Utilities::jsonFileToArray(JsonData::FOLDER->path() . '/likelySubtags.json');
+            self::$map = $data['supplemental']['likelySubtags'];
+        }
+
+        return self::$map;
+    }
+}

--- a/src/Services/LocaleConfigurator.php
+++ b/src/Services/LocaleConfigurator.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Services;
 
-use LiturgicalCalendar\Api\Enum\JsonData;
 use LiturgicalCalendar\Api\Enum\LitLocale;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
-use LiturgicalCalendar\Api\Utilities;
 
 /**
  * Deterministically applies the process-global locale state — setlocale(LC_ALL),
  * the LANGUAGE env var (which glibc gettext() reads above LC_MESSAGES), and ICU's
  * default — for a single request, in a leak-free way.
  *
- * Region resolution uses CLDR likely subtags (jsondata/likelySubtags.json) so a
+ * Region resolution uses CLDR likely subtags (via {@see LikelySubtags}) so a
  * region-less request locale (e.g. 'en', 'fr') maps to the installed system locale
  * ('en_US', 'fr_FR'). A real language whose system locale is not installed at all
  * throws — it must never silently fall through to English. Latin ('la'/'la_VA') is
@@ -26,9 +24,6 @@ use LiturgicalCalendar\Api\Utilities;
  */
 final class LocaleConfigurator
 {
-    /** @var array<string,string>|null Cached CLDR likelySubtags map (language => "lang-Script-Region"). */
-    private static ?array $likelySubtags = null;
-
     /**
      * Apply the process-global locale for the given request locale and return the
      * resolved runtime information.
@@ -50,7 +45,7 @@ final class LocaleConfigurator
 
         $region = \Locale::getRegion($canonical);
         if ($region === null || $region === '') {
-            $region = self::likelyRegion($primaryLanguage);
+            $region = LikelySubtags::regionFor($primaryLanguage);
         }
 
         $candidates = [];
@@ -98,30 +93,5 @@ final class LocaleConfigurator
         setlocale(LC_ALL, 'C');
         putenv('LANGUAGE');
         \Locale::setDefault($icuDefaultLocale);
-    }
-
-    /**
-     * Resolve the likely region subtag for a region-less language via CLDR likely
-     * subtags (e.g. 'en' → 'US', 'pt' → 'BR'). Returns '' when unknown.
-     *
-     * Only the region subtag is used: glibc rejects script-bearing locale names
-     * like "en_Latn_US", so the caller builds "en_US" from language + region.
-     */
-    private static function likelyRegion(string $language): string
-    {
-        if (self::$likelySubtags === null) {
-            /** @var array{supplemental:array{likelySubtags:array<string,string>}} $data */
-            $data                = Utilities::jsonFileToArray(JsonData::FOLDER->path() . '/likelySubtags.json');
-            self::$likelySubtags = $data['supplemental']['likelySubtags'];
-        }
-
-        $maximized = self::$likelySubtags[$language] ?? null;
-        if ($maximized === null) {
-            return '';
-        }
-
-        $canonical = \Locale::canonicalize($maximized);
-        $region    = \Locale::getRegion(( $canonical === null || $canonical === '' ) ? $maximized : $canonical);
-        return ( $region === null ) ? '' : $region;
     }
 }


### PR DESCRIPTION
Closes #749 — the two cleanups deferred from #745 (delivered as #746), which were left out to keep that refactor behavior-preserving and observable-output-stable.

## 1. Consolidate the two `likelySubtags.json` readers

`CalendarParams::maximizeLocale()` and `LocaleConfigurator::likelyRegion()` each parsed the same CLDR `supplemental.likelySubtags` data behind its own static cache. Both now delegate to a new `Services\LikelySubtags`, which loads and caches the map once and exposes the two shapes the callers need:

| Method | Returns | Consumer | Why that shape |
|-----------------------|-------------------------------------|----------------------|---------------------------------------------------------------|
| `maximize($language)` | full canonicalized tag `en_Latn_US` | `CalendarParams`     | maximizes a region-less request locale for `settings.locale`   |
| `regionFor($language)`| bare region subtag `US`             | `LocaleConfigurator` | glibc rejects script-bearing names, so it builds `lang_REGION` |

Both former contracts are preserved exactly, including the two *different* miss cases: `maximize()` returns its input unchanged, `regionFor()` returns `''`.

This was verified rather than assumed. A throwaway harness ran both previous implementations against the new one over **all 7788 CLDR keys**, plus misses (`qqq`, `zz`, `''`) and region-bearing inputs (`en_US`, `la`, `la_VA`, `xx-YY`): **zero divergence** on either shape.

## 2. Unify the model `setLocale()` argument

`EventsHandler::setLocale()` passed the raw `EventsParams->Locale`, while `CalendarHandler::prepareL10N()` passes the resolved runtime locale. It now passes the `runtimeLocale` from the `ConfiguredLocale` it was already building and discarding, so both handlers agree.

The characterization the issue asked for came out **narrower than feared**. Three consumers read the model's `self::$locale`, and two are already form-tolerant:

- `LitCommons::fullTranslate()` → `in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true)` — accepts `la` *and* `la_VA`
- `LitGrade::i18n()` → the same check
- the three `LitMassVariousNeeds` branches in `LiturgicalEventAbstract` → strict `self::$locale === 'la'`

So `/events?locale=la` renders correct Latin `common_lcl` and `grade_lcl` today; only the Masses for Various Needs commons diverge, and those would have rendered in **English** for a Latin request (`EventsParams->Locale` defaults to `la_VA`).

**No calendar in `jsondata/sourcedata/` currently declares an MVN common**, so the defect was latent — zero observable output change — and no fixture or golden master reaches the path. Hence the dedicated model test below.

## Tests

- `LikelySubtagsTest` — pins both shapes of the shared reader, the miss contracts, and that `regionFor()` strips the script subtag.
- `MassVariousNeedsLatinLocaleTest` — pins the Latin and non-Latin MVN branches that no fixture data exercises.
- `HandlerModelLocaleParityTest` — asserts the two handlers configure their models with the same locale. **All three of its cases fail against the pre-fix handler** (`la` vs `la_VA`, `it_IT` vs `it`), so it is a real guard.

## Verification

- `composer analyse` (PHPStan level 10) — clean
- `composer lint` — clean; pre-commit and pre-push hooks ran
- `CalendarGoldenMasterTest` — 9/9 green
- `composer test:quick` — 3370 tests, 179506 assertions, 17 errors

The 17 errors are all `phpunit_tests/WebSocket/*` client read-timeouts and are **pre-existing environmental baseline, not from this change**: stashing the entire changeset and re-running that suite alone gives the identical 17/17. That suite needs a WebSocket server started from the same checkout, which this working tree does not have.

## Out of scope (flagged, not changed)

- `EventsHandler` never sets `LitLocale::$PRIMARY_LANGUAGE` / `$RUNTIME_LOCALE`, which `CalendarHandler` does. Nothing on the `/events` path reads them today, so it is inert — but it is the same family of inconsistency as item 2 if it is worth tracking.
- The three `LitMassVariousNeeds` sites still use strict `=== 'la'` while everything around them is form-tolerant. This PR fixes the caller rather than the callee, per the issue's "standardize on one argument" acceptance criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved locale handling by resolving likely language regions, including when no region is supplied.
  * Calendar and event views now consistently use the resolved runtime locale.
  * Latin-language requests display Latin text consistently, including correctly joined Masses for Various Needs.
  * Unknown or incomplete language values receive safer fallback handling.

* **Tests**
  * Added coverage for locale normalisation, translated and Latin rendering, fallback behaviour, and consistency across calendar and event views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->