### PR TITLE
refactor(locale): publish the LitLocale statics from configure(); add LitLocale::isLatin()

### DIFF
--- a/phpunit_tests/Enum/LitLocaleIsLatinTest.php
+++ b/phpunit_tests/Enum/LitLocaleIsLatinTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers LitLocale::isLatin(), the single Latin-locale test introduced in #865 to
+ * replace four different ad-hoc spellings across src/.
+ *
+ * Both accepted forms must answer true: `la_VA` is what the request layer settles on
+ * (CalendarParams, EventsParams), while `la` is what LocaleConfigurator resolves at
+ * runtime, since Latin has no installable system locale. Recognising only one of them
+ * is what made the /events Masses for Various Needs commons render in English (#749).
+ */
+#[CoversClass(LitLocale::class)]
+final class LitLocaleIsLatinTest extends TestCase
+{
+    /**
+     * @return array<string,array{0:string}>
+     */
+    public static function latinForms(): array
+    {
+        return [
+            'primary language subtag' => [LitLocale::LATIN_PRIMARY_LANGUAGE],
+            'full locale'             => [LitLocale::LATIN],
+            'literal la'              => ['la'],
+            'literal la_VA'           => ['la_VA'],
+        ];
+    }
+
+    #[DataProvider('latinForms')]
+    public function testBothAcceptedLatinFormsAreRecognized(string $locale): void
+    {
+        self::assertTrue(LitLocale::isLatin($locale));
+    }
+
+    /**
+     * @return array<string,array{0:string}>
+     */
+    public static function nonLatinLocales(): array
+    {
+        return [
+            'Italian'                  => ['it_IT'],
+            'Italian primary language' => ['it'],
+            'English'                  => ['en_US'],
+            'Latin American Spanish'   => ['es_419'],
+            'empty string'             => [''],
+            // Deliberately not Latin: the CLDR-maximized form is never what reaches the
+            // rendering code, and treating it as Latin would paper over a params-layer
+            // regression rather than surface it.
+            'CLDR-maximized Latin'     => ['la_Latn_VA'],
+            'hyphenated Latin'         => ['la-VA'],
+            'lowercased region'        => ['la_va'],
+        ];
+    }
+
+    #[DataProvider('nonLatinLocales')]
+    public function testOtherLocalesAreNotLatin(string $locale): void
+    {
+        self::assertFalse(LitLocale::isLatin($locale));
+    }
+}

--- a/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
+++ b/phpunit_tests/Handlers/HandlerModelLocaleParityTest.php
@@ -21,6 +21,10 @@ use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventAbstract;
  * models branch on the strict primary-language form ('la') for the Masses for Various
  * Needs commons, so the two handlers disagreed on that path.
  *
+ * Also covers #865: LocaleConfigurator::configure() now publishes
+ * LitLocale::$PRIMARY_LANGUAGE and $RUNTIME_LOCALE, so /events sets them too rather
+ * than inheriting whatever a prior request in the same worker left behind.
+ *
  * @see \LiturgicalCalendar\Tests\Models\EventsPath\MassVariousNeedsLatinLocaleTest
  */
 final class HandlerModelLocaleParityTest extends AbstractHandlerTestCase
@@ -167,5 +171,27 @@ final class HandlerModelLocaleParityTest extends AbstractHandlerTestCase
         $eventsLocale = self::modelLocale(LiturgicalEventAbstract::class);
 
         self::assertSame($calendarLocale, $eventsLocale, 'The two handlers must configure their models with the same locale (#749).');
+    }
+
+    public function testEventsRequestPublishesTheLitLocaleStatics(): void
+    {
+        // Poison the statics first, so a pass proves /events actively sets them rather
+        // than merely agreeing with a value some earlier request happened to leave.
+        LitLocale::$PRIMARY_LANGUAGE = 'xx';
+        LitLocale::$RUNTIME_LOCALE   = 'xx_XX';
+
+        $response = ( new EventsHandler() )->handle($this->requestFor('GET', '/events', [])->withQueryParams(['locale' => 'la_VA']));
+        self::assertSame(200, $response->getStatusCode());
+
+        self::assertSame(
+            LitLocale::LATIN_PRIMARY_LANGUAGE,
+            LitLocale::$PRIMARY_LANGUAGE,
+            '/events must publish LitLocale::$PRIMARY_LANGUAGE (#865).'
+        );
+        self::assertSame(
+            LitLocale::LATIN_PRIMARY_LANGUAGE,
+            LitLocale::$RUNTIME_LOCALE,
+            '/events must publish LitLocale::$RUNTIME_LOCALE (#865).'
+        );
     }
 }

--- a/phpunit_tests/Models/Calendar/LitCommonsLatinFormsTest.php
+++ b/phpunit_tests/Models/Calendar/LitCommonsLatinFormsTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar;
+
+use LiturgicalCalendar\Api\Enum\LitCommon;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Models\Calendar\LitCommons;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `LitCommons::fullTranslate()` must render wholly in Latin for either accepted Latin
+ * form, never as a mixture (#865).
+ *
+ * The method builds one string from four locale-sensitive pieces: the `De Commune`
+ * prefix, the common's own name via `i18n()`, its possessive via `getPossessive()`,
+ * and the `vel` glue between multiple commons. Those four did not all ask the same
+ * question — `i18n()` and `getPossessive()` accepted both `la` and `la_VA`, while the
+ * prefix and the glue tested only `la`. Given `la_VA` the result was half Latin and
+ * half English: "From the Common Martyrum: … ; or …".
+ */
+#[CoversClass(LitCommons::class)]
+final class LitCommonsLatinFormsTest extends TestCase
+{
+    /**
+     * Two commons, so the `De Commune` prefix and the `vel` glue are both exercised
+     * alongside the name and possessive.
+     */
+    private function multipleCommons(): LitCommons
+    {
+        $commons = LitCommons::create([LitCommon::MARTYRUM, LitCommon::PASTORUM]);
+        self::assertNotNull($commons);
+        return $commons;
+    }
+
+    public function testBothLatinFormsProduceIdenticalOutput(): void
+    {
+        $commons = $this->multipleCommons();
+
+        self::assertSame(
+            $commons->fullTranslate(LitLocale::LATIN_PRIMARY_LANGUAGE),
+            $commons->fullTranslate(LitLocale::LATIN),
+            'fullTranslate() must not depend on which Latin form it is handed (#865).'
+        );
+    }
+
+    public function testFullLocaleLatinFormIsNotAMixture(): void
+    {
+        $translated = $this->multipleCommons()->fullTranslate(LitLocale::LATIN);
+
+        self::assertStringContainsString('De Commune', $translated, 'the prefix must be Latin');
+        self::assertStringContainsString('vel', $translated, 'the glue between commons must be Latin');
+        self::assertStringNotContainsString('From the Common', $translated);
+        self::assertStringNotContainsString('; or ', $translated);
+    }
+
+    public function testPrimaryLanguageLatinFormIsNotAMixture(): void
+    {
+        $translated = $this->multipleCommons()->fullTranslate(LitLocale::LATIN_PRIMARY_LANGUAGE);
+
+        self::assertStringContainsString('De Commune', $translated);
+        self::assertStringContainsString('vel', $translated);
+        self::assertStringNotContainsString('From the Common', $translated);
+        self::assertStringNotContainsString('; or ', $translated);
+    }
+
+    /**
+     * The complement: a non-Latin locale must still take the translated path, so the
+     * widening above cannot be mistaken for "always Latin".
+     */
+    public function testNonLatinLocaleIsNotRenderedInLatin(): void
+    {
+        $translated = $this->multipleCommons()->fullTranslate('en_US');
+
+        self::assertStringNotContainsString('De Commune', $translated);
+        self::assertStringContainsString('From the Common', $translated);
+    }
+}

--- a/phpunit_tests/Services/LocaleConfiguratorTest.php
+++ b/phpunit_tests/Services/LocaleConfiguratorTest.php
@@ -14,10 +14,12 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(LocaleConfigurator::class)]
 final class LocaleConfiguratorTest extends TestCase
 {
-    private string $savedApiFilePath    = '';
-    private string|false $savedLanguage = false;
-    private string $savedIcuDefault     = 'en';
-    private string|false $savedLocale   = false;
+    private string $savedApiFilePath     = '';
+    private string|false $savedLanguage  = false;
+    private string $savedIcuDefault      = 'en';
+    private string|false $savedLocale    = false;
+    private string $savedPrimaryLanguage = LitLocale::LATIN_PRIMARY_LANGUAGE;
+    private string $savedRuntimeLocale   = 'en_US';
 
     protected function setUp(): void
     {
@@ -25,6 +27,9 @@ final class LocaleConfiguratorTest extends TestCase
         $this->savedLanguage    = getenv('LANGUAGE');
         $this->savedIcuDefault  = \Locale::getDefault();
         $this->savedLocale      = setlocale(LC_ALL, 0);
+        // configure() now publishes these (#865), so this test mutates them too.
+        $this->savedPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+        $this->savedRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
 
         // JsonData::FOLDER->path() prefixes Router::$apiFilePath; point it at the repo root.
         Router::$apiFilePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
@@ -46,6 +51,8 @@ final class LocaleConfiguratorTest extends TestCase
             putenv('LANGUAGE=' . $this->savedLanguage);
         }
         \Locale::setDefault($this->savedIcuDefault);
+        LitLocale::$PRIMARY_LANGUAGE = $this->savedPrimaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = $this->savedRuntimeLocale;
     }
 
     public function testRegionlessLanguageResolvesViaLikelySubtags(): void
@@ -95,5 +102,24 @@ final class LocaleConfiguratorTest extends TestCase
     {
         $this->expectException(ServiceUnavailableException::class);
         LocaleConfigurator::configure('zz');
+    }
+
+    public function testConfigurePublishesTheLitLocaleStatics(): void
+    {
+        LocaleConfigurator::configure('fr');
+
+        self::assertSame('fr', LitLocale::$PRIMARY_LANGUAGE, 'configure() must publish the primary language (#865).');
+        self::assertStringStartsWith('fr', LitLocale::$RUNTIME_LOCALE, 'configure() must publish the runtime locale (#865).');
+    }
+
+    public function testConfigurePublishesTheLitLocaleStaticsForLatin(): void
+    {
+        // Latin takes the reset branch, which must publish just the same — otherwise a
+        // Latin request inherits the previous request's language.
+        LocaleConfigurator::configure('en');
+        LocaleConfigurator::configure(LitLocale::LATIN);
+
+        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, LitLocale::$PRIMARY_LANGUAGE);
+        self::assertSame(LitLocale::LATIN_PRIMARY_LANGUAGE, LitLocale::$RUNTIME_LOCALE);
     }
 }

--- a/src/Enum/LitColor.php
+++ b/src/Enum/LitColor.php
@@ -26,7 +26,7 @@ enum LitColor: string
      */
     public function i18n(string $locale): string
     {
-        $isLatin = in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true);
+        $isLatin = LitLocale::isLatin($locale);
         return match ($this) {
             /**translators: context = liturgical color */
             LitColor::GREEN  => ( $isLatin ? 'viridis' : _('green') ),

--- a/src/Enum/LitGrade.php
+++ b/src/Enum/LitGrade.php
@@ -125,7 +125,7 @@ enum LitGrade: int
      */
     public function i18n(string $locale, bool $html = true, bool $abbreviate = false): string
     {
-        $isLatin = in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true);
+        $isLatin = LitLocale::isLatin($locale);
 
         [
             'grade'     => $grade,

--- a/src/Enum/LitLocale.php
+++ b/src/Enum/LitLocale.php
@@ -28,6 +28,28 @@ class LitLocale
     }
 
     /**
+     * Check whether the given locale denotes Latin, in either of the forms the API
+     * accepts: the primary language subtag `la` or the full locale `la_VA`.
+     *
+     * Both reach the code that renders liturgical text — `la_VA` is what the request
+     * layer settles on (CalendarParams, EventsParams), while `la` is what
+     * LocaleConfigurator resolves at runtime, since Latin has no installable system
+     * locale. Comparing against only one of them silently drops Latin output for
+     * requests that arrive in the other form (#749, #865).
+     *
+     * Use this rather than an ad-hoc comparison anywhere the value being tested is a
+     * full locale string. `self::$PRIMARY_LANGUAGE` is a bare language subtag by
+     * construction and is compared to LATIN_PRIMARY_LANGUAGE directly.
+     *
+     * @param string $locale The locale value to test.
+     * @return bool True when the locale is Latin in either accepted form.
+     */
+    public static function isLatin(string $locale): bool
+    {
+        return in_array($locale, [self::LATIN, self::LATIN_PRIMARY_LANGUAGE], true);
+    }
+
+    /**
      * Check if the given array of locales is valid.
      *
      * @param string[] $values The array of locale values to validate.

--- a/src/Enum/LitSeason.php
+++ b/src/Enum/LitSeason.php
@@ -155,7 +155,7 @@ enum LitSeason: string
      */
     public function i18n(string $locale): string
     {
-        $isLatin = in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true);
+        $isLatin = LitLocale::isLatin($locale);
         return match ($this) {
             /**translators: context = liturgical season */
             LitSeason::ADVENT         => $isLatin ? 'Tempus Adventus'     : _('Advent'),

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -5217,11 +5217,10 @@ final class CalendarHandler extends AbstractHandler
             throw new ServiceUnavailableException('“Pride was the reason for the division of tongues, humility the reason they were reunited.” - St. Augustine, The City of God, Book XVI, Chapter 4');
         }
 
-        $configured                  = LocaleConfigurator::configure($this->CalendarParams->Locale);
-        LitLocale::$PRIMARY_LANGUAGE = $configured->primaryLanguage;
-        LitLocale::$RUNTIME_LOCALE   = $configured->runtimeLocale;
+        // configure() publishes LitLocale::$PRIMARY_LANGUAGE and $RUNTIME_LOCALE itself (#865).
+        $configured = LocaleConfigurator::configure($this->CalendarParams->Locale);
 
-        LiturgicalEvent::setLocale(LitLocale::$RUNTIME_LOCALE);
+        LiturgicalEvent::setLocale($configured->runtimeLocale);
 
         $this->createFormatters();
 

--- a/src/Models/Calendar/LitCommons.php
+++ b/src/Models/Calendar/LitCommons.php
@@ -254,7 +254,7 @@ final class LitCommons implements \JsonSerializable
      */
     public static function i18n(LitCommon $litCommon, string $locale): string
     {
-        return in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true)
+        return LitLocale::isLatin($locale)
             ? LitCommon::LATIN[$litCommon->name]
             : $litCommon->translate();
     }
@@ -272,7 +272,7 @@ final class LitCommons implements \JsonSerializable
      */
     private static function getPossessive(LitCommon $litCommon, string $locale): string
     {
-        return in_array($locale, [LitLocale::LATIN, LitLocale::LATIN_PRIMARY_LANGUAGE], true)
+        return LitLocale::isLatin($locale)
             ? ''
             : $litCommon->possessive();
     }

--- a/src/Models/Calendar/LitCommons.php
+++ b/src/Models/Calendar/LitCommons.php
@@ -197,7 +197,7 @@ final class LitCommons implements \JsonSerializable
         }
         */
 
-        $fromTheCommon = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'De Commune' : _('From the Common');
+        $fromTheCommon = LitLocale::isLatin($locale) ? 'De Commune' : _('From the Common');
 
         /** @var string[] $commonsLcl */
         $commonsLcl = array_map(function (LitCommonItem $litCommonItem) use ($locale, $fromTheCommon): string {
@@ -225,7 +225,7 @@ final class LitCommons implements \JsonSerializable
         }, $this->commons);
 
         /**translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..." */
-        $or = $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'vel' : _('or');
+        $or = LitLocale::isLatin($locale) ? 'vel' : _('or');
         return implode('; ' . $or . ' ', $commonsLcl);
     }
 

--- a/src/Models/Calendar/LiturgicalEvent.php
+++ b/src/Models/Calendar/LiturgicalEvent.php
@@ -145,19 +145,19 @@ final class LiturgicalEvent implements \JsonSerializable
             $this->common_lcl = $commons->fullTranslate(self::$locale);
         } elseif ($commons instanceof LitMassVariousNeeds) {
             $this->common     = [$commons];
-            $this->common_lcl = $commons->fullTranslate(self::$locale === LitLocale::LATIN_PRIMARY_LANGUAGE);
+            $this->common_lcl = $commons->fullTranslate(LitLocale::isLatin(self::$locale));
         } elseif ($litMassVariousNeedsArray) {
             /** @var LitMassVariousNeeds[] $commons */
             $this->common = $commons;
             $commonsLcl   = array_map(
                 function (LitMassVariousNeeds $item): string {
-                    return $item->fullTranslate(self::$locale === LitLocale::LATIN_PRIMARY_LANGUAGE);
+                    return $item->fullTranslate(LitLocale::isLatin(self::$locale));
                 },
                 $commons
             );
 
             /**translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..." */
-            $or               = self::$locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'vel' : _('or');
+            $or               = LitLocale::isLatin(self::$locale) ? 'vel' : _('or');
             $this->common_lcl = implode('; ' . $or . ' ', $commonsLcl);
         } else {
             /** @var LitCommons $commons */

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -1779,7 +1779,7 @@ final class LiturgicalEventCollection
         $litEventGradeLcl = '';
         if (self::dateIsSunday($litEvent->date) && $litEvent->grade->value < LitGrade::SOLEMNITY->value) {
             $dayOfTheWeek     = $this->dayOfTheWeek->format($litEvent->date->format('U')) ?: 'N/A';
-            $litEventGradeLcl = $this->CalendarParams->Locale === LitLocale::LATIN ? 'Die Domini' : ucfirst($dayOfTheWeek);
+            $litEventGradeLcl = LitLocale::isLatin($this->CalendarParams->Locale) ? 'Die Domini' : ucfirst($dayOfTheWeek);
         } else {
             if ($litEvent->grade->value > LitGrade::SOLEMNITY->value) {
                 $litEventGradeLcl = '<i>' . $litEvent->grade->i18n($this->CalendarParams->Locale, false) . '</i>';
@@ -1815,7 +1815,7 @@ final class LiturgicalEventCollection
                     if (self::dateIsSunday($VigilDate) && $coincidingEvent->event->grade->value < LitGrade::SOLEMNITY->value) {
                         //it's a Sunday
                         $dayOfTheWeek               = $this->dayOfTheWeek->format($VigilDate->format('U')) ?: 'N/A';
-                        $coincidingEvent->grade_lcl = $this->CalendarParams->Locale === LitLocale::LATIN
+                        $coincidingEvent->grade_lcl = LitLocale::isLatin($this->CalendarParams->Locale)
                             ? 'Die Domini'
                             : ucfirst($dayOfTheWeek);
                     } else {
@@ -2053,7 +2053,7 @@ final class LiturgicalEventCollection
                 throw new \RuntimeException('No Feast of the Lord found for ' . $currentLitEventDate->format('Y-m-d'));
             }
             $coincidingEvent->event     = $liturgicalEvent;
-            $coincidingEvent->grade_lcl = $this->CalendarParams->Locale === LitLocale::LATIN
+            $coincidingEvent->grade_lcl = LitLocale::isLatin($this->CalendarParams->Locale)
                 ? 'Die Domini'
                 : ucfirst($dayOfTheWeek);
         } elseif ($this->inSolemnities($currentLitEventDate) || $this->inFeastsLord($currentLitEventDate)) {

--- a/src/Models/EventsPath/LiturgicalEventAbstract.php
+++ b/src/Models/EventsPath/LiturgicalEventAbstract.php
@@ -90,18 +90,18 @@ abstract class LiturgicalEventAbstract implements \JsonSerializable
         } elseif ($commons instanceof LitMassVariousNeeds) {
             /** @var LitMassVariousNeeds $commons */
             $this->common     = [$commons];
-            $this->common_lcl = $commons->fullTranslate(self::$locale === LitLocale::LATIN_PRIMARY_LANGUAGE);
+            $this->common_lcl = $commons->fullTranslate(LitLocale::isLatin(self::$locale));
         } elseif ($litMassVariousNeedsArray) {
             /** @var LitMassVariousNeeds[] $commons */
             $this->common = $commons;
             $commonsLcl   = array_map(
                 function (LitMassVariousNeeds $item): string {
-                    return $item->fullTranslate(self::$locale === LitLocale::LATIN_PRIMARY_LANGUAGE);
+                    return $item->fullTranslate(LitLocale::isLatin(self::$locale));
                 },
                 $commons
             );
             /**translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..." */
-            $or               = self::$locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'vel' : _('or');
+            $or               = LitLocale::isLatin(self::$locale) ? 'vel' : _('or');
             $this->common_lcl = implode('; ' . $or . ' ', $commonsLcl);
         } else {
             /** @var LitCommons $commons */

--- a/src/Services/LocaleConfigurator.php
+++ b/src/Services/LocaleConfigurator.php
@@ -21,6 +21,8 @@ use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
  *
  * Centralizes logic previously duplicated across CalendarHandler::prepareL10N(),
  * EventsHandler::setLocale(), and FerialEventNameGenerator::initializeGettext() (#745).
+ * Also publishes the resolved locale to LitLocale::$PRIMARY_LANGUAGE and
+ * LitLocale::$RUNTIME_LOCALE, so every route gets them set, not just /calendar (#865).
  */
 final class LocaleConfigurator
 {
@@ -40,7 +42,7 @@ final class LocaleConfigurator
 
         if ($primaryLanguage === LitLocale::LATIN_PRIMARY_LANGUAGE) {
             self::reset(LitLocale::LATIN_PRIMARY_LANGUAGE);
-            return new ConfiguredLocale(LitLocale::LATIN_PRIMARY_LANGUAGE, LitLocale::LATIN_PRIMARY_LANGUAGE, true);
+            return self::publish(new ConfiguredLocale(LitLocale::LATIN_PRIMARY_LANGUAGE, LitLocale::LATIN_PRIMARY_LANGUAGE, true));
         }
 
         $region = \Locale::getRegion($canonical);
@@ -81,7 +83,25 @@ final class LocaleConfigurator
         putenv("LANGUAGE={$languageEnv}");
         \Locale::setDefault($normalizedLocale);
 
-        return new ConfiguredLocale($primaryLanguage, $normalizedLocale, false);
+        return self::publish(new ConfiguredLocale($primaryLanguage, $normalizedLocale, false));
+    }
+
+    /**
+     * Publish the resolved locale to the LitLocale statics that downstream code reads,
+     * then return it.
+     *
+     * Done here rather than in each caller so that no caller can forget: CalendarHandler
+     * set them by hand while EventsHandler and the temporale path did not, leaving those
+     * routes reading whatever a previous request in the same persistent worker left
+     * behind — or the mutually inconsistent class defaults ('la' and 'en_US') on a cold
+     * worker (#865).
+     */
+    private static function publish(ConfiguredLocale $configured): ConfiguredLocale
+    {
+        LitLocale::$PRIMARY_LANGUAGE = $configured->primaryLanguage;
+        LitLocale::$RUNTIME_LOCALE   = $configured->runtimeLocale;
+
+        return $configured;
     }
 
     /**

--- a/src/Utilities.php
+++ b/src/Utilities.php
@@ -453,7 +453,7 @@ class Utilities
                 return $txt->i18n($locale);
             }, $colors);
 
-            $or = $locale === LitLocale::LATIN || $locale === LitLocale::LATIN_PRIMARY_LANGUAGE ? 'vel' : _('or');
+            $or = LitLocale::isLatin($locale) ? 'vel' : _('or');
             return implode(' ' . $or . ' ', $colorStrings);
         }
     }


### PR DESCRIPTION
Closes #865 — the two follow-ups surfaced while doing #749 (delivered in #864). Both were latent; neither changes any output.

## 1. `configure()` publishes the `LitLocale` statics

`LocaleConfigurator::configure()` now sets `LitLocale::$PRIMARY_LANGUAGE` and `$RUNTIME_LOCALE` itself, and `CalendarHandler::prepareL10N()` drops the two lines that did it by hand.

Only `/calendar` had ever set them, so `/events` and the temporale path read whatever a prior request in the same persistent worker left behind — or, on a cold worker, the mutually inconsistent class defaults (`'la'` and `'en_US'`). No current reader of either static is reachable from those routes, so nothing is broken today; the next one added would have silently inherited a stale value, which is the leak class of #739/#743 through a static instead of the `LANGUAGE` env var.

Putting it in `configure()` rather than in each handler means no caller can forget. I checked the one thing that would have ruled this out: `configure()` has three callers — `CalendarHandler`, `EventsHandler` and `FerialEventNameGenerator` — and the third is reached only from `TemporaleHandler`, which `Router` dispatches as its own route rather than nesting inside calendar generation. So publishing cannot corrupt `$PRIMARY_LANGUAGE` mid-generation.

## 2. `LitLocale::isLatin()`

The issue said eleven sites. The real inventory is 31 comparisons in five spellings, and this PR converts the 15 where it matters:

| Spelling                                                   | Sites  | Converted |
|------------------------------------------------------------|--------|-----------|
| `in_array($locale, [LATIN, LATIN_PRIMARY_LANGUAGE], true)`   | 5      | yes       |
| `self::$locale === LATIN_PRIMARY_LANGUAGE`                   | 6      | yes       |
| `$this->CalendarParams->Locale === LATIN`                    | 3      | yes       |
| `$locale === LATIN \|\| $locale === LATIN_PRIMARY_LANGUAGE`  | 1      | yes       |
| `LitLocale::$PRIMARY_LANGUAGE === LATIN_PRIMARY_LANGUAGE`    | 16     | **no**    |

The 15 converted sites all compare a **full locale string**, where either Latin form is legitimate and the spelling therefore decides the answer — the exact asymmetry that made the `/events` Masses for Various Needs commons render in English (#749).

The 16 `$PRIMARY_LANGUAGE` comparisons are left alone deliberately: that static is a bare language subtag by construction, so comparing it to `'la'` is unambiguous and correct. Converting them would be a much larger diff across the Temporale engines and `CalendarHandler` for no reduction in risk.

One thing worth recording: the `CalendarParams` comparisons were correct but **fragile**. CLDR maximizes `la` to `la_Latn_VA`, which would fail a `=== 'la_VA'` test; they survive only because `validateLocaleParam()` falls through to reconstructing `'la_VA'` from language + region. `isLatin()` makes them independent of a normalization two layers away.

## Verification

**No observable output change, measured rather than assumed.** `/events` and `/calendar` were dumped across `la`, `la_VA`, `it` and `en` — 8 endpoint/locale combinations, ~3400 events' worth of `grade_lcl`, `common_lcl`, `color_lcl`, `month` and `day_of_the_week_long` — on this branch and on `development`. The two dumps are **byte-identical**. `engineCache` was cleared before each run, since its digest hashes only `jsondata/sourcedata` and the `.mo` files and would otherwise have served the other revision's cached calendars.

This mattered here: category 2 above genuinely *widens* behaviour (`la_VA` now takes Latin branches it previously missed), so "the tests pass" would not have been sufficient evidence on its own.

- `CalendarGoldenMasterTest` — 9/9 green
- `composer test:quick` — 3385 tests, 179534 assertions, 17 errors
- PHPStan level 10 clean; `composer lint` clean

The 17 errors are all `phpunit_tests/WebSocket/*` client read-timeouts — the same pre-existing local baseline as #864, where CI ran the same suite green. That suite needs a WebSocket server started from the same checkout, which this working tree does not have.

**New tests**, each verified to fail when the corresponding change is reverted:

- `LitLocaleIsLatinTest` — both accepted Latin forms, plus the near-misses (`la_Latn_VA`, `la-VA`, `la_va`) that must **not** count as Latin.
- `LocaleConfiguratorTest` — asserts `configure()` publishes on both the translated and the Latin reset branch, and now snapshots/restores the statics it started mutating.
- `HandlerModelLocaleParityTest` — poisons the statics to `xx`/`xx_XX`, then asserts an `/events` request sets them, so a pass proves the route publishes rather than merely agreeing with a leftover value.

Neutering `publish()` fails 3 of these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent support for the recognised Latin locales `la` and `la_VA`.
  * Locale configuration now reliably applies the resolved language and runtime locale.

* **Bug Fixes**
  * Improved Latin-language translations and formatting across calendars, events, grades, seasons, colours and other content.
  * Prevented mixed Latin and non-Latin output when using supported Latin locales.
  * Expanded coverage for Latin, non-Latin and invalid locale behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->