### PR TITLE
test: decide handler/repository availability at class level so teardown cannot fatal

### DIFF
--- a/phpunit_tests/Handlers/AbstractHandlerTestCase.php
+++ b/phpunit_tests/Handlers/AbstractHandlerTestCase.php
@@ -56,6 +56,36 @@ abstract class AbstractHandlerTestCase extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        // Decide whether this class can run BEFORE mutating any process-global state.
+        //
+        // A skip raised here aborts the whole class: PHPUnit then runs neither setUp()
+        // nor tearDown() nor tearDownAfterClass() for it. That is what makes the skip
+        // safe — a subclass tearDown() can never observe a snapshot its setUp() never
+        // got round to taking (#868). It is also why these checks must come first:
+        // anything pinned above a skip would never be restored.
+        //
+        // Both conditions are class-invariant (process env), so per-test checking bought
+        // nothing. Message visibility is identical either way: on PHPUnit 12 neither a
+        // per-test nor a suite-level skip reason is printed without --display-skipped,
+        // and both are printed with it.
+        $secret = self::env('JWT_SECRET');
+        if ($secret === null || strlen($secret) < 32) {
+            self::markTestSkipped(
+                'Handler test requires JWT_SECRET (32+ chars) in env. '
+                . 'See CLAUDE.md for the recommended values.'
+            );
+        }
+
+        if (static::$requiresDatabase) {
+            self::$pdo = self::connectToDatabase();
+            if (self::$pdo === null) {
+                self::markTestSkipped(
+                    'Handler test requires Postgres credentials in DB_HOST/DB_NAME/DB_USER/DB_PASSWORD. '
+                    . 'CI sets these via .env.local; locally, run scripts/init-db.sql.'
+                );
+            }
+        }
+
         // Pin Router::$apiPath + Router::$apiFilePath so handlers that read
         // them (for self-links + JsonData::*->path() filesystem lookups)
         // get stable, predictable values in tests. isset() is false for
@@ -69,35 +99,40 @@ abstract class AbstractHandlerTestCase extends TestCase
         // it to the project root with a trailing slash, matching Router's
         // production behaviour.
         Router::$apiFilePath = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+    }
 
-        if (static::$requiresDatabase) {
-            $host     = self::env('DB_HOST');
-            $port     = self::env('DB_PORT') ?? '5432';
-            $name     = self::env('DB_NAME');
-            $user     = self::env('DB_USER');
-            $password = self::env('DB_PASSWORD');
+    /**
+     * Open the test database connection, or return null when it is unavailable —
+     * whether because the credentials are absent or because Postgres cannot be reached.
+     */
+    private static function connectToDatabase(): ?PDO
+    {
+        $host     = self::env('DB_HOST');
+        $port     = self::env('DB_PORT') ?? '5432';
+        $name     = self::env('DB_NAME');
+        $user     = self::env('DB_USER');
+        $password = self::env('DB_PASSWORD');
 
-            if ($host === null || $name === null || $user === null || $password === null) {
-                self::$pdo = null;
-                return;
-            }
+        if ($host === null || $name === null || $user === null || $password === null) {
+            return null;
+        }
 
-            try {
-                self::$pdo = new PDO(
-                    sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $name),
-                    $user,
-                    $password,
-                    [
-                        PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-                        PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                        PDO::ATTR_EMULATE_PREPARES   => false,
-                        PDO::ATTR_TIMEOUT            => 5,
-                    ]
-                );
-                self::$pdo->exec("SET timezone TO 'Europe/Vatican'");
-            } catch (\PDOException $e) {
-                self::$pdo = null;
-            }
+        try {
+            $pdo = new PDO(
+                sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $name),
+                $user,
+                $password,
+                [
+                    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                    PDO::ATTR_EMULATE_PREPARES   => false,
+                    PDO::ATTR_TIMEOUT            => 5,
+                ]
+            );
+            $pdo->exec("SET timezone TO 'Europe/Vatican'");
+            return $pdo;
+        } catch (\PDOException $e) {
+            return null;
         }
     }
 
@@ -110,28 +145,12 @@ abstract class AbstractHandlerTestCase extends TestCase
 
     protected function setUp(): void
     {
+        // Only genuinely per-test work belongs here. Whether this class can run at all
+        // was settled in setUpBeforeClass(); by the time we get here, self::$pdo is
+        // non-null whenever a database was required (#868).
         if (static::$requiresDatabase) {
-            if (self::$pdo === null) {
-                $this->markTestSkipped(
-                    'Handler test requires Postgres credentials in DB_HOST/DB_NAME/DB_USER/DB_PASSWORD. '
-                    . 'CI sets these via .env.local; locally, run scripts/init-db.sql.'
-                );
-            }
-
-            self::$pdo->exec(
+            self::$pdo?->exec(
                 'TRUNCATE TABLE ' . implode(', ', self::TABLES) . ' RESTART IDENTITY CASCADE'
-            );
-        }
-
-        // Confirm the JWT env is set up at least to the minimum the
-        // services need (JwtServiceFactory::fromEnv rejects secrets
-        // shorter than 32 chars). Skipping (not failing) keeps the
-        // rest of the suite usable for devs without auth configured.
-        $secret = self::env('JWT_SECRET');
-        if ($secret === null || strlen($secret) < 32) {
-            $this->markTestSkipped(
-                'Handler test requires JWT_SECRET (32+ chars) in env. '
-                . 'See CLAUDE.md for the recommended values.'
             );
         }
     }

--- a/phpunit_tests/Handlers/AbstractHandlerTestCaseSkipContractTest.php
+++ b/phpunit_tests/Handlers/AbstractHandlerTestCaseSkipContractTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the two PHPUnit behaviours the #868 fix depends on, so neither can regress
+ * silently under a future PHPUnit upgrade.
+ *
+ * 1. `tearDown()` DOES run after a skip raised inside `setUp()`. This is the trap:
+ *    a class that snapshots state after a skipping `parent::setUp()` leaves its own
+ *    `tearDown()` reading properties that were never assigned — fatal for typed
+ *    properties without defaults, which is exactly how `CalendarHandlerLocaleLeakTest`
+ *    and `DecreesHandlerWriteTest` errored instead of skipping.
+ *
+ * 2. A skip raised in `setUpBeforeClass()` aborts the whole class: neither `setUp()`
+ *    nor `tearDown()` runs. That is why `AbstractHandlerTestCase` now decides
+ *    availability there — it makes the trap unreachable for every subclass.
+ *
+ * Both are asserted by running a nested PHPUnit process over fixture test classes,
+ * because a test cannot observe its own skipped lifecycle from the inside.
+ */
+#[CoversNothing]
+final class AbstractHandlerTestCaseSkipContractTest extends TestCase
+{
+    private string $fixtureDir = '';
+
+    protected function tearDown(): void
+    {
+        if ('' !== $this->fixtureDir && is_dir($this->fixtureDir)) {
+            foreach (glob($this->fixtureDir . '/*.php') ?: [] as $file) {
+                unlink($file);
+            }
+            rmdir($this->fixtureDir);
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * Write a one-off test class to disk and run it in a nested PHPUnit process.
+     */
+    private function runFixture(string $className, string $classBody): string
+    {
+        $root             = dirname(__DIR__, 2);
+        $this->fixtureDir = $root . '/phpunit_tests/SkipContractFixtures';
+        if (!is_dir($this->fixtureDir)) {
+            mkdir($this->fixtureDir, 0755, true);
+        }
+
+        $source = "<?php\ndeclare(strict_types=1);\n"
+            . "namespace LiturgicalCalendar\\Tests\\SkipContractFixtures;\n"
+            . "use PHPUnit\\Framework\\TestCase;\n"
+            . "final class {$className} extends TestCase\n{\n{$classBody}\n}\n";
+        file_put_contents($this->fixtureDir . '/' . $className . '.php', $source);
+
+        $cmd = sprintf(
+            'cd %s && vendor/bin/phpunit --no-configuration --bootstrap %s %s 2>&1',
+            escapeshellarg($root),
+            escapeshellarg($root . '/vendor/autoload.php'),
+            escapeshellarg($this->fixtureDir . '/' . $className . '.php')
+        );
+
+        return (string) shell_exec($cmd);
+    }
+
+    public function testTearDownRunsAfterASkipInSetUp(): void
+    {
+        $output = $this->runFixture('SkipInSetUpTest', <<<'PHP'
+    private string $neverAssigned;
+    protected function setUp(): void { $this->markTestSkipped('probe'); }
+    protected function tearDown(): void { echo "TEARDOWN_REACHED:" . $this->neverAssigned; }
+    public function testAnything(): void { self::assertTrue(true); }
+PHP);
+
+        // The uninitialized read proves tearDown() ran; PHPUnit reports it as an Error.
+        self::assertStringContainsString(
+            'must not be accessed before initialization',
+            $output,
+            'PHPUnit must still run tearDown() after a skip in setUp() — the premise of the #868 fix.'
+        );
+    }
+
+    public function testNeitherSetUpNorTearDownRunsAfterASkipInSetUpBeforeClass(): void
+    {
+        $output = $this->runFixture('SkipInSetUpBeforeClassTest', <<<'PHP'
+    private string $neverAssigned;
+    public static function setUpBeforeClass(): void { self::markTestSkipped('probe'); }
+    protected function setUp(): void { echo "SETUP_REACHED"; }
+    protected function tearDown(): void { echo "TEARDOWN_REACHED:" . $this->neverAssigned; }
+    public function testAnything(): void { self::assertTrue(true); }
+PHP);
+
+        self::assertStringNotContainsString('SETUP_REACHED', $output, 'a class-level skip must not run setUp()');
+        self::assertStringNotContainsString('TEARDOWN_REACHED', $output, 'a class-level skip must not run tearDown()');
+        self::assertStringNotContainsString(
+            'must not be accessed before initialization',
+            $output,
+            'a class-level skip must leave no lifecycle hook able to read uninitialized state (#868).'
+        );
+        self::assertStringContainsString('Skipped: 1', $output, 'the test must be reported as skipped, not errored');
+    }
+}

--- a/phpunit_tests/Handlers/AmbrosianLocaleEnforcementTest.php
+++ b/phpunit_tests/Handlers/AmbrosianLocaleEnforcementTest.php
@@ -56,8 +56,9 @@ final class AmbrosianLocaleEnforcementTest extends AbstractHandlerTestCase
      */
     protected function setUp(): void
     {
+        $this->savedServerName = $_SERVER['SERVER_NAME'] ?? null;
+
         parent::setUp();
-        $this->savedServerName  = $_SERVER['SERVER_NAME'] ?? null;
         $_SERVER['SERVER_NAME'] = 'localhost';
     }
 

--- a/phpunit_tests/Handlers/CalendarHandlerLocaleLeakTest.php
+++ b/phpunit_tests/Handlers/CalendarHandlerLocaleLeakTest.php
@@ -28,11 +28,14 @@ final class CalendarHandlerLocaleLeakTest extends AbstractHandlerTestCase
 
     protected function setUp(): void
     {
-        parent::setUp();
-
         // Snapshot every process-global bit of state this test (and the handlers it
         // invokes) will mutate, so tearDown() can restore the world exactly as it was
         // found rather than unconditionally clobbering values another test may rely on.
+        //
+        // Taken before parent::setUp() so the snapshot always happens: PHPUnit runs
+        // tearDown() after a skip raised inside setUp(), and these properties are typed
+        // with no defaults, so a snapshot taken after a skipping parent would leave
+        // tearDown() fatally reading uninitialized state (#868).
         $this->savedLocale          = setlocale(LC_ALL, 0) ?: 'C';
         $languageEnv                = getenv('LANGUAGE');
         $this->savedLanguageEnv     = false === $languageEnv ? null : $languageEnv;
@@ -41,6 +44,8 @@ final class CalendarHandlerLocaleLeakTest extends AbstractHandlerTestCase
         $this->savedRuntimeLocale   = LitLocale::$RUNTIME_LOCALE;
         $this->hadServerName        = array_key_exists('SERVER_NAME', $_SERVER);
         $this->savedServerName      = $this->hadServerName ? (string) $_SERVER['SERVER_NAME'] : null;
+
+        parent::setUp();
 
         // Force Router::isLocalhost() true so handle() bypasses the response cache and
         // actually runs prepareL10N() for every request (the leak is invisible when a

--- a/phpunit_tests/Handlers/CalendarScopedLocaleNegotiationTest.php
+++ b/phpunit_tests/Handlers/CalendarScopedLocaleNegotiationTest.php
@@ -60,8 +60,9 @@ final class CalendarScopedLocaleNegotiationTest extends AbstractHandlerTestCase
      */
     protected function setUp(): void
     {
+        $this->savedServerName = $_SERVER['SERVER_NAME'] ?? null;
+
         parent::setUp();
-        $this->savedServerName  = $_SERVER['SERVER_NAME'] ?? null;
         $_SERVER['SERVER_NAME'] = 'localhost';
     }
 

--- a/phpunit_tests/Handlers/DecreesHandlerWriteTest.php
+++ b/phpunit_tests/Handlers/DecreesHandlerWriteTest.php
@@ -15,7 +15,8 @@ use PHPUnit\Framework\Attributes\CoversClass;
 #[CoversClass(DecreesHandler::class)]
 final class DecreesHandlerWriteTest extends AbstractHandlerTestCase
 {
-    private string $backupDir;
+    /** Empty until setUp() allocates it; tearDown() must tolerate that (#868). */
+    private string $backupDir = '';
 
     protected function setUp(): void
     {
@@ -32,6 +33,13 @@ final class DecreesHandlerWriteTest extends AbstractHandlerTestCase
 
     protected function tearDown(): void
     {
+        // setUp() allocates the backup after parent::setUp(); if the class never got
+        // that far there is nothing to restore, and nothing was written either.
+        if ('' === $this->backupDir) {
+            parent::tearDown();
+            return;
+        }
+
         $src       = dirname(JsonData::DECREES_FILE->path());
         $backupSrc = $this->backupDir . '/decrees';
         // Only wipe the live directory when a non-empty backup exists to restore from;

--- a/phpunit_tests/Repositories/RepositoryTestCase.php
+++ b/phpunit_tests/Repositories/RepositoryTestCase.php
@@ -36,36 +36,7 @@ abstract class RepositoryTestCase extends TestCase
     public static function setUpBeforeClass(): void
     {
         self::$skipReason = null;
-
-        $host     = self::env('DB_HOST');
-        $port     = self::env('DB_PORT') ?? '5432';
-        $name     = self::env('DB_NAME');
-        $user     = self::env('DB_USER');
-        $password = self::env('DB_PASSWORD');
-
-        if ($host === null || $name === null || $user === null || $password === null) {
-            self::$pdo = null;
-            return;
-        }
-
-        try {
-            self::$pdo = new PDO(
-                sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $name),
-                $user,
-                $password,
-                [
-                    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
-                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-                    PDO::ATTR_EMULATE_PREPARES   => false,
-                    PDO::ATTR_TIMEOUT            => 5,
-                ]
-            );
-            // Pin the session TZ so date assertions don't drift by environment.
-            self::$pdo->exec("SET timezone TO 'Europe/Vatican'");
-        } catch (\PDOException $e) {
-            self::$pdo        = null;
-            self::$skipReason = 'Postgres unreachable: ' . $e->getMessage();
-        }
+        self::$pdo        = self::connect();
 
         // Skip at class level rather than per test. A skip raised here aborts the whole
         // class, so PHPUnit runs neither setUp() nor tearDown() for it — which is what
@@ -84,6 +55,47 @@ abstract class RepositoryTestCase extends TestCase
         }
     }
 
+    /**
+     * Open the test database connection, or return null when it is unavailable — whether
+     * because the credentials are absent or because Postgres cannot be reached.
+     *
+     * Every unavailable path RETURNS null rather than returning early from
+     * setUpBeforeClass(), so the single `self::$pdo === null` check there cannot be
+     * bypassed and the class can never proceed with a null connection.
+     */
+    private static function connect(): ?PDO
+    {
+        $host     = self::env('DB_HOST');
+        $port     = self::env('DB_PORT') ?? '5432';
+        $name     = self::env('DB_NAME');
+        $user     = self::env('DB_USER');
+        $password = self::env('DB_PASSWORD');
+
+        if ($host === null || $name === null || $user === null || $password === null) {
+            return null;
+        }
+
+        try {
+            $pdo = new PDO(
+                sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $name),
+                $user,
+                $password,
+                [
+                    PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                    PDO::ATTR_EMULATE_PREPARES   => false,
+                    PDO::ATTR_TIMEOUT            => 5,
+                ]
+            );
+            // Pin the session TZ so date assertions don't drift by environment.
+            $pdo->exec("SET timezone TO 'Europe/Vatican'");
+            return $pdo;
+        } catch (\PDOException $e) {
+            self::$skipReason = 'Postgres unreachable: ' . $e->getMessage();
+            return null;
+        }
+    }
+
     public static function tearDownAfterClass(): void
     {
         self::$pdo        = null;
@@ -97,7 +109,7 @@ abstract class RepositoryTestCase extends TestCase
         // CASCADE clears api_keys when applications get nuked (FK ON DELETE CASCADE);
         // listing every table explicitly is safer than relying on cascade alone and
         // keeps the truncate fast (these tables stay small in tests).
-        self::$pdo?->exec('TRUNCATE TABLE ' . implode(', ', self::TABLES) . ' RESTART IDENTITY CASCADE');
+        self::$pdo->exec('TRUNCATE TABLE ' . implode(', ', self::TABLES) . ' RESTART IDENTITY CASCADE');
     }
 
     private static ?string $skipReason = null;

--- a/phpunit_tests/Repositories/RepositoryTestCase.php
+++ b/phpunit_tests/Repositories/RepositoryTestCase.php
@@ -35,6 +35,8 @@ abstract class RepositoryTestCase extends TestCase
 
     public static function setUpBeforeClass(): void
     {
+        self::$skipReason = null;
+
         $host     = self::env('DB_HOST');
         $port     = self::env('DB_PORT') ?? '5432';
         $name     = self::env('DB_NAME');
@@ -61,10 +63,24 @@ abstract class RepositoryTestCase extends TestCase
             // Pin the session TZ so date assertions don't drift by environment.
             self::$pdo->exec("SET timezone TO 'Europe/Vatican'");
         } catch (\PDOException $e) {
-            self::$pdo = null;
-            // Defer reporting to setUp(); class-level skip messages aren't shown
-            // without --debug, but per-test skips are.
+            self::$pdo        = null;
             self::$skipReason = 'Postgres unreachable: ' . $e->getMessage();
+        }
+
+        // Skip at class level rather than per test. A skip raised here aborts the whole
+        // class, so PHPUnit runs neither setUp() nor tearDown() for it — which is what
+        // stops a subclass tearDown() reading a snapshot its setUp() never took (#868).
+        //
+        // This previously deferred to setUp() on the belief that suite-level skip
+        // reasons are hidden without --debug while per-test ones are shown. That is not
+        // true on PHPUnit 12: neither is printed without --display-skipped, and both are
+        // printed with it.
+        if (self::$pdo === null) {
+            self::markTestSkipped(
+                self::$skipReason
+                ?? 'Repository tests require Postgres credentials in DB_HOST/DB_NAME/DB_USER/DB_PASSWORD. '
+                . 'CI sets these via .env.local; locally, set them or run scripts/init-db.sql against your dev cluster.'
+            );
         }
     }
 
@@ -76,18 +92,12 @@ abstract class RepositoryTestCase extends TestCase
 
     protected function setUp(): void
     {
-        if (self::$pdo === null) {
-            $this->markTestSkipped(
-                self::$skipReason
-                ?? 'Repository tests require Postgres credentials in DB_HOST/DB_NAME/DB_USER/DB_PASSWORD. '
-                . 'CI sets these via .env.local; locally, set them or run scripts/init-db.sql against your dev cluster.'
-            );
-        }
-
+        // Availability was settled in setUpBeforeClass(); self::$pdo is non-null here.
+        //
         // CASCADE clears api_keys when applications get nuked (FK ON DELETE CASCADE);
         // listing every table explicitly is safer than relying on cascade alone and
         // keeps the truncate fast (these tables stay small in tests).
-        self::$pdo->exec('TRUNCATE TABLE ' . implode(', ', self::TABLES) . ' RESTART IDENTITY CASCADE');
+        self::$pdo?->exec('TRUNCATE TABLE ' . implode(', ', self::TABLES) . ' RESTART IDENTITY CASCADE');
     }
 
     private static ?string $skipReason = null;


### PR DESCRIPTION
Closes #868.

## The bug

PHPUnit runs `tearDown()` **even when `setUp()` raises a skip**. A class that snapshots process state *after* a skipping `parent::setUp()` therefore leaves its own `tearDown()` reading properties that were never assigned — fatal for typed properties without defaults.

On a host with no `JWT_SECRET` — a fresh clone, or a fresh worktree, since `.env.local` is gitignored and `git worktree add` does not copy it — two classes errored instead of skipping, with a message pointing at their own teardown rather than at the missing credential:

```
Error: Typed property CalendarHandlerLocaleLeakTest::$hadServerName must not be accessed before initialization
Error: Typed property DecreesHandlerWriteTest::$backupDir       must not be accessed before initialization
```

The issue named one class. Scanning all 302 test files for the shape found **two**; `DecreesHandlerWriteTest` was missed when filing.

## The fix

**Root cause, at the base classes.** `AbstractHandlerTestCase` and `RepositoryTestCase` now decide availability in `setUpBeforeClass()` rather than `setUp()`. A skip raised there aborts the whole class — PHPUnit runs neither `setUp()` nor `tearDown()` — so the trap is unreachable for every subclass, present and future. Both conditions are process env and therefore class-invariant, so per-test checking bought nothing.

Ordering matters and is deliberate: the checks run **before** any process-global state is pinned, because a class-level skip also means `tearDownAfterClass()` never runs to unpin it.

**A stale comment corrected.** `RepositoryTestCase` deferred its skip to `setUp()` on purpose, commenting that suite-level skip reasons are hidden without `--debug` while per-test ones are shown. That is not true on PHPUnit 12. Measured:

| Run | class-level reason | per-test reason |
|-----------------------|--------------------|-----------------|
| default               | hidden             | hidden          |
| `--display-skipped`   | shown              | shown           |

So the deferral bought nothing and cost the bug.

**The two classes are also made robust independently of the base**, because they want *different* fixes:

- `CalendarHandlerLocaleLeakTest` **snapshots ambient state** → its snapshot moves before `parent::setUp()`; that state exists whether or not the test runs.
- `DecreesHandlerWriteTest` **allocates a resource** (a copy of the decrees tree) → the allocation stays after `parent::setUp()`, since copying it for a skipped run is pure waste; instead `$backupDir` gains a `''` default and `tearDown()` returns early when it was never allocated.

`AmbrosianLocaleEnforcementTest` and `CalendarScopedLocaleNegotiationTest` move their snapshots too. They could not fatal — their properties are defaulted — but on a skip they unset a `SERVER_NAME` they never set.

**`ApiTestCase` is deliberately untouched.** It `fail()`s rather than skipping, so it has no such hazard. Its comment repeats the same stale belief about skip-message visibility, but changing `fail` to `skip` would change which runs are green — a separate decision, not a bug fix.

## Verification

**Reproduced end to end**, which the issue could not do: setting `JWT_SECRET` to a short value in the worktree gives, on `development`, 5 errors across the two classes; on this branch, **23 clean skips** carrying the `requires JWT_SECRET (32+ chars)` reason.

New `AbstractHandlerTestCaseSkipContractTest` pins both PHPUnit behaviours the fix rests on, by running fixture classes in a nested phpunit process:

1. `tearDown()` **does** run after a skip in `setUp()` — the trap itself.
2. A skip in `setUpBeforeClass()` runs **neither** hook — what makes the fix work.

If a future PHPUnit changes either, that test fails loudly rather than letting the base class quietly stop protecting anything.

- `composer test:quick` — 3391 tests, 179554 assertions, 11 skipped. The 17 errors are the pre-existing local `phpunit_tests/WebSocket/*` read-timeouts, unchanged in count and green in CI.
- `CalendarGoldenMasterTest` — 9/9
- PHPStan level 10 clean; `composer lint` clean
- Test-count accounting: 3389 on `development` + 2 new = 3391, so nothing that used to run is now being skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved test setup and cleanup when required database or authentication prerequisites are unavailable.
  - Prevented skipped test classes from triggering incomplete cleanup or state restoration.
  - Improved handling of locale and server state during test initialisation.

- **Tests**
  - Added coverage for PHPUnit skip behaviour, ensuring skipped tests are reported correctly without causing lifecycle errors.
  - Improved repository and handler test reliability when external services cannot be reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->