### PR TITLE
chore: regenerate i18n/litcal.pot from source files

### DIFF
--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-22 10:59+0000\n"
+"POT-Creation-Date: 2026-08-23 09:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -639,14 +639,14 @@ msgstr ""
 
 #. translators: %s is an ordinal number (1st, 2nd, 3rd)
 #. translators: %s is an ordinal number (first, second...)
-#: src/FerialEventNameGenerator.php:328 src/Handlers/CalendarHandler.php:2199
+#: src/FerialEventNameGenerator.php:328 src/Handlers/CalendarHandler.php:2401
 #, php-format
 msgid "of the %s Week of Advent"
 msgstr ""
 
 #. translators: %s is an ordinal number (2nd, 3rd, etc.) - Day of Christmas Octave
 #. translators: %s is an ordinal number (first, second...)
-#: src/FerialEventNameGenerator.php:347 src/Handlers/CalendarHandler.php:2259
+#: src/FerialEventNameGenerator.php:347 src/Handlers/CalendarHandler.php:2461
 #, php-format
 msgid "%s Day of the Octave of Christmas"
 msgstr ""
@@ -665,13 +665,13 @@ msgid "%s after Epiphany"
 msgstr ""
 
 #. translators: Day after Ash Wednesday pattern
-#: src/FerialEventNameGenerator.php:413 src/Handlers/CalendarHandler.php:2338
+#: src/FerialEventNameGenerator.php:413 src/Handlers/CalendarHandler.php:2540
 msgid "after Ash Wednesday"
 msgstr ""
 
 #. translators: %s is an ordinal number (1st, 2nd, 3rd)
 #. translators: %s is an ordinal number (first, second...)
-#: src/FerialEventNameGenerator.php:430 src/Handlers/CalendarHandler.php:2317
+#: src/FerialEventNameGenerator.php:430 src/Handlers/CalendarHandler.php:2519
 #, php-format
 msgid "of the %s Week of Lent"
 msgstr ""
@@ -683,14 +683,14 @@ msgid "%s within the Octave of Easter"
 msgstr ""
 
 #. translators: %s is an ordinal number (2nd, 3rd, etc.)
-#: src/FerialEventNameGenerator.php:463 src/Handlers/CalendarHandler.php:3327
+#: src/FerialEventNameGenerator.php:463 src/Handlers/CalendarHandler.php:3529
 #, php-format
 msgid "of the %s Week of Easter"
 msgstr ""
 
 #. translators: %s is an ordinal number (1st, 2nd, etc.)
-#: src/FerialEventNameGenerator.php:481 src/Handlers/CalendarHandler.php:3399
-#: src/Handlers/CalendarHandler.php:3447
+#: src/FerialEventNameGenerator.php:481 src/Handlers/CalendarHandler.php:3601
+#: src/Handlers/CalendarHandler.php:3649
 #, php-format
 msgid "of the %s Week of Ordinary Time"
 msgstr ""
@@ -701,30 +701,72 @@ msgstr ""
 msgid "%s of Holy Week"
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:545
+#: src/Handlers/CalendarHandler.php:550
 #, php-format
 msgid ""
 "The name of the diocese could not be derived from the diocese ID \"%s\"."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:911
+#: src/Handlers/CalendarHandler.php:916
 #, php-format
 msgid ""
 "Only years from 1970 and after are supported. You tried requesting the year "
 "%d."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:918
+#: src/Handlers/CalendarHandler.php:923
 #, php-format
 msgid "Only years until 9999 are supported. You tried requesting the year %d."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:1078
+#: src/Handlers/CalendarHandler.php:1083
 #, php-format
 msgid ""
 "The Ambrosian comune sanctorale event `%1$s` from the %2$s was skipped "
 "because a liturgical event with the same key was already defined by the "
 "Proprium de Tempore, which takes precedence."
+msgstr ""
+
+#: src/Handlers/CalendarHandler.php:1244
+#, php-format
+msgid ""
+"The diocesan calendar of %1$s tried to declare a new liturgical event `%2$s` "
+"for the year %3$d, but an event with that key already exists in the "
+"calendar. To override an existing celebration, use a `setProperty` row "
+"(`grade`, `name`, or `common`) instead of re-declaring it with `createNew`. "
+"The declaration was skipped."
+msgstr ""
+
+#: src/Handlers/CalendarHandler.php:1295
+#, php-format
+msgid ""
+"The diocesan calendar of %1$s tried to modify the liturgical event `%2$s`, "
+"but no such event exists in the calendar for the year %3$d. The modification "
+"was skipped."
+msgstr ""
+
+#: src/Handlers/CalendarHandler.php:1348
+#, php-format
+msgid ""
+"The diocesan calendar of %1$s declared a `setProperty:grade` override for "
+"the liturgical event `%2$s` for the year %3$d, but the grade was already set "
+"to that value. The override had no effect."
+msgstr ""
+
+#: src/Handlers/CalendarHandler.php:1398
+#, php-format
+msgid ""
+"The diocesan calendar of %1$s declared a `setProperty:common` override for "
+"the liturgical event `%2$s` for the year %3$d, but the Common was already "
+"set to that value. The override had no effect."
+msgstr ""
+
+#: src/Handlers/CalendarHandler.php:1428
+#, php-format
+msgid ""
+"The diocesan calendar of %1$s declared a `setProperty:name` override for the "
+"liturgical event `%2$s` for the year %3$d, but the name was already set to "
+"that value. The override had no effect."
 msgstr ""
 
 #. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Description of the reason for the transferral (ex. the Saturday preceding Palm Sunday), 5: actual date for the transferral, 6: Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments
@@ -738,24 +780,24 @@ msgstr ""
 #.  6: Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments
 #.
 #. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year, 4: Explicatory string for the transferral, 5: actual date for the transferral, 6: Reference to the norm that governs the transferral
-#: src/Handlers/CalendarHandler.php:1679 src/Handlers/CalendarHandler.php:1699
-#: src/Handlers/CalendarHandler.php:1750 src/Handlers/CalendarHandler.php:1802
+#: src/Handlers/CalendarHandler.php:1881 src/Handlers/CalendarHandler.php:1901
+#: src/Handlers/CalendarHandler.php:1952 src/Handlers/CalendarHandler.php:2004
 #, php-format
 msgid ""
 "The Solemnity '%1$s' falls on %2$s in the year %3$d, the celebration has "
 "been transferred to %4$s (%5$s) as per the %6$s."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:1683
+#: src/Handlers/CalendarHandler.php:1885
 msgid "the Saturday preceding Palm Sunday"
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:1686 src/Handlers/CalendarHandler.php:1706
-#: src/Handlers/CalendarHandler.php:1756 src/Handlers/CalendarHandler.php:1854
-#: src/Handlers/CalendarHandler.php:2436 src/Handlers/CalendarHandler.php:2730
-#: src/Handlers/CalendarHandler.php:3205 src/Handlers/CalendarHandler.php:3221
-#: src/Handlers/CalendarHandler.php:3239 src/Handlers/CalendarHandler.php:3278
-#: src/Models/Calendar/LiturgicalEventCollection.php:1736
+#: src/Handlers/CalendarHandler.php:1888 src/Handlers/CalendarHandler.php:1908
+#: src/Handlers/CalendarHandler.php:1958 src/Handlers/CalendarHandler.php:2056
+#: src/Handlers/CalendarHandler.php:2638 src/Handlers/CalendarHandler.php:2932
+#: src/Handlers/CalendarHandler.php:3407 src/Handlers/CalendarHandler.php:3423
+#: src/Handlers/CalendarHandler.php:3441 src/Handlers/CalendarHandler.php:3480
+#: src/Models/Calendar/LiturgicalEventCollection.php:1750
 #: src/Models/Decrees/DecreeEventMetadata.php:59
 #: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:54
 msgid ""
@@ -763,24 +805,24 @@ msgid ""
 "Sacraments"
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:1703
+#: src/Handlers/CalendarHandler.php:1905
 msgid "the Monday following the Second Sunday of Easter"
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:1754
+#: src/Handlers/CalendarHandler.php:1956
 msgid "the following Monday"
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:1806
+#: src/Handlers/CalendarHandler.php:2008
 msgid "the following day"
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:1808
+#: src/Handlers/CalendarHandler.php:2010
 msgid "General Norms for the Liturgical Year and the Calendar"
 msgstr ""
 
 #. translators: 1: Solemnity name, 2: Coinciding Solemnity name, 3: Requested calendar year
-#: src/Handlers/CalendarHandler.php:1813 src/Handlers/CalendarHandler.php:1828
+#: src/Handlers/CalendarHandler.php:2015 src/Handlers/CalendarHandler.php:2030
 #, php-format
 msgid ""
 "The Solemnity '%1$s' coincides with the Solemnity '%2$s' in the year %3$d. "
@@ -794,7 +836,7 @@ msgstr ""
 #.  3: Requested calendar year,
 #.  4: Decree of the Dicastery for Divine Worship and the Discipline of the Sacraments
 #.
-#: src/Handlers/CalendarHandler.php:1866
+#: src/Handlers/CalendarHandler.php:2068
 #, php-format
 msgid ""
 "Seeing that the Solemnity '%1$s' coincides with the Solemnity '%2$s' in the "
@@ -802,7 +844,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family
-#: src/Handlers/CalendarHandler.php:1951
+#: src/Handlers/CalendarHandler.php:2153
 #, php-format
 msgid ""
 "'%1$s' falls on a Sunday in the year %2$d, therefore the Feast '%3$s' is "
@@ -810,12 +852,12 @@ msgid ""
 msgstr ""
 
 #. translators: You can ignore this translation if the Feast has not been inserted by the Episcopal Conference
-#: src/Handlers/CalendarHandler.php:1977
+#: src/Handlers/CalendarHandler.php:2179
 msgid "Our Lord Jesus Christ, The Eternal High Priest"
 msgstr ""
 
 #. translators: 1: National Calendar, 2: Requested calendar year, 3: source of the rule
-#: src/Handlers/CalendarHandler.php:1989
+#: src/Handlers/CalendarHandler.php:2191
 #, php-format
 msgid ""
 "In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences to "
@@ -825,7 +867,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Superseding LiturgicalEvent grade, 3: Superseding LiturgicalEvent name, 4: Requested calendar year
-#: src/Handlers/CalendarHandler.php:2050 src/Handlers/CalendarHandler.php:2096
+#: src/Handlers/CalendarHandler.php:2252 src/Handlers/CalendarHandler.php:2298
 #, php-format
 msgid "'%1$s' is superseded by the %2$s '%3$s' in the year %4$d."
 msgstr ""
@@ -854,21 +896,21 @@ msgstr ""
 #.  5. Source of the information
 #.  6. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:2373 src/Handlers/CalendarHandler.php:2823
-#: src/Handlers/CalendarHandler.php:3048 src/Handlers/CalendarHandler.php:3912
+#: src/Handlers/CalendarHandler.php:2575 src/Handlers/CalendarHandler.php:3025
+#: src/Handlers/CalendarHandler.php:3250 src/Handlers/CalendarHandler.php:4114
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been added on %3$s since the year %4$d (%5$s), "
 "applicable to the year %6$d."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:2418 src/Handlers/CalendarHandler.php:2608
+#: src/Handlers/CalendarHandler.php:2620 src/Handlers/CalendarHandler.php:2810
 msgid ""
 "Vatican Press conference: Presentation of the Editio Typica Tertia of the "
 "Roman Missal"
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:2483
+#: src/Handlers/CalendarHandler.php:2685
 #, php-format
 msgid ""
 "The %1$s '%2$s' either falls between 17 Dec. and 24 Dec., or during the "
@@ -883,12 +925,12 @@ msgstr ""
 #.  4. Name of the liturgical event that is superseding
 #.  5. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:2521 src/Handlers/CalendarHandler.php:2569
+#: src/Handlers/CalendarHandler.php:2723 src/Handlers/CalendarHandler.php:2771
 #, php-format
 msgid "The %1$s '%2$s' is superseded by the %3$s '%4$s' in the year %5$d."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:2602
+#: src/Handlers/CalendarHandler.php:2804
 msgid "Apostolic Constitution Missale Romanum"
 msgstr ""
 
@@ -903,7 +945,7 @@ msgstr ""
 #.  8. Name of the liturgical event that is superseding
 #.  9. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:2631
+#: src/Handlers/CalendarHandler.php:2833
 #, php-format
 msgid ""
 "The %1$s '%2$s', added in the %3$s of the Roman Missal since the year %4$d "
@@ -931,7 +973,7 @@ msgstr ""
 #.  7. Name of superseding liturgical event
 #.  8. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:2677 src/Handlers/CalendarHandler.php:3103
+#: src/Handlers/CalendarHandler.php:2879 src/Handlers/CalendarHandler.php:3305
 #, php-format
 msgid ""
 "The %1$s '%2$s', added on %3$s since the year %4$d (%5$s), is however "
@@ -944,7 +986,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Handlers/CalendarHandler.php:2725
+#: src/Handlers/CalendarHandler.php:2927
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -952,7 +994,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
-#: src/Handlers/CalendarHandler.php:2774
+#: src/Handlers/CalendarHandler.php:2976
 #, php-format
 msgid ""
 "Cannot create mobile liturgical event '%1$s': can only be relative to "
@@ -960,7 +1002,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
-#: src/Handlers/CalendarHandler.php:2788
+#: src/Handlers/CalendarHandler.php:2990
 #, php-format
 msgid ""
 "Cannot create mobile liturgical event '%1$s' relative to liturgical event "
@@ -975,7 +1017,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Handlers/CalendarHandler.php:2879
+#: src/Handlers/CalendarHandler.php:3081
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to %3$s since the year %4$d, "
@@ -990,7 +1032,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Handlers/CalendarHandler.php:2901
+#: src/Handlers/CalendarHandler.php:3103
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been raised to the rank of %3$s since the year %4$d, "
@@ -1005,7 +1047,7 @@ msgstr ""
 #.  5. Requested calendar year
 #.  6. Source of the information
 #.
-#: src/Handlers/CalendarHandler.php:2911
+#: src/Handlers/CalendarHandler.php:3113
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been lowered to the rank of %3$s since the year %4$d, "
@@ -1018,7 +1060,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Handlers/CalendarHandler.php:2964
+#: src/Handlers/CalendarHandler.php:3166
 #, php-format
 msgid ""
 "'%1$s' has been declared a Doctor of the Church since the year %2$d, "
@@ -1035,7 +1077,7 @@ msgstr ""
 #.  7. Year from which the liturgical event has been added
 #.  8. Source of the information
 #.
-#: src/Handlers/CalendarHandler.php:3130
+#: src/Handlers/CalendarHandler.php:3332
 #, php-format
 msgid ""
 "In the year %1$d, the %2$s '%3$s' has been suppressed by the %4$s '%5$s', "
@@ -1043,7 +1085,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Handlers/CalendarHandler.php:3202
+#: src/Handlers/CalendarHandler.php:3404
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -1051,7 +1093,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year
-#: src/Handlers/CalendarHandler.php:3218
+#: src/Handlers/CalendarHandler.php:3420
 #, php-format
 msgid ""
 "The optional memorial '%1$s', which would have been superseded this year by "
@@ -1060,7 +1102,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information, 3: Requested calendar year, 4: Coinciding LiturgicalEvent grade, 5: Coinciding LiturgicalEvent name
-#: src/Handlers/CalendarHandler.php:3236
+#: src/Handlers/CalendarHandler.php:3438
 #, php-format
 msgid ""
 "The optional memorial '%1$s' has been transferred from Dec. 12 to Aug. 12 "
@@ -1069,7 +1111,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Source of the information
-#: src/Handlers/CalendarHandler.php:3275
+#: src/Handlers/CalendarHandler.php:3477
 #, php-format
 msgid ""
 "The Feast '%1$s' would have been suppressed this year ( 2009 ) since it "
@@ -1078,19 +1120,19 @@ msgid ""
 "the memorial."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:3490
+#: src/Handlers/CalendarHandler.php:3692
 msgid "Saturday Memorial of the Blessed Virgin Mary"
 msgstr ""
 
 #. translators: 1: wider_region, 2: metadata, 3: calendar_id
-#: src/Handlers/CalendarHandler.php:3565
+#: src/Handlers/CalendarHandler.php:3767
 #, php-format
 msgid ""
 "Could not find a %1$s property in the %2$s for the National Calendar %3$s."
 msgstr ""
 
 #. translators: 1: Event key, 2: Original date, 3: New date, 4: Requested calendar year
-#: src/Handlers/CalendarHandler.php:3595
+#: src/Handlers/CalendarHandler.php:3797
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved from %2$s to %3$s due to "
@@ -1106,7 +1148,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Handlers/CalendarHandler.php:3658
+#: src/Handlers/CalendarHandler.php:3860
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -1123,7 +1165,7 @@ msgstr ""
 #.  6. Requested calendar year
 #.  7. National or wider region calendar
 #.
-#: src/Handlers/CalendarHandler.php:3678
+#: src/Handlers/CalendarHandler.php:3880
 #, php-format
 msgid ""
 "The %1$s '%2$s', usually celebrated on %3$s, was suppressed by the %4$s "
@@ -1137,7 +1179,7 @@ msgstr ""
 #.  3. Requested calendar year
 #.  4. Source of the information
 #.
-#: src/Handlers/CalendarHandler.php:3762
+#: src/Handlers/CalendarHandler.php:3964
 #, php-format
 msgid ""
 "The Memorial '%1$s' coincides with another Memorial '%2$s' in the year %3$d. "
@@ -1145,7 +1187,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
-#: src/Handlers/CalendarHandler.php:3785
+#: src/Handlers/CalendarHandler.php:3987
 #, php-format
 msgid ""
 "The Feast '%1$s', usually celebrated on %2$s, coincides with another Feast "
@@ -1153,7 +1195,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. LiturgicalEvent name, 2. LiturgicalEvent date, 3. Coinciding liturgical event name, 4. Requested calendar year
-#: src/Handlers/CalendarHandler.php:3805
+#: src/Handlers/CalendarHandler.php:4007
 #, php-format
 msgid ""
 "The Solemnity '%1$s', usually celebrated on %2$s, coincides with the Sunday "
@@ -1161,7 +1203,7 @@ msgid ""
 "this?"
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:3845
+#: src/Handlers/CalendarHandler.php:4047
 #, php-format
 msgid ""
 "Cannot create liturgical event with key \"%1$s\": the day (%2$d) of the "
@@ -1169,7 +1211,7 @@ msgid ""
 "(%4$d) of the liturgical event year (%5$d)."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:3870
+#: src/Handlers/CalendarHandler.php:4072
 msgid ""
 "We should be creating a new liturgical event, however we do not seem to have "
 "the correct date information in order to proceed"
@@ -1181,7 +1223,7 @@ msgstr ""
 #.  3. Date of the liturgical event (localized date for fixed events, or mobile date expression for some mobile events)
 #.  4. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:3928
+#: src/Handlers/CalendarHandler.php:4130
 #, php-format
 msgid ""
 "The %1$s '%2$s' was not added to the calendar on %3$s because it conflicts "
@@ -1196,7 +1238,7 @@ msgstr ""
 #.  5. Year from which the name has been changed
 #.  6. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:3997
+#: src/Handlers/CalendarHandler.php:4199
 #, php-format
 msgid ""
 "The name of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -1210,7 +1252,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:4015
+#: src/Handlers/CalendarHandler.php:4217
 #, php-format
 msgid ""
 "The name of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -1227,7 +1269,7 @@ msgstr ""
 #.  6. Source of the information
 #.  7. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:4045
+#: src/Handlers/CalendarHandler.php:4247
 #, php-format
 msgid ""
 "The grade of the %1$s '%2$s' has been changed to '%3$s' in the national "
@@ -1241,7 +1283,7 @@ msgstr ""
 #.  4. Year from which the name has been changed
 #.  5. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:4064
+#: src/Handlers/CalendarHandler.php:4266
 #, php-format
 msgid ""
 "The grade of the celebration '%1$s' has been changed to '%2$s' in the "
@@ -1258,7 +1300,7 @@ msgstr ""
 #.  6. ID of the national calendar
 #.  7. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:4099
+#: src/Handlers/CalendarHandler.php:4301
 #, php-format
 msgid ""
 "The %1$s '%2$s' has been moved from %3$s to %4$s since the year %5$d in the "
@@ -1272,7 +1314,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:4118
+#: src/Handlers/CalendarHandler.php:4320
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -1287,7 +1329,7 @@ msgstr ""
 #.  4. ID of the national calendar
 #.  5. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:4149
+#: src/Handlers/CalendarHandler.php:4351
 #, php-format
 msgid ""
 "The liturgical event '%1$s' has been moved to %2$s since the year %3$d in "
@@ -1297,13 +1339,13 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Country name, 2. List of missals
-#: src/Handlers/CalendarHandler.php:4188
+#: src/Handlers/CalendarHandler.php:4390
 #, php-format
 msgid "Found Missals for region %1$s: %2$s."
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Handlers/CalendarHandler.php:4212
+#: src/Handlers/CalendarHandler.php:4414
 #, php-format
 msgid "Found a sanctorale data file for %s"
 msgstr ""
@@ -1317,7 +1359,7 @@ msgstr ""
 #.  6. Superseding liturgical event name
 #.  7. Requested calendar year
 #.
-#: src/Handlers/CalendarHandler.php:4248
+#: src/Handlers/CalendarHandler.php:4450
 #, php-format
 msgid ""
 "The %1$s '%2$s' (%3$s), added to the national calendar in the %4$s, is "
@@ -1325,13 +1367,13 @@ msgid ""
 msgstr ""
 
 #. translators: Name of the Roman Missal
-#: src/Handlers/CalendarHandler.php:4262
+#: src/Handlers/CalendarHandler.php:4464
 #, php-format
 msgid "Could not find a sanctorale data file for %s"
 msgstr ""
 
 #. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. New liturgical event name, 4: Requested calendar year, 5. Old date, 6. New date
-#: src/Handlers/CalendarHandler.php:4336
+#: src/Handlers/CalendarHandler.php:4538
 #, php-format
 msgid ""
 "The %1$s '%2$s' is transferred from %5$s to %6$s as per the %7$s, to make "
@@ -1339,7 +1381,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. LiturgicalEvent grade, 2. LiturgicalEvent name, 3. Old date, 4. New date, 5. Source of the information, 6. New liturgical event name, 7. Superseding liturgical event grade, 8. Superseding liturgical event name, 9: Requested calendar year
-#: src/Handlers/CalendarHandler.php:4354
+#: src/Handlers/CalendarHandler.php:4556
 #, php-format
 msgid ""
 "The %1$s '%2$s' would have been transferred from %3$s to %4$s as per the "
@@ -1348,7 +1390,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Name of the mobile liturgical event being created, 2. Name of the liturgical event that it is relative to
-#: src/Handlers/CalendarHandler.php:4552
+#: src/Handlers/CalendarHandler.php:4754
 #, php-format
 msgid ""
 "Cannot create mobile liturgical event '%1$s' relative to liturgical event "
@@ -1356,7 +1398,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1. Name of the mobile liturgical event being created, 2. event_key of the liturgical event that it is relative to, 3. List of valid keywords
-#: src/Handlers/CalendarHandler.php:4568
+#: src/Handlers/CalendarHandler.php:4770
 #, php-format
 msgid ""
 "Cannot create mobile liturgical event '%1$s': the `strtotime.relative_time` "
@@ -1365,7 +1407,7 @@ msgid ""
 msgstr ""
 
 #. translators: Do not translate 'strtotime'! 1. Name of the mobile liturgical event being created
-#: src/Handlers/CalendarHandler.php:4646
+#: src/Handlers/CalendarHandler.php:4848
 #, php-format
 msgid ""
 "Cannot create mobile liturgical event '%1$s': 'strtotime' property must be "
@@ -1373,7 +1415,7 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent name, 2: Name of the diocese, 3: LiturgicalEvent date, 4: Coinciding liturgical event name, 5: Requested calendar year
-#: src/Handlers/CalendarHandler.php:4726
+#: src/Handlers/CalendarHandler.php:4939
 #, php-format
 msgid ""
 "The Solemnity '%1$s', proper to the calendar of the %2$s and usually "
@@ -1382,18 +1424,18 @@ msgid ""
 msgstr ""
 
 #. translators: 1: LiturgicalEvent grade, 2: LiturgicalEvent name, 3: Name of the diocese, 4: LiturgicalEvent date, 5: Coinciding liturgical event name, 6: Requested calendar year
-#: src/Handlers/CalendarHandler.php:4751
+#: src/Handlers/CalendarHandler.php:4964
 #, php-format
 msgid ""
 "The %1$s '%2$s', proper to the calendar of the %3$s and usually celebrated "
 "on %4$s, is suppressed by the %5$s %6$s in the year %7$d."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:5139
+#: src/Handlers/CalendarHandler.php:5352
 msgid "Error converting Liturgical Calendar to XML."
 msgstr ""
 
-#: src/Handlers/CalendarHandler.php:5170
+#: src/Handlers/CalendarHandler.php:5383
 msgid "Error serializing Liturgical Calendar."
 msgstr ""
 
@@ -1412,6 +1454,7 @@ msgstr ""
 #. translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..."
 #: src/Models/Calendar/LitCommons.php:228
 #: src/Models/Calendar/LiturgicalEvent.php:160
+#: src/Models/Calendar/LiturgicalEventCollection.php:850
 #: src/Models/Calendar/Temporale/RomanTemporale.php:256
 #: src/Models/EventsPath/LiturgicalEventAbstract.php:104 src/Utilities.php:450
 #: src/Utilities.php:456
@@ -1419,15 +1462,15 @@ msgid "or"
 msgstr ""
 
 #. translators: in reference to the cycle of liturgical years (A, B, C; I, II)
-#: src/Models/Calendar/LiturgicalEventCollection.php:172
+#: src/Models/Calendar/LiturgicalEventCollection.php:173
 msgid "YEAR"
 msgstr ""
 
-#: src/Models/Calendar/LiturgicalEventCollection.php:173
+#: src/Models/Calendar/LiturgicalEventCollection.php:174
 msgid "Vigil Mass"
 msgstr ""
 
-#: src/Models/Calendar/LiturgicalEventCollection.php:1730
+#: src/Models/Calendar/LiturgicalEventCollection.php:1744
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
@@ -1435,7 +1478,7 @@ msgid ""
 "is confirmed as are I Vespers."
 msgstr ""
 
-#: src/Models/Calendar/LiturgicalEventCollection.php:1745
+#: src/Models/Calendar/LiturgicalEventCollection.php:1759
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
@@ -1444,7 +1487,7 @@ msgid ""
 "or an evening Mass."
 msgstr ""
 
-#: src/Models/Calendar/LiturgicalEventCollection.php:1755
+#: src/Models/Calendar/LiturgicalEventCollection.php:1769
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "
@@ -1453,7 +1496,7 @@ msgid ""
 "Vigil Mass or Vespers I."
 msgstr ""
 
-#: src/Models/Calendar/LiturgicalEventCollection.php:1840
+#: src/Models/Calendar/LiturgicalEventCollection.php:1854
 #, php-format
 msgid ""
 "The Vigil Mass for the %1$s '%2$s' coincides with the %3$s '%4$s' in the "


### PR DESCRIPTION
Automated update of `i18n/litcal.pot` translation template from source PHP files.

This PR was generated by the `gettext_update` CI job and is
auto-merged: the .pot is deterministic xgettext output with no
behavioural code, so there is nothing for CI to validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the translation catalogue date and refreshed references.
  * Added and revised messages for diocesan and national calendar validation.
  * Improved translated feedback for liturgical transfers, event conflicts, mobile events, serialisation errors and Vigil Mass precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->