### PR TITLE
fix(health): stop requiring an id on a rite-level calendar identity

### DIFF
--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -113,8 +113,18 @@ final class HealthTypedCalendarTest extends TestCase
                 ['kind' => 'rite', 'id' => 'ambrosian', 'rite' => 'ambrosian'],
                 '/ambrosian/2026?year_type=CIVIL'
             ],
-            // `general` names the one General Roman Calendar, so it is the only kind that needs no
-            // id: there is nothing to choose between.
+            // The shape UnitTestInterface actually sends for a rite-level calendar: `toCalendarIdentity()`
+            // maps the calendar select's empty option to `{kind: 'rite', rite}` and composes no id,
+            // because for this kind there is nothing to compose one from — the rite *is* the identity,
+            // and `calendarIdentity` in WebSocketMessage.json requires only `kind` and `rite`. This
+            // row is here because requiring an id for `rite` refused every General Roman Calendar run
+            // the client could start, while every existing row happened to carry one.
+            'rite level, no id'  => [
+                ['kind' => 'rite', 'rite' => 'roman'],
+                '/roman/2026?year_type=CIVIL'
+            ],
+            // `general` names the one General Roman Calendar, so it too needs no id: there is
+            // nothing to choose between.
             'general'            => [
                 ['kind' => 'general', 'rite' => 'roman'],
                 '/roman/2026?year_type=CIVIL'

--- a/src/Health.php
+++ b/src/Health.php
@@ -2513,9 +2513,15 @@ class Health implements MessageComponentInterface
                 // to the default for this category.
                 return Rite::default();
             case 'rite':
+                if (null === $id) {
+                    // The identity carried no id, which is legal for this kind: `calendar.rite`
+                    // alone names the calendar. There is therefore no second source of truth to
+                    // contradict the assertion with, which is exactly what null means here.
+                    return null;
+                }
                 // For a rite-level calendar the id *is* the rite, so an id that names no rite is
                 // not a rite disagreement — it is an identity that describes nothing.
-                $rite = Rite::tryFrom((string) $id);
+                $rite = Rite::tryFrom($id);
                 if (null === $rite) {
                     throw new \InvalidArgumentException("Unknown rite calendar: {$id}");
                 }
@@ -2579,9 +2585,14 @@ class Health implements MessageComponentInterface
         if (null !== $id && false === is_string($id)) {
             throw new \InvalidArgumentException('calendar.id must be a string.');
         }
-        // `general` is the only kind that needs no id: there is exactly one General Roman Calendar,
-        // so there is nothing to choose between. Every other kind names one of many.
-        if (null === $id && 'general' !== $kind) {
+        // `national` and `diocesan` are the only kinds that need an id: each names one of many.
+        // `general` names the single General Roman Calendar, and `rite` is already fully identified
+        // by `calendar.rite` — the rite *is* the identity, which is why the return below passes the
+        // rite as the calendar id rather than reading `$id` at all. Requiring an id for `rite`
+        // contradicted both that and the published schema, whose `calendarIdentity` requires only
+        // `kind` and `rite`; it refused every rite-level calendar the client could send
+        // (UnitTestInterface, General Roman Calendar run).
+        if (null === $id && in_array($kind, ['national', 'diocesan'], true)) {
             throw new \InvalidArgumentException("calendar.id is required for kind {$kind}.");
         }
 


### PR DESCRIPTION
## The failure

Every calendar-data request of a General Roman Calendar run on the live UnitTestInterface was refused:

```text
{type: 'protocolError', errorCode: 'invalid_message', text: 'calendar.id is required for kind rite.'}
… × 82
No frame has arrived for 60s; 82 request(s) never answered in full, leaving 246 check(s) unreported.
```

## Cause

`resolveCalendarIdentity()` required `calendar.id` for every kind except `general`. The client composes
`{kind: 'rite', rite: 'roman'}` for a rite-level calendar — and it is the only identity it *can* compose for
that kind, because the rite **is** the identity. `toCalendarIdentity()` in UnitTestInterface maps the calendar
select's empty option to exactly that shape.

The guard contradicted two things at once:

- **The published schema.** `calendarIdentity` in `jsondata/schemas/WebSocketMessage.json` requires only
  `kind` and `rite`; `id` is optional.
- **The function's own return.** For `ritecalendar` it passes `$assertedRite->value` as the calendar id and
  never reads `$id` at all — as its own comment says, "A rite-level calendar carries no separate identifier".

So the server demanded a property it had already documented as optional and then discarded.

## Fix

- Require an id only for `national` and `diocesan`, the two kinds that each name one of many. `general` names
  the single General Roman Calendar; `rite` is fully identified by `calendar.rite`.
- `actualRiteForKind()` returns null — "no second source of truth to contradict the assertion with" — for a
  rite-level identity carrying no id, rather than failing `Rite::tryFrom('')` and reporting the identity as
  describing nothing. Without this the first change would only have swapped one rejection for another.

## Test

`HealthTypedCalendarTest::typedIdentityProvider()` gained a `rite level, no id` row asserting
`{kind: 'rite', rite: 'roman'}` reaches `/roman/2026?year_type=CIVIL`. Every existing row happened to carry an
id, which is why the gap survived.

```text
vendor/bin/phpunit --filter Health
OK (480 tests, 2882 assertions)
```

`phpcs` clean.

## Related

The client's handling of the resulting rejections is a separate defect — a `protocolError` naming a `requestId`
never resolves that request, so the phase waits out the full 60s watchdog instead of failing in half a second.
Filed as UnitTestInterface#70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rite-level calendar identities can now be processed without a calendar ID.
  * Roman calendar requests are correctly resolved from the selected rite.
  * Calendar IDs remain required for national and diocesan identities.
  * Improved validation ensures supplied rite IDs match known rites.

* **Tests**
  * Added coverage for rite-level identities with and without calendar IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->