### PR TITLE
refactor(models): re-derive dependent fields from a mapping instead of per-property special cases

### DIFF
--- a/phpunit_tests/Handlers/EventsHandlerDerivedGradeConsistencyTest.php
+++ b/phpunit_tests/Handlers/EventsHandlerDerivedGradeConsistencyTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Handlers\EventsHandler;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * `/events` serializes `grade` next to `grade_lcl` and `grade_abbr`, which the catalog model
+ * derives from it. `EventsHandler` applies decree, wider-region and national `setProperty:grade`
+ * (and `makePatron`) rows by assigning `$event->grade` directly, which does not bring those labels
+ * with it — so the catalog could publish a FEAST whose own label still read "Memorial" (#872).
+ *
+ * These tests assert the invariant over the whole catalog rather than over the one event that
+ * happens to be affected today: every entry's labels must be the ones its OWN grade produces.
+ * Latin is requested so the expected strings come from `LitGrade`'s hardcoded Latin branch rather
+ * than from process-global gettext state.
+ */
+#[CoversClass(EventsHandler::class)]
+final class EventsHandlerDerivedGradeConsistencyTest extends AbstractHandlerTestCase
+{
+    /**
+     * Returns the catalog keyed by `event_key`, along with the locale the response says it was
+     * rendered in — which is NOT always the requested one: a national calendar that does not
+     * support Latin resolves to its own locale, and the labels must then match THAT.
+     *
+     * @param array<int, string> $pathParams
+     * @return array{0: array<string, array<string, mixed>>, 1: string}
+     */
+    private function catalogByKey(array $pathParams, string $uri): array
+    {
+        $response = ( new EventsHandler($pathParams) )->handle(
+            $this->requestFor('GET', $uri, ['Accept-Language' => 'la'])
+        );
+        self::assertSame(200, $response->getStatusCode());
+
+        $body  = $this->decodeJsonBody($response);
+        $byKey = [];
+        foreach ($body['litcal_events'] as $event) {
+            $byKey[$event['event_key']] = $event;
+        }
+        self::assertNotEmpty($byKey);
+
+        return [$byKey, $body['settings']['locale']];
+    }
+
+    /**
+     * @param array<string, array<string, mixed>> $catalog
+     */
+    private function assertGradeLabelsMatchGrade(array $catalog, string $locale, string $context): void
+    {
+        foreach ($catalog as $eventKey => $event) {
+            $grade = LitGrade::from($event['grade']);
+            self::assertSame(
+                $grade->i18n($locale, false, false),
+                $event['grade_lcl'],
+                sprintf('%s: `%s` publishes grade %d with the label of a different grade.', $context, $eventKey, $event['grade'])
+            );
+            self::assertSame(
+                $grade->i18n($locale, false, true),
+                $event['grade_abbr'],
+                sprintf('%s: `%s` publishes grade %d with the abbreviation of a different grade.', $context, $eventKey, $event['grade'])
+            );
+        }
+    }
+
+    /**
+     * The live instance of the defect: the 2016 decree raising St Mary Magdalene from a memorial to
+     * a feast is applied as a bare `grade` assignment, leaving her memorial labels in place.
+     */
+    public function testADecreeRaisedGradeCarriesItsOwnLabels(): void
+    {
+        [$catalog] = $this->catalogByKey([], '/events');
+
+        self::assertArrayHasKey('StMaryMagdalene', $catalog);
+        self::assertSame(LitGrade::FEAST->value, $catalog['StMaryMagdalene']['grade'], 'the decree raising St Mary Magdalene to a feast must have been applied');
+        self::assertSame(LitGrade::FEAST->i18n('la', false, false), $catalog['StMaryMagdalene']['grade_lcl']);
+        self::assertSame(LitGrade::FEAST->i18n('la', false, true), $catalog['StMaryMagdalene']['grade_abbr']);
+    }
+
+    public function testGeneralCatalogGradeLabelsAreConsistent(): void
+    {
+        [$catalog, $locale] = $this->catalogByKey([], '/events');
+        $this->assertGradeLabelsMatchGrade($catalog, $locale, 'general catalog');
+    }
+
+    public function testNationalCatalogGradeLabelsAreConsistent(): void
+    {
+        [$catalog, $locale] = $this->catalogByKey(['nation', 'US'], '/events/nation/US');
+        $this->assertGradeLabelsMatchGrade($catalog, $locale, 'US national catalog');
+
+        [$catalog, $locale] = $this->catalogByKey(['nation', 'IT'], '/events/nation/IT');
+        $this->assertGradeLabelsMatchGrade($catalog, $locale, 'IT national catalog');
+    }
+}

--- a/phpunit_tests/Models/Calendar/LiturgicalEventCollectionSetPropertyDerivationTest.php
+++ b/phpunit_tests/Models/Calendar/LiturgicalEventCollectionSetPropertyDerivationTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar;
+
+use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Enum\LitColor;
+use LiturgicalCalendar\Api\Enum\LitCommon;
+use LiturgicalCalendar\Api\Enum\LitEventType;
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Models\Calendar\LitCommons;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Models\Lectionary\ReadingsCommons;
+use LiturgicalCalendar\Api\Params\CalendarParams;
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * `LiturgicalEvent` derives several serialized fields from other properties, and
+ * `LiturgicalEventCollection::setProperty()` writes those source properties by reflection, behind
+ * the constructor's back (#872). These tests pin the invariant that makes that safe: after a write,
+ * every dependent field must read exactly as it would have if the event had been CONSTRUCTED with
+ * the new value — which is why each assertion compares against a freshly constructed reference
+ * event rather than against a hardcoded localized string (the model's locale is process-global
+ * static state, so a literal expectation would be order-dependent).
+ */
+#[CoversClass(LiturgicalEventCollection::class)]
+final class LiturgicalEventCollectionSetPropertyDerivationTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+    }
+
+    private function makeCollection(): LiturgicalEventCollection
+    {
+        $params = new CalendarParams();
+        $params->setParams(['year' => 2025, 'locale' => 'en']);
+
+        return new LiturgicalEventCollection($params);
+    }
+
+    /**
+     * @param LitColor|LitColor[] $color
+     */
+    private function makeEvent(
+        LitColor|array $color = LitColor::RED,
+        LitGrade $grade = LitGrade::FEAST,
+        ?string $displayGrade = null
+    ): LiturgicalEvent {
+        $common = LitCommons::create(['Martyrs:For Several Martyrs']);
+        self::assertNotNull($common);
+
+        $event            = new LiturgicalEvent('Test Event', new DateTime('2025-06-19'), $color, LitEventType::FIXED, $grade, $common, $displayGrade);
+        $event->event_key = 'TestEvent';
+        $event->setReadings(new ReadingsCommons(LitCommons::create([LitCommon::NONE])));
+
+        return $event;
+    }
+
+    public function testSetPropertyColorAlsoRefreshesTheLocalizedColor(): void
+    {
+        $cal = $this->makeCollection();
+        $cal->addLiturgicalEvent('TestEvent', $this->makeEvent(LitColor::RED));
+
+        $before = $cal->getLiturgicalEvent('TestEvent')->jsonSerialize()['color_lcl'];
+
+        self::assertTrue($cal->setProperty('TestEvent', 'color', [LitColor::WHITE]));
+
+        $after = $cal->getLiturgicalEvent('TestEvent')->jsonSerialize()['color_lcl'];
+        self::assertNotSame($before, $after, 'color_lcl must be re-derived after a `color` setProperty write, not left describing the previous colour.');
+        self::assertSame(
+            $this->makeEvent(LitColor::WHITE)->jsonSerialize()['color_lcl'],
+            $after,
+            'color_lcl after a write must equal what the constructor would have derived for the same colour.'
+        );
+    }
+
+    public function testSetPropertyGradeAlsoRefreshesTheLocalizedGradeFields(): void
+    {
+        $cal = $this->makeCollection();
+        $cal->addLiturgicalEvent('TestEvent', $this->makeEvent(LitColor::RED, LitGrade::FEAST));
+
+        self::assertTrue($cal->setProperty('TestEvent', 'grade', LitGrade::MEMORIAL));
+
+        $after     = $cal->getLiturgicalEvent('TestEvent')->jsonSerialize();
+        $reference = $this->makeEvent(LitColor::RED, LitGrade::MEMORIAL)->jsonSerialize();
+        self::assertSame($reference['grade_lcl'], $after['grade_lcl']);
+        self::assertSame($reference['grade_abbr'], $after['grade_abbr']);
+    }
+
+    public function testSetPropertyCommonAlsoRefreshesTheLocalizedCommon(): void
+    {
+        $cal = $this->makeCollection();
+        $cal->addLiturgicalEvent('TestEvent', $this->makeEvent());
+
+        $newCommon = LitCommons::create(['Proper']);
+        self::assertNotNull($newCommon);
+
+        $reference            = new LiturgicalEvent('Test Event', new DateTime('2025-06-19'), LitColor::RED, LitEventType::FIXED, LitGrade::FEAST, $newCommon);
+        $reference->event_key = 'TestEvent';
+        $reference->setReadings(new ReadingsCommons(LitCommons::create([LitCommon::NONE])));
+
+        self::assertTrue($cal->setProperty('TestEvent', 'common', $newCommon));
+
+        self::assertSame(
+            $reference->jsonSerialize()['common_lcl'],
+            $cal->getLiturgicalEvent('TestEvent')->jsonSerialize()['common_lcl'],
+            'common_lcl after a write must equal what the constructor would have derived for the same Common.'
+        );
+    }
+
+    /**
+     * An explicit `grade_display` override is authored, not derived: nothing can recompute it from
+     * the grade. The constructor's one grade-coupled rule is that a HIGHER_SOLEMNITY clears it to
+     * `''`; every other grade leaves the caller's value alone. A `grade` write must mirror exactly
+     * that, so an override survives an ordinary grade change (as `AllSouls` and `DedicationLateran`
+     * rely on) while a promotion to HIGHER_SOLEMNITY still clears it.
+     */
+    public function testGradeWriteLeavesAnExplicitGradeDisplayOverrideInPlace(): void
+    {
+        $cal = $this->makeCollection();
+        $cal->addLiturgicalEvent('TestEvent', $this->makeEvent(LitColor::RED, LitGrade::FEAST, 'Some Explicit Override'));
+
+        self::assertTrue($cal->setProperty('TestEvent', 'grade', LitGrade::MEMORIAL));
+
+        self::assertSame(
+            'Some Explicit Override',
+            $cal->getLiturgicalEvent('TestEvent')->jsonSerialize()['grade_display'],
+            'an explicit grade_display override must survive a non-HIGHER_SOLEMNITY grade change.'
+        );
+    }
+
+    public function testGradeWriteToHigherSolemnityClearsGradeDisplay(): void
+    {
+        $cal = $this->makeCollection();
+        $cal->addLiturgicalEvent('TestEvent', $this->makeEvent(LitColor::RED, LitGrade::FEAST, 'Some Explicit Override'));
+
+        self::assertTrue($cal->setProperty('TestEvent', 'grade', LitGrade::HIGHER_SOLEMNITY));
+
+        self::assertSame(
+            '',
+            $cal->getLiturgicalEvent('TestEvent')->jsonSerialize()['grade_display'],
+            'grade_display must be cleared to \'\' for HIGHER_SOLEMNITY, mirroring the constructor.'
+        );
+    }
+
+    /**
+     * `setProperty()` answers "did anything change?" for the caller. For an object-valued property
+     * that answer has to be about the VALUE: a freshly built `LitCommons` carrying exactly the same
+     * Commons is never `===` the stored one, so an identity comparison reports a change that did
+     * not happen, and callers are left to compare serialized values at each call site (#872).
+     */
+    public function testSetPropertyReportsNoChangeForAnEquivalentObjectValue(): void
+    {
+        $cal = $this->makeCollection();
+        $cal->addLiturgicalEvent('TestEvent', $this->makeEvent());
+
+        $equivalentCommon = LitCommons::create(['Martyrs:For Several Martyrs']);
+        self::assertNotNull($equivalentCommon);
+
+        self::assertFalse(
+            $cal->setProperty('TestEvent', 'common', $equivalentCommon),
+            'setProperty() must report false for a Common equivalent to the one already stored, even though it is a different object.'
+        );
+    }
+}

--- a/phpunit_tests/Models/DerivedFieldCoverageTest.php
+++ b/phpunit_tests/Models/DerivedFieldCoverageTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models;
+
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use LiturgicalCalendar\Api\Models\DerivedField;
+use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventAbstract;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The structural half of the guarantee that a derived field cannot silently stop being re-derived
+ * (#872).
+ *
+ * The other half is enforced by the type system: {@see DerivedField} is a closed enum, and
+ * {@see \LiturgicalCalendar\Api\Models\DerivesLiturgicalFieldsTrait::rederive()} dispatches over it
+ * with a `match` carrying no `default` arm, so adding a case without adding its derivation is a
+ * PHPStan `match.unhandled` error at analysis time and an `\UnhandledMatchError` at runtime.
+ *
+ * What the type system cannot see is the step BEFORE that: declaring a new derived property on a
+ * model and never adding a `DerivedField` case for it at all. These tests close that gap from both
+ * ends — every derived property must have a case, and every case must be reachable from some source
+ * property, so a case that exists but is wired to nothing is caught too.
+ */
+#[CoversClass(DerivedField::class)]
+final class DerivedFieldCoverageTest extends TestCase
+{
+    /**
+     * The two models that carry derived fields. Both use `DerivesLiturgicalFieldsTrait`; listing
+     * them explicitly means a third model that copies the pattern without the trait still has to be
+     * added here consciously.
+     *
+     * @return array<string, array{class-string}>
+     */
+    public static function modelProvider(): array
+    {
+        return [
+            'Calendar\LiturgicalEvent'           => [LiturgicalEvent::class],
+            'EventsPath\LiturgicalEventAbstract' => [LiturgicalEventAbstract::class],
+        ];
+    }
+
+    /**
+     * On both models the derived fields are exactly the non-public instance properties: the raw
+     * source properties they are derived from are all public, and the localized companions are not.
+     * So any non-public instance property that is NOT a declared `DerivedField` is either a new
+     * derived field nobody wired up, or a property that needs an explicit exemption here.
+     *
+     * @param class-string $model
+     */
+    #[DataProvider('modelProvider')]
+    public function testEveryNonPublicInstancePropertyIsADeclaredDerivedField(string $model): void
+    {
+        $reflection = new \ReflectionClass($model);
+        $checked    = 0;
+
+        foreach ($reflection->getProperties() as $property) {
+            if ($property->isStatic() || $property->isPublic()) {
+                continue;
+            }
+
+            ++$checked;
+            self::assertNotNull(
+                DerivedField::tryFrom($property->getName()),
+                sprintf(
+                    '%s::$%s is a non-public instance property of a liturgical event model, which on these models means a DERIVED field, '
+                    . 'but there is no DerivedField case for it — so nothing re-derives it after a write to whatever it is derived from. '
+                    . 'Add the case (and its arm in DerivesLiturgicalFieldsTrait::rederive()), or exempt the property here deliberately.',
+                    $model,
+                    $property->getName()
+                )
+            );
+        }
+
+        self::assertGreaterThan(0, $checked, $model . ' declares no non-public instance properties: this test is no longer checking anything.');
+    }
+
+    /**
+     * `grade_display` is public (clients read it, and `CalendarHandler` writes it directly for
+     * `AllSouls`), so the property sweep above cannot see it. It is nonetheless grade-coupled, and
+     * the coupling is the one decided in #872: a grade write clears it to `''` for a
+     * HIGHER_SOLEMNITY and otherwise leaves an explicit override alone.
+     */
+    public function testGradeDisplayIsWiredAsADependentOfGrade(): void
+    {
+        self::assertContains(DerivedField::GRADE_DISPLAY, DerivedField::dependentsOf('grade'));
+    }
+
+    /**
+     * A case that no source property invalidates would never be re-derived, however complete its
+     * `rederive()` arm looks.
+     */
+    public function testEveryDerivedFieldCaseIsReachableFromASourceProperty(): void
+    {
+        $reachable = [];
+        foreach (DerivedField::sourceProperties() as $sourceProperty) {
+            foreach (DerivedField::dependentsOf($sourceProperty) as $derivedField) {
+                $reachable[] = $derivedField;
+            }
+        }
+
+        foreach (DerivedField::cases() as $case) {
+            self::assertContains(
+                $case,
+                $reachable,
+                sprintf('DerivedField::%s is not listed as a dependent of any source property, so nothing would ever re-derive it.', $case->name)
+            );
+        }
+    }
+
+    public function testAnUnknownSourcePropertyHasNoDependents(): void
+    {
+        self::assertSame([], DerivedField::dependentsOf('psalter_week'));
+    }
+}

--- a/phpunit_tests/Models/EventsPath/LiturgicalEventAbstractMutatorTest.php
+++ b/phpunit_tests/Models/EventsPath/LiturgicalEventAbstractMutatorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Models\EventsPath;
 
+use LiturgicalCalendar\Api\Enum\LitColor;
 use LiturgicalCalendar\Api\Enum\LitGrade;
 use LiturgicalCalendar\Api\Models\Calendar\LitCommons;
 use LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventFixed;
@@ -94,5 +95,37 @@ final class LiturgicalEventAbstractMutatorTest extends TestCase
         $event->applyName('Ss. Protaso e Gervaso');
 
         self::assertSame('Ss. Protaso e Gervaso', $event->jsonSerialize()['name']);
+    }
+
+    /**
+     * `color_lcl` is serialized alongside `color` and had no re-derivation of its own before #872,
+     * in either model. No catalog code path writes `$color` today, so this covers the shared
+     * mechanism rather than a live caller: a write to `color` followed by the generic
+     * re-derivation must leave `color_lcl` describing the NEW colour.
+     */
+    public function testRederivingAfterAColorWriteRefreshesTheLocalizedColor(): void
+    {
+        $event  = $this->makeEvent();
+        $before = $event->jsonSerialize()['color_lcl'];
+
+        $event->color = [LitColor::WHITE];
+        $event->rederiveDependentsOf('color');
+
+        $after = $event->jsonSerialize();
+        self::assertSame(['white'], $after['color']);
+        self::assertNotSame($before, $after['color_lcl'], 'color_lcl must be re-derived, not left describing the previous colour.');
+        self::assertSame(
+            LiturgicalEventFixed::fromArray([
+                'event_key' => 'StsProtaseGervase',
+                'name'      => 'Ss. Protaso e Gervaso, martiri',
+                'month'     => 6,
+                'day'       => 19,
+                'grade'     => 4,
+                'color'     => ['white'],
+                'common'    => ['Martyrs:For Several Martyrs'],
+            ])->jsonSerialize()['color_lcl'],
+            $after['color_lcl'],
+            'color_lcl after a write must equal what the constructor would have derived for the same colour.'
+        );
     }
 }

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -1310,7 +1310,7 @@ final class CalendarHandler extends AbstractHandler
         // to (mis-applying) whichever branch happened to be written last.
         match (true) {
             $liturgicalEvent instanceof DiocesanLitCalItemSetPropertyGrade => $this->applySetPropertyGrade($key, $liturgicalEvent, $existingLiturgicalEvent),
-            $liturgicalEvent instanceof DiocesanLitCalItemSetPropertyCommon => $this->applySetPropertyCommon($key, $liturgicalEvent, $existingLiturgicalEvent),
+            $liturgicalEvent instanceof DiocesanLitCalItemSetPropertyCommon => $this->applySetPropertyCommon($key, $liturgicalEvent),
             $liturgicalEvent instanceof DiocesanLitCalItemSetPropertyName => $this->applySetPropertyName($key, $liturgicalEvent),
         };
     }
@@ -1360,27 +1360,14 @@ final class CalendarHandler extends AbstractHandler
      * rather than silently doing nothing, matching {@see self::applySetPropertyGrade()} and the
      * absent-key branch in {@see self::applyAmbrosianDiocesanSetProperty()}.
      *
-     * That redundancy is detected here rather than by `LiturgicalEventCollection::setProperty()`'s
-     * return value, because `setProperty()` decides "did anything change?" with `!==`, which for an
-     * **object** compares identity rather than value. `grade` (a `LitGrade` enum case, so a
-     * singleton) and `name` (a string) compare correctly there; `common` is a `LitCommons` object,
-     * and a freshly built one carrying exactly the same Commons is never `===` the stored one. So
-     * `setProperty()` would report success for a Common that did not actually change, and the
-     * redundant override would go unreported. Comparing the serialized values instead makes this
-     * arm behave like the other two.
-     *
-     * `$existingLiturgicalEvent->common` is typed `LitCommons|array` — the array shape holds
-     * `LitMassVariousNeeds` cases, which a `LitCommons` can never be equivalent to, so a non-`LitCommons`
-     * current value is by definition a real change.
-     *
-     * `setProperty()`'s return is not checked afterwards: its only two `false` conditions are an
-     * absent key (already handled by the caller, which returns before dispatching) and an
-     * identical value (excluded by the equivalence check above), so a `false` here is unreachable.
+     * That redundancy is `LiturgicalEventCollection::setProperty()`'s `false` return, exactly as it
+     * is for the grade and name arms. It used to need a serialized-value comparison here instead,
+     * because `setProperty()` compared object values by identity and so reported success for a
+     * freshly built `LitCommons` carrying exactly the same Commons; it now compares by value (#872).
      */
     private function applySetPropertyCommon(
         string $key,
-        DiocesanLitCalItemSetPropertyCommon $liturgicalEvent,
-        LiturgicalEvent $existingLiturgicalEvent
+        DiocesanLitCalItemSetPropertyCommon $liturgicalEvent
     ): void {
         if (null === $this->DiocesanData) {
             // Defensive only: the sole caller (applyAmbrosianDiocesanSetProperty()) is only ever
@@ -1388,11 +1375,7 @@ final class CalendarHandler extends AbstractHandler
             return;
         }
 
-        $existingCommon = $existingLiturgicalEvent->common;
-        $isRedundant    = $existingCommon instanceof LitCommons
-            && $existingCommon->jsonSerialize() === $liturgicalEvent->common->jsonSerialize();
-
-        if ($isRedundant) {
+        if (false === $this->Cal->setProperty($key, 'common', $liturgicalEvent->common)) {
             /**translators: 1. Diocese name, 2. Event key, 3. Requested calendar year */
             $this->Messages[] = sprintf(
                 _('The diocesan calendar of %1$s declared a `setProperty:common` override for the liturgical event `%2$s` for the year %3$d, but the Common was already set to that value. The override had no effect.'),
@@ -1400,10 +1383,7 @@ final class CalendarHandler extends AbstractHandler
                 $key,
                 $this->CalendarParams->Year
             );
-            return;
         }
-
-        $this->Cal->setProperty($key, 'common', $liturgicalEvent->common);
     }
 
     /**

--- a/src/Handlers/EventsHandler.php
+++ b/src/Handlers/EventsHandler.php
@@ -592,19 +592,19 @@ final class EventsHandler extends AbstractHandler
                 if (null === $existingLiturgicalEvent) {
                     throw new \RuntimeException('Thomas, called Didymus, one of the Twelve, was not with them when Jesus came. - John 20:24');
                 }
-                $existingLiturgicalEvent->name = $names[$key];
+                $existingLiturgicalEvent->applyName($names[$key]);
             } elseif ($decreeItem->liturgical_event instanceof DecreeItemSetPropertyGrade) {
                 $existingLiturgicalEvent = self::$liturgicalEvents->getEvent($key);
                 if (null === $existingLiturgicalEvent) {
                     throw new \RuntimeException('It would seem that Jonah has been swallowed by the whale.');
                 }
-                $existingLiturgicalEvent->grade = $decreeItem->liturgical_event->grade;
+                $existingLiturgicalEvent->applyGrade($decreeItem->liturgical_event->grade);
             } elseif ($decreeItem->liturgical_event instanceof DecreeItemMakeDoctor) {
                 $existingLiturgicalEvent = self::$liturgicalEvents->getEvent($key);
                 if (null === $existingLiturgicalEvent) {
                     throw new \RuntimeException('Is Ishmael lost in the desert again?');
                 }
-                $existingLiturgicalEvent->name = $names[$key];
+                $existingLiturgicalEvent->applyName($names[$key]);
             }
         }
     }
@@ -670,21 +670,21 @@ final class EventsHandler extends AbstractHandler
                         if (null === $existingLiturgicalEvent) {
                             throw new \RuntimeException('“The goat that was sent away presented a type of Him who takes away the sins of men.” – Justin Martyr');
                         }
-                        $existingLiturgicalEvent->grade = $litCalItem->liturgical_event->grade;
+                        $existingLiturgicalEvent->applyGrade($litCalItem->liturgical_event->grade);
                     } elseif ($litCalItem->liturgical_event instanceof LitCalItemSetPropertyName) {
                         $existingLiturgicalEvent = self::$liturgicalEvents->getEvent($litCalItem->liturgical_event->event_key);
                         if (null === $existingLiturgicalEvent) {
                             throw new \RuntimeException('No dove on this ark, did Noah already set it out?');
                         }
-                        $existingLiturgicalEvent->name = $litCalItem->liturgical_event->name;
+                        $existingLiturgicalEvent->applyName($litCalItem->liturgical_event->name);
                     } elseif ($litCalItem->liturgical_event instanceof LitCalItemMakePatron) {
                         $existingLiturgicalEvent = self::$liturgicalEvents->getEvent($litCalItem->liturgical_event->event_key);
                         if (null === $existingLiturgicalEvent) {
                             throw new \RuntimeException('“Son, why have you done this to us? Your father and I have been looking for you with great anxiety.” – Luke 2:48');
                         }
-                        $existingLiturgicalEvent->name = $litCalItem->liturgical_event->name;
+                        $existingLiturgicalEvent->applyName($litCalItem->liturgical_event->name);
                         if (property_exists($litCalItem->liturgical_event, 'grade')) {
-                            $existingLiturgicalEvent->grade = $litCalItem->liturgical_event->grade;
+                            $existingLiturgicalEvent->applyGrade($litCalItem->liturgical_event->grade);
                         }
                     } else {
                         throw new \ValueError('Unknown LitCalItem->liturgical_event type: ' . get_class($litCalItem->liturgical_event));
@@ -716,20 +716,20 @@ final class EventsHandler extends AbstractHandler
                     if (null === $existingLiturgicalEvent) {
                         throw new \RuntimeException("Unknown event key '{$key}' when setting name from National calendar");
                     }
-                    $existingLiturgicalEvent->name = $NationalCalendarI18nData[$key];
+                    $existingLiturgicalEvent->applyName($NationalCalendarI18nData[$key]);
                 } elseif ($litCalItem->liturgical_event instanceof LitCalItemSetPropertyGrade) {
                     $existingLiturgicalEvent = self::$liturgicalEvents->getEvent($key);
                     if (null === $existingLiturgicalEvent) {
                         throw new \RuntimeException("Unknown event key '{$key}' when setting grade from National calendar");
                     }
-                    $existingLiturgicalEvent->grade = $litCalItem->liturgical_event->grade;
+                    $existingLiturgicalEvent->applyGrade($litCalItem->liturgical_event->grade);
                 } elseif ($litCalItem->liturgical_event instanceof LitCalItemMakePatron) {
                     $existingLiturgicalEvent = self::$liturgicalEvents->getEvent($key);
                     if (null === $existingLiturgicalEvent) {
                         throw new \RuntimeException('Rising very early before dawn, he left and went off to a deserted place, where he prayed. Simon and those who were with him pursued him and on finding him said, “Everyone is looking for you.” - Mark 1:35-37');
                     }
-                    $existingLiturgicalEvent->name  = $NationalCalendarI18nData[$key];
-                    $existingLiturgicalEvent->grade = $litCalItem->liturgical_event->grade;
+                    $existingLiturgicalEvent->applyName($NationalCalendarI18nData[$key]);
+                    $existingLiturgicalEvent->applyGrade($litCalItem->liturgical_event->grade);
                 } elseif ($litCalItem->liturgical_event instanceof LitCalItemMoveEvent) {
                     // Do nothing
                 } else {

--- a/src/Models/Calendar/LiturgicalEvent.php
+++ b/src/Models/Calendar/LiturgicalEvent.php
@@ -12,6 +12,7 @@ use LiturgicalCalendar\Api\Enum\LitSeason;
 use LiturgicalCalendar\Api\Enum\LitMassVariousNeeds;
 use LiturgicalCalendar\Api\Http\Exception\ValidationException;
 use LiturgicalCalendar\Api\LatinUtils;
+use LiturgicalCalendar\Api\Models\DerivesLiturgicalFieldsTrait;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemCreateNewFixed;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemCreateNewMobile;
 use LiturgicalCalendar\Api\Models\Lectionary\ReadingsAbstract;
@@ -29,6 +30,14 @@ use LiturgicalCalendar\Api\Models\RegionalData\DiocesanData\DiocesanLitCalItemCr
 
 final class LiturgicalEvent implements \JsonSerializable
 {
+    /**
+     * `$color_lcl`, `$grade_lcl`, `$grade_abbr` and `$common_lcl` — the fields derived from
+     * `$color`, `$grade` and `$common` — together with `$locale` and the one implementation of
+     * each derivation, shared with the `/events` catalog model so the two endpoints cannot
+     * describe the same event differently (#872).
+     */
+    use DerivesLiturgicalFieldsTrait;
+
     public int $event_idx;
 
     /** The following properties are generally passed in the constructor */
@@ -75,14 +84,6 @@ final class LiturgicalEvent implements \JsonSerializable
     public ?LitSeason $liturgical_season = null;
     public bool $holy_day_of_obligation  = false;
 
-    /** The following properties are set based on properties passed in the constructor or on other properties */
-    private string $grade_lcl;
-    /** @var string[] */
-    private array $color_lcl;
-    private string $grade_abbr;
-    private string $common_lcl;
-
-    private static string $locale = LitLocale::LATIN_PRIMARY_LANGUAGE;
     private static \IntlDateFormatter $dayOfTheWeekShort;
     private static \IntlDateFormatter $dayOfTheWeekLong;
     private static \IntlDateFormatter $monthShort;
@@ -122,82 +123,39 @@ final class LiturgicalEvent implements \JsonSerializable
             }
         }
 
-        $this->event_idx     = self::$internal_index++;
-        $this->name          = $name;
-        $this->date          = $date; //DateTime object
-        $this->color         = is_array($color) ? $color : [$color];
-        $this->color_lcl     = array_map(
-            function (LitColor $item): string {
-                return $item->i18n(self::$locale);
-            },
-            $this->color
-        );
-        $this->type          = $type;
-        $this->grade         = $grade;
-        $this->grade_lcl     = $this->grade->i18n(self::$locale, false, false);
-        $this->grade_abbr    = $this->grade->i18n(self::$locale, false, true);
-        $this->grade_display = $this->grade === LitGrade::HIGHER_SOLEMNITY ? '' : $displayGrade;
-        $commons             = $common instanceof LitCommons || $common instanceof LitMassVariousNeeds || $litMassVariousNeedsArray
-                                ? $common
-                                : ( is_array($common) ? LitCommons::create($common) : LitCommons::create([$common]) );
+        $this->event_idx = self::$internal_index++;
+        $this->name      = $name;
+        $this->date      = $date; //DateTime object
+        $this->color     = is_array($color) ? $color : [$color];
+        $this->type      = $type;
+        $this->grade     = $grade;
+
+        // Assigned raw: an explicit display override is not derivable from the grade. deriveAllFields()
+        // below applies the one rule that IS grade-coupled, clearing it for a HIGHER_SOLEMNITY.
+        $this->grade_display = $displayGrade;
+
+        $commons = $common instanceof LitCommons || $common instanceof LitMassVariousNeeds || $litMassVariousNeedsArray
+                    ? $common
+                    : ( is_array($common) ? LitCommons::create($common) : LitCommons::create([$common]) );
         if ($commons instanceof LitCommons) {
-            $this->common     = $commons;
-            $this->common_lcl = $commons->fullTranslate(self::$locale);
+            $this->common = $commons;
         } elseif ($commons instanceof LitMassVariousNeeds) {
-            $this->common     = [$commons];
-            $this->common_lcl = $commons->fullTranslate(LitLocale::isLatin(self::$locale));
+            $this->common = [$commons];
         } elseif ($litMassVariousNeedsArray) {
             /** @var LitMassVariousNeeds[] $commons */
             $this->common = $commons;
-            $commonsLcl   = array_map(
-                function (LitMassVariousNeeds $item): string {
-                    return $item->fullTranslate(LitLocale::isLatin(self::$locale));
-                },
-                $commons
-            );
-
-            /**translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..." */
-            $or               = LitLocale::isLatin(self::$locale) ? 'vel' : _('or');
-            $this->common_lcl = implode('; ' . $or . ' ', $commonsLcl);
         } else {
+            // Defensive: LitCommons::create() only returns null for a LitMassVariousNeeds array,
+            // which the branch above already caught, so this is unreachable for the declared types.
             /** @var LitCommons $commons */
-            $commons          = LitCommons::create([LitCommon::NONE]);
-            $this->common     = $commons;
-            $this->common_lcl = '???';
+            $commons      = LitCommons::create([LitCommon::NONE]);
+            $this->common = $commons;
         }
-    }
 
-    /**
-     * Set the abbreviation for the grade of this liturgical event.
-     *
-     * @param string $abbreviation The abbreviation for the grade of this liturgical event.
-     * @return void
-     */
-    public function setGradeAbbreviation(string $abbreviation): void
-    {
-        $this->grade_abbr = $abbreviation;
-    }
-
-    /**
-     * Sets the localized grade for this liturgical event.
-     *
-     * @param string $grade_lcl The localized name of the grade for the liturgical event.
-     * @return void
-     */
-    public function setGradeLocalization(string $grade_lcl): void
-    {
-        $this->grade_lcl = $grade_lcl;
-    }
-
-    /**
-     * Sets the localized Common for this liturgical event.
-     *
-     * @param string $common_lcl The localized Common for the liturgical event.
-     * @return void
-     */
-    public function setCommonLocalization(string $common_lcl): void
-    {
-        $this->common_lcl = $common_lcl;
+        // Derive color_lcl / grade_lcl / grade_abbr / grade_display / common_lcl from the properties
+        // just assigned. The same call re-runs after any later write to one of them, so a constructed
+        // event and a mutated one describe themselves identically.
+        $this->deriveAllFields();
     }
 
     /**
@@ -849,10 +807,5 @@ final class LiturgicalEvent implements \JsonSerializable
             throw new \Exception('Invalid object provided to create LiturgicalEvent...');
         }
         return $isValid;
-    }
-
-    public function getCommonLcl(): string
-    {
-        return $this->common_lcl;
     }
 }

--- a/src/Models/Calendar/LiturgicalEventCollection.php
+++ b/src/Models/Calendar/LiturgicalEventCollection.php
@@ -6,7 +6,6 @@ use LiturgicalCalendar\Api\DateTime;
 use LiturgicalCalendar\Api\Enum\LitCommon;
 use LiturgicalCalendar\Api\Enum\LitGrade;
 use LiturgicalCalendar\Api\Enum\LitLocale;
-use LiturgicalCalendar\Api\Enum\LitMassVariousNeeds;
 use LiturgicalCalendar\Api\Enum\LitSeason;
 use LiturgicalCalendar\Api\Params\CalendarParams;
 use LiturgicalCalendar\Api\Map\LiturgicalEventsMap;
@@ -762,30 +761,30 @@ final class LiturgicalEventCollection
     }
 
     /**
-     * Updates the categorization of a liturgical event based on its grade and previous grade,
-     * and updates the grade_lcl and grade_abbr properties.
+     * Moves a liturgical event between the solemnities, feasts and memorials collections after its
+     * grade has changed.
      *
-     * This method modifies the liturgical event's position in the solemnities, feasts, or memorials
-     * collections according to its new grade. If the new grade is greater than or equal to
-     * FEAST_LORD, the liturgical event is added to the solemnities collection and removed from
-     * feasts or memorials if necessary. If the new grade is FEAST, it is moved to the feasts
-     * collection from solemnities or memorials. If the new grade is MEMORIAL, it is added to
-     * the memorials collection and removed from solemnities or feasts if needed.
+     * This is the COLLECTION-level consequence of a grade write, and the only one left here: the
+     * event's own grade-derived fields (`grade_lcl`, `grade_abbr`, `grade_display`) are re-derived
+     * by the model itself, from the locale the model was constructed with (#872).
+     *
+     * If the new grade is greater than or equal to FEAST_LORD, the liturgical event is added to the
+     * solemnities collection and removed from feasts or memorials if necessary. If the new grade is
+     * FEAST, it is moved to the feasts collection from solemnities or memorials. If the new grade is
+     * MEMORIAL, it is added to the memorials collection and removed from solemnities or feasts if
+     * needed.
      *
      * @param string $key The key associated with the liturgical event.
      * @param LitGrade $newGradeValue The new grade of the liturgical event.
      * @param LitGrade $oldGradeValue The previous grade of the liturgical event.
-     * @return void //$this->CalendarParams->Locale
+     * @return void
      */
-    private function handleGradeProperty(string $key, LitGrade $newGradeValue, LitGrade $oldGradeValue): void
+    private function recategorizeByGrade(string $key, LitGrade $newGradeValue, LitGrade $oldGradeValue): void
     {
         $litEvent = $this->liturgicalEvents->getEvent($key);
         if (null === $litEvent) {
             throw new \InvalidArgumentException('Invalid key: ' . $key . ' for LiturgicalEvents, valid keys are: ' . implode(', ', $this->liturgicalEvents->getKeys()));
         }
-        // Update the grade_lcl and grade_abbr properties
-        $litEvent->setGradeLocalization($newGradeValue->i18n($this->CalendarParams->Locale, false, false));
-        $litEvent->setGradeAbbreviation($newGradeValue->i18n($this->CalendarParams->Locale, false, true));
 
         if ($newGradeValue->value >= LitGrade::FEAST_LORD->value) {
             $this->solemnities->addEvent($litEvent);
@@ -814,66 +813,30 @@ final class LiturgicalEventCollection
     }
 
     /**
-     * Re-derives `common_lcl` after the `common` property of a liturgical event has been overwritten.
-     *
-     * `LiturgicalEvent::$common_lcl` is populated once in the constructor and is not kept in sync
-     * automatically when `$common` is later reassigned by reflection in {@see self::setProperty()}.
-     * This mirrors the branching the constructor uses to derive `common_lcl` from `$common`
-     * (`LitCommons::fullTranslate()` vs. the `LitMassVariousNeeds`/`LitMassVariousNeeds[]` cases),
-     * so that `common_lcl` never disagrees with the `common` it is supposed to describe.
-     *
-     * @param string $key The key associated with the liturgical event.
-     * @param LitCommons|array<int, LitMassVariousNeeds> $newValue The new value of the `common` property.
-     * @return void
-     */
-    private function handleCommonProperty(string $key, LitCommons|array $newValue): void
-    {
-        $litEvent = $this->liturgicalEvents->getEvent($key);
-        if (null === $litEvent) {
-            throw new \InvalidArgumentException('Invalid key: ' . $key . ' for LiturgicalEvents, valid keys are: ' . implode(', ', $this->liturgicalEvents->getKeys()));
-        }
-
-        $locale = $this->CalendarParams->Locale;
-
-        if ($newValue instanceof LitCommons) {
-            $commonLcl = $newValue->fullTranslate($locale);
-        } elseif (count($newValue) > 0 && $newValue[0] instanceof LitMassVariousNeeds) {
-            /** @var LitMassVariousNeeds[] $newValue */
-            $commonsLcl = array_map(
-                function (LitMassVariousNeeds $item) use ($locale): string {
-                    return $item->fullTranslate(LitLocale::isLatin($locale));
-                },
-                $newValue
-            );
-
-            /**translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..." */
-            $or        = LitLocale::isLatin($locale) ? 'vel' : _('or');
-            $commonLcl = implode('; ' . $or . ' ', $commonsLcl);
-        } else {
-            $commonLcl = '???';
-        }
-
-        $litEvent->setCommonLocalization($commonLcl);
-    }
-
-    /**
      * Sets a property of a liturgical event in the collection if it exists and matches the expected type.
      *
      * Uses reflection to ensure the property exists on the LiturgicalEvent object and checks the type
-     * of the value against the expected type of the property. If the property is "grade",
-     * it calls handleGradeProperty to update the liturgical event's categorization. If the property
-     * is "common", it calls handleCommonProperty to re-derive the localized `common_lcl`.
+     * of the value against the expected type of the property. After a successful write, every field
+     * the model DERIVES from that property is re-derived — see {@see \LiturgicalCalendar\Api\Models\DerivedField} for the mapping —
+     * so a serialized event can never describe itself with a label belonging to a value it no longer
+     * carries. Writing `grade` additionally moves the event between the solemnities/feasts/memorials
+     * collections.
      *
      * @param string $key The key of the liturgical event to modify.
      * @param string $property The property name to be set.
      * @param string|int|bool|array<int, mixed>|LitGrade|LitCommons $newValue The new value for the property.
-     * @return bool True if the property was successfully set, otherwise false.
+     * @return bool True if the property was actually changed, false if the key is unknown or the
+     *              event already carries an equivalent value.
      */
     public function setProperty(string $key, string $property, string|int|bool|array|LitGrade|LitCommons $newValue): bool
     {
         $reflect = new \ReflectionClass(new LiturgicalEvent('test', new DateTime('NOW')));
         if ($this->liturgicalEvents->hasKey($key)) {
             $litEvent = $this->liturgicalEvents->getEvent($key);
+            if (null === $litEvent) {
+                // Defensive only: hasKey() has just reported the key is present.
+                throw new \InvalidArgumentException(__METHOD__ . ": liturgical event `{$key}` disappeared from the collection between the key check and the lookup.");
+            }
             if ($reflect->hasProperty($property)) {
                 $oldValue            = $litEvent->{$property};
                 $reflectProperty     = $reflect->getProperty($property);
@@ -901,25 +864,26 @@ final class LiturgicalEventCollection
 
                 if (
                     ( $namedTypeCondition || $unionTypeCondition )
-                    && $litEvent->{$property} !== $newValue
+                    && false === self::isEquivalentValue($oldValue, $newValue)
                 ) {
                     $litEvent->{$property} = $newValue;
                 } else {
                     return false;
                 }
 
-                // If the value being updated is the grade, update the liturgical event's categorization
+                // Bring the written property's dependent fields with it. Unconditional: a property
+                // with no dependents re-derives nothing, so this cannot be forgotten for the next
+                // derived field the way an `if ($property === ...)` branch could.
+                $litEvent->rederiveDependentsOf($property);
+
+                // A grade change also moves the event between the collection's grade buckets, which
+                // is the collection's business rather than the event's.
                 if ($property === 'grade') {
                     /**
                      * @var LitGrade $newValue
                      * @var LitGrade $oldValue
                      */
-                    $this->handleGradeProperty($key, $newValue, $oldValue);
-                } elseif ($property === 'common') {
-                    /**
-                     * @var LitCommons|array<int, LitMassVariousNeeds> $newValue
-                     */
-                    $this->handleCommonProperty($key, $newValue);
+                    $this->recategorizeByGrade($key, $newValue, $oldValue);
                 }
                 return true;
             } else {
@@ -927,6 +891,26 @@ final class LiturgicalEventCollection
             }
         }
         return false;
+    }
+
+    /**
+     * Whether a write would be a no-op, i.e. whether the event already carries this value.
+     *
+     * `===` is the wrong question for an OBJECT: it asks whether this is the same instance, not
+     * whether it means the same thing. `grade` (a `LitGrade` enum case, so a singleton) and `name`
+     * (a string) happen to answer correctly, but a freshly built `LitCommons` carrying exactly the
+     * same Commons is never `===` the stored one, so `setProperty()` used to report a change that
+     * had not happened — leaving each caller to compare serialized values itself before delegating
+     * (#872). Object and array values are therefore compared by VALUE (`==`, which recurses into
+     * properties and elements); scalars keep the strict comparison, so no `0 == ''` surprises.
+     */
+    private static function isEquivalentValue(mixed $oldValue, mixed $newValue): bool
+    {
+        if (is_object($oldValue) || is_array($oldValue)) {
+            return $oldValue == $newValue;
+        }
+
+        return $oldValue === $newValue;
     }
 
     /**

--- a/src/Models/DerivedField.php
+++ b/src/Models/DerivedField.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models;
+
+/**
+ * The fields a liturgical event model computes from OTHER properties rather than receiving
+ * directly, together with the single declarative mapping of which source property invalidates
+ * which of them.
+ *
+ * Both event models — {@see \LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent} (the
+ * calculated `/calendar` event) and {@see \LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventAbstract}
+ * (the `/events` catalog entry) — derive these in their constructors and serialize them alongside
+ * the raw values they describe. Their raw sources are then written after construction:
+ * `LiturgicalEventCollection::setProperty()` writes them by reflection, and the catalog's
+ * `applyGrade()`/`applyCommon()` write them directly. Every such write has to bring the dependents
+ * with it, or the API publishes a numeric grade next to the label of a different grade, or a
+ * `common` next to the `common_lcl` of the Common it replaced.
+ *
+ * Before #872 that was done with one hardcoded `if` branch per field, added each time somebody was
+ * bitten — which is why `color_lcl` never got one at all. Here it is one row in {@see self::DEPENDENTS},
+ * and forgetting a row is visible in one place instead of being invisible in the middle of a
+ * 40-line method.
+ *
+ * The enum is deliberately closed: {@see DerivesLiturgicalFieldsTrait::rederive()} dispatches over
+ * it with a `match` that has no `default` arm, so a new case with no derivation is a PHPStan
+ * `match.unhandled` error at analysis time and an `\UnhandledMatchError` at runtime, never a
+ * silently stale serialized field. `DerivedFieldCoverageTest` closes the remaining direction: a new
+ * derived property on a model with no case here at all.
+ */
+enum DerivedField: string
+{
+    /** The localized colour names, derived from `color`. */
+    case COLOR_LCL = 'color_lcl';
+
+    /** The localized grade label, derived from `grade`. */
+    case GRADE_LCL = 'grade_lcl';
+
+    /** The abbreviated localized grade label, derived from `grade`. */
+    case GRADE_ABBR = 'grade_abbr';
+
+    /**
+     * The display override for the grade. Only PARTLY derived: it holds a caller-supplied string
+     * that no source property can reconstruct, and a grade write only clears it for a
+     * HIGHER_SOLEMNITY. See {@see DerivesLiturgicalFieldsTrait::deriveGradeDisplay()}.
+     */
+    case GRADE_DISPLAY = 'grade_display';
+
+    /** The localized Common (or Proper) description, derived from `common`. */
+    case COMMON_LCL = 'common_lcl';
+
+    /**
+     * Source property => the derived fields a write to it invalidates.
+     *
+     * Keys are the property names as written by `setProperty()` and by the catalog mutators.
+     *
+     * @var array<string, list<self>>
+     */
+    private const DEPENDENTS = [
+        'color'  => [self::COLOR_LCL],
+        'grade'  => [self::GRADE_LCL, self::GRADE_ABBR, self::GRADE_DISPLAY],
+        'common' => [self::COMMON_LCL],
+    ];
+
+    /**
+     * The derived fields invalidated by a write to `$sourceProperty`.
+     *
+     * A property with no dependents (`name`, `psalter_week`, `date`, …) yields an empty list, so
+     * callers can re-derive unconditionally after any write without knowing which properties matter.
+     *
+     * @return list<self>
+     */
+    public static function dependentsOf(string $sourceProperty): array
+    {
+        return self::DEPENDENTS[$sourceProperty] ?? [];
+    }
+
+    /**
+     * Every source property that has dependents, for callers that need to re-derive everything —
+     * the constructors, which populate all derived fields at once.
+     *
+     * @return list<string>
+     */
+    public static function sourceProperties(): array
+    {
+        return array_keys(self::DEPENDENTS);
+    }
+}

--- a/src/Models/DerivesLiturgicalFieldsTrait.php
+++ b/src/Models/DerivesLiturgicalFieldsTrait.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models;
+
+use LiturgicalCalendar\Api\Enum\LitColor;
+use LiturgicalCalendar\Api\Enum\LitGrade;
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Enum\LitMassVariousNeeds;
+use LiturgicalCalendar\Api\Models\Calendar\LitCommons;
+
+/**
+ * The derived fields of a liturgical event model, and the one implementation of how each is
+ * computed from the properties it describes.
+ *
+ * Shared by the two models that carry these fields — {@see \LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent}
+ * (`/calendar`) and {@see \LiturgicalCalendar\Api\Models\EventsPath\LiturgicalEventAbstract}
+ * (`/events`) — which previously held a hand-copied version each. That duplication is what let the
+ * two endpoints disagree about the same event (#872): a fix applied to one copy left the other
+ * describing a `common` it no longer carried.
+ *
+ * Constructors call {@see self::deriveAllFields()}; every post-construction write to a source
+ * property calls {@see self::rederiveDependentsOf()} with the property name. Both go through the
+ * same `derive*()` methods, so "what the field would have been if the event had been constructed
+ * this way" and "what the field is after a write" cannot drift apart.
+ *
+ * The using class supplies the source properties (`$color`, `$grade`, `$grade_display`, `$common`)
+ * and a `setLocale()` that assigns {@see self::$locale}.
+ */
+trait DerivesLiturgicalFieldsTrait
+{
+    /** @var string[] The localized colour names. Derived from `$color`. */
+    protected array $color_lcl;
+
+    /** The localized grade label. Derived from `$grade`. */
+    protected string $grade_lcl;
+
+    /** The abbreviated localized grade label. Derived from `$grade`. */
+    protected string $grade_abbr;
+
+    /** The localized Common (or Proper) description. Derived from `$common`. */
+    protected string $common_lcl;
+
+    /**
+     * The locale every derivation here reads.
+     *
+     * Static, and per using class (a trait's static properties are not shared between the classes
+     * that use it), matching the models' previous behaviour. It is the ONE locale a derived field
+     * is computed from: before #872 the `/calendar` model's constructor used this while
+     * `LiturgicalEventCollection` re-derived from `CalendarParams->Locale`, which is the
+     * un-normalized REQUEST locale (`la_VA` where this holds `la`, `it` where this holds `it_IT`).
+     * Those agree today only because the localization helpers branch on `LitLocale::isLatin()` and
+     * otherwise defer to process-global gettext — an accident, not a guarantee.
+     */
+    protected static string $locale = LitLocale::LATIN_PRIMARY_LANGUAGE;
+
+    /**
+     * Populates every derived field from the source properties as they currently stand.
+     *
+     * For constructors: assign the source properties (including any explicit `$grade_display`
+     * override), then call this once.
+     */
+    protected function deriveAllFields(): void
+    {
+        foreach (DerivedField::sourceProperties() as $sourceProperty) {
+            $this->rederiveDependentsOf($sourceProperty);
+        }
+    }
+
+    /**
+     * Re-derives every field that depends on `$sourceProperty`, after that property has been written.
+     *
+     * Safe to call for any property name: one with no dependents re-derives nothing, so a caller
+     * that writes properties generically (`LiturgicalEventCollection::setProperty()`, which writes
+     * by reflection) can call this after every write without special-casing which properties matter.
+     */
+    public function rederiveDependentsOf(string $sourceProperty): void
+    {
+        foreach (DerivedField::dependentsOf($sourceProperty) as $derivedField) {
+            $this->rederive($derivedField);
+        }
+    }
+
+    /**
+     * Dispatches one derived field to its derivation.
+     *
+     * No `default` arm, deliberately: the `match` is exhaustive over a closed enum, so PHPStan
+     * proves it complete today and re-flags it (`match.unhandled`) the moment a case is added
+     * without a derivation — which is the whole point of routing derivations through an enum
+     * rather than through an `if/elseif` chain that can simply be left one branch short.
+     */
+    private function rederive(DerivedField $derivedField): void
+    {
+        match ($derivedField) {
+            DerivedField::COLOR_LCL     => $this->deriveColorLcl(),
+            DerivedField::GRADE_LCL     => $this->deriveGradeLcl(),
+            DerivedField::GRADE_ABBR    => $this->deriveGradeAbbr(),
+            DerivedField::GRADE_DISPLAY => $this->deriveGradeDisplay(),
+            DerivedField::COMMON_LCL    => $this->deriveCommonLcl(),
+        };
+    }
+
+    private function deriveColorLcl(): void
+    {
+        $this->color_lcl = array_map(
+            function (LitColor $item): string {
+                return $item->i18n(self::$locale);
+            },
+            $this->color
+        );
+    }
+
+    private function deriveGradeLcl(): void
+    {
+        $this->grade_lcl = $this->grade->i18n(self::$locale, false, false);
+    }
+
+    private function deriveGradeAbbr(): void
+    {
+        $this->grade_abbr = $this->grade->i18n(self::$locale, false, true);
+    }
+
+    /**
+     * `grade_display` is only PARTLY derived, so this deliberately does less than the other
+     * derivations: it can clear the field, never repopulate it.
+     *
+     * The value is an authored display override (`CalendarHandler` writes `''` for `AllSouls` and
+     * the localized FEAST label for `DedicationLateran`) which nothing can recompute from the
+     * grade. The one rule the constructor couples to the grade is that a HIGHER_SOLEMNITY carries
+     * no displayable grade of its own, so it clears the field; every other grade leaves the
+     * caller's value untouched. A grade write mirrors exactly that, which is the precedence decided
+     * in #872: an explicit override survives an ordinary grade change, and a promotion to
+     * HIGHER_SOLEMNITY still clears it.
+     *
+     * Note the asymmetry: moving AWAY from HIGHER_SOLEMNITY leaves the `''` in place rather than
+     * restoring a display value there is no source for. That is intentional, not an oversight.
+     */
+    private function deriveGradeDisplay(): void
+    {
+        if ($this->grade === LitGrade::HIGHER_SOLEMNITY) {
+            $this->grade_display = '';
+        }
+    }
+
+    /**
+     * Mirrors the three shapes `$common` can hold: a `LitCommons` collection, one or more
+     * `LitMassVariousNeeds` cases (joined with the localized "or" glue), or — for a value that is
+     * neither, which the declared types make unreachable — the `'???'` marker the models have
+     * always used rather than a plausible-looking empty string.
+     */
+    private function deriveCommonLcl(): void
+    {
+        $common = $this->common;
+
+        if ($common instanceof LitCommons) {
+            $this->common_lcl = $common->fullTranslate(self::$locale);
+            return;
+        }
+
+        if (count($common) > 0 && $common[0] instanceof LitMassVariousNeeds) {
+            /** @var LitMassVariousNeeds[] $common */
+            $commonsLcl = array_map(
+                function (LitMassVariousNeeds $item): string {
+                    return $item->fullTranslate(LitLocale::isLatin(self::$locale));
+                },
+                $common
+            );
+
+            /**translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..." */
+            $or               = LitLocale::isLatin(self::$locale) ? 'vel' : _('or');
+            $this->common_lcl = implode('; ' . $or . ' ', $commonsLcl);
+            return;
+        }
+
+        $this->common_lcl = '???';
+    }
+
+    /**
+     * Overrides the abbreviated grade label with a value not derivable from the grade.
+     *
+     * Used for `DedicationLateran`, which is ranked as a FEAST_LORD but displayed as a FEAST. Like
+     * `grade_display`, such an override is authored: a later `grade` write re-derives the label
+     * from the new grade and discards it.
+     */
+    public function setGradeAbbreviation(string $abbreviation): void
+    {
+        $this->grade_abbr = $abbreviation;
+    }
+
+    /**
+     * @return string The liturgical commons localized for the current locale.
+     */
+    public function getCommonLcl(): string
+    {
+        return $this->common_lcl;
+    }
+}

--- a/src/Models/EventsPath/LiturgicalEventAbstract.php
+++ b/src/Models/EventsPath/LiturgicalEventAbstract.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Enum\LitGrade;
 use LiturgicalCalendar\Api\Enum\LitCommon;
 use LiturgicalCalendar\Api\Enum\LitMassVariousNeeds;
 use LiturgicalCalendar\Api\Models\Calendar\LitCommons;
+use LiturgicalCalendar\Api\Models\DerivesLiturgicalFieldsTrait;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeEventData;
 use LiturgicalCalendar\Api\Models\LiturgicalEventData;
 use LiturgicalCalendar\Api\Models\PropriumDeSanctisEvent;
@@ -16,6 +17,15 @@ use LiturgicalCalendar\Api\Models\PropriumDeTemporeEvent;
 
 abstract class LiturgicalEventAbstract implements \JsonSerializable
 {
+    /**
+     * `$color_lcl`, `$grade_lcl`, `$grade_abbr` and `$common_lcl` — the fields derived from
+     * `$color`, `$grade` and `$common` — together with `$locale` and the one implementation of
+     * each derivation, shared with the `/calendar` model. Before #872 this class carried its own
+     * hand-written copy of all of it, which is how `/events` and `/calendar` came to disagree
+     * about the same event.
+     */
+    use DerivesLiturgicalFieldsTrait;
+
     public int $event_idx;
 
     /** The following properties are generally passed in the constructor */
@@ -29,14 +39,6 @@ abstract class LiturgicalEventAbstract implements \JsonSerializable
     /** @var LitCommons|LitMassVariousNeeds[] */
     public LitCommons|array $common;  //["Proper"] or one or more Commons
 
-    /** The following properties are set based on properties passed in the constructor or on other properties */
-    protected string $grade_lcl;
-    /** @var string[] */
-    protected array $color_lcl;
-    protected string $grade_abbr;
-    protected string $common_lcl;
-
-    protected static string $locale      = LitLocale::LATIN_PRIMARY_LANGUAGE;
     protected static int $internal_index = 0;
 
     /**
@@ -65,101 +67,51 @@ abstract class LiturgicalEventAbstract implements \JsonSerializable
             }
             $litMassVariousNeedsArray = $common[0] instanceof LitMassVariousNeeds;
         }
-        $this->event_idx     = self::$internal_index++;
-        $this->event_key     = $event_key;
-        $this->name          = $name;
-        $this->color         = is_array($color) ? $color : [$color];
-        $this->color_lcl     = array_map(
-            function (LitColor $item): string {
-                return $item->i18n(self::$locale);
-            },
-            $this->color
-        );
-        $this->type          = $type;
-        $this->grade         = $grade;
-        $this->grade_lcl     = $this->grade->i18n(self::$locale, false, false);
-        $this->grade_abbr    = $this->grade->i18n(self::$locale, false, true);
-        $this->grade_display = $this->grade === LitGrade::HIGHER_SOLEMNITY ? '' : $displayGrade;
-        $commons             = $common instanceof LitCommons || $common instanceof LitMassVariousNeeds || $litMassVariousNeedsArray
-                                ? $common
-                                : ( is_array($common) ? LitCommons::create($common) : LitCommons::create([$common]) );
+        $this->event_idx = self::$internal_index++;
+        $this->event_key = $event_key;
+        $this->name      = $name;
+        $this->color     = is_array($color) ? $color : [$color];
+        $this->type      = $type;
+        $this->grade     = $grade;
+
+        // Assigned raw: an explicit display override is not derivable from the grade. deriveAllFields()
+        // below applies the one rule that IS grade-coupled, clearing it for a HIGHER_SOLEMNITY.
+        $this->grade_display = $displayGrade;
+
+        $commons = $common instanceof LitCommons || $common instanceof LitMassVariousNeeds || $litMassVariousNeedsArray
+                    ? $common
+                    : ( is_array($common) ? LitCommons::create($common) : LitCommons::create([$common]) );
         if ($commons instanceof LitCommons) {
-            /** @var LitCommons $commons */
-            $this->common     = $commons;
-            $this->common_lcl = $commons->fullTranslate(self::$locale);
+            $this->common = $commons;
         } elseif ($commons instanceof LitMassVariousNeeds) {
-            /** @var LitMassVariousNeeds $commons */
-            $this->common     = [$commons];
-            $this->common_lcl = $commons->fullTranslate(LitLocale::isLatin(self::$locale));
+            $this->common = [$commons];
         } elseif ($litMassVariousNeedsArray) {
             /** @var LitMassVariousNeeds[] $commons */
             $this->common = $commons;
-            $commonsLcl   = array_map(
-                function (LitMassVariousNeeds $item): string {
-                    return $item->fullTranslate(LitLocale::isLatin(self::$locale));
-                },
-                $commons
-            );
-            /**translators: when there are multiple possible commons, this will be the glue "[; or] From the Common of..." */
-            $or               = LitLocale::isLatin(self::$locale) ? 'vel' : _('or');
-            $this->common_lcl = implode('; ' . $or . ' ', $commonsLcl);
         } else {
+            // Defensive: LitCommons::create() only returns null for a LitMassVariousNeeds array,
+            // which the branch above already caught, so this is unreachable for the declared types.
             /** @var LitCommons $commons */
-            $commons          = LitCommons::create([LitCommon::NONE]);
-            $this->common     = $commons;
-            $this->common_lcl = '???';
+            $commons      = LitCommons::create([LitCommon::NONE]);
+            $this->common = $commons;
         }
+
+        // Derive color_lcl / grade_lcl / grade_abbr / grade_display / common_lcl from the properties
+        // just assigned. The same call re-runs after any later write to one of them, so a constructed
+        // catalog entry and a mutated one describe themselves identically.
+        $this->deriveAllFields();
     }
 
     /**
-     * Set the abbreviation for the grade of this liturgical event.
-     *
-     * @param string $abbreviation The abbreviation for the grade of this liturgical event.
-     * @return void
-     */
-    public function setGradeAbbreviation(string $abbreviation): void
-    {
-        $this->grade_abbr = $abbreviation;
-    }
-
-    /**
-     * Sets the localized grade for this liturgical event.
-     *
-     * @param string $grade_lcl The localized name of the grade for the liturgical event.
-     * @return void
-     */
-    public function setGradeLocalization(string $grade_lcl): void
-    {
-        $this->grade_lcl = $grade_lcl;
-    }
-
-    /**
-     * Changes the grade of this catalog entry, re-deriving the localized grade strings.
-     *
-     * `$grade_lcl` and `$grade_abbr` are computed in the constructor and are both serialized, so
-     * assigning `$grade` on its own would emit a numeric grade that disagrees with its own label.
-     *
-     * `$grade_display` is also grade-coupled in the constructor
-     * (`$this->grade_display = $this->grade === LitGrade::HIGHER_SOLEMNITY ? '' : $displayGrade;`)
-     * and takes precedence over `grade_lcl`/`grade_abbr` when serialized, so the same rule is
-     * mirrored here: a new HIGHER_SOLEMNITY grade clears it to `''`, otherwise any existing
-     * explicit override is left untouched (there is no new `$displayGrade` argument to apply here).
+     * Changes the grade of this catalog entry, re-deriving every field that describes the grade
+     * (`grade_lcl`, `grade_abbr`, and `grade_display`'s one grade-coupled rule).
      *
      * @param LitGrade $grade The new grade.
      */
     public function applyGrade(LitGrade $grade): void
     {
-        $this->grade      = $grade;
-        $this->grade_lcl  = $grade->i18n(self::$locale, false, false);
-        $this->grade_abbr = $grade->i18n(self::$locale, false, true);
-        // Deliberately one-directional, mirroring the constructor: moving TO HIGHER_SOLEMNITY
-        // clears grade_display, but moving AWAY from it leaves a previously-cleared '' in place
-        // rather than restoring some other display value there is no source for. Unreachable
-        // today (no caller currently moves an event away from HIGHER_SOLEMNITY), but kept
-        // asymmetric on purpose rather than "fixed" into a symmetry the data doesn't support.
-        if ($grade === LitGrade::HIGHER_SOLEMNITY) {
-            $this->grade_display = '';
-        }
+        $this->grade = $grade;
+        $this->rederiveDependentsOf('grade');
     }
 
     /**
@@ -169,8 +121,8 @@ abstract class LiturgicalEventAbstract implements \JsonSerializable
      */
     public function applyCommon(LitCommons $common): void
     {
-        $this->common     = $common;
-        $this->common_lcl = $common->fullTranslate(self::$locale);
+        $this->common = $common;
+        $this->rederiveDependentsOf('common');
     }
 
     /**
@@ -264,14 +216,6 @@ abstract class LiturgicalEventAbstract implements \JsonSerializable
             }
         }
         return true;
-    }
-
-    /**
-     * @return string The liturgical commons localized for the current locale.
-     */
-    public function getCommonLcl(): string
-    {
-        return $this->common_lcl;
     }
 
     /**


### PR DESCRIPTION
Closes #872.

## What changed

`LiturgicalEvent` (`/calendar`) and `LiturgicalEventAbstract` (`/events`) each derived five serialized fields from other properties, and each carried its own hand-written copy of how. Post-construction writes then had to remember to bring the dependents along, one `if` branch at a time — which is exactly the pattern that produced both Criticals in #870, and why `color_lcl` never got a branch at all.

Two new pieces replace the branches:

| | |
|---|---|
| `src/Models/DerivedField.php` | Closed enum of the derived fields + the single `source property => dependents` map. |
| `src/Models/DerivesLiturgicalFieldsTrait.php` | The one implementation of each derivation, used by **both** models. |

Constructors call `deriveAllFields()`; every later write calls `rederiveDependentsOf($property)`. Both run the same `derive*()` code, so "what the field would have been if the event had been constructed this way" and "what the field is after a write" cannot drift.

## How an omission is caught

`rederive()` dispatches with a `match` carrying no `default` arm. Adding a `DerivedField` case without its derivation is a **PHPStan `match.unhandled` error at analysis time** (verified by temporarily adding a case), and an `\UnhandledMatchError` at runtime — never a silently stale serialized field. `DerivedFieldCoverageTest` closes the other direction: a new derived property on a model with no case at all.

## Defects fixed along the way

- **`color_lcl` had no re-derivation in either model.** Latent for `/calendar` (nothing writes `color` today); now covered in both.
- **`/events` published a stale grade label — this one is live.** `EventsHandler` applied decree / wider-region / national `setProperty:grade` and `makePatron` rows with a bare `$event->grade = …`, bypassing `applyGrade()`. St Mary Magdalene came out as grade 4 with `grade_lcl` still reading *"Memoria obligatoria"* and `grade_abbr` `"M"`. #870 fixed `applyGrade()` itself; the four call sites that never used it were untouched. All eleven writes now go through `applyGrade()` / `applyName()`.
- **Object comparison in `setProperty()`.** `!==` asks about identity, not meaning, so an equivalent `LitCommons` always reported a change. Now compared by value in one place, and `CalendarHandler::applySetPropertyCommon()`'s per-call-site `jsonSerialize()` workaround is deleted — that arm reads like the `grade` and `name` arms again.
- **Two locale sources.** Re-derivation read `CalendarParams->Locale` (the raw request locale) while the constructor read the model's own normalized locale (`la_VA`→`la`, `it`→`it_IT`). Harmless today only because the helpers branch on `isLatin()`; there is now one source.

## `grade_display` precedence (the question #872 left open)

Decided as **constructor-mirroring** and encoded in `deriveGradeDisplay()`:

```
grade -> HIGHER_SOLEMNITY : grade_display = ''
grade -> anything else    : grade_display untouched
```

An explicit override is authored, not derivable — nothing can reconstruct it from a grade. `AllSouls` keeps its `''`, `DedicationLateran` keeps its `'FEAST'`. Documented and tested in both models.

## Verification

- `composer test`: **3652 passed**, 14 skipped (DB / OpenFGA / opcache env), 0 failures.
- **Golden master 9/9 byte-identical**, on a deliberately cleared `engineCache/` (its digest ignores PHP source, so a code-only change does not invalidate it).
- `composer analyse` (PHPStan level 10): no errors. `composer lint`, `composer parallel-lint`: clean.
- New tests: `DerivedFieldCoverageTest`, `LiturgicalEventCollectionSetPropertyDerivationTest`, `EventsHandlerDerivedGradeConsistencyTest` (asserts every catalog entry's labels match its own grade, in the locale the response resolved to), plus a `color_lcl` case in `LiturgicalEventAbstractMutatorTest`.

## Behaviour note

The constructors' unreachable `common` fallback (`LitCommons::create()` returning null for a shape the earlier branch already caught) previously set `common_lcl` to `'???'`; it now derives `''` from the NONE Common it assigns. The `'???'` marker is retained in the derivation for a value that is neither a `LitCommons` nor a `LitMassVariousNeeds[]`, which is what the old `handleCommonProperty()` did for writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event names, grades, abbreviations and colours now remain synchronised after calendar updates.
  * Grade changes, including special feast elevations, correctly refresh their displayed labels.
  * Redundant calendar overrides are handled consistently without applying unnecessary changes.
  * National, regional and general catalogue events now present consistent grade information.

* **Refactor**
  * Improved consistency and reliability of derived liturgical event details across calendars and event listings.

* **Tests**
  * Expanded coverage for event catalogue labels, calendar updates and derived-field behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->