### PR TITLE
refactor(temporale): fold setDate into a single shared create helper

### DIFF
--- a/phpunit_tests/Models/Calendar/Temporale/PropriumDeTemporeEventFactoryTest.php
+++ b/phpunit_tests/Models/Calendar/Temporale/PropriumDeTemporeEventFactoryTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Calendar\Temporale;
+
+use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\PropriumDeTemporeEventFactory;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pins the contract of the shared "date it, build it, add it" helper that
+ * `RomanTemporale`, `AmbrosianTemporale` and `CalendarHandler` all now route
+ * through (issue #724).
+ *
+ * The guard tests are the point of the refactor. Before the date was folded
+ * into the create call, callers wrote:
+ *
+ * ```php
+ * $ctx->propriumDeTempore['BadKey']->setDate($date);   // <- null-dereferences here
+ * $this->createPropriumDeTemporeLiturgicalEventByKey('BadKey', $ctx);
+ * ```
+ *
+ * so an unknown key blew up on the un-guarded `setDate()` line with a PHP
+ * error, never reaching the helper's `offsetExists()` check. Folding moved the
+ * mutation behind the guard, so an unknown key now raises the intended
+ * ServiceUnavailableException instead.
+ *
+ * Uses the Ambrosian harness purely because it wires a real
+ * PropriumDeTemporeMap + LiturgicalEventCollection; nothing here is
+ * rite-specific.
+ */
+#[CoversClass(PropriumDeTemporeEventFactory::class)]
+final class PropriumDeTemporeEventFactoryTest extends TestCase
+{
+    use AmbrosianTemporaleHarnessTrait;
+
+    private const YEAR = 2025;
+
+    private function context(): TemporaleContext
+    {
+        $messages = [];
+        return $this->buildContext(self::YEAR, $messages);
+    }
+
+    public function testAppliesTheGivenDateAndAddsTheEventToTheCalendar(): void
+    {
+        $ctx  = $this->context();
+        $date = DateTime::fromFormat('25-12-' . self::YEAR);
+
+        $event = PropriumDeTemporeEventFactory::create($ctx->propriumDeTempore, $ctx->cal, 'Christmas', $date);
+
+        self::assertSame('2025-12-25', $event->date->format('Y-m-d'));
+        self::assertSame($event, $ctx->cal->getLiturgicalEvent('Christmas'));
+        self::assertSame(
+            '2025-12-25',
+            $ctx->propriumDeTempore['Christmas']->date->format('Y-m-d'),
+            'The date must be written through to the Proprium de Tempore entry, as the old setDate() call did.'
+        );
+    }
+
+    public function testANullDateLeavesTheEntryDatedAsItAlreadyWas(): void
+    {
+        $ctx = $this->context();
+        $ctx->propriumDeTempore['Christmas']->setDate(DateTime::fromFormat('25-12-' . self::YEAR));
+
+        $event = PropriumDeTemporeEventFactory::create($ctx->propriumDeTempore, $ctx->cal, 'Christmas', null);
+
+        self::assertSame('2025-12-25', $event->date->format('Y-m-d'));
+    }
+
+    public function testAnUnknownKeyThrowsInsteadOfDereferencingNull(): void
+    {
+        $ctx = $this->context();
+
+        $this->expectException(ServiceUnavailableException::class);
+        $this->expectExceptionMessage('requires a key from the Proprium de Tempore, instead got NoSuchEvent');
+
+        PropriumDeTemporeEventFactory::create(
+            $ctx->propriumDeTempore,
+            $ctx->cal,
+            'NoSuchEvent',
+            DateTime::fromFormat('25-12-' . self::YEAR)
+        );
+    }
+
+    public function testANullKeyThrows(): void
+    {
+        $ctx = $this->context();
+
+        $this->expectException(ServiceUnavailableException::class);
+
+        PropriumDeTemporeEventFactory::create($ctx->propriumDeTempore, $ctx->cal, null, DateTime::fromFormat('25-12-' . self::YEAR));
+    }
+
+    public function testARejectedKeyAddsNothingToTheCalendar(): void
+    {
+        $ctx    = $this->context();
+        $before = $ctx->cal->getLiturgicalEvents()->getKeys();
+
+        try {
+            PropriumDeTemporeEventFactory::create(
+                $ctx->propriumDeTempore,
+                $ctx->cal,
+                'NoSuchEvent',
+                DateTime::fromFormat('25-12-' . self::YEAR)
+            );
+            self::fail('Expected a ServiceUnavailableException for an unknown key.');
+        } catch (ServiceUnavailableException) {
+            // expected
+        }
+
+        self::assertSame($before, $ctx->cal->getLiturgicalEvents()->getKeys());
+    }
+
+    public function testTheContextConvenienceMethodDelegatesToTheFactory(): void
+    {
+        $ctx = $this->context();
+
+        $event = $ctx->createPropriumDeTemporeEvent('Christmas', DateTime::fromFormat('25-12-' . self::YEAR));
+
+        self::assertSame('2025-12-25', $event->date->format('Y-m-d'));
+        self::assertSame($event, $ctx->cal->getLiturgicalEvent('Christmas'));
+    }
+}

--- a/src/Handlers/CalendarHandler.php
+++ b/src/Handlers/CalendarHandler.php
@@ -51,6 +51,7 @@ use LiturgicalCalendar\Api\Models\Calendar\Precedence\AmbrosianPrecedenceResolve
 use LiturgicalCalendar\Api\Models\Calendar\Precedence\PrecedenceContext;
 use LiturgicalCalendar\Api\Models\Calendar\Rite\RiteProfileFactory;
 use LiturgicalCalendar\Api\Models\Calendar\Sanctorale\AmbrosianSanctoraleLoader;
+use LiturgicalCalendar\Api\Models\Calendar\Temporale\PropriumDeTemporeEventFactory;
 use LiturgicalCalendar\Api\Models\Calendar\Temporale\TemporaleContext;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItem;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemCollection;
@@ -1672,18 +1673,19 @@ final class CalendarHandler extends AbstractHandler
     }
 
     /**
-     * Creates a LiturgicalEvent object from an entry in the Proprium de Tempore and adds it to the calendar
-     * @param string $key The key of the LiturgicalEvent in the Proprium de Tempore
+     * Dates an entry of the Proprium de Tempore, creates the LiturgicalEvent from it
+     * and adds it to the calendar, in one guarded call.
+     *
+     * Thin delegation to the shared {@see PropriumDeTemporeEventFactory::create()},
+     * which the temporale engines reach through {@see TemporaleContext::createPropriumDeTemporeEvent()}.
+     *
+     * @param ?string   $key  The key of the LiturgicalEvent in the Proprium de Tempore
+     * @param ?DateTime $date The event's date; `null` when the entry is dated elsewhere
      * @return LiturgicalEvent The new LiturgicalEvent object
      */
-    private function createPropriumDeTemporeLiturgicalEventByKey(?string $key = null): LiturgicalEvent
+    private function createPropriumDeTemporeLiturgicalEventByKey(?string $key = null, ?DateTime $date = null): LiturgicalEvent
     {
-        if (null === $key || false === $this->PropriumDeTempore->offsetExists($key)) {
-            throw new ServiceUnavailableException("createPropriumDeTemporeLiturgicalEventByKey requires a key from the Proprium de Tempore, instead got $key");
-        }
-        $event = LiturgicalEvent::fromObject($this->PropriumDeTempore[$key]);
-        $this->Cal->addLiturgicalEvent($key, $event);
-        return $event;
+        return PropriumDeTemporeEventFactory::create($this->PropriumDeTempore, $this->Cal, $key, $date);
     }
 
     /**
@@ -1707,7 +1709,7 @@ final class CalendarHandler extends AbstractHandler
         $DayOfEpiphany = (int) $Epiphany->date->format('j');
         for ($i = 2; $i < $DayOfEpiphany; $i++) {
             $dateTime = DateTime::fromFormat($i . '-1-' . $this->CalendarParams->Year);
-            if (false === self::dateIsSunday($dateTime) && $this->Cal->notInSolemnitiesFeastsOrMemorials($dateTime)) {
+            if (false === LiturgicalEventCollection::dateIsSunday($dateTime) && $this->Cal->notInSolemnitiesFeastsOrMemorials($dateTime)) {
                 $dayOfTheWeek  = $this->localeDateFormatter->getChristmasWeekdayIdentifier($dateTime);
                 $name          = $this->localeDateFormatter->formatChristmasWeekdayName($dayOfTheWeek);
                 $dayOfTheMonth = $dateTime->format('j');
@@ -1787,8 +1789,7 @@ final class CalendarHandler extends AbstractHandler
     {
         // Even though Mary Mother of God is a fixed date solemnity,
         // it is however found in the Proprium de Tempore and not in the Proprium de Sanctis
-        $this->PropriumDeTempore['MaryMotherOfGod']->setDate(DateTime::fromFormat('1-1-' . $this->CalendarParams->Year));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('MaryMotherOfGod');
+        $this->createPropriumDeTemporeLiturgicalEventByKey('MaryMotherOfGod', DateTime::fromFormat('1-1-' . $this->CalendarParams->Year));
 
         $propriumDeSanctisSolemnities = $this->missalsMap[RomanMissal::EDITIO_TYPICA_1970]->filterByGrade(LitGrade::SOLEMNITY);
 
@@ -2087,18 +2088,16 @@ final class CalendarHandler extends AbstractHandler
         if ($this->CalendarParams->Epiphany === Epiphany::SUNDAY_JAN2_JAN8) {
             $dateJan7 = DateTime::fromFormat('7-1-' . $this->CalendarParams->Year);
             $dateJan8 = DateTime::fromFormat('8-1-' . $this->CalendarParams->Year);
-            if (self::dateIsSunday($dateJan7)) {
+            if (LiturgicalEventCollection::dateIsSunday($dateJan7)) {
                 $this->BaptismLordFmt = '7-1-' . $this->CalendarParams->Year;
                 $this->BaptismLordMod = 'next Monday';
-            } elseif (self::dateIsSunday($dateJan8)) {
+            } elseif (LiturgicalEventCollection::dateIsSunday($dateJan8)) {
                 $this->BaptismLordFmt = '8-1-' . $this->CalendarParams->Year;
                 $this->BaptismLordMod = 'next Monday';
             }
         }
-        $this->PropriumDeTempore['BaptismLord']->setDate(DateTime::fromFormat($this->BaptismLordFmt)
+        $this->createPropriumDeTemporeLiturgicalEventByKey('BaptismLord', DateTime::fromFormat($this->BaptismLordFmt)
             ->modify($this->BaptismLordMod));
-
-        $this->createPropriumDeTemporeLiturgicalEventByKey('BaptismLord');
 
         // the other feasts of the Lord ( Presentation, Transfiguration and Triumph of the Holy Cross) are fixed date feasts
         // and are found in the Proprium de Sanctis
@@ -2124,10 +2123,8 @@ final class CalendarHandler extends AbstractHandler
             throw new ServiceUnavailableException('Christmas was not found among the LiturgicalEvents');
         }
 
-        if (self::dateIsSunday($Christmas->date)) {
-            $this->PropriumDeTempore['HolyFamily']->setDate(DateTime::fromFormat('30-12-' . $this->CalendarParams->Year));
-
-            $HolyFamily       = $this->createPropriumDeTemporeLiturgicalEventByKey('HolyFamily');
+        if (LiturgicalEventCollection::dateIsSunday($Christmas->date)) {
+            $HolyFamily       = $this->createPropriumDeTemporeLiturgicalEventByKey('HolyFamily', DateTime::fromFormat('30-12-' . $this->CalendarParams->Year));
             $this->Messages[] = sprintf(
                 /**translators: 1: LiturgicalEvent name (Christmas), 2: Requested calendar year, 3: LiturgicalEvent name (Holy Family), 4: New date for Holy Family */
                 _('\'%1$s\' falls on a Sunday in the year %2$d, therefore the Feast \'%3$s\' is celebrated on %4$s rather than on the Sunday after Christmas.'),
@@ -2137,8 +2134,7 @@ final class CalendarHandler extends AbstractHandler
                 $this->localeDateFormatter->formatLocalizedDate($HolyFamily->date)
             );
         } else {
-            $this->PropriumDeTempore['HolyFamily']->setDate(DateTime::fromFormat('25-12-' . $this->CalendarParams->Year)->modify('next Sunday'));
-            $this->createPropriumDeTemporeLiturgicalEventByKey('HolyFamily');
+            $this->createPropriumDeTemporeLiturgicalEventByKey('HolyFamily', DateTime::fromFormat('25-12-' . $this->CalendarParams->Year)->modify('next Sunday'));
         }
 
         // In 2012, Pope Benedict XVI gave faculty to the Episcopal Conferences
@@ -3809,7 +3805,7 @@ final class CalendarHandler extends AbstractHandler
 
             // Let's check if it was suppressed by a Solemnity, Feast, Memorial or Sunday,
             // so we can give some feedback and maybe even recreate the liturgical event if applicable
-            if ($this->Cal->inSolemnitiesFeastsOrMemorials($suppressedEvent->date) || self::dateIsSunday($suppressedEvent->date)) {
+            if ($this->Cal->inSolemnitiesFeastsOrMemorials($suppressedEvent->date) || LiturgicalEventCollection::dateIsSunday($suppressedEvent->date)) {
                 /** @var LitCalItemMakePatron $liturgicalEvent  */
                 $liturgicalEvent           = $litCalItem->liturgical_event;
                 $coincidingLiturgicalEvent = $this->Cal->determineSundaySolemnityOrFeast($suppressedEvent->date, $liturgicalEvent->event_key);
@@ -4549,17 +4545,6 @@ final class CalendarHandler extends AbstractHandler
         }
     }
 
-
-    /**
-     * Returns true if the given date is a Sunday.
-     *
-     * @param DateTime $dt The date to check.
-     * @return bool True if the given date is a Sunday, false otherwise.
-     */
-    private static function dateIsSunday(DateTime $dt): bool
-    {
-        return (int) $dt->format('N') === 7;
-    }
 
     /**
      * Returns true if the given date is not a Sunday.

--- a/src/Models/Calendar/Temporale/AmbrosianTemporale.php
+++ b/src/Models/Calendar/Temporale/AmbrosianTemporale.php
@@ -13,6 +13,7 @@ use LiturgicalCalendar\Api\Enum\LitSeason;
 use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
 use LiturgicalCalendar\Api\LatinUtils;
 use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
 use LiturgicalCalendar\Api\Utilities;
 
 /**
@@ -68,17 +69,23 @@ final class AmbrosianTemporale implements TemporaleEngine
     }
 
     /**
-     * Creates a LiturgicalEvent from the Ambrosian Proprium de Tempore by key and
-     * adds it to the calendar. (Duplicated from RomanTemporale; shared-helper
-     * de-dup tracked as existing debt.)
+     * Dates an entry of the Ambrosian Proprium de Tempore, creates the
+     * LiturgicalEvent and adds it to the calendar, then stamps the Ambrosian
+     * season onto it.
+     *
+     * The create itself is the shared {@see TemporaleContext::createPropriumDeTemporeEvent()};
+     * this wrapper exists only for the `stampSeason()` step, which the Roman
+     * engine has no equivalent of. The stamp must stay *after* the event is
+     * added, exactly as in the pre-fold code.
+     *
+     * @param ?string   $key  The key of the event in the Ambrosian Proprium de Tempore
+     * @param ?DateTime $date The event's date; `null` when the entry is dated elsewhere
+     * @param TemporaleContext $ctx The shared temporale context
+     * @return LiturgicalEvent The newly created LiturgicalEvent
      */
-    private function createPropriumDeTemporeLiturgicalEventByKey(?string $key, TemporaleContext $ctx): LiturgicalEvent
+    private function createPropriumDeTemporeLiturgicalEventByKey(?string $key, ?DateTime $date, TemporaleContext $ctx): LiturgicalEvent
     {
-        if (null === $key || false === $ctx->propriumDeTempore->offsetExists($key)) {
-            throw new ServiceUnavailableException("createPropriumDeTemporeLiturgicalEventByKey requires a key from the Proprium de Tempore, instead got $key");
-        }
-        $event = LiturgicalEvent::fromObject($ctx->propriumDeTempore[$key]);
-        $ctx->cal->addLiturgicalEvent($key, $event);
+        $event = $ctx->createPropriumDeTemporeEvent($key, $date);
         $this->stampSeason($event);
         return $event;
     }
@@ -103,18 +110,6 @@ final class AmbrosianTemporale implements TemporaleEngine
     }
 
     /**
-     * True if the given date falls on a Sunday. Used by
-     * `calculateAfterPentecostAnchors()` to guard the 3rd-Sunday-of-October
-     * computation for the Dedication of the Duomo di Milano, and by
-     * `martyrdomAnchor()` to guard the Aug 29 -> Sep 1 postponement of the
-     * Martyrdom of St John the Baptist when Aug 29 falls on a Sunday.
-     */
-    private static function dateIsSunday(DateTime $dt): bool
-    {
-        return (int) $dt->format('N') === 7;
-    }
-
-    /**
      * Advent I anchor: the Sunday strictly after Nov 11 (St Martin).
      * Single source of truth so calculateAdvent() and the Christ-the-King
      * anchor cannot drift when the deferred Nov-11-on-Sunday edge is implemented.
@@ -136,8 +131,7 @@ final class AmbrosianTemporale implements TemporaleEngine
         for ($i = 1; $i <= 6; $i++) {
             $key  = 'Advent' . $i;
             $date = ( clone $advent1 )->add(new \DateInterval('P' . ( ( $i - 1 ) * 7 ) . 'D'));
-            $ctx->propriumDeTempore[$key]->setDate($date);
-            $this->createPropriumDeTemporeLiturgicalEventByKey($key, $ctx);
+            $this->createPropriumDeTemporeLiturgicalEventByKey($key, $date, $ctx);
         }
     }
 
@@ -150,18 +144,14 @@ final class AmbrosianTemporale implements TemporaleEngine
     {
         $year = $ctx->params->Year;
 
-        $ctx->propriumDeTempore['Christmas']->setDate(DateTime::fromFormat('25-12-' . $year));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Christmas', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('Christmas', DateTime::fromFormat('25-12-' . $year), $ctx);
 
-        $ctx->propriumDeTempore['Circoncisione']->setDate(DateTime::fromFormat('1-1-' . $year));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Circoncisione', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('Circoncisione', DateTime::fromFormat('1-1-' . $year), $ctx);
 
         $epiphany = DateTime::fromFormat('6-1-' . $year);
-        $ctx->propriumDeTempore['Epiphany']->setDate($epiphany);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Epiphany', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('Epiphany', $epiphany, $ctx);
 
-        $ctx->propriumDeTempore['BaptismLord']->setDate(( clone $epiphany )->modify('next Sunday'));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('BaptismLord', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('BaptismLord', ( clone $epiphany )->modify('next Sunday'), $ctx);
     }
 
     /**
@@ -179,18 +169,14 @@ final class AmbrosianTemporale implements TemporaleEngine
         for ($i = 1; $i <= 5; $i++) {
             $key  = 'Lent' . $i;
             $date = ( clone $lent1 )->add(new \DateInterval('P' . ( ( $i - 1 ) * 7 ) . 'D'));
-            $ctx->propriumDeTempore[$key]->setDate($date);
-            $this->createPropriumDeTemporeLiturgicalEventByKey($key, $ctx);
+            $this->createPropriumDeTemporeLiturgicalEventByKey($key, $date, $ctx);
         }
 
-        $ctx->propriumDeTempore['AshesMonday']->setDate(( clone $lent1 )->add(new \DateInterval('P1D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('AshesMonday', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('AshesMonday', ( clone $lent1 )->add(new \DateInterval('P1D')), $ctx);
 
-        $ctx->propriumDeTempore['PalmSun']->setDate(Utilities::calcGregEaster($year)->sub(new \DateInterval('P7D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('PalmSun', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('PalmSun', Utilities::calcGregEaster($year)->sub(new \DateInterval('P7D')), $ctx);
 
-        $ctx->propriumDeTempore['SabatoTradSymb']->setDate(Utilities::calcGregEaster($year)->sub(new \DateInterval('P8D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('SabatoTradSymb', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('SabatoTradSymb', Utilities::calcGregEaster($year)->sub(new \DateInterval('P8D')), $ctx);
     }
 
     /**
@@ -203,32 +189,24 @@ final class AmbrosianTemporale implements TemporaleEngine
     {
         $year = $ctx->params->Year;
 
-        $ctx->propriumDeTempore['HolyThurs']->setDate(Utilities::calcGregEaster($year)->sub(new \DateInterval('P3D')));
-        $ctx->propriumDeTempore['GoodFri']->setDate(Utilities::calcGregEaster($year)->sub(new \DateInterval('P2D')));
-        $ctx->propriumDeTempore['EasterVigil']->setDate(Utilities::calcGregEaster($year)->sub(new \DateInterval('P1D')));
-        $ctx->propriumDeTempore['Easter']->setDate(Utilities::calcGregEaster($year));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('HolyThurs', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('GoodFri', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('EasterVigil', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Easter', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('HolyThurs', Utilities::calcGregEaster($year)->sub(new \DateInterval('P3D')), $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('GoodFri', Utilities::calcGregEaster($year)->sub(new \DateInterval('P2D')), $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('EasterVigil', Utilities::calcGregEaster($year)->sub(new \DateInterval('P1D')), $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('Easter', Utilities::calcGregEaster($year), $ctx);
 
         $octaveKeys = ['MonOctaveEaster', 'TueOctaveEaster', 'WedOctaveEaster', 'ThuOctaveEaster', 'FriOctaveEaster', 'SatOctaveEaster'];
         foreach ($octaveKeys as $offset => $key) {
-            $ctx->propriumDeTempore[$key]->setDate(Utilities::calcGregEaster($year)->add(new \DateInterval('P' . ( $offset + 1 ) . 'D')));
-            $this->createPropriumDeTemporeLiturgicalEventByKey($key, $ctx);
+            $this->createPropriumDeTemporeLiturgicalEventByKey($key, Utilities::calcGregEaster($year)->add(new \DateInterval('P' . ( $offset + 1 ) . 'D')), $ctx);
         }
 
         for ($i = 2; $i <= 7; $i++) {
             $key = 'Easter' . $i;
-            $ctx->propriumDeTempore[$key]->setDate(Utilities::calcGregEaster($year)->add(new \DateInterval('P' . ( 7 * ( $i - 1 ) ) . 'D')));
-            $this->createPropriumDeTemporeLiturgicalEventByKey($key, $ctx);
+            $this->createPropriumDeTemporeLiturgicalEventByKey($key, Utilities::calcGregEaster($year)->add(new \DateInterval('P' . ( 7 * ( $i - 1 ) ) . 'D')), $ctx);
         }
 
-        $ctx->propriumDeTempore['Ascension']->setDate(Utilities::calcGregEaster($year)->add(new \DateInterval('P39D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Ascension', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('Ascension', Utilities::calcGregEaster($year)->add(new \DateInterval('P39D')), $ctx);
 
-        $ctx->propriumDeTempore['Pentecost']->setDate(Utilities::calcGregEaster($year)->add(new \DateInterval('P49D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Pentecost', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('Pentecost', Utilities::calcGregEaster($year)->add(new \DateInterval('P49D')), $ctx);
     }
 
     /**
@@ -247,18 +225,16 @@ final class AmbrosianTemporale implements TemporaleEngine
 
         // 3rd Sunday of October = 1st Sunday on/after Oct 1, plus 2 weeks.
         $firstSundayOct = DateTime::fromFormat('1-10-' . $year);
-        if (false === self::dateIsSunday($firstSundayOct)) {
+        if (false === LiturgicalEventCollection::dateIsSunday($firstSundayOct)) {
             $firstSundayOct = $firstSundayOct->modify('next Sunday');
         }
         $dedication = ( clone $firstSundayOct )->add(new \DateInterval('P14D'));
-        $ctx->propriumDeTempore['DedicationDuomo']->setDate($dedication);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('DedicationDuomo', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('DedicationDuomo', $dedication, $ctx);
 
         // Christ the King = the Sunday before Advent I (Advent I = Sunday after Nov 11).
         $advent1    = $this->adventOne($year);
         $christKing = ( clone $advent1 )->sub(new \DateInterval('P7D'));
-        $ctx->propriumDeTempore['ChristKing']->setDate($christKing);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('ChristKing', $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey('ChristKing', $christKing, $ctx);
 
         // Pentecost-anchored celebrations (calendario ambrosiano, praenotanda pp. LXXV, LXXVII).
         // Placed here, before calculateAfterPentecostSundays() and calculateAfterPentecostWeekdays(),
@@ -286,8 +262,7 @@ final class AmbrosianTemporale implements TemporaleEngine
 
         $date = Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P' . $easterOffset . 'D'));
-        $ctx->propriumDeTempore[$key]->setDate($date);
-        $this->createPropriumDeTemporeLiturgicalEventByKey($key, $ctx);
+        $this->createPropriumDeTemporeLiturgicalEventByKey($key, $date, $ctx);
     }
 
     /**
@@ -317,7 +292,7 @@ final class AmbrosianTemporale implements TemporaleEngine
     private function martyrdomAnchor(int $year): DateTime
     {
         $aug29 = DateTime::fromFormat('29-8-' . $year);
-        return self::dateIsSunday($aug29) ? DateTime::fromFormat('1-9-' . $year) : $aug29;
+        return LiturgicalEventCollection::dateIsSunday($aug29) ? DateTime::fromFormat('1-9-' . $year) : $aug29;
     }
 
     /**
@@ -639,7 +614,7 @@ final class AmbrosianTemporale implements TemporaleEngine
         $year = $ctx->params->Year;
         $jan2 = DateTime::fromFormat('2-1-' . $year);
         $jan5 = DateTime::fromFormat('5-1-' . $year);
-        $sun  = self::dateIsSunday($jan2) ? $jan2 : ( clone $jan2 )->modify('next Sunday');
+        $sun  = LiturgicalEventCollection::dateIsSunday($jan2) ? $jan2 : ( clone $jan2 )->modify('next Sunday');
         if ($sun > $jan5) {
             // No Sunday falls within [Jan 2, Jan 5] this year -- "eventuale" not realized.
             return;

--- a/src/Models/Calendar/Temporale/PropriumDeTemporeEventFactory.php
+++ b/src/Models/Calendar/Temporale/PropriumDeTemporeEventFactory.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\Calendar\Temporale;
+
+use LiturgicalCalendar\Api\DateTime;
+use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
+use LiturgicalCalendar\Api\Models\PropriumDeTemporeMap;
+
+/**
+ * Single source of truth for "date a Proprium de Tempore entry, build a
+ * LiturgicalEvent from it, and add it to the calendar".
+ *
+ * Previously each of `RomanTemporale`, `AmbrosianTemporale` and
+ * `CalendarHandler` carried its own copy of this helper, and every caller had
+ * to write the event key twice — once to set the date on the map entry, once
+ * to create the event:
+ *
+ * ```php
+ * $ctx->propriumDeTempore['HolyThurs']->setDate($date);   // key, first time
+ * $this->createPropriumDeTemporeLiturgicalEventByKey('HolyThurs', $ctx); // again
+ * ```
+ *
+ * Folding the date into the create call makes the key appear once, and — more
+ * importantly — moves the mutation *behind* the existence check. In the old
+ * two-statement form an unknown key null-dereferenced on the `setDate()` line,
+ * before the guard in the helper ever ran; now it raises the intended
+ * {@see ServiceUnavailableException}.
+ */
+final class PropriumDeTemporeEventFactory
+{
+    /**
+     * Optionally dates the Proprium de Tempore entry for `$key`, builds a
+     * LiturgicalEvent from it and adds it to `$cal`.
+     *
+     * The operation order (`setDate` -> `fromObject` -> `addLiturgicalEvent`)
+     * is load-bearing and must not be rearranged: the golden-master fixtures
+     * for the Roman calendar depend on it.
+     *
+     * @param PropriumDeTemporeMap      $propriumDeTempore The rite's Proprium de Tempore
+     * @param LiturgicalEventCollection $cal               The calendar to add the event to
+     * @param ?string                   $key               The key of the event in the Proprium de Tempore
+     * @param ?DateTime                 $date              The event's date; `null` when the caller has
+     *                                                     already dated the entry by another path
+     * @return LiturgicalEvent The newly created LiturgicalEvent
+     * @throws ServiceUnavailableException If `$key` is null or absent from the Proprium de Tempore
+     */
+    public static function create(
+        PropriumDeTemporeMap $propriumDeTempore,
+        LiturgicalEventCollection $cal,
+        ?string $key,
+        ?DateTime $date = null
+    ): LiturgicalEvent {
+        if (null === $key || false === $propriumDeTempore->offsetExists($key)) {
+            throw new ServiceUnavailableException("createPropriumDeTemporeLiturgicalEventByKey requires a key from the Proprium de Tempore, instead got $key");
+        }
+
+        if (null !== $date) {
+            $propriumDeTempore[$key]->setDate($date);
+        }
+
+        $event = LiturgicalEvent::fromObject($propriumDeTempore[$key]);
+        $cal->addLiturgicalEvent($key, $event);
+        return $event;
+    }
+}

--- a/src/Models/Calendar/Temporale/RomanTemporale.php
+++ b/src/Models/Calendar/Temporale/RomanTemporale.php
@@ -10,8 +10,7 @@ use LiturgicalCalendar\Api\Enum\Ascension;
 use LiturgicalCalendar\Api\Enum\CorpusChristi;
 use LiturgicalCalendar\Api\Enum\Epiphany;
 use LiturgicalCalendar\Api\Enum\LitLocale;
-use LiturgicalCalendar\Api\Http\Exception\ServiceUnavailableException;
-use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
 
 /**
  * Roman-rite temporale engine.
@@ -36,32 +35,6 @@ final class RomanTemporale implements TemporaleEngine
     }
 
     /**
-     * Creates a new LiturgicalEvent from the Proprium de Tempore, keyed by the
-     * given event key, and adds it to the calendar.
-     *
-     * @param ?string $key The key of the event in the Proprium de Tempore
-     * @param TemporaleContext $ctx The shared temporale context
-     * @return LiturgicalEvent The new LiturgicalEvent object
-     */
-    private function createPropriumDeTemporeLiturgicalEventByKey(?string $key, TemporaleContext $ctx): LiturgicalEvent
-    {
-        if (null === $key || false === $ctx->propriumDeTempore->offsetExists($key)) {
-            throw new ServiceUnavailableException("createPropriumDeTemporeLiturgicalEventByKey requires a key from the Proprium de Tempore, instead got $key");
-        }
-        $event = LiturgicalEvent::fromObject($ctx->propriumDeTempore[$key]);
-        $ctx->cal->addLiturgicalEvent($key, $event);
-        return $event;
-    }
-
-    /**
-     * Returns true when the given date falls on a Sunday.
-     */
-    private static function dateIsSunday(DateTime $dt): bool
-    {
-        return (int) $dt->format('N') === 7;
-    }
-
-    /**
      * Calculates the dates for Holy Thursday, Good Friday, Easter Vigil and Easter Sunday
      * and creates the corresponding LiturgicalEvents in the calendar
      *
@@ -73,14 +46,10 @@ final class RomanTemporale implements TemporaleEngine
      */
     private function calculateEasterTriduum(TemporaleContext $ctx): void
     {
-        $ctx->propriumDeTempore['HolyThurs']->setDate(Utilities::calcGregEaster($ctx->params->Year)->sub(new \DateInterval('P3D')));
-        $ctx->propriumDeTempore['GoodFri']->setDate(Utilities::calcGregEaster($ctx->params->Year)->sub(new \DateInterval('P2D')));
-        $ctx->propriumDeTempore['EasterVigil']->setDate(Utilities::calcGregEaster($ctx->params->Year)->sub(new \DateInterval('P1D')));
-        $ctx->propriumDeTempore['Easter']->setDate(Utilities::calcGregEaster($ctx->params->Year));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('HolyThurs', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('GoodFri', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('EasterVigil', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Easter', $ctx);
+        $ctx->createPropriumDeTemporeEvent('HolyThurs', Utilities::calcGregEaster($ctx->params->Year)->sub(new \DateInterval('P3D')));
+        $ctx->createPropriumDeTemporeEvent('GoodFri', Utilities::calcGregEaster($ctx->params->Year)->sub(new \DateInterval('P2D')));
+        $ctx->createPropriumDeTemporeEvent('EasterVigil', Utilities::calcGregEaster($ctx->params->Year)->sub(new \DateInterval('P1D')));
+        $ctx->createPropriumDeTemporeEvent('Easter', Utilities::calcGregEaster($ctx->params->Year));
     }
 
     /**
@@ -96,36 +65,31 @@ final class RomanTemporale implements TemporaleEngine
     private function calculateChristmasEpiphany(TemporaleContext $ctx): void
     {
         // Calculate Christmas
-        $ctx->propriumDeTempore['Christmas']->setDate(DateTime::fromFormat('25-12-' . $ctx->params->Year));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Christmas', $ctx);
+        $ctx->createPropriumDeTemporeEvent('Christmas', DateTime::fromFormat('25-12-' . $ctx->params->Year));
 
         // Calculate Epiphany (and the "Second Sunday of Christmas" if applicable)
         switch ($ctx->params->Epiphany) {
             case Epiphany::JAN6:
-                $ctx->propriumDeTempore['Epiphany']->setDate(DateTime::fromFormat('6-1-' . $ctx->params->Year));
-                $this->createPropriumDeTemporeLiturgicalEventByKey('Epiphany', $ctx);
+                $ctx->createPropriumDeTemporeEvent('Epiphany', DateTime::fromFormat('6-1-' . $ctx->params->Year));
 
                 // if a Sunday falls between Jan. 2 and Jan. 5, it is called the "Second Sunday of Christmas"
                 $christmas2Day = array_find(
                     [2, 3, 4, 5],
-                    fn(int $day): bool => self::dateIsSunday(DateTime::fromFormat($day . '-1-' . $ctx->params->Year))
+                    fn(int $day): bool => LiturgicalEventCollection::dateIsSunday(DateTime::fromFormat($day . '-1-' . $ctx->params->Year))
                 );
                 if (null !== $christmas2Day) {
-                    $ctx->propriumDeTempore['Christmas2']->setDate(DateTime::fromFormat($christmas2Day . '-1-' . $ctx->params->Year));
-                    $this->createPropriumDeTemporeLiturgicalEventByKey('Christmas2', $ctx);
+                    $ctx->createPropriumDeTemporeEvent('Christmas2', DateTime::fromFormat($christmas2Day . '-1-' . $ctx->params->Year));
                 }
                 break;
             case Epiphany::SUNDAY_JAN2_JAN8:
                 //If January 2nd is a Sunday, then go with Jan 2nd
                 $dateTime = DateTime::fromFormat('2-1-' . $ctx->params->Year);
-                if (self::dateIsSunday($dateTime)) {
-                    $ctx->propriumDeTempore['Epiphany']->setDate($dateTime);
-                    $this->createPropriumDeTemporeLiturgicalEventByKey('Epiphany', $ctx);
+                if (LiturgicalEventCollection::dateIsSunday($dateTime)) {
+                    $ctx->createPropriumDeTemporeEvent('Epiphany', $dateTime);
                 } else {
                     //otherwise find the Sunday following Jan 2nd
                     $SundayOfEpiphany = $dateTime->modify('next Sunday');
-                    $ctx->propriumDeTempore['Epiphany']->setDate($SundayOfEpiphany);
-                    $this->createPropriumDeTemporeLiturgicalEventByKey('Epiphany', $ctx);
+                    $ctx->createPropriumDeTemporeEvent('Epiphany', $SundayOfEpiphany);
                 }
                 break;
         }
@@ -150,20 +114,16 @@ final class RomanTemporale implements TemporaleEngine
     private function calculateAscensionPentecost(TemporaleContext $ctx): void
     {
         if ($ctx->params->Ascension === Ascension::THURSDAY) {
-            $ctx->propriumDeTempore['Ascension']->setDate(Utilities::calcGregEaster($ctx->params->Year)->add(new \DateInterval('P39D')));
-            $this->createPropriumDeTemporeLiturgicalEventByKey('Ascension', $ctx);
-            $ctx->propriumDeTempore['Easter7']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+            $ctx->createPropriumDeTemporeEvent('Ascension', Utilities::calcGregEaster($ctx->params->Year)->add(new \DateInterval('P39D')));
+            $ctx->createPropriumDeTemporeEvent('Easter7', Utilities::calcGregEaster($ctx->params->Year)
                 ->add(new \DateInterval('P' . ( 7 * 6 ) . 'D')));
-            $this->createPropriumDeTemporeLiturgicalEventByKey('Easter7', $ctx);
         } elseif ($ctx->params->Ascension === Ascension::SUNDAY) {
-            $ctx->propriumDeTempore['Ascension']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+            $ctx->createPropriumDeTemporeEvent('Ascension', Utilities::calcGregEaster($ctx->params->Year)
                 ->add(new \DateInterval('P' . ( 7 * 6 ) . 'D')));
-            $this->createPropriumDeTemporeLiturgicalEventByKey('Ascension', $ctx);
         }
 
-        $ctx->propriumDeTempore['Pentecost']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Pentecost', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P' . ( 7 * 7 ) . 'D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Pentecost', $ctx);
     }
 
     /**
@@ -184,66 +144,48 @@ final class RomanTemporale implements TemporaleEngine
         //We calculate Sundays of Advent based on Christmas
         $christmasDateStr = '25-12-' . $ctx->params->Year;
 
-        $ctx->propriumDeTempore['Advent1']->setDate(DateTime::fromFormat($christmasDateStr)
+        $ctx->createPropriumDeTemporeEvent('Advent1', DateTime::fromFormat($christmasDateStr)
             ->modify('last Sunday')->sub(new \DateInterval('P' . ( 3 * 7 ) . 'D')));
-        $ctx->propriumDeTempore['Advent2']->setDate(DateTime::fromFormat($christmasDateStr)
+        $ctx->createPropriumDeTemporeEvent('Advent2', DateTime::fromFormat($christmasDateStr)
             ->modify('last Sunday')->sub(new \DateInterval('P' . ( 2 * 7 ) . 'D')));
-        $ctx->propriumDeTempore['Advent3']->setDate(DateTime::fromFormat($christmasDateStr)
+        $ctx->createPropriumDeTemporeEvent('Advent3', DateTime::fromFormat($christmasDateStr)
             ->modify('last Sunday')->sub(new \DateInterval('P7D')));
-        $ctx->propriumDeTempore['Advent4']->setDate(DateTime::fromFormat($christmasDateStr)
+        $ctx->createPropriumDeTemporeEvent('Advent4', DateTime::fromFormat($christmasDateStr)
             ->modify('last Sunday'));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Advent1', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Advent2', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Advent3', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Advent4', $ctx);
 
         //We calculate Sundays of Lent, Palm Sunday, Sundays of Easter, Trinity Sunday and Corpus Christi based on Easter
-        $ctx->propriumDeTempore['Lent1']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Lent1', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P' . ( 6 * 7 ) . 'D')));
-        $ctx->propriumDeTempore['Lent2']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Lent2', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P' . ( 5 * 7 ) . 'D')));
-        $ctx->propriumDeTempore['Lent3']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Lent3', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P' . ( 4 * 7 ) . 'D')));
-        $ctx->propriumDeTempore['Lent4']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Lent4', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P' . ( 3 * 7 ) . 'D')));
-        $ctx->propriumDeTempore['Lent5']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Lent5', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P' . ( 2 * 7 ) . 'D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Lent1', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Lent2', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Lent3', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Lent4', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Lent5', $ctx);
-        $ctx->propriumDeTempore['PalmSun']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('PalmSun', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P7D')));
-        $ctx->propriumDeTempore['Easter2']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Easter2', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P7D')));
-        $ctx->propriumDeTempore['Easter3']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Easter3', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P' . ( 7 * 2 ) . 'D')));
-        $ctx->propriumDeTempore['Easter4']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Easter4', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P' . ( 7 * 3 ) . 'D')));
-        $ctx->propriumDeTempore['Easter5']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Easter5', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P' . ( 7 * 4 ) . 'D')));
-        $ctx->propriumDeTempore['Easter6']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Easter6', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P' . ( 7 * 5 ) . 'D')));
-        $ctx->propriumDeTempore['Trinity']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('Trinity', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P' . ( 7 * 8 ) . 'D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('PalmSun', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Easter2', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Easter3', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Easter4', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Easter5', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Easter6', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('Trinity', $ctx);
         if ($ctx->params->CorpusChristi === CorpusChristi::THURSDAY) {
-            $ctx->propriumDeTempore['CorpusChristi']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+            $ctx->createPropriumDeTemporeEvent('CorpusChristi', Utilities::calcGregEaster($ctx->params->Year)
                 ->add(new \DateInterval('P' . ( 7 * 8 + 4 ) . 'D')));
-            $this->createPropriumDeTemporeLiturgicalEventByKey('CorpusChristi', $ctx);
             //Seeing the Sunday is not taken by Corpus Christi, it should be later taken by a Sunday of Ordinary Time
             // (they are calculated back to Pentecost)
         } elseif ($ctx->params->CorpusChristi === CorpusChristi::SUNDAY) {
-            $ctx->propriumDeTempore['CorpusChristi']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+            $ctx->createPropriumDeTemporeEvent('CorpusChristi', Utilities::calcGregEaster($ctx->params->Year)
                 ->add(new \DateInterval('P' . ( 7 * 9 ) . 'D')));
-            $this->createPropriumDeTemporeLiturgicalEventByKey('CorpusChristi', $ctx);
         }
 
         if ($ctx->params->Year >= 2000) {
@@ -271,9 +213,8 @@ final class RomanTemporale implements TemporaleEngine
      */
     private function calculateAshWednesday(TemporaleContext $ctx): void
     {
-        $ctx->propriumDeTempore['AshWednesday']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('AshWednesday', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P46D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('AshWednesday', $ctx);
     }
 
     /**
@@ -286,18 +227,14 @@ final class RomanTemporale implements TemporaleEngine
     {
         //Weekdays of Holy Week from Monday to Thursday inclusive
         // ( that is, thursday morning chrism Mass... the In Coena Domini Mass begins the Easter Triduum )
-        $ctx->propriumDeTempore['MonHolyWeek']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('MonHolyWeek', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P6D')));
-        $ctx->propriumDeTempore['TueHolyWeek']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('TueHolyWeek', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P5D')));
-        $ctx->propriumDeTempore['WedHolyWeek']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('WedHolyWeek', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P4D')));
-        $ctx->propriumDeTempore['HolyThursChrism']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('HolyThursChrism', Utilities::calcGregEaster($ctx->params->Year)
             ->sub(new \DateInterval('P3D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('MonHolyWeek', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('TueHolyWeek', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('WedHolyWeek', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('HolyThursChrism', $ctx);
     }
 
     /**
@@ -308,24 +245,18 @@ final class RomanTemporale implements TemporaleEngine
      */
     private function calculateEasterOctave(TemporaleContext $ctx): void
     {
-        $ctx->propriumDeTempore['MonOctaveEaster']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('MonOctaveEaster', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P1D')));
-        $ctx->propriumDeTempore['TueOctaveEaster']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('TueOctaveEaster', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P2D')));
-        $ctx->propriumDeTempore['WedOctaveEaster']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('WedOctaveEaster', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P3D')));
-        $ctx->propriumDeTempore['ThuOctaveEaster']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('ThuOctaveEaster', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P4D')));
-        $ctx->propriumDeTempore['FriOctaveEaster']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('FriOctaveEaster', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P5D')));
-        $ctx->propriumDeTempore['SatOctaveEaster']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('SatOctaveEaster', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P6D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('MonOctaveEaster', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('TueOctaveEaster', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('WedOctaveEaster', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('ThuOctaveEaster', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('FriOctaveEaster', $ctx);
-        $this->createPropriumDeTemporeLiturgicalEventByKey('SatOctaveEaster', $ctx);
     }
 
     /**
@@ -342,12 +273,10 @@ final class RomanTemporale implements TemporaleEngine
      */
     private function calculateMobileSolemnitiesOfTheLord(TemporaleContext $ctx): void
     {
-        $ctx->propriumDeTempore['SacredHeart']->setDate(Utilities::calcGregEaster($ctx->params->Year)
+        $ctx->createPropriumDeTemporeEvent('SacredHeart', Utilities::calcGregEaster($ctx->params->Year)
             ->add(new \DateInterval('P' . ( 7 * 9 + 5 ) . 'D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('SacredHeart', $ctx);
 
         //Christ the King is calculated backwards from the first sunday of advent
-        $ctx->propriumDeTempore['ChristKing']->setDate(DateTime::fromFormat('25-12-' . $ctx->params->Year)->modify('last Sunday')->sub(new \DateInterval('P' . ( 4 * 7 ) . 'D')));
-        $this->createPropriumDeTemporeLiturgicalEventByKey('ChristKing', $ctx);
+        $ctx->createPropriumDeTemporeEvent('ChristKing', DateTime::fromFormat('25-12-' . $ctx->params->Year)->modify('last Sunday')->sub(new \DateInterval('P' . ( 4 * 7 ) . 'D')));
     }
 }

--- a/src/Models/Calendar/Temporale/TemporaleContext.php
+++ b/src/Models/Calendar/Temporale/TemporaleContext.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Models\Calendar\Temporale;
 
+use LiturgicalCalendar\Api\DateTime;
 use LiturgicalCalendar\Api\LocaleDateFormatter;
+use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEvent;
 use LiturgicalCalendar\Api\Models\Calendar\LiturgicalEventCollection;
 use LiturgicalCalendar\Api\Models\PropriumDeTemporeMap;
 use LiturgicalCalendar\Api\Params\CalendarParams;
@@ -36,5 +38,22 @@ final class TemporaleContext
     public function addMessage(string $message): void
     {
         $this->messages[] = $message;
+    }
+
+    /**
+     * Dates the Proprium de Tempore entry for `$key` and adds the resulting
+     * LiturgicalEvent to the calendar, in one guarded call.
+     *
+     * Thin delegation to {@see PropriumDeTemporeEventFactory::create()} over
+     * this context's own Proprium de Tempore and calendar, so that engines
+     * need not thread those two collaborators through every call site.
+     *
+     * @param ?string   $key  The key of the event in the Proprium de Tempore
+     * @param ?DateTime $date The event's date; `null` when the entry has already been dated
+     * @return LiturgicalEvent The newly created LiturgicalEvent
+     */
+    public function createPropriumDeTemporeEvent(?string $key, ?DateTime $date = null): LiturgicalEvent
+    {
+        return PropriumDeTemporeEventFactory::create($this->propriumDeTempore, $this->cal, $key, $date);
     }
 }


### PR DESCRIPTION
Closes #724.

## What

Each temporale event was dated and created in two statements, repeating the event key both times:

```php
$ctx->propriumDeTempore['HolyThurs']->setDate($date);
$this->createPropriumDeTemporeLiturgicalEventByKey('HolyThurs', $ctx);
```

Two problems: the key is written twice (a copy/paste mismatch silently dates one key and creates another), and the mutation ran *before* the helper's `offsetExists()` guard, so an unknown key null-dereferenced instead of raising the intended `ServiceUnavailableException`.

Three copies of the helper existed, so — as the issue asks — the fold rides along with the de-dup rather than folding three separate copies.

| Piece | Change |
|-------|--------|
| `PropriumDeTemporeEventFactory` (new) | Single implementation of "date it, build it, add it", with optional `$date` for sites dated by another path |
| `TemporaleContext::createPropriumDeTemporeEvent()` | Thin delegation, so the stateless engines need not thread the map and calendar through every call site |
| `RomanTemporale` | Private helper deleted; 44 call sites folded |
| `AmbrosianTemporale` | 20 sites folded; keeps a private wrapper **solely** for its `stampSeason()` step, which still runs after the event is added |
| `CalendarHandler` | Private helper delegates to the same factory; 4 pairs folded |
| `dateIsSunday` | 3 private copies collapsed onto the already-public `LiturgicalEventCollection::dateIsSunday` (all four bodies were identical) |

Net −92 lines.

## On the gotchas the issue flagged

**The pairing was audited, not assumed.** Every `setDate` was matched to its create programmatically: exactly 44↔44 (Roman) and 20↔20 (Ambrosian), zero orphans. The one genuine non-pair — the handler's `ImmaculateHeart` `setDate`, which has no create call — is left untouched (#450).

**Operation order is preserved.** Per-event order (`setDate` → `fromObject` → `addLiturgicalEvent`) is unchanged, and so is the order events are added to the calendar. Roman's batched blocks (`setDate ×4` then `create ×4`) fold in place safely because within every batch the setDate order already equals the create order. I also confirmed no date expression reads another event's already-set date, so the interleaving change is inert.

## Verification

- **Golden master byte-identical**: 64,198 assertions before and after.
- `composer test:quick`: 3454 tests, 181,731 assertions, 11 skipped, exit 0.
- PHPStan L10, phpcs, parallel-lint: clean. Pre-commit hooks ran; nothing bypassed.
- Confirmed via reflection that PHPUnit loaded the worktree's `src/` rather than the shared checkout's, so the above results are about this branch.

Caveat for reviewers: the `Routes/*` tests in that suite hit `localhost:8000`, which serves a different checkout, so their green says nothing about this branch. The load-bearing gates here are the in-process golden-master and temporale suites.

## New test

`PropriumDeTemporeEventFactoryTest` (6 tests) pins the new validate-before-mutate behaviour, which nothing previously covered. It is a real guard, not a tautology: moving the mutation back in front of the check makes those cases fail with the old `TypeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent creation of Proprium de Tempore calendar events, with optional dates.
  * Invalid or missing event keys are rejected safely without altering the calendar.
  * Added a shared context method for convenient event creation.

* **Bug Fixes**
  * Improved Sunday detection consistency across calendar calculations.
  * Preserved existing event dates when no replacement date is provided.

* **Tests**
  * Added coverage for event creation, date handling, validation, calendar integrity, and context integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->