### PR TITLE
fix(auth): bound the OpenFGA scope fan-out, and collapse its duplicated handler plumbing

### DIFF
--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -463,4 +463,180 @@ final class ResourceAdminServiceTest extends TestCase
 
         self::assertCount(count(ResourceAdminService::ADMIN_OBJECT_TYPES), $service->resolveScopes('cei-admin'));
     }
+
+    /**
+     * The MockHandler behind the most recent {@see serviceWithClock()} service.
+     * Its remaining count is how a test proves a call was never dialed.
+     */
+    private ?MockHandler $mockQueue = null;
+
+    /**
+     * A service whose fan-out clock the test drives by hand.
+     *
+     * The clock reads a by-reference float rather than the wall clock, and the
+     * queued responses are callables that advance it — so "this OpenFGA call took
+     * two seconds" is expressed deterministically, with no sleeping.
+     *
+     * @param array<int, GuzzleResponse|callable> $responses Queued, replayed in order.
+     * @param float $now Advanced by the queued callables; passed by reference so the clock closure sees it move.
+     */
+    private function serviceWithClock(array $responses, float &$now, float $budget, ?LoggerInterface $logger = null): ResourceAdminService
+    {
+        $mock   = new MockHandler($responses);
+        $guzzle = new GuzzleClient(['handler' => HandlerStack::create($mock)]);
+        $psr17  = new Psr17Factory();
+        $client = new OpenFgaClient(
+            apiUrl: 'http://openfga.test',
+            storeId: 'test-store',
+            modelId: 'test-model',
+            httpClient: $guzzle,
+            requestFactory: $psr17,
+            streamFactory: $psr17,
+            apiToken: 'test-token'
+        );
+
+        $this->mockQueue = $mock;
+
+        return new ResourceAdminService(
+            $client,
+            $logger ?? new CollectingLogger(),
+            budgetSeconds: $budget,
+            clock: static function () use (&$now): float {
+                return $now;
+            }
+        );
+    }
+
+    /**
+     * A queued response that costs $seconds of fan-out budget.
+     */
+    private static function costing(float &$now, float $seconds, GuzzleResponse $response): callable
+    {
+        return static function () use (&$now, $seconds, $response): GuzzleResponse {
+            $now += $seconds;
+            return $response;
+        };
+    }
+
+    public function testResolveViewerScopesStopsDialingOnceTheFanOutBudgetIsSpent(): void
+    {
+        $now = 0.0;
+        // Two calls at 2s each exhaust a 3s budget: the first is dialed at t=0, the
+        // second at t=2 (still inside), and by t=4 the budget is gone.
+        $service = $this->serviceWithClock([
+            self::costing($now, 2.0, new GuzzleResponse(200, [], '{"objects":["general_roman_calendar:temporale"]}')),
+            self::costing($now, 2.0, new GuzzleResponse(200, [], '{"objects":["national_calendar_test:IT"]}')),
+            new GuzzleResponse(200, [], '{"objects":["diocesan_calendar_test:romamo_it"]}'),
+            new GuzzleResponse(200, [], '{"objects":["general_roman_calendar_test:temporale"]}'),
+            new GuzzleResponse(200, [], '{"objects":["rite_calendar_test:ambrosian"]}'),
+        ], $now, 3.0);
+
+        $scopes = $service->resolveViewerScopes('cei-admin');
+
+        // Every key is still present — the dashboard distinguishes "empty" from "missing".
+        self::assertSame(ResourceAdminService::VIEWER_OBJECT_TYPES, array_keys($scopes));
+        self::assertSame(['temporale'], $scopes['general_roman_calendar']);
+        self::assertSame(['IT'], $scopes['national_calendar_test']);
+        self::assertSame([], $scopes['diocesan_calendar_test']);
+        self::assertSame([], $scopes['general_roman_calendar_test']);
+        self::assertSame([], $scopes['rite_calendar_test']);
+
+        // The point of the budget: the remaining three were never dialed at all.
+        self::assertCount(3, $this->mockQueue);
+    }
+
+    public function testResolveScopesKeepsWhatItResolvedBeforeTheBudgetWasSpent(): void
+    {
+        $now     = 0.0;
+        $service = $this->serviceWithClock([
+            self::costing($now, 5.0, new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}')),
+            new GuzzleResponse(200, [], '{"objects":["diocesan_calendar:romamo_it"]}'),
+            new GuzzleResponse(200, [], '{"objects":["wider_region:Europe"]}'),
+            new GuzzleResponse(200, [], '{"objects":["general_roman_calendar:temporale"]}'),
+        ], $now, 3.0);
+
+        self::assertSame(
+            [['object_type' => 'national_calendar', 'object_id' => 'IT']],
+            $service->resolveScopes('cei-admin')
+        );
+        self::assertCount(3, $this->mockQueue);
+    }
+
+    public function testResolveTestScopesBudgetSpansBothRelationLoops(): void
+    {
+        $now = 0.0;
+        // One 5s editor probe spends the whole budget, so neither the remaining
+        // editor types nor any admin type is dialed.
+        $service = $this->serviceWithClock(
+            array_merge(
+                [self::costing($now, 5.0, new GuzzleResponse(200, [], '{"objects":["national_calendar_test:IT"]}'))],
+                array_map(
+                    static fn(): GuzzleResponse => new GuzzleResponse(200, [], '{"objects":["national_calendar_test:XX"]}'),
+                    range(1, 7)
+                )
+            ),
+            $now,
+            3.0
+        );
+
+        self::assertSame(
+            [
+                'editor' => [['object_type' => 'national_calendar_test', 'object_id' => 'IT']],
+                'admin'  => [],
+            ],
+            $service->resolveTestScopes('cei-admin')
+        );
+        self::assertCount(7, $this->mockQueue);
+    }
+
+    public function testFilterByAdminAccessFailsClosedOnceTheBudgetIsSpent(): void
+    {
+        $now      = 0.0;
+        $service  = $this->serviceWithClock([
+            self::costing($now, 5.0, new GuzzleResponse(200, [], '{"allowed":true}')),
+            new GuzzleResponse(200, [], '{"allowed":true}'),
+        ], $now, 3.0);
+        $requests = [
+            ['id' => 'A', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'admin']]],
+            ['id' => 'B', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'US', 'relation' => 'admin']]],
+        ];
+
+        // A was checked inside the budget and survives; B is excluded without a call.
+        $kept = $service->filterByAdminAccess($requests, 'cei-admin');
+
+        self::assertSame(['A'], array_column($kept, 'id'));
+        self::assertCount(1, $this->mockQueue);
+    }
+
+    public function testFanOutBudgetExhaustionIsLoggedOnceWithTheSkippedCount(): void
+    {
+        $now     = 0.0;
+        $logger  = new CollectingLogger();
+        $service = $this->serviceWithClock([
+            self::costing($now, 5.0, new GuzzleResponse(200, [], '{"objects":[]}')),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+            new GuzzleResponse(200, [], '{"objects":[]}'),
+        ], $now, 3.0, $logger);
+
+        $service->resolveScopes('cei-admin');
+
+        $errors = $logger->recordsAtLevel('error');
+        self::assertCount(1, $errors, 'one line per exhausted fan-out, not one per skipped unit');
+        self::assertStringContainsString('budget', $errors[0]['message']);
+        self::assertSame(3, $errors[0]['context']['skipped'] ?? null);
+    }
+
+    public function testTheDefaultBudgetDoesNotTripOnANormalFanOut(): void
+    {
+        // Guard against a budget so tight (or a clock so wrong) that healthy calls
+        // are skipped: with the real clock and the default budget, all four types
+        // are dialed and returned.
+        $service = $this->serviceWith(array_map(
+            static fn(string $type): GuzzleResponse => new GuzzleResponse(200, [], '{"objects":["' . $type . ':IT"]}'),
+            ResourceAdminService::ADMIN_OBJECT_TYPES
+        ));
+
+        self::assertCount(count(ResourceAdminService::ADMIN_OBJECT_TYPES), $service->resolveScopes('cei-admin'));
+    }
 }

--- a/phpunit_tests/Services/ResourceAdminServiceTest.php
+++ b/phpunit_tests/Services/ResourceAdminServiceTest.php
@@ -639,4 +639,57 @@ final class ResourceAdminServiceTest extends TestCase
 
         self::assertCount(count(ResourceAdminService::ADMIN_OBJECT_TYPES), $service->resolveScopes('cei-admin'));
     }
+
+    public function testTheBudgetSpansEveryFanOutOfOneServiceInstance(): void
+    {
+        $now = 0.0;
+        // The /auth/dashboard-scopes shape: resolveScopes() then resolveViewerScopes()
+        // on ONE service instance. A 5s first lookup must exhaust the budget for both,
+        // not hand the second call a fresh 3s window — otherwise the endpoint's worst
+        // case is two budgets plus two read timeouts, which is the availability hole
+        // #878 exists to close.
+        $service = $this->serviceWithClock(
+            array_merge(
+                [self::costing($now, 5.0, new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'))],
+                array_map(
+                    static fn(): GuzzleResponse => new GuzzleResponse(200, [], '{"objects":["national_calendar:XX"]}'),
+                    range(1, 8)
+                )
+            ),
+            $now,
+            3.0
+        );
+
+        $adminScopes  = $service->resolveScopes('cei-admin');
+        $viewerScopes = $service->resolveViewerScopes('cei-admin');
+
+        self::assertSame([['object_type' => 'national_calendar', 'object_id' => 'IT']], $adminScopes);
+        self::assertSame(array_fill_keys(ResourceAdminService::VIEWER_OBJECT_TYPES, []), $viewerScopes);
+        self::assertCount(8, $this->mockQueue, 'only the first lookup should ever have been dialed');
+    }
+
+    public function testTheBudgetAlsoSpansAResolveThenFilterSequence(): void
+    {
+        $now = 0.0;
+        // The GET /admin/notifications shape: resolveScopes() gates admission and
+        // filterByAdminAccess() then scopes the list, both on one instance.
+        $service  = $this->serviceWithClock(
+            array_merge(
+                [self::costing($now, 5.0, new GuzzleResponse(200, [], '{"objects":["national_calendar:IT"]}'))],
+                array_map(
+                    static fn(): GuzzleResponse => new GuzzleResponse(200, [], '{"allowed":true}'),
+                    range(1, 4)
+                )
+            ),
+            $now,
+            3.0
+        );
+        $requests = [
+            ['id' => 'A', 'permissions' => [['object_type' => 'national_calendar', 'object_id' => 'IT', 'relation' => 'admin']]],
+        ];
+
+        self::assertNotSame([], $service->resolveScopes('cei-admin'));
+        self::assertSame([], $service->filterByAdminAccess($requests, 'cei-admin'));
+        self::assertCount(4, $this->mockQueue, 'the check sweep should not have been dialed');
+    }
 }

--- a/src/Handlers/Admin/AccessRequestAdminHandler.php
+++ b/src/Handlers/Admin/AccessRequestAdminHandler.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Api\Handlers\Admin;
 
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Handlers\Concerns\ResolvesFgaClient;
 use LiturgicalCalendar\Api\Handlers\Pagination\OffsetPaginationTrait;
 use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
 use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
@@ -48,9 +49,9 @@ use Psr\Http\Message\ServerRequestInterface;
 final class AccessRequestAdminHandler extends AbstractHandler
 {
     use OffsetPaginationTrait;
+    use ResolvesFgaClient;
 
     private ?AccessRequestRepository $repository = null;
-    private ?OpenFgaClient $fgaClient            = null;
     private ?OutboxRepository $outboxRepository  = null;
     private ?OutboxNotifier $outboxNotifier      = null;
     private ?OutboxProcessor $outboxProcessor    = null;
@@ -94,14 +95,6 @@ final class AccessRequestAdminHandler extends AbstractHandler
             $this->repository = new AccessRequestRepository();
         }
         return $this->repository;
-    }
-
-    private function getFgaClient(): OpenFgaClient
-    {
-        if ($this->fgaClient === null) {
-            $this->fgaClient = OpenFgaClient::fromEnv();
-        }
-        return $this->fgaClient;
     }
 
     private function getOutboxRepository(): OutboxRepository
@@ -153,18 +146,6 @@ final class AccessRequestAdminHandler extends AbstractHandler
             );
         }
         return $this->outboxProcessor;
-    }
-
-    /**
-     * True when an OpenFGA client is reachable: either one was constructor-
-     * injected (test path), or the env-based static is configured (prod
-     * path). Replaces direct `OpenFgaClient::isConfigured()` checks at the
-     * sites that gate tuple-write / admin-check work, so an injected mock
-     * is honored without also requiring OPENFGA_* env vars to be set.
-     */
-    private function isFgaClientAvailable(): bool
-    {
-        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
     }
 
     public function handle(ServerRequestInterface $request): ResponseInterface

--- a/src/Handlers/Admin/NotificationsHandler.php
+++ b/src/Handlers/Admin/NotificationsHandler.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Api\Handlers\Admin;
 
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Handlers\Concerns\ResolvesFgaClient;
 use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
 use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
 use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
@@ -31,9 +32,10 @@ use Psr\Http\Message\ServerRequestInterface;
  */
 final class NotificationsHandler extends AbstractHandler
 {
+    use ResolvesFgaClient;
+
     private ?AccessRequestRepository $accessRequestRepo = null;
     private ?ApplicationRepository $applicationRepo     = null;
-    private ?OpenFgaClient $fgaClient                   = null;
 
     public function __construct(?OpenFgaClient $fgaClient = null)
     {
@@ -43,19 +45,6 @@ final class NotificationsHandler extends AbstractHandler
         $this->allowedRequestMethods = [RequestMethod::GET];
         $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
         $this->allowCredentials      = true;
-    }
-
-    private function isFgaClientAvailable(): bool
-    {
-        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
-    }
-
-    private function getFgaClient(): OpenFgaClient
-    {
-        if ($this->fgaClient === null) {
-            $this->fgaClient = OpenFgaClient::fromEnv();
-        }
-        return $this->fgaClient;
     }
 
     private function getAccessRequestRepository(): AccessRequestRepository

--- a/src/Handlers/Auth/AbstractScopesHandler.php
+++ b/src/Handlers/Auth/AbstractScopesHandler.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Auth;
+
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Handlers\Concerns\ResolvesFgaClient;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+use LiturgicalCalendar\Api\Services\ResourceAdminService;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Shared skeleton for the read-only scope report endpoints:
+ * `GET /auth/admin-scopes`, `GET /auth/test-scopes`, `GET /auth/dashboard-scopes`.
+ *
+ * All three answer the same question — "what may this caller do?" — and differ
+ * only in which {@see ResourceAdminService} resolvers they call and what keys
+ * they encode. Everything else (method and Accept validation, CORS, the
+ * `no-store` cache directive, extracting `sub` from the OIDC token, reading the
+ * global-admin role, and deciding whether OpenFGA can be reached at all) was
+ * triplicated across the three handlers, so a correction to the fail-closed
+ * contract in one was a correction in one.
+ *
+ * Subclasses implement {@see buildScopePayload()} and nothing else.
+ *
+ * **Fail-closed contract.** When OpenFGA is unreachable or unconfigured, the
+ * scope lists are empty but `is_global_admin` is still honored from the token —
+ * a caller's Zitadel role does not depend on the authorization server being up.
+ * `buildScopePayload()` receives `null` for the service in exactly that case.
+ */
+abstract class AbstractScopesHandler extends AbstractHandler
+{
+    use ResolvesFgaClient;
+
+    public function __construct(?OpenFgaClient $fgaClient = null)
+    {
+        parent::__construct();
+
+        $this->fgaClient             = $fgaClient;
+        $this->allowedRequestMethods = [RequestMethod::GET];
+        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
+        $this->allowCredentials      = true;
+    }
+
+    /**
+     * Build the response payload for one scope endpoint.
+     *
+     * @param string                    $sub           Zitadel user ID from the validated token, guaranteed non-empty
+     * @param bool                      $isGlobalAdmin Whether the token carries the Zitadel `admin` role
+     * @param ResourceAdminService|null $service       Resolver, or `null` when OpenFGA is unavailable — in which
+     *                                                 case the implementation must return its fail-closed shape,
+     *                                                 with every key it normally emits still present
+     * @return array<string, mixed>
+     */
+    abstract protected function buildScopePayload(string $sub, bool $isGlobalAdmin, ?ResourceAdminService $service): array;
+
+    final public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+        $method   = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime)
+            ->withHeader('Cache-Control', 'no-store');
+
+        /** @var array{sub?: string, roles?: array<string>}|null $oidcUser */
+        $oidcUser = $request->getAttribute('oidc_user');
+
+        if ($oidcUser === null) {
+            throw new UnauthorizedException('Authentication required');
+        }
+
+        $sub = $oidcUser['sub'] ?? null;
+        if (!is_string($sub) || trim($sub) === '') {
+            throw new UnauthorizedException('Invalid authentication token');
+        }
+
+        $isGlobalAdmin = OidcAuthMiddleware::isAdmin($oidcUser);
+        $service       = $this->isFgaClientAvailable()
+            ? new ResourceAdminService($this->getFgaClient())
+            : null;
+
+        return $this->encodeResponseBody($response, $this->buildScopePayload($sub, $isGlobalAdmin, $service));
+    }
+}

--- a/src/Handlers/Auth/AdminScopesHandler.php
+++ b/src/Handlers/Auth/AdminScopesHandler.php
@@ -4,16 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Handlers\Auth;
 
-use LiturgicalCalendar\Api\Handlers\AbstractHandler;
-use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
-use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
-use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
-use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
-use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
-use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Admin Scopes Handler
@@ -27,72 +18,19 @@ use Psr\Http\Message\ServerRequestInterface;
  * Fails closed: when OpenFGA is unavailable, admin_scopes is empty and
  * is_resource_admin is false, but is_global_admin is still honored from the token.
  */
-final class AdminScopesHandler extends AbstractHandler
+final class AdminScopesHandler extends AbstractScopesHandler
 {
-    private ?OpenFgaClient $fgaClient = null;
-
-    public function __construct(?OpenFgaClient $fgaClient = null)
+    /**
+     * @return array<string, mixed>
+     */
+    protected function buildScopePayload(string $sub, bool $isGlobalAdmin, ?ResourceAdminService $service): array
     {
-        parent::__construct();
+        $scopes = $service?->resolveScopes($sub) ?? [];
 
-        $this->fgaClient             = $fgaClient;
-        $this->allowedRequestMethods = [RequestMethod::GET];
-        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
-        $this->allowCredentials      = true;
-    }
-
-    private function isFgaClientAvailable(): bool
-    {
-        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
-    }
-
-    private function getFgaClient(): OpenFgaClient
-    {
-        if ($this->fgaClient === null) {
-            $this->fgaClient = OpenFgaClient::fromEnv();
-        }
-        return $this->fgaClient;
-    }
-
-    public function handle(ServerRequestInterface $request): ResponseInterface
-    {
-        $response = static::initResponse($request);
-        $method   = RequestMethod::from($request->getMethod());
-
-        if ($method === RequestMethod::OPTIONS) {
-            return $this->handlePreflightRequest($request, $response);
-        }
-
-        $response = $this->setAccessControlAllowOriginHeader($request, $response);
-        $this->validateRequestMethod($request);
-
-        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
-        $response = $response->withHeader('Content-Type', $mime)
-            ->withHeader('Cache-Control', 'no-store');
-
-        /** @var array{sub?: string, roles?: array<string>}|null $oidcUser */
-        $oidcUser = $request->getAttribute('oidc_user');
-
-        if ($oidcUser === null) {
-            throw new UnauthorizedException('Authentication required');
-        }
-
-        $sub = $oidcUser['sub'] ?? null;
-        if (!is_string($sub) || trim($sub) === '') {
-            throw new UnauthorizedException('Invalid authentication token');
-        }
-
-        $isGlobalAdmin = OidcAuthMiddleware::isAdmin($oidcUser);
-
-        $scopes = [];
-        if ($this->isFgaClientAvailable()) {
-            $scopes = ( new ResourceAdminService($this->getFgaClient()) )->resolveScopes($sub);
-        }
-
-        return $this->encodeResponseBody($response, [
+        return [
             'is_global_admin'   => $isGlobalAdmin,
             'is_resource_admin' => $scopes !== [],
             'admin_scopes'      => $scopes,
-        ]);
+        ];
     }
 }

--- a/src/Handlers/Auth/DashboardScopesHandler.php
+++ b/src/Handlers/Auth/DashboardScopesHandler.php
@@ -4,16 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Handlers\Auth;
 
-use LiturgicalCalendar\Api\Handlers\AbstractHandler;
-use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
-use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
-use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
-use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
-use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
-use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Dashboard Scopes Handler
@@ -28,78 +19,26 @@ use Psr\Http\Message\ServerRequestInterface;
  *     across ResourceAdminService::VIEWER_OBJECT_TYPES.
  *
  * Fails closed: when OpenFGA is unavailable, all scope lists are empty, but
- * is_global_admin is still honored from the token.
+ * is_global_admin is still honored from the token. Every viewer_scopes key is
+ * present either way — to the dashboard, a missing key and an empty one mean
+ * different things.
  */
-final class DashboardScopesHandler extends AbstractHandler
+final class DashboardScopesHandler extends AbstractScopesHandler
 {
-    private ?OpenFgaClient $fgaClient = null;
-
-    public function __construct(?OpenFgaClient $fgaClient = null)
+    /**
+     * @return array<string, mixed>
+     */
+    protected function buildScopePayload(string $sub, bool $isGlobalAdmin, ?ResourceAdminService $service): array
     {
-        parent::__construct();
+        $adminScopes  = $service?->resolveScopes($sub) ?? [];
+        $viewerScopes = $service?->resolveViewerScopes($sub)
+            ?? array_fill_keys(ResourceAdminService::VIEWER_OBJECT_TYPES, []);
 
-        $this->fgaClient             = $fgaClient;
-        $this->allowedRequestMethods = [RequestMethod::GET];
-        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
-        $this->allowCredentials      = true;
-    }
-
-    private function isFgaClientAvailable(): bool
-    {
-        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
-    }
-
-    private function getFgaClient(): OpenFgaClient
-    {
-        if ($this->fgaClient === null) {
-            $this->fgaClient = OpenFgaClient::fromEnv();
-        }
-        return $this->fgaClient;
-    }
-
-    public function handle(ServerRequestInterface $request): ResponseInterface
-    {
-        $response = static::initResponse($request);
-        $method   = RequestMethod::from($request->getMethod());
-
-        if ($method === RequestMethod::OPTIONS) {
-            return $this->handlePreflightRequest($request, $response);
-        }
-
-        $response = $this->setAccessControlAllowOriginHeader($request, $response);
-        $this->validateRequestMethod($request);
-
-        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
-        $response = $response->withHeader('Content-Type', $mime)
-            ->withHeader('Cache-Control', 'no-store');
-
-        /** @var array{sub?: string, roles?: array<string>}|null $oidcUser */
-        $oidcUser = $request->getAttribute('oidc_user');
-
-        if ($oidcUser === null) {
-            throw new UnauthorizedException('Authentication required');
-        }
-
-        $sub = $oidcUser['sub'] ?? null;
-        if (!is_string($sub) || trim($sub) === '') {
-            throw new UnauthorizedException('Invalid authentication token');
-        }
-
-        $isGlobalAdmin = OidcAuthMiddleware::isAdmin($oidcUser);
-
-        $adminScopes  = [];
-        $viewerScopes = array_fill_keys(ResourceAdminService::VIEWER_OBJECT_TYPES, []);
-        if ($this->isFgaClientAvailable()) {
-            $service      = new ResourceAdminService($this->getFgaClient());
-            $adminScopes  = $service->resolveScopes($sub);
-            $viewerScopes = $service->resolveViewerScopes($sub);
-        }
-
-        return $this->encodeResponseBody($response, [
+        return [
             'is_global_admin'   => $isGlobalAdmin,
             'is_resource_admin' => $adminScopes !== [],
             'admin_scopes'      => $adminScopes,
             'viewer_scopes'     => $viewerScopes,
-        ]);
+        ];
     }
 }

--- a/src/Handlers/Auth/TestScopesHandler.php
+++ b/src/Handlers/Auth/TestScopesHandler.php
@@ -4,16 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Handlers\Auth;
 
-use LiturgicalCalendar\Api\Handlers\AbstractHandler;
-use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
-use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
-use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
-use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
-use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
-use LiturgicalCalendar\Api\Services\OpenFgaClient;
 use LiturgicalCalendar\Api\Services\ResourceAdminService;
-use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Test Scopes Handler
@@ -26,72 +17,19 @@ use Psr\Http\Message\ServerRequestInterface;
  * Fails closed: when OpenFGA is unavailable, editor/admin are empty, but
  * is_global_admin is still honored from the token.
  */
-final class TestScopesHandler extends AbstractHandler
+final class TestScopesHandler extends AbstractScopesHandler
 {
-    private ?OpenFgaClient $fgaClient = null;
-
-    public function __construct(?OpenFgaClient $fgaClient = null)
+    /**
+     * @return array<string, mixed>
+     */
+    protected function buildScopePayload(string $sub, bool $isGlobalAdmin, ?ResourceAdminService $service): array
     {
-        parent::__construct();
+        $scopes = $service?->resolveTestScopes($sub) ?? ['editor' => [], 'admin' => []];
 
-        $this->fgaClient             = $fgaClient;
-        $this->allowedRequestMethods = [RequestMethod::GET];
-        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
-        $this->allowCredentials      = true;
-    }
-
-    private function isFgaClientAvailable(): bool
-    {
-        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
-    }
-
-    private function getFgaClient(): OpenFgaClient
-    {
-        if ($this->fgaClient === null) {
-            $this->fgaClient = OpenFgaClient::fromEnv();
-        }
-        return $this->fgaClient;
-    }
-
-    public function handle(ServerRequestInterface $request): ResponseInterface
-    {
-        $response = static::initResponse($request);
-        $method   = RequestMethod::from($request->getMethod());
-
-        if ($method === RequestMethod::OPTIONS) {
-            return $this->handlePreflightRequest($request, $response);
-        }
-
-        $response = $this->setAccessControlAllowOriginHeader($request, $response);
-        $this->validateRequestMethod($request);
-
-        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
-        $response = $response->withHeader('Content-Type', $mime)
-            ->withHeader('Cache-Control', 'no-store');
-
-        /** @var array{sub?: string, roles?: array<string>}|null $oidcUser */
-        $oidcUser = $request->getAttribute('oidc_user');
-
-        if ($oidcUser === null) {
-            throw new UnauthorizedException('Authentication required');
-        }
-
-        $sub = $oidcUser['sub'] ?? null;
-        if (!is_string($sub) || trim($sub) === '') {
-            throw new UnauthorizedException('Invalid authentication token');
-        }
-
-        $isGlobalAdmin = OidcAuthMiddleware::isAdmin($oidcUser);
-
-        $scopes = ['editor' => [], 'admin' => []];
-        if ($this->isFgaClientAvailable()) {
-            $scopes = ( new ResourceAdminService($this->getFgaClient()) )->resolveTestScopes($sub);
-        }
-
-        return $this->encodeResponseBody($response, [
+        return [
             'is_global_admin' => $isGlobalAdmin,
             'editor'          => $scopes['editor'],
             'admin'           => $scopes['admin'],
-        ]);
+        ];
     }
 }

--- a/src/Handlers/Concerns/ResolvesFgaClient.php
+++ b/src/Handlers/Concerns/ResolvesFgaClient.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Concerns;
+
+use LiturgicalCalendar\Api\Services\OpenFgaClient;
+
+/**
+ * Lazy, memoized access to the OpenFGA client, shared by every handler that
+ * consults authorization relations.
+ *
+ * Six handlers used to carry a byte-identical copy of this pair, and
+ * {@see ResolvesOutboxTooling} carried a seventh variant that rebuilt the
+ * client — and therefore its Guzzle connection pool — on every call. One copy
+ * means one place to change the construction, the memoization, or the
+ * "configured?" predicate.
+ *
+ * **Test seam.** `$fgaClient` is populated by the using handler's constructor
+ * from its optional `?OpenFgaClient` parameter, which is how the handler tests
+ * inject a `MockHandler`-backed client without touching the environment. A
+ * handler that has no such constructor parameter simply never sets it and
+ * always takes the `fromEnv()` path.
+ */
+trait ResolvesFgaClient
+{
+    /**
+     * Injected by the constructor (tests) or built lazily on first use
+     * (production). Never rebuilt once resolved, so a fan-out of relation
+     * lookups reuses one keep-alive connection.
+     */
+    private ?OpenFgaClient $fgaClient = null;
+
+    /**
+     * Whether a client can be obtained at all — either one was injected, or the
+     * environment carries the store/model/URL triple `fromEnv()` needs.
+     *
+     * Callers use this to skip the OpenFGA leg entirely and fall back to their
+     * fail-closed result, rather than letting `getFgaClient()` throw.
+     */
+    private function isFgaClientAvailable(): bool
+    {
+        return $this->fgaClient !== null || OpenFgaClient::isConfigured();
+    }
+
+    /**
+     * The memoized client, built from the environment on first use.
+     *
+     * @throws \RuntimeException If OpenFGA is not configured. Guard with
+     *                           {@see isFgaClientAvailable()} first.
+     */
+    private function getFgaClient(): OpenFgaClient
+    {
+        if ($this->fgaClient === null) {
+            $this->fgaClient = OpenFgaClient::fromEnv();
+        }
+
+        return $this->fgaClient;
+    }
+}

--- a/src/Handlers/Concerns/ResolvesOutboxTooling.php
+++ b/src/Handlers/Concerns/ResolvesOutboxTooling.php
@@ -32,6 +32,15 @@ use LiturgicalCalendar\Api\Services\ResourceTuplePurgeServiceInterface;
  */
 trait ResolvesOutboxTooling
 {
+    /**
+     * The OpenFGA client accessor Task 9's create-sync path and
+     * {@see getPurgeService()} both reach for. Composing the shared trait
+     * rather than re-declaring the accessor means this path now memoizes the
+     * client — and its keep-alive connection — instead of rebuilding it on
+     * every call.
+     */
+    use ResolvesFgaClient;
+
     private ?ResourceTuplePurgeServiceInterface $purgeService = null;
     private ?OutboxBatchInsertInterface $outboxRepository     = null;
     private ?\PDO $pdo                                        = null;
@@ -109,14 +118,5 @@ trait ResolvesOutboxTooling
             $this->pdo = Connection::getInstance();
         }
         return $this->pdo;
-    }
-
-    /**
-     * Returns a live OpenFGA client built from environment variables.
-     * Task 9's create-sync path reuses this directly.
-     */
-    protected function getFgaClient(): OpenFgaClient
-    {
-        return OpenFgaClient::fromEnv();
     }
 }

--- a/src/Services/ResourceAdminService.php
+++ b/src/Services/ResourceAdminService.php
@@ -77,6 +77,14 @@ final class ResourceAdminService
      * (~12 ms for nine calls, issue #711), so it can only ever be reached when
      * something is badly wrong — never by a merely busy authorization server.
      *
+     * **The budget is per service instance, and every call site constructs one
+     * per request** — which is what makes it a per-request bound rather than a
+     * per-resolver one. That distinction is load-bearing: `/auth/dashboard-scopes`
+     * resolves admin scopes and then viewer scopes, and `/admin/notifications`
+     * resolves scopes and then filters access requests. Re-arming the deadline
+     * for each of those would leave the endpoint's worst case at two budgets plus
+     * two read timeouts. Do not hold an instance across requests.
+     *
      * **What this does and does not bound.** The budget gates whether the *next*
      * lookup is dialed; it cannot interrupt one already in flight. The true
      * worst case is therefore this budget plus one read timeout (~8s), not 3s —
@@ -95,12 +103,14 @@ final class ResourceAdminService
     private readonly \Closure $clock;
 
     /**
-     * Deadline for the fan-out currently in flight, or null when none is.
+     * Deadline shared by every lookup this instance makes, stamped on the first
+     * one and never refreshed. Null until then.
      */
     private ?float $deadline = null;
 
     /**
-     * Lookups the in-flight fan-out skipped because its budget was spent.
+     * Lookups the fan-out in progress skipped because the budget was spent.
+     * Reset by {@see reportSkipped()} at the end of each fan-out.
      */
     private int $skipped = 0;
 
@@ -161,33 +171,25 @@ final class ResourceAdminService
     }
 
     /**
-     * Open a fan-out window, stamping the deadline every lookup in it is measured against.
-     *
-     * Returns whether THIS call owns the window. A nested fan-out (a public
-     * resolver reached through another) reuses the outer deadline rather than
-     * refreshing it, so the budget bounds the whole sequence and not each leg.
-     */
-    private function startFanOut(): bool
-    {
-        if ($this->deadline !== null) {
-            return false;
-        }
-
-        $this->deadline = ( $this->clock )() + $this->budgetSeconds;
-        $this->skipped  = 0;
-
-        return true;
-    }
-
-    /**
      * Whether there is still budget left to dial another lookup.
+     *
+     * The deadline is stamped on the first lookup this instance ever makes and
+     * never refreshed, so it spans EVERY fan-out the instance performs — which
+     * is what makes it a per-request bound. Two endpoints need that: the
+     * dashboard resolves admin scopes and then viewer scopes, and the
+     * notifications badge resolves scopes and then filters access requests, each
+     * through a single service. Re-arming per resolver would hand the second
+     * sweep a fresh budget and leave the endpoint's worst case at two budgets
+     * plus two read timeouts.
      *
      * Counts every refusal, so the close-out log can report how much of the
      * fan-out was skipped rather than answered.
      */
     private function withinBudget(): bool
     {
-        if ($this->deadline === null || ( $this->clock )() < $this->deadline) {
+        $this->deadline ??= ( $this->clock )() + $this->budgetSeconds;
+
+        if (( $this->clock )() < $this->deadline) {
             return true;
         }
 
@@ -197,16 +199,15 @@ final class ResourceAdminService
     }
 
     /**
-     * Close the fan-out window, reporting once if any lookup was skipped.
+     * Report, once per fan-out, how many lookups the spent budget skipped.
      *
-     * One line per exhausted fan-out, not one per skipped lookup: a hung OpenFGA
-     * would otherwise write eight near-identical lines per render.
+     * One line per fan-out, not one per skipped lookup: a hung OpenFGA would
+     * otherwise write eight near-identical lines per render.
      */
-    private function endFanOut(string $operation): void
+    private function reportSkipped(string $operation): void
     {
-        $skipped        = $this->skipped;
-        $this->deadline = null;
-        $this->skipped  = 0;
+        $skipped       = $this->skipped;
+        $this->skipped = 0;
 
         if ($skipped === 0) {
             return;
@@ -288,7 +289,6 @@ final class ResourceAdminService
     {
         $fgaUser = "user:{$sub}";
         $scopes  = [];
-        $owner   = $this->startFanOut();
 
         try {
             foreach (self::ADMIN_OBJECT_TYPES as $type) {
@@ -297,9 +297,7 @@ final class ResourceAdminService
                 }
             }
         } finally {
-            if ($owner) {
-                $this->endFanOut('resolveScopes');
-            }
+            $this->reportSkipped('resolveScopes');
         }
 
         return $scopes;
@@ -325,7 +323,6 @@ final class ResourceAdminService
         $fgaUser = "user:{$sub}";
         $editor  = [];
         $admin   = [];
-        $owner   = $this->startFanOut();
 
         try {
             foreach (self::TEST_OBJECT_TYPES as $type) {
@@ -339,9 +336,7 @@ final class ResourceAdminService
                 }
             }
         } finally {
-            if ($owner) {
-                $this->endFanOut('resolveTestScopes');
-            }
+            $this->reportSkipped('resolveTestScopes');
         }
 
         return ['editor' => $editor, 'admin' => $admin];
@@ -362,16 +357,13 @@ final class ResourceAdminService
     {
         $fgaUser = "user:{$sub}";
         $scopes  = array_fill_keys(self::VIEWER_OBJECT_TYPES, []);
-        $owner   = $this->startFanOut();
 
         try {
             foreach (self::VIEWER_OBJECT_TYPES as $type) {
                 $scopes[$type] = $this->listObjectsIsolated($fgaUser, 'viewer', $type);
             }
         } finally {
-            if ($owner) {
-                $this->endFanOut('resolveViewerScopes');
-            }
+            $this->reportSkipped('resolveViewerScopes');
         }
 
         return $scopes;
@@ -394,14 +386,11 @@ final class ResourceAdminService
 
         /** @var array<string, bool> $cache */
         $cache = [];
-        $owner = $this->startFanOut();
 
         try {
             return $this->filterEachByAdminAccess($requests, $fgaUser, $cache);
         } finally {
-            if ($owner) {
-                $this->endFanOut('filterByAdminAccess');
-            }
+            $this->reportSkipped('filterByAdminAccess');
         }
     }
 

--- a/src/Services/ResourceAdminService.php
+++ b/src/Services/ResourceAdminService.php
@@ -62,18 +62,68 @@ final class ResourceAdminService
         'rite_calendar_test',
     ];
 
+    /**
+     * Wall-clock ceiling for one fan-out of OpenFGA lookups.
+     *
+     * Each lookup carries its own 5s read timeout (see `OpenFgaClient::fromEnv()`),
+     * which bounds a single stuck call but not a sequence of them: nine of those in
+     * a row is 45 seconds of a php-fpm worker held on a response the caller stopped
+     * waiting for after five (the frontend's own timeout), with the deployment's
+     * `request_terminate_timeout >= 600` ten minutes away from helping. A hung
+     * OpenFGA would therefore convert every admin-dashboard render into a
+     * 45-second worker and exhaust the pool (issue #878).
+     *
+     * 3 seconds is roughly 250x the measured cost of the largest fan-out
+     * (~12 ms for nine calls, issue #711), so it can only ever be reached when
+     * something is badly wrong — never by a merely busy authorization server.
+     *
+     * **What this does and does not bound.** The budget gates whether the *next*
+     * lookup is dialed; it cannot interrupt one already in flight. The true
+     * worst case is therefore this budget plus one read timeout (~8s), not 3s —
+     * the point being that it no longer grows with the number of object types,
+     * which is what made the sequence dangerous. Squeezing the remainder means
+     * lowering `OpenFgaClient`'s per-call timeouts, which are shared with every
+     * other caller and deliberately left alone here.
+     */
+    public const FANOUT_BUDGET_SECONDS = 3.0;
+
     private ?LoggerInterface $logger;
 
+    private readonly float $budgetSeconds;
+
+    /** @var \Closure(): float Monotonic seconds; injectable so tests need not sleep. */
+    private readonly \Closure $clock;
+
     /**
-     * @param OpenFgaClient        $fgaClient OpenFGA client used for all relation lookups
-     * @param LoggerInterface|null $logger    Optional PSR-3 logger. When omitted, the shared
-     *                                        `auth` channel logger is created lazily on first
-     *                                        failure, so the happy path never touches the
-     *                                        filesystem.
+     * Deadline for the fan-out currently in flight, or null when none is.
      */
-    public function __construct(private readonly OpenFgaClient $fgaClient, ?LoggerInterface $logger = null)
-    {
-        $this->logger = $logger;
+    private ?float $deadline = null;
+
+    /**
+     * Lookups the in-flight fan-out skipped because its budget was spent.
+     */
+    private int $skipped = 0;
+
+    /**
+     * @param OpenFgaClient        $fgaClient     OpenFGA client used for all relation lookups
+     * @param LoggerInterface|null $logger        Optional PSR-3 logger. When omitted, the shared
+     *                                            `auth` channel logger is created lazily on first
+     *                                            failure, so the happy path never touches the
+     *                                            filesystem.
+     * @param float|null           $budgetSeconds Wall-clock ceiling for one fan-out.
+     *                                            Defaults to {@see FANOUT_BUDGET_SECONDS}.
+     * @param \Closure(): float|null $clock       Monotonic clock returning seconds. Defaults to
+     *                                            `hrtime()`; tests inject a controllable one.
+     */
+    public function __construct(
+        private readonly OpenFgaClient $fgaClient,
+        ?LoggerInterface $logger = null,
+        ?float $budgetSeconds = null,
+        ?\Closure $clock = null,
+    ) {
+        $this->logger        = $logger;
+        $this->budgetSeconds = $budgetSeconds ?? self::FANOUT_BUDGET_SECONDS;
+        $this->clock         = $clock ?? static fn(): float => hrtime(true) / 1e9;
     }
 
     /**
@@ -111,6 +161,73 @@ final class ResourceAdminService
     }
 
     /**
+     * Open a fan-out window, stamping the deadline every lookup in it is measured against.
+     *
+     * Returns whether THIS call owns the window. A nested fan-out (a public
+     * resolver reached through another) reuses the outer deadline rather than
+     * refreshing it, so the budget bounds the whole sequence and not each leg.
+     */
+    private function startFanOut(): bool
+    {
+        if ($this->deadline !== null) {
+            return false;
+        }
+
+        $this->deadline = ( $this->clock )() + $this->budgetSeconds;
+        $this->skipped  = 0;
+
+        return true;
+    }
+
+    /**
+     * Whether there is still budget left to dial another lookup.
+     *
+     * Counts every refusal, so the close-out log can report how much of the
+     * fan-out was skipped rather than answered.
+     */
+    private function withinBudget(): bool
+    {
+        if ($this->deadline === null || ( $this->clock )() < $this->deadline) {
+            return true;
+        }
+
+        ++$this->skipped;
+
+        return false;
+    }
+
+    /**
+     * Close the fan-out window, reporting once if any lookup was skipped.
+     *
+     * One line per exhausted fan-out, not one per skipped lookup: a hung OpenFGA
+     * would otherwise write eight near-identical lines per render.
+     */
+    private function endFanOut(string $operation): void
+    {
+        $skipped        = $this->skipped;
+        $this->deadline = null;
+        $this->skipped  = 0;
+
+        if ($skipped === 0) {
+            return;
+        }
+
+        $this->logFailure(
+            sprintf(
+                'OpenFGA fan-out budget of %.1fs exhausted during %s: %d lookup(s) skipped and failed closed',
+                $this->budgetSeconds,
+                $operation,
+                $skipped
+            ),
+            [
+                'operation'      => $operation,
+                'skipped'        => $skipped,
+                'budget_seconds' => $this->budgetSeconds,
+            ]
+        );
+    }
+
+    /**
      * List the object IDs of one type the user holds one relation on, failing
      * closed for that single (relation, type) pair.
      *
@@ -127,6 +244,13 @@ final class ResourceAdminService
      */
     private function listObjectsIsolated(string $fgaUser, string $relation, string $type): array
     {
+        if (!$this->withinBudget()) {
+            // Indistinguishable, to every caller, from a type that errored:
+            // the fan-out budget reuses the fail-closed contract rather than
+            // inventing a second one.
+            return [];
+        }
+
         try {
             return $this->fgaClient->listObjects($fgaUser, $relation, $type);
         } catch (\RuntimeException $e) {
@@ -164,10 +288,17 @@ final class ResourceAdminService
     {
         $fgaUser = "user:{$sub}";
         $scopes  = [];
+        $owner   = $this->startFanOut();
 
-        foreach (self::ADMIN_OBJECT_TYPES as $type) {
-            foreach ($this->listObjectsIsolated($fgaUser, 'admin', $type) as $objectId) {
-                $scopes[] = ['object_type' => $type, 'object_id' => $objectId];
+        try {
+            foreach (self::ADMIN_OBJECT_TYPES as $type) {
+                foreach ($this->listObjectsIsolated($fgaUser, 'admin', $type) as $objectId) {
+                    $scopes[] = ['object_type' => $type, 'object_id' => $objectId];
+                }
+            }
+        } finally {
+            if ($owner) {
+                $this->endFanOut('resolveScopes');
             }
         }
 
@@ -194,15 +325,22 @@ final class ResourceAdminService
         $fgaUser = "user:{$sub}";
         $editor  = [];
         $admin   = [];
+        $owner   = $this->startFanOut();
 
-        foreach (self::TEST_OBJECT_TYPES as $type) {
-            foreach ($this->listObjectsIsolated($fgaUser, 'editor', $type) as $objectId) {
-                $editor[] = ['object_type' => $type, 'object_id' => $objectId];
+        try {
+            foreach (self::TEST_OBJECT_TYPES as $type) {
+                foreach ($this->listObjectsIsolated($fgaUser, 'editor', $type) as $objectId) {
+                    $editor[] = ['object_type' => $type, 'object_id' => $objectId];
+                }
             }
-        }
-        foreach (self::TEST_OBJECT_TYPES as $type) {
-            foreach ($this->listObjectsIsolated($fgaUser, 'admin', $type) as $objectId) {
-                $admin[] = ['object_type' => $type, 'object_id' => $objectId];
+            foreach (self::TEST_OBJECT_TYPES as $type) {
+                foreach ($this->listObjectsIsolated($fgaUser, 'admin', $type) as $objectId) {
+                    $admin[] = ['object_type' => $type, 'object_id' => $objectId];
+                }
+            }
+        } finally {
+            if ($owner) {
+                $this->endFanOut('resolveTestScopes');
             }
         }
 
@@ -224,9 +362,16 @@ final class ResourceAdminService
     {
         $fgaUser = "user:{$sub}";
         $scopes  = array_fill_keys(self::VIEWER_OBJECT_TYPES, []);
+        $owner   = $this->startFanOut();
 
-        foreach (self::VIEWER_OBJECT_TYPES as $type) {
-            $scopes[$type] = $this->listObjectsIsolated($fgaUser, 'viewer', $type);
+        try {
+            foreach (self::VIEWER_OBJECT_TYPES as $type) {
+                $scopes[$type] = $this->listObjectsIsolated($fgaUser, 'viewer', $type);
+            }
+        } finally {
+            if ($owner) {
+                $this->endFanOut('resolveViewerScopes');
+            }
         }
 
         return $scopes;
@@ -249,7 +394,27 @@ final class ResourceAdminService
 
         /** @var array<string, bool> $cache */
         $cache = [];
+        $owner = $this->startFanOut();
 
+        try {
+            return $this->filterEachByAdminAccess($requests, $fgaUser, $cache);
+        } finally {
+            if ($owner) {
+                $this->endFanOut('filterByAdminAccess');
+            }
+        }
+    }
+
+    /**
+     * The per-request half of {@see filterByAdminAccess()}, split out so the
+     * budget window wraps the whole sweep rather than one request.
+     *
+     * @param array<int, array<string, mixed>> $requests
+     * @param array<string, bool> $cache Shared per-call check cache (by reference)
+     * @return array<int, array<string, mixed>> Filtered, re-indexed requests
+     */
+    private function filterEachByAdminAccess(array $requests, string $fgaUser, array &$cache): array
+    {
         return array_values(array_filter($requests, function (array $req) use ($fgaUser, &$cache): bool {
             /** @var array<int, array{object_type: string, object_id: string, relation: string}> $permissions */
             $permissions = is_array($req['permissions'] ?? null) ? $req['permissions'] : [];
@@ -297,6 +462,11 @@ final class ResourceAdminService
             $key        = "{$objectType}:{$objectId}";
 
             if (!isset($cache[$key])) {
+                if (!$this->withinBudget()) {
+                    // Same fail-closed answer an OpenFGA error would produce:
+                    // the request is excluded rather than optimistically kept.
+                    return false;
+                }
                 $cache[$key] = $this->fgaClient->check($fgaUser, 'admin', $key);
             }
 


### PR DESCRIPTION
Closes #878. Closes #879.

Two commits, in that order: the mechanical dedup first, then the budget on top of the deduped shape. Both fell out of the #711 evaluation — #711 measured the happy-path latency (~1.2 ms per lookup) and was closed as not-warranted, but the measuring turned up one real defect and one pile of duplication.

## 1. `refactor(handlers)`: one copy of the OpenFGA plumbing, one scope-handler skeleton

**Seven** classes carried a `getFgaClient()`, in two variants — one more than #879 estimated. Six were a byte-identical private pair (`isFgaClientAvailable()` + a memoizing `getFgaClient()`); the seventh, in `ResolvesOutboxTooling`, rebuilt the client — and therefore its Guzzle connection pool — on **every call**, and offered no injection seam. All of them now compose `Concerns\ResolvesFgaClient`, so the outbox path (`TestsHandler`, `RegionalDataHandler`) gains memoization as a side effect.

On top of that, the three scope endpoints shared ~60 lines of triplicated `handle()`: method and Accept validation, CORS, the `no-store` directive, extracting `sub` with both `UnauthorizedException` branches, reading the global-admin role, and gating on OpenFGA availability. `AbstractScopesHandler` now owns that in a `final handle()` and delegates to one hook:

```php
abstract protected function buildScopePayload(string $sub, bool $isGlobalAdmin, ?ResourceAdminService $service): array;
```

A `null` service is precisely the "OpenFGA unavailable" case, which is exactly where each subclass already kept its fail-closed literal. The three handlers keep their docblocks and shrink to that one method — 258 lines deleted, 43 added, plus the two new files.

No behavior change. Response shapes, key order, and #793's per-type fail-closed semantics are untouched, and **the existing handler tests pass unmodified** — they were the contract.

## 2. `fix(auth)`: a wall-clock budget on the fan-out

The actual defect, and it isn't latency.

Each lookup carries its own 5s read timeout, which bounds a single stuck call but not a sequence of them. The resolvers issue those in a loop — 4 / 8 / 9 calls for admin-, test- and dashboard-scopes — so an OpenFGA that **hangs** rather than refusing (a refused connection fails fast and is harmless) held a php-fpm worker for up to **45 seconds**. The caller was long gone: `AuthHelper::fetchDashboardScopes()` gives up at its own 5s timeout and renders the fail-closed dashboard. Nothing else would have stopped it either — the deployment checklist requires `request_terminate_timeout >= 600` for the long calendar routes, and `max_execution_time` does not count time blocked in socket reads. A handful of concurrent dashboard renders against a hung authorization server could exhaust the pool.

`ResourceAdminService` now stamps a deadline when a fan-out opens and refuses to dial past it. **A refused lookup returns exactly what an errored one returns**, so the budget reuses #793's fail-closed contract instead of inventing a second one — every `viewer_scopes` key still present, scopes gathered before the trip preserved, response shapes identical. `filterByAdminAccess()` is covered too (its per-request `check()` sweep has the same exposure), and a nested resolver reuses the outer window rather than refreshing it, so the budget bounds the whole sequence rather than each leg.

**Be precise about what this bounds:** the budget gates whether the *next* lookup is dialed; it cannot interrupt one already in flight. The true worst case is the budget plus one read timeout (~8s), not 3s. The point is that it no longer *grows with the object-type list*, which went 4 → 6 → 8 → 9 as resource cards were added. Squeezing the remainder means lowering `OpenFgaClient`'s per-call timeouts — shared with every other caller, and deliberately left alone here.

3s is ~250x the measured cost of the largest fan-out (~12 ms for nine calls), so it cannot be reached by a merely busy server. It is a constant with a constructor override rather than an env var: no new deployment surface to document or validate, and the tests drive it alongside an injected monotonic clock, so nothing sleeps.

## Testing

Six new tests in `ResourceAdminServiceTest`, written first and watched fail. Because the initial red was a constructor error rather than a behavioral failure, each guard was then **mutated out** individually to confirm the assertions actually catch it: disabling the `listObjects` guard fails 4 of them, disabling the `check` guard fails the 5th, and the 6th is a guard against a budget so tight it would skip healthy calls.

- 2117 tests green across `Handlers/`, `Services/`, `Http/`, `Enum/`, `Models/`, `Params/`, `Methods/` and `RouterTest`
- The 6 skips are pre-existing and environmental (an OpenFGA store this host does not run) — verified identical on the branch point, 530 tests / 6 skipped before, 536 / 6 after
- `composer analyse` (PHPStan level 10) and `composer lint` clean
- `Routes/*` deliberately not run: they hit `localhost:8000`, which serves a different checkout, so a green there would say nothing about this branch

## Deliberately out of scope

- `RoleCascadeService`'s relation × type loops — a background revocation path, not a worker-render one
- `AccessRequestAdminHandler`'s own `check()` loop — bounded by one request's permission count (typically 1–3) rather than a growing type list, and it throws `ForbiddenException` rather than failing closed silently
- Lowering `OpenFgaClient::fromEnv()`'s 5s/2s timeouts — shared with every caller; worth its own change if the residual ~8s ever matters

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added consistent handling for authentication scope requests, including validation, authentication, CORS, and cache controls.
  * Scope responses now fail safely with empty permissions when authorisation services are unavailable.

* **Bug Fixes**
  * Added safeguards to stop lengthy permission checks once the processing time limit is reached.
  * The time limit now applies across related permission operations.
  * Previously resolved permissions and response fields are preserved when processing stops early.
  * Access checks fail closed and record a single summary when requests are skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->