### PR TITLE
feat(ws): honour a response format on executeValidation

### DIFF
--- a/jsondata/schemas/WebSocketMessage.json
+++ b/jsondata/schemas/WebSocketMessage.json
@@ -57,7 +57,10 @@
                 "validate": { "type": "string", "pattern": "^[^\\x00]*$" },
                 "sourceFile": { "type": "string", "pattern": "^[^\\x00]*$" },
                 "sourceFolder": { "type": "string", "pattern": "^[^\\x00]*$" },
-                "responsetype": { "type": "string" },
+                "responseFormat": {
+                    "description": "The representation to request from the API for a URL-addressed check, sent as an Accept header. JSON and YML only: every resource path other than /calendar answers 406 to application/xml and text/calendar, which is why XML and ICS are valid on validateCalendar and not here. Replaces the retired `responsetype`, which executeValidation() never read.",
+                    "enum": ["JSON", "YML"]
+                },
                 "rite": { "type": "string" },
                 "protocol": { "$ref": "#/definitions/protocolVersion" },
                 "runToken": { "$ref": "#/definitions/correlationId" },

--- a/phpunit_tests/Handlers/EasterHandlerTest.php
+++ b/phpunit_tests/Handlers/EasterHandlerTest.php
@@ -26,6 +26,52 @@ final class EasterHandlerTest extends AbstractHandlerTestCase
         }
     }
 
+    /**
+     * A cache that cannot be written costs the client a cache entry, not its answer.
+     *
+     * This handler is the only one of its family that caches serialised output to disk, and it used
+     * to `throw new ServiceUnavailableException('Failed to write cache file')` when the write failed
+     * — so on a read-only rootfs (a hardened deployment, or the API's own docker image) `/easter`
+     * alone answered **500**, and only for a representation with no pre-warmed file beside it. The
+     * shipped image carries `en.json` and `la.json`, which is exactly why JSON looked healthy while
+     * `Accept: application/yaml` did not: the first YAML request tried to create `la.yml` and died
+     * with "Failed to open stream: Read-only file system".
+     *
+     * The unwritable directory is simulated by putting a *file* where the cache directory belongs,
+     * which makes both `mkdir()` and `file_put_contents()` fail without needing root or a real
+     * read-only mount, and without depending on the test runner's uid.
+     */
+    public function testAnUnwritableCacheDoesNotCostTheClientItsResponse(): void
+    {
+        $cacheDir = self::CACHE_DIR;
+        if (is_dir($cacheDir)) {
+            foreach ((array) glob($cacheDir . '/*') as $file) {
+                if (is_string($file) && is_file($file)) {
+                    unlink($file);
+                }
+            }
+            rmdir($cacheDir);
+        }
+        // A regular file where the directory should be: mkdir() fails, and so does every write into it.
+        file_put_contents($cacheDir, 'not a directory');
+
+        try {
+            $response = @( new EasterHandler() )->handle(
+                $this->requestFor('GET', '/easter', ['Accept-Language' => 'la'])
+            );
+
+            self::assertSame(200, $response->getStatusCode(), 'an unwritable cache must not become a 5xx');
+            $body = $this->decodeJsonBody($response);
+            self::assertArrayHasKey('litcal_easter', $body);
+            self::assertNotEmpty($body['litcal_easter'], 'the response must be fully computed, not truncated');
+            self::assertNotEmpty($response->getHeaderLine('ETag'), 'the ETag is computed from the body, not from the cache');
+        } finally {
+            if (is_file($cacheDir)) {
+                unlink($cacheDir);
+            }
+        }
+    }
+
     public function testOptionsPreflightSucceeds(): void
     {
         $response = ( new EasterHandler() )->handle(

--- a/phpunit_tests/HealthResourceFormatTest.php
+++ b/phpunit_tests/HealthResourceFormatTest.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Ratchet\ConnectionInterface;
+
+/**
+ * `executeValidation` honours the response format it is asked for.
+ *
+ * Until this landed, `responsetype` rode along on every resource check and was never read: the URL
+ * was fetched under default content negotiation (JSON) whatever the client selected, while the
+ * client's own card labelled the result with the format it had asked for. Picking YAML in
+ * UnitTestInterface's Resources runner therefore produced a page of green cards claiming to have
+ * parsed YAML, over thirty-odd payloads that were all JSON — a wrong-green manufactured by the
+ * interface whose job is to detect them.
+ *
+ * **The mechanism is the Accept header, and that is not a stylistic choice.** `return_type` is a
+ * property of `CalendarParams`, so it exists only on `/calendar`; every route a resource check
+ * addresses negotiates through `Negotiator`, which reads `Accept` and nothing else. Appending
+ * `?return_type=YML` to `/calendars` returns `application/json` with a 200 — the exact shape of a
+ * silent wrong-green — which is why {@see Health::ACCEPT_HEADER_FOR_FORMAT} exists and why the first
+ * test here asserts on the queued request's Guzzle options rather than only on the frames.
+ */
+#[CoversClass(Health::class)]
+final class HealthResourceFormatTest extends TestCase
+{
+    use HealthQueueIsolationTrait;
+
+    private const CALENDARS_URL = 'http://localhost:8000/calendars';
+
+    /** A minimal but genuinely-YAML body: `json_decode()` fails on it, `Yaml::parse()` does not. */
+    private const YAML_BODY = "litcal_metadata:\n    national_calendars: []\n";
+
+    public static function setUpBeforeClass(): void
+    {
+        Router::getApiPaths();
+        CheckableInventory::reset();
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        CheckableInventory::reset();
+    }
+
+    private ?string $appEnvBackup = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->appEnvBackup = isset($_ENV['APP_ENV']) && is_string($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : null;
+        $_ENV['APP_ENV']    = 'test';
+    }
+
+    protected function tearDown(): void
+    {
+        if (null === $this->appEnvBackup) {
+            unset($_ENV['APP_ENV']);
+        } else {
+            $_ENV['APP_ENV'] = $this->appEnvBackup;
+        }
+        parent::tearDown();
+    }
+
+    // ---------------------------------------------------------------- harness
+
+    private static function stubConnection(int $resourceId = 1)
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     */
+    private static function send(Health $health, ConnectionInterface $conn, array $payload): void
+    {
+        ob_start();
+        $health->onMessage($conn, (string) json_encode($payload));
+        ob_end_clean();
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    private static function framesOf(ConnectionInterface $conn): array
+    {
+        /** @var object{sent: list<string>} $conn */
+        return array_map(static fn (string $raw): \stdClass => json_decode($raw), $conn->sent);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private static function queuedRequests(Health $health): array
+    {
+        /** @var list<array<string, mixed>> */
+        return ( new \ReflectionProperty(Health::class, 'queue') )->getValue($health);
+    }
+
+    private static function fulfilQueued(Health $health, int $index, int $status, string $body, string $contentType): void
+    {
+        $queued = self::queuedRequests($health);
+        self::assertArrayHasKey($index, $queued, "expected a queued request at index {$index}");
+        /** @var \Closure(ResponseInterface):void $resolve */
+        $resolve = $queued[$index]['resolve'];
+
+        ob_start();
+        $resolve(new Response($status, ['Content-Type' => $contentType], $body));
+        ob_end_clean();
+    }
+
+    /**
+     * @param array<string, mixed> $extra
+     * @return array<string, mixed>
+     */
+    private static function resourceCheck(array $extra = []): array
+    {
+        return array_merge([
+            'action'     => 'executeValidation',
+            'category'   => 'resourceDataCheck',
+            'validate'   => 'calendars-path',
+            'sourceFile' => self::CALENDARS_URL,
+            'requestId'  => 'req-fmt'
+        ], $extra);
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    private static function stepFrames(ConnectionInterface $conn, string $step): array
+    {
+        return array_values(array_filter(
+            self::framesOf($conn),
+            static fn (\stdClass $f): bool => ( $f->step ?? null ) === $step
+        ));
+    }
+
+    // ---------------------------------------------------------------- the Accept header
+
+    /**
+     * The assertion the whole change exists for: the format reaches the wire as an Accept header.
+     *
+     * Asserted on the queued Guzzle options rather than on a frame, because a frame cannot tell the
+     * difference between "fetched as YAML" and "fetched as JSON and labelled YAML" — which is exactly
+     * the bug. `cachedGet()` keys its cache on `serialize($options)`, so this also establishes that
+     * the two formats of one URL cannot collide in the cache.
+     */
+    public function testAYmlResourceCheckIsFetchedWithAYamlAcceptHeader(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, self::resourceCheck(['responseFormat' => 'YML']));
+
+        $queued = self::queuedRequests($health);
+        self::assertArrayHasKey(0, $queued, 'the check queued no HTTP request');
+        self::assertSame(self::CALENDARS_URL, $queued[0]['url']);
+        /** @var array{headers?: array<string, string>} $options */
+        $options = $queued[0]['options'];
+        self::assertSame(
+            'application/yaml',
+            $options['headers']['Accept'] ?? null,
+            'the requested format never reached the request'
+        );
+    }
+
+    /**
+     * The default is JSON, explicitly asked for rather than left to the server's own default, so a
+     * message that names no format still pins one on the wire.
+     */
+    public function testAResourceCheckWithNoFormatAsksForJson(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, self::resourceCheck());
+
+        $queued = self::queuedRequests($health);
+        self::assertArrayHasKey(0, $queued);
+        /** @var array{headers?: array<string, string>} $options */
+        $options = $queued[0]['options'];
+        self::assertSame('application/json', $options['headers']['Accept'] ?? null);
+    }
+
+    // ---------------------------------------------------------------- the parses step
+
+    /**
+     * A YAML body decodes on the `parses` step instead of failing it.
+     *
+     * Before the format was threaded through, this arm ran `json_decode()` over whatever came back,
+     * so honouring the Accept header without also teaching the parse step YAML would have turned
+     * every YAML check red on syntax — trading a silent wrong-green for a loud wrong-red.
+     */
+    public function testAYamlBodyParsesAsYaml(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, self::resourceCheck(['responseFormat' => 'YML']));
+        self::fulfilQueued($health, 0, 200, self::YAML_BODY, 'application/yaml');
+
+        $parses = self::stepFrames($conn, 'parses');
+        self::assertCount(1, $parses, 'exactly one frame per step');
+        self::assertSame('pass', $parses[0]->status);
+        self::assertStringContainsString('decoded as YAML', $parses[0]->text);
+    }
+
+    /**
+     * And a body that is not valid YAML fails it, naming YAML rather than JSON — a client reading
+     * "could not be decoded as JSON" after asking for YAML would hunt the wrong problem.
+     */
+    public function testAMalformedYamlBodyFailsTheParseStepNamingYaml(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, self::resourceCheck(['responseFormat' => 'YML']));
+        self::fulfilQueued($health, 0, 200, "key: [unclosed\n  bad: : :\n", 'application/yaml');
+
+        $parses = self::stepFrames($conn, 'parses');
+        self::assertCount(1, $parses);
+        self::assertSame('fail', $parses[0]->status);
+        self::assertStringContainsString('as YAML', $parses[0]->text);
+        self::assertStringNotContainsString('as JSON', $parses[0]->text);
+    }
+
+    /**
+     * A JSON check is unchanged, wording included. The rename of the message must not silently
+     * reword every existing frame a client may be matching on.
+     */
+    public function testAJsonBodyStillParsesAndStillSaysJson(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, self::resourceCheck(['responseFormat' => 'JSON']));
+        self::fulfilQueued($health, 0, 200, '{"litcal_metadata":{}}', 'application/json');
+
+        $parses = self::stepFrames($conn, 'parses');
+        self::assertCount(1, $parses);
+        self::assertSame('pass', $parses[0]->status);
+        self::assertStringContainsString('decoded as JSON', $parses[0]->text);
+    }
+
+    // ---------------------------------------------------------------- rejections
+
+    /**
+     * `responsetype` is retired on this action now, and says what replaces it.
+     *
+     * It was deliberately left accepted for as long as nothing read it. A client still sending the
+     * old spelling once the new one is honoured would have its choice silently ignored and every
+     * check fetched as JSON while its cards claimed otherwise, so silence stopped being harmless.
+     */
+    public function testTheRetiredResponsetypeIsRefusedWithItsReplacement(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, self::resourceCheck(['responsetype' => 'YML']));
+
+        $frames = self::framesOf($conn);
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame(ProtocolErrorCode::RETIRED_PROPERTY->value, $frames[0]->errorCode);
+        self::assertSame(
+            'responsetype is not part of a executeValidation message: responseFormat replaces it.',
+            $frames[0]->text
+        );
+        self::assertSame([], self::queuedRequests($health), 'a refused message must not fetch anything');
+    }
+
+    /**
+     * XML and ICS are valid on `validateCalendar` and not here.
+     *
+     * Not a stylistic restriction: `/calendar` serves all four, and every route a resource check
+     * addresses answers **406** to `application/xml` and `text/calendar`. Accepting them would hand a
+     * client a format the check can only ever fail on, and `ReturnTypeParam::from()` throws a
+     * `\ValueError` — an `\Error` Ratchet does not catch — on anything outside its own list, so an
+     * unvalidated format is a process-killing hazard rather than merely a useless one.
+     */
+    #[DataProvider('formatsValidOnCalendarButNotOnResources')]
+    public function testAFormatNoResourcePathServesIsRefused(string $format): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, self::resourceCheck(['responseFormat' => $format]));
+
+        $frames = self::framesOf($conn);
+        self::assertSame('protocolError', $frames[0]->type);
+        self::assertSame([], self::queuedRequests($health), 'a refused message must not fetch anything');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function formatsValidOnCalendarButNotOnResources(): array
+    {
+        return [
+            'XML' => ['XML'],
+            'ICS' => ['ICS']
+        ];
+    }
+}

--- a/phpunit_tests/HealthResourceFormatTest.php
+++ b/phpunit_tests/HealthResourceFormatTest.php
@@ -271,6 +271,32 @@ final class HealthResourceFormatTest extends TestCase
         self::assertStringContainsString('decoded as JSON', $parses[0]->text);
     }
 
+    /**
+     * A failure that never reached a decode names no format at all.
+     *
+     * `handleValidationHttpFailure()` and `handleValidationDataError()` used to say "as JSON"
+     * unconditionally. That was invisible while nothing could ask for anything else; once YML is
+     * honoured it becomes a frame telling a client its YAML request failed to decode as JSON, which
+     * sends the reader after a format problem when the real one is an HTTP status. Nothing was
+     * decoded on either arm, so the wording is format-neutral rather than merely corrected — see the
+     * comments at both sites.
+     */
+    public function testAnHttpFailureNamesNoFormatAtAll(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::stubConnection();
+
+        self::send($health, $conn, self::resourceCheck(['responseFormat' => 'YML']));
+        self::fulfilQueued($health, 0, 503, '{"status":503}', 'application/problem+json');
+
+        $parses = self::stepFrames($conn, 'parses');
+        self::assertCount(1, $parses);
+        self::assertSame('fail', $parses[0]->status);
+        self::assertStringContainsString('HTTP 503', $parses[0]->text, 'the real reason must survive');
+        self::assertStringNotContainsString('as JSON', $parses[0]->text);
+        self::assertStringNotContainsString('as YAML', $parses[0]->text);
+    }
+
     // ---------------------------------------------------------------- rejections
 
     /**

--- a/phpunit_tests/HealthValidationDataErrorTest.php
+++ b/phpunit_tests/HealthValidationDataErrorTest.php
@@ -108,7 +108,7 @@ final class HealthValidationDataErrorTest extends TestCase
         self::assertSame('.proprium-de-tempore.file-exists', $frames[0]->classes);
 
         self::assertSame('error', $frames[1]->type);
-        self::assertSame('Could not decode the Data file jsondata/x.json as JSON because it is not readable', $frames[1]->text);
+        self::assertSame('Could not decode the Data file jsondata/x.json because it is not readable', $frames[1]->text);
         self::assertSame('.proprium-de-tempore.json-valid', $frames[1]->classes);
 
         self::assertSame('error', $frames[2]->type);

--- a/src/Handlers/EasterHandler.php
+++ b/src/Handlers/EasterHandler.php
@@ -248,12 +248,24 @@ final class EasterHandler extends AbstractHandler
         $responseHash = md5($contents);
         $response     = $response->withHeader('ETag', "\"{$responseHash}\"");
 
-        if (!is_dir('engineCache/easter/')) {
-            mkdir('engineCache/easter/', 0774, true);
-        }
-
-        if (false === file_put_contents($cacheFile, $contents)) {
-            throw new ServiceUnavailableException('Failed to write cache file');
+        // The cache is an optimisation, not part of the response, so a cache that cannot be written
+        // must not cost the client its answer. It used to: `engineCache/` is not writable on a
+        // read-only rootfs (a hardened deployment, or the API's own docker image), and this handler
+        // is the only one of its family that caches serialised output at all — so `/easter` alone
+        // answered 500 there, and only for a representation with no pre-warmed file beside it. The
+        // shipped image carries `en.json` and `la.json`, which is why JSON looked fine and
+        // `Accept: application/yaml` did not: the first YAML request tried to create `la.yml` and
+        // died with "Failed to open stream: Read-only file system".
+        //
+        // Suppressed rather than guarded with `is_writable()`: the directory can be writable and the
+        // write still fail (quota, a race with another worker), and the two outcomes deserve the same
+        // treatment. The failure is reported to the log so a deployment that meant its cache to work
+        // can still find out that it does not.
+        $cacheDirReady = is_dir('engineCache/easter/') || @mkdir('engineCache/easter/', 0774, true) || is_dir('engineCache/easter/');
+        if (false === $cacheDirReady || false === @file_put_contents($cacheFile, $contents)) {
+            // `error_log()`, matching {@see \LiturgicalCalendar\Api\ApcuCache}'s treatment of a cache
+            // backend that will not co-operate: the request is served, the operator finds out.
+            error_log('Easter cache write failed for ' . $cacheFile . '; serving the response uncached.');
         }
 
         if (

--- a/src/Health.php
+++ b/src/Health.php
@@ -2176,7 +2176,13 @@ class Health implements MessageComponentInterface
             $target,
             Step::PARSES,
             Status::FAIL,
-            "Could not decode the Data file $dataPath as JSON because it is not readable",
+            // Format-neutral on purpose, and unlike {@see Health::processValidationData()}'s
+            // wording, which names the format because a decode was genuinely attempted in it.
+            // Nothing was decoded here: the read failed. Naming a format would be noise at best,
+            // and a small untruth whenever the request asked for one this arm does not know about
+            // — this method serves both the filesystem arm (always JSON) and the URL arm's reject
+            // handler (whatever `responseFormat` asked for).
+            "Could not decode the Data file $dataPath because it is not readable",
             null,
             $runToken,
             requestId: $requestId
@@ -2255,7 +2261,10 @@ class Health implements MessageComponentInterface
             $target,
             Step::PARSES,
             Status::FAIL,
-            "Could not decode the Data file $dataPath as JSON because the request for it returned HTTP $status",
+            // Format-neutral for the same reason as the unreadable-file arm above: a non-2xx means
+            // no decode was attempted at all, so the format that was asked for is not what went
+            // wrong and naming it would only mislead.
+            "Could not decode the Data file $dataPath because the request for it returned HTTP $status",
             null,
             $runToken,
             requestId: $requestId

--- a/src/Health.php
+++ b/src/Health.php
@@ -32,6 +32,7 @@ use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
@@ -170,7 +171,21 @@ class Health implements MessageComponentInterface
      * @var array<string, array{shape: string, retired: array<string, string>}>
      */
     private const RETIRED_PROPERTIES = [
-        'validateSource'   => [
+        'executeValidation' => [
+            'shape'   => 'executeValidation message',
+            'retired' => [
+                // Retired late, and deliberately so. Until this action honoured a response format,
+                // `responsetype` was the one optional property left un-retired on the grounds that
+                // `executeValidation()` never read it, so retiring it "would answer a question no
+                // client is asking". The moment the action started reading a format that reasoning
+                // expired: a client still sending the old spelling would now have its choice
+                // silently ignored and every check fetched as JSON while its cards claimed YAML,
+                // which is precisely the wrong-green this interface exists to detect. Same
+                // replacement sentence as `validateCalendar`'s, because it is the same rename.
+                'responsetype' => 'responseFormat replaces it.'
+            ]
+        ],
+        'validateSource'    => [
             'shape'   => 'validateSource message',
             'retired' => [
                 // `executeValidation` spread the address across a schema-resolution strategy and a
@@ -181,7 +196,7 @@ class Health implements MessageComponentInterface
                 'sourceFolder' => 'target.id replaces it.'
             ]
         ],
-        'validateCalendar' => [
+        'validateCalendar'  => [
             'shape'   => 'validateCalendar message with an object calendar',
             'retired' => [
                 'category'     => 'calendar.kind replaces it.',
@@ -200,7 +215,7 @@ class Health implements MessageComponentInterface
                 'rite'         => 'calendar.rite replaces it.'
             ]
         ],
-        'runTest'          => [
+        'runTest'           => [
             'shape'   => 'runTest message',
             'retired' => [
                 'category' => 'calendar.kind replaces it.',
@@ -223,6 +238,33 @@ class Health implements MessageComponentInterface
      * @var string[]
      */
     private const VALIDATABLE_RESPONSE_FORMATS = ['JSON', 'XML', 'ICS', 'YML'];
+
+    /**
+     * The response formats a *resource* check can ask the API for.
+     *
+     * Narrower than {@see Health::VALIDATABLE_RESPONSE_FORMATS}, and for a reason that lives in the
+     * API rather than in this class: `return_type` is a `CalendarParams` property, so it exists only
+     * on `/calendar`, and every other route negotiates purely on `Accept` through
+     * {@see \LiturgicalCalendar\Api\Http\Negotiator}. Those routes serve `application/json` and
+     * `application/yaml` and answer **406** to `application/xml` and `text/calendar`. Offering XML or
+     * ICS here would therefore hand a client a format the check can only fail on.
+     *
+     * @var string[]
+     */
+    private const VALIDATABLE_RESOURCE_FORMATS = ['JSON', 'YML'];
+
+    /**
+     * The Accept header each validatable resource format asks for.
+     *
+     * `application/yaml` and nothing else: the API's {@see \LiturgicalCalendar\Api\Http\Enum\AcceptHeader}
+     * does not list `application/x-yaml` or `text/yaml`, and both come back 406.
+     *
+     * @var array<string, string>
+     */
+    private const ACCEPT_HEADER_FOR_FORMAT = [
+        'JSON' => 'application/json',
+        'YML'  => 'application/yaml'
+    ];
 
     /**
      * The shape a correlation identifier must have: 1 to 64 characters of `A-Za-z0-9_-`.
@@ -1512,6 +1554,13 @@ class Health implements MessageComponentInterface
     private function executeValidation(\stdClass $validation, ConnectionInterface $to, ?string $requestId = null): void
     {
         $runToken = $this->resolveRunToken($to);
+
+        // This action retires a property now (`responsetype`), so it needs the same gate the three
+        // reshaped v2 actions already run. It had none before, because it retired nothing.
+        if ($this->rejectRetiredProperties($validation, 'executeValidation', $to, requestId: $requestId)) {
+            return;
+        }
+
         // First thing is try to determine the schema that we will be validating against,
         // and the path to the source file or folder that we will be validating against the schema.
         // Our purpose here is to set the $pathForSchema and $dataPath variables.
@@ -1519,6 +1568,24 @@ class Health implements MessageComponentInterface
         $dataPath      = null;
         $category      = (string) $validation->category;
         $validate      = (string) $validation->validate;
+
+        // Absent means JSON, which is what every client sent before this action honoured a format
+        // at all and what the API serves when nothing asks otherwise — so an old message keeps
+        // behaving exactly as it did. A *present* value is checked against the narrow list rather
+        // than trusted: `ReturnTypeParam::from()` throws a `\ValueError` on anything it does not
+        // know, and a `\ValueError` is an `\Error` that Ratchet's `IoServer::handleData` does not
+        // catch, so an unusable format would kill the WebSocket process instead of being answered.
+        // Same hazard {@see Health::VALIDATABLE_RESPONSE_FORMATS} documents, reached by this door.
+        $responseFormat = property_exists($validation, 'responseFormat') ? $validation->responseFormat : 'JSON';
+        if (false === is_string($responseFormat) || false === in_array($responseFormat, self::VALIDATABLE_RESOURCE_FORMATS, true)) {
+            $this->rejectMessage(
+                $to,
+                ProtocolErrorCode::INVALID_MESSAGE,
+                'executeValidation responseFormat must be one of: ' . implode(', ', self::VALIDATABLE_RESOURCE_FORMATS) . '.',
+                requestId: $requestId
+            );
+            return;
+        }
 
         // Source data checks validate data directly in the filesystem, not through the API
         if ($category === 'sourceDataCheck') {
@@ -1698,7 +1765,8 @@ class Health implements MessageComponentInterface
             $category,
             $pathForSchema,
             $sourceFolder,
-            requestId: $requestId
+            requestId: $requestId,
+            responseFormat: $responseFormat
         );
     }
 
@@ -1759,7 +1827,8 @@ class Health implements MessageComponentInterface
         ?string $classFragment = null,
         ?\stdClass $target = null,
         ?string $requestId = null,
-        ?array $expectedLocales = null
+        ?array $expectedLocales = null,
+        string $responseFormat = 'JSON'
     ): void {
         $pathForSchema ??= $label;
         // Read before $dataPath is made absolute below, so the two stay distinguishable.
@@ -1986,7 +2055,13 @@ class Health implements MessageComponentInterface
                 /** @var PromiseInterface<array{data: string, status: int, fromCache: bool, retryAfter: ?string}> $httpPromise */
                 $httpPromise = $this->cachedGet(
                     $dataPath,
-                    [],
+                    // The whole mechanism, in one line. `return_type` is a `CalendarParams` property
+                    // and therefore exists only on `/calendar`; every route a resource check
+                    // addresses negotiates on `Accept` alone, so appending `?return_type=YML` here
+                    // would be ignored and the check would validate JSON while reporting YAML.
+                    // `cachedGet()` keys its cache on `serialize($options)`, so the two formats of
+                    // one URL cannot collide in the cache either.
+                    ['headers' => ['Accept' => self::ACCEPT_HEADER_FOR_FORMAT[$responseFormat]]],
                     300,
                     $to,
                     // If this fetch is dropped because its run was abandoned, the request ends here
@@ -1996,7 +2071,7 @@ class Health implements MessageComponentInterface
                     }
                 );
                 $httpPromise->then(
-                    function (array $result) use ($to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $requestId, $target) {
+                    function (array $result) use ($to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $requestId, $target, $responseFormat) {
                         /** @var array{data: string, status: int, fromCache: bool, retryAfter: ?string} $result */
                         $data       = $result['data'];
                         $status     = $result['status'];
@@ -2009,7 +2084,7 @@ class Health implements MessageComponentInterface
                         // there — must not be reached at all for a resource the API refused. 429/5xx
                         // are included (#834), reported the same way as any other refusal.
                         if (self::isHttpSuccessStatus($status)) {
-                            $this->processValidationData($data, $to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $target, requestId: $requestId);
+                            $this->processValidationData($data, $to, $validationForMessages, $dataPath, $schema, $pathForSchema, $runToken, $target, requestId: $requestId, responseFormat: $responseFormat);
                         } else {
                             $this->handleValidationHttpFailure($status, $data, $retryAfter, $to, $validationForMessages, $dataPath, $runToken, $target, requestId: $requestId);
                         }
@@ -2305,6 +2380,40 @@ class Health implements MessageComponentInterface
     }
 
     /**
+     * Decode a fetched payload in the representation it was requested in.
+     *
+     * Extracted rather than inlined for the same reason {@see Health::decodeHttpCacheEntry()} is: the
+     * contract is unit-testable on its own, without a cache backend or the ReactPHP loop, and the
+     * `parses` step is exactly where a wrong-green would be cheapest to introduce and dearest to spot.
+     *
+     * YAML failures arrive as a thrown {@see ParseException} where JSON's arrive as a sentinel and an
+     * error string, so both are normalised to the same `{data, error}` shape and the caller stays
+     * format-agnostic. `Yaml::parse()` is given `PARSE_OBJECT_FOR_MAP` so a mapping decodes to
+     * `\stdClass` exactly as `json_decode()` leaves it — the schema validator is handed one shape,
+     * not two, and every existing schema keeps applying unchanged.
+     *
+     * @param string $data The raw body as fetched.
+     * @param string $responseFormat One of {@see Health::VALIDATABLE_RESOURCE_FORMATS}.
+     * @return array{data: mixed, error: ?string} `error` is null exactly when the decode succeeded.
+     */
+    private static function decodeValidationPayload(string $data, string $responseFormat): array
+    {
+        if ('YML' === $responseFormat) {
+            try {
+                return ['data' => Yaml::parse($data, Yaml::PARSE_OBJECT_FOR_MAP), 'error' => null];
+            } catch (ParseException $e) {
+                return ['data' => null, 'error' => $e->getMessage()];
+            }
+        }
+
+        $decoded = json_decode($data);
+
+        return json_last_error() === JSON_ERROR_NONE
+            ? ['data' => $decoded, 'error' => null]
+            : ['data' => null, 'error' => json_last_error_msg()];
+    }
+
+    /**
      * Process the validation of data against a schema.
      *
      * @param ExecuteValidationSourceFolder|ExecuteValidationSourceFile|ExecuteValidationResource $validation The validation object.
@@ -2313,8 +2422,10 @@ class Health implements MessageComponentInterface
      * @param ?string $requestId The correlation id of the request that caused this frame, captured by the handler when
      *        the request arrived and passed explicitly rather than read from any per-connection store; see
      *        {@see Health::onMessage()} for why that distinction is load-bearing.
+     * @param string $responseFormat The representation the body was fetched in, one of
+     *        {@see Health::VALIDATABLE_RESOURCE_FORMATS}; decides how the `parses` step decodes it.
      */
-    private function processValidationData(string $data, ConnectionInterface $to, \stdClass $validation, string $dataPath, ?string $schema, string $pathForSchema, ?string $runToken = null, ?\stdClass $target = null, ?string $requestId = null): void
+    private function processValidationData(string $data, ConnectionInterface $to, \stdClass $validation, string $dataPath, ?string $schema, string $pathForSchema, ?string $runToken = null, ?\stdClass $target = null, ?string $requestId = null, string $responseFormat = 'JSON'): void
     {
         // `validate` carries the class fragment: see the note where $validationForMessages is built.
         $validate = (string) $validation->validate;
@@ -2332,15 +2443,23 @@ class Health implements MessageComponentInterface
             requestId: $requestId
         );
 
-        $jsonData = json_decode($data);
-        if (json_last_error() === JSON_ERROR_NONE) {
+        // The `parses` step asks whether the representation the API actually sent is well formed, so
+        // it must decode in the format that was *asked for*. Decoding YAML with `json_decode()` would
+        // fail every YAML check on syntax; decoding it and then handing the result to the schema
+        // validator is what makes a YAML run test the same schemas the JSON run does. A source file
+        // read off disk is always JSON and reaches here with the default.
+        $parsed     = self::decodeValidationPayload($data, $responseFormat);
+        $jsonData   = $parsed['data'];
+        $parseError = $parsed['error'];
+        $formatName = 'YML' === $responseFormat ? 'YAML' : 'JSON';
+        if (null === $parseError) {
             $this->sendStepResult(
                 $to,
                 $validate,
                 $target,
                 Step::PARSES,
                 Status::PASS,
-                "The Data file $dataPath was successfully decoded as JSON",
+                "The Data file $dataPath was successfully decoded as $formatName",
                 null,
                 $runToken,
                 requestId: $requestId
@@ -2402,7 +2521,7 @@ class Health implements MessageComponentInterface
                 $target,
                 Step::PARSES,
                 Status::FAIL,
-                "There was an error decoding the Data file $dataPath as JSON: " . json_last_error_msg() . ". Raw data = &lt;&lt;&lt;JSON\n" . $data . "\n&gt;&gt;&gt;",
+                "There was an error decoding the Data file $dataPath as $formatName: " . $parseError . ". Raw data = &lt;&lt;&lt;$formatName\n" . $data . "\n&gt;&gt;&gt;",
                 null,
                 $runToken,
                 requestId: $requestId
@@ -2420,7 +2539,7 @@ class Health implements MessageComponentInterface
                 $target,
                 Step::VALIDATES,
                 Status::FAIL,
-                "Unable to verify schema for dataPath {$dataPath} and category {$category} since Data file $dataPath could not be decoded as JSON",
+                "Unable to verify schema for dataPath {$dataPath} and category {$category} since Data file $dataPath could not be decoded as $formatName",
                 null,
                 $runToken,
                 requestId: $requestId
@@ -2678,7 +2797,7 @@ class Health implements MessageComponentInterface
      * says one true, specific thing, and a client sending two retired properties hears about the
      * second on its next attempt. See {@see Health::RETIRED_PROPERTIES} for why the rule exists.
      *
-     * @param 'validateSource'|'validateCalendar'|'runTest' $action The reshaped action being handled.
+     * @param 'validateSource'|'validateCalendar'|'runTest'|'executeValidation' $action The reshaped action being handled.
      * @return bool True when the message was rejected and the caller must stop.
      */
     private function rejectRetiredProperties(\stdClass $message, string $action, ConnectionInterface $to, ?string $requestId = null): bool


### PR DESCRIPTION
## The bug

`responsetype` rode along on every `executeValidation` message and was **never read**. The URL was fetched under default content negotiation — JSON — whatever the client selected, while the client's own card labelled the result with the format it had asked for.

Picking YAML in UnitTestInterface's Resources runner therefore produced a page of green cards claiming to have parsed YAML, over thirty-odd payloads that were all JSON. A wrong-green manufactured by the interface whose job is to detect them.

## The mechanism is `Accept`, and that isn't a stylistic choice

`return_type` is a property of `CalendarParams`, so it exists **only** on `/calendar` — `CalendarHandler` derives it from the negotiated Accept (line 5788) and then lets the query string override it. Every route a resource check addresses negotiates through `Negotiator`, which reads `Accept` and nothing else.

```
GET /calendars?return_type=YML   ->  200 application/json     # the exact shape of a silent wrong-green
GET /calendars  Accept: application/yaml  ->  200 application/yaml
```

So appending a query parameter would have looked like a fix and changed nothing. That is why `HealthResourceFormatTest` asserts on the **queued request's Guzzle options**, not only on the frames: a frame cannot tell "fetched as YAML" from "fetched as JSON and labelled YAML", which is the entire bug.

## Why JSON and YML only

Measured across all thirteen endpoint families the Resources runner checks (`/calendars`, `/decrees`, `/tests/{rite}`, `/events/{rite}`, `/easter`, `/schemas`, `/missals`, `/missals/{id}`, and the `/data` + `/events` wider-region / nation / diocese paths):

| | `application/json` | `application/yaml` | `application/xml` | `text/calendar` |
|---|---|---|---|---|
| all 13 resource families | ✅ | ✅ | **406** | **406** |
| `/calendar/{...}` | ✅ | ✅ | ✅ | ✅ |

XML and ICS are valid on `validateCalendar` and not here — that is what `VALIDATABLE_RESOURCE_FORMATS` records. A format outside it is rejected rather than passed on, for the same reason `VALIDATABLE_RESPONSE_FORMATS` is narrow: `ReturnTypeParam::from()` throws a `\ValueError`, which is an `\Error` that Ratchet's `IoServer::handleData` does not catch, so an unusable format kills the process rather than being answered.

`application/x-yaml` and `text/yaml` both 406 too — `AcceptHeader` lists neither — hence a single mapping constant rather than a guess at the wire value.

## The `parses` step had to follow

Honouring the header without teaching the parse step YAML would have traded a silent wrong-green for a loud wrong-red: `json_decode()` fails on every YAML body. `decodeValidationPayload()` decodes in the format that was asked for, extracted rather than inlined for the reason `decodeHttpCacheEntry()` is — the contract is unit-testable without a cache backend or the ReactPHP loop.

`Yaml::parse()` is given `PARSE_OBJECT_FOR_MAP` so a mapping decodes to `\stdClass` exactly as `json_decode()` leaves it. The schema validator is handed one shape, not two, and **every existing schema keeps applying unchanged** — which is what makes this worth doing: it puts the API's YAML serialiser under the same schemas its JSON output already passes, across ~30 real payloads. Nothing tests that today.

## Retiring `responsetype`

It was deliberately left accepted for as long as nothing read it — *"retiring it would answer a question no client is asking"*. The moment the action honours a format, silence stops being harmless: an unmigrated client would have its choice ignored and every check fetched as JSON while its cards claimed otherwise, which is the original bug wearing a new hat.

`executeValidation` had no `rejectRetiredProperties()` gate at all, because it retired nothing. It has one now, and the rejection names the replacement:

```
responsetype is not part of a executeValidation message: responseFormat replaces it.
```

**This is a breaking change for a client that sends `responsetype`**, in the same clean-break style as `validateCalendar`'s identical rename. It needs to land before the matching UnitTestInterface change. Absent means JSON — asked for explicitly rather than left to the server's default — so a client that never sent a format is unaffected.

## `/easter`: the one endpoint that could not serve YAML at all

`EasterHandler` is the only handler of the thirteen that caches serialised output to disk, and a failed cache write threw `ServiceUnavailableException`. On a read-only rootfs — a hardened deployment, or this API's own docker image — `/easter` answered **500**, and only for a representation with no pre-warmed file beside it. The image ships `en.json` and `la.json`, which is exactly why JSON looked healthy while `Accept: application/yaml` died with:

```
file_put_contents(engineCache/easter/la.yml): Failed to open stream: Read-only file system
```

The cache is an optimisation, not part of the response. The write failure is now logged via `error_log()` — matching `ApcuCache`'s treatment of a backend that will not co-operate — and the client gets its answer. Suppressed rather than guarded with `is_writable()`, because the directory can be writable and the write still fail (quota, a race with another worker), and both deserve the same treatment.

Folded into this PR rather than filed separately because it is the one endpoint the change above cannot make green on its own.

## Tests

`HealthResourceFormatTest` (new, 8 tests): the Accept header reaches the wire for YML and for the JSON default; a YAML body parses; a malformed YAML body fails naming **YAML** rather than JSON (a client reading "could not be decoded as JSON" after asking for YAML hunts the wrong problem); the JSON wording is unchanged; the retired property is refused with its replacement and fetches nothing; XML and ICS are refused and fetch nothing.

`EasterHandlerTest` (+1): simulates the unwritable cache with a regular file where the directory belongs, so both `mkdir()` and the write fail without needing root or a real read-only mount. Mutation-checked against the old `throw`, which reproduces the 500 exactly.

## Verification

PHPStan level 10 clean · phpcs clean · php-parallel-lint clean (672 files) · markdownlint clean · **3507 tests pass** (11 skipped), including all 495 `Health` tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resource checks now support JSON and YAML response formats through content negotiation.
  - Improved validation for resource paths, identifiers, years and rite-specific requests.
  - Queued requests now clearly report when superseded or cancelled.

- **Bug Fixes**
  - Unwritable cache directories no longer prevent Easter responses from being served.
  - HTTP errors, retry information and malformed cached responses are handled more reliably.
  - YAML parsing now provides clearer validation errors.
  - Retired response-format options and unsupported XML/ICS formats are rejected consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->