### PR TITLE
feat(ws): advertise response formats per action, not as a flat union

### DIFF
--- a/jsondata/schemas/WebSocketFrame.json
+++ b/jsondata/schemas/WebSocketFrame.json
@@ -45,12 +45,16 @@
                 },
                 "capabilities": {
                     "type": "object",
-                    "description": "What this server can be asked for. Every list is derived on the server from whatever already defines it — the Rite, Step and Status enums, the response formats the calendar validator actually has a branch for, and the actions this contract's inbound schema declares — so an advertisement cannot go stale against the behaviour it describes. `responseFormats` is deliberately narrower than the formats the REST API accepts: it lists only those the WebSocket calendar validation can act on.",
+                    "description": "What this server can be asked for. Every entry is derived on the server from whatever already defines it — the Rite, Step and Status enums, the per-action format lists the validators actually have a branch for, and the actions this contract's inbound schema declares — so an advertisement cannot go stale against the behaviour it describes. `responseFormats` is deliberately narrower than the formats the REST API accepts: it lists only what each WebSocket action can act on.",
                     "required": ["rites", "actions", "responseFormats", "steps", "statuses"],
                     "properties": {
                         "rites": { "type": "array", "items": { "type": "string" } },
                         "actions": { "type": "array", "items": { "type": "string" } },
-                        "responseFormats": { "type": "array", "items": { "type": "string" } },
+                        "responseFormats": {
+                            "type": "object",
+                            "description": "Keyed by action, because `responseFormat` is a property of a message and what may go in it depends on which message. `validateCalendar` addresses `/calendar`, which serves all four representations; `executeValidation` addresses the other routes, every one of which answers 406 to application/xml and text/calendar, so it takes JSON and YML only. An action that carries no response format at all — `validateSource`, which reads files off disk, and `runTest`, which returns a verdict — is absent rather than present with an empty list: absence says the action has no format to choose, where [] would claim it supports none.",
+                            "additionalProperties": { "type": "array", "items": { "type": "string" } }
+                        },
                         "steps": { "type": "array", "items": { "type": "string" } },
                         "statuses": { "type": "array", "items": { "type": "string" } }
                     }

--- a/phpunit_tests/HealthHelloFrameTest.php
+++ b/phpunit_tests/HealthHelloFrameTest.php
@@ -185,19 +185,84 @@ final class HealthHelloFrameTest extends TestCase
     }
 
     /**
-     * The response formats advertised are the ones `validateCalendar()` has a validation branch for —
-     * narrower than `ReturnTypeParam`, deliberately, because a format outside that list reaches
+     * The response formats advertised are the ones each action has a validation branch for — narrower
+     * than `ReturnTypeParam`, deliberately, because a format outside that list reaches
      * `ReturnTypeParam::from()` and throws a `\ValueError`, which Ratchet does not catch. Advertising
      * the wider list would invite a client to kill the server.
+     *
+     * Read back off the two constants rather than written out here, for the reason the whole frame is
+     * built that way: a literal in the test would let the advertisement and the behaviour drift
+     * together in the one direction nothing else catches.
      */
-    public function testOnlyTheValidatableResponseFormatsAreAdvertised(): void
+    public function testEachActionAdvertisesTheFormatsItCanActOn(): void
     {
         $frame = $this->helloFrameFor(self::createStubConnection(5));
 
-        /** @var list<string> $validatable */
-        $validatable = ( new \ReflectionClassConstant(Health::class, 'VALIDATABLE_RESPONSE_FORMATS') )->getValue();
+        /** @var list<string> $calendarFormats */
+        $calendarFormats = ( new \ReflectionClassConstant(Health::class, 'VALIDATABLE_RESPONSE_FORMATS') )->getValue();
+        /** @var list<string> $resourceFormats */
+        $resourceFormats = ( new \ReflectionClassConstant(Health::class, 'VALIDATABLE_RESOURCE_FORMATS') )->getValue();
 
-        self::assertSame($validatable, $frame->capabilities->responseFormats ?? null);
+        $advertised = $frame->capabilities->responseFormats ?? null;
+        self::assertInstanceOf(\stdClass::class, $advertised, 'keyed by action, not a flat list');
+        self::assertSame($calendarFormats, $advertised->validateCalendar ?? null);
+        self::assertSame($resourceFormats, $advertised->executeValidation ?? null);
+    }
+
+    /**
+     * The per-action lists genuinely differ, so the reshape says something the flat union could not.
+     *
+     * Without this, an advertisement that happened to give both actions the same list would satisfy
+     * the test above while re-introducing exactly the over-broad claim the reshape removed: XML and
+     * ICS advertised for `executeValidation`, which every route it addresses answers 406 to.
+     */
+    public function testTheResourceActionAdvertisesNeitherXmlNorIcs(): void
+    {
+        $advertised = $this->helloFrameFor(self::createStubConnection(6))->capabilities->responseFormats;
+
+        self::assertNotEquals(
+            $advertised->validateCalendar,
+            $advertised->executeValidation,
+            'a per-action advertisement that says the same thing for both is the flat union again'
+        );
+        self::assertNotContains('XML', $advertised->executeValidation);
+        self::assertNotContains('ICS', $advertised->executeValidation);
+    }
+
+    /**
+     * An action with no response format is absent, not present with an empty list.
+     *
+     * `validateSource` reads files off disk and `runTest` returns a verdict, so neither has a
+     * representation to choose. `[]` would be a different and misleading claim — "supports no
+     * formats" rather than "takes no format" — and a client checking `formats.length > 0` before
+     * offering a picker would read the two the same way.
+     */
+    public function testAnActionThatTakesNoFormatIsAbsentRatherThanEmpty(): void
+    {
+        $advertised = $this->helloFrameFor(self::createStubConnection(7))->capabilities->responseFormats;
+
+        self::assertObjectNotHasProperty('validateSource', $advertised);
+        self::assertObjectNotHasProperty('runTest', $advertised);
+    }
+
+    /**
+     * Every advertised key is an action the server actually dispatches.
+     *
+     * Guards the direction the constant cannot: a typo'd or retired action name would advertise
+     * formats for a message the server would refuse outright.
+     */
+    public function testEveryAdvertisedActionIsOneTheServerAccepts(): void
+    {
+        $frame      = $this->helloFrameFor(self::createStubConnection(8));
+        $advertised = $frame->capabilities->responseFormats;
+
+        foreach (array_keys((array) $advertised) as $action) {
+            self::assertContains(
+                (string) $action,
+                $frame->capabilities->actions,
+                "responseFormats advertises {$action}, which the server does not accept"
+            );
+        }
     }
 
     /**

--- a/phpunit_tests/WebSocket/LitCalTestServerTest.php
+++ b/phpunit_tests/WebSocket/LitCalTestServerTest.php
@@ -72,12 +72,30 @@ final class LitCalTestServerTest extends TestCase
 
         $capabilities = $hello->capabilities ?? null;
         $this->assertIsObject($capabilities);
-        foreach (['rites', 'actions', 'responseFormats', 'steps', 'statuses'] as $capability) {
+        foreach (['rites', 'actions', 'steps', 'statuses'] as $capability) {
             $this->assertIsArray($capabilities->{$capability} ?? null, "capabilities.{$capability} is missing");
             $this->assertNotEmpty($capabilities->{$capability});
         }
         $this->assertContains('validateSource', $capabilities->actions);
         $this->assertContains('complete', $capabilities->steps);
+
+        // `responseFormats` is the one capability that is not a flat list: it is keyed by action,
+        // because `responseFormat` is a property of a message and what may go in it depends on which
+        // message. Asserted on the wire and not only in {@see \LiturgicalCalendar\Tests\HealthHelloFrameTest}
+        // because that is this suite's whole reason to exist — the unit test builds the frame, this one
+        // reads what a client actually receives.
+        $responseFormats = $capabilities->responseFormats ?? null;
+        $this->assertIsObject($responseFormats, 'capabilities.responseFormats is missing, or is still a flat list');
+        $this->assertNotEmpty((array) $responseFormats);
+        foreach ((array) $responseFormats as $action => $formats) {
+            $this->assertIsArray($formats, "capabilities.responseFormats.{$action} is not a list of formats");
+            $this->assertNotEmpty($formats, "capabilities.responseFormats.{$action} is empty; an action with no format is omitted, not listed empty");
+            $this->assertContains(
+                (string) $action,
+                $capabilities->actions,
+                "capabilities.responseFormats advertises {$action}, which capabilities.actions does not"
+            );
+        }
 
         // No run correlation, which is what makes the frame invisible to a client that predates it:
         // both shipped runners drop a frame whose runToken does not match the run they are on.

--- a/src/Health.php
+++ b/src/Health.php
@@ -261,6 +261,32 @@ class Health implements MessageComponentInterface
      *
      * @var array<string, string>
      */
+    /**
+     * The response formats each action accepts, keyed by action.
+     *
+     * `responseFormat` is a property of a *message*, so what may go in it is a per-action question,
+     * not a per-server one — which is what the flat union this replaced could not say.
+     * `validateCalendar` addresses `/calendar`, which serves all four representations;
+     * `executeValidation` addresses every other route, and each of those answers 406 to
+     * `application/xml` and `text/calendar`.
+     *
+     * Composed from the two constants that already govern the behaviour rather than restated as a
+     * third list, for the reason {@see Health::helloFrame()} gives about every other capability: an
+     * advertisement assembled from something else can go stale against it, and this one silently,
+     * since a wrong advertisement misleads a client without failing any test that does not compare
+     * the two.
+     *
+     * An action carrying no response format at all is **absent**, not present with an empty list:
+     * `validateSource` reads files off disk and `runTest` returns a verdict, so neither has a format
+     * to choose. Absence says exactly that, where `[]` would claim they support none.
+     *
+     * @var array<string, string[]>
+     */
+    private const RESPONSE_FORMATS_BY_ACTION = [
+        'validateCalendar'  => self::VALIDATABLE_RESPONSE_FORMATS,
+        'executeValidation' => self::VALIDATABLE_RESOURCE_FORMATS
+    ];
+
     private const ACCEPT_HEADER_FOR_FORMAT = [
         'JSON' => 'application/json',
         'YML'  => 'application/yaml'
@@ -585,10 +611,18 @@ class Health implements MessageComponentInterface
      * be one more of them, and one that fails silently, since a stale advertisement misleads a client
      * without breaking any test that does not compare it against the source.
      *
-     * `responseFormats` advertises the narrow list on purpose. `ReturnTypeParam` knows more formats,
+     * `responseFormats` advertises the narrow lists on purpose. `ReturnTypeParam` knows more formats,
      * but `ReturnTypeParam::from()` throws a `\ValueError` on the ones `validateCalendar()` has no
      * branch for, and a `\ValueError` is an `\Error` that Ratchet does not catch — so advertising the
      * wider set would invite a client to kill the server by taking the advertisement at its word.
+     *
+     * It is keyed **by action** rather than flat, because `responseFormat` is a property of a message
+     * and what may go in it depends on which message: `/calendar` serves all four representations
+     * while every route a resource check addresses answers 406 to `application/xml` and
+     * `text/calendar`. The flat union that preceded this was accurate for `validateCalendar` and
+     * over-broad for `executeValidation` — it advertised two formats that action can only fail on.
+     * See {@see Health::RESPONSE_FORMATS_BY_ACTION}, which is composed from the two constants that
+     * already govern the behaviour rather than restated beside them.
      *
      * **This frame must stay unsolicited-safe.** It is sent on connect, before the connection is on
      * any run, so `sendMessage()` stamps no `runToken` onto it — and that is exactly why the shipped
@@ -602,7 +636,7 @@ class Health implements MessageComponentInterface
         $capabilities                  = new \stdClass();
         $capabilities->rites           = array_column(Rite::cases(), 'value');
         $capabilities->actions         = $this->messageValidator->supportedActions();
-        $capabilities->responseFormats = self::VALIDATABLE_RESPONSE_FORMATS;
+        $capabilities->responseFormats = (object) self::RESPONSE_FORMATS_BY_ACTION;
         $capabilities->steps           = array_column(Step::cases(), 'value');
         $capabilities->statuses        = array_column(Status::cases(), 'value');
 


### PR DESCRIPTION
Follow-up to #885, which left this loose end.

## The problem

`capabilities.responseFormats` was a single flat list:

```json
"responseFormats": ["JSON", "XML", "ICS", "YML"]
```

Accurate for `validateCalendar`; **over-broad for `executeValidation`**. Every route a resource check addresses answers 406 to `application/xml` and `text/calendar`, so the advertisement offered that action two formats it can only ever fail on.

It was also the one capability in the frame not derived from whatever defines the behaviour. `rites`, `steps` and `statuses` come from their enums; `actions` comes from the inbound schema. `helloFrame()`'s own docblock says why: *"a hand-written capability list would be one more of them, and one that fails silently, since a stale advertisement misleads a client without breaking any test that does not compare it against the source."*

## The shape

```json
"responseFormats": {
  "validateCalendar":  ["JSON", "XML", "ICS", "YML"],
  "executeValidation": ["JSON", "YML"]
}
```

Keyed by action, because `responseFormat` is a property of a **message** — what may go in it depends on which message. `RESPONSE_FORMATS_BY_ACTION` is composed from `VALIDATABLE_RESPONSE_FORMATS` and `VALIDATABLE_RESOURCE_FORMATS`, the two constants that already govern the behaviour, rather than restated as a third list beside them.

**Actions with no format are absent, not empty.** `validateSource` reads files off disk; `runTest` returns a verdict. Neither has a representation to choose. Absence says that; `[]` would claim they support *none* — a different and misleading claim, and one a client checking `formats.length > 0` before offering a picker would read identically.

## Why per-action and not per-endpoint

Both were considered. The per-endpoint truth lives in `allowedAcceptHeaders`, **instance** state set in 17 handler constructors — most of them auth/admin routes no check ever touches — so `Health` cannot enumerate it without constructing them all. And a client does not ask that question: it picks one format per run and sends it on every message, so the natural key is the message's action.

## Clean break

Nothing consumes the flat list. UnitTestInterface's `readHello()` stores `capabilities` and `capabilities()` exposes them, but no call site reads `responseFormats`. Carrying a parallel field would mean two things to keep in sync — the staleness this change removes.

## Tests

Four replace the one that asserted the flat list, each covering a direction the constant alone cannot:

| test | guards |
|---|---|
| `testEachActionAdvertisesTheFormatsItCanActOn` | each action advertises its own list, read back off the constants rather than a literal |
| `testTheResourceActionAdvertisesNeitherXmlNorIcs` | the two lists genuinely differ — an advertisement giving both the same list would otherwise pass as "per-action" while being the flat union again |
| `testAnActionThatTakesNoFormatIsAbsentRatherThanEmpty` | absent, not `[]` |
| `testEveryAdvertisedActionIsOneTheServerAccepts` | no key names an action the server would refuse |

`WebSocketFrame.json` is updated to match, and the pairing is real rather than nominal: `testTheHelloFrameMatchesThePublishedContract` validates a frame the server **actually emitted** against the published schema. Mutation-checked — reverting the schema to `type: array` fails it with *"the hello frame the server emits does not match the published contract"*.

## Verification

PHPStan level 10 clean · phpcs clean · markdownlint clean · **3511 tests pass** (11 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The WebSocket hello response now advertises supported response formats for each action individually.
  * Calendar validation supports JSON, YAML, XML and ICS formats.
  * Validation execution supports JSON and YAML formats only.
  * Actions without supported response formats are omitted from the capability list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->