### PR TITLE
fix(compose): keep ZITADEL_EXTERNALPORT and the issuer in step with ZITADEL_PORT

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,12 @@ services:
       # See "What's next" to learn about how to serve Zitadel on a different domain or IP.
       ZITADEL_EXTERNALDOMAIN: localhost
 
+      # Must track the published host port below. Zitadel derives its OIDC issuer from
+      # EXTERNALDOMAIN/EXTERNALPORT/EXTERNALSECURE, so without this line overriding
+      # ZITADEL_PORT moved the binding while the issuer silently stayed at :8080 —
+      # tokens minted for an issuer nothing could reach.
+      ZITADEL_EXTERNALPORT: ${ZITADEL_PORT:-8080}
+
       # See "What's next" to learn about how to enable TLS.
       ZITADEL_EXTERNALSECURE: false
       ZITADEL_TLS_ENABLED: false

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -34,7 +34,10 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-ZITADEL_URL="${ZITADEL_URL:-http://localhost:8080}"
+# Derived from ZITADEL_PORT so the ZITADEL_ISSUER this script writes into .env agrees
+# with the port docker-compose.yml publishes. Hardcoding :8080 here meant that
+# overriding the port produced a stale issuer in every .env this script touches.
+ZITADEL_URL="${ZITADEL_URL:-http://localhost:${ZITADEL_PORT:-8080}}"
 FRONTEND_PORT="${FRONTEND_PORT:-3000}"
 TESTS_PORT="${TESTS_PORT:-3003}"
 MAX_RETRIES=30


### PR DESCRIPTION
Half of a parameterization was missing, and it failed silently when used.

## The bug

`docker-compose.yml:105` already publishes Zitadel on `127.0.0.1:${ZITADEL_PORT:-8080}:8080` — but the file sets **no `ZITADEL_EXTERNALPORT` at all**, so it defaults to `8080` inside the container. Zitadel derives its OIDC issuer from `EXTERNALDOMAIN`/`EXTERNALPORT`/`EXTERNALSECURE`, so:

```
ZITADEL_PORT=8090  →  published on :8090, issuer still http://localhost:8080
```

Zitadel mints tokens for an issuer nothing can reach, and clients validate against one that no longer answers. The override looked supported and was quietly broken.

`scripts/setup-zitadel.sh` had the same split from the other side. It writes `ZITADEL_ISSUER` into every `.env` it touches from `ZITADEL_URL`, which hardcoded `:8080` — so even a correct compose override was overwritten by a stale issuer in `.env`.

## The fix

- `ZITADEL_EXTERNALPORT: ${ZITADEL_PORT:-8080}` in compose, commented with why it must track the published port.
- `ZITADEL_URL="${ZITADEL_URL:-http://localhost:${ZITADEL_PORT:-8080}}"` in the setup script.

## Not parameterized, on purpose

The login sidecar's `ZITADEL_API_URL: http://localhost:8080` stays hardcoded. `network_mode: service:zitadel` puts it inside Zitadel's own network namespace, so that names the **container** port, which never moves. Parameterizing it would break the login UI the moment `ZITADEL_PORT` was overridden.

## Verification

Defaults byte-identical:

```
ZITADEL_EXTERNALPORT: "8080"     zitadel ports: [('8080', 8080), ('8081', 3000)]
```

Override moves port and issuer together, sidecar untouched:

```
$ ZITADEL_PORT=8090 docker compose config
ZITADEL_EXTERNALPORT: "8090"     zitadel ports: [('8090', 8080), ('8081', 3000)]
login sidecar ZITADEL_API_URL: http://localhost:8080   <-- correctly unchanged
```

Script derivation: default → `http://localhost:8080`; `ZITADEL_PORT=8090` → `http://localhost:8090`. `bash -n` clean.

## Related

Pairs with Liturgical-Calendar/LiturgicalCalendarFrontend's `fix/zitadel-port-overridable`, which makes the same variable move the Frontend stack's ports and issuer. **Merge this one first** — that PR's `.env.example` documents `setup-zitadel.sh --update-env` deriving the issuer from `ZITADEL_PORT`, which is the behaviour this PR introduces (the canonical script lives here and is COPYed into the litcal-api image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OIDC issuer URLs when running on a custom Zitadel port.
  * Kept generated environment settings aligned with the port published by Docker Compose.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->