### PR TITLE
fix(setup-zitadel): read the ports from .env instead of guessing them

### DIFF
--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -44,56 +44,76 @@ ROLES=("admin" "developer" "calendar_editor" "test_editor")
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${SCRIPT_DIR}/.."
 
-# Read a single KEY=value out of the project's .env WITHOUT sourcing it.
+# Resolve a single configuration key the way `docker compose` would.
 #
-# `docker compose` reads .env for its own interpolation, so the ports declared there
-# are the stack's source of truth. This script has to agree with them: it writes
-# ZITADEL_ISSUER into .env files and registers OIDC redirect URIs in Zitadel, and a
-# port it guessed differently from compose produces exactly the silent disagreement
-# those values exist to prevent. Before this, `./scripts/setup-zitadel.sh --update-env`
-# run from a bare shell would happily overwrite a ZITADEL_PORT=8090 stack's issuer
-# with http://localhost:8080.
+# compose reads .env for its own interpolation, so the ports declared there are the
+# stack's source of truth. This script has to agree with them: it writes ZITADEL_ISSUER
+# into .env files and registers OIDC redirect URIs, and a port it resolved differently
+# from compose produces exactly the silent disagreement those values exist to prevent.
 #
-# Precedence matches compose: an exported shell variable beats .env, which beats the
-# built-in default. The accepted spellings were derived by testing compose rather than
-# assumed, because a parser that is merely close reintroduces the disagreement this
-# helper exists to remove. Compose reads all of these as the same value:
-#     KEY=v      KEY="v"      KEY = "v"      '  KEY=v'
-#     KEY: v                    (colon delimiter)
-#     KEY=v # comment           (comment needs WHITESPACE before the '#')
-# but `KEY=v# x` keeps the literal `v# x`, so the '#' is only a comment when a space
-# precedes it. Quoted values take the quoted span and ignore any trailing text.
+# PRIMARY PATH: ask compose itself, via `docker compose config --environment`. That is
+# authoritative by construction — it cannot disagree with compose — and costs ~40ms.
+# It matters because compose's .env handling is richer than it looks: it accepts `:` as
+# well as `=`, strips a comment only when whitespace precedes the '#', and interpolates
+# values, so `ZITADEL_PORT=${LOCAL_PORT:-8080}` resolves rather than arriving literally.
+# Three successive hand-written approximations of that parser each missed a case.
 #
-# Parsed with grep/cut rather than `source`, because .env holds secrets and arbitrary
-# shell in a config file must never be executed. Always exits 0 so `set -e` cannot
-# trip on a missing file or an absent key.
+# FALLBACK: a conservative literal reader, for when docker is absent or PROJECT_DIR has
+# no valid compose file. It handles the common spellings but deliberately does NOT try to
+# interpolate; a value it cannot resolve is reported rather than guessed at.
+#
+# Precedence in both paths matches compose: exported shell variable, then .env, then the
+# built-in default. .env is never `source`d — it holds secrets, and arbitrary shell in a
+# config file must not be executed.
+COMPOSE_ENV_CACHE=""
+COMPOSE_ENV_TRIED=false
+
 env_file_value() {
     local key="$1"
+
+    if [ "$COMPOSE_ENV_TRIED" = false ]; then
+        COMPOSE_ENV_TRIED=true
+        if command -v docker >/dev/null 2>&1; then
+            COMPOSE_ENV_CACHE=$( cd "$PROJECT_DIR" && docker compose config --environment 2>/dev/null ) || COMPOSE_ENV_CACHE=""
+        fi
+    fi
+
+    local line=""
+    if [ -n "$COMPOSE_ENV_CACHE" ]; then
+        line=$(printf '%s\n' "$COMPOSE_ENV_CACHE" | grep -E "^${key}=" | tail -n 1) || true
+        if [ -n "$line" ]; then
+            printf '%s' "${line#*=}"
+            return 0
+        fi
+        # compose answered and did not set this key: it is genuinely unset.
+        return 0
+    fi
+
     local file="${PROJECT_DIR}/.env"
     [ -f "$file" ] || return 0
-
-    local line
     line=$(grep -E "^[[:space:]]*${key}[[:space:]]*[:=]" "$file" 2>/dev/null | tail -n 1) || return 0
     [ -n "$line" ] || return 0
 
-    # Strip the key and its delimiter, then trim surrounding whitespace.
     local val="${line#*[:=]}"
     val="${val#"${val%%[![:space:]]*}"}"
     val="${val%"${val##*[![:space:]]}"}"
 
     if [[ $val == '"'* ]]; then
-        # Quoted: take the quoted span and ignore anything after it, as compose does.
         val="${val#\"}"
         val="${val%%\"*}"
     elif [[ $val == "'"* ]]; then
         val="${val#\'}"
         val="${val%%\'*}"
     elif [[ $val =~ ^(.*[^[:space:]])[[:space:]]+#.*$ ]]; then
-        # Unquoted: a comment begins at WHITESPACE followed by '#'. Without the
-        # whitespace the '#' is part of the value — compose reads `PORT=80# x` as
-        # the literal `80# x` — so this must not strip every '#'.
         val="${BASH_REMATCH[1]}"
     elif [[ $val =~ ^# ]]; then
+        val=""
+    fi
+
+    if [[ $val == *'${'* || $val == *'$'[A-Za-z_]* ]]; then
+        echo -e "${YELLOW}Warning:${NC} ${key} in ${file} uses variable interpolation (${val})," >&2
+        echo -e "         which only docker compose can resolve, and it is unavailable here." >&2
+        echo -e "         Falling back to the built-in default. Export ${key} to be explicit." >&2
         val=""
     fi
 

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -55,10 +55,14 @@ PROJECT_DIR="${SCRIPT_DIR}/.."
 # with http://localhost:8080.
 #
 # Precedence matches compose: an exported shell variable beats .env, which beats the
-# built-in default. The accepted spellings match compose too — verified against it,
-# which reads all of `KEY=v`, `KEY="v"`, `  KEY=v` and `KEY = "v"` as the same value,
-# so surrounding whitespace and wrapping quotes are tolerated here rather than
-# silently missing a key compose would have honoured.
+# built-in default. The accepted spellings were derived by testing compose rather than
+# assumed, because a parser that is merely close reintroduces the disagreement this
+# helper exists to remove. Compose reads all of these as the same value:
+#     KEY=v      KEY="v"      KEY = "v"      '  KEY=v'
+#     KEY: v                    (colon delimiter)
+#     KEY=v # comment           (comment needs WHITESPACE before the '#')
+# but `KEY=v# x` keeps the literal `v# x`, so the '#' is only a comment when a space
+# precedes it. Quoted values take the quoted span and ignore any trailing text.
 #
 # Parsed with grep/cut rather than `source`, because .env holds secrets and arbitrary
 # shell in a config file must never be executed. Always exits 0 so `set -e` cannot
@@ -67,9 +71,33 @@ env_file_value() {
     local key="$1"
     local file="${PROJECT_DIR}/.env"
     [ -f "$file" ] || return 0
-    grep -E "^[[:space:]]*${key}[[:space:]]*=" "$file" 2>/dev/null | tail -n 1 | cut -d= -f2- \
-        | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
-              -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/"
+
+    local line
+    line=$(grep -E "^[[:space:]]*${key}[[:space:]]*[:=]" "$file" 2>/dev/null | tail -n 1) || return 0
+    [ -n "$line" ] || return 0
+
+    # Strip the key and its delimiter, then trim surrounding whitespace.
+    local val="${line#*[:=]}"
+    val="${val#"${val%%[![:space:]]*}"}"
+    val="${val%"${val##*[![:space:]]}"}"
+
+    if [[ $val == '"'* ]]; then
+        # Quoted: take the quoted span and ignore anything after it, as compose does.
+        val="${val#\"}"
+        val="${val%%\"*}"
+    elif [[ $val == "'"* ]]; then
+        val="${val#\'}"
+        val="${val%%\'*}"
+    elif [[ $val =~ ^(.*[^[:space:]])[[:space:]]+#.*$ ]]; then
+        # Unquoted: a comment begins at WHITESPACE followed by '#'. Without the
+        # whitespace the '#' is part of the value — compose reads `PORT=80# x` as
+        # the literal `80# x` — so this must not strip every '#'.
+        val="${BASH_REMATCH[1]}"
+    elif [[ $val =~ ^# ]]; then
+        val=""
+    fi
+
+    printf '%s' "$val"
 }
 
 # Configuration
@@ -81,9 +109,26 @@ env_file_value() {
 ZITADEL_PORT="${ZITADEL_PORT:-$(env_file_value ZITADEL_PORT)}"
 FRONTEND_PORT="${FRONTEND_PORT:-$(env_file_value FRONTEND_PORT)}"
 TESTS_PORT="${TESTS_PORT:-$(env_file_value TESTS_PORT)}"
+ZITADEL_URL_EXPLICIT="${ZITADEL_URL:-}"
 ZITADEL_URL="${ZITADEL_URL:-http://localhost:${ZITADEL_PORT:-8080}}"
 FRONTEND_PORT="${FRONTEND_PORT:-3000}"
 TESTS_PORT="${TESTS_PORT:-3003}"
+
+# An explicit ZITADEL_URL still wins outright — a deployment on a real domain needs that,
+# and the port is meaningless there. But when it names a DIFFERENT port than the stack
+# publishes, the script would health-check, call and write an issuer for one port while
+# compose served another. That is precisely the silent disagreement this section exists to
+# prevent, so make it audible rather than guessing which the operator meant.
+if [ -n "$ZITADEL_URL_EXPLICIT" ] && [ -n "${ZITADEL_PORT:-}" ]; then
+    _url_port="${ZITADEL_URL_EXPLICIT##*:}"
+    _url_port="${_url_port%%/*}"
+    if [[ $_url_port =~ ^[0-9]+$ ]] && [ "$_url_port" != "$ZITADEL_PORT" ]; then
+        echo -e "${YELLOW}Warning:${NC} ZITADEL_URL (${ZITADEL_URL_EXPLICIT}) names port ${_url_port}," >&2
+        echo -e "         but ZITADEL_PORT is ${ZITADEL_PORT}. Proceeding with ZITADEL_URL." >&2
+        echo -e "         If that is not intended, unset ZITADEL_URL or align the two." >&2
+    fi
+    unset _url_port
+fi
 
 # Parse command line arguments
 UPDATE_ENV="${UPDATE_ENV:-false}"

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -33,13 +33,6 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
-# Configuration
-# Derived from ZITADEL_PORT so the ZITADEL_ISSUER this script writes into .env agrees
-# with the port docker-compose.yml publishes. Hardcoding :8080 here meant that
-# overriding the port produced a stale issuer in every .env this script touches.
-ZITADEL_URL="${ZITADEL_URL:-http://localhost:${ZITADEL_PORT:-8080}}"
-FRONTEND_PORT="${FRONTEND_PORT:-3000}"
-TESTS_PORT="${TESTS_PORT:-3003}"
 MAX_RETRIES=30
 RETRY_INTERVAL=5
 
@@ -50,6 +43,47 @@ ROLES=("admin" "developer" "calendar_editor" "test_editor")
 # Directories
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="${SCRIPT_DIR}/.."
+
+# Read a single KEY=value out of the project's .env WITHOUT sourcing it.
+#
+# `docker compose` reads .env for its own interpolation, so the ports declared there
+# are the stack's source of truth. This script has to agree with them: it writes
+# ZITADEL_ISSUER into .env files and registers OIDC redirect URIs in Zitadel, and a
+# port it guessed differently from compose produces exactly the silent disagreement
+# those values exist to prevent. Before this, `./scripts/setup-zitadel.sh --update-env`
+# run from a bare shell would happily overwrite a ZITADEL_PORT=8090 stack's issuer
+# with http://localhost:8080.
+#
+# Precedence matches compose: an exported shell variable beats .env, which beats the
+# built-in default. The accepted spellings match compose too — verified against it,
+# which reads all of `KEY=v`, `KEY="v"`, `  KEY=v` and `KEY = "v"` as the same value,
+# so surrounding whitespace and wrapping quotes are tolerated here rather than
+# silently missing a key compose would have honoured.
+#
+# Parsed with grep/cut rather than `source`, because .env holds secrets and arbitrary
+# shell in a config file must never be executed. Always exits 0 so `set -e` cannot
+# trip on a missing file or an absent key.
+env_file_value() {
+    local key="$1"
+    local file="${PROJECT_DIR}/.env"
+    [ -f "$file" ] || return 0
+    grep -E "^[[:space:]]*${key}[[:space:]]*=" "$file" 2>/dev/null | tail -n 1 | cut -d= -f2- \
+        | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' \
+              -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'\$/\1/"
+}
+
+# Configuration
+# Each port falls back through: exported variable -> .env -> built-in default.
+# ZITADEL_URL is derived from ZITADEL_PORT so the ZITADEL_ISSUER written into every
+# .env this script touches names the port compose actually publishes. FRONTEND_PORT
+# and TESTS_PORT matter for the same reason: they build the redirect URIs registered
+# with the OIDC clients, and a redirect URI on the wrong port fails login outright.
+ZITADEL_PORT="${ZITADEL_PORT:-$(env_file_value ZITADEL_PORT)}"
+FRONTEND_PORT="${FRONTEND_PORT:-$(env_file_value FRONTEND_PORT)}"
+TESTS_PORT="${TESTS_PORT:-$(env_file_value TESTS_PORT)}"
+ZITADEL_URL="${ZITADEL_URL:-http://localhost:${ZITADEL_PORT:-8080}}"
+FRONTEND_PORT="${FRONTEND_PORT:-3000}"
+TESTS_PORT="${TESTS_PORT:-3003}"
 
 # Parse command line arguments
 UPDATE_ENV="${UPDATE_ENV:-false}"


### PR DESCRIPTION
Follow-up to #888, closing the last place where the port could silently disagree with itself.

## The bug

`scripts/setup-zitadel.sh` writes `ZITADEL_ISSUER` into every `.env` it touches and registers the OIDC redirect URIs for both apps — but it resolved `ZITADEL_PORT`, `FRONTEND_PORT` and `TESTS_PORT` from its own shell environment only, never from `.env`, which is where `docker compose` reads them.

So on a stack running `ZITADEL_PORT=8090`:

```bash
./scripts/setup-zitadel.sh --update-env      # writes ZITADEL_ISSUER=http://localhost:8080
```

It wrote the wrong issuer straight back over the working value, silently undoing the configuration it was asked to update. #888 fixed the derivation but left the input hardcoded to the shell.

`FRONTEND_PORT` and `TESTS_PORT` are the same bug with a sharper edge — they build the redirect URIs registered with the **LiturgicalCalendar Frontend** and **LiturgicalCalendar Tests** OIDC apps (`create_oidc_app` call sites). A redirect URI on the wrong port fails login outright rather than degrading.

## The fix

An `env_file_value` helper reads a single `KEY=value` from `${PROJECT_DIR}/.env`. All three ports now fall back through **exported variable → `.env` → built-in default**, which is compose's own precedence.

`.env` is parsed with `grep`/`cut`, never `source`d: it holds secrets, and arbitrary shell in a config file must not be executed. The helper always exits 0 so `set -e` can't trip on a missing file or absent key.

The config block moved below the `SCRIPT_DIR`/`PROJECT_DIR` definitions, since it now depends on them. `ZITADEL_URL` isn't *used* until line ~111, so nothing observes the reorder.

## On matching compose exactly

I checked the accepted `.env` spellings against compose rather than assuming them. Compose reads all four of these as the same value:

```
KEY=v      KEY="v"      '  KEY=v'      'KEY = "v"'
```

My first cut of the helper matched the first three and **missed `KEY = "v"`** — which would have reintroduced precisely the disagreement this change exists to prevent. The pattern now tolerates whitespace around `=` and wrapping quotes of either kind.

## Verification

Seven scenarios against the real code path (including `PROJECT_DIR` resolution, exercised the way the Frontend's wrapper extracts this script):

| Case | Result |
|---------------------------------|-----------------------------|
| no `.env` at all | `:8080` / 3000 / 3003 |
| `.env` sets `ZITADEL_PORT=8090` | `http://localhost:8090` |
| exported var vs `.env` | exported wins (`:9999`) |
| `KEY = "8095"` (compose-style) | `http://localhost:8095` |
| commented-out key | ignored; siblings still read |
| empty `.env` | defaults |
| single-quoted value | `TESTS_PORT=3009` |

And against the live stack: with the real `ZITADEL_PORT=8090` in the Frontend's `.env`, it resolves `ZITADEL_URL=http://localhost:8090`. `bash -n` clean.

## Incidental finding

This script already creates a **second OIDC app, "LiturgicalCalendar Tests"**, with redirect URI `http://localhost:${TESTS_PORT}/auth/callback.php` — and it is present in the running instance (`projections.apps7` lists it alongside "LiturgicalCalendar Frontend"). That client registration was assumed to be a manual prerequisite for the planned UnitTestInterface OIDC migration; it is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Zitadel configuration parsing for common `KEY=value` and `KEY:value` formats.
  - Correctly handles whitespace, quoted values, inline comments, and comment-only values.
  - Ensured environment-file contents are read safely without executing shell code.
  - Improved reliability when settings are missing or incomplete.
  - Preserves explicit Zitadel URLs and warns when their port differs from the configured port.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->