### PR TITLE
fix(setup-zitadel): configure the docker stack's own .env, not just the apps'

### DIFF
--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -1030,6 +1030,30 @@ main() {
         for entry in "${projects[@]}"; do
             local label="${entry%%:*}"
             local dir="${entry#*:}"
+
+            # The docker stack's compose file lives in the Frontend project, and it interpolates
+            # from .env — and ONLY from .env. resolve_env_file() above prefers .env.development
+            # when it exists, so on that very common layout every value written so far has landed
+            # somewhere compose never reads, leaving the stack on whatever .env happened to hold.
+            # That is why this block targets .env explicitly rather than "$target" — and why it sits
+            # OUTSIDE the "$target" guard below: a fresh checkout with no env file at all resolves to
+            # an empty target, and skipping the stack's own .env in exactly the case that most needs
+            # it written is the opposite of useful. update_env_file() creates the file if absent.
+            #
+            # ZITADEL_TESTS_CLIENT_ID is the one that has no equivalent anywhere else: the compose
+            # gives litcal-tests its OWN client, because Zitadel rejects a redirect_uri that is not
+            # registered against the client making the request and the test interface's callback is
+            # on its own port. Handed the Frontend's client, its login fails with "The requested
+            # redirect_uri is missing in the client configuration".
+            if [ "$label" = "Frontend" ]; then
+                local compose_env="${dir}/.env"
+                update_env_file "$compose_env" "ZITADEL_ISSUER" "${ZITADEL_URL}"
+                update_env_file "$compose_env" "ZITADEL_PROJECT_ID" "$PROJECT_ID"
+                update_env_file "$compose_env" "ZITADEL_CLIENT_ID" "$FRONTEND_CLIENT_ID"
+                update_env_file "$compose_env" "ZITADEL_TESTS_CLIENT_ID" "$TESTS_CLIENT_ID"
+                echo -e "${GREEN}Updated docker stack env: ${compose_env}${NC}"
+            fi
+
             local target
             target=$(resolve_env_file "$dir")
             if [ -n "$target" ]; then
@@ -1040,26 +1064,6 @@ main() {
                 else
                     update_env_file "$target" "ZITADEL_CLIENT_ID" "$FRONTEND_CLIENT_ID"
                 fi
-                # The docker stack's compose file lives in the Frontend project, and it interpolates
-                # from .env — and ONLY from .env. resolve_env_file() above prefers .env.development
-                # when it exists, so on that very common layout every value written so far has landed
-                # somewhere compose never reads, leaving the stack on whatever .env happened to hold.
-                # That is why this block targets .env explicitly rather than "$target".
-                #
-                # ZITADEL_TESTS_CLIENT_ID is the one that has no equivalent anywhere else: the compose
-                # gives litcal-tests its OWN client, because Zitadel rejects a redirect_uri that is not
-                # registered against the client making the request and the test interface's callback is
-                # on its own port. Handed the Frontend's client, its login fails with "The requested
-                # redirect_uri is missing in the client configuration".
-                if [ "$label" = "Frontend" ]; then
-                    local compose_env="${dir}/.env"
-                    update_env_file "$compose_env" "ZITADEL_ISSUER" "${ZITADEL_URL}"
-                    update_env_file "$compose_env" "ZITADEL_PROJECT_ID" "$PROJECT_ID"
-                    update_env_file "$compose_env" "ZITADEL_CLIENT_ID" "$FRONTEND_CLIENT_ID"
-                    update_env_file "$compose_env" "ZITADEL_TESTS_CLIENT_ID" "$TESTS_CLIENT_ID"
-                    echo -e "${GREEN}Updated docker stack env: ${compose_env}${NC}"
-                fi
-
                 # Only the API needs a machine token for Management API calls
                 if [ "$label" = "API" ]; then
                     update_env_file "$target" "ZITADEL_MACHINE_TOKEN" "$SERVICE_ACCOUNT_PAT"

--- a/scripts/setup-zitadel.sh
+++ b/scripts/setup-zitadel.sh
@@ -1040,6 +1040,26 @@ main() {
                 else
                     update_env_file "$target" "ZITADEL_CLIENT_ID" "$FRONTEND_CLIENT_ID"
                 fi
+                # The docker stack's compose file lives in the Frontend project, and it interpolates
+                # from .env — and ONLY from .env. resolve_env_file() above prefers .env.development
+                # when it exists, so on that very common layout every value written so far has landed
+                # somewhere compose never reads, leaving the stack on whatever .env happened to hold.
+                # That is why this block targets .env explicitly rather than "$target".
+                #
+                # ZITADEL_TESTS_CLIENT_ID is the one that has no equivalent anywhere else: the compose
+                # gives litcal-tests its OWN client, because Zitadel rejects a redirect_uri that is not
+                # registered against the client making the request and the test interface's callback is
+                # on its own port. Handed the Frontend's client, its login fails with "The requested
+                # redirect_uri is missing in the client configuration".
+                if [ "$label" = "Frontend" ]; then
+                    local compose_env="${dir}/.env"
+                    update_env_file "$compose_env" "ZITADEL_ISSUER" "${ZITADEL_URL}"
+                    update_env_file "$compose_env" "ZITADEL_PROJECT_ID" "$PROJECT_ID"
+                    update_env_file "$compose_env" "ZITADEL_CLIENT_ID" "$FRONTEND_CLIENT_ID"
+                    update_env_file "$compose_env" "ZITADEL_TESTS_CLIENT_ID" "$TESTS_CLIENT_ID"
+                    echo -e "${GREEN}Updated docker stack env: ${compose_env}${NC}"
+                fi
+
                 # Only the API needs a machine token for Management API calls
                 if [ "$label" = "API" ]; then
                     update_env_file "$target" "ZITADEL_MACHINE_TOKEN" "$SERVICE_ACCOUNT_PAT"


### PR DESCRIPTION
Follow-up to #888 / #889, and the last place the stack could be left half-configured.

## The bug

`--update-env` writes `ZITADEL_ISSUER`, `ZITADEL_PROJECT_ID` and `ZITADEL_CLIENT_ID` to whatever `resolve_env_file()` picks:

```bash
for variant in ".env.local" ".env.development" ".env"; do ...
```

But **docker compose interpolates `.env`, and only `.env`.** On the very common layout where a project has a `.env.development` — which the real LiturgicalCalendarFrontend checkout does — every value written landed somewhere compose never reads, and the stack kept whatever `.env` happened to contain. A stale `ZITADEL_ISSUER` there silently survived a port change, which is precisely what #888 and #889 set out to stop.

It also made a claim in the Frontend's `.env.example` untrue: it says `setup-zitadel.sh --update-env` derives the issuer from `ZITADEL_PORT` correctly. It does — into the wrong file.

## The fix

The Frontend project owns the stack's compose file, so its `.env` is now written explicitly, in addition to the app-level file `resolve_env_file()` chose.

`ZITADEL_TESTS_CLIENT_ID` is the value with no equivalent anywhere else. The compose gives `litcal-tests` its **own** client — Zitadel rejects a `redirect_uri` that is not registered against the client making the request, and the test interface's callback is on its own port. Handed the Frontend's client, its login fails with:

```
The requested redirect_uri is missing in the client configuration.
```

Observed while implementing UnitTestInterface#87. Until now that variable had to be set by hand.

## Verification

A harness runs the **real** write loop over a fixture whose Frontend has both a `.env.development` and a `.env` carrying a deliberately stale client id:

```
=== Frontend/.env — what docker compose reads ===
  ZITADEL_ISSUER=http://localhost:8090      # was http://localhost:8080
  ZITADEL_CLIENT_ID=FRONTEND_CID            # was STALE
  ZITADEL_PROJECT_ID=PROJ123
  ZITADEL_TESTS_CLIENT_ID=TESTS_CID         # new

=== UnitTestInterface/.env ===
  ZITADEL_CLIENT_ID=TESTS_CID               # still its own client, unchanged behaviour
```

`bash -n` clean.

## One observation, not fixed here

`detect_self_label()` returns `API` when `src/Router.php` exists and `Frontend` otherwise — so a run whose `PROJECT_DIR` is UnitTestInterface would label itself `Frontend` and receive the Frontend's client id. It does not arise in practice (the wrapper ships only in the Frontend repo, and sibling discovery labels UTI correctly as `Tests`), so I have left it alone rather than widen this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker Compose environment setup, including fresh checkouts.
  * Ensured frontend and test services use the correct OpenID Connect configuration and client credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->