### PR TITLE
fix(ws): raise the handshake header limit so a logged-in user can connect

### DIFF
--- a/bin/LitCalTestServer.php
+++ b/bin/LitCalTestServer.php
@@ -1,6 +1,5 @@
 <?php
 
-
 // Refuse any entry that is not the CLI. This file is the Ratchet WebSocket server — systemd runs it
 // as `php bin/LitCalTestServer.php` — and it ends in `IoServer::factory(...)->run()`, i.e. it
 // binds WS_PORT and enters an event loop.
@@ -58,7 +57,7 @@ if (null === $autoloaderPath) {
 require_once $autoloaderPath;
 
 use Ratchet\Server\IoServer;
-use Ratchet\Http\HttpServer;
+use LiturgicalCalendar\Api\Http\Server\LargeHeaderHttpServer;
 use Ratchet\WebSocket\WsServer;
 use LiturgicalCalendar\Api\Health;
 use Dotenv\Dotenv;
@@ -155,8 +154,12 @@ $wsPort = filter_var($_ENV['WS_PORT'] ?? null, FILTER_VALIDATE_INT, [
     'options' => ['min_range' => 1, 'max_range' => 65535],
 ]) ?: 8082;
 
+// LargeHeaderHttpServer rather than Ratchet's HttpServer: this host shares a registrable domain with
+// the sites that log in through Zitadel, so a COOKIE_DOMAIN-scoped session rides along on every
+// handshake — several kilobytes of JWT this server never reads — and Ratchet's 4096-byte default
+// answers 413. See that class for the measurements.
 $server = IoServer::factory(
-    new HttpServer(
+    new LargeHeaderHttpServer(
         new WsServer(
             new Health()
         )

--- a/phpunit_tests/Http/Server/LargeHeaderHttpServerTest.php
+++ b/phpunit_tests/Http/Server/LargeHeaderHttpServerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Tests\Http\Server;
+
+use LiturgicalCalendar\Api\Http\Server\LargeHeaderHttpServer;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+use Ratchet\Http\HttpServerInterface;
+
+/**
+ * The WebSocket handshake limit, which exists because this server shares a registrable domain with sites
+ * that authenticate against Zitadel: their `COOKIE_DOMAIN`-scoped session is sent on every handshake, and
+ * Ratchet's 4096-byte default answered 413 once the JWTs grew past it.
+ *
+ * These assert the behaviour rather than the wiring wherever possible — an oversized handshake is refused,
+ * a merely large one is accepted — because the fragile part is that a subclass can still reach Ratchet's
+ * protected parser. If a future Ratchet renames it, the boundary tests fail rather than the limit silently
+ * reverting to 4096 and taking every logged-in user's WebSocket with it.
+ */
+final class LargeHeaderHttpServerTest extends TestCase
+{
+    /**
+     * A connection that records what the server sent and whether it was closed.
+     *
+     * @return array{0: ConnectionInterface, 1: \stdClass}
+     */
+    private function connection(): array
+    {
+        $log = new \stdClass();
+        /** @var string $log->sent */
+        $log->sent   = '';
+        $log->closed = false;
+
+        $conn = new class ($log) implements ConnectionInterface {
+            public \stdClass $log;
+
+            // Both are declared rather than left dynamic: Ratchet sets them on the connection object it
+            // is given, and PHP 8.2 deprecates creating properties that way. A real ReactPHP connection
+            // carries them too.
+            public bool $httpHeadersReceived = false;
+            public string $httpBuffer        = '';
+
+            public function __construct(\stdClass $log)
+            {
+                $this->log = $log;
+            }
+
+            public function send($data): ConnectionInterface
+            {
+                $this->log->sent .= (string) $data;
+                return $this;
+            }
+
+            public function close(): void
+            {
+                $this->log->closed = true;
+            }
+        };
+
+        return [$conn, $log];
+    }
+
+    /**
+     * A syntactically complete handshake whose Cookie header is $cookieBytes long, mimicking the
+     * COOKIE_DOMAIN-scoped Zitadel session a browser attaches here without being asked.
+     */
+    private function handshake(int $cookieBytes): string
+    {
+        $headers = [
+            'GET / HTTP/1.1',
+            'Host: litcal-test.example.org:9443',
+            'Upgrade: websocket',
+            'Connection: Upgrade',
+            'Sec-WebSocket-Key: x3JJHMbDL1EzLkh9GBhXDw==',
+            'Sec-WebSocket-Version: 13',
+        ];
+
+        if ($cookieBytes > 0) {
+            $headers[] = 'Cookie: litcal_access_token=' . str_repeat('A', $cookieBytes);
+        }
+
+        return implode("\r\n", $headers) . "\r\n\r\n";
+    }
+
+    private function server(?int $maxSize = null): LargeHeaderHttpServer
+    {
+        // A stub, not a mock: nothing here asserts on the wrapped component's calls, and PHPUnit
+        // rightly notices an expectation-free mock.
+        $component = $this->createStub(HttpServerInterface::class);
+
+        return null === $maxSize
+            ? new LargeHeaderHttpServer($component)
+            : new LargeHeaderHttpServer($component, $maxSize);
+    }
+
+    public function testAcceptsAHandshakeThatRatchetsDefaultWouldHaveRefused(): void
+    {
+        // ~5 KB: over Ratchet's 4096 default, comfortably under this class's limit. This is the case that
+        // was breaking in production — a logged-in user's cookies pushing the handshake past the default.
+        [$conn, $log] = $this->connection();
+        $server       = $this->server();
+
+        $server->onOpen($conn);
+        $server->onMessage($conn, $this->handshake(5000));
+
+        $this->assertFalse($log->closed, 'A ~5 KB handshake must not be refused.');
+        $this->assertStringNotContainsString('413', $log->sent);
+    }
+
+    public function testStillRefusesAHandshakeBeyondTheRaisedLimit(): void
+    {
+        // Raised, not removed: the cap is a denial-of-service guard, and an unauthenticated client must
+        // still not be able to make this server buffer without bound.
+        [$conn, $log] = $this->connection();
+        $server       = $this->server();
+
+        $server->onOpen($conn);
+        $server->onMessage($conn, $this->handshake(LargeHeaderHttpServer::MAX_HANDSHAKE_BYTES + 1000));
+
+        $this->assertTrue($log->closed, 'A handshake beyond the limit must be refused.');
+        $this->assertStringContainsString('413', $log->sent);
+    }
+
+    public function testHonoursAnExplicitLimit(): void
+    {
+        [$conn, $log] = $this->connection();
+        $server       = $this->server(2048);
+
+        $server->onOpen($conn);
+        $server->onMessage($conn, $this->handshake(4000));
+
+        $this->assertTrue($log->closed, 'An explicit limit must be applied instead of the default.');
+        $this->assertStringContainsString('413', $log->sent);
+    }
+
+    public function testDefaultLimitIsWellClearOfARealZitadelSession(): void
+    {
+        // Measured on a live session: litcal_access_token ~1082 B and litcal_id_token ~1586 B, before a
+        // refresh token or anything else the parent domain carries. The default has to clear that with
+        // room to spare, or this fix only postpones the outage.
+        $this->assertGreaterThan(
+            8192,
+            LargeHeaderHttpServer::MAX_HANDSHAKE_BYTES,
+            'The limit must leave headroom above a full Zitadel session plus ordinary browser headers.'
+        );
+    }
+}

--- a/src/Http/Server/LargeHeaderHttpServer.php
+++ b/src/Http/Server/LargeHeaderHttpServer.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Http\Server;
+
+use Ratchet\Http\HttpServer;
+use Ratchet\Http\HttpServerInterface;
+
+/**
+ * A Ratchet {@see HttpServer} whose WebSocket handshake may carry larger headers.
+ *
+ * Ratchet caps the handshake request at `HttpRequestParser::$maxSize`, 4096 bytes by default, and answers
+ * `413 Request Entity Too Large` above it. That is ample for a WebSocket handshake — until the browser
+ * attaches cookies.
+ *
+ * This server shares a registrable domain with the sites that authenticate against Zitadel, so a
+ * `COOKIE_DOMAIN`-scoped session is sent here too, on every handshake, despite this server never reading
+ * a cookie. Zitadel's tokens are JWTs: measured on a live session, `litcal_access_token` and
+ * `litcal_id_token` alone are ~2.7 KB of `Cookie:` header, before a refresh token or anything else the
+ * domain carries. Add a browser's ordinary handshake headers and 4096 is reachable — at which point every
+ * WebSocket connection fails for a logged-in user and succeeds again the moment they log out, with the
+ * browser reporting only "WebSocket connection failed".
+ *
+ * Measured against this server before the change:
+ *
+ *     ~4020 B handshake -> HTTP/1.1 101 Switching Protocols
+ *     ~4220 B handshake -> HTTP/1.1 413 Request Entity Too Large
+ *
+ * The cap is a denial-of-service guard, so it is raised rather than removed. There is no way to stop the
+ * browser sending the cookies: a host cannot opt out of a parent-domain cookie, and narrowing
+ * `COOKIE_DOMAIN` would break the cross-subdomain sharing it exists to provide.
+ */
+final class LargeHeaderHttpServer extends HttpServer
+{
+    /**
+     * Four times Ratchet's default. Comfortably clears a full Zitadel session plus a browser's usual
+     * headers, and still bounds the buffer an unauthenticated client can make this server allocate.
+     */
+    public const MAX_HANDSHAKE_BYTES = 16384;
+
+    public function __construct(HttpServerInterface $component, int $maxSize = self::MAX_HANDSHAKE_BYTES)
+    {
+        parent::__construct($component);
+
+        // `$_reqParser` is protected on HttpServer and `maxSize` is public on the parser, so a subclass is
+        // the supported way to reach it — Ratchet exposes no setter and no constructor argument.
+        $this->_reqParser->maxSize = $maxSize;
+    }
+}


### PR DESCRIPTION
Fixes a live-server symptom on `litcal-tests.johnromanodorazio.com`: **every WebSocket connection fails while the user is logged in at `litcal-staging`, and starts working the instant they log out.** The browser reports only `WebSocket connection failed`.

## Root cause

Ratchet caps the handshake request at `HttpRequestParser::$maxSize` — **4096 bytes** — and answers `413 Request Entity Too Large` above it. That is ample for a WebSocket handshake, until the browser attaches cookies.

The WS host shares a registrable domain with the sites that authenticate against Zitadel, so a `COOKIE_DOMAIN`-scoped session is sent here on **every handshake**, despite this server never reading a cookie. Zitadel's tokens are JWTs — measured on a live session, `litcal_access_token` (1082 B) and `litcal_id_token` (1586 B) alone are ~2.7 KB of `Cookie:` header, before a refresh token or anything else the domain carries. Add a browser's ordinary handshake headers and 4096 is reachable.

## Measured, not inferred

A raw handshake against this server, varying only the cookie size. **Before:**

```
~3820 B  ->  HTTP/1.1 101 Switching Protocols
~4020 B  ->  HTTP/1.1 101 Switching Protocols
~4220 B  ->  HTTP/1.1 413 Request Entity Too Large
```

**After:**

```
~4420 B  ->  HTTP/1.1 101 Switching Protocols
~16020 B ->  HTTP/1.1 101 Switching Protocols
~16420 B ->  HTTP/1.1 413 Request Entity Too Large
```

## The fix

`LargeHeaderHttpServer`, a small `HttpServer` subclass, sets the parser's limit to 16 KB. Ratchet exposes no setter and no constructor argument, and `$_reqParser` is `protected`, so a subclass is the supported way to reach it.

The cap is a denial-of-service guard, so it is **raised, not removed** — 16 KB clears a full Zitadel session plus ordinary headers, and still bounds what an unauthenticated client can make this server allocate.

## Why not stop sending the cookies instead

A host cannot opt out of a parent-domain cookie, and narrowing `COOKIE_DOMAIN` would break the cross-subdomain sharing it exists to provide. The waste is real — several kilobytes per handshake that this server discards — but it is not addressable from this side.

## Note on deployment

This needs the WebSocket server restarted to take effect (`systemctl restart` on the unit that runs `bin/LitCalTestServer.php`), since it is a long-running process rather than a per-request one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebSocket connections now support larger handshake headers, accommodating substantial session cookies.
  * Added configurable handshake size limits, with a higher default limit to reduce connection failures.

* **Bug Fixes**
  * Prevented oversized handshakes from being rejected prematurely while retaining explicit maximum-size enforcement.
  * Server entrypoint now rejects non-command-line execution requests safely.

* **Tests**
  * Added coverage for accepted, rejected, and custom handshake-size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->