### PR TITLE
feat(ws): authenticate the Health WebSocket server (#894)

### DIFF
--- a/bin/LitCalTestServer.php
+++ b/bin/LitCalTestServer.php
@@ -60,6 +60,7 @@ use Ratchet\Server\IoServer;
 use LiturgicalCalendar\Api\Http\Server\LargeHeaderHttpServer;
 use Ratchet\WebSocket\WsServer;
 use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Services\WsCallerResolver;
 use Dotenv\Dotenv;
 
 $dotenv = Dotenv::createImmutable($projectFolder, ['.env', '.env.local', '.env.development', '.env.test', '.env.staging', '.env.production'], false);
@@ -154,6 +155,27 @@ $wsPort = filter_var($_ENV['WS_PORT'] ?? null, FILTER_VALIDATE_INT, [
     'options' => ['min_range' => 1, 'max_range' => 65535],
 ]) ?: 8082;
 
+// Settle the caller-verification machinery before the loop starts — #894.
+//
+// The JWKS fetch is the reason this happens here rather than lazily. Ratchet is a single-threaded
+// ReactPHP loop, so a fetch inside onOpen() stalls every other connection for its duration; paying it
+// once at boot means steady-state handshakes are pure CPU and only a key rotation ever costs one.
+//
+// A failure to warm is deliberately not fatal: the server starts, and the first connection needing
+// RS256 verification pays the fetch instead. What it must never do is fail *open* — an unverifiable
+// caller is anonymous, and an anonymous caller may not start a run.
+//
+// The line is printed because losing a verification path is invisible from the outside: every real
+// user simply stops being able to run anything, which looks like a permissions bug rather than a
+// misconfiguration. Naming the live paths at startup is what makes that diagnosable.
+$callerResolver = WsCallerResolver::fromEnv();
+$jwksWarmed     = $callerResolver->warmKeySet();
+echo sprintf(
+    "Caller verification: %s. JWKS pre-warmed: %s\n",
+    $callerResolver->describeAvailablePaths(),
+    $jwksWarmed ? 'yes' : 'no'
+);
+
 // LargeHeaderHttpServer rather than Ratchet's HttpServer: this host shares a registrable domain with
 // the sites that log in through Zitadel, so a COOKIE_DOMAIN-scoped session rides along on every
 // handshake — several kilobytes of JWT this server never reads — and Ratchet's 4096-byte default
@@ -161,7 +183,7 @@ $wsPort = filter_var($_ENV['WS_PORT'] ?? null, FILTER_VALIDATE_INT, [
 $server = IoServer::factory(
     new LargeHeaderHttpServer(
         new WsServer(
-            new Health()
+            new Health($callerResolver)
         )
     ),
     $wsPort,

--- a/docs/superpowers/plans/2026-08-27-ws-health-auth.md
+++ b/docs/superpowers/plans/2026-08-27-ws-health-auth.md
@@ -1,0 +1,1750 @@
+# Health WebSocket Authentication Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-
+> task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop anonymous callers starting validation runs on the Health WebSocket server, by identifying the caller from the handshake cookie and gating every action on a
+permission the `hello` frame also advertises.
+
+**Architecture:** `Health::onOpen()` resolves a `WsCaller` from the `Cookie:` header on `$conn->httpRequest` (Zitadel RS256 via a shared `CachedKeySet`, else legacy
+HS256), remembers it per `resourceId`, and advertises its permissions on the `hello` frame. `Health::onMessage()` asks one `TestRunPolicy` object twice: coarsely at the
+top, before any run state is mutated, and again with the message's `TestTarget` once the message has been validated. Anonymous connections are accepted and refused per
+action, never closed.
+
+**Tech Stack:** PHP 8.4, Ratchet/ReactPHP, `firebase/php-jwt` (`CachedKeySet`), `symfony/cache` (`FilesystemAdapter`), PHPUnit 12, PHPStan level 10, PSR-12 via phpcs.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-ws-health-auth-design.md`
+
+## Global Constraints
+
+- PHP >= 8.4. Short array syntax, 4-space indent, single quotes unless interpolating.
+- PHPStan level 10 must pass: `composer analyse`. Suppress only with `@phpstan-ignore <identifier>`, never a bare `@phpstan-ignore-line`.
+- phpcs must pass: `composer lint`. Auto-fix with `composer lint:fix`.
+- Markdown must pass `composer lint:md` (180-char lines, blank lines around lists and fences, aligned tables).
+- **Never `--no-verify`.** If a hook fails, fix the cause.
+- **No network calls inside the ReactPHP event loop.** Roles come from the token claim only; the Zitadel Management API fallback that `OidcAuthMiddleware` uses is
+deliberately NOT carried into the WebSocket path.
+- Everything fails **closed**: any caller that cannot be verified is anonymous, and an anonymous caller may not run.
+- `SUPPORTED_PROTOCOL_VERSIONS` stays `[1]`. No version bump.
+- Run the suite with `composer test:quick`. Never pass a bare `--exclude-group` on the CLI: it un-fences `golden-master-generate`, which rewrites the fixtures it is checked against.
+- Mark a new test `slow` only with a **measured** reason, and only with the `#[Group('slow')]` attribute — never an `@group` docblock.
+
+---
+
+## File Structure
+
+**Create:**
+
+| Path                                    | Responsibility                                                |
+|-----------------------------------------|---------------------------------------------------------------|
+| `src/Models/Auth/WsCaller.php`          | Immutable identity of one WebSocket connection.               |
+| `src/Models/Auth/TestTarget.php`        | What a message wants validated; the seam's parameter.         |
+| `src/Services/TestRunPolicy.php`        | The single answer to "may this caller start a run?".          |
+| `src/Services/ZitadelRoles.php`         | Read the Zitadel project-roles claim off a token payload.     |
+| `src/Services/ZitadelKeySetFactory.php` | Build and memoize a `CachedKeySet` per issuer.                |
+| `src/Services/WsCallerResolver.php`     | Handshake -> `WsCaller`. Cookie parsing plus two-step verify. |
+
+**Modify:**
+
+| Path                                          | Change                                                            |
+|-----------------------------------------------|-------------------------------------------------------------------|
+| `src/Enum/ProtocolErrorCode.php`              | Two new cases.                                                    |
+| `jsondata/schemas/WebSocketFrame.json`        | `hello.caller`; two new `errorCode` values.                       |
+| `src/Http/Middleware/OidcAuthMiddleware.php`  | Delegate `getKeySet()` and role-claim reading to the new helpers. |
+| `src/Health.php`                              | Resolve, remember, advertise, gate.                               |
+| `bin/LitCalTestServer.php`                    | Warm the key set at boot; log which verify paths are live.        |
+| `phpunit_tests/WebSocket/WsTestClient.php`    | Optional `Cookie:` header on the handshake.                       |
+| `phpunit_tests/WebSocket/*Test.php` (4 files) | Authenticate; skip loudly without `JWT_SECRET`.                   |
+
+---
+
+### Task 1: `WsCaller` and `TestRunPolicy`
+
+Pure logic, no I/O. Everything else depends on these names.
+
+**Files:**
+
+- Create: `src/Models/Auth/WsCaller.php`
+- Create: `src/Models/Auth/TestTarget.php`
+- Create: `src/Services/TestRunPolicy.php`
+- Test: `phpunit_tests/Services/TestRunPolicyTest.php`
+
+**Interfaces:**
+
+- Produces: `WsCaller::anonymous(): self`, `WsCaller::authenticated(string $sub, array $roles): self`,
+  readonly `$authenticated`, `$sub`, `$roles`, `hasAnyRole(string ...$roles): bool`.
+  `TestTarget::__construct(?string $kind, ?string $rite, ?string $calendarId)`,
+  `TestTarget::fromMessage(mixed $message): ?self`.
+  `TestRunPolicy::RUN_TESTS_ROLES`, `TestRunPolicy::mayRun(WsCaller $caller, ?TestTarget $target = null): bool`.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Models\Auth\TestTarget;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use LiturgicalCalendar\Api\Services\TestRunPolicy;
+use PHPUnit\Framework\TestCase;
+
+final class TestRunPolicyTest extends TestCase
+{
+    public function testAnonymousCallerMayNotRun(): void
+    {
+        $this->assertFalse((new TestRunPolicy())->mayRun(WsCaller::anonymous()));
+    }
+
+    public function testAuthenticatedCallerWithoutQualifyingRoleMayNotRun(): void
+    {
+        $caller = WsCaller::authenticated('user-1', ['developer', 'calendar_editor']);
+        $this->assertFalse((new TestRunPolicy())->mayRun($caller));
+    }
+
+    public function testTestEditorMayRun(): void
+    {
+        $caller = WsCaller::authenticated('user-1', ['test_editor']);
+        $this->assertTrue((new TestRunPolicy())->mayRun($caller));
+    }
+
+    public function testAdminMayRun(): void
+    {
+        $caller = WsCaller::authenticated('user-1', ['admin']);
+        $this->assertTrue((new TestRunPolicy())->mayRun($caller));
+    }
+
+    public function testTargetIsAcceptedAndIgnoredByTheCoarsePolicy(): void
+    {
+        $policy = new TestRunPolicy();
+        $target = new TestTarget('rite', 'roman', null);
+        $this->assertTrue($policy->mayRun(WsCaller::authenticated('u', ['admin']), $target));
+        $this->assertFalse($policy->mayRun(WsCaller::anonymous(), $target));
+    }
+
+    public function testTargetIsReadFromAValidateCalendarMessage(): void
+    {
+        $message = json_decode('{"action":"validateCalendar","calendar":{"kind":"rite","rite":"roman"}}');
+        $target  = TestTarget::fromMessage($message);
+        $this->assertNotNull($target);
+        $this->assertSame('rite', $target->kind);
+        $this->assertSame('roman', $target->rite);
+    }
+
+    public function testTargetIsNullWhenTheMessageNamesNone(): void
+    {
+        $this->assertNull(TestTarget::fromMessage(json_decode('{"action":"runTest"}')));
+        $this->assertNull(TestTarget::fromMessage('not an object'));
+    }
+
+    public function testRolesAreDeduplicatedAndAnonymousHasNone(): void
+    {
+        $caller = WsCaller::authenticated('u', ['admin', 'admin']);
+        $this->assertSame(['admin'], $caller->roles);
+        $this->assertSame([], WsCaller::anonymous()->roles);
+        $this->assertNull(WsCaller::anonymous()->sub);
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/TestRunPolicyTest.php`
+Expected: FAIL — `Class "LiturgicalCalendar\Api\Models\Auth\WsCaller" not found`.
+
+- [ ] **Step 3: Implement `WsCaller`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\Auth;
+
+/**
+ * The identity of one WebSocket connection, settled once at handshake time.
+ *
+ * Anonymity is a state, not a failure: {@see \LiturgicalCalendar\Api\Services\WsCallerResolver}
+ * answers with an anonymous caller for a missing cookie, an expired token and a forged one alike,
+ * because the connection is accepted either way and the refusal happens per action.
+ */
+final readonly class WsCaller
+{
+    /**
+     * @param array<int, string> $roles
+     */
+    private function __construct(
+        public bool $authenticated,
+        public ?string $sub,
+        public array $roles
+    ) {
+    }
+
+    public static function anonymous(): self
+    {
+        return new self(false, null, []);
+    }
+
+    /**
+     * @param array<int, string> $roles
+     */
+    public static function authenticated(string $sub, array $roles): self
+    {
+        /** @var array<int, string> $clean */
+        $clean = array_values(array_unique(array_filter($roles, 'is_string')));
+        return new self(true, $sub, $clean);
+    }
+
+    public function hasAnyRole(string ...$roles): bool
+    {
+        return [] !== array_intersect($roles, $this->roles);
+    }
+}
+```
+
+- [ ] **Step 4: Implement `TestTarget`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\Auth;
+
+/**
+ * What a message wants validated, in the terms a permission check would need.
+ *
+ * Carried through {@see \LiturgicalCalendar\Api\Services\TestRunPolicy::mayRun()} from day one even
+ * though the coarse policy ignores it. The alternative — adding the parameter when a fine-grained
+ * policy arrives — would mean changing every call site at exactly the moment the behaviour changes,
+ * which is the worst time to be moving plumbing.
+ */
+final readonly class TestTarget
+{
+    public function __construct(
+        public ?string $kind,
+        public ?string $rite,
+        public ?string $calendarId
+    ) {
+    }
+
+    /**
+     * Read the target off a validated message, or null when the message names none.
+     *
+     * Takes `mixed` for the same reason {@see \LiturgicalCalendar\Api\Health::declaredCorrelationId()}
+     * does: the caller holds a raw `json_decode()` result, and narrowing it here would narrow it for
+     * every guard downstream.
+     */
+    public static function fromMessage(mixed $message): ?self
+    {
+        if (false === $message instanceof \stdClass || false === property_exists($message, 'calendar')) {
+            return null;
+        }
+
+        $calendar = $message->calendar;
+        if (false === $calendar instanceof \stdClass) {
+            return null;
+        }
+
+        $read = static function (string $property) use ($calendar): ?string {
+            if (false === property_exists($calendar, $property)) {
+                return null;
+            }
+            $value = $calendar->{$property};
+            return is_string($value) ? $value : null;
+        };
+
+        $kind = $read('kind');
+        $rite = $read('rite');
+        // The id property is named for the kind it belongs to; the first one present wins.
+        $calendarId = $read('calendar') ?? $read('nation') ?? $read('diocese');
+
+        if (null === $kind && null === $rite && null === $calendarId) {
+            return null;
+        }
+
+        return new self($kind, $rite, $calendarId);
+    }
+}
+```
+
+- [ ] **Step 5: Implement `TestRunPolicy`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Models\Auth\TestTarget;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+
+/**
+ * Whether a caller may start a validation run.
+ *
+ * One object, asked by both the `hello` frame and the action gate, so the advertisement and the
+ * enforcement cannot disagree — the failure mode that made UnitTestInterface's client-side gate
+ * worth closing in the first place.
+ *
+ * `$target` is accepted and ignored. A fine-grained implementation would resolve it through
+ * {@see TestScopeResolver} to a `*_test` object and ask OpenFGA; the seam exists so that arriving
+ * changes one class rather than a protocol.
+ */
+class TestRunPolicy
+{
+    /**
+     * The roles permitted to start a run.
+     *
+     * The same pair UnitTestInterface enforces in `JwtAuth::RUN_TESTS_ROLES` when storing a run's
+     * result. They are not shared through a package, so this server is the one that answers and the
+     * client is told — see the `caller` object on the `hello` frame.
+     *
+     * @var array<int, string>
+     */
+    public const RUN_TESTS_ROLES = ['admin', 'test_editor'];
+
+    public function mayRun(WsCaller $caller, ?TestTarget $target = null): bool
+    {
+        if (false === $caller->authenticated) {
+            return false;
+        }
+
+        return $caller->hasAnyRole(...self::RUN_TESTS_ROLES);
+    }
+}
+```
+
+- [ ] **Step 6: Run the test and confirm it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/TestRunPolicyTest.php`
+Expected: PASS, 8 tests.
+
+- [ ] **Step 7: Lint, analyse, commit**
+
+```bash
+composer lint:fix
+composer analyse
+git add src/Models/Auth/WsCaller.php src/Models/Auth/TestTarget.php src/Services/TestRunPolicy.php phpunit_tests/Services/TestRunPolicyTest.php
+git commit -m "feat(ws): add WsCaller identity and TestRunPolicy permission seam"
+```
+
+---
+
+### Task 2: Share the Zitadel key set and role-claim reading
+
+A DRY refactor ahead of the new consumer, so the WebSocket resolver does not re-implement JWKS
+plumbing that already exists in `OidcAuthMiddleware`. Behaviour must not change.
+
+**Files:**
+
+- Create: `src/Services/ZitadelRoles.php`
+- Create: `src/Services/ZitadelKeySetFactory.php`
+- Modify: `src/Http/Middleware/OidcAuthMiddleware.php` (`getKeySet()`, the roles-claim block in `extractUserInfo()`)
+- Test: `phpunit_tests/Services/ZitadelRolesTest.php`
+
+**Interfaces:**
+
+- Consumes: nothing from Task 1.
+- Produces: `ZitadelRoles::CLAIM`, `ZitadelRoles::fromPayload(object $payload): array<int, string>`,
+  `ZitadelKeySetFactory::for(string $issuer, ?string $internalUrl, int $cacheTtl): CachedKeySet`.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Services\ZitadelRoles;
+use PHPUnit\Framework\TestCase;
+
+final class ZitadelRolesTest extends TestCase
+{
+    public function testReadsRoleNamesFromTheProjectRolesClaim(): void
+    {
+        $payload = json_decode('{"' . ZitadelRoles::CLAIM . '":{"admin":{"org_id":"1"},"test_editor":{"org_id":"1"}}}');
+        $this->assertSame(['admin', 'test_editor'], ZitadelRoles::fromPayload($payload));
+    }
+
+    public function testReturnsEmptyWhenTheClaimIsAbsent(): void
+    {
+        $this->assertSame([], ZitadelRoles::fromPayload(json_decode('{"sub":"u"}')));
+    }
+
+    public function testReturnsEmptyWhenTheClaimIsNotAnObject(): void
+    {
+        $payload = json_decode('{"' . ZitadelRoles::CLAIM . '":"admin"}');
+        $this->assertSame([], ZitadelRoles::fromPayload($payload));
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/ZitadelRolesTest.php`
+Expected: FAIL — class not found.
+
+- [ ] **Step 3: Implement `ZitadelRoles`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+/**
+ * The Zitadel project-roles claim, read the one way.
+ *
+ * Zitadel returns roles as an object keyed by role name — `{"admin": {"org_id": "1"}}` — so the role
+ * names are the keys, not the values.
+ */
+final class ZitadelRoles
+{
+    public const CLAIM = 'urn:zitadel:iam:org:project:roles';
+
+    /**
+     * @return array<int, string>
+     */
+    public static function fromPayload(object $payload): array
+    {
+        if (false === isset($payload->{self::CLAIM})) {
+            return [];
+        }
+
+        $claim = $payload->{self::CLAIM};
+        if (false === is_object($claim) && false === is_array($claim)) {
+            return [];
+        }
+
+        /** @var array<int, string> $roles */
+        $roles = array_values(array_filter(array_keys((array) $claim), 'is_string'));
+
+        return $roles;
+    }
+}
+```
+
+- [ ] **Step 4: Implement `ZitadelKeySetFactory`**
+
+Move the body of `OidcAuthMiddleware::getKeySet()` verbatim, including the static per-issuer memo and
+the `Host`-header middleware for the Docker-internal URL. Note the cache directory: from
+`src/Services/` the project root is `dirname(__DIR__, 2)`, not `dirname(__DIR__, 3)` as it was from
+`src/Http/Middleware/`.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use Firebase\JWT\CachedKeySet;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\HttpFactory;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+/**
+ * Builds and memoizes the Zitadel JWKS key set.
+ *
+ * Shared by {@see \LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware} and
+ * {@see WsCallerResolver} so both reach the same filesystem cache: a key already fetched by the HTTP
+ * API is a key the WebSocket server does not have to fetch, which matters because the WebSocket
+ * server fetches from inside a single-threaded event loop.
+ */
+final class ZitadelKeySetFactory
+{
+    /** @var array<string, CachedKeySet> */
+    private static array $keySets = [];
+
+    public static function for(string $issuer, ?string $internalUrl = null, int $cacheTtl = 3600): CachedKeySet
+    {
+        $issuer = rtrim($issuer, '/');
+
+        if (isset(self::$keySets[$issuer])) {
+            return self::$keySets[$issuer];
+        }
+
+        $jwksUri = $issuer . '/oauth/v2/keys';
+
+        if (null !== $internalUrl && '' !== $internalUrl) {
+            // Rewrite the JWKS URI for Docker networking. CachedKeySet uses PSR-18 sendRequest(),
+            // which does not apply Guzzle's default headers, so the Host header is injected here or
+            // Zitadel refuses a request addressed to the compose service name.
+            $jwksUri    = rtrim($internalUrl, '/') . '/oauth/v2/keys';
+            $hostHeader = ZitadelHostHeader::deriveFromIssuer($issuer);
+            $stack      = HandlerStack::create();
+            $stack->push(Middleware::mapRequest(
+                static fn(RequestInterface $request): RequestInterface => $request->withHeader('Host', $hostHeader)
+            ));
+            $httpClient = new Client(['handler' => $stack]);
+        } else {
+            $httpClient = new Client();
+        }
+
+        $cacheDir = dirname(__DIR__, 2) . '/cache';
+
+        self::$keySets[$issuer] = new CachedKeySet(
+            $jwksUri,
+            $httpClient,
+            new HttpFactory(),
+            new FilesystemAdapter('jwks', $cacheTtl, $cacheDir),
+            $cacheTtl,
+            true // Rate limit JWKS fetches
+        );
+
+        return self::$keySets[$issuer];
+    }
+}
+```
+
+- [ ] **Step 5: Point `OidcAuthMiddleware` at both helpers**
+
+Replace the body of `getKeySet()` with
+`return ZitadelKeySetFactory::for($this->issuer, $this->internalUrl, $this->cacheTtl);`
+and delete the now-unused `self::$keySets` property and the imports it alone needed
+(`CachedKeySet`, `Client`, `HandlerStack`, `Middleware`, `HttpFactory`, `RequestInterface` — keep any
+still used elsewhere in the file).
+
+In `extractUserInfo()`, replace the inline roles-claim loop with `$roles = ZitadelRoles::fromPayload($payload);`
+and **leave the Management-API fallback below it exactly as it is** — that fallback belongs to the HTTP
+path, which may block.
+
+- [ ] **Step 6: Run the affected suites**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/ZitadelRolesTest.php phpunit_tests/Services/ZitadelServiceTest.php phpunit_tests/Services/ZitadelHostHeaderTest.php phpunit_tests/Http`
+Expected: PASS, no behaviour change.
+
+- [ ] **Step 7: Lint, analyse, commit**
+
+```bash
+composer lint:fix
+composer analyse
+git add src/Services/ZitadelRoles.php src/Services/ZitadelKeySetFactory.php src/Http/Middleware/OidcAuthMiddleware.php phpunit_tests/Services/ZitadelRolesTest.php
+git commit -m "refactor(auth): extract shared Zitadel key set factory and roles-claim reader"
+```
+
+---
+
+### Task 3: `WsCallerResolver`
+
+**Files:**
+
+- Create: `src/Services/WsCallerResolver.php`
+- Test: `phpunit_tests/Services/WsCallerResolverTest.php`
+
+**Interfaces:**
+
+- Consumes: `WsCaller` (Task 1), `ZitadelRoles`, `ZitadelKeySetFactory` (Task 2).
+- Produces: `WsCallerResolver::fromEnv(): self`, `fromHandshake(?RequestInterface $request): WsCaller`,
+  `fromToken(string $token): WsCaller`, `parseCookieHeader(string $header): array<string, string>`,
+  `warmKeySet(): bool`, `describeAvailablePaths(): string`.
+
+- [ ] **Step 1: Write the failing test**
+
+`EnvIsolationTrait::withoutEnv()` is the existing helper for exercising "service not configured"
+branches without leaking the host's `.env.local` into assertions.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use GuzzleHttp\Psr7\Request;
+use LiturgicalCalendar\Api\Services\JwtService;
+use LiturgicalCalendar\Api\Services\WsCallerResolver;
+use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
+use PHPUnit\Framework\TestCase;
+
+final class WsCallerResolverTest extends TestCase
+{
+    use EnvIsolationTrait;
+
+    private const SECRET = 'a-test-secret-that-is-at-least-32-characters-long';
+
+    private function resolver(): WsCallerResolver
+    {
+        return new WsCallerResolver(new JwtService(self::SECRET), null, null);
+    }
+
+    private function tokenFor(string $sub, array $roles): string
+    {
+        return (new JwtService(self::SECRET))->generate($sub, ['roles' => $roles]);
+    }
+
+    public function testNoRequestIsAnonymous(): void
+    {
+        $this->assertFalse($this->resolver()->fromHandshake(null)->authenticated);
+    }
+
+    public function testNoCookieHeaderIsAnonymous(): void
+    {
+        $request = new Request('GET', '/');
+        $this->assertFalse($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testLegacyHs256CookieIsAuthenticatedWithItsRoles(): void
+    {
+        $token   = $this->tokenFor('someone', ['test_editor']);
+        $request = new Request('GET', '/', ['Cookie' => 'litcal_access_token=' . $token]);
+
+        $caller = $this->resolver()->fromHandshake($request);
+
+        $this->assertTrue($caller->authenticated);
+        $this->assertSame('someone', $caller->sub);
+        $this->assertSame(['test_editor'], $caller->roles);
+    }
+
+    public function testCookieIsFoundAmongOthers(): void
+    {
+        $token   = $this->tokenFor('someone', ['admin']);
+        $request = new Request('GET', '/', [
+            'Cookie' => 'other=1; litcal_access_token=' . $token . '; litcal_id_token=zzz',
+        ]);
+
+        $this->assertTrue($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testGarbageTokenIsAnonymousRatherThanAnError(): void
+    {
+        $request = new Request('GET', '/', ['Cookie' => 'litcal_access_token=not.a.jwt']);
+        $this->assertFalse($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testExpiredTokenIsAnonymous(): void
+    {
+        $expired = (new JwtService(self::SECRET, 'HS256', -10))->generate('someone', ['roles' => ['admin']]);
+        $request = new Request('GET', '/', ['Cookie' => 'litcal_access_token=' . $expired]);
+        $this->assertFalse($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testTokenWithoutRolesClaimAuthenticatesWithNoRoles(): void
+    {
+        $token  = (new JwtService(self::SECRET))->generate('someone');
+        $caller = $this->resolver()->fromToken($token);
+
+        $this->assertTrue($caller->authenticated);
+        $this->assertSame([], $caller->roles);
+    }
+
+    public function testMalformedCookieHeaderDoesNotThrow(): void
+    {
+        $request = new Request('GET', '/', ['Cookie' => '=; ;;  ; nonsense']);
+        $this->assertFalse($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testCookieValuesAreUrlDecoded(): void
+    {
+        $parsed = WsCallerResolver::parseCookieHeader('a=one%20two');
+        $this->assertSame('one two', $parsed['a']);
+    }
+
+    public function testResolverWithNoVerificationPathAtAllIsAnonymous(): void
+    {
+        $this->withoutEnv(['JWT_SECRET', 'ZITADEL_ISSUER', 'ZITADEL_CLIENT_ID'], function (): void {
+            $resolver = WsCallerResolver::fromEnv();
+            $request  = new Request('GET', '/', ['Cookie' => 'litcal_access_token=anything']);
+
+            $this->assertFalse($resolver->fromHandshake($request)->authenticated);
+            $this->assertStringContainsString('none', strtolower($resolver->describeAvailablePaths()));
+        });
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/WsCallerResolverTest.php`
+Expected: FAIL — class not found.
+
+- [ ] **Step 3: Implement `WsCallerResolver`**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use Firebase\JWT\JWT;
+use LiturgicalCalendar\Api\Http\CookieHelper;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Who is on the other end of a WebSocket handshake.
+ *
+ * Two things make this a separate service rather than a reuse of `OidcAuthMiddleware`:
+ *
+ *  1. The handshake carries a PSR-7 **`RequestInterface`**, not a `ServerRequestInterface`, so there
+ *     is no `getCookieParams()` and the `Cookie:` header is parsed here.
+ *  2. It runs inside a single-threaded ReactPHP loop, so it must not make a network call per
+ *     connection. Roles are read from the token claim only; the Management-API lookup that
+ *     `OidcAuthMiddleware` falls back to is deliberately absent. A Zitadel token issued without the
+ *     project-roles claim therefore reads as authenticated with no roles, and is refused — which is
+ *     the fail-closed direction.
+ *
+ * Every failure yields {@see WsCaller::anonymous()}. Nothing here throws: the connection is accepted
+ * either way, and the refusal happens per action.
+ */
+final class WsCallerResolver
+{
+    public function __construct(
+        private readonly ?JwtService $jwtService,
+        private readonly ?string $issuer,
+        private readonly ?string $internalUrl,
+        private readonly int $cacheTtl = 3600
+    ) {
+    }
+
+    /**
+     * Build from the environment, degrading rather than throwing.
+     *
+     * A missing `JWT_SECRET` or a missing `ZITADEL_ISSUER` disables that one verification path and
+     * leaves the other working. Disabling both is legal and means every caller is anonymous.
+     */
+    public static function fromEnv(): self
+    {
+        try {
+            $jwtService = JwtServiceFactory::fromEnv();
+        } catch (\Throwable) {
+            $jwtService = null;
+        }
+
+        $issuerEnv      = getenv('ZITADEL_ISSUER') ?: ( $_ENV['ZITADEL_ISSUER'] ?? '' );
+        $internalUrlEnv = getenv('ZITADEL_INTERNAL_URL') ?: ( $_ENV['ZITADEL_INTERNAL_URL'] ?? '' );
+
+        $issuer      = is_string($issuerEnv) && '' !== $issuerEnv ? $issuerEnv : null;
+        $internalUrl = is_string($internalUrlEnv) && '' !== $internalUrlEnv ? $internalUrlEnv : null;
+
+        return new self($jwtService, $issuer, $internalUrl);
+    }
+
+    public function fromHandshake(?RequestInterface $request): WsCaller
+    {
+        if (null === $request) {
+            return WsCaller::anonymous();
+        }
+
+        $cookies = self::parseCookieHeader($request->getHeaderLine('Cookie'));
+        $token   = CookieHelper::getAccessToken($cookies);
+
+        if (null === $token || '' === $token) {
+            return WsCaller::anonymous();
+        }
+
+        return $this->fromToken($token);
+    }
+
+    /**
+     * Zitadel first, legacy second — the same order {@see \LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware}
+     * uses, and for the same reason: a live deployment issues RS256, while HS256 tokens still exist.
+     */
+    public function fromToken(string $token): WsCaller
+    {
+        if (null !== $this->issuer) {
+            try {
+                $payload = JWT::decode($token, ZitadelKeySetFactory::for($this->issuer, $this->internalUrl, $this->cacheTtl));
+                $sub     = $payload->sub ?? null;
+                if (is_string($sub) && '' !== $sub) {
+                    return WsCaller::authenticated($sub, ZitadelRoles::fromPayload($payload));
+                }
+            } catch (\Throwable) {
+                // Not a Zitadel token, or the key set is unreachable. Fall through to the legacy path.
+            }
+        }
+
+        if (null !== $this->jwtService) {
+            $payload = $this->jwtService->verify($token);
+            if (null !== $payload) {
+                $sub = $payload->sub ?? null;
+                if (is_string($sub) && '' !== $sub) {
+                    $roles = $payload->roles ?? [];
+                    /** @var array<int, string> $roleList */
+                    $roleList = is_array($roles) ? array_values(array_filter($roles, 'is_string')) : [];
+                    return WsCaller::authenticated($sub, $roleList);
+                }
+            }
+        }
+
+        return WsCaller::anonymous();
+    }
+
+    /**
+     * Parse a `Cookie:` header into a name => value map.
+     *
+     * @return array<string, string>
+     */
+    public static function parseCookieHeader(string $header): array
+    {
+        $cookies = [];
+
+        foreach (explode(';', $header) as $pair) {
+            $pair = trim($pair);
+            if ('' === $pair || false === str_contains($pair, '=')) {
+                continue;
+            }
+            [$name, $value] = explode('=', $pair, 2);
+            $name           = trim($name);
+            if ('' === $name) {
+                continue;
+            }
+            $cookies[$name] = urldecode(trim($value));
+        }
+
+        return $cookies;
+    }
+
+    /**
+     * Fetch the JWKS once, off the event loop, so `onOpen()` never pays for it.
+     *
+     * @return bool Whether a key set was fetched. False means RS256 verification is unavailable or
+     *              not configured; it is not a reason to refuse to start.
+     */
+    public function warmKeySet(): bool
+    {
+        if (null === $this->issuer) {
+            return false;
+        }
+
+        try {
+            $keySet = ZitadelKeySetFactory::for($this->issuer, $this->internalUrl, $this->cacheTtl);
+            // offsetExists() drives the fetch without needing to know a key id.
+            $keySet->offsetExists('warm');
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * Which verification paths are live, for a startup log line. A deployment that has silently lost
+     * one of them degrades every real user to anonymous, which is safe but total, and worth saying.
+     */
+    public function describeAvailablePaths(): string
+    {
+        $paths = [];
+        if (null !== $this->issuer) {
+            $paths[] = 'Zitadel RS256';
+        }
+        if (null !== $this->jwtService) {
+            $paths[] = 'legacy HS256';
+        }
+
+        return [] === $paths ? 'none (every caller will be anonymous)' : implode(' + ', $paths);
+    }
+}
+```
+
+- [ ] **Step 4: Run the test and confirm it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Services/WsCallerResolverTest.php`
+Expected: PASS, 11 tests.
+
+- [ ] **Step 5: Lint, analyse, commit**
+
+```bash
+composer lint:fix
+composer analyse
+git add src/Services/WsCallerResolver.php phpunit_tests/Services/WsCallerResolverTest.php
+git commit -m "feat(ws): resolve the calling identity from the handshake cookie"
+```
+
+---
+
+### Task 4: Two new protocol error codes
+
+**Files:**
+
+- Modify: `src/Enum/ProtocolErrorCode.php`
+- Modify: `jsondata/schemas/WebSocketFrame.json` (`definitions/protocolError/properties/errorCode/enum`)
+- Test: `phpunit_tests/Enum/ProtocolErrorCodeSchemaTest.php`
+
+**Interfaces:**
+
+- Produces: `ProtocolErrorCode::NOT_AUTHENTICATED` (`not_authenticated`), `ProtocolErrorCode::INSUFFICIENT_ROLE` (`insufficient_role`).
+
+- [ ] **Step 1: Write the failing test**
+
+This test also guards the pairing that is easy to break later: an enum case with no schema entry
+produces a frame the published contract rejects.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use PHPUnit\Framework\TestCase;
+
+final class ProtocolErrorCodeSchemaTest extends TestCase
+{
+    public function testTheAuthenticationCodesExist(): void
+    {
+        $this->assertSame('not_authenticated', ProtocolErrorCode::NOT_AUTHENTICATED->value);
+        $this->assertSame('insufficient_role', ProtocolErrorCode::INSUFFICIENT_ROLE->value);
+    }
+
+    public function testEveryEnumCaseIsDeclaredInTheFrameSchema(): void
+    {
+        $schemaPath = dirname(__DIR__, 2) . '/jsondata/schemas/WebSocketFrame.json';
+        $schema     = json_decode((string) file_get_contents($schemaPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $declared = $schema['definitions']['protocolError']['properties']['errorCode']['enum'];
+        $cases    = array_column(ProtocolErrorCode::cases(), 'value');
+
+        sort($declared);
+        sort($cases);
+        $this->assertSame($cases, $declared, 'Every ProtocolErrorCode must be declared in WebSocketFrame.json');
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/Enum/ProtocolErrorCodeSchemaTest.php`
+Expected: FAIL — undefined constant `NOT_AUTHENTICATED`.
+
+- [ ] **Step 3: Add the enum cases**
+
+Append to `src/Enum/ProtocolErrorCode.php`, with a docblock explaining why these are two codes and not one:
+
+```php
+    /**
+     * The caller is not logged in — the connection carried no usable credential.
+     *
+     * Separate from {@see self::INSUFFICIENT_ROLE} by the rule this enum opens with: the remedy
+     * differs. This one is answered by logging in; the other cannot be, and telling a logged-in
+     * `developer` to log in again is advice that cannot help.
+     */
+    case NOT_AUTHENTICATED = 'not_authenticated';
+
+    /**
+     * The caller is logged in, but holds none of the roles that may start a validation run.
+     *
+     * The remedy is to be granted a role, not to re-authenticate.
+     */
+    case INSUFFICIENT_ROLE = 'insufficient_role';
+```
+
+- [ ] **Step 4: Add both values to the schema**
+
+In `jsondata/schemas/WebSocketFrame.json`, append `"not_authenticated"` and `"insufficient_role"` to
+`definitions/protocolError/properties/errorCode/enum`. Edit programmatically to preserve formatting:
+
+```bash
+python3 - <<'PY'
+import json, collections
+p = 'jsondata/schemas/WebSocketFrame.json'
+d = json.load(open(p), object_pairs_hook=collections.OrderedDict)
+e = d['definitions']['protocolError']['properties']['errorCode']['enum']
+for v in ('not_authenticated', 'insufficient_role'):
+    if v not in e:
+        e.append(v)
+json.dump(d, open(p, 'w'), indent=4, ensure_ascii=False)
+open(p, 'a').write('\n')
+PY
+git diff --stat jsondata/schemas/WebSocketFrame.json
+```
+
+Verify the diff touches only the enum array. If the whole file reformats, revert and match the
+existing indent width instead.
+
+- [ ] **Step 5: Run the test and confirm it passes**
+
+Run: `vendor/bin/phpunit phpunit_tests/Enum/ProtocolErrorCodeSchemaTest.php`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+composer lint:fix
+git add src/Enum/ProtocolErrorCode.php jsondata/schemas/WebSocketFrame.json phpunit_tests/Enum/ProtocolErrorCodeSchemaTest.php
+git commit -m "feat(ws): add not_authenticated and insufficient_role protocol error codes"
+```
+
+---
+
+### Task 5: Resolve, remember and advertise the caller
+
+**Files:**
+
+- Modify: `src/Health.php` (constructor, `onOpen()`, `onClose()`, `helloFrame()`)
+- Modify: `jsondata/schemas/WebSocketFrame.json` (`definitions/hello`)
+- Test: `phpunit_tests/HealthCallerFrameTest.php`
+
+**Interfaces:**
+
+- Consumes: `WsCaller`, `TestRunPolicy` (Task 1), `WsCallerResolver` (Task 3).
+- Produces: `Health::__construct(?WsCallerResolver $callerResolver = null, ?TestRunPolicy $policy = null)`;
+  `hello.caller` on the wire.
+
+- [ ] **Step 1: Write the failing test**
+
+`helloFrame()` is private, so reach it the way the existing `HealthHelloFrameTest` does — read that
+file first and follow its access pattern rather than inventing a second one.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use PHPUnit\Framework\TestCase;
+
+final class HealthCallerFrameTest extends TestCase
+{
+    private function helloFor(WsCaller $caller): \stdClass
+    {
+        $health = new Health();
+        $method = new \ReflectionMethod(Health::class, 'helloFrame');
+        /** @var \stdClass $frame */
+        $frame = $method->invoke($health, $caller);
+        return $frame;
+    }
+
+    public function testAnonymousCallerIsAdvertisedAsUnpermitted(): void
+    {
+        $frame = $this->helloFor(WsCaller::anonymous());
+
+        $this->assertObjectHasProperty('caller', $frame);
+        $this->assertFalse($frame->caller->authenticated);
+        $this->assertFalse($frame->caller->permissions->runTests);
+    }
+
+    public function testTestEditorIsAdvertisedAsPermitted(): void
+    {
+        $frame = $this->helloFor(WsCaller::authenticated('someone', ['test_editor']));
+
+        $this->assertTrue($frame->caller->authenticated);
+        $this->assertTrue($frame->caller->permissions->runTests);
+    }
+
+    public function testAuthenticatedWithoutRoleIsAuthenticatedButUnpermitted(): void
+    {
+        $frame = $this->helloFor(WsCaller::authenticated('someone', ['developer']));
+
+        $this->assertTrue($frame->caller->authenticated);
+        $this->assertFalse($frame->caller->permissions->runTests);
+    }
+
+    public function testCapabilitiesAreUnchanged(): void
+    {
+        $frame = $this->helloFor(WsCaller::anonymous());
+
+        $this->assertObjectHasProperty('capabilities', $frame);
+        $this->assertObjectNotHasProperty('caller', $frame->capabilities);
+        $this->assertSame(1, $frame->protocol);
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/HealthCallerFrameTest.php`
+Expected: FAIL — `helloFrame()` takes no arguments.
+
+- [ ] **Step 3: Add the collaborators and per-connection state to `Health`**
+
+Add the imports, two readonly properties initialized in the constructor (lazily defaulted so
+construction order is unchanged — see `HealthConstructionOrderTest`), and the caller map beside
+`$runTokens`:
+
+```php
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use LiturgicalCalendar\Api\Services\TestRunPolicy;
+use LiturgicalCalendar\Api\Services\WsCallerResolver;
+```
+
+```php
+    /** @var array<int, WsCaller> The identity settled at handshake time, per connection. */
+    private array $callers = [];
+
+    private WsCallerResolver $callerResolver;
+
+    private TestRunPolicy $policy;
+```
+
+`Health::__construct()` currently takes no parameters, so add
+`?WsCallerResolver $callerResolver = null, ?TestRunPolicy $policy = null`.
+
+Place the two assignments **after** the `Router::$apiFilePath` guard block, not before it. That guard
+is documented as needing to come before anything that resolves a path, and while neither of these
+does, moving code above it is exactly the kind of edit its comment exists to prevent:
+
+```php
+        $this->callerResolver = $callerResolver ?? WsCallerResolver::fromEnv();
+        $this->policy         = $policy ?? new TestRunPolicy();
+```
+
+- [ ] **Step 4: Resolve in `onOpen()`, forget in `onClose()`**
+
+In `onOpen()`, before the `sendMessage(...helloFrame())` call and after the `resourceId` guard:
+
+```php
+        // Settled once, here, rather than per message: the handshake is the only moment the cookie is
+        // on the wire. `httpRequest` is a PSR-7 RequestInterface set by Ratchet's WsServer and reached
+        // through AbstractConnectionDecorator's magic getter.
+        $request                     = isset($conn->httpRequest) ? $conn->httpRequest : null;
+        $caller                      = $this->callerResolver->fromHandshake($request instanceof RequestInterface ? $request : null);
+        $this->callers[$resourceId]  = $caller;
+```
+
+Add `use Psr\Http\Message\RequestInterface;` to the imports, and change the hello send to
+`$this->sendMessage($conn, $this->helloFrame($caller));`.
+
+In `onClose()`, beside the other per-connection cleanup:
+
+```php
+        unset($this->callers[$resourceId]);
+```
+
+- [ ] **Step 5: Advertise on the hello frame**
+
+Change `helloFrame()` to take the caller and attach a `caller` sibling — not a member of
+`capabilities`, which is documented as server-derived and must stay that way:
+
+```php
+    private function helloFrame(WsCaller $caller): \stdClass
+    {
+        // ... existing $capabilities assembly, unchanged ...
+
+        $permissions           = new \stdClass();
+        $permissions->runTests = $this->policy->mayRun($caller);
+
+        $callerFrame                = new \stdClass();
+        $callerFrame->authenticated = $caller->authenticated;
+        $callerFrame->permissions   = $permissions;
+
+        $frame       = new \stdClass();
+        $frame->type = 'hello';
+        $frame->protocol     = max(WebSocketMessageValidator::SUPPORTED_PROTOCOL_VERSIONS);
+        $frame->capabilities = $capabilities;
+        // A sibling of `capabilities`, deliberately: that object answers what this *server* can be
+        // asked for, every entry derived from an enum so it cannot go stale. Who is asking is a
+        // different axis, and per-connection, so it does not belong inside it.
+        $frame->caller = $callerFrame;
+
+        return $frame;
+    }
+```
+
+- [ ] **Step 6: Declare `caller` in the schema**
+
+```bash
+python3 - <<'PY'
+import json, collections
+p = 'jsondata/schemas/WebSocketFrame.json'
+d = json.load(open(p), object_pairs_hook=collections.OrderedDict)
+hello = d['definitions']['hello']
+if 'caller' not in hello['required']:
+    hello['required'].append('caller')
+hello['properties']['caller'] = collections.OrderedDict([
+    ('type', 'object'),
+    ('description',
+     'Who this server believes is on the other end of the connection, and what they may ask for. Sent '
+     'on `hello` because that is the one frame every client receives before it can act, and because a '
+     'permission the client reads from the server cannot drift from the one the server enforces — both '
+     'come from the same policy object. `authenticated` says whether a credential was verified; '
+     '`permissions` says what follows from it. A caller may be authenticated and still permitted '
+     'nothing.'),
+    ('required', ['authenticated', 'permissions']),
+    ('properties', collections.OrderedDict([
+        ('authenticated', collections.OrderedDict([('type', 'boolean')])),
+        ('permissions', collections.OrderedDict([
+            ('type', 'object'),
+            ('required', ['runTests']),
+            ('properties', collections.OrderedDict([
+                ('runTests', collections.OrderedDict([
+                    ('type', 'boolean'),
+                    ('description',
+                     'Whether this caller may start a validation run. False for an anonymous caller and '
+                     'for an authenticated one holding none of the permitted roles; a client should '
+                     'render its run controls from this rather than from a role list of its own.'),
+                ])),
+            ])),
+        ])),
+    ])),
+])
+json.dump(d, open(p, 'w'), indent=4, ensure_ascii=False)
+open(p, 'a').write('\n')
+PY
+git diff --stat jsondata/schemas/WebSocketFrame.json
+```
+
+- [ ] **Step 7: Run the tests and confirm they pass**
+
+Run: `vendor/bin/phpunit phpunit_tests/HealthCallerFrameTest.php phpunit_tests/HealthHelloFrameTest.php phpunit_tests/HealthConstructionOrderTest.php phpunit_tests/HealthFrameProjectionTest.php`
+Expected: PASS. If `HealthHelloFrameTest` calls `helloFrame()` with no argument, update those call
+sites to pass `WsCaller::anonymous()` — that is a real contract change, not a test workaround.
+
+- [ ] **Step 8: Lint, analyse, commit**
+
+```bash
+composer lint:fix
+composer analyse
+git add src/Health.php jsondata/schemas/WebSocketFrame.json phpunit_tests/HealthCallerFrameTest.php phpunit_tests/HealthHelloFrameTest.php
+git commit -m "feat(ws): resolve the caller at handshake and advertise it on the hello frame"
+```
+
+---
+
+### Task 6: Gate every action
+
+The heart of the change. Two call sites, for the reason the spec gives.
+
+**Files:**
+
+- Modify: `src/Health.php` (`onMessage()`)
+- Test: `phpunit_tests/HealthActionGateTest.php`
+
+**Interfaces:**
+
+- Consumes: everything from Tasks 1, 3, 5.
+- Produces: refusal frames carrying `not_authenticated` / `insufficient_role`.
+
+- [ ] **Step 1: Write the failing test**
+
+The `CheckableInventory::reset()` assertion is the one that proves the early placement is
+load-bearing. The stub-policy test is what keeps the target-scoped seam from being dead code.
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\Auth\TestTarget;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use LiturgicalCalendar\Api\Services\TestRunPolicy;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+final class HealthActionGateTest extends TestCase
+{
+    private ?string $appEnvBackup = null;
+
+    /** @var array<int, Health> Built during a test, drained afterwards. */
+    private array $built = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Keeps handleHttpResponse() out of its development-only debug-logging branch, as
+        // HealthFulfilHandlerThrowTest does.
+        $this->appEnvBackup = isset($_ENV['APP_ENV']) && is_string($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : null;
+        $_ENV['APP_ENV']    = 'test';
+    }
+
+    /**
+     * Drain any work a permitted message queued.
+     *
+     * Health queues outbound calendar fetches and drives them from the ReactPHP loop; left in place,
+     * they are issued at PHPUnit shutdown against whatever is listening on the configured API port —
+     * a real HTTP request from a unit test, attributed to a suite that has already reported green.
+     */
+    protected function tearDown(): void
+    {
+        foreach ($this->built as $health) {
+            ( new \ReflectionProperty(Health::class, 'queue') )->setValue($health, []);
+            ( new \ReflectionProperty(Health::class, 'inFlight') )->setValue($health, 0);
+        }
+        $this->built = [];
+
+        if (null === $this->appEnvBackup) {
+            unset($_ENV['APP_ENV']);
+        } else {
+            $_ENV['APP_ENV'] = $this->appEnvBackup;
+        }
+        parent::tearDown();
+    }
+
+    /** @return array{0: Health, 1: ConnectionInterface, 2: array<int, \stdClass>} */
+    private function serverFor(WsCaller $caller, ?TestRunPolicy $policy = null): array
+    {
+        $sent = new \ArrayObject();
+
+        $conn = new class ($sent) implements ConnectionInterface {
+            public int $resourceId = 1;
+            public function __construct(private \ArrayObject $sent)
+            {
+            }
+            public function send($data)
+            {
+                $this->sent[] = json_decode((string) $data);
+                return $this;
+            }
+            public function close()
+            {
+            }
+        };
+
+        $health        = new Health(null, $policy);
+        $this->built[] = $health;
+
+        // Seed the identity the handshake would have settled.
+        $callers = new \ReflectionProperty(Health::class, 'callers');
+        $callers->setValue($health, [1 => $caller]);
+
+        return [$health, $conn, $sent];
+    }
+
+    private function validateCalendarMessage(): string
+    {
+        return json_encode([
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'rite', 'rite' => 'roman'],
+            'year'           => 2024,
+            'responseFormat' => 'JSON',
+            'requestId'      => 'req-1',
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    private function refusals(\ArrayObject $sent): array
+    {
+        return array_values(array_filter(
+            iterator_to_array($sent),
+            static fn(\stdClass $f): bool => 'protocolError' === ( $f->type ?? null )
+        ));
+    }
+
+    public function testAnonymousCallerIsRefusedWithNotAuthenticated(): void
+    {
+        [$health, $conn, $sent] = $this->serverFor(WsCaller::anonymous());
+
+        $health->onMessage($conn, $this->validateCalendarMessage());
+
+        $refusals = $this->refusals($sent);
+        $this->assertCount(1, $refusals);
+        $this->assertSame(ProtocolErrorCode::NOT_AUTHENTICATED->value, $refusals[0]->errorCode);
+        $this->assertSame('req-1', $refusals[0]->requestId, 'the refusal must be correlated');
+    }
+
+    public function testAuthenticatedWithoutRoleIsRefusedWithInsufficientRole(): void
+    {
+        [$health, $conn, $sent] = $this->serverFor(WsCaller::authenticated('u', ['developer']));
+
+        $health->onMessage($conn, $this->validateCalendarMessage());
+
+        $refusals = $this->refusals($sent);
+        $this->assertCount(1, $refusals);
+        $this->assertSame(ProtocolErrorCode::INSUFFICIENT_ROLE->value, $refusals[0]->errorCode);
+    }
+
+    public function testARefusedMessageDoesNotInstallItsRunToken(): void
+    {
+        [$health, $conn, ] = $this->serverFor(WsCaller::anonymous());
+
+        $message = json_decode($this->validateCalendarMessage());
+        $message->runToken = 'run-1';
+        $health->onMessage($conn, json_encode($message, JSON_THROW_ON_ERROR));
+
+        $tokens = new \ReflectionProperty(Health::class, 'runTokens');
+        $this->assertSame([], $tokens->getValue($health), 'an unauthorized message must not install a run token');
+    }
+
+    public function testAPermittedCallerIsNotRefused(): void
+    {
+        [$health, $conn, $sent] = $this->serverFor(WsCaller::authenticated('u', ['admin']));
+
+        $health->onMessage($conn, $this->validateCalendarMessage());
+
+        $this->assertSame([], $this->refusals($sent));
+    }
+
+    public function testTheTargetScopedGateCanRefuseAMessageTheCoarseGateAllowed(): void
+    {
+        $policy = new class extends TestRunPolicy {
+            public function mayRun(WsCaller $caller, ?TestTarget $target = null): bool
+            {
+                // Coarse question: yes. Target-scoped question: no.
+                return null === $target;
+            }
+        };
+
+        [$health, $conn, $sent] = $this->serverFor(WsCaller::authenticated('u', ['admin']), $policy);
+
+        $health->onMessage($conn, $this->validateCalendarMessage());
+
+        $refusals = $this->refusals($sent);
+        $this->assertCount(1, $refusals);
+        $this->assertSame(ProtocolErrorCode::INSUFFICIENT_ROLE->value, $refusals[0]->errorCode);
+    }
+}
+```
+
+- [ ] **Step 2: Run it and confirm it fails**
+
+Run: `vendor/bin/phpunit phpunit_tests/HealthActionGateTest.php`
+Expected: FAIL — no refusal frame is sent.
+
+- [ ] **Step 3: Decide early, beside `$protocolViolation`**
+
+In `onMessage()`, immediately after `$protocolViolation` is computed:
+
+```php
+        // Decided here and answered below, for the same reason `$protocolViolation` is — #894.
+        //
+        // The *question* has to be asked before the run-token block, because that block installs a
+        // token and can rebuild the checkable inventory, and a caller this server is about to refuse
+        // must be able to do neither. The *answer* waits until `requestId` has been read, so the
+        // refusal reaches the client correlated to the request it is waiting on.
+        //
+        // This is the coarse question only — it depends on the caller, not on the message, so it can
+        // be settled before the message is understood. The target-scoped question is asked further
+        // down, once the message has been validated and its target can be trusted.
+        $caller            = $this->callers[$resourceId] ?? WsCaller::anonymous();
+        $permissionRefusal = null;
+        if (null === $protocolViolation && false === $this->policy->mayRun($caller)) {
+            $permissionRefusal = $caller->authenticated
+                ? [ProtocolErrorCode::INSUFFICIENT_ROLE, 'This account may not start validation runs. Ask an administrator to grant the test_editor role.']
+                : [ProtocolErrorCode::NOT_AUTHENTICATED, 'Log in to start validation runs.'];
+        }
+```
+
+Then add `&& null === $permissionRefusal` to the condition on the run-token install block, beside the
+existing `null === $protocolViolation`.
+
+- [ ] **Step 4: Answer late, after the protocol-violation answer**
+
+Immediately after the `if (null !== $protocolViolation) { ... return; }` block:
+
+```php
+        if (null !== $permissionRefusal) {
+            [$refusalCode, $refusalText] = $permissionRefusal;
+            // The connection id has no reader on the wire; it belongs in the log line, not in prose
+            // the client has to display.
+            echo sprintf('Refused %1$s from connection %2$d', $refusalCode->value, $resourceId);
+            $this->rejectMessage($from, $refusalCode, $refusalText, requestId: $requestId, runToken: $declaredRunToken);
+            return;
+        }
+```
+
+- [ ] **Step 5: Ask the target-scoped question before dispatch**
+
+Immediately before the `switch ($messageReceived->action)` dispatch block, inside the guard that has
+already established the message is a validated `\stdClass` with an `action`:
+
+```php
+            // The seam the coarse check above deliberately left open. Asked here rather than at the
+            // top because a target read from an unvalidated message is a guess, and a permission
+            // decision must not rest on one. A coarse policy answers this the same way it answered
+            // above; a fine-grained one does not, which is the whole point.
+            $target = TestTarget::fromMessage($messageReceived);
+            if (null !== $target && false === $this->policy->mayRun($caller, $target)) {
+                $this->rejectMessage(
+                    $from,
+                    ProtocolErrorCode::INSUFFICIENT_ROLE,
+                    'This account may not start validation runs for the calendar this message names.',
+                    requestId: $requestId
+                );
+                return;
+            }
+```
+
+Add `use LiturgicalCalendar\Api\Models\Auth\TestTarget;` to the imports.
+
+- [ ] **Step 6: Run the tests and confirm they pass**
+
+Run: `vendor/bin/phpunit phpunit_tests/HealthActionGateTest.php`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 7: Run the whole Health suite for regressions**
+
+Run: `vendor/bin/phpunit --filter Health`
+Expected: PASS. Existing in-process Health tests construct `Health` directly and drive `onMessage()`
+without a handshake, so they now see an anonymous caller and will be refused. Fix them by seeding a
+permitted caller the way `HealthActionGateTest::serverFor()` does — a shared helper in
+`phpunit_tests/Support/` is worth extracting once the second suite needs it.
+
+- [ ] **Step 8: Lint, analyse, commit**
+
+```bash
+composer lint:fix
+composer analyse
+git add src/Health.php phpunit_tests/
+git commit -m "feat(ws): refuse validation actions from callers that may not run them"
+```
+
+---
+
+### Task 7: Authenticate the over-the-wire tests
+
+**Files:**
+
+- Modify: `phpunit_tests/WebSocket/WsTestClient.php`
+- Modify: `phpunit_tests/WebSocket/ExecuteUnitTestTest.php`, `ExecuteValidationTest.php`, `LitCalTestServerTest.php`, `ValidateCalendarTest.php`
+- Create: `phpunit_tests/Support/WsAuthTrait.php`
+
+**Interfaces:**
+
+- Consumes: `JwtService`.
+- Produces: `WsTestClient::connect(string $host, int $port, float $timeoutSeconds = 5.0, ?string $accessToken = null): self`;
+  `WsAuthTrait::wsAccessTokenOrSkip(array $roles = ['admin']): string`.
+
+- [ ] **Step 1: Add the trait**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use LiturgicalCalendar\Api\Services\JwtServiceFactory;
+
+/**
+ * A minted access token for the WebSocket tests.
+ *
+ * Skips loudly rather than letting a suite pass unexecuted: a fresh worktree has no `.env.local`, so
+ * `JWT_SECRET` is absent, and a test that quietly stops exercising the gate it was written to guard
+ * is worse than one that fails.
+ */
+trait WsAuthTrait
+{
+    /**
+     * @param array<int, string> $roles
+     */
+    protected function wsAccessTokenOrSkip(array $roles = ['admin']): string
+    {
+        try {
+            $jwtService = JwtServiceFactory::fromEnv();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped('JWT_SECRET is not configured, so no WebSocket credential can be minted: ' . $e->getMessage());
+        }
+
+        return $jwtService->generate('phpunit', ['roles' => $roles]);
+    }
+}
+```
+
+- [ ] **Step 2: Send the cookie from `WsTestClient`**
+
+Add the parameter and one header line to the hand-rolled handshake:
+
+```php
+    public static function connect(string $host, int $port, float $timeoutSeconds = 5.0, ?string $accessToken = null): self
+```
+
+and build the request with the cookie when a token is supplied:
+
+```php
+        $cookieHeader = null !== $accessToken && '' !== $accessToken
+            ? 'Cookie: litcal_access_token=' . $accessToken . "\r\n"
+            : '';
+
+        $request = "GET / HTTP/1.1\r\n"
+            . "Host: $host:$port\r\n"
+            . "Upgrade: websocket\r\n"
+            . "Connection: Upgrade\r\n"
+            . "Sec-WebSocket-Key: $key\r\n"
+            . "Sec-WebSocket-Version: 13\r\n"
+            . $cookieHeader
+            . "\r\n";
+```
+
+- [ ] **Step 3: Pass a token from each of the four suites**
+
+In each file, `use WsAuthTrait;` and change every `WsTestClient::connect($host, $port)` call to
+`WsTestClient::connect($host, $port, 5.0, $this->wsAccessTokenOrSkip())`.
+
+- [ ] **Step 4: Add anonymous coverage over the wire**
+
+Append to `phpunit_tests/WebSocket/LitCalTestServerTest.php`:
+
+```php
+    public function testAnonymousConnectionIsAdvertisedAsUnpermitted(): void
+    {
+        $client = WsTestClient::connect(self::wsHost(), self::wsPort());
+        $hello  = $client->readHelloFrame();
+
+        $this->assertNotNull($hello);
+        $this->assertFalse($hello->caller->authenticated);
+        $this->assertFalse($hello->caller->permissions->runTests);
+
+        $client->close();
+    }
+```
+
+Match the host/port accessors this suite already uses; read it first rather than assuming the names
+above.
+
+- [ ] **Step 5: Start a server from this worktree and run the suite**
+
+The suite talks to `WS_PORT`; a worktree's `.env.local` must name a port the shared server is not on,
+or a green run proves nothing about this branch.
+
+```bash
+grep '^WS_PORT=' .env.local     # must NOT be the shared server's port
+composer ws:start
+vendor/bin/phpunit phpunit_tests/WebSocket
+composer ws:stop
+```
+
+Expected: PASS. Prove the target before believing the result: stop the server and re-run — every test
+must SKIP. A green run with no server of your own was talking to somebody else's.
+
+- [ ] **Step 6: Commit**
+
+```bash
+composer lint:fix
+git add phpunit_tests/
+git commit -m "test(ws): authenticate the over-the-wire suites and cover the anonymous case"
+```
+
+---
+
+### Task 8: Warm the key set at boot and say what is live
+
+**Files:**
+
+- Modify: `bin/LitCalTestServer.php`
+
+**Interfaces:**
+
+- Consumes: `WsCallerResolver` (Task 3).
+
+- [ ] **Step 1: Warm before the loop starts**
+
+Immediately before the `IoServer::factory(` call, and after the Dotenv block:
+
+```php
+// Fetch the Zitadel signing keys once, here, off the event loop. Ratchet is single-threaded, so a
+// JWKS fetch inside onOpen() stalls every other connection for its duration; paying it at boot means
+// steady-state handshakes are pure CPU and only a key rotation ever costs a fetch.
+//
+// A failure is not fatal and must not be: the server starts, and the first connection needing RS256
+// pays the fetch instead. What it must never do is fail open — an unverifiable caller is anonymous.
+$callerResolver = \LiturgicalCalendar\Api\Services\WsCallerResolver::fromEnv();
+$warmed         = $callerResolver->warmKeySet();
+echo sprintf(
+    "Caller verification paths: %s. JWKS pre-warmed: %s\n",
+    $callerResolver->describeAvailablePaths(),
+    $warmed ? 'yes' : 'no'
+);
+```
+
+and pass it in: `new Health($callerResolver)`.
+
+- [ ] **Step 2: Start the server and read the line**
+
+```bash
+composer ws:start
+sleep 2
+tail -5 logs/php-error-litcaltestserver.log 2>/dev/null
+composer ws:stop
+```
+
+Expected: a line naming the live paths. On a dev box with `ZITADEL_ISSUER` set but Zitadel down, expect
+`JWKS pre-warmed: no` and a server that still starts.
+
+- [ ] **Step 3: Commit**
+
+```bash
+composer lint:fix
+git add bin/LitCalTestServer.php
+git commit -m "feat(ws): pre-warm the JWKS off the event loop and log live verification paths"
+```
+
+---
+
+### Task 9: Full verification
+
+- [ ] **Step 1: Whole suite**
+
+Run: `composer test:quick`
+Expected: 0 failures. Baseline before this work was 3515 tests, 183729 assertions, 28 skipped.
+A rise in skips means a credential went missing, not that a test became irrelevant — investigate any
+increase.
+
+- [ ] **Step 2: Static analysis and style**
+
+```bash
+composer analyse
+composer lint
+composer lint:md
+```
+
+Expected: all clean. If `composer analyse` reports "... is not a file", a sibling worktree was deleted
+out from under the shared PHPStan cache: `rm -rf /tmp/phpstan` and re-run.
+
+- [ ] **Step 3: Schema lint**
+
+Run: `composer lint:openapi`
+Expected: clean.
+
+- [ ] **Step 4: Manual check against a real anonymous client**
+
+```bash
+composer ws:start
+php -r '$s=stream_socket_client("tcp://127.0.0.1:".getenv("WS_PORT"));fwrite($s,"GET / HTTP/1.1\r\nHost: x\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: ".base64_encode(random_bytes(16))."\r\nSec-WebSocket-Version: 13\r\n\r\n");usleep(300000);echo fread($s,4096);'
+composer ws:stop
+```
+
+Expected: `101 Switching Protocols` followed by a `hello` frame whose `caller.permissions.runTests` is
+false. The connection must **open** — closing it is the behaviour this design deliberately rejected.
+
+- [ ] **Step 5: Push and open the PR**
+
+Write the PR body to a file first — a heredoc inside a `git`/`gh` invocation is refused by the
+worktree-isolation guard:
+
+```bash
+git push -u origin HEAD
+printf '%s\n' \
+  'Closes #894.' '' \
+  'The Health WebSocket server accepted any connection and dispatched run-starting actions on that' \
+  'basis alone. It now identifies the caller from the handshake cookie, advertises what they may do' \
+  'on the `hello` frame, and refuses `validateSource`, `executeValidation`, `validateCalendar`,' \
+  '`runTest` and `cancelRun` from callers that may not run them.' '' \
+  'Anonymous connections are still accepted, deliberately: both UnitTestInterface runner pages call' \
+  'connect() unconditionally at module load, so closing the handshake would put every anonymous' \
+  'visitor into a reconnect loop for the sake of a page that only replays past runs.' '' \
+  'Design: `docs/superpowers/specs/2026-08-27-ws-health-auth-design.md`' '' \
+  'UnitTestInterface follow-up is tracked in that spec; the API change is safe to deploy first.' \
+  > /tmp/pr-body.md
+gh pr create --base development --title "feat(ws): authenticate the Health WebSocket server (#894)" --body-file /tmp/pr-body.md
+```
+
+Target `development`, never `stable`. `gh pr merge` from a worktree exits 1 *after* merging fine —
+verify with `gh pr view --json state` rather than retrying on the exit code.
+
+---
+
+## Follow-up: UnitTestInterface (separate repository)
+
+Not part of this plan's deliverable, and deliberately so: the rollout is API-first, and the API change
+is safe on its own — UnitTestInterface's current client ignores unknown `hello` fields and its Run
+button is already role-gated client-side, so nobody who could legitimately run loses the ability
+between the two deploys.
+
+The follow-up work, in `../../UnitTestInterface`:
+
+1. `assets/js/wsProtocol.js` — `consumeHello()` stores `frame.caller`; `resetHello()` clears it; add a
+   `callerPermissions()` accessor beside `capabilities()`.
+2. `assets/js/common.js` — `canRunTests()` prefers the server's verdict, falling back to
+   `LitCalConfig.canRunTests` before `hello` arrives.
+3. `assets/js/index.js`, `assets/js/resources.js` — `ReadyToRunTests.check()` folds in the server verdict.
+4. Update the CLAUDE.md section "Reading Past Runs is Public; Running Tests is Not", which currently
+   records the gap as accepted.
+
+Note that repository gained four PR checks (phpcs, eslint, markdownlint, Playwright); the e2e runner has
+no components-js symlink and no WebSocket server.

--- a/docs/superpowers/specs/2026-08-27-ws-health-auth-design.md
+++ b/docs/superpowers/specs/2026-08-27-ws-health-auth-design.md
@@ -302,16 +302,42 @@ HTTP API authenticates.
 Every one of these fails closed — an unverifiable caller is anonymous, and an anonymous caller may not
 run:
 
-| Condition                  | Result                                                         |
-|----------------------------|----------------------------------------------------------------|
-| No `Cookie` header         | Anonymous caller; connection opens; privileged actions refused |
-| `ZITADEL_ISSUER` unset     | HS256-only resolution; RS256 tokens read as anonymous          |
-| JWKS unreachable           | RS256 tokens read as anonymous; HS256 unaffected               |
-| `JWT_SECRET` unset         | HS256 verification unavailable; those tokens read as anonymous |
-| Token expired or malformed | Anonymous caller                                               |
+| Condition                        | Result                                                         |
+|----------------------------------|----------------------------------------------------------------|
+| No `Cookie` header               | Anonymous caller; connection opens; privileged actions refused |
+| `ZITADEL_ISSUER` unset           | HS256-only resolution; RS256 tokens read as anonymous          |
+| Issuer set, no client/project id | RS256 path disabled entirely; see below                        |
+| Token `iss` or `aud` mismatch    | Anonymous caller                                               |
+| JWKS unreachable                 | RS256 tokens read as anonymous; HS256 unaffected               |
+| JWKS slow rather than refused    | Bounded by a finite fetch timeout; then anonymous              |
+| `JWT_SECRET` unset               | HS256 verification unavailable; those tokens read as anonymous |
+| Token expired or malformed       | Anonymous caller                                               |
 
 The `ZITADEL_ISSUER` row is the one to watch in staging: it degrades every real user to anonymous, which
 is safe but total. It is worth a startup log line naming which verification paths are live.
+
+### The audience boundary
+
+Raised in review and worth stating as a rule rather than a row. A signature proves a token is genuine,
+not that it is *this application's*: Zitadel signs every token in an instance with the same keys, so
+verifying the signature alone accepts a correctly-signed token minted for any other application in that
+instance — and one carrying `admin` or `test_editor` among its project roles would then be handed a run.
+
+`OidcAuthMiddleware::tryOidcValidation()` already checks `iss` and `aud` (against the client id, and the
+project id for machine-to-machine tokens) after decoding. The WebSocket resolver applies the same rule,
+and treats an issuer it cannot audience-check as **no RS256 path at all** rather than as an
+unaudienced one — an empty audience list must never mean "nothing to compare, so accept". That
+configuration is the one most likely to look correct while behaving as though Zitadel were switched
+off, so the startup line names it explicitly.
+
+### The fetch has to be bounded
+
+`CachedKeySet` fetches synchronously from inside `JWT::decode()` on a cold cache or an unknown `kid`,
+and Guzzle's default `timeout` and `connect_timeout` are both `0` — wait indefinitely. In the HTTP API
+that costs one php-fpm worker; here it stalls the single Ratchet loop for every connected client at
+once. A refused connection was never the hazard, because it fails instantly; a provider that accepts the
+connection and then goes quiet is, and it is indistinguishable from a healthy one until a timeout that
+does not exist expires. Both clients the key-set factory builds carry finite timeouts.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-08-27-ws-health-auth-design.md
+++ b/docs/superpowers/specs/2026-08-27-ws-health-auth-design.md
@@ -1,0 +1,326 @@
+# Authenticating the Health WebSocket server
+
+Design for API issue [#894](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/issues/894),
+"Health WebSocket server accepts unauthenticated connections: anyone can start a validation run".
+
+## Problem
+
+`Health::onOpen()` accepts any WebSocket connection without authenticating it. The server is publicly
+reachable at `wss://litcal-test.johnromanodorazio.com`, and `onMessage()` dispatches `validateSource`,
+`executeValidation`, `validateCalendar`, `runTest` and `cancelRun` on that basis alone. A single
+rite-level run scaffolds 82 calendar-data years, each one an HTTP request from the WebSocket server to
+the public API. An anonymous caller can spend the API's rate-limit budget and the WebSocket server's
+CPU at no cost to themselves, from a five-line script that never loads the page.
+
+UnitTestInterface gates its Run Tests button on `JwtAuth::canRunTests()` (roles `admin` or
+`test_editor`), but that gate is client-side only — its own `CLAUDE.md` records the gap as accepted.
+The button is not the weak link; the socket is.
+
+This is resource abuse, not disclosure. A run reveals only which validations fail, which is already
+public through the Past Runs listing.
+
+## Decisions
+
+Four decisions shape everything below. The first three were settled during design; the fourth follows
+from them.
+
+1. **Refusal is per-action, not per-handshake.** Every connection is accepted. The `hello` frame
+   carries the caller's permissions, and each privileged action is gated on the way in.
+2. **The permission question is coarse today, with a seam for fine-grained later.** Day one mirrors
+   `canRunTests()`; the policy object accepts the target from the start so an OpenFGA-backed
+   implementation needs no protocol change.
+3. **One credential transport: a `Cookie` header.** No subprotocol bearer, no shared-secret fallback,
+   no environment bypass.
+4. **No protocol version bump.** The changes are additive in the sense this contract already
+   distinguishes.
+
+### Why per-action rather than closing the handshake
+
+The issue proposes closing the connection in `onOpen()` with a policy-violation code. That was
+reconsidered on a measurement: `wsClient.connect()` is called unconditionally at module load in both
+UnitTestInterface runner pages (`assets/js/index.js:2544`, `assets/js/resources.js:811`), with a
+reconnect timer behind it. Every anonymous visitor opens a socket today, purely to replay past runs.
+
+Closing the handshake on them produces a connect/close/reconnect loop and a red "disconnected" badge
+unless UnitTestInterface changes in the same deploy. Per-action refusal closes the actual abuse vector
+— dispatched work — while anonymous replay keeps working and the connection badge stays honest.
+
+It also buys something the handshake approach cannot: the server can *tell* the client what it may do,
+which is what removes the client-side-only gate rather than merely duplicating it.
+
+The cost is that anonymous sockets stay open. They are idle: no work is dispatched, and no run state is
+allocated. Rate-limiting them is out of scope (see [Out of scope](#out-of-scope)).
+
+## Section 1 — Identity
+
+### Reading the credential
+
+`WsServer::onOpen()` assigns `$conn->httpRequest` (`vendor/plesk/ratchetphp/src/Ratchet/WebSocket/WsServer.php:131`)
+and `Ratchet\AbstractConnectionDecorator::__get()` forwards attribute reads to the wrapped connection,
+so `Health::onOpen()` can already reach it. No plumbing change is needed.
+
+One catch drives a small helper: `$conn->httpRequest` is a PSR-7 **`RequestInterface`**, not a
+`ServerRequestInterface`, so it has no `getCookieParams()`. The `Cookie:` header is parsed into an
+array here, and that array is handed to the existing `CookieHelper::getAccessToken()` so the cookie
+name lives in exactly one place.
+
+That the cookie arrives at all is already established, not assumed: `LargeHeaderHttpServer` exists
+precisely because a `COOKIE_DOMAIN`-scoped Zitadel session rides along on every handshake — measured at
+~2.7 KB of `Cookie:` header — and Ratchet's 4096-byte default answered 413. The token has been arriving
+all along, unread.
+
+### Verifying it
+
+Production cookies hold Zitadel RS256 tokens; the legacy HS256 flavour still exists. A new service
+resolves both, mirroring `OidcAuthMiddleware`'s two-step:
+
+1. **Zitadel RS256** via `Firebase\JWT\CachedKeySet` over the same `FilesystemAdapter` pattern
+   `OidcAuthMiddleware.php:421` uses.
+2. **Otherwise legacy HS256** via `JwtService::verify()`.
+
+**It must not call `/auth/me`.** UnitTestInterface's `JwtAuth` docblock records that `/auth/me` verifies
+with the API's HS256 service alone and answers `401 Invalid or expired token` to a perfectly valid
+Zitadel token. An HTTP call per connection inside a single-threaded event loop would be the wrong shape
+even if it worked.
+
+### Not blocking the event loop
+
+The JWKS fetch is the hazard: `CachedKeySet` fetches over HTTP on a cache miss, and Ratchet is a single
+ReactPHP loop. Mitigation is to warm the key set once in `bin/LitCalTestServer.php`, before
+`IoServer::factory()`. Steady-state `onOpen()` is then pure CPU, and only a key rotation costs one
+blocking fetch, shared across every connection rather than paid per connection.
+
+A failure to warm at boot is not fatal and must not be: the server starts, and the first connection
+needing RS256 verification pays the fetch. What it must not do is fail *open* — see
+[Failure modes](#failure-modes).
+
+### What is remembered
+
+Verification yields a small immutable value object per connection:
+
+```php
+final readonly class WsCaller
+{
+    public function __construct(
+        public bool $authenticated,
+        public ?string $sub,
+        /** @var array<int, string> */
+        public array $roles,
+    ) {}
+}
+```
+
+It is stored per `resourceId` alongside `runTokens`, and dropped in `onClose()` with the other
+per-connection state.
+
+**Anonymous is not an error.** No cookie, an expired token, and a garbage token all yield an anonymous
+`WsCaller` and the connection proceeds. This is what decision 1 requires.
+
+## Section 2 — The permission seam
+
+One object answers the permission question, consulted by both the `hello` frame and the action gate, so
+the two cannot drift:
+
+```php
+TestRunPolicy::mayRun(WsCaller $caller, ?TestTarget $target = null): bool
+```
+
+The day-one body is coarse: `admin` or `test_editor`. That mirrors UnitTestInterface's
+`JwtAuth::RUN_TESTS_ROLES` and follows the API's own convention of an admin bypass over a required role
+(`AuthorizationMiddleware`).
+
+`WsCaller`, `TestRunPolicy` and `TestTarget` are all new. `TestScopeResolver`
+(`src/Services/TestScopeResolver.php`) already exists and is what a later fine-grained policy would
+resolve a `TestTarget` through.
+
+`$target` is the seam. The coarse policy ignores it, but it is accepted and threaded from day one
+because:
+
+- every gated message already names its target (`validateCalendar` carries `calendar: {kind, rite, …}`);
+- OpenFGA already models the destination object types — `national_calendar_test`,
+  `diocesan_calendar_test`, `general_roman_calendar_test`, `rite_calendar_test` — with rite-qualified
+  `<rite>/<calendarId>` ids resolved by `TestScopeResolver`.
+
+Swapping in an FGA-backed policy later is then one class, with no protocol change and no new plumbing.
+
+### On drift
+
+The issue asks that the role check "mirror the one UnitTestInterface enforces on storing a run, so 'may
+start a run' and 'may store its result' do not drift apart". This design closes that in the opposite
+direction from a mirror: rather than the API hand-copying a predicate from another repository, the API
+answers the question and UnitTestInterface stops deciding. A copied constant in two repositories is
+exactly how the two answers would drift; a served answer cannot.
+
+## Section 3 — Protocol
+
+### Where the gate sits in `onMessage()`
+
+`Health::onMessage()` already solves this shape of problem for `$protocolViolation`: the violation is
+computed at the top of the method and answered further down, after `$requestId` has been read, so the
+refusal is correlated to the request the client is waiting on. The file calls this deciding early and
+answering late.
+
+The permission check splits along the same seam, and the split falls out of decision 2:
+
+- **Early**, computed beside `$protocolViolation`. This is the coarse question, which depends only on
+  the caller and not on the message, so it can be answered before the message is understood. The
+  run-token install block is gated on it as well as on `$protocolViolation` — otherwise an unauthorized
+  caller still triggers `CheckableInventory::reset()`, which is real work and real state mutation.
+  The refusal frame is sent where `$protocolViolation`'s is sent, so it carries `requestId` and
+  `runToken`.
+- **Later**, after schema validation and immediately before dispatch. This is the target-scoped
+  question. Today it is a no-op, because the coarse policy already returned true. It is where the FGA
+  check will land, and by then the target has been validated rather than guessed from an unparsed blob.
+
+Every action is gated, `cancelRun` included. `cancelRun` only affects the sender's own connection, so
+gating it changes nothing in practice; uniformity is worth more than the exception, because the next
+action added inherits the gate by default.
+
+### The `hello` frame
+
+`hello` gains a sibling to `capabilities`, not a member of it:
+
+```json
+{
+  "type": "hello",
+  "protocol": 1,
+  "capabilities": { "...": "unchanged" },
+  "caller": {
+    "authenticated": true,
+    "permissions": { "runTests": true }
+  }
+}
+```
+
+`capabilities` is documented as what the *server* can be asked for, with every entry derived from an
+enum so that an advertisement cannot go stale against the behaviour it describes. A per-connection
+identity value has no business inside an object whose stated virtue is server-derivation.
+
+`caller` is safe to send unprompted for the same reason the rest of `hello` is: the frame carries no run
+correlation, and both shipped v1 runners drop untagged frames before their `type` dispatch, so a client
+that does not understand it never sees it.
+
+### Schema changes
+
+In `jsondata/schemas/WebSocketFrame.json`:
+
+- `definitions/hello/properties` gains `caller`; `definitions/hello/required` gains `"caller"`.
+- `definitions/protocolError/properties/errorCode/enum` gains `not_authenticated` and
+  `insufficient_role`.
+
+Nothing in that schema sets `additionalProperties: false` except `capabilities.responseFormats`, so both
+additions are backward-compatible for validators. Adding `caller` to `required` makes the schema reject
+a `hello` from a server predating this change, which is the intended meaning: the schema describes this
+server's contract, not the union of every server that ever spoke it.
+
+### Two error codes, not one
+
+`ProtocolErrorCode` gains:
+
+| Case                | Value               | The client's remedy |
+|---------------------|---------------------|---------------------|
+| `NOT_AUTHENTICATED` | `not_authenticated` | Log in.             |
+| `INSUFFICIENT_ROLE` | `insufficient_role` | Request a role.     |
+
+The enum's own docblock states the rule: a code exists where a client would *act* differently, and where
+it would only display the reason, the reason is prose in `text`. These are two different actions.
+Collapsing them into one would tell a logged-in `developer` to go and log in, which is advice that
+cannot help.
+
+### No version bump
+
+`WebSocketFrame.json` records the precedent explicitly. The terminal frame was gated behind a protocol
+version because a new frame type changes the stream a v1 client counts; `protocolError` was ungated
+because a new code on a frame the client already receives changes nothing for it. A new field on an
+existing frame and two new codes are both the ungated kind, so `SUPPORTED_PROTOCOL_VERSIONS` is
+untouched.
+
+## Section 4 — Clients and tests
+
+### UnitTestInterface
+
+- `consumeHello()` (`assets/js/wsProtocol.js:457`) stores `frame.caller` beside the capabilities it
+  already remembers, and `resetHello()` clears it.
+- A `callerPermissions()` accessor joins `capabilities()`.
+- `canRunTests()` in `assets/js/common.js` prefers the server's verdict over the render-time
+  `LitCalConfig.canRunTests`, falling back to the current behaviour before `hello` arrives.
+- `ReadyToRunTests.check()` folds the server verdict in.
+
+This is the change that actually closes the gap UnitTestInterface's `CLAUDE.md` documents. Anonymous
+visitors keep a green badge and working replay.
+
+### Test client
+
+`WsTestClient::connect()` gains an optional access token, written as a `Cookie:` header into the
+hand-rolled RFC 6455 handshake. A helper mints an HS256 token via
+`JwtService::generate($user, ['roles' => ['admin']])` from `JWT_SECRET` — the legacy flavour, verified
+locally with no Zitadel dependency in the test path.
+
+Four suites drive the server over the wire and need it: `phpunit_tests/WebSocket/ExecuteUnitTestTest.php`,
+`ExecuteValidationTest.php`, `LitCalTestServerTest.php`, `ValidateCalendarTest.php`.
+
+**Skip loudly, never pass silently.** A worktree with no `.env.local` has no `JWT_SECRET`. Those tests
+must skip with a stated reason rather than sail through unexecuted, which is a known way for a new
+regression test to "pass" without ever running.
+
+### New coverage
+
+| Scenario                              | Expected                                                           |
+|---------------------------------------|--------------------------------------------------------------------|
+| Anonymous connect                     | `hello.caller.authenticated: false`, `permissions.runTests: false` |
+| Anonymous privileged action           | `protocolError` `not_authenticated`, correlated by `requestId`     |
+| Anonymous privileged action           | `CheckableInventory::reset()` did **not** fire                     |
+| Authenticated, no qualifying role     | `protocolError` `insufficient_role`                                |
+| Authenticated `test_editor` / `admin` | Behaviour unchanged from today                                     |
+| Expired or malformed token            | Treated as anonymous, connection still opens                       |
+
+The `CheckableInventory::reset()` assertion is the one that proves the early placement in
+`onMessage()` is load-bearing rather than decorative.
+
+## Section 5 — Rollout and operations
+
+### Order
+
+API first, UnitTestInterface second. That order is safe rather than merely conventional: the API change
+is additive, UnitTestInterface's current client ignores unknown `hello` fields, and its Run button is
+already role-gated client-side. An admin still runs; an anonymous user's button was already disabled.
+Nobody who could legitimately run loses the ability between the two deploys.
+
+### Deployment
+
+**The WebSocket server deploys by restart, not by `git pull`.** It is a long-running ReactPHP process
+that never re-reads `src/`, so a pull ships half a `Health.php` change. The implementation plan must
+carry this as an explicit step.
+
+### Configuration
+
+No new environment variables. `ZITADEL_ISSUER` and `ZITADEL_CLIENT_ID` are already present wherever the
+HTTP API authenticates.
+
+### Failure modes
+
+Every one of these fails closed — an unverifiable caller is anonymous, and an anonymous caller may not
+run:
+
+| Condition                  | Result                                                         |
+|----------------------------|----------------------------------------------------------------|
+| No `Cookie` header         | Anonymous caller; connection opens; privileged actions refused |
+| `ZITADEL_ISSUER` unset     | HS256-only resolution; RS256 tokens read as anonymous          |
+| JWKS unreachable           | RS256 tokens read as anonymous; HS256 unaffected               |
+| `JWT_SECRET` unset         | HS256 verification unavailable; those tokens read as anonymous |
+| Token expired or malformed | Anonymous caller                                               |
+
+The `ZITADEL_ISSUER` row is the one to watch in staging: it degrades every real user to anonymous, which
+is safe but total. It is worth a startup log line naming which verification paths are live.
+
+## Out of scope
+
+Deliberately deferred, and each is a separate piece of work:
+
+- **Rate-limiting anonymous sockets.** Per-action gating means an anonymous connection allocates no run
+  state, so the remaining cost is a file descriptor. Worth revisiting if idle-socket volume becomes
+  measurable.
+- **The fine-grained FGA policy body.** The seam is built; the implementation is not.
+- **`Sec-WebSocket-Protocol` transport.** No caller needs it today. Browsers send the cookie, and
+  non-browser callers can set the header.
+- **Authenticating result storage.** Already enforced server-side by UnitTestInterface's `results.php`.

--- a/jsondata/schemas/WebSocketFrame.json
+++ b/jsondata/schemas/WebSocketFrame.json
@@ -36,7 +36,7 @@
         "hello": {
             "type": "object",
             "description": "Sent once, unprompted, as soon as a client connects — API issue #806 section F. It carries no run correlation, and that is load-bearing rather than incidental: both shipped v1 runners guard their message handler on the frame's runToken matching the run they are on, so an untagged frame is dropped before it reaches their `type` dispatch, where an unrecognised type is painted as a failed check. A `hello` sent at any other moment — once the connection is on a run — would be stamped with a run token and would then be visible to a client that cannot read it.",
-            "required": ["type", "protocol", "capabilities"],
+            "required": ["type", "protocol", "capabilities", "caller"],
             "properties": {
                 "type": { "const": "hello" },
                 "protocol": {
@@ -57,6 +57,28 @@
                         },
                         "steps": { "type": "array", "items": { "type": "string" } },
                         "statuses": { "type": "array", "items": { "type": "string" } }
+                    }
+                },
+                "caller": {
+                    "type": "object",
+                    "description": "Who this server believes is on the other end of this connection, and what follows from it — API issue #894. A sibling of `capabilities` rather than a member of it: that object answers what the *server* can be asked for, with every entry derived from the enum that already defines it so it cannot go stale, while this is per-connection and derived from the credential on the handshake. Sent on `hello` because it is the one frame every client receives before it can act, and because a permission the client reads from the server cannot drift from the one the server enforces — both are the same policy object's answer. Identity is settled at the handshake and never revisited: a WebSocket frame carries no headers, so a connection that was not identified as it opened cannot be identified later. A client whose user logs in reconnects.",
+                    "required": ["authenticated", "permissions"],
+                    "properties": {
+                        "authenticated": {
+                            "type": "boolean",
+                            "description": "Whether a credential was presented and verified. False for a connection that sent no cookie and equally for one whose token was expired, forged or unreadable — the distinction is deliberately not published, and an anonymous connection is accepted rather than closed."
+                        },
+                        "permissions": {
+                            "type": "object",
+                            "description": "What this caller may ask for. Separate from `authenticated` because the two can disagree in the direction that matters: a caller may be authenticated and still permitted nothing.",
+                            "required": ["runTests"],
+                            "properties": {
+                                "runTests": {
+                                    "type": "boolean",
+                                    "description": "Whether this caller may start a validation run. False for an anonymous caller and for an authenticated one holding none of the permitted roles. A client should render its run controls from this rather than from a role list of its own; a message sent anyway is refused with errorCode `not_authenticated` or `insufficient_role`."
+                                }
+                            }
+                        }
                     }
                 }
             }

--- a/jsondata/schemas/WebSocketFrame.json
+++ b/jsondata/schemas/WebSocketFrame.json
@@ -130,7 +130,9 @@
                         "unknown_target_id",
                         "invalid_message",
                         "internal_error",
-                        "unsupported_protocol"
+                        "unsupported_protocol",
+                        "not_authenticated",
+                        "insufficient_role"
                     ]
                 },
                 "text": { "type": "string", "description": "Why, phrased for the client that sent the message: the failure names the client's own action and property names, not this server's schema internals, and never its filesystem paths." }

--- a/phpunit_tests/Enum/ProtocolErrorCodeSchemaTest.php
+++ b/phpunit_tests/Enum/ProtocolErrorCodeSchemaTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Enum;
+
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use PHPUnit\Framework\TestCase;
+
+final class ProtocolErrorCodeSchemaTest extends TestCase
+{
+    public function testTheAuthenticationCodesExist(): void
+    {
+        $this->assertSame('not_authenticated', ProtocolErrorCode::NOT_AUTHENTICATED->value);
+        $this->assertSame('insufficient_role', ProtocolErrorCode::INSUFFICIENT_ROLE->value);
+    }
+
+    /**
+     * An enum case with no schema entry produces a frame the published contract rejects, and the two
+     * lists are edited in different files — so the pairing is asserted rather than remembered.
+     */
+    public function testEveryEnumCaseIsDeclaredInTheFrameSchema(): void
+    {
+        $schemaPath = dirname(__DIR__, 2) . '/jsondata/schemas/WebSocketFrame.json';
+        $contents   = file_get_contents($schemaPath);
+        $this->assertIsString($contents);
+
+        /** @var array<string, mixed> $schema */
+        $schema = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+
+        /** @var array<int, string> $declared */
+        $declared = $schema['definitions']['protocolError']['properties']['errorCode']['enum'];
+        /** @var array<int, string> $cases */
+        $cases = array_column(ProtocolErrorCode::cases(), 'value');
+
+        sort($declared);
+        sort($cases);
+
+        $this->assertSame($cases, $declared, 'Every ProtocolErrorCode must be declared in WebSocketFrame.json');
+    }
+}

--- a/phpunit_tests/HealthActionGateTest.php
+++ b/phpunit_tests/HealthActionGateTest.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\Auth\TestTarget;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
+use LiturgicalCalendar\Api\Services\TestRunPolicy;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * The action gate — #894.
+ *
+ * The gate is asked in two places and the split is the design, not an accident:
+ *
+ * **Early**, beside `$protocolViolation`, comes the coarse question. It depends only on the caller
+ * and not on the message, so it can be settled before the message is understood — which it has to be,
+ * because the run-token block below it installs a token and can rebuild the checkable inventory, and
+ * a caller about to be refused must be able to do neither.
+ * {@see testARefusedMessageDoesNotRebuildTheInventory()} is what proves that placement is
+ * load-bearing rather than decorative; move the check below that block and it is the test that fails.
+ *
+ * **Late**, after schema validation, comes the target-scoped question. A target read from an
+ * unvalidated message is a guess, and a permission decision must not rest on one. The coarse policy
+ * answers it the same way it answered above, so
+ * {@see testTheTargetScopedGateCanRefuseAMessageTheCoarseGateAllowed()} drives it with a stub policy
+ * — otherwise the seam would be unexercised code, which is the same thing as absent code.
+ */
+#[CoversClass(Health::class)]
+final class HealthActionGateTest extends TestCase
+{
+    use HealthQueueIsolationTrait;
+
+    private ?string $appEnvBackup = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Keeps handleHttpResponse() out of its development-only debug-logging branch, as
+        // HealthFulfilHandlerThrowTest does.
+        $this->appEnvBackup = isset($_ENV['APP_ENV']) && is_string($_ENV['APP_ENV']) ? $_ENV['APP_ENV'] : null;
+        $_ENV['APP_ENV']    = 'test';
+    }
+
+    protected function tearDown(): void
+    {
+        if (null === $this->appEnvBackup) {
+            unset($_ENV['APP_ENV']);
+        } else {
+            $_ENV['APP_ENV'] = $this->appEnvBackup;
+        }
+        parent::tearDown();
+    }
+
+    /**
+     * A Ratchet connection that records what it was sent. `resourceId` is a dynamic public property
+     * Ratchet assigns and is not part of `ConnectionInterface`, so this is a stub rather than a mock.
+     */
+    private static function createStubConnection(int $resourceId): ConnectionInterface
+    {
+        return new class ($resourceId) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    /**
+     * A Health with the identity a handshake would have settled, without running the handshake.
+     *
+     * @return array{0: Health, 1: ConnectionInterface}
+     */
+    private function serverFor(WsCaller $caller, ?TestRunPolicy $policy = null): array
+    {
+        $health = $this->newHealth(null, $policy);
+        $conn   = self::createStubConnection(1);
+
+        ( new \ReflectionProperty(Health::class, 'callers') )->setValue($health, [1 => $caller]);
+
+        return [$health, $conn];
+    }
+
+    private function validateCalendarMessage(string $requestId = 'req-1'): string
+    {
+        return json_encode([
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'rite', 'rite' => 'roman'],
+            'year'           => 2024,
+            'responseFormat' => 'JSON',
+            'requestId'      => $requestId,
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return list<\stdClass>
+     */
+    private function refusals(ConnectionInterface $conn): array
+    {
+        /** @var object{sent: list<string>} $conn */
+        $frames = [];
+        foreach ($conn->sent as $raw) {
+            $frame = json_decode($raw);
+            if ($frame instanceof \stdClass && 'protocolError' === ( $frame->type ?? null )) {
+                $frames[] = $frame;
+            }
+        }
+
+        return $frames;
+    }
+
+    private function deliver(Health $health, ConnectionInterface $conn, string $message): void
+    {
+        ob_start();
+        $health->onMessage($conn, $message);
+        ob_end_clean();
+    }
+
+    public function testAnonymousCallerIsRefusedWithNotAuthenticated(): void
+    {
+        [$health, $conn] = $this->serverFor(WsCaller::anonymous());
+
+        $this->deliver($health, $conn, $this->validateCalendarMessage());
+
+        $refusals = $this->refusals($conn);
+        $this->assertCount(1, $refusals);
+        $this->assertSame(ProtocolErrorCode::NOT_AUTHENTICATED->value, $refusals[0]->errorCode);
+        $this->assertSame('req-1', $refusals[0]->requestId ?? null, 'the refusal must be correlated to the request');
+    }
+
+    public function testAuthenticatedWithoutRoleIsRefusedWithInsufficientRole(): void
+    {
+        [$health, $conn] = $this->serverFor(WsCaller::authenticated('u', ['developer']));
+
+        $this->deliver($health, $conn, $this->validateCalendarMessage());
+
+        $refusals = $this->refusals($conn);
+        $this->assertCount(1, $refusals);
+        $this->assertSame(
+            ProtocolErrorCode::INSUFFICIENT_ROLE->value,
+            $refusals[0]->errorCode,
+            'a logged-in caller must not be told to log in'
+        );
+    }
+
+    public function testARefusedMessageDoesNotInstallItsRunToken(): void
+    {
+        [$health, $conn] = $this->serverFor(WsCaller::anonymous());
+
+        $message           = json_decode($this->validateCalendarMessage());
+        $message->runToken = 'run-1';
+        $this->deliver($health, $conn, json_encode($message, JSON_THROW_ON_ERROR));
+
+        $tokens = ( new \ReflectionProperty(Health::class, 'runTokens') )->getValue($health);
+        $this->assertSame([], $tokens, 'an unauthorized message must not install a run token');
+    }
+
+    /**
+     * The reason the coarse check sits above the run-token block rather than below it.
+     */
+    public function testARefusedMessageDoesNotRebuildTheInventory(): void
+    {
+        [$health, $conn] = $this->serverFor(WsCaller::anonymous());
+
+        // Memoize the inventory. `reset()` nulls `$items`, so a non-null `$items` afterwards is
+        // exactly the statement that no reset happened.
+        CheckableInventory::byId('an-id-that-matches-nothing-but-builds-the-index');
+        $items = new \ReflectionProperty(CheckableInventory::class, 'items');
+        $this->assertNotNull($items->getValue(), 'precondition: the inventory is memoized');
+
+        $message           = json_decode($this->validateCalendarMessage());
+        $message->runToken = 'run-2';
+        $this->deliver($health, $conn, json_encode($message, JSON_THROW_ON_ERROR));
+
+        $this->assertNotNull(
+            $items->getValue(),
+            'a refused message must not reset the checkable inventory — the coarse check has to sit above the run-token block'
+        );
+    }
+
+    public function testAPermittedCallerIsNotRefused(): void
+    {
+        [$health, $conn] = $this->serverFor(WsCaller::authenticated('u', ['admin']));
+
+        $this->deliver($health, $conn, $this->validateCalendarMessage());
+
+        $this->assertSame([], $this->refusals($conn));
+    }
+
+    public function testATestEditorIsNotRefused(): void
+    {
+        [$health, $conn] = $this->serverFor(WsCaller::authenticated('u', ['test_editor']));
+
+        $this->deliver($health, $conn, $this->validateCalendarMessage());
+
+        $this->assertSame([], $this->refusals($conn));
+    }
+
+    /**
+     * Keeps the fine-grained seam alive. A policy that says yes to the caller and no to the target
+     * must be able to stop the message, or the second call site is dead code.
+     */
+    public function testTheTargetScopedGateCanRefuseAMessageTheCoarseGateAllowed(): void
+    {
+        $policy = new class extends TestRunPolicy {
+            public function mayRun(WsCaller $caller, ?TestTarget $target = null): bool
+            {
+                // Coarse question: yes. Target-scoped question: no.
+                return null === $target;
+            }
+        };
+
+        [$health, $conn] = $this->serverFor(WsCaller::authenticated('u', ['admin']), $policy);
+
+        $this->deliver($health, $conn, $this->validateCalendarMessage());
+
+        $refusals = $this->refusals($conn);
+        $this->assertCount(1, $refusals);
+        $this->assertSame(ProtocolErrorCode::INSUFFICIENT_ROLE->value, $refusals[0]->errorCode);
+        $this->assertSame('req-1', $refusals[0]->requestId ?? null);
+    }
+
+    /**
+     * A connection that never opened has no entry in the caller map. It must read as anonymous, not
+     * as permitted — the whole change fails open otherwise.
+     */
+    public function testAConnectionWithNoRecordedCallerIsAnonymous(): void
+    {
+        $health = $this->newHealth();
+        $conn   = self::createStubConnection(99);
+
+        $this->deliver($health, $conn, $this->validateCalendarMessage());
+
+        $refusals = $this->refusals($conn);
+        $this->assertCount(1, $refusals);
+        $this->assertSame(ProtocolErrorCode::NOT_AUTHENTICATED->value, $refusals[0]->errorCode);
+    }
+}

--- a/phpunit_tests/HealthCallerFrameTest.php
+++ b/phpunit_tests/HealthCallerFrameTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use GuzzleHttp\Psr7\Request;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use LiturgicalCalendar\Api\Services\JwtService;
+use LiturgicalCalendar\Api\Services\WsCallerResolver;
+use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Ratchet\ConnectionInterface;
+
+/**
+ * The `caller` object on the `hello` frame — #894.
+ *
+ * The frame is where the permission *advertisement* lives, and the point of putting it there is that
+ * a client no longer has to decide for itself who may run tests. UnitTestInterface used to, from a
+ * role list of its own, and its own CLAUDE.md recorded that the resulting gate was client-side only.
+ * An advertisement that came from anywhere other than the object that also enforces the rule would
+ * reintroduce exactly that gap, so {@see testTheAdvertisementComesFromThePolicy()} pins the two
+ * together.
+ *
+ * `caller` is a **sibling** of `capabilities`, not a member of it. That object answers what this
+ * server can be asked for, with every entry derived from an enum so that it cannot go stale; who is
+ * asking is per-connection and derived from a cookie, so it does not belong inside it.
+ */
+#[CoversClass(Health::class)]
+final class HealthCallerFrameTest extends TestCase
+{
+    // onOpen() queues the connect-time /calendars metadata fetch. See the trait.
+    use HealthQueueIsolationTrait;
+
+    /** Free of the words JwtServiceFactory treats as placeholder secrets. */
+    private const SECRET = 'kFj9wQz2Lm7XpR4tVbN8sHc1YdG6aE0u';
+
+    /**
+     * The `Health` cache statics `onOpen()` writes, saved so this file can put them back.
+     *
+     * @var array<string, mixed>
+     */
+    private array $cacheStateBackup = [];
+
+    /** @var list<string> */
+    private const CACHE_STATICS = ['cacheInitialized', 'cacheEnabled', 'cacheBackend', 'redis'];
+
+    /**
+     * Skip the cache-init block inside `onOpen()`, for the reason `HealthHelloFrameTest` documents at
+     * length: it turns caching on process-wide, and six other Health suites are written against it
+     * being off. Setting `cacheInitialized` first is the flag's own way of saying "already done".
+     */
+    protected function setUp(): void
+    {
+        foreach (self::CACHE_STATICS as $name) {
+            $property                      = new \ReflectionProperty(Health::class, $name);
+            $this->cacheStateBackup[$name] = $property->getValue();
+        }
+
+        ( new \ReflectionProperty(Health::class, 'cacheInitialized') )->setValue(null, true);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->cacheStateBackup as $name => $value) {
+            ( new \ReflectionProperty(Health::class, $name) )->setValue(null, $value);
+        }
+        $this->cacheStateBackup = [];
+    }
+
+    /**
+     * A Ratchet connection carrying an upgrade request, the way `WsServer` leaves one.
+     *
+     * `httpRequest` and `resourceId` are dynamic public properties Ratchet assigns and neither is
+     * part of `ConnectionInterface`, so this is a stub rather than a PHPUnit mock — same convention
+     * as `HealthHelloFrameTest`.
+     */
+    private static function createStubConnection(int $resourceId, ?Request $httpRequest = null): ConnectionInterface
+    {
+        return new class ($resourceId, $httpRequest) implements ConnectionInterface {
+            /** @var list<string> */
+            public array $sent = [];
+
+            public function __construct(public int $resourceId, public ?Request $httpRequest)
+            {
+            }
+
+            public function send($data)
+            {
+                $this->sent[] = (string) $data;
+
+                return $this;
+            }
+
+            public function close()
+            {
+            }
+        };
+    }
+
+    private function resolver(): WsCallerResolver
+    {
+        return new WsCallerResolver(new JwtService(self::SECRET), null, null);
+    }
+
+    /**
+     * @param array<int, string> $roles
+     */
+    private function requestWithToken(array $roles): Request
+    {
+        $token = ( new JwtService(self::SECRET) )->generate('someone', ['roles' => $roles]);
+
+        return new Request('GET', '/', ['Cookie' => 'litcal_access_token=' . $token]);
+    }
+
+    /**
+     * Open a connection and return the `hello` frame it was sent.
+     */
+    private function helloFrameFor(ConnectionInterface $conn): \stdClass
+    {
+        $health = $this->newHealth($this->resolver());
+
+        ob_start();
+        $health->onOpen($conn);
+        ob_end_clean();
+
+        /** @var object{sent: list<string>} $conn */
+        self::assertNotEmpty($conn->sent, 'a connecting client was sent nothing at all');
+
+        $frame = json_decode($conn->sent[0]);
+        self::assertInstanceOf(\stdClass::class, $frame, 'the first frame is not a JSON object');
+
+        return $frame;
+    }
+
+    public function testAConnectionWithNoCookieIsAdvertisedAsAnonymousAndUnpermitted(): void
+    {
+        $frame = $this->helloFrameFor(self::createStubConnection(1));
+
+        $this->assertObjectHasProperty('caller', $frame);
+        $this->assertFalse($frame->caller->authenticated);
+        $this->assertFalse($frame->caller->permissions->runTests);
+    }
+
+    public function testATestEditorCookieIsAdvertisedAsPermitted(): void
+    {
+        $conn  = self::createStubConnection(2, $this->requestWithToken(['test_editor']));
+        $frame = $this->helloFrameFor($conn);
+
+        $this->assertTrue($frame->caller->authenticated);
+        $this->assertTrue($frame->caller->permissions->runTests);
+    }
+
+    public function testAnAdminCookieIsAdvertisedAsPermitted(): void
+    {
+        $conn  = self::createStubConnection(3, $this->requestWithToken(['admin']));
+        $frame = $this->helloFrameFor($conn);
+
+        $this->assertTrue($frame->caller->permissions->runTests);
+    }
+
+    public function testARoleThatCannotRunIsAuthenticatedButUnpermitted(): void
+    {
+        $conn  = self::createStubConnection(4, $this->requestWithToken(['developer']));
+        $frame = $this->helloFrameFor($conn);
+
+        $this->assertTrue($frame->caller->authenticated, 'the credential was valid');
+        $this->assertFalse($frame->caller->permissions->runTests, 'but the role may not run');
+    }
+
+    /**
+     * The advertisement must be the policy's answer, not a second opinion. A stub that inverts the
+     * verdict has to move the frame with it.
+     */
+    public function testTheAdvertisementComesFromThePolicy(): void
+    {
+        $policy = new class extends \LiturgicalCalendar\Api\Services\TestRunPolicy {
+            public function mayRun(
+                WsCaller $caller,
+                ?\LiturgicalCalendar\Api\Models\Auth\TestTarget $target = null
+            ): bool {
+                return true;
+            }
+        };
+
+        $health = $this->newHealth($this->resolver(), $policy);
+        $conn   = self::createStubConnection(5);
+
+        ob_start();
+        $health->onOpen($conn);
+        ob_end_clean();
+
+        /** @var object{sent: list<string>} $conn */
+        $frame = json_decode($conn->sent[0]);
+        self::assertInstanceOf(\stdClass::class, $frame);
+
+        $this->assertFalse($frame->caller->authenticated, 'no cookie was sent');
+        $this->assertTrue($frame->caller->permissions->runTests, 'yet the policy said yes');
+    }
+
+    public function testCapabilitiesAreUnchangedAndDoNotCarryTheCaller(): void
+    {
+        $frame = $this->helloFrameFor(self::createStubConnection(6));
+
+        $this->assertObjectHasProperty('capabilities', $frame);
+        $this->assertObjectNotHasProperty('caller', $frame->capabilities);
+        $this->assertSame(1, $frame->protocol, 'the contract version is unchanged by #894');
+    }
+
+    /**
+     * Per-connection state has to be forgotten with the connection, like `runTokens` beside it.
+     */
+    public function testTheCallerIsForgottenWhenTheConnectionCloses(): void
+    {
+        $health = $this->newHealth($this->resolver());
+        $conn   = self::createStubConnection(7, $this->requestWithToken(['admin']));
+
+        ob_start();
+        $health->onOpen($conn);
+        $callers = ( new \ReflectionProperty(Health::class, 'callers') )->getValue($health);
+        $this->assertArrayHasKey(7, $callers);
+
+        $health->onClose($conn);
+        ob_end_clean();
+
+        $callers = ( new \ReflectionProperty(Health::class, 'callers') )->getValue($health);
+        $this->assertArrayNotHasKey(7, $callers);
+    }
+}

--- a/phpunit_tests/HealthCancelRunTest.php
+++ b/phpunit_tests/HealthCancelRunTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests;
 use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -34,6 +35,10 @@ final class HealthCancelRunTest extends TestCase
     // currently dispatched at shutdown — but the protection belongs to anything that builds a
     // Health, not to whichever file last remembered it. See the trait.
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     /**
      * A minimal Ratchet connection that records every outbound frame. `resourceId` is a dynamic public

--- a/phpunit_tests/HealthCorrelationTest.php
+++ b/phpunit_tests/HealthCorrelationTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -54,6 +55,10 @@ use Ratchet\ConnectionInterface;
 final class HealthCorrelationTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     /**
      * A calendar response body minimal enough to reach {@see \LiturgicalCalendar\Api\Test\LitTestRunner},

--- a/phpunit_tests/HealthFulfilHandlerThrowTest.php
+++ b/phpunit_tests/HealthFulfilHandlerThrowTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -47,6 +48,10 @@ use Ratchet\ConnectionInterface;
 final class HealthFulfilHandlerThrowTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     /** A calendar body that decodes but lacks the four keys the JSON branch requires. */
     private const TRUNCATED_CALENDAR_BODY = '{"litcal":[]}';

--- a/phpunit_tests/HealthHttpStatusExistsTest.php
+++ b/phpunit_tests/HealthHttpStatusExistsTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\ApcuShimStore;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -37,6 +38,10 @@ use Psr\Http\Message\ResponseInterface;
 final class HealthHttpStatusExistsTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     /** The exact 400 the issue quotes, refusing an Ambrosian year before the rite's lower bound. */
     private const AMBROSIAN_400_BODY = '{"type":"https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request","title":"Bad Request","status":400,"detail":"The Ambrosian rite is only available from 1976 onward (the first reformed Ambrosian Missal); requested year 1970."}';

--- a/phpunit_tests/HealthProtocolValidationTest.php
+++ b/phpunit_tests/HealthProtocolValidationTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -28,6 +29,10 @@ use Ratchet\ConnectionInterface;
 final class HealthProtocolValidationTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     /**
      * A folder created under the project root for the leak probe, so the path the read failure

--- a/phpunit_tests/HealthProtocolVersionTest.php
+++ b/phpunit_tests/HealthProtocolVersionTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests;
 use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -37,6 +38,10 @@ use Ratchet\ConnectionInterface;
 final class HealthProtocolVersionTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     /** Same stub convention as HealthCancelRunTest; see the note there. */
     private static function createStubConnection(int $resourceId)

--- a/phpunit_tests/HealthResourceFormatTest.php
+++ b/phpunit_tests/HealthResourceFormatTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -37,6 +38,10 @@ use Ratchet\ConnectionInterface;
 final class HealthResourceFormatTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     private const CALENDARS_URL = 'http://localhost:8000/calendars';
 

--- a/phpunit_tests/HealthRiteRequestPathTest.php
+++ b/phpunit_tests/HealthRiteRequestPathTest.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -28,6 +29,10 @@ use PHPUnit\Framework\TestCase;
 final class HealthRiteRequestPathTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     /**
      * @return array<string, array{0: string, 1: int, 2: string, 3: Rite, 4: string}>

--- a/phpunit_tests/HealthSourceFileFailureArmsTest.php
+++ b/phpunit_tests/HealthSourceFileFailureArmsTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -47,6 +48,10 @@ use Ratchet\ConnectionInterface;
 final class HealthSourceFileFailureArmsTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     /**
      * A path under the project root that is deliberately not a file.

--- a/phpunit_tests/HealthSupersededRequestTest.php
+++ b/phpunit_tests/HealthSupersededRequestTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
@@ -47,6 +48,10 @@ use Ratchet\ConnectionInterface;
 final class HealthSupersededRequestTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     public static function setUpBeforeClass(): void
     {

--- a/phpunit_tests/HealthTerminalFrameTest.php
+++ b/phpunit_tests/HealthTerminalFrameTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use Nyholm\Psr7\Response;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -46,6 +47,10 @@ use Ratchet\ConnectionInterface;
 final class HealthTerminalFrameTest extends TestCase
 {
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     /** A calendar body that decodes but lacks the four keys the JSON branch requires. */
     private const TRUNCATED_CALENDAR_BODY = '{"litcal":[]}';

--- a/phpunit_tests/HealthTypedCalendarTest.php
+++ b/phpunit_tests/HealthTypedCalendarTest.php
@@ -10,6 +10,7 @@ use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -76,6 +77,10 @@ final class HealthTypedCalendarTest extends TestCase
 {
     // Every Health here queues a real calendar URL; see the trait for why that must be defused.
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     public static function setUpBeforeClass(): void
     {

--- a/phpunit_tests/HealthValidateSourceTest.php
+++ b/phpunit_tests/HealthValidateSourceTest.php
@@ -12,6 +12,7 @@ use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use LiturgicalCalendar\Tests\Support\BrokenInventoryTrait;
+use LiturgicalCalendar\Tests\Support\AuthorizedHealthTrait;
 use LiturgicalCalendar\Tests\Support\HealthQueueIsolationTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -36,6 +37,10 @@ final class HealthValidateSourceTest extends TestCase
 {
     use BrokenInventoryTrait;
     use HealthQueueIsolationTrait;
+
+    // This suite exercises behaviour downstream of the #894 permission gate; it drives
+    // onMessage() without a handshake, so without this every message would be refused.
+    use AuthorizedHealthTrait;
 
     public static function setUpBeforeClass(): void
     {

--- a/phpunit_tests/Services/TestRunPolicyTest.php
+++ b/phpunit_tests/Services/TestRunPolicyTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Models\Auth\TestTarget;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use LiturgicalCalendar\Api\Services\TestRunPolicy;
+use PHPUnit\Framework\TestCase;
+
+final class TestRunPolicyTest extends TestCase
+{
+    public function testAnonymousCallerMayNotRun(): void
+    {
+        $this->assertFalse(( new TestRunPolicy() )->mayRun(WsCaller::anonymous()));
+    }
+
+    public function testAuthenticatedCallerWithoutQualifyingRoleMayNotRun(): void
+    {
+        $caller = WsCaller::authenticated('user-1', ['developer', 'calendar_editor']);
+        $this->assertFalse(( new TestRunPolicy() )->mayRun($caller));
+    }
+
+    public function testTestEditorMayRun(): void
+    {
+        $caller = WsCaller::authenticated('user-1', ['test_editor']);
+        $this->assertTrue(( new TestRunPolicy() )->mayRun($caller));
+    }
+
+    public function testAdminMayRun(): void
+    {
+        $caller = WsCaller::authenticated('user-1', ['admin']);
+        $this->assertTrue(( new TestRunPolicy() )->mayRun($caller));
+    }
+
+    public function testTargetIsAcceptedAndIgnoredByTheCoarsePolicy(): void
+    {
+        $policy = new TestRunPolicy();
+        $target = new TestTarget('rite', 'roman', null);
+        $this->assertTrue($policy->mayRun(WsCaller::authenticated('u', ['admin']), $target));
+        $this->assertFalse($policy->mayRun(WsCaller::anonymous(), $target));
+    }
+
+    public function testTargetIsReadFromAValidateCalendarMessage(): void
+    {
+        $message = json_decode('{"action":"validateCalendar","calendar":{"kind":"rite","rite":"roman"}}');
+        $target  = TestTarget::fromMessage($message);
+        $this->assertNotNull($target);
+        $this->assertSame('rite', $target->kind);
+        $this->assertSame('roman', $target->rite);
+    }
+
+    public function testTargetIsNullWhenTheMessageNamesNone(): void
+    {
+        $this->assertNull(TestTarget::fromMessage(json_decode('{"action":"runTest"}')));
+        $this->assertNull(TestTarget::fromMessage('not an object'));
+    }
+
+    public function testRolesAreDeduplicatedAndAnonymousHasNone(): void
+    {
+        $caller = WsCaller::authenticated('u', ['admin', 'admin']);
+        $this->assertSame(['admin'], $caller->roles);
+        $this->assertSame([], WsCaller::anonymous()->roles);
+        $this->assertNull(WsCaller::anonymous()->sub);
+    }
+}

--- a/phpunit_tests/Services/TestRunPolicyTest.php
+++ b/phpunit_tests/Services/TestRunPolicyTest.php
@@ -57,6 +57,51 @@ final class TestRunPolicyTest extends TestCase
         $this->assertNull(TestTarget::fromMessage('not an object'));
     }
 
+    public function testTargetIsNullWhenCalendarIsNotAnObject(): void
+    {
+        $this->assertNull(TestTarget::fromMessage(json_decode('{"action":"validateCalendar","calendar":"roman"}')));
+    }
+
+    public function testTargetIsNullWhenCalendarIsAnObjectNamingNothingUseful(): void
+    {
+        $this->assertNull(TestTarget::fromMessage(json_decode('{"action":"validateCalendar","calendar":{"year":2024}}')));
+    }
+
+    /**
+     * The id property is named for the kind it belongs to, so each spelling has to be read.
+     */
+    public function testTargetReadsTheNationId(): void
+    {
+        $target = TestTarget::fromMessage(json_decode('{"calendar":{"kind":"nation","nation":"IT"}}'));
+        $this->assertNotNull($target);
+        $this->assertSame('nation', $target->kind);
+        $this->assertSame('IT', $target->calendarId);
+        $this->assertNull($target->rite);
+    }
+
+    public function testTargetReadsTheDioceseId(): void
+    {
+        $target = TestTarget::fromMessage(json_decode('{"calendar":{"kind":"diocese","diocese":"milano_it","rite":"ambrosian"}}'));
+        $this->assertNotNull($target);
+        $this->assertSame('milano_it', $target->calendarId);
+        $this->assertSame('ambrosian', $target->rite);
+    }
+
+    public function testTargetIgnoresNonStringProperties(): void
+    {
+        $target = TestTarget::fromMessage(json_decode('{"calendar":{"kind":123,"rite":"roman"}}'));
+        $this->assertNotNull($target);
+        $this->assertNull($target->kind, 'a non-string kind is absent, not coerced');
+        $this->assertSame('roman', $target->rite);
+    }
+
+    public function testAnonymousCallerHoldsNoRoleAtAll(): void
+    {
+        $this->assertFalse(WsCaller::anonymous()->hasAnyRole('admin', 'test_editor'));
+        $this->assertTrue(WsCaller::authenticated('u', ['test_editor'])->hasAnyRole('admin', 'test_editor'));
+        $this->assertFalse(WsCaller::authenticated('u', ['developer'])->hasAnyRole('admin', 'test_editor'));
+    }
+
     public function testRolesAreDeduplicatedAndAnonymousHasNone(): void
     {
         $caller = WsCaller::authenticated('u', ['admin', 'admin']);

--- a/phpunit_tests/Services/WsCallerAudienceTest.php
+++ b/phpunit_tests/Services/WsCallerAudienceTest.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use GuzzleHttp\Psr7\Request;
+use LiturgicalCalendar\Api\Services\JwtService;
+use LiturgicalCalendar\Api\Services\WsCallerResolver;
+use LiturgicalCalendar\Api\Services\ZitadelKeySetFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The token-audience boundary — raised in review on #894.
+ *
+ * A signature proves a token is *genuine*, not that it is *yours*. Zitadel signs every token in an
+ * instance with the same keys, so verifying the signature alone accepts any correctly-signed token
+ * from any other application in that instance — and if such a token happens to carry `admin` or
+ * `test_editor` among its project roles, the permission gate hands it a validation run. That is a
+ * confused deputy, and the first version of `WsCallerResolver` had it: it mirrored
+ * `OidcAuthMiddleware`'s *decode* step without its `iss`/`aud` checks.
+ *
+ * The rule is exercised through the pure predicate rather than through `JWT::decode()`, so it can be
+ * asserted exhaustively without an RSA keypair or a live provider — the crypto is `firebase/php-jwt`'s
+ * to test, while *which tokens this application accepts* is ours.
+ */
+final class WsCallerAudienceTest extends TestCase
+{
+    private const ISSUER    = 'https://zitadel.example.test';
+    private const CLIENT_ID = 'client-123';
+    private const PROJECT   = 'project-456';
+
+    protected function tearDown(): void
+    {
+        ZitadelKeySetFactory::reset();
+        parent::tearDown();
+    }
+
+    private function payload(string $iss, mixed $aud): object
+    {
+        return (object) ['sub' => 'someone', 'iss' => $iss, 'aud' => $aud];
+    }
+
+    public function testATokenForThisClientIsAccepted(): void
+    {
+        $this->assertTrue(WsCallerResolver::isIntendedFor(
+            $this->payload(self::ISSUER, self::CLIENT_ID),
+            self::ISSUER,
+            [self::CLIENT_ID, self::PROJECT]
+        ));
+    }
+
+    public function testATokenForTheProjectIsAccepted(): void
+    {
+        $this->assertTrue(WsCallerResolver::isIntendedFor(
+            $this->payload(self::ISSUER, self::PROJECT),
+            self::ISSUER,
+            [self::CLIENT_ID, self::PROJECT]
+        ));
+    }
+
+    public function testAnAudienceArrayIsAcceptedWhenItContainsOne(): void
+    {
+        $this->assertTrue(WsCallerResolver::isIntendedFor(
+            $this->payload(self::ISSUER, ['someone-else', self::CLIENT_ID]),
+            self::ISSUER,
+            [self::CLIENT_ID, self::PROJECT]
+        ));
+    }
+
+    /**
+     * The finding, stated as a test: a genuine token for a different application must not pass.
+     */
+    public function testATokenForAnotherApplicationIsRejected(): void
+    {
+        $this->assertFalse(WsCallerResolver::isIntendedFor(
+            $this->payload(self::ISSUER, 'some-other-app'),
+            self::ISSUER,
+            [self::CLIENT_ID, self::PROJECT]
+        ));
+    }
+
+    public function testATokenFromAnotherIssuerIsRejected(): void
+    {
+        $this->assertFalse(WsCallerResolver::isIntendedFor(
+            $this->payload('https://evil.example.test', self::CLIENT_ID),
+            self::ISSUER,
+            [self::CLIENT_ID, self::PROJECT]
+        ));
+    }
+
+    public function testATrailingSlashOnTheIssuerIsNotAMismatch(): void
+    {
+        $this->assertTrue(WsCallerResolver::isIntendedFor(
+            $this->payload(self::ISSUER . '/', self::CLIENT_ID),
+            self::ISSUER,
+            [self::CLIENT_ID]
+        ));
+    }
+
+    public function testAMissingAudienceIsRejected(): void
+    {
+        $this->assertFalse(WsCallerResolver::isIntendedFor(
+            (object) ['sub' => 'someone', 'iss' => self::ISSUER],
+            self::ISSUER,
+            [self::CLIENT_ID]
+        ));
+    }
+
+    public function testAMissingIssuerIsRejected(): void
+    {
+        $this->assertFalse(WsCallerResolver::isIntendedFor(
+            (object) ['sub' => 'someone', 'aud' => self::CLIENT_ID],
+            self::ISSUER,
+            [self::CLIENT_ID]
+        ));
+    }
+
+    public function testANonStringAudienceShapeIsRejected(): void
+    {
+        $this->assertFalse(WsCallerResolver::isIntendedFor(
+            $this->payload(self::ISSUER, 42),
+            self::ISSUER,
+            [self::CLIENT_ID]
+        ));
+    }
+
+    /**
+     * An empty audience list would otherwise mean "match nothing to check, so accept" — the direction
+     * that turns a misconfiguration into an open door.
+     */
+    public function testAnEmptyAudienceListAcceptsNothing(): void
+    {
+        $this->assertFalse(WsCallerResolver::isIntendedFor(
+            $this->payload(self::ISSUER, self::CLIENT_ID),
+            self::ISSUER,
+            []
+        ));
+    }
+
+    /**
+     * And the resolver as a whole agrees: an issuer it cannot audience-check is not a path it offers.
+     */
+    public function testAnIssuerWithNoAudienceConfiguredDisablesTheZitadelPath(): void
+    {
+        $resolver = new WsCallerResolver(null, self::ISSUER, null);
+
+        $this->assertFalse($resolver->warmKeySet(), 'nothing worth warming');
+        $this->assertStringContainsString('DISABLED', $resolver->describeAvailablePaths());
+    }
+
+    public function testAnIssuerWithAnAudienceOffersTheZitadelPath(): void
+    {
+        $resolver = new WsCallerResolver(null, self::ISSUER, null, 3600, self::CLIENT_ID);
+
+        $described = $resolver->describeAvailablePaths();
+        $this->assertStringContainsString('Zitadel RS256', $described);
+        $this->assertStringNotContainsString('DISABLED', $described);
+    }
+
+    /**
+     * The legacy path is untouched by all of this: it is verified against a secret this API owns, so
+     * there is no other application whose tokens it could confuse for its own.
+     */
+    public function testTheLegacyPathStillWorksWithAnUnaudiencedIssuer(): void
+    {
+        $secret   = 'kFj9wQz2Lm7XpR4tVbN8sHc1YdG6aE0u';
+        $resolver = new WsCallerResolver(new JwtService($secret), self::ISSUER, null);
+        $token    = ( new JwtService($secret) )->generate('someone', ['roles' => ['admin']]);
+        $request  = new Request('GET', '/', ['Cookie' => 'litcal_access_token=' . $token]);
+
+        $this->assertTrue($resolver->fromHandshake($request)->authenticated);
+    }
+}

--- a/phpunit_tests/Services/WsCallerResolverTest.php
+++ b/phpunit_tests/Services/WsCallerResolverTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use GuzzleHttp\Psr7\Request;
+use LiturgicalCalendar\Api\Services\JwtService;
+use LiturgicalCalendar\Api\Services\WsCallerResolver;
+use LiturgicalCalendar\Tests\Support\EnvIsolationTrait;
+use PHPUnit\Framework\TestCase;
+
+final class WsCallerResolverTest extends TestCase
+{
+    use EnvIsolationTrait;
+
+    /**
+     * Deliberately free of the words JwtServiceFactory treats as placeholders — this is handed to
+     * JwtService directly, but a secret that would be rejected by the factory reads as a mistake.
+     */
+    private const SECRET = 'kFj9wQz2Lm7XpR4tVbN8sHc1YdG6aE0u';
+
+    private function resolver(): WsCallerResolver
+    {
+        return new WsCallerResolver(new JwtService(self::SECRET), null, null);
+    }
+
+    /**
+     * @param array<int, string> $roles
+     */
+    private function tokenFor(string $sub, array $roles): string
+    {
+        return ( new JwtService(self::SECRET) )->generate($sub, ['roles' => $roles]);
+    }
+
+    public function testNoRequestIsAnonymous(): void
+    {
+        $this->assertFalse($this->resolver()->fromHandshake(null)->authenticated);
+    }
+
+    public function testNoCookieHeaderIsAnonymous(): void
+    {
+        $this->assertFalse($this->resolver()->fromHandshake(new Request('GET', '/'))->authenticated);
+    }
+
+    public function testLegacyHs256CookieIsAuthenticatedWithItsRoles(): void
+    {
+        $token   = $this->tokenFor('someone', ['test_editor']);
+        $request = new Request('GET', '/', ['Cookie' => 'litcal_access_token=' . $token]);
+
+        $caller = $this->resolver()->fromHandshake($request);
+
+        $this->assertTrue($caller->authenticated);
+        $this->assertSame('someone', $caller->sub);
+        $this->assertSame(['test_editor'], $caller->roles);
+    }
+
+    public function testCookieIsFoundAmongOthers(): void
+    {
+        $token   = $this->tokenFor('someone', ['admin']);
+        $request = new Request('GET', '/', [
+            'Cookie' => 'other=1; litcal_access_token=' . $token . '; litcal_id_token=zzz',
+        ]);
+
+        $this->assertTrue($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testGarbageTokenIsAnonymousRatherThanAnError(): void
+    {
+        $request = new Request('GET', '/', ['Cookie' => 'litcal_access_token=not.a.jwt']);
+        $this->assertFalse($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testTokenSignedWithAnotherSecretIsAnonymous(): void
+    {
+        $forged  = ( new JwtService('Zx3mQ8vT1kL6yW9pB4nR7cJ2hD5sF0gA') )->generate('someone', ['roles' => ['admin']]);
+        $request = new Request('GET', '/', ['Cookie' => 'litcal_access_token=' . $forged]);
+
+        $this->assertFalse($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testExpiredTokenIsAnonymous(): void
+    {
+        $expired = ( new JwtService(self::SECRET, 'HS256', -10) )->generate('someone', ['roles' => ['admin']]);
+        $request = new Request('GET', '/', ['Cookie' => 'litcal_access_token=' . $expired]);
+
+        $this->assertFalse($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testTokenWithoutRolesClaimAuthenticatesWithNoRoles(): void
+    {
+        $token  = ( new JwtService(self::SECRET) )->generate('someone');
+        $caller = $this->resolver()->fromToken($token);
+
+        $this->assertTrue($caller->authenticated);
+        $this->assertSame([], $caller->roles);
+    }
+
+    public function testMalformedCookieHeaderDoesNotThrow(): void
+    {
+        $request = new Request('GET', '/', ['Cookie' => '=; ;;  ; nonsense']);
+        $this->assertFalse($this->resolver()->fromHandshake($request)->authenticated);
+    }
+
+    public function testCookieValuesAreUrlDecoded(): void
+    {
+        $parsed = WsCallerResolver::parseCookieHeader('a=one%20two');
+        $this->assertSame('one two', $parsed['a']);
+    }
+
+    public function testResolverWithNoVerificationPathAtAllIsAnonymous(): void
+    {
+        $this->withoutEnv(['JWT_SECRET', 'ZITADEL_ISSUER', 'ZITADEL_INTERNAL_URL'], function (): void {
+            $resolver = WsCallerResolver::fromEnv();
+            $request  = new Request('GET', '/', ['Cookie' => 'litcal_access_token=anything']);
+
+            $this->assertFalse($resolver->fromHandshake($request)->authenticated);
+            $this->assertStringContainsString('none', strtolower($resolver->describeAvailablePaths()));
+            $this->assertFalse($resolver->warmKeySet(), 'nothing to warm without an issuer');
+        });
+    }
+
+    public function testDescribeNamesTheLegacyPathWhenOnlyItIsConfigured(): void
+    {
+        $this->assertStringContainsString('HS256', $this->resolver()->describeAvailablePaths());
+    }
+}

--- a/phpunit_tests/Services/WsCallerResolverZitadelTest.php
+++ b/phpunit_tests/Services/WsCallerResolverZitadelTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use GuzzleHttp\Psr7\Request;
+use LiturgicalCalendar\Api\Services\JwtService;
+use LiturgicalCalendar\Api\Services\WsCallerResolver;
+use LiturgicalCalendar\Api\Services\ZitadelKeySetFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * What the resolver does when Zitadel is configured but unreachable — #894.
+ *
+ * This is the failure mode most likely to be met in anger, and the one whose wrong answer would be
+ * worst: a WebSocket server that treated "cannot reach the identity provider" as "no opinion, let
+ * them through" would hand the whole gate to anyone who could take Zitadel offline. Every assertion
+ * here is a statement that the degradation is *closed*, and that a path that still works keeps
+ * working.
+ *
+ * The issuer is a port nothing listens on, so the JWKS fetch fails instantly rather than by timeout.
+ */
+final class WsCallerResolverZitadelTest extends TestCase
+{
+    private const SECRET = 'kFj9wQz2Lm7XpR4tVbN8sHc1YdG6aE0u';
+
+    /** Nothing listens here; connection is refused immediately. */
+    private const DEAD_ISSUER = 'http://127.0.0.1:1';
+
+    protected function tearDown(): void
+    {
+        // The factory memoizes per issuer for the life of the process. Left in place, this file's
+        // fake issuer would be handed to any later test that happened to name it.
+        ZitadelKeySetFactory::reset();
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<int, string> $roles
+     */
+    private function hs256Token(string $sub, array $roles): string
+    {
+        return ( new JwtService(self::SECRET) )->generate($sub, ['roles' => $roles]);
+    }
+
+    public function testAnUnreachableProviderDoesNotBreakTheLegacyPath(): void
+    {
+        $resolver = new WsCallerResolver(new JwtService(self::SECRET), self::DEAD_ISSUER, null);
+        $request  = new Request('GET', '/', [
+            'Cookie' => 'litcal_access_token=' . $this->hs256Token('someone', ['admin']),
+        ]);
+
+        $caller = $resolver->fromHandshake($request);
+
+        $this->assertTrue($caller->authenticated, 'the Zitadel attempt must fall through, not abort');
+        $this->assertSame(['admin'], $caller->roles);
+    }
+
+    public function testAnUnreachableProviderWithNoLegacyPathIsAnonymous(): void
+    {
+        $resolver = new WsCallerResolver(null, self::DEAD_ISSUER, null);
+        $request  = new Request('GET', '/', [
+            'Cookie' => 'litcal_access_token=' . $this->hs256Token('someone', ['admin']),
+        ]);
+
+        $this->assertFalse(
+            $resolver->fromHandshake($request)->authenticated,
+            'no verification path can reach a verdict, so the caller is anonymous'
+        );
+    }
+
+    public function testWarmingReportsFailureWithoutThrowing(): void
+    {
+        $resolver = new WsCallerResolver(new JwtService(self::SECRET), self::DEAD_ISSUER, null);
+
+        $this->assertFalse($resolver->warmKeySet(), 'an unreachable JWKS is reported, not raised');
+    }
+
+    public function testBothPathsAreNamedWhenBothAreConfigured(): void
+    {
+        $resolver = new WsCallerResolver(new JwtService(self::SECRET), self::DEAD_ISSUER, null);
+
+        $described = $resolver->describeAvailablePaths();
+
+        $this->assertStringContainsString('Zitadel RS256', $described);
+        $this->assertStringContainsString('legacy HS256', $described);
+    }
+
+    public function testOnlyTheZitadelPathIsNamedWhenTheLegacySecretIsAbsent(): void
+    {
+        $resolver = new WsCallerResolver(null, self::DEAD_ISSUER, null);
+
+        $described = $resolver->describeAvailablePaths();
+
+        $this->assertStringContainsString('Zitadel RS256', $described);
+        $this->assertStringNotContainsString('HS256', $described);
+    }
+
+    public function testTheInternalUrlVariantIsAcceptedForDockerNetworking(): void
+    {
+        $resolver = new WsCallerResolver(null, 'https://zitadel.example.test', 'http://zitadel:8080');
+
+        // The Host-header rewrite path is exercised on the way to a failed fetch; what matters is
+        // that it is reached without throwing and still refuses.
+        $this->assertFalse($resolver->warmKeySet());
+        $this->assertFalse($resolver->fromToken('whatever')->authenticated);
+    }
+}

--- a/phpunit_tests/Services/ZitadelKeySetFactoryTest.php
+++ b/phpunit_tests/Services/ZitadelKeySetFactoryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use Firebase\JWT\CachedKeySet;
+use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
+use LiturgicalCalendar\Api\Services\ZitadelKeySetFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The shared JWKS key set — #894.
+ *
+ * The memoization is the point rather than an optimisation detail: the WebSocket server verifies
+ * tokens from inside a single-threaded ReactPHP loop, where a fetch stalls every other connection,
+ * so a key set rebuilt per call would reintroduce exactly the cost the sharing exists to remove.
+ */
+final class ZitadelKeySetFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        ZitadelKeySetFactory::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        ZitadelKeySetFactory::reset();
+        parent::tearDown();
+    }
+
+    public function testTheSameIssuerIsMemoized(): void
+    {
+        $first  = ZitadelKeySetFactory::for('https://issuer.example.test');
+        $second = ZitadelKeySetFactory::for('https://issuer.example.test');
+
+        $this->assertInstanceOf(CachedKeySet::class, $first);
+        $this->assertSame($first, $second);
+    }
+
+    /**
+     * A trailing slash is a spelling, not a different provider — and `OidcAuthMiddleware` already
+     * rtrims it when it stores the issuer, so the factory must agree or the two callers would build
+     * separate key sets for the same server.
+     */
+    public function testATrailingSlashNamesTheSameIssuer(): void
+    {
+        $bare    = ZitadelKeySetFactory::for('https://issuer.example.test');
+        $slashed = ZitadelKeySetFactory::for('https://issuer.example.test/');
+
+        $this->assertSame($bare, $slashed);
+    }
+
+    public function testDifferentIssuersGetDifferentKeySets(): void
+    {
+        $one = ZitadelKeySetFactory::for('https://one.example.test');
+        $two = ZitadelKeySetFactory::for('https://two.example.test');
+
+        $this->assertNotSame($one, $two);
+    }
+
+    public function testResetDropsTheMemo(): void
+    {
+        $before = ZitadelKeySetFactory::for('https://issuer.example.test');
+        ZitadelKeySetFactory::reset();
+        $after = ZitadelKeySetFactory::for('https://issuer.example.test');
+
+        $this->assertNotSame($before, $after);
+    }
+
+    public function testTheInternalUrlVariantStillProducesAKeySet(): void
+    {
+        $keySet = ZitadelKeySetFactory::for('https://issuer.example.test', 'http://zitadel:8080');
+
+        $this->assertInstanceOf(CachedKeySet::class, $keySet);
+    }
+
+    /**
+     * `OidcAuthMiddleware::resetKeySetCache()` is public API that predates the factory; it now
+     * delegates, and this pins that it still clears what callers expect it to clear.
+     */
+    public function testTheMiddlewareResetHelperStillClearsTheSharedMemo(): void
+    {
+        $before = ZitadelKeySetFactory::for('https://issuer.example.test');
+        OidcAuthMiddleware::resetKeySetCache();
+        $after = ZitadelKeySetFactory::for('https://issuer.example.test');
+
+        $this->assertNotSame($before, $after);
+    }
+}

--- a/phpunit_tests/Services/ZitadelKeySetFactoryTest.php
+++ b/phpunit_tests/Services/ZitadelKeySetFactoryTest.php
@@ -76,6 +76,26 @@ final class ZitadelKeySetFactoryTest extends TestCase
     }
 
     /**
+     * The JWKS fetch must be bounded, and this is the guard against the bound being dropped.
+     *
+     * `CachedKeySet` fetches synchronously from inside `JWT::decode()` on a cold cache or an unknown
+     * `kid`, and Guzzle's default for both options is 0 — wait forever. In the HTTP API that costs one
+     * php-fpm worker; in the WebSocket server it stalls the single Ratchet event loop for every
+     * connected client at once. A provider that accepts the connection and then goes quiet is
+     * indistinguishable from a healthy one without a timeout.
+     */
+    public function testTheJwksFetchIsBounded(): void
+    {
+        $options = ZitadelKeySetFactory::HTTP_OPTIONS;
+
+        $this->assertArrayHasKey('connect_timeout', $options);
+        $this->assertArrayHasKey('timeout', $options);
+        $this->assertGreaterThan(0, $options['connect_timeout'], 'zero means wait indefinitely');
+        $this->assertGreaterThan(0, $options['timeout'], 'zero means wait indefinitely');
+        $this->assertLessThanOrEqual(10, $options['timeout'], 'a fetch this slow will not produce a useful answer');
+    }
+
+    /**
      * `OidcAuthMiddleware::resetKeySetCache()` is public API that predates the factory; it now
      * delegates, and this pins that it still clears what callers expect it to clear.
      */

--- a/phpunit_tests/Services/ZitadelRolesTest.php
+++ b/phpunit_tests/Services/ZitadelRolesTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Services\ZitadelRoles;
+use PHPUnit\Framework\TestCase;
+
+final class ZitadelRolesTest extends TestCase
+{
+    public function testReadsRoleNamesFromTheProjectRolesClaim(): void
+    {
+        $payload = json_decode('{"' . ZitadelRoles::CLAIM . '":{"admin":{"org_id":"1"},"test_editor":{"org_id":"1"}}}');
+        $this->assertInstanceOf(\stdClass::class, $payload);
+        $this->assertSame(['admin', 'test_editor'], ZitadelRoles::fromPayload($payload));
+    }
+
+    public function testReturnsEmptyWhenTheClaimIsAbsent(): void
+    {
+        $payload = json_decode('{"sub":"u"}');
+        $this->assertInstanceOf(\stdClass::class, $payload);
+        $this->assertSame([], ZitadelRoles::fromPayload($payload));
+    }
+
+    public function testReturnsEmptyWhenTheClaimIsNotAnObject(): void
+    {
+        $payload = json_decode('{"' . ZitadelRoles::CLAIM . '":"admin"}');
+        $this->assertInstanceOf(\stdClass::class, $payload);
+        $this->assertSame([], ZitadelRoles::fromPayload($payload));
+    }
+
+    public function testReturnsEmptyWhenTheClaimIsAnEmptyObject(): void
+    {
+        $payload = json_decode('{"' . ZitadelRoles::CLAIM . '":{}}');
+        $this->assertInstanceOf(\stdClass::class, $payload);
+        $this->assertSame([], ZitadelRoles::fromPayload($payload));
+    }
+}

--- a/phpunit_tests/Support/AuthorizedHealthTrait.php
+++ b/phpunit_tests/Support/AuthorizedHealthTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use LiturgicalCalendar\Api\Models\Auth\TestTarget;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use LiturgicalCalendar\Api\Services\TestRunPolicy;
+use PHPUnit\Framework\Attributes\Before;
+
+/**
+ * Declares that a suite exercises behaviour *downstream* of the #894 permission gate.
+ *
+ * Those suites drive `Health::onMessage()` directly, without a handshake, so no `WsCaller` was ever
+ * settled for the connection — and an unknown connection reads as anonymous, which is the fail-closed
+ * direction the gate is built on. Every one of their messages would be refused before reaching the
+ * behaviour they are actually about.
+ *
+ * The authorization is stated **once per suite** rather than once per `newHealth()` call, and stated
+ * as a policy rather than as a seeded caller. Both choices matter:
+ *
+ *  - Once per suite, because "this file is not about the gate" is a property of the file. Threading a
+ *    permissive argument through ~150 call sites would say the same thing 150 times and let one of
+ *    them drift.
+ *  - A policy rather than a caller, because a caller has to be seeded per `resourceId` and these
+ *    suites mint connection ids freely; a policy is answered for whatever connection turns up.
+ *
+ * It is deliberately **not** the default in {@see HealthQueueIsolationTrait}. A default that
+ * authorized every test Health would make the gate invisible to the suite — the precise failure mode
+ * this issue exists to fix, reintroduced one layer down. A suite opts in, in writing.
+ *
+ * {@see \LiturgicalCalendar\Tests\HealthActionGateTest} is the suite that must never use this.
+ */
+trait AuthorizedHealthTrait
+{
+    #[Before]
+    protected function authorizeHealthByDefault(): void
+    {
+        $this->defaultPolicy = new class extends TestRunPolicy {
+            public function mayRun(WsCaller $caller, ?TestTarget $target = null): bool
+            {
+                return true;
+            }
+        };
+    }
+}

--- a/phpunit_tests/Support/HealthQueueIsolationTrait.php
+++ b/phpunit_tests/Support/HealthQueueIsolationTrait.php
@@ -41,6 +41,15 @@ trait HealthQueueIsolationTrait
     private array $trackedHealths = [];
 
     /**
+     * The policy {@see newHealth()} uses when a call site names none.
+     *
+     * Null means the real one. {@see AuthorizedHealthTrait} sets it, and is the only thing that
+     * should: a suite downstream of the #894 gate says so once, in writing, rather than every
+     * `newHealth()` in the suite quietly being permitted.
+     */
+    protected ?TestRunPolicy $defaultPolicy = null;
+
+    /**
      * A Health whose queue will be defused when the test ends.
      *
      * The two collaborators are pass-through rather than convenience: a suite that needs a Health
@@ -50,7 +59,7 @@ trait HealthQueueIsolationTrait
      */
     protected function newHealth(?WsCallerResolver $callerResolver = null, ?TestRunPolicy $policy = null): Health
     {
-        $health                 = new Health($callerResolver, $policy);
+        $health                 = new Health($callerResolver, $policy ?? $this->defaultPolicy);
         $this->trackedHealths[] = $health;
 
         return $health;

--- a/phpunit_tests/Support/HealthQueueIsolationTrait.php
+++ b/phpunit_tests/Support/HealthQueueIsolationTrait.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Support;
 
 use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Services\TestRunPolicy;
+use LiturgicalCalendar\Api\Services\WsCallerResolver;
 use PHPUnit\Framework\Attributes\After;
 
 /**
@@ -40,10 +42,15 @@ trait HealthQueueIsolationTrait
 
     /**
      * A Health whose queue will be defused when the test ends.
+     *
+     * The two collaborators are pass-through rather than convenience: a suite that needs a Health
+     * with a stubbed caller resolver or permission policy would otherwise have to write
+     * `new Health($resolver)` by hand, which is precisely the untracked construction this trait
+     * exists to stop. Both default to null, which is what `Health` reads as "build the real one".
      */
-    protected function newHealth(): Health
+    protected function newHealth(?WsCallerResolver $callerResolver = null, ?TestRunPolicy $policy = null): Health
     {
-        $health                 = new Health();
+        $health                 = new Health($callerResolver, $policy);
         $this->trackedHealths[] = $health;
 
         return $health;

--- a/phpunit_tests/Support/WsAuthTrait.php
+++ b/phpunit_tests/Support/WsAuthTrait.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Support;
+
+use LiturgicalCalendar\Api\Services\JwtServiceFactory;
+
+/**
+ * A minted access token for the tests that drive the WebSocket server over the wire.
+ *
+ * Those tests reach `Health` through a real handshake, so — since #894 — they need a real credential
+ * on it. The legacy HS256 flavour is used rather than a Zitadel token because the API owns the secret
+ * and can therefore mint one locally: an RS256 token would need a live provider, which would make a
+ * unit-test suite depend on Zitadel being up.
+ *
+ * **Skips loudly rather than passing unexecuted.** A fresh worktree has no `.env.local`, so
+ * `JWT_SECRET` is absent and no token can be minted. A suite that quietly stopped exercising the
+ * server would still report green, which is worse than a red one: the test was written to guard
+ * something, and silence is indistinguishable from success.
+ */
+trait WsAuthTrait
+{
+    /**
+     * @param array<int, string> $roles
+     */
+    protected function wsAccessTokenOrSkip(array $roles = ['admin']): string
+    {
+        try {
+            $jwtService = JwtServiceFactory::fromEnv();
+        } catch (\Throwable $e) {
+            $this->markTestSkipped(
+                'JWT_SECRET is not configured, so no WebSocket credential can be minted: ' . $e->getMessage()
+            );
+        }
+
+        return $jwtService->generate('phpunit', ['roles' => $roles]);
+    }
+}

--- a/phpunit_tests/WebSocket/ExecuteUnitTestTest.php
+++ b/phpunit_tests/WebSocket/ExecuteUnitTestTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\WebSocket;
 
+use LiturgicalCalendar\Tests\Support\WsAuthTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -27,6 +28,10 @@ use PHPUnit\Framework\TestCase;
  */
 final class ExecuteUnitTestTest extends TestCase
 {
+    // Since #894 a run-starting action needs a credential on the handshake. See the trait for why
+    // the absence of JWT_SECRET must skip rather than pass.
+    use WsAuthTrait;
+
     private string $wsHost;
     private int $wsPort;
     private string $apiHost;
@@ -82,7 +87,7 @@ final class ExecuteUnitTestTest extends TestCase
      */
     private function executeUnitTest(array $payload): \stdClass
     {
-        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 30.0);
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 30.0, $this->wsAccessTokenOrSkip());
         try {
             $encoded = json_encode($payload, JSON_THROW_ON_ERROR);
             $client->sendText($encoded);

--- a/phpunit_tests/WebSocket/ExecuteValidationTest.php
+++ b/phpunit_tests/WebSocket/ExecuteValidationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\WebSocket;
 
 use LiturgicalCalendar\Api\Enum\ProtocolErrorCode;
+use LiturgicalCalendar\Tests\Support\WsAuthTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,6 +35,10 @@ use PHPUnit\Framework\TestCase;
  */
 final class ExecuteValidationTest extends TestCase
 {
+    // Since #894 a run-starting action needs a credential on the handshake. See the trait for why
+    // the absence of JWT_SECRET must skip rather than pass.
+    use WsAuthTrait;
+
     private string $wsHost;
     private int $wsPort;
     private string $apiHost;
@@ -71,7 +76,7 @@ final class ExecuteValidationTest extends TestCase
      */
     private function executeValidation(array $payload, int $expectedFrames): array
     {
-        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 30.0);
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 30.0, $this->wsAccessTokenOrSkip());
         try {
             $client->sendText(json_encode($payload, JSON_THROW_ON_ERROR));
 

--- a/phpunit_tests/WebSocket/LitCalTestServerTest.php
+++ b/phpunit_tests/WebSocket/LitCalTestServerTest.php
@@ -11,6 +11,7 @@ use LiturgicalCalendar\Api\Enum\Step;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Router;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
+use LiturgicalCalendar\Tests\Support\WsAuthTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -37,6 +38,10 @@ use PHPUnit\Framework\TestCase;
  */
 final class LitCalTestServerTest extends TestCase
 {
+    // Since #894 a run-starting action needs a credential on the handshake. See the trait for why
+    // the absence of JWT_SECRET must skip rather than pass.
+    use WsAuthTrait;
+
     private string $wsHost;
     private int $wsPort;
 
@@ -73,7 +78,7 @@ final class LitCalTestServerTest extends TestCase
         // that is not this code — the handshake test is not special, it is merely where the drift
         // was visible. Checking here means one stale server produces one clear diagnosis instead of
         // a scatter of unrelated-looking failures, or worse, passes.
-        $client = WsTestClient::connect($this->wsHost, $this->wsPort);
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 5.0, $this->wsAccessTokenOrSkip());
         $hello  = $client->hello();
         $client->close();
         self::assertNotNull($hello, 'a connecting client was not sent a hello frame');
@@ -162,7 +167,7 @@ final class LitCalTestServerTest extends TestCase
      */
     public function testTheServerAdvertisesItsContractOnConnect(): void
     {
-        $client = WsTestClient::connect($this->wsHost, $this->wsPort);
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 5.0, $this->wsAccessTokenOrSkip());
 
         $hello = $client->hello();
         $this->assertNotNull($hello, 'a connecting client was not sent a hello frame');
@@ -187,7 +192,7 @@ final class LitCalTestServerTest extends TestCase
 
     public function testHandshakeAndEcho(): void
     {
-        $client = WsTestClient::connect($this->wsHost, $this->wsPort);
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 5.0, $this->wsAccessTokenOrSkip());
 
         // The handler answers any well-formed JSON with an unknown action back
         // as `{"type":"protocolError","errorCode":"unknown_action","text":"Unknown action from
@@ -218,7 +223,7 @@ final class LitCalTestServerTest extends TestCase
         // server replies with a protocolError frame carrying errorCode invalid_json, and the text
         // carries the same json_last_error_msg() reason the server logs, since errorCode alone
         // cannot distinguish "Syntax error" from "Malformed UTF-8 characters".
-        $client = WsTestClient::connect($this->wsHost, $this->wsPort);
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 5.0, $this->wsAccessTokenOrSkip());
         $client->sendText('definitely not json');
         $reply = $client->receiveText();
 
@@ -235,7 +240,7 @@ final class LitCalTestServerTest extends TestCase
 
     public function testMessageWithoutActionReportsValidationError(): void
     {
-        $client = WsTestClient::connect($this->wsHost, $this->wsPort);
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 5.0, $this->wsAccessTokenOrSkip());
         $client->sendText('{"foo":"bar"}');
         $reply = $client->receiveText();
 
@@ -244,6 +249,86 @@ final class LitCalTestServerTest extends TestCase
         $this->assertSame('protocolError', $decoded->type);
         $this->assertSame(ProtocolErrorCode::MISSING_ACTION->value, $decoded->errorCode);
         $this->assertStringContainsString('No action specified', (string) $decoded->text);
+
+        $client->close();
+    }
+
+    /**
+     * An anonymous connection **opens** — #894.
+     *
+     * The issue proposed closing the handshake instead, and this test is where that decision is
+     * visible on the wire: both shipped UnitTestInterface runner pages call `connect()`
+     * unconditionally at module load, with a reconnect timer behind it, so refusing the handshake
+     * would put every anonymous visitor into a connect/close/reconnect loop for the sake of a page
+     * that only replays past runs. The connection is accepted; the work is what is refused.
+     */
+    public function testAnAnonymousConnectionOpensAndIsAdvertisedAsUnpermitted(): void
+    {
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort);
+        $hello  = $client->hello();
+
+        $this->assertNotNull($hello, 'an anonymous client must still be sent a hello frame');
+        $this->assertObjectHasProperty('caller', $hello);
+        $this->assertFalse($hello->caller->authenticated);
+        $this->assertFalse($hello->caller->permissions->runTests);
+
+        $client->close();
+    }
+
+    /**
+     * And the advertisement is honoured: the action it says is unavailable really is refused.
+     */
+    public function testAnAnonymousConnectionIsRefusedARunStartingAction(): void
+    {
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort);
+        $client->sendText(json_encode([
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'rite', 'rite' => Rite::ROMAN->value],
+            'year'           => 2024,
+            'responseFormat' => 'JSON',
+            'requestId'      => 'anon-1',
+        ], JSON_THROW_ON_ERROR));
+
+        $decoded = json_decode($client->receiveText());
+
+        $this->assertIsObject($decoded);
+        $this->assertSame('protocolError', $decoded->type);
+        $this->assertSame(ProtocolErrorCode::NOT_AUTHENTICATED->value, $decoded->errorCode);
+        $this->assertSame('anon-1', $decoded->requestId ?? null, 'the refusal must be correlated');
+
+        $client->close();
+    }
+
+    /**
+     * A credential with no qualifying role is authenticated and still refused, with the code that
+     * says so. Telling this caller to log in would be advice that cannot help them.
+     */
+    public function testACredentialWithoutAQualifyingRoleIsRefusedWithInsufficientRole(): void
+    {
+        $client = WsTestClient::connect(
+            $this->wsHost,
+            $this->wsPort,
+            5.0,
+            $this->wsAccessTokenOrSkip(['developer'])
+        );
+
+        $hello = $client->hello();
+        $this->assertNotNull($hello);
+        $this->assertTrue($hello->caller->authenticated, 'the credential was valid');
+        $this->assertFalse($hello->caller->permissions->runTests, 'but the role may not run');
+
+        $client->sendText(json_encode([
+            'action'         => 'validateCalendar',
+            'calendar'       => ['kind' => 'rite', 'rite' => Rite::ROMAN->value],
+            'year'           => 2024,
+            'responseFormat' => 'JSON',
+            'requestId'      => 'norole-1',
+        ], JSON_THROW_ON_ERROR));
+
+        $decoded = json_decode($client->receiveText());
+
+        $this->assertIsObject($decoded);
+        $this->assertSame(ProtocolErrorCode::INSUFFICIENT_ROLE->value, $decoded->errorCode);
 
         $client->close();
     }

--- a/phpunit_tests/WebSocket/ValidateCalendarTest.php
+++ b/phpunit_tests/WebSocket/ValidateCalendarTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\WebSocket;
 
+use LiturgicalCalendar\Tests\Support\WsAuthTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -34,6 +35,10 @@ use PHPUnit\Framework\TestCase;
  */
 final class ValidateCalendarTest extends TestCase
 {
+    // Since #894 a run-starting action needs a credential on the handshake. See the trait for why
+    // the absence of JWT_SECRET must skip rather than pass.
+    use WsAuthTrait;
+
     private string $wsHost;
     private int $wsPort;
     private string $apiHost;
@@ -75,7 +80,7 @@ final class ValidateCalendarTest extends TestCase
      */
     private function validateCalendar(array $payload, int $expectedFrames): array
     {
-        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 30.0);
+        $client = WsTestClient::connect($this->wsHost, $this->wsPort, 30.0, $this->wsAccessTokenOrSkip());
         try {
             $client->sendText(json_encode($payload, JSON_THROW_ON_ERROR));
 

--- a/phpunit_tests/WebSocket/WsTestClient.php
+++ b/phpunit_tests/WebSocket/WsTestClient.php
@@ -49,7 +49,13 @@ final class WsTestClient
      *
      * @throws \RuntimeException on transport failure or non-101 server response.
      */
-    public static function connect(string $host, int $port, float $timeoutSeconds = 5.0): self
+    /**
+     * @param string|null $accessToken When given, sent as the `litcal_access_token` cookie on the
+     *                                 handshake. Since #894 the server settles the caller's identity
+     *                                 from that cookie and refuses run-starting actions without it;
+     *                                 a connection with no token still opens, and is anonymous.
+     */
+    public static function connect(string $host, int $port, float $timeoutSeconds = 5.0, ?string $accessToken = null): self
     {
         $sock = @stream_socket_client(
             sprintf('tcp://%s:%d', $host, $port),
@@ -68,12 +74,19 @@ final class WsTestClient
             sha1($key . '258EAFA5-E914-47DA-95CA-C5AB0DC85B11', true)
         );
 
+        // The credential rides on the handshake because that is the only place it can: a WebSocket
+        // frame carries no headers, so a connection not identified as it opens never can be.
+        $cookieHeader = null !== $accessToken && '' !== $accessToken
+            ? 'Cookie: litcal_access_token=' . $accessToken . "\r\n"
+            : '';
+
         $request = "GET / HTTP/1.1\r\n"
             . "Host: $host:$port\r\n"
             . "Upgrade: websocket\r\n"
             . "Connection: Upgrade\r\n"
             . "Sec-WebSocket-Key: $key\r\n"
             . "Sec-WebSocket-Version: 13\r\n"
+            . $cookieHeader
             . "\r\n";
 
         fwrite($sock, $request);

--- a/src/Enum/ProtocolErrorCode.php
+++ b/src/Enum/ProtocolErrorCode.php
@@ -32,4 +32,21 @@ enum ProtocolErrorCode: string
      * field. The `hello` frame names the version that would have worked.
      */
     case UNSUPPORTED_PROTOCOL = 'unsupported_protocol';
+
+    /**
+     * The connection carried no usable credential — #894.
+     *
+     * Separate from {@see self::INSUFFICIENT_ROLE} by the rule this enum opens with, and the
+     * separation is the whole reason there are two: the remedies differ. This one is answered by
+     * logging in. The other cannot be, and telling a logged-in `developer` to log in again is advice
+     * that cannot help them.
+     */
+    case NOT_AUTHENTICATED = 'not_authenticated';
+
+    /**
+     * The caller is logged in, but holds none of the roles that may start a validation run.
+     *
+     * The remedy is to be granted a role, not to re-authenticate. A client can say so.
+     */
+    case INSUFFICIENT_ROLE = 'insufficient_role';
 }

--- a/src/Health.php
+++ b/src/Health.php
@@ -28,8 +28,11 @@ use LiturgicalCalendar\Api\Enum\Step;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
+use LiturgicalCalendar\Api\Services\TestRunPolicy;
+use LiturgicalCalendar\Api\Services\WsCallerResolver;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use Symfony\Component\Yaml\Exception\ParseException;
@@ -37,6 +40,7 @@ use Symfony\Component\Yaml\Yaml;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataCalendars;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
 use LiturgicalCalendar\Api\Test\LitTestRunner;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -355,11 +359,31 @@ class Health implements MessageComponentInterface
     private WebSocketMessageValidator $messageValidator;
 
     /**
+     * The identity settled at handshake time, per connection — #894.
+     *
+     * Keyed by `resourceId` and dropped in {@see self::onClose()}, exactly like `$runTokens` above.
+     * Settled once because the handshake is the only moment a credential is on the wire: a WebSocket
+     * frame carries no headers, so a connection not identified as it opened never can be.
+     *
+     * @var array<int, WsCaller>
+     */
+    private array $callers = [];
+
+    private WsCallerResolver $callerResolver;
+
+    private TestRunPolicy $policy;
+
+    /**
      * Initializes the Health object with an empty SplObjectStorage.
      *
      * The SplObjectStorage is used to store client connections.
+     *
+     * @param WsCallerResolver|null $callerResolver Reads the caller off a handshake. Defaults to one
+     *                                              built from the environment.
+     * @param TestRunPolicy|null    $policy         Answers whether a caller may start a run. Defaults
+     *                                              to the coarse role check.
      */
-    public function __construct()
+    public function __construct(?WsCallerResolver $callerResolver = null, ?TestRunPolicy $policy = null)
     {
         $this->clients = new \SplObjectStorage();
 
@@ -378,6 +402,11 @@ class Health implements MessageComponentInterface
         if (false === isset(Router::$apiFilePath)) {
             Router::getApiPaths();
         }
+
+        // After the path guard above, deliberately: neither of these resolves a path today, but that
+        // comment is there to stop code migrating above it, and this is code.
+        $this->callerResolver = $callerResolver ?? WsCallerResolver::fromEnv();
+        $this->policy         = $policy ?? new TestRunPolicy();
 
         // A server that cannot validate is misconfigured, and should fail here — where an operator
         // sees it, before a client ever connects — rather than answering every message with an
@@ -434,10 +463,22 @@ class Health implements MessageComponentInterface
             echo "New connection! ({$conn->resourceId}) and current working directory is " . getcwd() . "\n";
         }
 
+        // Who is calling, settled here and nowhere else — #894. The handshake is the only moment the
+        // credential is on the wire, because a WebSocket frame carries no headers.
+        //
+        // `httpRequest` is a dynamic property Ratchet's `WsServer` assigns to the wrapped connection,
+        // reached through `AbstractConnectionDecorator::__get()`. It is a PSR-7 `RequestInterface`
+        // rather than a `ServerRequestInterface`, which is why the resolver parses the `Cookie:`
+        // header itself. A connection without one — every test stub, and any future transport — reads
+        // as anonymous rather than erroring.
+        $handshake                        = isset($conn->httpRequest) ? $conn->httpRequest : null;
+        $caller                           = $this->callerResolver->fromHandshake($handshake instanceof RequestInterface ? $handshake : null);
+        $this->callers[$conn->resourceId] = $caller;
+
         // Announce the contract before anything is asked of the client — #806 section F. Sent here,
         // ahead of the cache and metadata bootstrapping below, because those are this server's
         // concerns and neither gates the client's ability to read this frame.
-        $this->sendMessage($conn, $this->helloFrame());
+        $this->sendMessage($conn, $this->helloFrame($caller));
 
         // Initialize Router paths before creating logger (LoggerFactory needs Router::$apiFilePath)
         Router::getApiPaths();
@@ -631,7 +672,7 @@ class Health implements MessageComponentInterface
      * dispatch that UnitTestInterface#46 made paint an unrecognised type as a failed check. Sending
      * this frame at any other moment would break the live UI. Pinned by `HealthHelloFrameTest`.
      */
-    private function helloFrame(): \stdClass
+    private function helloFrame(WsCaller $caller): \stdClass
     {
         $capabilities                  = new \stdClass();
         $capabilities->rites           = array_column(Rite::cases(), 'value');
@@ -646,6 +687,26 @@ class Health implements MessageComponentInterface
         // would have been accepted learns it from the refusal, which names them.
         $frame->protocol     = max(WebSocketMessageValidator::SUPPORTED_PROTOCOL_VERSIONS);
         $frame->capabilities = $capabilities;
+
+        // A **sibling** of `capabilities`, deliberately — #894. That object answers what this server
+        // can be asked for, with every entry derived from the enum that already defines it so that an
+        // advertisement cannot go stale against the behaviour it describes. Who is asking is
+        // per-connection and derived from a cookie, so putting it there would quietly break the one
+        // property `capabilities` is built to have.
+        //
+        // The permission is read from the same {@see TestRunPolicy} that refuses the actions in
+        // `onMessage()`, and that is the entire point of sending it: a client that renders its run
+        // controls from this cannot disagree with the server about who may run. UnitTestInterface
+        // used to decide for itself, from a role list of its own, and its own CLAUDE.md recorded the
+        // resulting gate as client-side only.
+        $permissions           = new \stdClass();
+        $permissions->runTests = $this->policy->mayRun($caller);
+
+        $callerFrame                = new \stdClass();
+        $callerFrame->authenticated = $caller->authenticated;
+        $callerFrame->permissions   = $permissions;
+
+        $frame->caller = $callerFrame;
 
         return $frame;
     }
@@ -980,6 +1041,7 @@ class Health implements MessageComponentInterface
         unset($this->clients[$conn]);
         unset($this->cacheHitCounters[$resourceId]);
         unset($this->runTokens[$resourceId]);
+        unset($this->callers[$resourceId]);
         echo "Connection {$resourceId} has disconnected\n";
     }
 

--- a/src/Health.php
+++ b/src/Health.php
@@ -28,6 +28,7 @@ use LiturgicalCalendar\Api\Enum\Step;
 use LiturgicalCalendar\Api\Http\Enum\ReturnTypeParam;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use LiturgicalCalendar\Api\Models\Auth\TestTarget;
 use LiturgicalCalendar\Api\Models\Auth\WsCaller;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
@@ -740,6 +741,30 @@ class Health implements MessageComponentInterface
         // the second.
         $protocolViolation = WebSocketMessageValidator::protocolViolation($messageReceived);
 
+        // May this caller start a run at all — #894. Decided here and answered below, for exactly the
+        // reason `$protocolViolation` above is.
+        //
+        // The **question** has to be asked here, because the run-token block immediately below
+        // installs a token and can rebuild the checkable inventory, and a caller this server is about
+        // to refuse must be able to do neither. The **answer** waits until `$requestId` has been
+        // read, so the refusal reaches the client correlated to the request it is waiting on.
+        //
+        // This is the coarse question only: it depends on the caller, not on the message, which is
+        // what makes it answerable before the message is understood. The target-scoped question is
+        // asked further down, once the message has been validated and its target can be trusted —
+        // a permission decision must not rest on a field read out of an unvalidated blob.
+        //
+        // A connection with no entry here — one that never went through `onOpen()` — reads as
+        // anonymous. That direction is deliberate and load-bearing: the unknown case must fail
+        // closed.
+        $caller            = $this->callers[$resourceId] ?? WsCaller::anonymous();
+        $permissionRefusal = null;
+        if (null === $protocolViolation && false === $this->policy->mayRun($caller)) {
+            $permissionRefusal = $caller->authenticated
+                ? [ProtocolErrorCode::INSUFFICIENT_ROLE, 'This account may not start validation runs. Ask an administrator to grant the test_editor role.']
+                : [ProtocolErrorCode::NOT_AUTHENTICATED, 'Log in to start validation runs.'];
+        }
+
         // The run token the message declares, as opposed to the one this connection is on. Needed
         // because a message refused for its protocol never gets its token stored, and a rejection
         // frame carrying no token is dropped by the shipped clients — they discard any frame whose
@@ -753,6 +778,9 @@ class Health implements MessageComponentInterface
         // the queue of the run that replaced it.
         if (
             null === $protocolViolation
+            // Beside the protocol check, and for the same reason: this block mutates run state, and
+            // a message that is about to be refused must not reach it — #894.
+            && null === $permissionRefusal
             &&
             $messageReceived instanceof \stdClass
             && property_exists($messageReceived, 'action')
@@ -839,6 +867,18 @@ class Health implements MessageComponentInterface
             return;
         }
 
+        // The answer to the question asked at the top of this method — #894. Here rather than there
+        // so it carries `requestId`, and behind the protocol check because a message this server
+        // cannot read is not a message whose caller it can meaningfully judge.
+        if (null !== $permissionRefusal) {
+            [$refusalCode, $refusalText] = $permissionRefusal;
+            // The connection id has no reader on the wire; it is server-internal state and belongs in
+            // the log line, not in prose a client has to parse or display.
+            echo sprintf('Refused %1$s from connection %2$d', $refusalCode->value, $resourceId);
+            $this->rejectMessage($from, $refusalCode, $refusalText, requestId: $requestId, runToken: $declaredRunToken);
+            return;
+        }
+
         if (
             json_last_error() === JSON_ERROR_NONE
             && $messageReceived instanceof \stdClass
@@ -882,6 +922,29 @@ class Health implements MessageComponentInterface
             && $messageReceived instanceof \stdClass
             && property_exists($messageReceived, 'action')
         ) {
+            // The seam the coarse check at the top of this method deliberately left open — #894.
+            //
+            // Asked *here* rather than there because a target read from an unvalidated message is a
+            // guess, and a permission decision must not rest on one: by this point the message has
+            // been through the schema, so `calendar.kind` and `calendar.rite` are what they claim.
+            //
+            // The coarse policy answers this the same way it answered above, so today this refuses
+            // nothing. It is not dead code: a fine-grained policy — one resolving the target through
+            // `TestScopeResolver` to a `*_test` object and asking OpenFGA — changes only which
+            // object `mayRun()` is, and this call site is what makes that a one-class change rather
+            // than a protocol change.
+            $target = TestTarget::fromMessage($messageReceived);
+            if (null !== $target && false === $this->policy->mayRun($caller, $target)) {
+                echo sprintf('Refused %1$s for a named target from connection %2$d', ProtocolErrorCode::INSUFFICIENT_ROLE->value, $resourceId);
+                $this->rejectMessage(
+                    $from,
+                    ProtocolErrorCode::INSUFFICIENT_ROLE,
+                    'This account may not start validation runs for the calendar this message names.',
+                    requestId: $requestId
+                );
+                return;
+            }
+
             try {
                 switch ($messageReceived->action) {
                     case 'executeValidation':

--- a/src/Http/Middleware/OidcAuthMiddleware.php
+++ b/src/Http/Middleware/OidcAuthMiddleware.php
@@ -6,16 +6,12 @@ namespace LiturgicalCalendar\Api\Http\Middleware;
 
 use Firebase\JWT\CachedKeySet;
 use Firebase\JWT\JWT;
-use GuzzleHttp\Client;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Middleware;
-use GuzzleHttp\Psr7\HttpFactory;
-use Psr\Http\Message\RequestInterface;
 use LiturgicalCalendar\Api\Http\CookieHelper;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Models\Auth\User;
 use LiturgicalCalendar\Api\Services\JwtServiceFactory;
-use LiturgicalCalendar\Api\Services\ZitadelHostHeader;
+use LiturgicalCalendar\Api\Services\ZitadelKeySetFactory;
+use LiturgicalCalendar\Api\Services\ZitadelRoles;
 use LiturgicalCalendar\Api\Services\ZitadelService;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use Psr\Http\Message\ServerRequestInterface;
@@ -44,13 +40,6 @@ class OidcAuthMiddleware implements MiddlewareInterface
     private int $cacheTtl;
     private bool $jwtFallback;
     private LoggerInterface $logger;
-
-    /**
-     * Cached JWKS key sets, keyed by issuer URL.
-     *
-     * @var array<string, CachedKeySet>
-     */
-    private static array $keySets = [];
 
     /**
      * Create the OIDC authentication middleware.
@@ -324,45 +313,7 @@ class OidcAuthMiddleware implements MiddlewareInterface
      */
     private function getKeySet(): CachedKeySet
     {
-        if (isset(self::$keySets[$this->issuer])) {
-            return self::$keySets[$this->issuer];
-        }
-
-        $jwksUri = $this->issuer . '/oauth/v2/keys';
-
-        if ($this->internalUrl !== null) {
-            // Rewrite JWKS URI to use internal URL for Docker networking
-            $jwksUri = $this->internalUrl . '/oauth/v2/keys';
-
-            // CachedKeySet uses PSR-18 sendRequest() which doesn't apply Guzzle's
-            // default headers. Use middleware to inject the Host header so Zitadel
-            // accepts requests sent to the Docker service name.
-            $hostHeader = ZitadelHostHeader::deriveFromIssuer($this->issuer);
-            $stack      = HandlerStack::create();
-            $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($hostHeader) {
-                return $request->withHeader('Host', $hostHeader);
-            }));
-            $httpClient = new Client(['handler' => $stack]);
-        } else {
-            $httpClient = new Client();
-        }
-        $httpFactory = new HttpFactory();
-
-        // Use filesystem cache for JWKS (PSR-6 compatible)
-        $cacheDir = dirname(__DIR__, 3) . '/cache';
-        $cache    = new FilesystemAdapter('jwks', $this->cacheTtl, $cacheDir);
-
-        // Create cached key set
-        self::$keySets[$this->issuer] = new CachedKeySet(
-            $jwksUri,
-            $httpClient,
-            $httpFactory,
-            $cache,
-            $this->cacheTtl,
-            true // Rate limit JWKS fetches
-        );
-
-        return self::$keySets[$this->issuer];
+        return ZitadelKeySetFactory::for($this->issuer, $this->internalUrl, $this->cacheTtl);
     }
 
     /**
@@ -392,22 +343,11 @@ class OidcAuthMiddleware implements MiddlewareInterface
             'preferred_username' => is_string($preferredUsername) ? $preferredUsername : null,
         ];
 
-        // Zitadel-specific: Extract project roles
-        // Zitadel uses the claim: urn:zitadel:iam:org:project:roles
-        $rolesClaimKey = 'urn:zitadel:iam:org:project:roles';
+        // Zitadel-specific: Extract project roles. Shared with the WebSocket server's caller
+        // resolver, so that the HTTP path and the WebSocket path cannot read the same token's roles
+        // differently and authorize the same person differently.
         /** @var array<string> $roles */
-        $roles = [];
-
-        if (isset($payload->{$rolesClaimKey})) {
-            // Zitadel returns roles as object with role name as key
-            // e.g., {"admin": {"org_id": "123"}, "developer": {"org_id": "123"}}
-            $rolesData = (array) $payload->{$rolesClaimKey};
-            foreach (array_keys($rolesData) as $role) {
-                if (is_string($role)) {
-                    $roles[] = $role;
-                }
-            }
-        }
+        $roles = ZitadelRoles::fromPayload($payload);
 
         // If roles are not present in the token (e.g., JWT Profile grant for service accounts),
         // look them up via the Zitadel Management API with a short-lived cache
@@ -518,6 +458,6 @@ class OidcAuthMiddleware implements MiddlewareInterface
      */
     public static function resetKeySetCache(): void
     {
-        self::$keySets = [];
+        ZitadelKeySetFactory::reset();
     }
 }

--- a/src/Models/Auth/TestTarget.php
+++ b/src/Models/Auth/TestTarget.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\Auth;
+
+/**
+ * What a message wants validated, in the terms a permission check would need.
+ *
+ * Threaded through {@see \LiturgicalCalendar\Api\Services\TestRunPolicy::mayRun()} from day one even
+ * though the coarse policy ignores it. Adding the parameter later — at the moment a fine-grained
+ * policy arrives — would mean moving plumbing through every call site in the same change that alters
+ * who may do what, which is the worst possible time to be doing it.
+ */
+final readonly class TestTarget
+{
+    public function __construct(
+        public ?string $kind,
+        public ?string $rite,
+        public ?string $calendarId
+    ) {
+    }
+
+    /**
+     * Read the target off a message, or null when the message names none.
+     *
+     * Takes `mixed` for the same reason {@see \LiturgicalCalendar\Api\Health::declaredCorrelationId()}
+     * does: the caller holds a raw `json_decode()` result, and narrowing it here would narrow it for
+     * every guard downstream.
+     */
+    public static function fromMessage(mixed $message): ?self
+    {
+        if (false === $message instanceof \stdClass || false === property_exists($message, 'calendar')) {
+            return null;
+        }
+
+        $calendar = $message->calendar;
+        if (false === $calendar instanceof \stdClass) {
+            return null;
+        }
+
+        $read = static function (string $property) use ($calendar): ?string {
+            if (false === property_exists($calendar, $property)) {
+                return null;
+            }
+
+            $value = $calendar->{$property};
+
+            return is_string($value) ? $value : null;
+        };
+
+        $kind = $read('kind');
+        $rite = $read('rite');
+        // The id property is named for the kind it belongs to; the first one present wins.
+        $calendarId = $read('calendar') ?? $read('nation') ?? $read('diocese');
+
+        if (null === $kind && null === $rite && null === $calendarId) {
+            return null;
+        }
+
+        return new self($kind, $rite, $calendarId);
+    }
+}

--- a/src/Models/Auth/WsCaller.php
+++ b/src/Models/Auth/WsCaller.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Models\Auth;
+
+/**
+ * The identity of one WebSocket connection, settled once at handshake time.
+ *
+ * Settled *once* rather than per message because the handshake is the only moment the credential is
+ * on the wire: a WebSocket frame carries no headers, so a connection that was not identified as it
+ * opened can never be identified afterwards.
+ *
+ * Anonymity is a state here, not a failure. {@see \LiturgicalCalendar\Api\Services\WsCallerResolver}
+ * answers with an anonymous caller for a missing cookie, an expired token and a forged one alike,
+ * because the connection is accepted either way and the refusal happens per action — see
+ * {@see \LiturgicalCalendar\Api\Services\TestRunPolicy}.
+ */
+final readonly class WsCaller
+{
+    /**
+     * @param array<int, string> $roles
+     */
+    private function __construct(
+        public bool $authenticated,
+        public ?string $sub,
+        public array $roles
+    ) {
+    }
+
+    public static function anonymous(): self
+    {
+        return new self(false, null, []);
+    }
+
+    /**
+     * @param array<int, string> $roles
+     */
+    public static function authenticated(string $sub, array $roles): self
+    {
+        /** @var array<int, string> $clean */
+        $clean = array_values(array_unique(array_filter($roles, 'is_string')));
+
+        return new self(true, $sub, $clean);
+    }
+
+    public function hasAnyRole(string ...$roles): bool
+    {
+        return [] !== array_intersect($roles, $this->roles);
+    }
+}

--- a/src/Services/TestRunPolicy.php
+++ b/src/Services/TestRunPolicy.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Models\Auth\TestTarget;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+
+/**
+ * Whether a caller may start a validation run.
+ *
+ * One object, asked by both the `hello` frame and the action gate in {@see \LiturgicalCalendar\Api\Health},
+ * so the advertisement and the enforcement cannot disagree. That is the whole point: the gap #894
+ * closes is not that UnitTestInterface asked the wrong question, but that it answered its own — a
+ * role test in the client can drift from the one the server would apply, and a disabled button is
+ * not a gate at all.
+ *
+ * Not `final`, deliberately. A fine-grained implementation subclasses this to resolve `$target`
+ * through {@see TestScopeResolver} to a `*_test` object and ask OpenFGA; the seam exists so that
+ * arriving changes one class rather than a protocol.
+ */
+class TestRunPolicy
+{
+    /**
+     * The roles permitted to start a run.
+     *
+     * The same pair UnitTestInterface enforces in `JwtAuth::RUN_TESTS_ROLES` when storing a run's
+     * result, so that "may start a run" and "may store its result" stay the same question. They are
+     * not shared through a package and must not be: a constant copied into two repositories is
+     * precisely how the two answers would drift. This server answers, and the client is told — see
+     * the `caller` object on the `hello` frame.
+     *
+     * @var array<int, string>
+     */
+    public const RUN_TESTS_ROLES = ['admin', 'test_editor'];
+
+    /**
+     * @param TestTarget|null $target What the message wants validated, when it names anything.
+     *                                Accepted and ignored by this coarse implementation.
+     */
+    public function mayRun(WsCaller $caller, ?TestTarget $target = null): bool
+    {
+        if (false === $caller->authenticated) {
+            return false;
+        }
+
+        return $caller->hasAnyRole(...self::RUN_TESTS_ROLES);
+    }
+}

--- a/src/Services/WsCallerResolver.php
+++ b/src/Services/WsCallerResolver.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use Firebase\JWT\JWT;
+use LiturgicalCalendar\Api\Http\CookieHelper;
+use LiturgicalCalendar\Api\Models\Auth\WsCaller;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * Who is on the other end of a WebSocket handshake.
+ *
+ * Two things make this a separate service rather than a reuse of
+ * {@see \LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware}:
+ *
+ *  1. The handshake carries a PSR-7 **`RequestInterface`**, not a `ServerRequestInterface` — Ratchet's
+ *     `WsServer` assigns the raw upgrade request — so there is no `getCookieParams()` and the
+ *     `Cookie:` header is parsed here.
+ *  2. It runs inside a single-threaded ReactPHP loop, so it must not make a network call per
+ *     connection. Roles are read from the token claim only; the Zitadel Management API lookup that
+ *     `OidcAuthMiddleware` falls back to when a token carries no roles claim is deliberately absent.
+ *     A token issued without that claim therefore reads as authenticated with no roles, and is
+ *     refused — which is the fail-closed direction, and the only one acceptable here.
+ *
+ * Every failure yields {@see WsCaller::anonymous()}. Nothing here throws and nothing here closes a
+ * connection: the connection is accepted either way, and the refusal happens per action.
+ */
+final class WsCallerResolver
+{
+    public function __construct(
+        private readonly ?JwtService $jwtService,
+        private readonly ?string $issuer,
+        private readonly ?string $internalUrl,
+        private readonly int $cacheTtl = 3600
+    ) {
+    }
+
+    /**
+     * Build from the environment, degrading rather than throwing.
+     *
+     * A missing `JWT_SECRET` or a missing `ZITADEL_ISSUER` disables that one verification path and
+     * leaves the other working. Disabling both is legal and means every caller is anonymous — safe,
+     * but total, which is why {@see self::describeAvailablePaths()} exists to say so at startup.
+     */
+    public static function fromEnv(): self
+    {
+        try {
+            $jwtService = JwtServiceFactory::fromEnv();
+        } catch (\Throwable) {
+            $jwtService = null;
+        }
+
+        // Both tables are consulted for the same reason OidcAuthMiddleware consults both: Dotenv does
+        // not always populate putenv().
+        $issuerEnv      = getenv('ZITADEL_ISSUER') ?: ( $_ENV['ZITADEL_ISSUER'] ?? '' );
+        $internalUrlEnv = getenv('ZITADEL_INTERNAL_URL') ?: ( $_ENV['ZITADEL_INTERNAL_URL'] ?? '' );
+
+        $issuer      = is_string($issuerEnv) && '' !== $issuerEnv ? $issuerEnv : null;
+        $internalUrl = is_string($internalUrlEnv) && '' !== $internalUrlEnv ? $internalUrlEnv : null;
+
+        return new self($jwtService, $issuer, $internalUrl);
+    }
+
+    public function fromHandshake(?RequestInterface $request): WsCaller
+    {
+        if (null === $request) {
+            return WsCaller::anonymous();
+        }
+
+        $cookies = self::parseCookieHeader($request->getHeaderLine('Cookie'));
+        $token   = CookieHelper::getAccessToken($cookies);
+
+        if (null === $token || '' === $token) {
+            return WsCaller::anonymous();
+        }
+
+        return $this->fromToken($token);
+    }
+
+    /**
+     * Zitadel first, legacy second — the same order `OidcAuthMiddleware` uses, and for the same
+     * reason: a live deployment issues RS256, while HS256 tokens still exist and still work.
+     */
+    public function fromToken(string $token): WsCaller
+    {
+        if (null !== $this->issuer) {
+            try {
+                $payload = JWT::decode(
+                    $token,
+                    ZitadelKeySetFactory::for($this->issuer, $this->internalUrl, $this->cacheTtl)
+                );
+                $sub     = $payload->sub ?? null;
+                if (is_string($sub) && '' !== $sub) {
+                    return WsCaller::authenticated($sub, ZitadelRoles::fromPayload($payload));
+                }
+            } catch (\Throwable) {
+                // Not a Zitadel token, or the key set is unreachable. Either way this is not the
+                // place to distinguish them: fall through to the legacy path, and if that also
+                // declines, the caller is anonymous.
+            }
+        }
+
+        if (null !== $this->jwtService) {
+            try {
+                $payload = $this->jwtService->verify($token);
+            } catch (\Throwable) {
+                // `JwtService::verify()` catches the four JWT exceptions it expects, but
+                // `JWT::decode()` also throws a bare `DomainException` for a payload that is not
+                // valid UTF-8 — which any sufficiently mangled token produces. On the HTTP side that
+                // surfaces as a 500 through the error middleware; here it would escape `onOpen()`
+                // into the event loop, so it is caught and read as what it is: not a token.
+                $payload = null;
+            }
+
+            if (null !== $payload) {
+                $sub = $payload->sub ?? null;
+                if (is_string($sub) && '' !== $sub) {
+                    $roles = $payload->roles ?? [];
+                    /** @var array<int, string> $roleList */
+                    $roleList = is_array($roles) ? array_values(array_filter($roles, 'is_string')) : [];
+
+                    return WsCaller::authenticated($sub, $roleList);
+                }
+            }
+        }
+
+        return WsCaller::anonymous();
+    }
+
+    /**
+     * Parse a `Cookie:` header into a name => value map.
+     *
+     * Hand-rolled because the handshake request is a `RequestInterface`, which has no cookie
+     * accessor at all. The shape is deliberately the one `CookieHelper` already expects, so the
+     * cookie's *name* stays defined in exactly one place.
+     *
+     * @return array<string, string>
+     */
+    public static function parseCookieHeader(string $header): array
+    {
+        $cookies = [];
+
+        foreach (explode(';', $header) as $pair) {
+            $pair = trim($pair);
+            if ('' === $pair || false === str_contains($pair, '=')) {
+                continue;
+            }
+
+            [$name, $value] = explode('=', $pair, 2);
+
+            $name = trim($name);
+            if ('' === $name) {
+                continue;
+            }
+
+            $cookies[$name] = urldecode(trim($value));
+        }
+
+        return $cookies;
+    }
+
+    /**
+     * Fetch the JWKS once, off the event loop, so `onOpen()` never pays for it.
+     *
+     * @return bool Whether a key set was reached. False means RS256 verification is unavailable or
+     *              not configured; it is never a reason to refuse to start the server.
+     */
+    public function warmKeySet(): bool
+    {
+        if (null === $this->issuer) {
+            return false;
+        }
+
+        try {
+            $keySet = ZitadelKeySetFactory::for($this->issuer, $this->internalUrl, $this->cacheTtl);
+            // offsetExists() drives the fetch without needing to know a key id in advance. The
+            // answer is irrelevant; reaching the endpoint at all is the point.
+            $keySet->offsetExists('warm');
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * Which verification paths are live, for a startup log line.
+     *
+     * A deployment that has silently lost one of them degrades every caller it would have verified to
+     * anonymous. That is the safe direction, but it is total and it is invisible from the outside —
+     * every user simply stops being able to run anything — so the server says which paths it has.
+     */
+    public function describeAvailablePaths(): string
+    {
+        $paths = [];
+
+        if (null !== $this->issuer) {
+            $paths[] = 'Zitadel RS256';
+        }
+
+        if (null !== $this->jwtService) {
+            $paths[] = 'legacy HS256';
+        }
+
+        return [] === $paths ? 'none (every caller will be anonymous)' : implode(' + ', $paths);
+    }
+}

--- a/src/Services/WsCallerResolver.php
+++ b/src/Services/WsCallerResolver.php
@@ -29,12 +29,84 @@ use Psr\Http\Message\RequestInterface;
  */
 final class WsCallerResolver
 {
+    /**
+     * @param string|null $clientId  Zitadel client id, accepted as a token audience.
+     * @param string|null $projectId Zitadel project id, also accepted — Zitadel puts it in `aud` for
+     *                               machine-to-machine tokens where a user token carries the client id.
+     */
     public function __construct(
         private readonly ?JwtService $jwtService,
         private readonly ?string $issuer,
         private readonly ?string $internalUrl,
-        private readonly int $cacheTtl = 3600
+        private readonly int $cacheTtl = 3600,
+        private readonly ?string $clientId = null,
+        private readonly ?string $projectId = null
     ) {
+    }
+
+    /**
+     * Whether a decoded Zitadel payload was actually issued *to this application, by this provider*.
+     *
+     * A signature proves a token is genuine, not that it is meant for you. Zitadel signs every token
+     * in an instance with the same keys, so without this check any correctly-signed token from any
+     * other application in the same instance verifies here — and if it happens to carry `admin` or
+     * `test_editor` among its project roles, it is handed permission to start runs. That is a
+     * confused-deputy hole, not a theoretical one.
+     *
+     * `OidcAuthMiddleware::tryOidcValidation()` performs exactly these two checks after decoding;
+     * this is the same rule, kept as a pure function so both the WebSocket path and its tests can
+     * reach it without a live provider.
+     *
+     * @param array<int, string> $validAudiences The client id and project id, empty entries removed.
+     */
+    public static function isIntendedFor(object $payload, string $issuer, array $validAudiences): bool
+    {
+        // An unconfigured audience list would accept everything, so it accepts nothing instead.
+        if ([] === $validAudiences) {
+            return false;
+        }
+
+        $iss = $payload->iss ?? null;
+        if (false === is_string($iss) || rtrim($iss, '/') !== rtrim($issuer, '/')) {
+            return false;
+        }
+
+        $aud = $payload->aud ?? null;
+
+        if (is_string($aud)) {
+            return in_array($aud, $validAudiences, true);
+        }
+
+        if (is_array($aud)) {
+            return [] !== array_intersect(array_filter($aud, 'is_string'), $validAudiences);
+        }
+
+        return false;
+    }
+
+    /**
+     * The audiences a token may name to be accepted here.
+     *
+     * @return array<int, string>
+     */
+    private function validAudiences(): array
+    {
+        return array_values(array_filter(
+            [$this->clientId, $this->projectId],
+            static fn(?string $v): bool => is_string($v) && '' !== $v
+        ));
+    }
+
+    /**
+     * Whether the RS256 path can reach a trustworthy verdict at all.
+     *
+     * An issuer with no audience to check against cannot: it could verify that a token is genuine but
+     * not that it was meant for this application, and accepting on that basis is worse than not
+     * accepting at all. So the path is reported and treated as unavailable rather than as permissive.
+     */
+    private function zitadelUsable(): bool
+    {
+        return null !== $this->issuer && [] !== $this->validAudiences();
     }
 
     /**
@@ -56,11 +128,15 @@ final class WsCallerResolver
         // not always populate putenv().
         $issuerEnv      = getenv('ZITADEL_ISSUER') ?: ( $_ENV['ZITADEL_ISSUER'] ?? '' );
         $internalUrlEnv = getenv('ZITADEL_INTERNAL_URL') ?: ( $_ENV['ZITADEL_INTERNAL_URL'] ?? '' );
+        $clientIdEnv    = getenv('ZITADEL_CLIENT_ID') ?: ( $_ENV['ZITADEL_CLIENT_ID'] ?? '' );
+        $projectIdEnv   = getenv('ZITADEL_PROJECT_ID') ?: ( $_ENV['ZITADEL_PROJECT_ID'] ?? '' );
 
         $issuer      = is_string($issuerEnv) && '' !== $issuerEnv ? $issuerEnv : null;
         $internalUrl = is_string($internalUrlEnv) && '' !== $internalUrlEnv ? $internalUrlEnv : null;
+        $clientId    = is_string($clientIdEnv) && '' !== $clientIdEnv ? $clientIdEnv : null;
+        $projectId   = is_string($projectIdEnv) && '' !== $projectIdEnv ? $projectIdEnv : null;
 
-        return new self($jwtService, $issuer, $internalUrl);
+        return new self($jwtService, $issuer, $internalUrl, 3600, $clientId, $projectId);
     }
 
     public function fromHandshake(?RequestInterface $request): WsCaller
@@ -85,14 +161,20 @@ final class WsCallerResolver
      */
     public function fromToken(string $token): WsCaller
     {
-        if (null !== $this->issuer) {
+        if (null !== $this->issuer && $this->zitadelUsable()) {
             try {
                 $payload = JWT::decode(
                     $token,
                     ZitadelKeySetFactory::for($this->issuer, $this->internalUrl, $this->cacheTtl)
                 );
                 $sub     = $payload->sub ?? null;
-                if (is_string($sub) && '' !== $sub) {
+                // The signature says the token is genuine; `isIntendedFor()` says it was issued to
+                // this application. Both are required, and skipping the second would accept any
+                // correctly-signed token from any other app in the same Zitadel instance.
+                if (
+                    is_string($sub) && '' !== $sub
+                    && self::isIntendedFor($payload, $this->issuer, $this->validAudiences())
+                ) {
                     return WsCaller::authenticated($sub, ZitadelRoles::fromPayload($payload));
                 }
             } catch (\Throwable) {
@@ -169,7 +251,9 @@ final class WsCallerResolver
      */
     public function warmKeySet(): bool
     {
-        if (null === $this->issuer) {
+        // Nothing to warm for a path that will not be used. Warming an unaudienced issuer would
+        // fetch keys this resolver has already decided it cannot trust a token against.
+        if (null === $this->issuer || false === $this->zitadelUsable()) {
             return false;
         }
 
@@ -196,8 +280,12 @@ final class WsCallerResolver
     {
         $paths = [];
 
-        if (null !== $this->issuer) {
+        if ($this->zitadelUsable()) {
             $paths[] = 'Zitadel RS256';
+        } elseif (null !== $this->issuer) {
+            // Named explicitly, because this is the configuration most likely to look correct and
+            // behave as though Zitadel were switched off: an issuer is set, so nothing looks missing.
+            $paths[] = 'Zitadel RS256 DISABLED (ZITADEL_ISSUER is set but neither ZITADEL_CLIENT_ID nor ZITADEL_PROJECT_ID is, so no token audience can be checked)';
         }
 
         if (null !== $this->jwtService) {

--- a/src/Services/ZitadelKeySetFactory.php
+++ b/src/Services/ZitadelKeySetFactory.php
@@ -24,6 +24,28 @@ use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 final class ZitadelKeySetFactory
 {
     /**
+     * Finite timeouts for the JWKS fetch.
+     *
+     * Guzzle's defaults for both options are `0`, meaning "wait indefinitely", and `CachedKeySet`
+     * fetches **synchronously** from inside `JWT::decode()` whenever it meets an unknown `kid` or a
+     * cold cache. In the HTTP API that blocks one php-fpm worker; in the WebSocket server it blocks
+     * the entire Ratchet event loop, for every connected client at once, until the socket gives up.
+     *
+     * A refused connection fails instantly and was never the hazard. A provider that accepts the
+     * connection and then goes quiet — a blackholing firewall, an overloaded node — is, and it is
+     * indistinguishable from a healthy one until the timeout that did not exist expires.
+     *
+     * Kept short deliberately: a JWKS fetch that has taken four seconds is not going to produce a
+     * useful answer, and the failure path is anonymous rather than broken.
+     *
+     * @var array{connect_timeout: float, timeout: float}
+     */
+    public const HTTP_OPTIONS = [
+        'connect_timeout' => 2.0,
+        'timeout'         => 4.0,
+    ];
+
+    /**
      * Cached key sets, keyed by issuer URL, so several OIDC providers can coexist.
      *
      * @var array<string, CachedKeySet>
@@ -51,9 +73,9 @@ final class ZitadelKeySetFactory
             $stack->push(Middleware::mapRequest(
                 static fn(RequestInterface $request): RequestInterface => $request->withHeader('Host', $hostHeader)
             ));
-            $httpClient = new Client(['handler' => $stack]);
+            $httpClient = new Client(self::HTTP_OPTIONS + ['handler' => $stack]);
         } else {
-            $httpClient = new Client();
+            $httpClient = new Client(self::HTTP_OPTIONS);
         }
 
         // Note the depth: from src/Services/ the project root is two levels up, where it was three

--- a/src/Services/ZitadelKeySetFactory.php
+++ b/src/Services/ZitadelKeySetFactory.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use Firebase\JWT\CachedKeySet;
+use GuzzleHttp\Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Middleware;
+use GuzzleHttp\Psr7\HttpFactory;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+/**
+ * Builds and memoizes the Zitadel JWKS key set.
+ *
+ * Shared by {@see \LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware} and
+ * {@see WsCallerResolver} so that both reach the same filesystem cache. That sharing is not merely
+ * tidy: the WebSocket server verifies tokens from inside a single-threaded ReactPHP loop, where a
+ * JWKS fetch stalls every other connection for its duration, so a key the HTTP API has already
+ * fetched is a key the WebSocket server does not have to.
+ */
+final class ZitadelKeySetFactory
+{
+    /**
+     * Cached key sets, keyed by issuer URL, so several OIDC providers can coexist.
+     *
+     * @var array<string, CachedKeySet>
+     */
+    private static array $keySets = [];
+
+    public static function for(string $issuer, ?string $internalUrl = null, int $cacheTtl = 3600): CachedKeySet
+    {
+        $issuer = rtrim($issuer, '/');
+
+        if (isset(self::$keySets[$issuer])) {
+            return self::$keySets[$issuer];
+        }
+
+        $jwksUri = $issuer . '/oauth/v2/keys';
+
+        if (null !== $internalUrl && '' !== $internalUrl) {
+            // Rewrite the JWKS URI to the internal URL for Docker networking. CachedKeySet uses
+            // PSR-18 sendRequest(), which does not apply Guzzle's default headers, so the Host header
+            // is injected by middleware or Zitadel refuses a request addressed to the compose
+            // service name.
+            $jwksUri    = rtrim($internalUrl, '/') . '/oauth/v2/keys';
+            $hostHeader = ZitadelHostHeader::deriveFromIssuer($issuer);
+            $stack      = HandlerStack::create();
+            $stack->push(Middleware::mapRequest(
+                static fn(RequestInterface $request): RequestInterface => $request->withHeader('Host', $hostHeader)
+            ));
+            $httpClient = new Client(['handler' => $stack]);
+        } else {
+            $httpClient = new Client();
+        }
+
+        // Note the depth: from src/Services/ the project root is two levels up, where it was three
+        // from src/Http/Middleware/. Both must land on the same directory or the two callers would
+        // keep separate caches and the sharing above would be a fiction.
+        $cacheDir = dirname(__DIR__, 2) . '/cache';
+
+        self::$keySets[$issuer] = new CachedKeySet(
+            $jwksUri,
+            $httpClient,
+            new HttpFactory(),
+            new FilesystemAdapter('jwks', $cacheTtl, $cacheDir),
+            $cacheTtl,
+            true // Rate limit JWKS fetches
+        );
+
+        return self::$keySets[$issuer];
+    }
+
+    /**
+     * Drop every memoized key set. Useful for testing.
+     */
+    public static function reset(): void
+    {
+        self::$keySets = [];
+    }
+}

--- a/src/Services/ZitadelRoles.php
+++ b/src/Services/ZitadelRoles.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+/**
+ * The Zitadel project-roles claim, read the one way.
+ *
+ * Zitadel returns roles as an object keyed by role name — `{"admin": {"org_id": "1"}}` — so the role
+ * names are the *keys*, not the values. Reading it as a list is the mistake this class exists to
+ * stop being made twice: {@see \LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware} and
+ * {@see WsCallerResolver} both need the answer, and a caller whose roles are read differently by the
+ * HTTP path and the WebSocket path is authorized differently by each.
+ */
+final class ZitadelRoles
+{
+    public const CLAIM = 'urn:zitadel:iam:org:project:roles';
+
+    /**
+     * @return array<int, string>
+     */
+    public static function fromPayload(object $payload): array
+    {
+        if (false === isset($payload->{self::CLAIM})) {
+            return [];
+        }
+
+        $claim = $payload->{self::CLAIM};
+        if (false === is_object($claim) && false === is_array($claim)) {
+            return [];
+        }
+
+        /** @var array<int, string> $roles */
+        $roles = array_values(array_filter(array_keys((array) $claim), 'is_string'));
+
+        return $roles;
+    }
+}


### PR DESCRIPTION
Closes #894.

`Health::onOpen()` accepted any connection, and `onMessage()` dispatched `validateSource`,
`executeValidation`, `validateCalendar`, `runTest` and `cancelRun` on that basis alone. This
identifies the caller from the handshake cookie, advertises what they may do on the `hello` frame,
and refuses every run-starting action from a caller that may not run one.

## The connection is still accepted

The issue proposed closing the handshake with a policy-violation code. That was reconsidered on a
measurement: both UnitTestInterface runner pages call `wsClient.connect()` unconditionally at module
load (`assets/js/index.js:2544`, `assets/js/resources.js:811`), with a reconnect timer behind it. Every
anonymous visitor opens a socket today, purely to replay past runs — so closing the handshake would
put them all into a connect/close/reconnect loop with a red status badge, for a page that was working
fine.

Per-action refusal closes the actual abuse vector, which is dispatched work, and keeps anonymous
replay working. It also buys something closing the handshake cannot: the server can *tell* the client
what it may do, so UnitTestInterface can stop deciding for itself. Its own CLAUDE.md records that its
`canRunTests()` gate is client-side only; a served answer cannot drift from the enforced one, because
both are the same `TestRunPolicy` object.

## How the caller is identified

`WsServer` assigns the upgrade request to `$conn->httpRequest`, and `LargeHeaderHttpServer` already
exists because a `COOKIE_DOMAIN`-scoped Zitadel session rides along on every handshake — measured at
~2.7 KB. The token has been arriving all along, unread.

It is a PSR-7 `RequestInterface`, not a `ServerRequestInterface`, so there is no `getCookieParams()`
and `WsCallerResolver` parses the `Cookie:` header itself, then hands the result to the existing
`CookieHelper::getAccessToken()` so the cookie name stays defined once.

Verification mirrors `OidcAuthMiddleware`: Zitadel RS256 via a shared `CachedKeySet`, else legacy
HS256. Two deliberate differences, both because this runs inside a single-threaded ReactPHP loop:

- **No network call per connection.** Roles come from the token claim only; the Zitadel
  Management-API fallback is not carried over. A token with no roles claim is authenticated with no
  roles, and is refused — the fail-closed direction.
- **The JWKS is pre-warmed at boot**, before `IoServer::factory()`, so steady-state handshakes are
  pure CPU and only a key rotation costs a fetch. A failed warm is not fatal; the server starts and
  the first RS256 connection pays for it.

Everything fails closed. No cookie, an expired token, a forged token, a missing `JWT_SECRET`, an
unreachable JWKS — all yield an anonymous caller, and an anonymous caller may not run.

## Where the gate sits

`onMessage()` asks the policy twice, and the split is the design:

- **Early**, beside `$protocolViolation`, the coarse question — which depends only on the caller, so
  it can be settled before the message is understood. It has to be, because the run-token block below
  installs a token and can call `CheckableInventory::reset()`, and a caller about to be refused must
  reach neither. The answer waits until `$requestId` is read, so the refusal is correlated — the same
  decide-early/answer-late shape the file already uses for the protocol check.
- **Late**, after schema validation, the target-scoped question. A target read from an unvalidated
  message is a guess, and a permission decision must not rest on one. The coarse policy answers it
  identically today, so a stub policy exercises it in the tests — an unexercised seam is an absent
  one.

## Protocol

Additive, and no version bump: `WebSocketFrame.json` records the precedent that a new frame type is
gated because it changes the stream a v1 client counts, while a new code on a frame the client already
receives is not. `hello` gains a `caller` sibling to `capabilities` — that object is derived from enums
so it cannot go stale, and a per-connection value has no business inside it. `ProtocolErrorCode` gains
`not_authenticated` and `insufficient_role`: two codes because the remedies differ, and telling a
logged-in `developer` to log in again is advice that cannot help.

## Rollout

API first, UnitTestInterface second, and that order is safe rather than conventional: the API change is
additive, UTI's client ignores unknown `hello` fields, and its Run button is already role-gated
client-side. Nobody who could legitimately run loses the ability between the two deploys. The UTI
follow-up is written up at the end of the design doc.

**The WebSocket server deploys by restart, not `git pull`** — it is a long-running process that loads
`src/Health.php` once at boot.

## Verification

- Full suite green; the four over-the-wire suites were run against a server started from this branch,
  and re-run with it stopped to confirm all 20 SKIP rather than silently answering from the shared
  server on 8082.
- The `JWT_SECRET`-absent skip path was forced and confirmed to name the missing variable, so a fresh
  worktree cannot pass those tests unexecuted.
- `composer analyse` (PHPStan level 10), `composer lint`, `composer lint:md`, `composer lint:openapi`
  all clean.

## Noted, not fixed here

`JwtService::verify()` catches four JWT exceptions but not the bare `DomainException` that
`JWT::decode()` raises for a non-UTF-8 payload, so a sufficiently mangled token escapes it. On the HTTP
side that surfaces as a 500 where a 401 is meant. `WsCallerResolver` guards against it locally rather
than changing shared HTTP semantics in this PR.

Design: `docs/superpowers/specs/2026-08-27-ws-health-auth-design.md`
Plan: `docs/superpowers/plans/2026-08-27-ws-health-auth.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added access-token authentication for Health WebSocket connections.
  - Anonymous connections remain open, but cannot start validation runs.
  - Starting validation runs requires administrator or test-editor permissions.
  - Welcome messages now show authentication status and available permissions.
  - Added clear errors for unauthenticated requests and insufficient permissions.
  - Added support for modern and legacy token verification.

- **Tests**
  - Expanded coverage for authentication, permissions, connection behaviour and protocol responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->