### PR TITLE
fix(auth): read JWT configuration from the process environment too

### DIFF
--- a/phpunit_tests/Services/JwtServiceFactoryTest.php
+++ b/phpunit_tests/Services/JwtServiceFactoryTest.php
@@ -16,24 +16,58 @@ final class JwtServiceFactoryTest extends TestCase
     /** @var array<string,mixed> */
     private array $savedEnv = [];
 
+    /** @var array<string,string|false> */
+    private array $savedGetenv = [];
+
+    /** @var array<string,mixed> */
+    private array $savedServer = [];
+
     private const UNSET = "\0__unset__\0";
 
+    /** @var list<string> */
+    private const MANAGED = ['JWT_SECRET', 'JWT_ALGORITHM', 'JWT_EXPIRY', 'JWT_REFRESH_EXPIRY', 'APP_ENV'];
+
+    /**
+     * All three homes are cleared, not just `$_ENV`.
+     *
+     * Since the factory reads `getenv()` ahead of `$_ENV`, clearing only the latter would let a
+     * developer who happens to export `JWT_SECRET` in their shell silently change what every test in
+     * this file is measuring — and it would pass, against the wrong value.
+     */
     protected function setUp(): void
     {
-        foreach (['JWT_SECRET', 'JWT_ALGORITHM', 'JWT_EXPIRY', 'JWT_REFRESH_EXPIRY', 'APP_ENV'] as $k) {
-            $this->savedEnv[$k] = array_key_exists($k, $_ENV) ? $_ENV[$k] : self::UNSET;
-            unset($_ENV[$k]);
+        foreach (self::MANAGED as $k) {
+            $this->savedEnv[$k]    = array_key_exists($k, $_ENV) ? $_ENV[$k] : self::UNSET;
+            $this->savedServer[$k] = array_key_exists($k, $_SERVER) ? $_SERVER[$k] : self::UNSET;
+            $this->savedGetenv[$k] = getenv($k);
+            unset($_ENV[$k], $_SERVER[$k]);
+            putenv($k);
         }
         $_ENV['APP_ENV'] = 'test';
     }
 
     protected function tearDown(): void
     {
-        foreach ($this->savedEnv as $k => $v) {
-            if ($v === self::UNSET) {
+        foreach (self::MANAGED as $k) {
+            $env = $this->savedEnv[$k];
+            if ($env === self::UNSET) {
                 unset($_ENV[$k]);
             } else {
-                $_ENV[$k] = $v;
+                $_ENV[$k] = $env;
+            }
+
+            $server = $this->savedServer[$k];
+            if ($server === self::UNSET) {
+                unset($_SERVER[$k]);
+            } else {
+                $_SERVER[$k] = $server;
+            }
+
+            $orig = $this->savedGetenv[$k];
+            if ($orig === false) {
+                putenv($k);
+            } else {
+                putenv($k . '=' . $orig);
             }
         }
     }
@@ -140,6 +174,73 @@ final class JwtServiceFactoryTest extends TestCase
         $_ENV['JWT_SECRET'] = 'change-this-please-its-the-default-x';
         // Should not throw; the placeholder check is production-only.
         $svc = JwtServiceFactory::fromEnv();
+        self::assertSame(3600, $svc->getExpiry());
+    }
+
+    // ------------------------------------------------------- configuration that lives in the environment
+
+    /**
+     * The shape a CLI entrypoint actually sees, and the regression this guards.
+     *
+     * `variables_order` is `GPCS`, so an inherited environment variable never reaches `$_ENV`; the CLI
+     * SAPI merges the environment into `$_SERVER` instead; and `Dotenv::createImmutable()` then
+     * declines to write the value from `.env.local` into `$_ENV`, because it can already see one.
+     * Reading `$_ENV` alone therefore found nothing and threw — which is how the WebSocket server came
+     * to report `Caller verification: none` while the HTTP API, whose SAPI rebuilds `$_SERVER` per
+     * request, signed tokens from the very same file.
+     *
+     * Reproduced here by hand rather than by spawning a process: the three homes are set exactly as
+     * PHP leaves them under CLI.
+     */
+    public function testSecretIsFoundWhenItLivesOnlyInTheProcessEnvironment(): void
+    {
+        putenv('JWT_SECRET=' . self::VALID_SECRET);
+        $_SERVER['JWT_SECRET'] = self::VALID_SECRET; // as the CLI SAPI merges it
+        unset($_ENV['JWT_SECRET']);                  // as Dotenv leaves it
+
+        $svc = JwtServiceFactory::fromEnv();
+
+        self::assertSame(3600, $svc->getExpiry());
+    }
+
+    public function testEveryOptionIsFoundInTheProcessEnvironment(): void
+    {
+        putenv('JWT_SECRET=' . self::VALID_SECRET);
+        putenv('JWT_ALGORITHM=HS512');
+        putenv('JWT_EXPIRY=120');
+        putenv('JWT_REFRESH_EXPIRY=240');
+
+        $svc = JwtServiceFactory::fromEnv();
+
+        self::assertSame(120, $svc->getExpiry());
+        self::assertSame(240, $svc->getRefreshExpiry());
+    }
+
+    /**
+     * A pre-existing environment variable wins over the file, which is Dotenv's own immutable rule —
+     * so the factory must not disagree with the loader about which value is in force.
+     */
+    public function testTheProcessEnvironmentWinsOverEnvSuperglobal(): void
+    {
+        putenv('JWT_EXPIRY=111');
+        $_ENV['JWT_EXPIRY'] = '222';
+        $_ENV['JWT_SECRET'] = self::VALID_SECRET;
+
+        self::assertSame(111, JwtServiceFactory::fromEnv()->getExpiry());
+    }
+
+    /**
+     * An empty environment variable is not an answer. `getenv()` returning `''` must fall through to
+     * `$_ENV` rather than being taken as "configured, to nothing" — otherwise a stray `export
+     * JWT_SECRET=` would take the service down with a confusing message.
+     */
+    public function testAnEmptyProcessEnvironmentValueFallsBackToEnvSuperglobal(): void
+    {
+        putenv('JWT_SECRET=');
+        $_ENV['JWT_SECRET'] = self::VALID_SECRET;
+
+        $svc = JwtServiceFactory::fromEnv();
+
         self::assertSame(3600, $svc->getExpiry());
     }
 }

--- a/phpunit_tests/Services/JwtServiceFactoryTest.php
+++ b/phpunit_tests/Services/JwtServiceFactoryTest.php
@@ -203,6 +203,39 @@ final class JwtServiceFactoryTest extends TestCase
         self::assertSame(3600, $svc->getExpiry());
     }
 
+    /**
+     * `is_numeric('1.5')` is true and `(int) '1.5'` is 1, so a fractional lifetime used to be accepted
+     * and silently became one second. A lifetime is a whole number of seconds or it is a mistake.
+     */
+    public function testFractionalExpiryIsRejected(): void
+    {
+        $_ENV['JWT_SECRET'] = self::VALID_SECRET;
+        $_ENV['JWT_EXPIRY'] = '1.5';
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('JWT_EXPIRY');
+        JwtServiceFactory::fromEnv();
+    }
+
+    public function testFractionalRefreshExpiryIsRejected(): void
+    {
+        $_ENV['JWT_SECRET']         = self::VALID_SECRET;
+        $_ENV['JWT_REFRESH_EXPIRY'] = '86400.5';
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('JWT_REFRESH_EXPIRY');
+        JwtServiceFactory::fromEnv();
+    }
+
+    /**
+     * Scientific notation is numeric too, and casts to something unrecognisable.
+     */
+    public function testExponentialExpiryIsRejected(): void
+    {
+        $_ENV['JWT_SECRET'] = self::VALID_SECRET;
+        $_ENV['JWT_EXPIRY'] = '1e3';
+        $this->expectException(\RuntimeException::class);
+        JwtServiceFactory::fromEnv();
+    }
+
     public function testEveryOptionIsFoundInTheProcessEnvironment(): void
     {
         putenv('JWT_SECRET=' . self::VALID_SECRET);

--- a/src/Services/JwtServiceFactory.php
+++ b/src/Services/JwtServiceFactory.php
@@ -58,6 +58,74 @@ class JwtServiceFactory
     ];
 
     /**
+     * Read one configuration value from the environment, from either place it can live.
+     *
+     * **`getenv()` first, and `$_ENV` is not enough on its own.** Reading only `$_ENV` works under
+     * the web SAPIs and fails under CLI, which is how the WebSocket server ended up unable to
+     * authenticate anybody while the HTTP API — same checkout, same `.env.local`, same Dotenv call —
+     * was signing tokens perfectly well. The mechanism:
+     *
+     *  - `variables_order` is `GPCS` in the shipped ini files, so **no** `E`: an inherited environment
+     *    variable never reaches `$_ENV` by itself.
+     *  - The CLI SAPI nevertheless merges the whole environment into **`$_SERVER`**, where the web
+     *    SAPIs rebuild `$_SERVER` per request from HTTP variables instead.
+     *  - `Dotenv::createImmutable()` refuses to overwrite a variable it can already see, and it sees
+     *    `$_SERVER`. So under CLI it declines to write the value from `.env.local` into `$_ENV`,
+     *    which is then empty, while under the web SAPI it writes it happily.
+     *
+     * The net effect is that a CLI entrypoint whose `JWT_SECRET` comes from the *environment* —
+     * systemd `Environment=`, `docker run -e`, a compose `environment:` block, a parent process such
+     * as Playwright — reads no secret at all and throws. Measured, with the value present in
+     * `getenv()` throughout: `$_ENV[JWT_SECRET]` ABSENT and
+     * `RuntimeException: JWT_SECRET environment variable is required`.
+     *
+     * `getenv()` takes precedence deliberately, matching both Dotenv's own immutable semantics — a
+     * pre-existing environment variable wins over a file — and the existing convention in
+     * {@see \LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware} and {@see WsCallerResolver}.
+     *
+     * Sibling sites read `$_ENV` alone in CLI contexts and have the same exposure, left alone here
+     * rather than swept in: `Health`'s `REDIS_*` lookups and `bin/LitCalTestServer.php`'s `WS_HOST` /
+     * `WS_PORT`. Neither is a credential, and both fail visibly rather than silently.
+     */
+    private static function env(string $name): ?string
+    {
+        $fromGetenv = getenv($name);
+        if (is_string($fromGetenv) && '' !== $fromGetenv) {
+            return $fromGetenv;
+        }
+
+        $fromEnv = $_ENV[$name] ?? null;
+
+        return is_string($fromEnv) && '' !== $fromEnv ? $fromEnv : null;
+    }
+
+    /**
+     * A token lifetime in seconds, read from the environment.
+     *
+     * @param string $name    The variable to read.
+     * @param int    $default Used when the variable is absent or empty.
+     * @throws \RuntimeException If the value is not numeric, or is not greater than zero.
+     */
+    private static function positiveSeconds(string $name, int $default): int
+    {
+        $raw = self::env($name);
+        if ($raw === null) {
+            return $default;
+        }
+
+        if (!is_numeric($raw)) {
+            throw new \RuntimeException($name . ' must be a numeric value (got: ' . $raw . ')');
+        }
+
+        $seconds = (int) $raw;
+        if ($seconds <= 0) {
+            throw new \RuntimeException($name . ' must be a positive integer (got: ' . $seconds . ')');
+        }
+
+        return $seconds;
+    }
+
+    /**
      * Check if a secret appears to be a placeholder value.
      *
      * @param string $secret The secret to check.
@@ -93,8 +161,10 @@ class JwtServiceFactory
      */
     public static function fromEnv(): JwtService
     {
-        $secret = $_ENV['JWT_SECRET'] ?? null;
-        if ($secret === null || !is_string($secret) || $secret === '') {
+        // `env()` returns null for both "absent" and "present but empty", which is the same answer
+        // here: there is no secret to sign with.
+        $secret = self::env('JWT_SECRET');
+        if ($secret === null) {
             throw new \RuntimeException('JWT_SECRET environment variable is required and must be a non-empty string');
         }
         if (strlen($secret) < 32) {
@@ -110,39 +180,16 @@ class JwtServiceFactory
             );
         }
 
-        $algorithmEnv = $_ENV['JWT_ALGORITHM'] ?? 'HS256';
-        $algorithm    = is_string($algorithmEnv) ? $algorithmEnv : 'HS256';
+        $algorithm = self::env('JWT_ALGORITHM') ?? 'HS256';
         if (!in_array($algorithm, self::SUPPORTED_ALGORITHMS, true)) {
             throw new \RuntimeException('JWT_ALGORITHM must be one of: ' . implode(', ', self::SUPPORTED_ALGORITHMS));
         }
 
-        $expiryEnv = $_ENV['JWT_EXPIRY'] ?? null;
-        if ($expiryEnv === null) {
-            $expiry = 3600;
-        } elseif (is_string($expiryEnv) && !is_numeric($expiryEnv)) {
-            throw new \RuntimeException('JWT_EXPIRY must be a numeric value (got: ' . $expiryEnv . ')');
-        } elseif (!is_numeric($expiryEnv)) {
-            throw new \RuntimeException('JWT_EXPIRY must be a numeric value (got type: ' . get_debug_type($expiryEnv) . ')');
-        } else {
-            $expiry = (int) $expiryEnv;
-            if ($expiry <= 0) {
-                throw new \RuntimeException('JWT_EXPIRY must be a positive integer (got: ' . $expiry . ')');
-            }
-        }
-
-        $refreshExpiryEnv = $_ENV['JWT_REFRESH_EXPIRY'] ?? null;
-        if ($refreshExpiryEnv === null) {
-            $refreshExpiry = 604800;
-        } elseif (is_string($refreshExpiryEnv) && !is_numeric($refreshExpiryEnv)) {
-            throw new \RuntimeException('JWT_REFRESH_EXPIRY must be a numeric value (got: ' . $refreshExpiryEnv . ')');
-        } elseif (!is_numeric($refreshExpiryEnv)) {
-            throw new \RuntimeException('JWT_REFRESH_EXPIRY must be a numeric value (got type: ' . get_debug_type($refreshExpiryEnv) . ')');
-        } else {
-            $refreshExpiry = (int) $refreshExpiryEnv;
-            if ($refreshExpiry <= 0) {
-                throw new \RuntimeException('JWT_REFRESH_EXPIRY must be a positive integer (got: ' . $refreshExpiry . ')');
-            }
-        }
+        // Both lifetimes are read the same way. The `get_debug_type()` arm the two blocks used to
+        // carry is gone with the `mixed` they used to receive: an environment variable is a string or
+        // it is absent, and `env()` now says which.
+        $expiry        = self::positiveSeconds('JWT_EXPIRY', 3600);
+        $refreshExpiry = self::positiveSeconds('JWT_REFRESH_EXPIRY', 604800);
 
         return new JwtService($secret, $algorithm, $expiry, $refreshExpiry);
     }

--- a/src/Services/JwtServiceFactory.php
+++ b/src/Services/JwtServiceFactory.php
@@ -113,8 +113,12 @@ class JwtServiceFactory
             return $default;
         }
 
-        if (!is_numeric($raw)) {
-            throw new \RuntimeException($name . ' must be a numeric value (got: ' . $raw . ')');
+        // Integer syntax, not merely numeric syntax. `is_numeric('1.5')` is true and `(int) '1.5'` is
+        // 1, so the looser check this replaces accepted `JWT_EXPIRY=1.5` and quietly issued tokens
+        // that expired after one second — a value nobody typed, from a value nobody was told was
+        // wrong. Raised in review on #896; the behaviour predates this change.
+        if (1 !== preg_match('/^[+-]?\d+$/', $raw)) {
+            throw new \RuntimeException($name . ' must be a whole number of seconds (got: ' . $raw . ')');
         }
 
         $seconds = (int) $raw;


### PR DESCRIPTION
Follow-up to #895. `JwtServiceFactory::fromEnv()` reads `$_ENV` alone, which works under the web SAPIs
and **fails under CLI** — so the WebSocket server could not authenticate anybody, while the HTTP API,
from the same checkout and the same `.env.local`, signed tokens perfectly well.

## The mechanism

Measured, not reasoned:

| | `$_SERVER['JWT_SECRET']` | Dotenv writes `$_ENV`? | `fromEnv()` |
|---------------------------|--------------------------|------------------------|-------------|
| **CLI** (WebSocket server) | **true** — the SAPI merges the environment in | **no** | throws |
| **cli-server** (HTTP API)  | false — rebuilt per request from HTTP vars | yes | works |

1. `variables_order` is `GPCS` in the shipped ini files — no `E` — so an inherited environment variable
   never reaches `$_ENV` by itself.
2. The **CLI** SAPI nevertheless merges the whole environment into `$_SERVER`.
3. `Dotenv::createImmutable()` refuses to overwrite a variable it can already see, and it sees
   `$_SERVER`. Under CLI it therefore declines to write the value from `.env.local` into `$_ENV`,
   which is then empty.

The exact failure, with the value present in `getenv()` throughout:

```
$_ENV[JWT_SECRET]: ABSENT
RuntimeException: JWT_SECRET environment variable is required and must be a non-empty string
```

`APP_ENV` was written normally in the same run, which proves Dotenv itself worked — only the
*inherited* variable is skipped.

## Reproduced end to end

The real `bin/LitCalTestServer.php`, with `JWT_SECRET` inherited:

```
before: Caller verification: Zitadel RS256.
after:  Caller verification: Zitadel RS256 + legacy HS256.
```

That startup line is from #895 and is what made this findable at all — it reported
`Caller verification: none (every caller will be anonymous)` in UnitTestInterface CI.

## Not test-only

Eight call sites use this factory, including every auth handler. Any **CLI** context whose
`JWT_SECRET` comes from the environment rather than a file hits it: systemd `Environment=`,
`docker run -e`, a compose `environment:` block, or a parent process such as Playwright. The
WebSocket server is the one CLI entrypoint that needs JWT, which is why #894 surfaced it — but a
deployment that moves `JWT_SECRET` out of `.env.local` would hit it on the HTTP side too the moment
anything runs under CLI.

## The change

`getenv()` takes precedence over `$_ENV` deliberately, matching Dotenv's own immutable semantics — a
pre-existing environment variable wins over a file — and the convention already in
`OidcAuthMiddleware` and `WsCallerResolver`, both of which read `getenv(...) ?: $_ENV[...]` with a
comment saying why.

Reading through one helper collapsed the `mixed`-typed guards the four values used to need (PHPStan
flagged them as provably redundant once the reader returned `?string`), and the two expiry values now
share one reader rather than repeating twenty lines. An empty `getenv()` falls through to `$_ENV`
rather than counting as "configured, to nothing".

The test `setUp` now clears `$_ENV`, `$_SERVER` **and** `putenv` rather than `$_ENV` alone — otherwise
a developer who exports `JWT_SECRET` would silently change what all sixteen tests measure, and they
would pass against the wrong value.

## Deliberately not swept in

Two sibling `$_ENV`-only reads have the same exposure in CLI contexts and are named in the docblock
rather than changed here: `Health`'s `REDIS_*` lookups and `bin/LitCalTestServer.php`'s `WS_HOST` /
`WS_PORT`. Neither is a credential, and both fail visibly rather than silently.

## Verification

- 4 new tests covering the CLI shape (`getenv` + `$_SERVER` set, `$_ENV` absent), all four values from
  the environment, `getenv` winning over `$_ENV`, and an empty `getenv` falling through.
- Full suite: 3595 tests, 0 failures (3591 before, +4).
- `composer analyse` (PHPStan level 10), `composer lint` clean.

Unblocks UnitTestInterface#96, whose e2e cannot go green until this is on `development` — that suite
builds the API from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JWT configuration now works consistently across command-line and web environments.
  * Process environment values take precedence, with fallback to application environment settings when unavailable or empty.
  * Token expiry settings now require positive whole numbers, rejecting fractional and exponential values.

* **Tests**
  * Added coverage for environment-based JWT configuration and expiry validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->