### PR TITLE
feat(decrees): model urls_langs as an explicit per-language URL override

### DIFF
--- a/jsondata/schemas/LitCalDecreesPath.json
+++ b/jsondata/schemas/LitCalDecreesPath.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "LitCalDecreesPath",
-    "description": "Response of the GET /decrees index: decrees issued by the Dicastery for Divine Worship and the Discipline of the Sacraments or Apostolic Letters and similar dispositions from the Supreme Pontiff that determine new data in the calculation of the Liturgical Calendar. Response items carry the localized event name (for name-bearing decree types), the api_path self-link, and lectionary readings when available; the urls_langs commodity from the source data is not exposed.",
+    "description": "Response of the GET /decrees index: decrees issued by the Dicastery for Divine Worship and the Discipline of the Sacraments or Apostolic Letters and similar dispositions from the Supreme Pontiff that determine new data in the calculation of the Liturgical Calendar. Response items carry the localized event name (for name-bearing decree types), the api_path self-link, and lectionary readings when available; urls_langs is exposed whenever the source defines it: it is an explicit per-language override that cannot be derived from url + url_lang_map, so a client building per-language links must be told about it.",
     "type": "object",
     "additionalProperties": false,
     "properties": {
@@ -425,6 +425,9 @@
                 },
                 "url_lang_map": {
                     "$ref": "./LitCalDecreesSource.json#/definitions/DecreeLangs"
+                },
+                "urls_langs": {
+                    "$ref": "./LitCalDecreesSource.json#/definitions/DecreeURLS"
                 }
             },
             "required": [
@@ -454,6 +457,9 @@
                 },
                 "url_lang_map": {
                     "$ref": "./LitCalDecreesSource.json#/definitions/DecreeLangs"
+                },
+                "urls_langs": {
+                    "$ref": "./LitCalDecreesSource.json#/definitions/DecreeURLS"
                 }
             },
             "required": [
@@ -484,6 +490,9 @@
                 },
                 "url_lang_map": {
                     "$ref": "./LitCalDecreesSource.json#/definitions/DecreeLangs"
+                },
+                "urls_langs": {
+                    "$ref": "./LitCalDecreesSource.json#/definitions/DecreeURLS"
                 }
             },
             "required": [
@@ -510,6 +519,9 @@
                 },
                 "url_lang_map": {
                     "$ref": "./LitCalDecreesSource.json#/definitions/DecreeLangs"
+                },
+                "urls_langs": {
+                    "$ref": "./LitCalDecreesSource.json#/definitions/DecreeURLS"
                 }
             },
             "required": [

--- a/jsondata/schemas/LitCalDecreesSource.json
+++ b/jsondata/schemas/LitCalDecreesSource.json
@@ -493,6 +493,7 @@
         },
         "DecreeURLS": {
             "type": "object",
+            "minProperties": 1,
             "additionalProperties": false,
             "patternProperties": {
                 "^(de|en|es|fr|it|la|pl|pt)$": {

--- a/jsondata/schemas/LitCalDecreesSource.json
+++ b/jsondata/schemas/LitCalDecreesSource.json
@@ -495,12 +495,12 @@
             "type": "object",
             "additionalProperties": false,
             "patternProperties": {
-                "(de|en|es|fr|it|la|pl|pt)": {
+                "^(de|en|es|fr|it|la|pl|pt)$": {
                     "type": "string",
                     "pattern": "^https?:\\\/\\\/(www|press)\\.vatican\\.va\\\/((roman_curia\\\/congregations\\\/ccdds\\\/documents\\\/[-_%a-z0-9]+)|(content\\\/salastampa\\\/it\\\/bollettino\\\/pubblico\\\/[0-9\\\/]+)|(content\\\/[-_%\\\/a-z0-9]+))\\.(html|pdf)(#[%a-zD]+)?$"
                 }
             },
-            "description": "precalculated per-language decree URLs; a commodity for consuming clients, derivable from url + url_lang_map",
+            "description": "explicit per-language decree URLs, overriding what url + url_lang_map would produce for the languages named here. Sparse: a language absent from this map still derives its URL from the url template. Required when a language's document does not fit the template at all \u2014 e.g. a Latin text published as an annex to the Italian page, differing in both path segment and filename.",
             "title": "DecreeURLS"
         },
         "DecreeLangs": {

--- a/phpunit_tests/Handlers/DecreesHandlerResponseSchemaTest.php
+++ b/phpunit_tests/Handlers/DecreesHandlerResponseSchemaTest.php
@@ -42,11 +42,34 @@ final class DecreesHandlerResponseSchemaTest extends AbstractHandlerTestCase
         $this->addToAssertionCount(1);
     }
 
-    public function testUrlsLangsInResponseMetadataIsRejected(): void
+    /**
+     * urls_langs is an explicit per-language override, not a derived commodity, so unlike
+     * before it IS exposed: a client building per-language links cannot compute it.
+     */
+    public function testUrlsLangsInResponseMetadataIsAccepted(): void
     {
-        // The models drop urls_langs; a response carrying it must not validate.
         $body                                          = $this->decreesIndexBody();
         $body->litcal_decrees[0]->metadata->urls_langs = (object) ['en' => 'https://www.vatican.va/roman_curia/congregations/ccdds/documents/test.html'];
+        Schema::import(LitSchema::DECREES->path())->in($body);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testUrlsLangsWithANonUrlValueIsRejected(): void
+    {
+        $body                                          = $this->decreesIndexBody();
+        $body->litcal_decrees[0]->metadata->urls_langs = (object) ['en' => 'not-a-vatican-url'];
+        $this->expectException(\Swaggest\JsonSchema\Exception::class);
+        Schema::import(LitSchema::DECREES->path())->in($body);
+    }
+
+    /**
+     * Guards the anchoring of DecreeURLS.patternProperties: unanchored, a key such as
+     * `xxde` matched the language alternation and slipped past additionalProperties:false.
+     */
+    public function testUrlsLangsWithAnUnknownLanguageKeyIsRejected(): void
+    {
+        $body                                          = $this->decreesIndexBody();
+        $body->litcal_decrees[0]->metadata->urls_langs = (object) ['xxde' => 'https://www.vatican.va/roman_curia/congregations/ccdds/documents/test.html'];
         $this->expectException(\Swaggest\JsonSchema\Exception::class);
         Schema::import(LitSchema::DECREES->path())->in($body);
     }

--- a/phpunit_tests/Handlers/DecreesHandlerResponseSchemaTest.php
+++ b/phpunit_tests/Handlers/DecreesHandlerResponseSchemaTest.php
@@ -63,6 +63,19 @@ final class DecreesHandlerResponseSchemaTest extends AbstractHandlerTestCase
     }
 
     /**
+     * An empty override map is meaningless and UrlsLangs::__construct() rejects it, so the
+     * schema must refuse it first rather than let it reach the constructor guard. Mirrors
+     * the minProperties DecreeLangs has always carried.
+     */
+    public function testEmptyUrlsLangsIsRejected(): void
+    {
+        $body                                          = $this->decreesIndexBody();
+        $body->litcal_decrees[0]->metadata->urls_langs = new \stdClass();
+        $this->expectException(\Swaggest\JsonSchema\Exception::class);
+        Schema::import(LitSchema::DECREES->path())->in($body);
+    }
+
+    /**
      * Guards the anchoring of DecreeURLS.patternProperties: unanchored, a key such as
      * `xxde` matched the language alternation and slipped past additionalProperties:false.
      */

--- a/phpunit_tests/Models/Decrees/DecreeUrlsLangsOverrideTest.php
+++ b/phpunit_tests/Models/Decrees/DecreeUrlsLangsOverrideTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Decrees;
+
+use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Models\Decrees\DecreeItemMakeDoctorMetadata;
+use LiturgicalCalendar\Api\Models\Decrees\UrlsLangs;
+use LiturgicalCalendar\Api\Models\RegionalData\UrlLangMap;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Covers the `urls_langs` per-language override and its interaction with the
+ * `url` + `url_lang_map` template.
+ *
+ * The motivating case is the decree declaring John Henry Newman a Doctor of the
+ * Church: six languages share one template, while the Latin text is published as
+ * an annex to the Italian page and so differs in both path segment and filename.
+ */
+final class DecreeUrlsLangsOverrideTest extends TestCase
+{
+    private const NEWMAN_TEMPLATE = 'https://www.vatican.va/content/romancuria/%s/dicasteri/dicastero-culto-divino-e-disciplina-sacramenti/documenti/20251109-decreto-iscrizione-newman.html';
+    private const NEWMAN_LATIN    = 'https://www.vatican.va/content/romancuria/it/dicasteri/dicastero-culto-divino-e-disciplina-sacramenti/documenti/20251109-annesso-decreto-iscrizione-newman-la.html';
+
+    private static string $originalPrimaryLanguage;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$originalPrimaryLanguage = LitLocale::$PRIMARY_LANGUAGE;
+    }
+
+    protected function tearDown(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = self::$originalPrimaryLanguage;
+    }
+
+    /** @param array<string,string> $urlsLangs */
+    private static function newmanMetadata(array $urlsLangs = []): DecreeItemMakeDoctorMetadata
+    {
+        $data = [
+            'action'       => 'makeDoctor',
+            'since_year'   => 2026,
+            'url'          => self::NEWMAN_TEMPLATE,
+            'url_lang_map' => ['de' => 'de', 'en' => 'en', 'es' => 'es', 'fr' => 'fr', 'it' => 'it', 'pt' => 'pt'],
+        ];
+        if ([] !== $urlsLangs) {
+            $data['urls_langs'] = $urlsLangs;
+        }
+        return DecreeItemMakeDoctorMetadata::fromArray($data);
+    }
+
+    private static function hrefOf(string $html): string
+    {
+        self::assertSame(1, preg_match('/href="([^"]+)"/', $html, $m), 'expected a single href in the rendered link');
+        return html_entity_decode($m[1], ENT_QUOTES, 'UTF-8');
+    }
+
+    public function testOverrideWinsForTheLanguageItNames(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'la';
+        $metadata                    = self::newmanMetadata(['la' => self::NEWMAN_LATIN]);
+
+        self::assertSame(self::NEWMAN_LATIN, self::hrefOf($metadata->getUrl()));
+    }
+
+    public function testLanguagesWithoutAnOverrideStillUseTheTemplate(): void
+    {
+        $metadata = self::newmanMetadata(['la' => self::NEWMAN_LATIN]);
+
+        foreach (['de', 'en', 'es', 'fr', 'it', 'pt'] as $lang) {
+            LitLocale::$PRIMARY_LANGUAGE = $lang;
+            self::assertSame(
+                sprintf(self::NEWMAN_TEMPLATE, $lang),
+                self::hrefOf($metadata->getUrl()),
+                "language `{$lang}` should resolve through the template, not the override"
+            );
+        }
+    }
+
+    public function testWithoutAnyOverrideBehaviourIsUnchanged(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'it';
+        $metadata                    = self::newmanMetadata();
+
+        self::assertSame(sprintf(self::NEWMAN_TEMPLATE, 'it'), self::hrefOf($metadata->getUrl()));
+    }
+
+    /**
+     * A language absent from a non-empty override map must fall through to the template
+     * rather than borrowing another language's document — the reason UrlsLangs::get()
+     * deliberately has no la/en fallback.
+     */
+    public function testAbsentLanguageDoesNotBorrowAnotherLanguagesOverride(): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'en';
+        $metadata                    = self::newmanMetadata(['la' => self::NEWMAN_LATIN]);
+
+        $href = self::hrefOf($metadata->getUrl());
+        self::assertNotSame(self::NEWMAN_LATIN, $href);
+        self::assertSame(sprintf(self::NEWMAN_TEMPLATE, 'en'), $href);
+    }
+
+    public function testOverrideIsSerialisedSoClientsCanSeeIt(): void
+    {
+        $serialised = self::newmanMetadata(['la' => self::NEWMAN_LATIN])->jsonSerialize();
+
+        self::assertArrayHasKey('urls_langs', $serialised);
+        self::assertSame(['la' => self::NEWMAN_LATIN], $serialised['urls_langs']);
+    }
+
+    public function testAbsentOverrideIsOmittedFromSerialisation(): void
+    {
+        self::assertArrayNotHasKey('urls_langs', self::newmanMetadata()->jsonSerialize());
+    }
+
+    public function testGetReducesARegionalTagToItsPrimarySubtag(): void
+    {
+        $urlsLangs = UrlsLangs::fromArray(['en' => 'https://www.vatican.va/content/example-en.html']);
+
+        self::assertSame('https://www.vatican.va/content/example-en.html', $urlsLangs->get('en-US'));
+        self::assertNull($urlsLangs->get('de-DE'));
+    }
+
+    public function testEmptyOverrideMapIsRejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        UrlsLangs::fromArray([]);
+    }
+
+    /**
+     * Regression: getBestLangFromMap() tested the primary subtag but indexed the map with the
+     * full tag, so a regional tag matched the guard and then read a key that does not exist.
+     */
+    public function testUrlLangMapResolvesARegionalTagToItsPrimarySubtag(): void
+    {
+        $map = UrlLangMap::fromArray(['de' => 'ge', 'en' => 'en', 'la' => 'la']);
+
+        self::assertSame('ge', $map->getBestLangFromMap('de-DE'));
+        self::assertSame('en', $map->getBestLangFromMap('en-GB'));
+    }
+}

--- a/phpunit_tests/Models/Decrees/DecreeUrlsLangsOverrideTest.php
+++ b/phpunit_tests/Models/Decrees/DecreeUrlsLangsOverrideTest.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Models\Decrees;
 
 use LiturgicalCalendar\Api\Enum\LitLocale;
+use LiturgicalCalendar\Api\Models\Decrees\DecreeEventMetadata;
+use LiturgicalCalendar\Api\Models\Decrees\DecreeItemCreateNewMetadata;
 use LiturgicalCalendar\Api\Models\Decrees\DecreeItemMakeDoctorMetadata;
+use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyGradeMetadata;
+use LiturgicalCalendar\Api\Models\Decrees\DecreeItemSetPropertyNameMetadata;
 use LiturgicalCalendar\Api\Models\Decrees\UrlsLangs;
 use LiturgicalCalendar\Api\Models\RegionalData\UrlLangMap;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -138,5 +143,104 @@ final class DecreeUrlsLangsOverrideTest extends TestCase
 
         self::assertSame('ge', $map->getBestLangFromMap('de-DE'));
         self::assertSame('en', $map->getBestLangFromMap('en-GB'));
+    }
+
+    // ---- every metadata subclass, through both entry points -------------------
+
+    /**
+     * The four metadata subclasses each parse `urls_langs` independently, and each does so
+     * twice — once from a stdClass and once from an array. Covering only one class through
+     * one path left the other seven combinations to be taken on trust.
+     *
+     * @return array<string,array{class-string<DecreeEventMetadata>,array<string,mixed>}>
+     */
+    public static function metadataClassProvider(): array
+    {
+        return [
+            'createNew'         => [DecreeItemCreateNewMetadata::class, ['action' => 'createNew']],
+            'makeDoctor'        => [DecreeItemMakeDoctorMetadata::class, ['action' => 'makeDoctor']],
+            'setProperty:grade' => [DecreeItemSetPropertyGradeMetadata::class, ['action' => 'setProperty', 'property' => 'grade']],
+            'setProperty:name'  => [DecreeItemSetPropertyNameMetadata::class, ['action' => 'setProperty', 'property' => 'name']],
+        ];
+    }
+
+    /**
+     * @param class-string<DecreeEventMetadata> $class
+     * @param array<string,mixed>               $extra
+     */
+    #[DataProvider('metadataClassProvider')]
+    public function testOverrideIsParsedFromAnArrayByEverySubclass(string $class, array $extra): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'la';
+
+        $metadata = $class::fromArray($extra + [
+            'since_year'   => 2026,
+            'url'          => self::NEWMAN_TEMPLATE,
+            'url_lang_map' => ['it' => 'it'],
+            'urls_langs'   => ['la' => self::NEWMAN_LATIN],
+        ]);
+
+        self::assertSame(self::NEWMAN_LATIN, self::hrefOf($metadata->getUrl()));
+        self::assertSame(['la' => self::NEWMAN_LATIN], $metadata->jsonSerialize()['urls_langs']);
+    }
+
+    /**
+     * @param class-string<DecreeEventMetadata> $class
+     * @param array<string,mixed>               $extra
+     */
+    #[DataProvider('metadataClassProvider')]
+    public function testOverrideIsParsedFromAnObjectByEverySubclass(string $class, array $extra): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'la';
+
+        $data               = (object) ( $extra + [
+            'since_year' => 2026,
+            'url'        => self::NEWMAN_TEMPLATE,
+        ] );
+        $data->url_lang_map = (object) ['it' => 'it'];
+        $data->urls_langs   = (object) ['la' => self::NEWMAN_LATIN];
+
+        $metadata = $class::fromObject($data);
+
+        self::assertSame(self::NEWMAN_LATIN, self::hrefOf($metadata->getUrl()));
+        self::assertSame(['la' => self::NEWMAN_LATIN], $metadata->jsonSerialize()['urls_langs']);
+    }
+
+    /**
+     * @param class-string<DecreeEventMetadata> $class
+     * @param array<string,mixed>               $extra
+     */
+    #[DataProvider('metadataClassProvider')]
+    public function testAbsentOverrideLeavesEverySubclassOnTheTemplate(string $class, array $extra): void
+    {
+        LitLocale::$PRIMARY_LANGUAGE = 'it';
+
+        $metadata = $class::fromArray($extra + [
+            'since_year'   => 2026,
+            'url'          => self::NEWMAN_TEMPLATE,
+            'url_lang_map' => ['it' => 'it'],
+        ]);
+
+        self::assertSame(sprintf(self::NEWMAN_TEMPLATE, 'it'), self::hrefOf($metadata->getUrl()));
+        self::assertArrayNotHasKey('urls_langs', $metadata->jsonSerialize());
+    }
+
+    // ---- UrlsLangs guards -----------------------------------------------------
+
+    public function testAValueThatIsNotAUrlIsRejected(): void
+    {
+        // The likely authoring slip: pasting the Vatican language token, or the template,
+        // into a field that wants a finished URL.
+        $this->expectException(\ValueError::class);
+        UrlsLangs::fromArray(['la' => 'la']);
+    }
+
+    public function testGetRejectsAnUnparseableLanguageTag(): void
+    {
+        $urlsLangs = UrlsLangs::fromArray(['la' => self::NEWMAN_LATIN]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        // Locale::getPrimaryLanguage() returns null rather than a subtag past its length limit.
+        $urlsLangs->get(str_repeat('a', 200));
     }
 }

--- a/src/Models/Decrees/DecreeEventMetadata.php
+++ b/src/Models/Decrees/DecreeEventMetadata.php
@@ -15,9 +15,15 @@ abstract class DecreeEventMetadata extends AbstractJsonRepresentation
 
     public readonly ?UrlLangMap $url_lang_map;
 
+    /**
+     * Explicit per-language URLs, overriding the `url` + `url_lang_map` template for the
+     * languages they name. Sparse: a language absent here still resolves via the template.
+     */
+    public readonly ?UrlsLangs $urls_langs;
+
     public readonly CalEventAction $action;
 
-    protected function __construct(int $since_year, CalEventAction $action, string $url, ?UrlLangMap $url_lang_map = null)
+    protected function __construct(int $since_year, CalEventAction $action, string $url, ?UrlLangMap $url_lang_map = null, ?UrlsLangs $urls_langs = null)
     {
         if ($since_year < 1800) {
             throw new \ValueError('$since_year parameter must represent a year from the 19th century or later');
@@ -33,21 +39,31 @@ abstract class DecreeEventMetadata extends AbstractJsonRepresentation
         $this->action       = $action;
         $this->url          = $url;
         $this->url_lang_map = $url_lang_map;
+        $this->urls_langs   = $urls_langs;
     }
 
     /**
      * Returns an HTML string representing the decree source,
      * with a link to the original decree document.
      *
-     * If the decree URL contains a language placeholder, it is replaced with the
-     * best language code available from the language map.
+     * Resolution order for the current language:
+     *  1. an explicit `urls_langs` override, used verbatim;
+     *  2. otherwise, the `url` template with the `%s` placeholder replaced by the best
+     *     language token from `url_lang_map`;
+     *  3. otherwise, the `url` as given.
+     *
+     * The override wins because it exists precisely for the languages the template cannot
+     * express — a Vatican document whose path or filename differs from every other language.
      *
      * @return string The HTML string representing the decree source
      */
     public function getUrl(): string
     {
-        $url = $this->url;
-        if (null !== $this->url_lang_map && str_contains($this->url, '%s')) {
+        $url      = $this->url;
+        $override = $this->urls_langs?->get(LitLocale::$PRIMARY_LANGUAGE);
+        if (null !== $override) {
+            $url = $override;
+        } elseif (null !== $this->url_lang_map && str_contains($this->url, '%s')) {
             $vaticanLangCode = $this->url_lang_map->getBestLangFromMap(LitLocale::$PRIMARY_LANGUAGE);
             $url             = sprintf($this->url, $vaticanLangCode);
         }
@@ -73,6 +89,11 @@ abstract class DecreeEventMetadata extends AbstractJsonRepresentation
         ];
         if (null !== $this->url_lang_map && !empty($this->url_lang_map->url_lang_map)) {
             $returnArray['url_lang_map'] = $this->url_lang_map->url_lang_map;
+        }
+        // Exposed, unlike before: an override is not derivable from url + url_lang_map,
+        // so a client that builds per-language links needs to be told about it.
+        if (null !== $this->urls_langs && !empty($this->urls_langs->urls_langs)) {
+            $returnArray['urls_langs'] = $this->urls_langs->urls_langs;
         }
         return $returnArray;
     }

--- a/src/Models/Decrees/DecreeItem.php
+++ b/src/Models/Decrees/DecreeItem.php
@@ -20,6 +20,7 @@ use LiturgicalCalendar\Api\Router;
  *      strtotime?:string
  * }
  * @phpstan-type UrlLangMapObject \stdClass&object<string,string>
+ * @phpstan-type UrlsLangsObject \stdClass&object<string,string>
  * @phpstan-type DecreeItemMetadataObject \stdClass&object{
  *      action:string,
  *      since_year:int,
@@ -27,7 +28,8 @@ use LiturgicalCalendar\Api\Router;
  *      url:string,
  *      reason?:string,
  *      property?:string,
- *      url_lang_map?:UrlLangMapObject
+ *      url_lang_map?:UrlLangMapObject,
+ *      urls_langs?:UrlsLangsObject
  * }
  * @phpstan-type DecreeItemFromObject \stdClass&object{
  *      decree_id:string,
@@ -56,7 +58,8 @@ use LiturgicalCalendar\Api\Router;
  *      url:string,
  *      reason?:string,
  *      property?:string,
- *      url_lang_map?:array<string,string>
+ *      url_lang_map?:array<string,string>,
+ *      urls_langs?:array<string,string>
  * }
  * @phpstan-type DecreeItemFromArray array{
  *      decree_id:string,

--- a/src/Models/Decrees/DecreeItemCreateNewMetadata.php
+++ b/src/Models/Decrees/DecreeItemCreateNewMetadata.php
@@ -4,6 +4,7 @@ namespace LiturgicalCalendar\Api\Models\Decrees;
 
 use LiturgicalCalendar\Api\Enum\CalEventAction;
 use LiturgicalCalendar\Api\Models\RegionalData\UrlLangMap;
+use LiturgicalCalendar\Api\Models\Decrees\UrlsLangs;
 
 /**
  * @phpstan-import-type DecreeItemMetadataObject from DecreeItem
@@ -11,9 +12,9 @@ use LiturgicalCalendar\Api\Models\RegionalData\UrlLangMap;
  */
 final class DecreeItemCreateNewMetadata extends DecreeEventMetadata
 {
-    private function __construct(int $since_year, string $url, ?UrlLangMap $url_lang_map)
+    private function __construct(int $since_year, string $url, ?UrlLangMap $url_lang_map, ?UrlsLangs $urls_langs)
     {
-        parent::__construct($since_year, CalEventAction::CreateNew, $url, $url_lang_map);
+        parent::__construct($since_year, CalEventAction::CreateNew, $url, $url_lang_map, $urls_langs);
     }
 
     /**
@@ -40,10 +41,16 @@ final class DecreeItemCreateNewMetadata extends DecreeEventMetadata
             $url_lang_map = UrlLangMap::fromObject($data->url_lang_map);
         }
 
+        $urls_langs = null;
+        if (isset($data->urls_langs)) {
+            $urls_langs = UrlsLangs::fromObject($data->urls_langs);
+        }
+
         return new static(
             $data->since_year,
             $data->url,
-            $url_lang_map
+            $url_lang_map,
+            $urls_langs
         );
     }
 
@@ -72,10 +79,16 @@ final class DecreeItemCreateNewMetadata extends DecreeEventMetadata
             $url_lang_map = UrlLangMap::fromArray($urlLangMap);
         }
 
+        $urls_langs = null;
+        if (isset($data['urls_langs'])) {
+            $urls_langs = UrlsLangs::fromArray($data['urls_langs']);
+        }
+
         return new static(
             $data['since_year'],
             $data['url'],
-            $url_lang_map
+            $url_lang_map,
+            $urls_langs
         );
     }
 }

--- a/src/Models/Decrees/DecreeItemMakeDoctorMetadata.php
+++ b/src/Models/Decrees/DecreeItemMakeDoctorMetadata.php
@@ -4,6 +4,7 @@ namespace LiturgicalCalendar\Api\Models\Decrees;
 
 use LiturgicalCalendar\Api\Enum\CalEventAction;
 use LiturgicalCalendar\Api\Models\RegionalData\UrlLangMap;
+use LiturgicalCalendar\Api\Models\Decrees\UrlsLangs;
 
 /**
  * @phpstan-import-type DecreeItemMetadataObject from DecreeItem
@@ -11,9 +12,9 @@ use LiturgicalCalendar\Api\Models\RegionalData\UrlLangMap;
  */
 final class DecreeItemMakeDoctorMetadata extends DecreeEventMetadata
 {
-    private function __construct(int $since_year, string $url, ?UrlLangMap $url_lang_map)
+    private function __construct(int $since_year, string $url, ?UrlLangMap $url_lang_map, ?UrlsLangs $urls_langs)
     {
-        parent::__construct($since_year, CalEventAction::MakeDoctor, $url, $url_lang_map);
+        parent::__construct($since_year, CalEventAction::MakeDoctor, $url, $url_lang_map, $urls_langs);
     }
 
 
@@ -35,10 +36,16 @@ final class DecreeItemMakeDoctorMetadata extends DecreeEventMetadata
             $url_lang_map = UrlLangMap::fromObject($data->url_lang_map);
         }
 
+        $urls_langs = null;
+        if (isset($data->urls_langs)) {
+            $urls_langs = UrlsLangs::fromObject($data->urls_langs);
+        }
+
         return new static(
             $data->since_year,
             $data->url,
-            $url_lang_map
+            $url_lang_map,
+            $urls_langs
         );
     }
 
@@ -64,10 +71,16 @@ final class DecreeItemMakeDoctorMetadata extends DecreeEventMetadata
             $url_lang_map = UrlLangMap::fromArray($data['url_lang_map']);
         }
 
+        $urls_langs = null;
+        if (isset($data['urls_langs'])) {
+            $urls_langs = UrlsLangs::fromArray($data['urls_langs']);
+        }
+
         return new static(
             $data['since_year'],
             $data['url'],
-            $url_lang_map
+            $url_lang_map,
+            $urls_langs
         );
     }
 }

--- a/src/Models/Decrees/DecreeItemSetPropertyGradeMetadata.php
+++ b/src/Models/Decrees/DecreeItemSetPropertyGradeMetadata.php
@@ -4,19 +4,21 @@ namespace LiturgicalCalendar\Api\Models\Decrees;
 
 use LiturgicalCalendar\Api\Enum\CalEventAction;
 use LiturgicalCalendar\Api\Models\RegionalData\UrlLangMap;
+use LiturgicalCalendar\Api\Models\Decrees\UrlsLangs;
 
 /**
  * @phpstan-import-type UrlLangMapObject from DecreeItem
- * @phpstan-type DecreeItemSetPropertyGradeMetadataObject \stdClass&object{action:'setProperty',since_year:int,until_year?:int,url?:string,reason?:string,property:'grade',url_lang_map?:UrlLangMapObject}
- * @phpstan-type DecreeItemSetPropertyGradeMetadataArray array{action:'setProperty',since_year:int,until_year?:int,url:string,reason?:string,property:'grade',url_lang_map?:array<string,string>}
+ * @phpstan-import-type UrlsLangsObject from DecreeItem
+ * @phpstan-type DecreeItemSetPropertyGradeMetadataObject \stdClass&object{action:'setProperty',since_year:int,until_year?:int,url?:string,reason?:string,property:'grade',url_lang_map?:UrlLangMapObject,urls_langs?:UrlsLangsObject}
+ * @phpstan-type DecreeItemSetPropertyGradeMetadataArray array{action:'setProperty',since_year:int,until_year?:int,url:string,reason?:string,property:'grade',url_lang_map?:array<string,string>,urls_langs?:array<string,string>}
  */
 final class DecreeItemSetPropertyGradeMetadata extends DecreeEventMetadata
 {
     public readonly string $property;
 
-    private function __construct(int $since_year, string $url, ?UrlLangMap $url_lang_map)
+    private function __construct(int $since_year, string $url, ?UrlLangMap $url_lang_map, ?UrlsLangs $urls_langs)
     {
-        parent::__construct($since_year, CalEventAction::SetProperty, $url, $url_lang_map);
+        parent::__construct($since_year, CalEventAction::SetProperty, $url, $url_lang_map, $urls_langs);
         $this->property = 'grade';
     }
 
@@ -51,10 +53,16 @@ final class DecreeItemSetPropertyGradeMetadata extends DecreeEventMetadata
             $url_lang_map = UrlLangMap::fromObject($data->url_lang_map);
         }
 
+        $urls_langs = null;
+        if (isset($data->urls_langs)) {
+            $urls_langs = UrlsLangs::fromObject($data->urls_langs);
+        }
+
         return new static(
             $data->since_year,
             $data->url,
-            $url_lang_map
+            $url_lang_map,
+            $urls_langs
         );
     }
 
@@ -94,10 +102,16 @@ final class DecreeItemSetPropertyGradeMetadata extends DecreeEventMetadata
             $url_lang_map = UrlLangMap::fromArray($data['url_lang_map']);
         }
 
+        $urls_langs = null;
+        if (array_key_exists('urls_langs', $data)) {
+            $urls_langs = UrlsLangs::fromArray($data['urls_langs']);
+        }
+
         return new static(
             $data['since_year'],
             $data['url'],
-            $url_lang_map
+            $url_lang_map,
+            $urls_langs
         );
     }
 

--- a/src/Models/Decrees/DecreeItemSetPropertyNameMetadata.php
+++ b/src/Models/Decrees/DecreeItemSetPropertyNameMetadata.php
@@ -4,19 +4,21 @@ namespace LiturgicalCalendar\Api\Models\Decrees;
 
 use LiturgicalCalendar\Api\Enum\CalEventAction;
 use LiturgicalCalendar\Api\Models\RegionalData\UrlLangMap;
+use LiturgicalCalendar\Api\Models\Decrees\UrlsLangs;
 
 /**
  * @phpstan-import-type UrlLangMapObject from DecreeItem
- * @phpstan-type DecreeItemSetPropertyNameMetadataObject \stdClass&object{action:'setProperty',since_year:int,until_year?:int,url?:string,reason?:string,property:'name',url_lang_map?:UrlLangMapObject}
- * @phpstan-type DecreeItemSetPropertyNameMetadataArray array{action:'setProperty',since_year:int,until_year?:int,url:string,reason?:string,property:'name',url_lang_map?:array<string,string>}
+ * @phpstan-import-type UrlsLangsObject from DecreeItem
+ * @phpstan-type DecreeItemSetPropertyNameMetadataObject \stdClass&object{action:'setProperty',since_year:int,until_year?:int,url?:string,reason?:string,property:'name',url_lang_map?:UrlLangMapObject,urls_langs?:UrlsLangsObject}
+ * @phpstan-type DecreeItemSetPropertyNameMetadataArray array{action:'setProperty',since_year:int,until_year?:int,url:string,reason?:string,property:'name',url_lang_map?:array<string,string>,urls_langs?:array<string,string>}
  */
 final class DecreeItemSetPropertyNameMetadata extends DecreeEventMetadata
 {
     public readonly string $property;
 
-    private function __construct(int $since_year, string $url, ?UrlLangMap $url_lang_map)
+    private function __construct(int $since_year, string $url, ?UrlLangMap $url_lang_map, ?UrlsLangs $urls_langs)
     {
-        parent::__construct($since_year, CalEventAction::SetProperty, $url, $url_lang_map);
+        parent::__construct($since_year, CalEventAction::SetProperty, $url, $url_lang_map, $urls_langs);
         $this->property = 'name';
     }
 
@@ -47,10 +49,16 @@ final class DecreeItemSetPropertyNameMetadata extends DecreeEventMetadata
             $url_lang_map = UrlLangMap::fromObject($data->url_lang_map);
         }
 
+        $urls_langs = null;
+        if (isset($data->urls_langs)) {
+            $urls_langs = UrlsLangs::fromObject($data->urls_langs);
+        }
+
         return new static(
             $data->since_year,
             $data->url,
-            $url_lang_map
+            $url_lang_map,
+            $urls_langs
         );
     }
 
@@ -86,10 +94,16 @@ final class DecreeItemSetPropertyNameMetadata extends DecreeEventMetadata
             $url_lang_map = UrlLangMap::fromArray($data['url_lang_map']);
         }
 
+        $urls_langs = null;
+        if (isset($data['urls_langs'])) {
+            $urls_langs = UrlsLangs::fromArray($data['urls_langs']);
+        }
+
         return new static(
             $data['since_year'],
             $data['url'],
-            $url_lang_map
+            $url_lang_map,
+            $urls_langs
         );
     }
 

--- a/src/Models/Decrees/UrlsLangs.php
+++ b/src/Models/Decrees/UrlsLangs.php
@@ -36,8 +36,12 @@ final class UrlsLangs extends AbstractJsonSrcData
 
         $sanitized = [];
         foreach ($urls_langs as $lang => $url) {
+            // Validate, not merely sanitize. An override is a finished URL that replaces the
+            // template outright, and this class is constructible directly — a caller that has
+            // not been through the schema (or has pasted a language token, or the template
+            // itself) must be refused here rather than silently stored.
             $filtered = filter_var($url, FILTER_SANITIZE_URL);
-            if (false === $filtered) {
+            if (false === $filtered || false === filter_var($filtered, FILTER_VALIDATE_URL)) {
                 throw new \ValueError("`urls_langs.{$lang}` must be a valid URL");
             }
             $sanitized[$lang] = htmlspecialchars($filtered, ENT_QUOTES);

--- a/src/Models/Decrees/UrlsLangs.php
+++ b/src/Models/Decrees/UrlsLangs.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace LiturgicalCalendar\Api\Models\Decrees;
+
+use LiturgicalCalendar\Api\Models\AbstractJsonSrcData;
+
+/**
+ * Explicit per-language decree URLs, overriding what `url` + `url_lang_map` would produce.
+ *
+ * The `url` + `url_lang_map` pair covers the common case, where every language shares one
+ * URL template differing only by a language token substituted into the `%s` placeholder.
+ * Some decrees break that rule: the Latin text of the Newman decree, for instance, is
+ * published as an annex to the Italian page, so both its path segment and its filename
+ * differ from every other language.
+ *
+ * This map is the escape hatch for those languages. It is a sparse override, not a cache:
+ * a language present here takes its URL verbatim, and any language absent from it still
+ * derives its URL from the template. A decree may therefore carry an override for a single
+ * language while all the others continue to resolve through `url_lang_map`.
+ *
+ * @see DecreeEventMetadata::getUrl() for the resolution order
+ */
+final class UrlsLangs extends AbstractJsonSrcData
+{
+    /** @var array<string,string> */
+    public readonly array $urls_langs;
+
+    /**
+     * @param array<string,string> $urls_langs Map of ISO 639-1 language code to the full decree URL for that language
+     */
+    private function __construct(array $urls_langs)
+    {
+        if (empty($urls_langs)) {
+            throw new \InvalidArgumentException('UrlsLangs must not be empty.');
+        }
+
+        $sanitized = [];
+        foreach ($urls_langs as $lang => $url) {
+            $filtered = filter_var($url, FILTER_SANITIZE_URL);
+            if (false === $filtered) {
+                throw new \ValueError("`urls_langs.{$lang}` must be a valid URL");
+            }
+            $sanitized[$lang] = htmlspecialchars($filtered, ENT_QUOTES);
+        }
+
+        $this->urls_langs = $sanitized;
+    }
+
+    /**
+     * Creates a new instance from an associative array.
+     *
+     * @param array<string,string> $data Map of ISO 639-1 language codes to full decree URLs.
+     * @return static A new instance of the class.
+     */
+    protected static function fromArrayInternal(array $data): static
+    {
+        return new static($data);
+    }
+
+    /**
+     * Creates a new instance from an object.
+     *
+     * @param \stdClass&object<string,string> $data The object to create an instance from.
+     * @return static A new instance of the class.
+     */
+    protected static function fromObjectInternal(\stdClass $data): static
+    {
+        /** @var array<string,string> $dataArray */
+        $dataArray = (array) $data;
+        return new static($dataArray);
+    }
+
+    /**
+     * Retrieves the overriding URL for a language, or null when that language has no override.
+     *
+     * Unlike UrlLangMap::getBestLangFromMap(), this deliberately does NOT fall back to another
+     * language: an absent language means "no override", which sends the caller back to the
+     * `url` + `url_lang_map` template. Falling back here would hand one language another
+     * language's document.
+     *
+     * @param string $lang The ISO 639-1 language code (a regional tag such as `en-US` is reduced to its primary subtag)
+     * @return string|null The full URL for that language, or null when none is defined
+     */
+    public function get(string $lang): ?string
+    {
+        $baseLocale = \Locale::getPrimaryLanguage($lang);
+        if (null === $baseLocale) {
+            throw new \InvalidArgumentException('Invalid language code: ' . $lang);
+        }
+
+        return $this->urls_langs[$baseLocale] ?? null;
+    }
+}

--- a/src/Models/RegionalData/UrlLangMap.php
+++ b/src/Models/RegionalData/UrlLangMap.php
@@ -78,7 +78,9 @@ final class UrlLangMap extends AbstractJsonSrcData
         }
 
         if (array_key_exists($baseLocale, $this->url_lang_map)) {
-            return $this->url_lang_map[$lang];
+            // Index with the primary subtag, not the full tag: the map is keyed by ISO 639-1,
+            // so a regional tag such as `en-US` matches the `en` key but has no key of its own.
+            return $this->url_lang_map[$baseLocale];
         } elseif (array_key_exists('la', $this->url_lang_map)) {
             return $this->url_lang_map['la'];
         } elseif (array_key_exists('en', $this->url_lang_map)) {


### PR DESCRIPTION
Closes #493.

## The problem

`url` + `url_lang_map` assumes every language shares one URL template differing only by a token substituted into `%s`. The decree declaring John Henry Newman a Doctor of the Church breaks that. Six languages fit the pattern:

```
https://www.vatican.va/content/romancuria/%s/dicasteri/…/20251109-decreto-iscrizione-newman.html
```

but the Latin text is published as an **annex to the Italian page**, so both the path segment and the filename differ:

```
https://www.vatican.va/content/romancuria/it/dicasteri/…/20251109-annesso-decreto-iscrizione-newman-la.html
```

A single `%s` cannot express that. This isn't Vatican inconsistency so much as a genuinely different document, which is a good argument for modelling it as an explicit override rather than contorting the template.

## What I found

`urls_langs` already existed in `LitCalDecreesSource.json`, in exactly the right shape — language → full URL, validated against the `DecreeURL` pattern — but **nothing read it**:

- `grep -rn "urls_langs" src/` → no matches.
- `LitCalDecreesPath.json` documented it as deliberately *not exposed*.
- 13 of 14 decrees carry it, fully materialised.

So it was inert: a cache nobody consumed, while `DecreeEventMetadata::getUrl()` did the only live resolution via `sprintf`.

## Why this is safe

I checked every entry: **all 88 language-entries across the 13 decrees are byte-identical to `str_replace('%s', token, url)`**. Making `urls_langs` win when present is therefore a **provable no-op for every existing decree**, precisely because they already agree with the derivation.

## The change

Resolution becomes `urls_langs[lang] ?? sprintf(url, url_lang_map[lang])`, letting Newman carry `{"la": "…"}` alone.

- **New `UrlsLangs` value object.** Sparse, and deliberately **without** the `la`/`en` fallback that `UrlLangMap::getBestLangFromMap()` has: an absent language means "no override" and falls through to the template. Falling back here would hand one language another language's document.
- **Now serialised.** A client building per-language links cannot derive an override, so it must be told. The Path schema's four metadata responses gain the field and the "not exposed" description is corrected.

## Two latent defects fixed along the way

- `UrlLangMap::getBestLangFromMap()` tested the primary subtag but indexed the map with the **full tag**, so `en-US` passed the guard and then read a key that doesn't exist. Unreachable today (callers pass a bare subtag), but wrong.
- `DecreeURLS.patternProperties` was **unanchored**, so with `additionalProperties: false` a key like `xxde` still matched the language alternation.

## Testing

- 9 new tests in `DecreeUrlsLangsOverrideTest` covering override-wins, template fall-through, the no-fallback guarantee, serialisation, regional-tag reduction, and the `getBestLangFromMap` regression.
- `DecreesHandlerResponseSchemaTest`'s rejection test **inverted** to match the new contract, plus two guards: a non-URL value and an unknown language key (the anchoring fix) must still be refused.
- 69 decree-related tests green; phpcs and PHPStan **level 10** clean.
- Verified end to end with Newman's real URLs: `la` resolves to the annex, the other six to the template, and `jsonSerialize()` emits the sparse override.

## Note

Three `LitCalTestServerTest` WebSocket tests fail locally (anonymous connection, role gating). They fail identically on `development` from the same checkout and skip in a clean worktree — they only run with a local ws server on :8081. Pre-existing and unrelated.

## Follow-up

Frontend editor + card support is ready in `LiturgicalCalendarFrontend#feature/decree-url-overrides`. **Merge this first** — the frontend sends `urls_langs`, which the API would otherwise reject as an unknown property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyuj9umG6o8PzJ4BFf6Xp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicit per-language decree URL overrides.
  * Overrides are now accepted, validated, and included in metadata responses.
  * Language-region tags resolve correctly to their primary language where applicable.

* **Bug Fixes**
  * Invalid URLs and unsupported language codes are rejected.
  * URL overrides now take precedence only for the specified language, while other languages retain existing resolution behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->