### PR TITLE
fix(cors): hand the origin allow-list to /tests as well

### DIFF
--- a/phpunit_tests/RouterCorsAllowListDriftTest.php
+++ b/phpunit_tests/RouterCorsAllowListDriftTest.php
@@ -75,30 +75,52 @@ final class RouterCorsAllowListDriftTest extends TestCase
         return substr($src, $start, $end - $start);
     }
 
+    /**
+     * The guard and the call must be one relation, not two facts.
+     *
+     * Asserting merely that each string appears somewhere in the route block is too weak:
+     * a route could call setAllowedOrigins($allowedOrigins) unconditionally, or from an
+     * unrelated branch, and still satisfy both. What matters is that the shared helper and
+     * the localhost check together *guard* the assignment — that is the shape that was
+     * missing for /tests, and the shape a future route could get wrong while still
+     * mentioning all the right identifiers. testThePatternRejectsADecoupledGuard below
+     * pins that this pattern actually discriminates.
+     */
+    private const GUARDED_CALL = '/Router::restrictsOriginsForWrite\(.*?\)\s*&&\s*false\s*===\s*Router::isLocalhost\(\)\s*\)\s*\{\s*\$\w+->setAllowedOrigins\(\$allowedOrigins\);/s';
+
     #[DataProvider('credentialedWriteRouteProvider')]
-    public function testRouteHandsTheOriginAllowListToItsHandler(string $route): void
+    public function testRouteGuardsTheAllowListCallWithTheSharedHelper(string $route): void
     {
-        self::assertStringContainsString(
-            'setAllowedOrigins($allowedOrigins)',
+        self::assertMatchesRegularExpression(
+            self::GUARDED_CALL,
             self::caseBlock($route),
-            "the `{$route}` route allows credentials on writes but never passes the configured "
-            . 'origin allow-list to its handler, so it will echo any Origin it is given'
+            "the `{$route}` route must pass the configured origin allow-list to its handler from "
+            . 'inside the restrictsOriginsForWrite() + isLocalhost() guard, so that the write '
+            . 'preflight is covered and the call cannot drift outside the condition'
         );
     }
 
     /**
-     * The allow-list must be gated on the shared helper, not on an inline method check:
-     * an inline `in_array($method, [PUT, PATCH, DELETE])` silently excludes the OPTIONS
-     * preflight, which is the only point a cross-origin write can actually be refused.
+     * The guard pattern is only worth anything if it rejects the shape it exists to catch:
+     * both identifiers present, but the allow-list applied outside the condition.
      */
-    #[DataProvider('credentialedWriteRouteProvider')]
-    public function testRouteGatesTheAllowListOnTheSharedHelper(string $route): void
+    public function testThePatternRejectsADecoupledGuard(): void
     {
-        self::assertStringContainsString(
-            'Router::restrictsOriginsForWrite(',
-            self::caseBlock($route),
-            "the `{$route}` route must gate its allow-list on restrictsOriginsForWrite(), "
-            . 'so the write preflight is covered and not just the write itself'
-        );
+        $decoupled = <<<'PHP'
+        case 'bogus':
+            $bogusHandler = new BogusHandler();
+            if (
+                Router::restrictsOriginsForWrite(
+                    $this->request->getMethod(),
+                    $this->request->getHeaderLine('Access-Control-Request-Method')
+                )
+                && false === Router::isLocalhost()
+            ) {
+                $somethingUnrelated = true;
+            }
+            $bogusHandler->setAllowedOrigins($allowedOrigins);
+        PHP;
+
+        self::assertDoesNotMatchRegularExpression(self::GUARDED_CALL, $decoupled);
     }
 }

--- a/phpunit_tests/RouterCorsAllowListDriftTest.php
+++ b/phpunit_tests/RouterCorsAllowListDriftTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Router;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A route whose handler allows credentials but which Router never hands the origin
+ * allow-list to.
+ *
+ * This is the failure /tests was. It enabled credentials for cookie-authenticated writes
+ * from the admin-tests page, but its `case` in Router::route() never called
+ * setAllowedOrigins(), so the handler kept AbstractHandler's default of ['*'] and echoed
+ * back whatever Origin it was given, with Access-Control-Allow-Credentials: true. Nothing
+ * failed; the route simply never consulted the configured list. Divergence between "this
+ * handler allows credentials" and "Router restricts its origins" was silent, and stayed
+ * silent until someone went looking. Here it is a red test.
+ *
+ * Router::route() constructs handlers, emits and calls die(), so it cannot be exercised
+ * in-process (see RouterTest's docblock). The wiring is therefore asserted against the
+ * source of each route's `case` block, which is the only place the omission is visible.
+ *
+ * Only these routes are asserted. The /auth and /admin routes also construct
+ * credential-allowing handlers and are also unwired, and are deliberately NOT listed: they
+ * are a larger change with its own blast radius, not a forgotten line, and asserting them
+ * here would turn this into a permanently red test rather than a drift guard. They are
+ * covered instead by the access token being SameSite=Lax, which keeps a cross-site fetch
+ * from carrying the cookie at all.
+ */
+#[CoversClass(Router::class)]
+final class RouterCorsAllowListDriftTest extends TestCase
+{
+    /**
+     * Routes whose handler sets allowCredentials and which accept write methods.
+     *
+     * @return array<string,array{string}>
+     */
+    public static function credentialedWriteRouteProvider(): array
+    {
+        return [
+            'missals'   => ['missals'],
+            'decrees'   => ['decrees'],
+            'data'      => ['data'],
+            'temporale' => ['temporale'],
+            'tests'     => ['tests'],
+        ];
+    }
+
+    private static function routerSource(): string
+    {
+        $path = dirname(__DIR__) . '/src/Router.php';
+        $src  = file_get_contents($path);
+        self::assertIsString($src, "could not read {$path}");
+        return $src;
+    }
+
+    /**
+     * Extract the body of a single `case '<route>':` block from Router::route()'s switch,
+     * up to the `break;` that closes it.
+     */
+    private static function caseBlock(string $route): string
+    {
+        $src   = self::routerSource();
+        $start = strpos($src, "case '{$route}':");
+        self::assertNotFalse($start, "no `case '{$route}':` block found in Router.php");
+
+        $end = strpos($src, 'break;', $start);
+        self::assertNotFalse($end, "`case '{$route}':` has no closing break;");
+
+        return substr($src, $start, $end - $start);
+    }
+
+    #[DataProvider('credentialedWriteRouteProvider')]
+    public function testRouteHandsTheOriginAllowListToItsHandler(string $route): void
+    {
+        self::assertStringContainsString(
+            'setAllowedOrigins($allowedOrigins)',
+            self::caseBlock($route),
+            "the `{$route}` route allows credentials on writes but never passes the configured "
+            . 'origin allow-list to its handler, so it will echo any Origin it is given'
+        );
+    }
+
+    /**
+     * The allow-list must be gated on the shared helper, not on an inline method check:
+     * an inline `in_array($method, [PUT, PATCH, DELETE])` silently excludes the OPTIONS
+     * preflight, which is the only point a cross-origin write can actually be refused.
+     */
+    #[DataProvider('credentialedWriteRouteProvider')]
+    public function testRouteGatesTheAllowListOnTheSharedHelper(string $route): void
+    {
+        self::assertStringContainsString(
+            'Router::restrictsOriginsForWrite(',
+            self::caseBlock($route),
+            "the `{$route}` route must gate its allow-list on restrictsOriginsForWrite(), "
+            . 'so the write preflight is covered and not just the write itself'
+        );
+    }
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -676,6 +676,20 @@ class Router
                     AcceptHeader::JSON,
                     AcceptHeader::YAML
                 ]);
+                // TestsHandler allows credentials (cookie-authenticated writes from the
+                // admin-tests page) but was the only such route never given the allow-list,
+                // so every origin was echoed back with Access-Control-Allow-Credentials.
+                // AUTHENTICATION_ROADMAP lists "other write operations" as origin-specific;
+                // /tests PUT/PATCH/DELETE are exactly that.
+                if (
+                    Router::restrictsOriginsForWrite(
+                        $this->request->getMethod(),
+                        $this->request->getHeaderLine('Access-Control-Request-Method')
+                    )
+                    && false === Router::isLocalhost()
+                ) {
+                    $testsHandler->setAllowedOrigins($allowedOrigins);
+                }
                 $this->handler = $testsHandler;
                 break;
             case 'temporale':


### PR DESCRIPTION
Follow-up to #898. **Stacked on `fix/decrees-cors-allow-credentials`** because it uses `Router::restrictsOriginsForWrite()` introduced there — GitHub will retarget this to `development` when #898 merges.

## The gap

`/tests` was the only credential-allowing route Router never passed the configured allow-list to. Its `case` set methods, content types and accept headers, but never called `setAllowedOrigins()`, so `TestsHandler` kept `AbstractHandler`'s default of `['*']` and echoed back whatever `Origin` it was given, with `Access-Control-Allow-Credentials: true`.

Confirmed against the live API:

```
$ curl -X OPTIONS .../api/dev/tests/SomeTest \
    -H "Origin: https://evil.example.com" -H "Access-Control-Request-Method: DELETE"
access-control-allow-origin: https://evil.example.com
access-control-allow-credentials: true
```

`AUTHENTICATION_ROADMAP.md` already lists "other write operations" as origin-specific, and `/tests` PUT/PATCH/DELETE are exactly that — so this is a forgotten line, not a new policy.

## Severity, stated accurately

**This is hardening, not an open door**, and I want to be precise because I overstated the related risk on #898 before checking the cookie policy.

The access token cookie is `SameSite=Lax` (hardcoded in `CookieHelper`, no env override to `None`). A cross-site `fetch` from an unrelated origin therefore does **not** carry it, and the request arrives unauthenticated no matter what the CORS headers say.

What the allow-list actually protects against is a **same-site** origin. `SameSite` is scoped to the registrable domain, so every `*.johnromanodorazio.com` host is same-site and *does* send the cookie — which is exactly why the staging frontend can call the production API at all. For a hostile or compromised subdomain, the CORS check is the only barrier, and it was failing open.

## Drift test

`Router::route()` constructs handlers, emits and calls `die()`, so the wiring isn't reachable in-process (as `RouterTest`'s own docblock notes). `RouterCorsAllowListDriftTest` therefore asserts against Router's source that each credential-allowing write route both passes the allow-list and gates it on `restrictsOriginsForWrite()`.

This is the guard that would have caught `/tests`: nothing failed, the route simply never consulted the list, and the divergence was silent. Verified as real coverage — removing the new line again turns the `tests` case red.

## Deliberately out of scope

`/auth` and `/admin` construct credential-allowing handlers and are **likewise unwired** — `/auth/me`, `/auth/login` and `/admin/users` all echo an arbitrary origin on preflight today. They're excluded from the drift list on purpose: that's a larger blast radius needing its own change and its own verification that no legitimate origin gets locked out, and listing them here would make the guard permanently red instead of useful.

Two things worth deciding separately:

1. Whether `/auth` and `/admin` should be wired the same way.
2. Whether production sets `CORS_ALLOWED_ORIGINS` to a real list. `parseCorsAllowedOrigins()` maps unset or `*` to `['*']`, in which case none of this restricts anything — and `docs/PRODUCTION_SECURITY.md` already has "lists specific origins (not `*`)" as a checklist item.

phpcs and PHPStan level 10 clean; 74 router/CORS/tests-handler tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyuj9umG6o8PzJ4BFf6Xp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the tests route to enforce the configured CORS origin allow-list for write requests and preflight requests.
  - Improved protection for cookie-authenticated requests from unauthorised origins.

- **Tests**
  - Added coverage to ensure routes consistently apply the configured origin restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->