### PR TITLE
chore: regenerate i18n/litcal.pot from source files

### DIFF
--- a/i18n/litcal.pot
+++ b/i18n/litcal.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-23 13:18+0000\n"
+"POT-Creation-Date: 2026-08-28 10:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -798,7 +798,7 @@ msgstr ""
 #: src/Handlers/CalendarHandler.php:3383 src/Handlers/CalendarHandler.php:3399
 #: src/Handlers/CalendarHandler.php:3417 src/Handlers/CalendarHandler.php:3456
 #: src/Models/Calendar/LiturgicalEventCollection.php:1734
-#: src/Models/Decrees/DecreeEventMetadata.php:59
+#: src/Models/Decrees/DecreeEventMetadata.php:75
 #: src/Models/RegionalData/NationalData/LitCalItemMakePatronMetadata.php:54
 msgid ""
 "Decree of the Dicastery for Divine Worship and the Discipline of the "


### PR DESCRIPTION
Automated update of `i18n/litcal.pot` translation template from source PHP files.

This PR was generated by the `gettext_update` CI job and is
auto-merged: the .pot is deterministic xgettext output with no
behavioural code, so there is nothing for CI to validate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the translation template metadata to reflect the latest creation date.
  * Refreshed the source reference for the decree message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->