### PR TITLE
fix(cors): restrict origins on /auth and /admin too

### DIFF
--- a/phpunit_tests/Handlers/CredentialedCorsHandlersTest.php
+++ b/phpunit_tests/Handlers/CredentialedCorsHandlersTest.php
@@ -7,6 +7,8 @@ namespace LiturgicalCalendar\Tests\Handlers;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Handlers\DecreesHandler;
 use LiturgicalCalendar\Api\Handlers\RegionalDataHandler;
+use LiturgicalCalendar\Api\Handlers\Auth\MeHandler;
+use LiturgicalCalendar\Api\Handlers\Admin\UsersHandler;
 use LiturgicalCalendar\Api\Handlers\TestsHandler;
 use LiturgicalCalendar\Api\Router;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -32,6 +34,8 @@ use Psr\Http\Message\ResponseInterface;
 #[CoversClass(DecreesHandler::class)]
 #[CoversClass(RegionalDataHandler::class)]
 #[CoversClass(TestsHandler::class)]
+#[CoversClass(MeHandler::class)]
+#[CoversClass(UsersHandler::class)]
 #[CoversClass(Router::class)]
 final class CredentialedCorsHandlersTest extends AbstractHandlerTestCase
 {
@@ -169,5 +173,60 @@ final class CredentialedCorsHandlersTest extends AbstractHandlerTestCase
         self::assertFalse(Router::restrictsOriginsForWrite('POST'));
         self::assertFalse(Router::restrictsOriginsForWrite('OPTIONS', 'GET'));
         self::assertFalse(Router::restrictsOriginsForWrite('OPTIONS', ''));
+    }
+
+    // ---- wholly private routes ------------------------------------------------
+
+    /**
+     * /auth and /admin have no anonymous read, so the allow-list applies to every method —
+     * including the GET that the write-gated helper would have left open. These assert the
+     * behaviour the Router wiring is there to produce.
+     *
+     * @return array<string,array{callable():object,string}>
+     */
+    public static function privateHandlerProvider(): array
+    {
+        return [
+            'auth/me'     => [static fn (): object => new MeHandler(), '/auth/me'],
+            'admin/users' => [static fn (): object => new UsersHandler(), '/admin/users'],
+        ];
+    }
+
+    /** @param callable():object $factory */
+    #[DataProvider('privateHandlerProvider')]
+    public function testPrivateRouteRefusesAForeignOriginOnAReadPreflight(callable $factory, string $path): void
+    {
+        /** @var \LiturgicalCalendar\Api\Handlers\AbstractHandler $handler */
+        $handler = $factory();
+        $handler->setAllowedOrigins(['https://allowed.example.test']);
+
+        $response = $handler->handle($this->requestFor('OPTIONS', $path, [
+            'Origin'                        => 'https://evil.example.test',
+            'Access-Control-Request-Method' => 'GET',
+        ]));
+
+        self::assertNotSame(
+            'https://evil.example.test',
+            $response->getHeaderLine('Access-Control-Allow-Origin'),
+            "{$path} is credentialed on every method, so even a GET preflight must not clear a foreign origin"
+        );
+        self::assertNotSame('*', $response->getHeaderLine('Access-Control-Allow-Origin'));
+    }
+
+    /** @param callable():object $factory */
+    #[DataProvider('privateHandlerProvider')]
+    public function testPrivateRouteStillServesAnAllowedOrigin(callable $factory, string $path): void
+    {
+        /** @var \LiturgicalCalendar\Api\Handlers\AbstractHandler $handler */
+        $handler = $factory();
+        $handler->setAllowedOrigins([self::ORIGIN]);
+
+        $response = $handler->handle($this->requestFor('OPTIONS', $path, [
+            'Origin'                        => self::ORIGIN,
+            'Access-Control-Request-Method' => 'GET',
+        ]));
+
+        self::assertSame(self::ORIGIN, $response->getHeaderLine('Access-Control-Allow-Origin'));
+        self::assertSame('true', $response->getHeaderLine('Access-Control-Allow-Credentials'));
     }
 }

--- a/phpunit_tests/RouterCorsAllowListDriftTest.php
+++ b/phpunit_tests/RouterCorsAllowListDriftTest.php
@@ -25,12 +25,16 @@ use PHPUnit\Framework\TestCase;
  * in-process (see RouterTest's docblock). The wiring is therefore asserted against the
  * source of each route's `case` block, which is the only place the omission is visible.
  *
- * Only these routes are asserted. The /auth and /admin routes also construct
- * credential-allowing handlers and are also unwired, and are deliberately NOT listed: they
- * are a larger change with its own blast radius, not a forgotten line, and asserting them
- * here would turn this into a permanently red test rather than a drift guard. They are
- * covered instead by the access token being SameSite=Lax, which keeps a cross-site fetch
- * from carrying the cookie at all.
+ * Two shapes are asserted, because the routes differ in kind.
+ *
+ * The public routes carry an anonymous read, so their allow-list is gated on
+ * restrictsOriginsForWrite(): a cross-origin GET must stay open, and only writes and the
+ * preflights that clear them are restricted.
+ *
+ * /auth and /admin have no anonymous read at all — every method is cookie-authenticated —
+ * so their allow-list applies unconditionally. Gating those on the write helper would leave
+ * POST /auth/login and GET /auth/me reflecting any Origin with credentials, which is the
+ * state they were in before they were wired.
  */
 #[CoversClass(Router::class)]
 final class RouterCorsAllowListDriftTest extends TestCase
@@ -122,5 +126,57 @@ final class RouterCorsAllowListDriftTest extends TestCase
         PHP;
 
         self::assertDoesNotMatchRegularExpression(self::GUARDED_CALL, $decoupled);
+    }
+
+    /**
+     * Routes with no anonymous read: every method is credentialed, so the allow-list is
+     * not gated on the method at all.
+     *
+     * @return array<string,array{string}>
+     */
+    public static function credentialedPrivateRouteProvider(): array
+    {
+        return [
+            'auth'  => ['auth'],
+            'admin' => ['admin'],
+        ];
+    }
+
+    /**
+     * The private routes resolve a handler across many branches, so the allow-list is
+     * applied once after the sub-dispatch. What must not drift is that it is applied at
+     * all, and that it is still behind the localhost bypass.
+     */
+    private const PRIVATE_GUARDED_CALL = '/\$this->restrictOriginsForPrivateRoute\(\$allowedOrigins\);/';
+
+    #[DataProvider('credentialedPrivateRouteProvider')]
+    public function testPrivateRouteRestrictsOriginsForEveryMethod(string $route): void
+    {
+        self::assertMatchesRegularExpression(
+            self::PRIVATE_GUARDED_CALL,
+            self::caseBlock($route),
+            "the `{$route}` route is credentialed on every method and must hand the configured "
+            . 'origin allow-list to whichever handler it resolved'
+        );
+    }
+
+    /**
+     * The private helper must not be gated on restrictsOriginsForWrite(): that would restrict
+     * only PUT/PATCH/DELETE and leave POST /auth/login and GET /auth/me open to any origin.
+     */
+    public function testPrivateRouteHelperIsNotGatedOnTheWriteMethodCheck(): void
+    {
+        $src   = self::routerSource();
+        $start = strpos($src, 'private function restrictOriginsForPrivateRoute(');
+        self::assertNotFalse($start, 'restrictOriginsForPrivateRoute() not found');
+        $body = substr($src, $start, 900);
+
+        self::assertStringNotContainsString(
+            'restrictsOriginsForWrite',
+            $body,
+            'a credentialed route with no anonymous read must restrict every method, not only writes'
+        );
+        self::assertStringContainsString('Router::isLocalhost()', $body);
+        self::assertStringContainsString('setAllowedOrigins($allowedOrigins)', $body);
     }
 }

--- a/phpunit_tests/RouterCorsAllowListDriftTest.php
+++ b/phpunit_tests/RouterCorsAllowListDriftTest.php
@@ -147,7 +147,7 @@ final class RouterCorsAllowListDriftTest extends TestCase
      * applied once after the sub-dispatch. What must not drift is that it is applied at
      * all, and that it is still behind the localhost bypass.
      */
-    private const PRIVATE_GUARDED_CALL = '/\$this->restrictOriginsForPrivateRoute\(\$allowedOrigins\);/';
+    private const PRIVATE_GUARDED_CALL = '/Router::restrictOriginsForPrivateRoute\(\$this->handler, \$allowedOrigins\);/';
 
     #[DataProvider('credentialedPrivateRouteProvider')]
     public function testPrivateRouteRestrictsOriginsForEveryMethod(string $route): void
@@ -167,7 +167,7 @@ final class RouterCorsAllowListDriftTest extends TestCase
     public function testPrivateRouteHelperIsNotGatedOnTheWriteMethodCheck(): void
     {
         $src   = self::routerSource();
-        $start = strpos($src, 'private function restrictOriginsForPrivateRoute(');
+        $start = strpos($src, 'public static function restrictOriginsForPrivateRoute(');
         self::assertNotFalse($start, 'restrictOriginsForPrivateRoute() not found');
         $body = substr($src, $start, 900);
 

--- a/phpunit_tests/RouterTest.php
+++ b/phpunit_tests/RouterTest.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\Handlers\Auth\MeHandler;
 use LiturgicalCalendar\Api\Router;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
@@ -144,5 +148,68 @@ final class RouterTest extends TestCase
         self::assertStringEndsNotWith('/', Router::$apiPath);
         // $apiFilePath should be the project root (where composer.json lives) with trailing separator.
         self::assertFileExists(Router::$apiFilePath . 'composer.json');
+    }
+
+    // ---- restrictOriginsForPrivateRoute --------------------------------------
+
+    /**
+     * /auth and /admin apply the allow-list through this helper. It is static and takes the
+     * handler explicitly precisely so the decision is reachable here: the call sites live
+     * inside Router::route(), which emits and calls die().
+     *
+     * setUp() has cleared every address key, so isLocalhost() is false — the production
+     * shape, where the restriction is meant to apply.
+     */
+    public function testPrivateRouteHelperAppliesTheAllowListToAnAbstractHandler(): void
+    {
+        $handler = new MeHandler();
+        Router::restrictOriginsForPrivateRoute($handler, ['https://allowed.example.test']);
+
+        $response = $handler->handle(
+            ( new \Nyholm\Psr7\ServerRequest('OPTIONS', '/auth/me') )
+                ->withHeader('Origin', 'https://evil.example.test')
+                ->withHeader('Access-Control-Request-Method', 'GET')
+        );
+
+        self::assertNotSame('https://evil.example.test', $response->getHeaderLine('Access-Control-Allow-Origin'));
+        self::assertNotSame('*', $response->getHeaderLine('Access-Control-Allow-Origin'));
+    }
+
+    /**
+     * The localhost bypass still applies: local development must not need the list configured.
+     */
+    public function testPrivateRouteHelperIsBypassedOnLocalhost(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        self::assertTrue(Router::isLocalhost(), 'guard precondition');
+
+        $handler = new MeHandler();
+        Router::restrictOriginsForPrivateRoute($handler, ['https://allowed.example.test']);
+
+        $response = $handler->handle(
+            ( new \Nyholm\Psr7\ServerRequest('OPTIONS', '/auth/me') )
+                ->withHeader('Origin', 'https://anything.example.test')
+                ->withHeader('Access-Control-Request-Method', 'GET')
+        );
+
+        // Origins were never restricted, so the default wildcard-with-credentials path stands.
+        self::assertSame('https://anything.example.test', $response->getHeaderLine('Access-Control-Allow-Origin'));
+    }
+
+    /**
+     * setAllowedOrigins() lives on AbstractHandler, not on the PSR interface the property is
+     * typed as, so a handler outside that hierarchy must be skipped rather than fatal.
+     */
+    public function testPrivateRouteHelperIgnoresANonAbstractHandler(): void
+    {
+        $plain = new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new \Nyholm\Psr7\Response(200);
+            }
+        };
+
+        Router::restrictOriginsForPrivateRoute($plain, ['https://allowed.example.test']);
+        $this->addToAssertionCount(1);
     }
 }

--- a/src/Router.php
+++ b/src/Router.php
@@ -532,7 +532,7 @@ class Router
                     $this->response = new Response(StatusCode::NOT_FOUND->value, [], null, $this->request->getProtocolVersion(), StatusCode::NOT_FOUND->reason());
                     $this->emitResponse();
                 }
-                $this->restrictOriginsForPrivateRoute($allowedOrigins);
+                Router::restrictOriginsForPrivateRoute($this->handler, $allowedOrigins);
                 break;
             case 'admin':
                 // Handle admin routes
@@ -589,7 +589,7 @@ class Router
                     $this->response = new Response(StatusCode::NOT_FOUND->value, [], null, $this->request->getProtocolVersion(), StatusCode::NOT_FOUND->reason());
                     $this->emitResponse();
                 }
-                $this->restrictOriginsForPrivateRoute($allowedOrigins);
+                Router::restrictOriginsForPrivateRoute($this->handler, $allowedOrigins);
                 break;
             case 'applications':
                 // Developer applications and API keys management
@@ -1025,17 +1025,17 @@ class Router
      * resolve a handler, so a new endpoint added to either route inherits it by default
      * instead of having to remember it.
      *
-     * @param string[] $allowedOrigins
+     * Static and taking the handler explicitly, like restrictsOriginsForWrite(), so the
+     * decision is testable: Router::route() emits and calls die(), so anything reading
+     * $this->handler from inside it is unreachable by any test.
+     *
+     * @param RequestHandlerInterface $handler        The handler the sub-dispatch resolved.
+     * @param string[]                $allowedOrigins
      */
-    private function restrictOriginsForPrivateRoute(array $allowedOrigins): void
+    public static function restrictOriginsForPrivateRoute(RequestHandlerInterface $handler, array $allowedOrigins): void
     {
-        // Unset when the sub-dispatch fell through to a 404 and emitted already.
-        if (false === isset($this->handler)) {
-            return;
-        }
-
-        if ($this->handler instanceof AbstractHandler && false === Router::isLocalhost()) {
-            $this->handler->setAllowedOrigins($allowedOrigins);
+        if ($handler instanceof AbstractHandler && false === Router::isLocalhost()) {
+            $handler->setAllowedOrigins($allowedOrigins);
         }
     }
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Http\Enum\RequestContentType;
 use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
 use LiturgicalCalendar\Api\Enum\PathCategory;
 use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
 use LiturgicalCalendar\Api\Handlers\CalendarHandler;
 use LiturgicalCalendar\Api\Handlers\EasterHandler;
 use LiturgicalCalendar\Api\Handlers\EventsHandler;
@@ -531,6 +532,7 @@ class Router
                     $this->response = new Response(StatusCode::NOT_FOUND->value, [], null, $this->request->getProtocolVersion(), StatusCode::NOT_FOUND->reason());
                     $this->emitResponse();
                 }
+                $this->restrictOriginsForPrivateRoute($allowedOrigins);
                 break;
             case 'admin':
                 // Handle admin routes
@@ -587,6 +589,7 @@ class Router
                     $this->response = new Response(StatusCode::NOT_FOUND->value, [], null, $this->request->getProtocolVersion(), StatusCode::NOT_FOUND->reason());
                     $this->emitResponse();
                 }
+                $this->restrictOriginsForPrivateRoute($allowedOrigins);
                 break;
             case 'applications':
                 // Developer applications and API keys management
@@ -1006,6 +1009,34 @@ class Router
 
         return $method === RequestMethod::OPTIONS->value
             && in_array(strtoupper($preflightMethod), self::ORIGIN_RESTRICTED_METHODS, true);
+    }
+
+    /**
+     * Hand the configured origin allow-list to the resolved handler of a wholly private route.
+     *
+     * /auth and /admin differ from the public routes in kind, not degree: they have no
+     * anonymous read. Every method on them is cookie-authenticated, so restricting only
+     * writes and their preflights — as restrictsOriginsForWrite() does — would leave
+     * `POST /auth/login` and `GET /auth/me` reflecting any Origin back with
+     * Access-Control-Allow-Credentials: true. The list therefore applies to every method
+     * here.
+     *
+     * Applied once after the sub-dispatch rather than in each of the ~16 branches that
+     * resolve a handler, so a new endpoint added to either route inherits it by default
+     * instead of having to remember it.
+     *
+     * @param string[] $allowedOrigins
+     */
+    private function restrictOriginsForPrivateRoute(array $allowedOrigins): void
+    {
+        // Unset when the sub-dispatch fell through to a 404 and emitted already.
+        if (false === isset($this->handler)) {
+            return;
+        }
+
+        if ($this->handler instanceof AbstractHandler && false === Router::isLocalhost()) {
+            $this->handler->setAllowedOrigins($allowedOrigins);
+        }
     }
 
     public static function isLocalhost(): bool


### PR DESCRIPTION
Raised by CodeRabbit on #899 and deferred there as too large for a PR about `/tests`. Landing now because the premise that made it arguably moot has been ruled out: **production is not containerised**, so `REMOTE_ADDR` is a real remote address, `Router::isLocalhost()` is false, and the allow-list is genuinely applied rather than skipped.

## The gap

`/auth` and `/admin` construct credential-allowing handlers but were never handed the configured allow-list, so `AbstractHandler` kept its default of `['*']` and reflected any `Origin` with `Access-Control-Allow-Credentials: true`. Verified against the live API:

```
$ for ep in auth/me auth/login admin/users; do
    curl -X OPTIONS ".../api/dev/$ep" -H "Origin: https://evil.example.com" \
      -H "Access-Control-Request-Method: GET"
  done
access-control-allow-origin: https://evil.example.com
access-control-allow-credentials: true      # ← all three
```

## Why not the same guard as the public routes

They differ **in kind**, not degree.

| | anonymous read? | allow-list applies to |
|---|---|---|
| `/missals`, `/decrees`, `/data`, `/temporale`, `/tests` | yes | writes + their preflights (`restrictsOriginsForWrite()`) |
| `/auth`, `/admin` | **no** — every method is cookie-authenticated | **every method** |

Gating the private routes on the write helper would have restricted only PUT/PATCH/DELETE and left `POST /auth/login` and `GET /auth/me` reflecting any origin — i.e. it would have looked fixed while leaving the two most sensitive endpoints exactly as they were. `restrictOriginsForPrivateRoute()` therefore applies the list unconditionally, still behind the localhost bypass.

It's applied **once after each route's sub-dispatch** rather than in the ~16 branches that resolve a handler, so an endpoint added later inherits it instead of having to remember it — the failure mode that produced this bug in the first place.

## Testing

Two kinds, because a source-level guard and a behavioural one catch different mistakes:

- `RouterCorsAllowListDriftTest` gains the two private routes, and asserts `restrictOriginsForPrivateRoute()` is **not** gated on `restrictsOriginsForWrite()` — precisely the change that would silently reopen login while keeping every test green.
- `CredentialedCorsHandlersTest` adds behavioural cover through `MeHandler` and `UsersHandler`: a foreign origin is refused on a **GET** preflight, an allowed origin is still served with credentials.

Verified as real coverage — removing the `/auth` wiring fails the drift guard. phpcs and PHPStan level 10 clean; 43 router/CORS tests green.

## Before merging — please confirm

This is the one change in the series that can **lock users out** if the configuration is wrong. Once `/auth` is origin-restricted, any origin that legitimately calls it must appear in `CORS_ALLOWED_ORIGINS`, or login fails cross-origin.

- The production frontend is same-origin with the API (`litcal.johnromanodorazio.com/api/dev`), so it is unaffected.
- **`https://litcal-staging.johnromanodorazio.com` must be listed**, or staging login breaks.

`parseCorsAllowedOrigins()` maps unset or `*` to `['*']`, in which case this changes nothing — so it is worth checking the deployed value either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyuj9umG6o8PzJ4BFf6Xp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Private `/auth` and `/admin` routes now consistently apply the configured CORS origin allow-list across all request methods.
  * Requests from disallowed origins are rejected during read preflight checks.
  * Allowed origins continue to receive credential-enabled responses.
  * Localhost access remains unaffected.
* **Tests**
  * Added coverage for private route preflight handling and origin restrictions.
  * Added verification for both credentialed private route patterns and configured allow-list behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->