### PR TITLE
feat(locales): curate supported locales, and stop 500ing on the rest

### DIFF
--- a/jsondata/supportedLocales.json
+++ b/jsondata/supportedLocales.json
@@ -1,0 +1,14 @@
+{
+    "general_roman_calendar": {
+        "official": [
+            "en",
+            "fr",
+            "it",
+            "la",
+            "nl"
+        ],
+        "candidates": {
+            "hr": "Lectionary complete across all ten corpora and a gettext catalogue exists, but decreed-event names are incomplete (StJohnNewman has none). Promote once names are covered."
+        }
+    }
+}

--- a/phpunit_tests/Models/Lectionary/ReadingsMapLocaleStrictnessTest.php
+++ b/phpunit_tests/Models/Lectionary/ReadingsMapLocaleStrictnessTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Models\Lectionary;
+
+use LiturgicalCalendar\Api\Models\Lectionary\ReadingsFerial;
+use LiturgicalCalendar\Api\Models\Lectionary\ReadingsMap;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * A missing readings offset must be fatal for an officially supported locale and
+ * harmless for any other.
+ *
+ * This is the regression guard for #904: a decree created without full lectionary
+ * coverage took the whole Croatian calendar down with a 500, because a missing
+ * offset always threw regardless of whether the locale promised completeness.
+ */
+#[CoversClass(ReadingsMap::class)]
+final class ReadingsMapLocaleStrictnessTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        SupportedLocales::reset();
+    }
+
+    private function mapWithOneEvent(?string $locale): ReadingsMap
+    {
+        $map = new ReadingsMap();
+        $map->addFromArray([
+            'StKnownEvent' => [
+                'first_reading'      => 'Sir 39, 8-14',
+                'responsorial_psalm' => 'Ps 39, 2',
+                'gospel_acclamation' => 'Mt 23, 9b',
+                'gospel'             => 'Mt 13, 47-52'
+            ]
+        ]);
+        $map->setLocale($locale);
+
+        return $map;
+    }
+
+    public function testAKnownOffsetIsReturnedRegardlessOfLocale(): void
+    {
+        $readings = $this->mapWithOneEvent('en')->getReadings('StKnownEvent');
+
+        self::assertSame('Sir 39, 8-14', $readings->first_reading);
+    }
+
+    #[DataProvider('officialLocales')]
+    public function testAMissingOffsetThrowsForAnOfficialLocale(string $locale): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No readings found for offset: StMissingEvent');
+
+        $this->mapWithOneEvent($locale)->getReadings('StMissingEvent');
+    }
+
+    /** @return array<string, array{string}> */
+    public static function officialLocales(): array
+    {
+        return ['en' => ['en'], 'fr' => ['fr'], 'it' => ['it'], 'la' => ['la'], 'nl' => ['nl']];
+    }
+
+    #[DataProvider('unofficialLocales')]
+    public function testAMissingOffsetYieldsEmptyReadingsForAnUnofficialLocale(string $locale): void
+    {
+        $readings = $this->mapWithOneEvent($locale)->getReadings('StMissingEvent');
+
+        self::assertInstanceOf(ReadingsFerial::class, $readings);
+        self::assertSame('', $readings->first_reading);
+        self::assertSame('', $readings->responsorial_psalm);
+        self::assertSame('', $readings->gospel_acclamation);
+        self::assertSame('', $readings->gospel);
+    }
+
+    /** @return array<string, array{string}> */
+    public static function unofficialLocales(): array
+    {
+        return ['hr' => ['hr'], 'es' => ['es'], 'de' => ['de']];
+    }
+
+    public function testAMapWithNoLocaleIsLenient(): void
+    {
+        // Fixtures and array-built maps carry no locale; they must not throw.
+        $readings = $this->mapWithOneEvent(null)->getReadings('StMissingEvent');
+
+        self::assertSame('', $readings->gospel);
+    }
+
+    public function testTheCroatianCaseFromIssue904(): void
+    {
+        // Exactly the shape that 500'd: StJohnNewman present in some locales,
+        // absent from the Croatian lectionary.
+        $readings = $this->mapWithOneEvent('hr')->getReadings('StJohnNewman');
+
+        self::assertSame('', $readings->first_reading);
+    }
+}

--- a/phpunit_tests/Services/SupportedLocalesTest.php
+++ b/phpunit_tests/Services/SupportedLocalesTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services;
+
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SupportedLocales::class)]
+final class SupportedLocalesTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        SupportedLocales::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        SupportedLocales::reset();
+    }
+
+    public function testTheCuratedResourceIsReadable(): void
+    {
+        $official = SupportedLocales::official();
+
+        self::assertNotEmpty($official);
+        self::assertContainsOnlyString($official);
+    }
+
+    /**
+     * Pins the list the API has always advertised. Changing it is a deliberate
+     * governance decision, so it should require editing this test too.
+     */
+    public function testTheOfficialListMatchesWhatTheApiAdvertises(): void
+    {
+        self::assertSame(['en', 'fr', 'it', 'la', 'nl'], SupportedLocales::official());
+    }
+
+    #[DataProvider('officialLocales')]
+    public function testOfficialLocalesAreRecognised(string $locale): void
+    {
+        self::assertTrue(SupportedLocales::isOfficial($locale));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function officialLocales(): array
+    {
+        return [
+            'bare language'  => ['en'],
+            'full locale'    => ['en_US'],
+            'latin bare'     => ['la'],
+            'latin vatican'  => ['la_VA'],
+            'dutch regional' => ['nl_NL'],
+        ];
+    }
+
+    #[DataProvider('unofficialLocales')]
+    public function testUnofficialLocalesAreNotRecognised(string $locale): void
+    {
+        self::assertFalse(SupportedLocales::isOfficial($locale));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function unofficialLocales(): array
+    {
+        return [
+            'croatian' => ['hr'],
+            'spanish'  => ['es'],
+            'german'   => ['de'],
+            'empty'    => [''],
+            'nonsense' => ['zz_ZZ'],
+        ];
+    }
+
+    public function testCroatianIsNotYetOfficial(): void
+    {
+        // Croatian has a complete lectionary across all ten corpora and a gettext
+        // catalogue, but incomplete decreed-event names. Promoting it is tracked
+        // in the resource's `candidates` block; until then it must degrade, not throw.
+        self::assertFalse(SupportedLocales::isOfficial('hr'));
+    }
+
+    public function testTheFallbackMatchesTheHistoricalConstant(): void
+    {
+        self::assertSame(['en', 'fr', 'it', 'la', 'nl'], SupportedLocales::FALLBACK);
+    }
+}

--- a/src/Enum/JsonData.php
+++ b/src/Enum/JsonData.php
@@ -471,6 +471,12 @@ enum JsonData: string
      */
     case CATHOLIC_DIOCESES_LATIN_RITE = JsonDataConstants::CATHOLIC_DIOCESES_LATIN_RITE;
 
+    /**
+     * The curated list of officially supported locales.
+     * Evaluates to 'jsondata/supportedLocales.json'.
+     */
+    case SUPPORTED_LOCALES_FILE = JsonDataConstants::SUPPORTED_LOCALES_FILE;
+
     public function path(): string
     {
         return Router::$apiFilePath . $this->value;

--- a/src/Enum/JsonDataConstants.php
+++ b/src/Enum/JsonDataConstants.php
@@ -490,4 +490,10 @@ class JsonDataConstants
      * Evaluates to 'jsondata/world_dioceses.json'.
      */
     public const CATHOLIC_DIOCESES_LATIN_RITE = JsonDataConstants::FOLDER . '/world_dioceses.json';
+
+    /**
+     * The curated list of officially supported locales.
+     * Evaluates to 'jsondata/supportedLocales.json'.
+     */
+    public const SUPPORTED_LOCALES_FILE = JsonDataConstants::FOLDER . '/supportedLocales.json';
 }

--- a/src/Enum/LitLocale.php
+++ b/src/Enum/LitLocale.php
@@ -78,7 +78,11 @@ class LitLocale
      */
     public static function getSupportedLocales(): array
     {
-        return self::$values + self::$AllAvailableLocales;
+        // array_merge, not `+`: the union operator preserves left-hand KEYS, so on
+        // these numerically-indexed arrays ['la','la_VA'] + ['af','af_NA','af_ZA',…]
+        // yields ['la','la_VA','af_ZA',…] — silently dropping the first two ICU
+        // locales. Fixed in #904.
+        return array_values(array_unique(array_merge(self::$values, self::$AllAvailableLocales)));
     }
 
     /**

--- a/src/Models/Lectionary/ReadingsGeneralRoman.php
+++ b/src/Models/Lectionary/ReadingsGeneralRoman.php
@@ -79,7 +79,7 @@ final class ReadingsGeneralRoman
         ];
 
         foreach ($filesToLoad as $key => $file) {
-            $this->{$key} = ReadingsMap::fromFile($file);
+            $this->{$key} = ReadingsMap::fromFile($file, $locale);
         }
     }
 

--- a/src/Models/Lectionary/ReadingsMap.php
+++ b/src/Models/Lectionary/ReadingsMap.php
@@ -2,6 +2,7 @@
 
 namespace LiturgicalCalendar\Api\Models\Lectionary;
 
+use LiturgicalCalendar\Api\Services\SupportedLocales;
 use LiturgicalCalendar\Api\Utilities;
 
 /**
@@ -186,6 +187,20 @@ final class ReadingsMap implements \ArrayAccess
      *
      * Initializes an empty $readings array property.
      */
+    /**
+     * The locale this map was loaded for, when known.
+     *
+     * Drives whether a missing offset is a defect or merely untranslated work in
+     * progress — see {@see getReadings()}. Null when the map was built without a
+     * locale (array fixtures, tests), which is treated as unofficial, i.e. lenient.
+     */
+    private ?string $locale = null;
+
+    public function setLocale(?string $locale): void
+    {
+        $this->locale = $locale;
+    }
+
     public function __construct()
     {
         $this->readings = [];
@@ -370,7 +385,20 @@ final class ReadingsMap implements \ArrayAccess
      *
      * If the offset points to a ReadingsFestiveWithVigil, it returns the day readings.
      * If the offset points to any other type of readings, it returns the readings object as is.
-     * If the offset does not exist, it returns null.
+     *
+     * A missing offset is handled according to whether this map's locale is
+     * officially supported (see {@see SupportedLocales}):
+     *
+     * - **official** — throws. An official locale promises complete data, so a gap
+     *   is a defect that must surface rather than be papered over.
+     * - **not official** — returns an empty readings object. This is byte-identical
+     *   to what an explicitly blank entry produces, and blank entries are already
+     *   normal in this corpus (StHildegardBingen is blank in `la`, `es` and `hr`).
+     *   Partial translation work must never take down a calendar (#904).
+     *
+     * (Before #904 this method always threw, while this docblock claimed it
+     *  returned null and the return type did not admit null. The contract now
+     *  matches the code.)
      *
      * @param string $offset The offset to retrieve the readings from.
      * @return ReadingsMultipleSchemas|ReadingsChristmas|ReadingsEasterVigil|ReadingsPalmSunday|ReadingsFestive|ReadingsFerial|ReadingsWithEvening|ReadingsSeasonal The readings for the specified offset.
@@ -380,7 +408,16 @@ final class ReadingsMap implements \ArrayAccess
         $readingsObject = $this->readings[$offset] ?? null;
 
         if (null === $readingsObject) {
-            throw new \InvalidArgumentException("No readings found for offset: $offset, available offsets: " . implode(', ', array_keys($this->readings)));
+            if (null !== $this->locale && SupportedLocales::isOfficial($this->locale)) {
+                throw new \InvalidArgumentException("No readings found for offset: $offset, available offsets: " . implode(', ', array_keys($this->readings)));
+            }
+
+            return ReadingsFerial::fromArray([
+                'first_reading'      => '',
+                'responsorial_psalm' => '',
+                'gospel_acclamation' => '',
+                'gospel'             => ''
+            ]);
         }
 
         if ($readingsObject instanceof ReadingsFestiveWithVigil) {
@@ -397,7 +434,7 @@ final class ReadingsMap implements \ArrayAccess
      * @return ReadingsMap The readings loaded from the file.
      * @throws \InvalidArgumentException If the file does not exist, is not readable, or contains invalid JSON.
      */
-    public static function fromFile(string $file): ReadingsMap
+    public static function fromFile(string $file, ?string $locale = null): ReadingsMap
     {
         $dataRaw = Utilities::rawContentsFromFile($file);
 
@@ -408,6 +445,7 @@ final class ReadingsMap implements \ArrayAccess
 
         $readingsMap = new self();
         $readingsMap->addFromArray($dataJson);
+        $readingsMap->setLocale($locale);
         return $readingsMap;
     }
 

--- a/src/Services/CalendarMetadataProvider.php
+++ b/src/Services/CalendarMetadataProvider.php
@@ -18,6 +18,7 @@ use LiturgicalCalendar\Api\Models\Metadata\MetadataDiocesanCalendarItem;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataNationalCalendarItem;
 use LiturgicalCalendar\Api\Models\Metadata\MetadataWiderRegionItem;
 use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
 use LiturgicalCalendar\Api\Utilities;
 
 /**
@@ -53,7 +54,6 @@ final class CalendarMetadataProvider
      */
     private static ?CatholicDiocesesMap $worldDiocesesLatinRite = null;
 
-    private const array FULLY_TRANSLATED_LOCALES = ['en', 'fr', 'it', 'nl', 'la'];
 
     /**
      * Builds and returns the complete calendars metadata index from local
@@ -302,7 +302,7 @@ final class CalendarMetadataProvider
         // language, and array_intersect preserves duplicates from its first arg).
         $metadata->locales = array_values(array_unique(array_intersect(
             array_merge(['en'], array_map('basename', $folderGlob)),
-            self::FULLY_TRANSLATED_LOCALES
+            SupportedLocales::official()
         )));
     }
 

--- a/src/Services/SupportedLocales.php
+++ b/src/Services/SupportedLocales.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services;
+
+use LiturgicalCalendar\Api\Enum\JsonDataConstants;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Utilities;
+
+/**
+ * The curated set of locales this deployment considers officially supported.
+ *
+ * "Officially supported" is a promise, not a description of what happens to be
+ * on disk: an official locale must have a complete set of resources, and missing
+ * data for one is a defect that should fail loudly. A locale outside the list is
+ * work in progress — partial data for it must degrade quietly, never error.
+ *
+ * The list previously lived as `CalendarMetadataProvider::FULLY_TRANSLATED_LOCALES`,
+ * a private constant referenced exactly once, to filter the `/calendars` response.
+ * It described the contract without enforcing it anywhere, which is how a decree
+ * written with partial lectionary coverage could take down a whole calendar
+ * (issues #902, #904). Moving it to a resource makes it curatable and, more
+ * importantly, makes it consultable by the code that must honour it.
+ *
+ * Reading is memoized for the process: the file is small and, unlike calendar
+ * source data, is not written by the `/data` endpoints at request time.
+ */
+final class SupportedLocales
+{
+    /**
+     * Fallback used when the resource cannot be read.
+     *
+     * Deliberately the historical value of FULLY_TRANSLATED_LOCALES. A deployment
+     * whose resource file is missing or corrupt degrades to the long-standing
+     * behaviour rather than either supporting nothing (which would make every
+     * calendar unofficial and silently disable enforcement) or supporting
+     * everything (which would make every incomplete locale throw).
+     *
+     * @var list<string>
+     */
+    public const FALLBACK = ['en', 'fr', 'it', 'la', 'nl'];
+
+    /** @var list<string>|null */
+    private static ?array $official = null;
+
+    /**
+     * The locales officially supported for the General Roman Calendar.
+     *
+     * @return list<string>
+     */
+    public static function official(): array
+    {
+        if (self::$official !== null) {
+            return self::$official;
+        }
+
+        try {
+            $data = Utilities::jsonFileToObject(self::resourcePath());
+
+            $grc      = $data->general_roman_calendar ?? null;
+            $declared = ( $grc instanceof \stdClass && is_array($grc->official ?? null) )
+                ? $grc->official
+                : [];
+
+            $locales = array_values(array_filter(
+                $declared,
+                static fn (mixed $v): bool => is_string($v) && $v !== ''
+            ));
+        } catch (\Throwable $e) {
+            error_log('SupportedLocales: falling back to the built-in list — ' . $e->getMessage());
+            $locales = [];
+        }
+
+        return self::$official = ( $locales === [] ? self::FALLBACK : $locales );
+    }
+
+    /**
+     * Whether $locale is officially supported.
+     *
+     * Compares on the primary language subtag, so `en_US` and `en` both match the
+     * declared `en`: the resource lists languages, while requests may carry a
+     * full locale.
+     */
+    public static function isOfficial(string $locale): bool
+    {
+        if ($locale === '') {
+            return false;
+        }
+
+        $primary = \Locale::getPrimaryLanguage($locale) ?? $locale;
+
+        return in_array($primary, self::official(), true)
+            || in_array($locale, self::official(), true);
+    }
+
+    /**
+     * Absolute path to the curated resource.
+     *
+     * `JsonData::…->path()` cannot be used here: it reads `Router::$apiFilePath`,
+     * a typed static that is only initialised once a request is being routed. This
+     * service is also consulted from unit tests and CLI tooling, where accessing it
+     * raises "must not be accessed before initialization" — which would silently
+     * route every such caller to the fallback list and make enforcement untested.
+     */
+    private static function resourcePath(): string
+    {
+        $root = isset(Router::$apiFilePath) && Router::$apiFilePath !== ''
+            ? Router::$apiFilePath
+            : dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
+
+        return $root . JsonDataConstants::SUPPORTED_LOCALES_FILE;
+    }
+
+    /**
+     * Reset the memoized list. Tests only.
+     */
+    public static function reset(): void
+    {
+        self::$official = null;
+    }
+}


### PR DESCRIPTION
Refs #904. Fixes the live 500 on `/calendar?locale=hr`.

## The bug

`https://litcal.johnromanodorazio.com/api/dev/calendar?locale=hr` returns **500**.

Croatian is not an officially supported locale, so incomplete data for it should degrade quietly.
Instead `ReadingsMap::getReadings()` threw on any missing offset — even though **its own docblock
promised the opposite**:

> *If the offset does not exist, it returns null.*

The return type did not admit `null` either. The documented contract was graceful degradation; the
implementation never matched it. That is what took the Croatian calendar down when a decree was
created without full lectionary coverage (#903).

## Why it could not be fixed locally

There was no usable definition of "officially supported" to check against.

`CalendarMetadataProvider::FULLY_TRANSLATED_LOCALES` held the answer, but it was `private` and
referenced **exactly once** — to filter the `/calendars` response. It described the contract without
enforcing it anywhere. Meanwhile `LitLocale::getSupportedLocales()` accepted roughly 700 ICU locales.

## What changed

**`jsondata/supportedLocales.json`** — the curated list, alongside the other top-level reference data
(`likelySubtags.json`, `world_dioceses.json`), behind a `SupportedLocales` service. Same five
locales; no change to what `/calendars` advertises.

**Locale-aware strictness in `ReadingsMap`:**

| Situation | Behaviour |
| ------------------------------------ | --------------------------------------------- |
| missing offset, locale **official**  | throws — an official locale promises complete data |
| missing offset, locale **not official** | empty readings object |
| map built with no locale (fixtures)  | lenient |

The empty object is byte-identical to what an explicitly blank entry produces, and blank entries are
already normal in this corpus — `StHildegardBingen` is blank in `la`, `es` and `hr` today. So
**no call site changes signature**, and "missing key" and "key present but blank" finally mean the
same thing, which is the inconsistency behind the original failure.

Promoting a locale therefore *tightens* enforcement, which is the intended direction.

**Incidental fix** — `LitLocale::getSupportedLocales()` used `+` on numerically-indexed arrays, which
preserves left-hand keys and silently dropped entries:

```php
["la","la_VA"] + ["af","af_NA","af_ZA","agq"]
// → ["la","la_VA","af_ZA","agq"]      af and af_NA gone
```

Now `array_merge`; verified `af` and `af_NA` are present again (852 locales).

## Croatian stays unofficial

Its lectionary is complete across all ten corpora and it has a gettext catalogue, but decreed-event
names are not complete — `StJohnNewman` has none. Promoting it today would immediately make that data
incomplete by the new rule. The resource records the reason in a `candidates` block so the next
person does not have to rediscover it.

## Verification

- 25 new tests, 43 assertions — `SupportedLocalesTest` and `ReadingsMapLocaleStrictnessTest`, the
  latter reproducing the exact Croatian failure shape as a regression guard.
- 640 tests green across schemas, metadata provider and the new suites.
- `composer analyse` — PHPStan level 10, no errors.
- `/calendars` still advertises `["en","fr","it","la","nl"]` — unchanged.
- Full quick suite: only the three pre-existing `LitCalTestServerTest` failures, which fail
  identically on a clean `development` checkout.

## Not in this PR

Admin curation of the list is **blocked on #902**: curation writes `supportedLocales.json` on the
deployed server, so until the change-request workflow exists an admin's promotion would be wiped by
the next deploy. Per the decision on #904, promotions will land as reviewed pull requests, giving
governance decisions a git history.

Still to come on #904: a `LocaleReadinessChecker` (the pre-flight test that gates promotion, reusable
as a CI completeness guard) and the admin UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyuj9umG6o8PzJ4BFf6Xp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added official locale support for English, French, Italian, Latin and Dutch.
  - Added recognition of officially supported locales, including full locale codes.
- **Bug Fixes**
  - Corrected locale discovery so all available ICU locales are included.
  - Reading maps now apply the requested locale consistently.
  - Missing readings now produce appropriate errors for official locales while remaining graceful for unofficial or unspecified locales.
- **Documentation**
  - Added curated locale metadata for the General Roman Calendar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->