### PR TITLE
feat(locales): locale readiness checker and admin curation surface

### DIFF
--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -9910,7 +9910,8 @@
                         "exists",
                         "parses",
                         "validates"
-                      ]
+                      ],
+                      "expected_locales": null
                     },
                     {
                       "id": "sanctorale:roman:US_2011:i18n",
@@ -9923,7 +9924,8 @@
                         "exists",
                         "parses",
                         "validates"
-                      ]
+                      ],
+                      "expected_locales": null
                     }
                   ]
                 }

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -101,6 +101,10 @@
       "description": "Curation surface for the locales the API declares officially supported. An official locale promises complete data: missing data for one is an error, while a locale outside the list degrades quietly."
     },
     {
+      "name": "Admin - Outbox",
+      "description": "Inspection and retry management for the OpenFGA reconciliation outbox. Global admins only."
+    },
+    {
       "name": "Applications",
       "description": "Developer application management (create, update, delete applications and API keys)"
     },
@@ -4447,6 +4451,161 @@
           },
           "404": {
             "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      }
+    },
+    "/admin/outbox": {
+      "get": {
+        "tags": [
+          "Admin - Outbox"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List or summarise OpenFGA outbox rows",
+        "operationId": "adminListOutbox",
+        "description": "Inspect the OpenFGA reconciliation outbox. With `summary=1` returns per-status counts and the age of the oldest pending row instead of a row listing. Global admins only.",
+        "parameters": [
+          {
+            "name": "summary",
+            "in": "query",
+            "required": false,
+            "description": "When truthy, return per-status counts instead of a row listing.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "1"
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "required": false,
+            "description": "Filter by row status.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "retrying",
+                "succeeded",
+                "failed_terminal"
+              ]
+            }
+          },
+          {
+            "name": "access_request_id",
+            "in": "query",
+            "required": false,
+            "description": "Filter to rows raised by one access request.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Page size. Values outside 1-200 fall back to the default of 50.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 200,
+              "default": 50
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Rows to skip.",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: A row listing, or a summary when `summary` is set",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/OutboxListResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OutboxSummaryResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
+        }
+      }
+    },
+    "/admin/outbox/{id}/retry": {
+      "post": {
+        "tags": [
+          "Admin - Outbox"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Return a failed row to the queue",
+        "operationId": "adminRetryOutboxRow",
+        "description": "Reset a `failed_terminal` row to `pending` and nudge the consumer, rather than waiting for the next cron backstop run. Only rows in `failed_terminal` may be retried. Global admins only.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Outbox row id.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK: Row reset to pending",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OutboxRetryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "description": "Not Found: No outbox row with that id"
+          },
+          "409": {
+            "description": "Conflict: The row is not in failed_terminal state"
           }
         }
       }
@@ -10090,6 +10249,192 @@
   },
   "components": {
     "schemas": {
+      "OutboxRow": {
+        "type": "object",
+        "description": "One OpenFGA tuple operation the API has committed to perform.",
+        "required": [
+          "id",
+          "operation",
+          "fga_user",
+          "fga_relation",
+          "fga_object",
+          "status",
+          "attempts",
+          "next_attempt_at",
+          "last_error",
+          "last_error_code",
+          "metadata",
+          "created_at",
+          "completed_at"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "write_tuple",
+              "delete_tuple"
+            ]
+          },
+          "fga_user": {
+            "type": "string",
+            "example": "user:abc123"
+          },
+          "fga_relation": {
+            "type": "string",
+            "example": "editor"
+          },
+          "fga_object": {
+            "type": "string",
+            "example": "national_calendar:USA"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "retrying",
+              "succeeded",
+              "failed_terminal"
+            ]
+          },
+          "attempts": {
+            "type": "integer"
+          },
+          "next_attempt_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_error_code": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          }
+        }
+      },
+      "OutboxListResponse": {
+        "type": "object",
+        "required": [
+          "items",
+          "count",
+          "total",
+          "limit",
+          "offset",
+          "has_more"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OutboxRow"
+            }
+          },
+          "count": {
+            "type": "integer",
+            "description": "Rows in this page."
+          },
+          "total": {
+            "type": "integer",
+            "description": "Rows matching the filter across all pages."
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "offset": {
+            "type": "integer"
+          },
+          "has_more": {
+            "type": "boolean"
+          }
+        }
+      },
+      "OutboxSummaryResponse": {
+        "type": "object",
+        "required": [
+          "counts",
+          "oldest_pending_age_seconds"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "counts": {
+            "type": "object",
+            "description": "All four statuses are always present, defaulting to zero.",
+            "required": [
+              "pending",
+              "retrying",
+              "succeeded",
+              "failed_terminal"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "pending": {
+                "type": "integer"
+              },
+              "retrying": {
+                "type": "integer"
+              },
+              "succeeded": {
+                "type": "integer"
+              },
+              "failed_terminal": {
+                "type": "integer"
+              }
+            }
+          },
+          "oldest_pending_age_seconds": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Age of the oldest row awaiting drain, or null when none is pending."
+          }
+        }
+      },
+      "OutboxRetryResponse": {
+        "type": "object",
+        "required": [
+          "success",
+          "id",
+          "row"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer"
+          },
+          "row": {
+            "$ref": "#/components/schemas/OutboxRow"
+          }
+        }
+      },
       "LocaleReadinessCheck": {
         "type": "object",
         "description": "One readiness probe against one locale.",

--- a/jsondata/schemas/openapi.json
+++ b/jsondata/schemas/openapi.json
@@ -97,6 +97,10 @@
       "description": "Admin operations for application approval workflow (approve, reject, revoke)"
     },
     {
+      "name": "Admin - Supported Locales",
+      "description": "Curation surface for the locales the API declares officially supported. An official locale promises complete data: missing data for one is an error, while a locale outside the list degrades quietly."
+    },
+    {
       "name": "Applications",
       "description": "Developer application management (create, update, delete applications and API keys)"
     },
@@ -4344,6 +4348,93 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AdminApplicationActionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound404"
+          }
+        }
+      }
+    },
+    "/admin/locales": {
+      "get": {
+        "tags": [
+          "Admin - Supported Locales"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List candidate locales with their readiness",
+        "operationId": "adminListSupportedLocales",
+        "description": "Every locale for which any resource exists, which of them are officially supported, and whether each has everything an official locale requires. Restricted to global admins: which locales the API declares supported is a governance decision about its published contract, not a per-resource one. Read-only; the `curation` object explains why.",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SupportedLocalesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized401"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden403"
+          }
+        }
+      }
+    },
+    "/admin/locales/{locale}": {
+      "get": {
+        "tags": [
+          "Admin - Supported Locales"
+        ],
+        "security": [
+          {
+            "BearerAuth": []
+          },
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Readiness report for one locale",
+        "operationId": "adminGetLocaleReadiness",
+        "description": "The full set of readiness probes for a single locale, each listing the concrete identifiers that are missing. Advisory probes are reported but do not affect `ready`.",
+        "parameters": [
+          {
+            "name": "locale",
+            "in": "path",
+            "required": true,
+            "description": "Locale to report on. Must be one of the candidates returned by `/admin/locales`.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "hr"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocaleReadinessReport"
                 }
               }
             }
@@ -9999,6 +10090,134 @@
   },
   "components": {
     "schemas": {
+      "LocaleReadinessCheck": {
+        "type": "object",
+        "description": "One readiness probe against one locale.",
+        "required": [
+          "name",
+          "passed",
+          "advisory",
+          "summary",
+          "missing"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Probe identifier.",
+            "example": "decree_names"
+          },
+          "passed": {
+            "type": "boolean"
+          },
+          "advisory": {
+            "type": "boolean",
+            "description": "When true the probe is reported but does not affect readiness."
+          },
+          "summary": {
+            "type": "string",
+            "example": "1 decreed event has no name"
+          },
+          "missing": {
+            "type": "array",
+            "description": "Concrete identifiers, file paths or event keys, that are absent.",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LocaleReadinessReport": {
+        "type": "object",
+        "required": [
+          "locale",
+          "official",
+          "ready",
+          "checks"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "locale": {
+            "type": "string",
+            "example": "hr"
+          },
+          "official": {
+            "type": "boolean",
+            "description": "Whether the locale is currently declared officially supported."
+          },
+          "ready": {
+            "type": "boolean",
+            "description": "Whether every non-advisory probe passed, i.e. the locale could be promoted safely."
+          },
+          "checks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LocaleReadinessCheck"
+            }
+          }
+        }
+      },
+      "SupportedLocalesResponse": {
+        "type": "object",
+        "required": [
+          "official",
+          "candidates",
+          "curation"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "official": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "candidates": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "locale",
+                "official",
+                "ready",
+                "summary"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "locale": {
+                  "type": "string"
+                },
+                "official": {
+                  "type": "boolean"
+                },
+                "ready": {
+                  "type": "boolean"
+                },
+                "summary": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "curation": {
+            "type": "object",
+            "description": "Whether promotion can be performed through the API, and why not when it cannot.",
+            "required": [
+              "writable",
+              "reason"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "writable": {
+                "type": "boolean"
+              },
+              "reason": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
       "TemporaleGetResponse": {
         "type": "object",
         "description": "Response object containing temporale events and locale information",

--- a/phpunit_tests/Handlers/LocalesAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/LocalesAdminHandlerTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Handlers;
+
+use LiturgicalCalendar\Api\Handlers\Admin\LocalesAdminHandler;
+use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LocalesAdminHandler::class)]
+final class LocalesAdminHandlerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        SupportedLocales::reset();
+    }
+
+    /** @param array<string, mixed>|null $oidcUser */
+    private function request(string $path, ?array $oidcUser): ServerRequest
+    {
+        $request = ( new ServerRequest('GET', $path) )->withHeader('Accept', 'application/json');
+
+        return $oidcUser === null ? $request : $request->withAttribute('oidc_user', $oidcUser);
+    }
+
+    /** @return array<string, mixed> */
+    private function globalAdmin(): array
+    {
+        return ['sub' => 'admin-1', 'roles' => ['admin']];
+    }
+
+    /** @param string[] $pathParams @return array<string, mixed> */
+    private function json(array $pathParams, string $path, ?array $oidcUser): array
+    {
+        $response = ( new LocalesAdminHandler($pathParams) )->handle($this->request($path, $oidcUser));
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode((string) $response->getBody(), true);
+
+        return $decoded;
+    }
+
+    public function testAnUnauthenticatedCallerIsRejected(): void
+    {
+        $this->expectException(UnauthorizedException::class);
+
+        ( new LocalesAdminHandler(['locales']) )->handle($this->request('/admin/locales', null));
+    }
+
+    public function testANonAdminIsForbidden(): void
+    {
+        $this->expectException(ForbiddenException::class);
+
+        ( new LocalesAdminHandler(['locales']) )
+            ->handle($this->request('/admin/locales', ['sub' => 'editor-1', 'roles' => ['calendar_editor']]));
+    }
+
+    public function testTheListNamesEveryCandidateAndFlagsTheOfficialOnes(): void
+    {
+        $body = $this->json(['locales'], '/admin/locales', $this->globalAdmin());
+
+        self::assertSame(SupportedLocales::official(), $body['official']);
+        self::assertNotEmpty($body['candidates']);
+
+        $byLocale = array_column($body['candidates'], null, 'locale');
+        self::assertTrue($byLocale['en']['official']);
+        self::assertTrue($byLocale['en']['ready']);
+        self::assertFalse($byLocale['hr']['official']);
+    }
+
+    /**
+     * An operator seeing a green "ready" must be told why there is no promote
+     * button, rather than being left to wonder.
+     */
+    public function testTheListExplainsWhyCurationIsNotWritableYet(): void
+    {
+        $body = $this->json(['locales'], '/admin/locales', $this->globalAdmin());
+
+        self::assertFalse($body['curation']['writable']);
+        self::assertStringContainsString('#902', $body['curation']['reason']);
+    }
+
+    public function testASingleLocaleReturnsItsFullReport(): void
+    {
+        $body = $this->json(['locales', 'hr'], '/admin/locales/hr', $this->globalAdmin());
+
+        self::assertSame('hr', $body['locale']);
+        self::assertFalse($body['official']);
+        self::assertFalse($body['ready']);
+        self::assertNotEmpty($body['checks']);
+    }
+
+    public function testAnOfficialLocaleReportsReady(): void
+    {
+        $body = $this->json(['locales', 'la'], '/admin/locales/la', $this->globalAdmin());
+
+        self::assertTrue($body['official']);
+        self::assertTrue($body['ready']);
+    }
+
+    public function testALocaleWithNoResourcesIsNotFound(): void
+    {
+        $this->expectException(NotFoundException::class);
+
+        ( new LocalesAdminHandler(['locales', 'zz']) )
+            ->handle($this->request('/admin/locales/zz', $this->globalAdmin()));
+    }
+}

--- a/phpunit_tests/Handlers/LocalesAdminHandlerTest.php
+++ b/phpunit_tests/Handlers/LocalesAdminHandlerTest.php
@@ -9,22 +9,22 @@ use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
 use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
 use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
 use LiturgicalCalendar\Api\Services\SupportedLocales;
-use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
 
 #[CoversClass(LocalesAdminHandler::class)]
-final class LocalesAdminHandlerTest extends TestCase
+final class LocalesAdminHandlerTest extends AbstractHandlerTestCase
 {
     protected function setUp(): void
     {
+        parent::setUp();
         SupportedLocales::reset();
     }
 
     /** @param array<string, mixed>|null $oidcUser */
-    private function request(string $path, ?array $oidcUser): ServerRequest
+    private function request(string $path, ?array $oidcUser): ServerRequestInterface
     {
-        $request = ( new ServerRequest('GET', $path) )->withHeader('Accept', 'application/json');
+        $request = $this->requestFor('GET', $path);
 
         return $oidcUser === null ? $request : $request->withAttribute('oidc_user', $oidcUser);
     }
@@ -38,11 +38,9 @@ final class LocalesAdminHandlerTest extends TestCase
     /** @param string[] $pathParams @return array<string, mixed> */
     private function json(array $pathParams, string $path, ?array $oidcUser): array
     {
-        $response = ( new LocalesAdminHandler($pathParams) )->handle($this->request($path, $oidcUser));
-        /** @var array<string, mixed> $decoded */
-        $decoded = json_decode((string) $response->getBody(), true);
-
-        return $decoded;
+        return $this->decodeJsonBody(
+            ( new LocalesAdminHandler($pathParams) )->handle($this->request($path, $oidcUser))
+        );
     }
 
     public function testAnUnauthenticatedCallerIsRejected(): void

--- a/phpunit_tests/Services/Locale/LocaleReadinessCheckerTest.php
+++ b/phpunit_tests/Services/Locale/LocaleReadinessCheckerTest.php
@@ -142,6 +142,34 @@ final class LocaleReadinessCheckerTest extends TestCase
         self::assertArrayHasKey('missing', $json['checks'][0]);
     }
 
+    /**
+     * The blank-readings probe is advisory: it reports a real content gap that four
+     * of the five official locales currently have, so gating on it would fail them
+     * all at once. It must therefore never influence `ready()`.
+     */
+    public function testAdvisoryChecksAreReportedButDoNotGate(): void
+    {
+        $report = $this->checker->check('fr');
+
+        self::assertTrue($report->ready(), 'an advisory failure must not make a locale unready');
+        self::assertNotEmpty($report->advisories());
+        self::assertSame(['decree_readings_populated'], array_map(
+            static fn (LocaleReadinessCheck $c): string => $c->name,
+            $report->advisories()
+        ));
+        self::assertSame([], $report->failures());
+    }
+
+    public function testAdvisoryChecksAreFlaggedInTheSerialisedReport(): void
+    {
+        /** @var array{checks: list<array{name: string, advisory: bool}>} $json */
+        $json     = json_decode((string) json_encode($this->checker->check('fr')), true);
+        $advisory = array_column($json['checks'], 'advisory', 'name');
+
+        self::assertTrue($advisory['decree_readings_populated']);
+        self::assertFalse($advisory['decree_names']);
+    }
+
     public function testPluralAgreement(): void
     {
         self::assertSame('1 event has', LocaleReadinessCheck::plural(1, 'event has', 'events have'));

--- a/phpunit_tests/Services/Locale/LocaleReadinessCheckerTest.php
+++ b/phpunit_tests/Services/Locale/LocaleReadinessCheckerTest.php
@@ -170,6 +170,137 @@ final class LocaleReadinessCheckerTest extends TestCase
         self::assertFalse($advisory['decree_names']);
     }
 
+    /**
+     * An unreadable decree corpus must fail, not pass vacuously.
+     *
+     * Before this guard, a missing or corrupt decrees.json produced an empty event
+     * list, every downstream probe passed with "all 0 newly created events ...",
+     * and the locale reported READY — a silent false pass inside the tool built to
+     * prevent silent false passes.
+     */
+    #[DataProvider('unreadableCorpora')]
+    public function testAnUnreadableDecreeCorpusIsNotReady(string $contents): void
+    {
+        $root = $this->rootWithDecrees($contents);
+
+        try {
+            $report = ( new LocaleReadinessChecker($root) )->check('en');
+
+            self::assertFalse($report->ready(), 'an unreadable decrees.json must not report ready');
+            self::assertContains('decree_source', array_map(
+                static fn (LocaleReadinessCheck $c): string => $c->name,
+                $report->failures()
+            ));
+        } finally {
+            self::removeTree($root);
+        }
+    }
+
+    /** @return array<string, array{string}> */
+    public static function unreadableCorpora(): array
+    {
+        return [
+            'absent'       => [''],
+            'invalid json' => ['{ this is not json'],
+            'not an array' => ['"a bare string"'],
+        ];
+    }
+
+    public function testAReadableCorpusPassesTheSourceCheck(): void
+    {
+        $source = $this->checker->check('en');
+
+        foreach ($source->checks as $check) {
+            if ($check->name === 'decree_source') {
+                self::assertTrue($check->passed);
+                return;
+            }
+        }
+
+        self::fail('no decree_source check was produced');
+    }
+
+    /**
+     * `describe()` must not report a failed advisory as a passed check.
+     */
+    public function testDescribeCountsOnlyChecksThatActuallyPassed(): void
+    {
+        $report = $this->checker->check('fr');
+        $passed = count(array_filter($report->checks, static fn (LocaleReadinessCheck $c): bool => $c->passed));
+
+        self::assertTrue($report->ready());
+        self::assertNotSame($passed, count($report->checks), 'fr is expected to have an advisory failure');
+
+        $described = $report->describe();
+        self::assertStringContainsString(sprintf('%d of %d checks passed', $passed, count($report->checks)), $described);
+        self::assertStringContainsString('advisory not met', $described);
+    }
+
+    public function testDescribeOmitsTheAdvisoryClauseWhenThereIsNothingToReport(): void
+    {
+        $report = new LocaleReadinessReport('xx', false, [
+            new LocaleReadinessCheck('a', true, 'fine'),
+            new LocaleReadinessCheck('b', true, 'fine', [], true)
+        ]);
+
+        self::assertSame('xx: ready (2 of 2 checks passed)', $report->describe());
+    }
+
+    /**
+     * A copy of the real data tree with decrees.json replaced, so every other probe
+     * still passes and the corpus check is the only variable.
+     */
+    private function rootWithDecrees(string $contents): string
+    {
+        $root = sys_get_temp_dir() . '/litcal-readiness-' . bin2hex(random_bytes(6)) . '/';
+        $repo = dirname(__DIR__, 3) . '/';
+
+        self::copyTree($repo . 'jsondata', $root . 'jsondata');
+        self::copyTree($repo . 'i18n', $root . 'i18n');
+
+        $decrees = $root . 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+        if ($contents === '') {
+            unlink($decrees);
+        } else {
+            file_put_contents($decrees, $contents);
+        }
+
+        return $root;
+    }
+
+    private static function copyTree(string $from, string $to): void
+    {
+        mkdir($to, 0o755, true);
+        /** @var \RecursiveIteratorIterator<\RecursiveDirectoryIterator> $it */
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($from, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+        foreach ($it as $item) {
+            $target = $to . DIRECTORY_SEPARATOR . $it->getSubPathName();
+            if ($item->isDir()) {
+                mkdir($target, 0o755, true);
+            } else {
+                copy($item->getPathname(), $target);
+            }
+        }
+    }
+
+    private static function removeTree(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $it = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($it as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+        rmdir($dir);
+    }
+
     public function testPluralAgreement(): void
     {
         self::assertSame('1 event has', LocaleReadinessCheck::plural(1, 'event has', 'events have'));

--- a/phpunit_tests/Services/Locale/LocaleReadinessCheckerTest.php
+++ b/phpunit_tests/Services/Locale/LocaleReadinessCheckerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\Locale;
+
+use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessCheck;
+use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessChecker;
+use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessReport;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(LocaleReadinessChecker::class)]
+#[CoversClass(LocaleReadinessReport::class)]
+#[CoversClass(LocaleReadinessCheck::class)]
+final class LocaleReadinessCheckerTest extends TestCase
+{
+    private LocaleReadinessChecker $checker;
+
+    protected function setUp(): void
+    {
+        SupportedLocales::reset();
+        $this->checker = new LocaleReadinessChecker();
+    }
+
+    /**
+     * The guard that matters: promoting a locale turns quiet degradation into hard
+     * failures, so an already-official locale must never be incomplete. If this
+     * fails, either data regressed or a locale was promoted too early.
+     */
+    #[DataProvider('officialLocales')]
+    public function testEveryOfficialLocaleIsReady(string $locale): void
+    {
+        $report = $this->checker->check($locale);
+
+        self::assertTrue(
+            $report->ready(),
+            $report->describe() . "\n" . implode("\n", array_map(
+                static fn (LocaleReadinessCheck $c): string => '  ' . $c->name . ': ' . implode(', ', $c->missing),
+                $report->failures()
+            ))
+        );
+    }
+
+    /** @return array<string, array{string}> */
+    public static function officialLocales(): array
+    {
+        $cases = [];
+        foreach (SupportedLocales::official() as $locale) {
+            $cases[$locale] = [$locale];
+        }
+
+        return $cases;
+    }
+
+    public function testAnOfficialLocaleIsReportedAsOfficial(): void
+    {
+        self::assertTrue($this->checker->check('en')->official);
+    }
+
+    public function testAnUnofficialLocaleIsReportedAsSuch(): void
+    {
+        self::assertFalse($this->checker->check('hr')->official);
+    }
+
+    /**
+     * Croatian is the live example of a promotion candidate: complete lectionary,
+     * gettext catalogue present, but a decreed event still unnamed. If this ever
+     * starts passing, hr has become promotable and the resource should say so.
+     */
+    public function testCroatianIsBlockedOnlyByDecreeNames(): void
+    {
+        $report = $this->checker->check('hr');
+
+        self::assertFalse($report->ready());
+        self::assertSame(['decree_names'], array_map(
+            static fn (LocaleReadinessCheck $c): string => $c->name,
+            $report->failures()
+        ));
+    }
+
+    public function testAnUntranslatedLocaleFailsOnLectionaryCorpora(): void
+    {
+        $failing = array_map(
+            static fn (LocaleReadinessCheck $c): string => $c->name,
+            $this->checker->check('es')->failures()
+        );
+
+        self::assertContains('lectionary_corpora', $failing);
+    }
+
+    public function testDecreesThatOnlyModifyAnEventDoNotRequireDecreeReadings(): void
+    {
+        // StMaryMagdalene_Upgrade (setProperty), StMartha_NameChange (setProperty),
+        // StThereseChildJesus_Doctor and StIrenaeus_Doctor (makeDoctor) leave their
+        // events in the sanctorale, where the readings already live. Requiring
+        // decree readings for them would flag every official locale as incomplete.
+        $readings = $this->namedCheck($this->checker->check('en'), 'decree_readings');
+
+        self::assertTrue($readings->passed);
+        self::assertNotContains('StMaryMagdalene', $readings->missing);
+        self::assertNotContains('StIrenaeus', $readings->missing);
+    }
+
+    public function testEnglishNeedsNoGettextCatalogue(): void
+    {
+        $check = $this->namedCheck($this->checker->check('en'), 'gettext_catalogue');
+
+        self::assertTrue($check->passed);
+        self::assertStringContainsString('source language', $check->summary);
+    }
+
+    public function testAnUnknownLocaleFailsEverySubstantiveCheck(): void
+    {
+        $report = $this->checker->check('zz');
+
+        self::assertFalse($report->ready());
+        self::assertFalse($report->official);
+    }
+
+    public function testCheckOfficialLocalesCoversTheWholeList(): void
+    {
+        $reports = $this->checker->checkOfficialLocales();
+
+        self::assertCount(count(SupportedLocales::official()), $reports);
+        foreach ($reports as $report) {
+            self::assertTrue($report->official);
+        }
+    }
+
+    public function testTheReportSerialisesForTheAdminInterface(): void
+    {
+        $json = json_decode((string) json_encode($this->checker->check('hr')), true);
+
+        self::assertIsArray($json);
+        self::assertSame('hr', $json['locale']);
+        self::assertFalse($json['ready']);
+        self::assertFalse($json['official']);
+        self::assertNotEmpty($json['checks']);
+        self::assertArrayHasKey('missing', $json['checks'][0]);
+    }
+
+    public function testPluralAgreement(): void
+    {
+        self::assertSame('1 event has', LocaleReadinessCheck::plural(1, 'event has', 'events have'));
+        self::assertSame('2 events have', LocaleReadinessCheck::plural(2, 'event has', 'events have'));
+        self::assertSame('0 events have', LocaleReadinessCheck::plural(0, 'event has', 'events have'));
+    }
+
+    private function namedCheck(LocaleReadinessReport $report, string $name): LocaleReadinessCheck
+    {
+        foreach ($report->checks as $check) {
+            if ($check->name === $name) {
+                return $check;
+            }
+        }
+
+        self::fail('No check named ' . $name);
+    }
+}

--- a/src/Handlers/Admin/LocalesAdminHandler.php
+++ b/src/Handlers/Admin/LocalesAdminHandler.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Handlers\Admin;
+
+use LiturgicalCalendar\Api\Handlers\AbstractHandler;
+use LiturgicalCalendar\Api\Http\Enum\AcceptabilityLevel;
+use LiturgicalCalendar\Api\Http\Enum\AcceptHeader;
+use LiturgicalCalendar\Api\Http\Enum\RequestMethod;
+use LiturgicalCalendar\Api\Http\Exception\ForbiddenException;
+use LiturgicalCalendar\Api\Http\Exception\NotFoundException;
+use LiturgicalCalendar\Api\Http\Exception\UnauthorizedException;
+use LiturgicalCalendar\Api\Http\Middleware\OidcAuthMiddleware;
+use LiturgicalCalendar\Api\Services\Locale\LocaleReadinessChecker;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Curation surface for the officially supported locales (#904).
+ *
+ * - `GET /admin/locales`            — every candidate locale, official flag, readiness
+ * - `GET /admin/locales/{locale}`   — the full readiness report for one locale
+ *
+ * Read-only by design, for now. Promotion writes `jsondata/supportedLocales.json`
+ * on the deployed server, which the next deploy would overwrite — the problem
+ * tracked in #902. Until change requests can carry that write, promotion stays a
+ * reviewed pull request, and this endpoint exists to tell an operator whether
+ * such a pull request would be safe to open.
+ *
+ * Restricted to global (Zitadel) admins: this is a governance decision about the
+ * API's published contract, not a per-resource one, so resource-admin scopes do
+ * not apply.
+ */
+final class LocalesAdminHandler extends AbstractHandler
+{
+    private ?LocaleReadinessChecker $checker;
+
+    /**
+     * @param string[] $requestPathParams
+     */
+    public function __construct(array $requestPathParams = [], ?LocaleReadinessChecker $checker = null)
+    {
+        parent::__construct($requestPathParams);
+
+        $this->checker               = $checker;
+        $this->allowedRequestMethods = [RequestMethod::GET];
+        $this->allowedAcceptHeaders  = [AcceptHeader::JSON];
+        $this->allowCredentials      = true;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $response = static::initResponse($request);
+        $method   = RequestMethod::from($request->getMethod());
+
+        if ($method === RequestMethod::OPTIONS) {
+            return $this->handlePreflightRequest($request, $response);
+        }
+
+        $response = $this->setAccessControlAllowOriginHeader($request, $response);
+        $this->validateRequestMethod($request);
+
+        $mime     = $this->validateAcceptHeader($request, AcceptabilityLevel::LAX);
+        $response = $response->withHeader('Content-Type', $mime)->withHeader('Cache-Control', 'no-store');
+
+        /** @var array{sub?: string, roles?: array<string>}|null $oidcUser */
+        $oidcUser = $request->getAttribute('oidc_user');
+        if ($oidcUser === null) {
+            throw new UnauthorizedException('Authentication required');
+        }
+
+        if (false === OidcAuthMiddleware::isAdmin($oidcUser)) {
+            throw new ForbiddenException('Global admin role required to curate supported locales');
+        }
+
+        $locale = $this->requestedLocale();
+
+        return $this->encodeResponseBody(
+            $response,
+            null === $locale ? $this->listPayload() : $this->reportPayload($locale)
+        );
+    }
+
+    /**
+     * The `{locale}` segment of `/admin/locales/{locale}`, when present.
+     *
+     * `requestPathParams` carries the segments after `/admin`, so index 0 is
+     * `locales` itself.
+     */
+    private function requestedLocale(): ?string
+    {
+        $segment = $this->requestPathParams[1] ?? null;
+
+        return is_string($segment) && $segment !== '' ? $segment : null;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listPayload(): array
+    {
+        $checker = $this->checker();
+        $reports = array_map(
+            static fn (string $locale): array => [
+                'locale'   => $locale,
+                'official' => SupportedLocales::isOfficial($locale),
+                'ready'    => $checker->check($locale)->ready(),
+                'summary'  => $checker->check($locale)->describe(),
+            ],
+            $checker->knownLocales()
+        );
+
+        return [
+            'official'   => SupportedLocales::official(),
+            'candidates' => $reports,
+            // Surfaced rather than left implicit: an operator who sees a green
+            // "ready" here should know why there is no promote button yet.
+            'curation'   => [
+                'writable' => false,
+                'reason'   => 'Promotion writes jsondata/supportedLocales.json, which the next deploy would overwrite (see issue #902). Promote by opening a pull request against that file.',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function reportPayload(string $locale): array
+    {
+        $checker = $this->checker();
+
+        if (false === in_array($locale, $checker->knownLocales(), true)) {
+            throw new NotFoundException(sprintf('No resources found for locale "%s"', $locale));
+        }
+
+        /** @var array<string, mixed> $payload */
+        $payload = json_decode((string) json_encode($checker->check($locale)), true);
+
+        return $payload;
+    }
+
+    private function checker(): LocaleReadinessChecker
+    {
+        return $this->checker ??= new LocaleReadinessChecker();
+    }
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -30,6 +30,7 @@ use LiturgicalCalendar\Api\Handlers\Auth\EmailVerificationHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\AccessRequestAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\ApplicationAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\NotificationsHandler as AdminNotificationsHandler;
+use LiturgicalCalendar\Api\Handlers\Admin\LocalesAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Admin\OutboxAdminHandler;
 use LiturgicalCalendar\Api\Handlers\Auth\AdminScopesHandler;
 use LiturgicalCalendar\Api\Handlers\Auth\DashboardScopesHandler;
@@ -575,6 +576,12 @@ class Router
                         // POST /admin/applications/{uuid}/revoke - Revoke an approved application
                         $applicationAdminHandler = new ApplicationAdminHandler();
                         $this->handler           = $applicationAdminHandler;
+                    } elseif ($adminRoute === 'locales') {
+                        // Supported-locale curation (#904)
+                        // GET /admin/locales           - Candidate locales, official flag, readiness
+                        // GET /admin/locales/{locale}  - Full readiness report for one locale
+                        $localesAdminHandler = new LocalesAdminHandler($requestPathParts);
+                        $this->handler       = $localesAdminHandler;
                     } elseif ($adminRoute === 'outbox') {
                         // Admin outbox management routes
                         // GET  /admin/outbox?status=…&summary=…  - List/summary

--- a/src/Services/Locale/LocaleReadinessCheck.php
+++ b/src/Services/Locale/LocaleReadinessCheck.php
@@ -20,7 +20,8 @@ final readonly class LocaleReadinessCheck implements \JsonSerializable
         public string $name,
         public bool $passed,
         public string $summary,
-        public array $missing = []
+        public array $missing = [],
+        public bool $advisory = false
     ) {
     }
 
@@ -29,15 +30,21 @@ final readonly class LocaleReadinessCheck implements \JsonSerializable
      * @param \Closure(int): string   $whenFailed Receives the count, so the caller
      *                                            can agree number with its own noun.
      */
-    public static function of(string $name, array $missing, string $whenPassed, \Closure $whenFailed): self
-    {
+    public static function of(
+        string $name,
+        array $missing,
+        string $whenPassed,
+        \Closure $whenFailed,
+        bool $advisory = false
+    ): self {
         $passed = $missing === [];
 
         return new self(
             $name,
             $passed,
             $passed ? $whenPassed : $whenFailed(count($missing)),
-            $missing
+            $missing,
+            $advisory
         );
     }
 
@@ -50,15 +57,16 @@ final readonly class LocaleReadinessCheck implements \JsonSerializable
     }
 
     /**
-     * @return array{name: string, passed: bool, summary: string, missing: list<string>}
+     * @return array{name: string, passed: bool, advisory: bool, summary: string, missing: list<string>}
      */
     public function jsonSerialize(): array
     {
         return [
-            'name'    => $this->name,
-            'passed'  => $this->passed,
-            'summary' => $this->summary,
-            'missing' => $this->missing,
+            'name'     => $this->name,
+            'passed'   => $this->passed,
+            'advisory' => $this->advisory,
+            'summary'  => $this->summary,
+            'missing'  => $this->missing,
         ];
     }
 }

--- a/src/Services/Locale/LocaleReadinessCheck.php
+++ b/src/Services/Locale/LocaleReadinessCheck.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Locale;
+
+/**
+ * The outcome of one readiness probe against one locale.
+ *
+ * `missing` is deliberately a list of concrete identifiers — file paths, event
+ * keys — rather than a count. An operator deciding whether to promote a locale
+ * needs to know *what* is absent, and a count cannot be acted on.
+ */
+final readonly class LocaleReadinessCheck implements \JsonSerializable
+{
+    /**
+     * @param list<string> $missing
+     */
+    public function __construct(
+        public string $name,
+        public bool $passed,
+        public string $summary,
+        public array $missing = []
+    ) {
+    }
+
+    /**
+     * @param list<string>            $missing
+     * @param \Closure(int): string   $whenFailed Receives the count, so the caller
+     *                                            can agree number with its own noun.
+     */
+    public static function of(string $name, array $missing, string $whenPassed, \Closure $whenFailed): self
+    {
+        $passed = $missing === [];
+
+        return new self(
+            $name,
+            $passed,
+            $passed ? $whenPassed : $whenFailed(count($missing)),
+            $missing
+        );
+    }
+
+    /**
+     * "1 event" / "3 events" — used by callers building failure summaries.
+     */
+    public static function plural(int $count, string $singular, string $plural): string
+    {
+        return $count . ' ' . ( $count === 1 ? $singular : $plural );
+    }
+
+    /**
+     * @return array{name: string, passed: bool, summary: string, missing: list<string>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'name'    => $this->name,
+            'passed'  => $this->passed,
+            'summary' => $this->summary,
+            'missing' => $this->missing,
+        ];
+    }
+}

--- a/src/Services/Locale/LocaleReadinessChecker.php
+++ b/src/Services/Locale/LocaleReadinessChecker.php
@@ -83,6 +83,7 @@ final class LocaleReadinessChecker
             [
                 $this->checkGettextCatalogue($locale),
                 $this->checkLectionaryCorpora($locale),
+                $this->checkDecreeSource(),
                 $this->checkDecreeReadings($locale, $this->createdEventKeys()),
                 $this->checkDecreeNames($locale, $this->namedEventKeys()),
                 $this->checkUniversalMissals($locale),
@@ -333,6 +334,47 @@ final class LocaleReadinessChecker
     }
 
     /**
+     * Whether the decree corpus itself can be read.
+     *
+     * Without this, a missing or unparseable `decrees.json` yields an empty event
+     * list, and every downstream probe then passes vacuously — "all 0 newly created
+     * events have a readings entry" — reporting the locale READY. A checker whose
+     * entire purpose is to stop silent false passes must not contain one.
+     *
+     * Gating, and deliberately locale-independent: if the corpus is unreadable then
+     * nothing about any locale has actually been verified.
+     */
+    private function checkDecreeSource(): LocaleReadinessCheck
+    {
+        $relative = JsonDataConstants::DECREES_FILE;
+
+        if (!is_file($this->root . $relative)) {
+            return LocaleReadinessCheck::of(
+                'decree_source',
+                [$relative],
+                '',
+                static fn (int $n): string => 'the decrees corpus is missing, so no decreed event could be checked'
+            );
+        }
+
+        if (null === $this->decrees()) {
+            return LocaleReadinessCheck::of(
+                'decree_source',
+                [$relative],
+                '',
+                static fn (int $n): string => 'the decrees corpus could not be parsed, so no decreed event could be checked'
+            );
+        }
+
+        return LocaleReadinessCheck::of(
+            'decree_source',
+            [],
+            'the decrees corpus is readable',
+            static fn (int $n): string => ''
+        );
+    }
+
+    /**
      * Event keys introduced by a decree, i.e. those with `action: createNew`.
      *
      * Only these need an entry in the decrees lectionary. A decree that merely
@@ -346,7 +388,7 @@ final class LocaleReadinessChecker
     private function createdEventKeys(): array
     {
         $keys = [];
-        foreach ($this->decrees() as $decree) {
+        foreach ($this->decrees() ?? [] as $decree) {
             $metadata = $decree['metadata'] ?? null;
             if (!is_array($metadata) || ( $metadata['action'] ?? null ) !== 'createNew') {
                 continue;
@@ -391,19 +433,38 @@ final class LocaleReadinessChecker
     }
 
     /**
-     * @return list<array<string, mixed>>
+     * The decree corpus, or null when it is absent or cannot be parsed.
+     *
+     * Nullable on purpose: "there are no decrees" and "the decrees cannot be read"
+     * are different facts, and collapsing them is what let an unreadable corpus
+     * report as ready. {@see checkDecreeSource()} turns the null into a failure.
+     *
+     * @return list<array<string, mixed>>|null
      */
-    private function decrees(): array
+    private function decrees(): ?array
     {
         $path = $this->root . JsonDataConstants::DECREES_FILE;
         if (!is_file($path)) {
-            return [];
+            return null;
         }
 
-        /** @var list<array<string, mixed>> $decrees */
-        $decrees = $this->decodeArray($path);
+        $raw = file_get_contents($path);
+        if (false === $raw) {
+            return null;
+        }
 
-        return $decrees;
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return null;
+        }
+
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        /** @var list<array<string, mixed>> $decoded */
+        return $decoded;
     }
 
     /**

--- a/src/Services/Locale/LocaleReadinessChecker.php
+++ b/src/Services/Locale/LocaleReadinessChecker.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Locale;
+
+use LiturgicalCalendar\Api\Enum\JsonDataConstants;
+use LiturgicalCalendar\Api\Router;
+use LiturgicalCalendar\Api\Services\SupportedLocales;
+
+/**
+ * Answers "does this locale have everything an official locale must have?".
+ *
+ * Promotion to officially supported is not a label — it changes behaviour.
+ * `ReadingsMap::getReadings()` throws for an official locale and degrades quietly
+ * for any other, so promoting a locale whose data is incomplete converts silent
+ * gaps into 500s. This is the pre-flight that must pass first (#904).
+ *
+ * Three callers, one implementation:
+ *
+ * - the admin interface, gating the promote action
+ * - CI, asserting every already-official locale is still complete
+ * - `Health`, reporting drift on a running deployment
+ *
+ * Read-only: it inspects files and never writes.
+ */
+final class LocaleReadinessChecker
+{
+    /**
+     * The ten General Roman lectionary corpora. A locale missing any one of them
+     * cannot serve a complete calendar.
+     *
+     * @var list<string>
+     */
+    private const LECTIONARY_CORPORA = [
+        JsonDataConstants::LECTIONARY_SUNDAYS_SOLEMNITIES_A_FOLDER,
+        JsonDataConstants::LECTIONARY_SUNDAYS_SOLEMNITIES_B_FOLDER,
+        JsonDataConstants::LECTIONARY_SUNDAYS_SOLEMNITIES_C_FOLDER,
+        JsonDataConstants::LECTIONARY_WEEKDAYS_ORDINARY_I_FOLDER,
+        JsonDataConstants::LECTIONARY_WEEKDAYS_ORDINARY_II_FOLDER,
+        JsonDataConstants::LECTIONARY_WEEKDAYS_ADVENT_FOLDER,
+        JsonDataConstants::LECTIONARY_WEEKDAYS_CHRISTMAS_FOLDER,
+        JsonDataConstants::LECTIONARY_WEEKDAYS_LENT_FOLDER,
+        JsonDataConstants::LECTIONARY_WEEKDAYS_EASTER_FOLDER,
+        JsonDataConstants::LECTIONARY_SAINTS_FOLDER,
+    ];
+
+    /**
+     * Missals belonging to the universal calendar. The national editions
+     * (`propriumdesanctis_IT_1983`, `propriumdesanctis_US_2011`) are deliberately
+     * excluded: they are only ever read for their own nation's calendar, so
+     * requiring every official locale to translate them would be wrong.
+     *
+     * @var list<string>
+     */
+    private const UNIVERSAL_MISSALS = [
+        'propriumdetempore',
+        'propriumdesanctis_1970',
+        'propriumdesanctis_2002',
+        'propriumdesanctis_2008',
+    ];
+
+    private string $root;
+
+    public function __construct(?string $root = null)
+    {
+        // Router::$apiFilePath is a typed static that is only initialised while a
+        // request is routed; this service also runs from CI and the CLI.
+        $this->root = $root
+            ?? ( isset(Router::$apiFilePath) && Router::$apiFilePath !== ''
+                ? Router::$apiFilePath
+                : dirname(__DIR__, 3) . DIRECTORY_SEPARATOR );
+    }
+
+    /**
+     * Run every probe against $locale.
+     */
+    public function check(string $locale): LocaleReadinessReport
+    {
+        return new LocaleReadinessReport(
+            $locale,
+            SupportedLocales::isOfficial($locale),
+            [
+                $this->checkGettextCatalogue($locale),
+                $this->checkLectionaryCorpora($locale),
+                $this->checkDecreeReadings($locale, $this->createdEventKeys()),
+                $this->checkDecreeNames($locale, $this->namedEventKeys()),
+                $this->checkUniversalMissals($locale),
+            ]
+        );
+    }
+
+    /**
+     * Run every probe against every currently official locale.
+     *
+     * @return list<LocaleReadinessReport>
+     */
+    public function checkOfficialLocales(): array
+    {
+        return array_map(
+            fn (string $locale): LocaleReadinessReport => $this->check($locale),
+            SupportedLocales::official()
+        );
+    }
+
+    private function checkGettextCatalogue(string $locale): LocaleReadinessCheck
+    {
+        // `en` is the source language: strings are authored in it, so it has no
+        // catalogue of its own and never will.
+        if ($locale === 'en') {
+            return new LocaleReadinessCheck(
+                'gettext_catalogue',
+                true,
+                'not required — en is the untranslated source language'
+            );
+        }
+
+        $dir     = $this->root . JsonDataConstants::FOLDER . '/../i18n/' . $locale;
+        $missing = is_dir($dir) ? [] : ['i18n/' . $locale];
+
+        return LocaleReadinessCheck::of(
+            'gettext_catalogue',
+            $missing,
+            'catalogue present',
+            static fn (int $n): string => 'no gettext catalogue'
+        );
+    }
+
+    private function checkLectionaryCorpora(string $locale): LocaleReadinessCheck
+    {
+        $missing = [];
+        foreach (self::LECTIONARY_CORPORA as $corpus) {
+            $relative = $corpus . '/' . $locale . '.json';
+            if (!is_file($this->root . $relative)) {
+                $missing[] = $relative;
+            }
+        }
+
+        return LocaleReadinessCheck::of(
+            'lectionary_corpora',
+            $missing,
+            sprintf('all %d corpora present', count(self::LECTIONARY_CORPORA)),
+            static fn (int $n): string => sprintf('missing %d of %d lectionary corpora', $n, count(self::LECTIONARY_CORPORA))
+        );
+    }
+
+    /**
+     * Every decreed event must have a readings entry in this locale's decrees
+     * lectionary — present, though its values may legitimately be empty.
+     *
+     * This is the exact gap that took down the Croatian calendar: the key being
+     * absent is what threw, not the readings being blank.
+     *
+     * @param list<string> $decreedEventKeys
+     */
+    private function checkDecreeReadings(string $locale, array $decreedEventKeys): LocaleReadinessCheck
+    {
+        $relative = JsonDataConstants::LECTIONARY_DECREES_FOLDER . '/' . $locale . '.json';
+        $present  = $this->jsonKeys($this->root . $relative);
+
+        if ($present === null) {
+            return LocaleReadinessCheck::of('decree_readings', [$relative], '', static fn (int $n): string => 'decrees lectionary file absent');
+        }
+
+        $missing = array_values(array_diff($decreedEventKeys, $present));
+
+        return LocaleReadinessCheck::of(
+            'decree_readings',
+            $missing,
+            sprintf('all %d newly created events have a readings entry', count($decreedEventKeys)),
+            static fn (int $n): string => LocaleReadinessCheck::plural($n, 'newly created event has', 'newly created events have') . ' no readings entry'
+        );
+    }
+
+    /**
+     * Every decreed event must have a NON-EMPTY name in this locale.
+     *
+     * Unlike readings, a blank name is a real gap: it renders as an empty string
+     * in the calendar. Croatian currently fails exactly here.
+     *
+     * @param list<string> $decreedEventKeys
+     */
+    private function checkDecreeNames(string $locale, array $decreedEventKeys): LocaleReadinessCheck
+    {
+        $relative = JsonDataConstants::DECREES_FOLDER . '/i18n/' . $locale . '.json';
+        $path     = $this->root . $relative;
+
+        if (!is_file($path)) {
+            return LocaleReadinessCheck::of('decree_names', [$relative], '', static fn (int $n): string => 'decrees i18n file absent');
+        }
+
+        /** @var array<string, mixed> $names */
+        $names   = $this->decodeArray($path);
+        $missing = [];
+        foreach ($decreedEventKeys as $key) {
+            $value = $names[$key] ?? null;
+            if (!is_string($value) || trim($value) === '') {
+                $missing[] = $key;
+            }
+        }
+
+        return LocaleReadinessCheck::of(
+            'decree_names',
+            $missing,
+            sprintf('all %d decreed events are named', count($decreedEventKeys)),
+            static fn (int $n): string => LocaleReadinessCheck::plural($n, 'decreed event has', 'decreed events have') . ' no name'
+        );
+    }
+
+    private function checkUniversalMissals(string $locale): LocaleReadinessCheck
+    {
+        $missing = [];
+        foreach (self::UNIVERSAL_MISSALS as $missal) {
+            $relative = JsonDataConstants::MISSALS_FOLDER . '/' . $missal . '/i18n/' . $locale . '.json';
+            if (!is_file($this->root . $relative)) {
+                $missing[] = $relative;
+            }
+        }
+
+        return LocaleReadinessCheck::of(
+            'universal_missals',
+            $missing,
+            sprintf('all %d universal missals translated', count(self::UNIVERSAL_MISSALS)),
+            static fn (int $n): string => LocaleReadinessCheck::plural($n, 'universal missal is', 'universal missals are') . ' untranslated'
+        );
+    }
+
+    /**
+     * Event keys introduced by a decree, i.e. those with `action: createNew`.
+     *
+     * Only these need an entry in the decrees lectionary. A decree that merely
+     * modifies an existing celebration — `setProperty` raising a memorial to a
+     * feast, `makeDoctor` adding a title — leaves the event in the sanctorale,
+     * where its readings already live. Requiring readings for those would flag
+     * every official locale as incomplete for data that is correct.
+     *
+     * @return list<string>
+     */
+    private function createdEventKeys(): array
+    {
+        $keys = [];
+        foreach ($this->decrees() as $decree) {
+            $metadata = $decree['metadata'] ?? null;
+            if (!is_array($metadata) || ( $metadata['action'] ?? null ) !== 'createNew') {
+                continue;
+            }
+
+            $event = $decree['liturgical_event'] ?? null;
+            if (is_array($event) && is_string($event['event_key'] ?? null) && $event['event_key'] !== '') {
+                $keys[] = $event['event_key'];
+            }
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    /**
+     * Event keys that the decrees i18n corpus names, taken as the union across
+     * every locale file.
+     *
+     * Self-defining on purpose: which decrees supply a name is not derivable from
+     * the action alone — `makeDoctor` adds a title and so needs one, while
+     * `setProperty` raising a grade does not. Taking the union asserts the
+     * invariant that actually matters: whatever any locale names, every official
+     * locale must name too.
+     *
+     * @return list<string>
+     */
+    private function namedEventKeys(): array
+    {
+        $dir = $this->root . JsonDataConstants::DECREES_FOLDER . '/i18n';
+        if (!is_dir($dir)) {
+            return [];
+        }
+
+        $keys = [];
+        foreach (glob($dir . '/*.json') ?: [] as $file) {
+            foreach (array_keys($this->decodeArray($file)) as $key) {
+                $keys[] = (string) $key;
+            }
+        }
+
+        return array_values(array_unique($keys));
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function decrees(): array
+    {
+        $path = $this->root . JsonDataConstants::DECREES_FILE;
+        if (!is_file($path)) {
+            return [];
+        }
+
+        /** @var list<array<string, mixed>> $decrees */
+        $decrees = $this->decodeArray($path);
+
+        return $decrees;
+    }
+
+    /**
+     * Top-level keys of a JSON object file, or null when the file is unreadable.
+     *
+     * @return list<string>|null
+     */
+    private function jsonKeys(string $path): ?array
+    {
+        if (!is_file($path)) {
+            return null;
+        }
+
+        return array_map('strval', array_keys($this->decodeArray($path)));
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    private function decodeArray(string $path): array
+    {
+        $raw = file_get_contents($path);
+        if (false === $raw) {
+            return [];
+        }
+
+        try {
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException) {
+            return [];
+        }
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/src/Services/Locale/LocaleReadinessChecker.php
+++ b/src/Services/Locale/LocaleReadinessChecker.php
@@ -91,6 +91,40 @@ final class LocaleReadinessChecker
     }
 
     /**
+     * Every locale for which any resource exists, official or not.
+     *
+     * The union of gettext catalogues, decrees i18n files and lectionary corpora,
+     * so the admin interface can offer a promotion candidate list without an
+     * operator having to know what is on disk. Sorted for stable presentation.
+     *
+     * @return list<string>
+     */
+    public function knownLocales(): array
+    {
+        $locales = SupportedLocales::official();
+
+        $catalogues = glob($this->root . 'i18n/*', GLOB_ONLYDIR) ?: [];
+        foreach ($catalogues as $dir) {
+            $locales[] = basename($dir);
+        }
+
+        $globs = [
+            $this->root . JsonDataConstants::DECREES_FOLDER . '/i18n/*.json',
+            $this->root . JsonDataConstants::LECTIONARY_SAINTS_FOLDER . '/*.json',
+        ];
+        foreach ($globs as $pattern) {
+            foreach (glob($pattern) ?: [] as $file) {
+                $locales[] = basename($file, '.json');
+            }
+        }
+
+        $locales = array_values(array_unique($locales));
+        sort($locales);
+
+        return $locales;
+    }
+
+    /**
      * Run every probe against every currently official locale.
      *
      * @return list<LocaleReadinessReport>

--- a/src/Services/Locale/LocaleReadinessChecker.php
+++ b/src/Services/Locale/LocaleReadinessChecker.php
@@ -86,6 +86,7 @@ final class LocaleReadinessChecker
                 $this->checkDecreeReadings($locale, $this->createdEventKeys()),
                 $this->checkDecreeNames($locale, $this->namedEventKeys()),
                 $this->checkUniversalMissals($locale),
+                $this->checkDecreeReadingsPopulated($locale, $this->createdEventKeys()),
             ]
         );
     }
@@ -110,8 +111,18 @@ final class LocaleReadinessChecker
 
         $globs = [
             $this->root . JsonDataConstants::DECREES_FOLDER . '/i18n/*.json',
-            $this->root . JsonDataConstants::LECTIONARY_SAINTS_FOLDER . '/*.json',
+            $this->root . JsonDataConstants::LECTIONARY_DECREES_FOLDER . '/*.json',
         ];
+        foreach (self::LECTIONARY_CORPORA as $corpus) {
+            $globs[] = $this->root . $corpus . '/*.json';
+        }
+
+        // Deliberately NOT the missals: the national editions carry region-specific
+        // translations (`propriumdesanctis_US_2011/i18n/en_US.json`,
+        // `propriumdesanctis_IT_1983/i18n/it_IT.json`), and surfacing en_US and it_IT
+        // here would offer them as candidates for General Roman promotion, which they
+        // are not. Universal-missal coverage is still probed per locale by
+        // checkUniversalMissals(); it just does not define the candidate set.
         foreach ($globs as $pattern) {
             foreach (glob($pattern) ?: [] as $file) {
                 $locales[] = basename($file, '.json');
@@ -238,6 +249,68 @@ final class LocaleReadinessChecker
             $missing,
             sprintf('all %d decreed events are named', count($decreedEventKeys)),
             static fn (int $n): string => LocaleReadinessCheck::plural($n, 'decreed event has', 'decreed events have') . ' no name'
+        );
+    }
+
+    /**
+     * How many decreed events have a readings entry that is present but BLANK.
+     *
+     * Advisory, not gating — and the distinction is load-bearing. These events do
+     * not appear in `sanctorum` at all, so the decrees lectionary is their only
+     * source of readings: a blank entry means the calendar serves none. By that
+     * standard four of the five currently official locales are incomplete (fr, it
+     * and nl have 10 of 11 blank, la has 9), and gating on it would fail them all
+     * at once.
+     *
+     * Reported so the gap is visible in the admin interface and can be closed
+     * deliberately. Promote this to gating (drop the `true`) once the content
+     * exists, or the build goes red for locales the API already advertises.
+     *
+     * @param list<string> $createdEventKeys
+     */
+    private function checkDecreeReadingsPopulated(string $locale, array $createdEventKeys): LocaleReadinessCheck
+    {
+        $path = $this->root . JsonDataConstants::LECTIONARY_DECREES_FOLDER . '/' . $locale . '.json';
+        if (!is_file($path)) {
+            return LocaleReadinessCheck::of(
+                'decree_readings_populated',
+                [],
+                'not applicable — no decrees lectionary for this locale',
+                static fn (int $n): string => '',
+                true
+            );
+        }
+
+        /** @var array<string, mixed> $readings */
+        $readings = $this->decodeArray($path);
+
+        $blank = [];
+        foreach ($createdEventKeys as $key) {
+            $entry = $readings[$key] ?? null;
+            if (!is_array($entry)) {
+                continue; // absence is the gating check's business, not this one
+            }
+
+            $hasText = false;
+            foreach ($entry as $value) {
+                if (is_string($value) && trim($value) !== '') {
+                    $hasText = true;
+                    break;
+                }
+            }
+
+            if (false === $hasText) {
+                $blank[] = $key;
+            }
+        }
+
+        return LocaleReadinessCheck::of(
+            'decree_readings_populated',
+            $blank,
+            sprintf('all %d newly created events have readings text', count($createdEventKeys)),
+            static fn (int $n): string => LocaleReadinessCheck::plural($n, 'newly created event has', 'newly created events have')
+                . ' an empty readings entry',
+            true
         );
     }
 

--- a/src/Services/Locale/LocaleReadinessReport.php
+++ b/src/Services/Locale/LocaleReadinessReport.php
@@ -73,7 +73,18 @@ final readonly class LocaleReadinessReport implements \JsonSerializable
     public function describe(): string
     {
         if ($this->ready()) {
-            return sprintf('%s: ready (%d checks passed)', $this->locale, count($this->checks));
+            $passed = count(array_filter($this->checks, static fn (LocaleReadinessCheck $c): bool => $c->passed));
+
+            // Count what actually passed, not how many probes ran. A locale can be
+            // ready while an advisory probe failed, and reporting those as passed
+            // would misrepresent the very gap the advisory tier exists to surface.
+            $summary = sprintf('%s: ready (%d of %d checks passed', $this->locale, $passed, count($this->checks));
+
+            $advisories = $this->advisories();
+
+            return $advisories === []
+                ? $summary . ')'
+                : $summary . sprintf(', %d advisory not met)', count($advisories));
         }
 
         $names = array_map(static fn (LocaleReadinessCheck $c): string => $c->name, $this->failures());

--- a/src/Services/Locale/LocaleReadinessReport.php
+++ b/src/Services/Locale/LocaleReadinessReport.php
@@ -29,6 +29,10 @@ final readonly class LocaleReadinessReport implements \JsonSerializable
     public function ready(): bool
     {
         foreach ($this->checks as $check) {
+            if ($check->advisory) {
+                continue;
+            }
+
             if (false === $check->passed) {
                 return false;
             }
@@ -44,7 +48,23 @@ final readonly class LocaleReadinessReport implements \JsonSerializable
      */
     public function failures(): array
     {
-        return array_values(array_filter($this->checks, static fn (LocaleReadinessCheck $c): bool => !$c->passed));
+        return array_values(array_filter(
+            $this->checks,
+            static fn (LocaleReadinessCheck $c): bool => !$c->passed && !$c->advisory
+        ));
+    }
+
+    /**
+     * Advisory checks that did not pass — reported, never gating.
+     *
+     * @return list<LocaleReadinessCheck>
+     */
+    public function advisories(): array
+    {
+        return array_values(array_filter(
+            $this->checks,
+            static fn (LocaleReadinessCheck $c): bool => !$c->passed && $c->advisory
+        ));
     }
 
     /**

--- a/src/Services/Locale/LocaleReadinessReport.php
+++ b/src/Services/Locale/LocaleReadinessReport.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\Locale;
+
+/**
+ * Whether a locale has everything an officially supported locale must have.
+ *
+ * `ready` is the gate: an operator may only promote a locale for which this is
+ * true, because promotion turns missing data from a quiet degradation into a
+ * hard failure (see {@see \LiturgicalCalendar\Api\Services\SupportedLocales}).
+ */
+final readonly class LocaleReadinessReport implements \JsonSerializable
+{
+    /**
+     * @param list<LocaleReadinessCheck> $checks
+     */
+    public function __construct(
+        public string $locale,
+        public bool $official,
+        public array $checks
+    ) {
+    }
+
+    /**
+     * True when every probe passed, i.e. the locale may be promoted safely.
+     */
+    public function ready(): bool
+    {
+        foreach ($this->checks as $check) {
+            if (false === $check->passed) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * The probes that failed, for callers that only want the problems.
+     *
+     * @return list<LocaleReadinessCheck>
+     */
+    public function failures(): array
+    {
+        return array_values(array_filter($this->checks, static fn (LocaleReadinessCheck $c): bool => !$c->passed));
+    }
+
+    /**
+     * A one-line human summary, used by Health and by CI failure messages.
+     */
+    public function describe(): string
+    {
+        if ($this->ready()) {
+            return sprintf('%s: ready (%d checks passed)', $this->locale, count($this->checks));
+        }
+
+        $names = array_map(static fn (LocaleReadinessCheck $c): string => $c->name, $this->failures());
+
+        return sprintf('%s: NOT ready — failing %s', $this->locale, implode(', ', $names));
+    }
+
+    /**
+     * @return array{locale: string, official: bool, ready: bool, checks: list<LocaleReadinessCheck>}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'locale'   => $this->locale,
+            'official' => $this->official,
+            'ready'    => $this->ready(),
+            'checks'   => $this->checks,
+        ];
+    }
+}


### PR DESCRIPTION
Refs #904. Follows #905, which made the supported-locale list a curated resource.

## What this adds

**`LocaleReadinessChecker`** — answers "does this locale have everything an official locale must
have?" with five probes:

| Probe | Requires |
| ------------------- | ----------------------------------------------------------- |
| `gettext_catalogue` | `i18n/{locale}/` (skipped for `en`, the source language) |
| `lectionary_corpora`| all ten General Roman corpora |
| `decree_readings`   | a readings entry for every **newly created** decreed event |
| `decree_names`      | a non-empty name for every named decreed event |
| `universal_missals` | the four universal missals translated |

Promotion is not a label change — it flips `ReadingsMap` from degrading quietly to throwing. So this
is the pre-flight that has to pass first, and the guard that keeps already-official locales complete.

**`GET /admin/locales`** and **`GET /admin/locales/{locale}`** — the curation surface, restricted to
global Zitadel admins.

**CI guard** — `testEveryOfficialLocaleIsReady` fails the build if an official locale's data
regresses, with the missing identifiers in the failure message.

## Two bugs the checker found in itself

Running it against real data before shipping caught both:

1. **Only `createNew` decrees need decree readings.** `setProperty` (raising a grade) and
   `makeDoctor` (adding a title) leave the event in the sanctorale, where its readings already live.
   The first draft required entries for all of them and so reported **all five official locales as
   incomplete** for data that is perfectly correct.
2. **Which decrees supply a *name* is not derivable from the action.** `makeDoctor` needs one;
   `setProperty` raising a grade does not. The required set is now the union of keys across every
   locale's i18n file, which asserts the invariant that actually matters: whatever any locale names,
   every official locale must name too.

## Result

The checker independently reproduces the conclusion reached by hand on #904:

```text
en  official:yes ready:YES  all checks passed
fr  official:yes ready:YES  all checks passed
it  official:yes ready:YES  all checks passed
la  official:yes ready:YES  all checks passed
nl  official:yes ready:YES  all checks passed
hr  official:no  ready:no   decree_names -> StJohnNewman
es  official:no  ready:no   missing 10 of 10 lectionary corpora
de  official:no  ready:no   corpora, decrees lectionary, 12 names
```

**Croatian is one Croatian name away from being promotable.** Supply a name for `StJohnNewman` and
`hr` passes every probe.

## Read-only, and the response says why

`curation.writable` is `false` and carries its reason. Promotion writes
`jsondata/supportedLocales.json` on the deployed server, which the next deploy would overwrite
(#902), so an operator seeing a green "ready" is told why there is no promote button rather than left
to wonder. Promotion stays a reviewed pull request until change requests can carry that write — the
right audit trail for a governance decision regardless.

## Verification

- 22 new tests, 48 assertions; 53 green across the locale suites, the handler and the router.
- `composer analyse` — PHPStan level 10, no errors.
- `/admin/locales` returns 401 unauthenticated, 403 for a non-admin, 404 for a locale with no
  resources on disk.

A companion frontend PR adds the admin view over these endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyuj9umG6o8PzJ4BFf6Xp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only admin endpoints to list known locales and view detailed readiness reports.
  * Reports show official status, readiness, failed checks, advisory findings and missing requirements.
  * Added checks for catalogues, lectionary content, decree readings, decree names and missal translations.
  * Added guidance explaining that locale promotion is managed through the supported-locales pull request process.

* **Tests**
  * Added comprehensive coverage for access control, locale reporting, readiness checks, advisory results, JSON output and missing locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->