### PR TITLE
docs(openapi): suppress eight verified no-illogical-composition false positives

### DIFF
--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -24,3 +24,72 @@ jsondata/schemas/openapi.json:
       #/paths/~1tests~1{rite}/get/responses/200/content/application~1json/example/litcal_tests/0
     - >-
       #/paths/~1tests~1{rite}/get/responses/200/content/application~1json/example/litcal_tests/0/test_type
+
+# ---------------------------------------------------------------------------
+# `no-illogical-composition-keywords` (#908)
+#
+# All eight entries below are Redocly engine false positives, not spec defects.
+# The rule reports:
+#
+#   "Schemas in `oneOf` must be mutually exclusive. Found overlapping schemas:
+#    ... Both schemas define `liturgical_event`, `metadata` without constraints
+#    that exclude each other."
+#
+# Its overlap check compares TOP-LEVEL property names only. It does not descend
+# into the constraints that actually discriminate these branches, and every one
+# of the eight was verified by hand to be genuinely exclusive. Three different
+# mechanisms are in play, which is why no single fix covers them:
+#
+#   1. Nested `const` (LitCalDecreesSource, LitCalDecreesPath x2,
+#      LitCalDecreeWritePayload, WiderRegionCalendar). Branches are separated by
+#      `metadata.action` — createNew / setProperty / makeDoctor / makePatron /
+#      moveEvent — and, where `action` alone is not enough, additionally by
+#      `metadata.property` (grade / name / common). No document satisfies two.
+#
+#   2. `required` + `additionalProperties: false` (NationalCalendar,
+#      DiocesanCalendar). The createNew pair shares `action: "createNew"`, but
+#      the Fixed branch requires `day` + `month` while the Mobile branch requires
+#      `strtotime`, and both close the object. A document carrying `day`/`month`
+#      cannot match Mobile, and one carrying `strtotime` cannot match Fixed.
+#
+#   3. Nullness (LitCalEventsPath). The four `settings` branches enumerate the
+#      four legal combinations of `national_calendar` and `diocesan_calendar`
+#      being a string or `null`: (str,str), (str,null), (null,null),
+#      (null,str). Both referenced definitions are non-nullable enums of
+#      `type: string`, so exactly one branch matches any given document.
+#
+# Redocly's own suggested remedy — "add a discriminator" — does not apply. An
+# OpenAPI `discriminator` requires `propertyName` to name a TOP-LEVEL property,
+# and these discriminate on `metadata.action`, which is nested. Making a
+# conforming discriminator possible would mean hoisting `action` to the top level
+# of every calendar item: a change to the on-disk format of every national,
+# diocesan and wider-region file, and to every handler that reads them. That was
+# considered and rejected as wildly disproportionate to silencing a linter.
+#
+# Do NOT delete these to "fix" the warning without re-verifying the branches are
+# actually ambiguous, and do NOT widen them to ignore the rule file-wide: a
+# genuinely non-exclusive `oneOf` added later must still be caught. The entries
+# are per-pointer for exactly that reason.
+# ---------------------------------------------------------------------------
+jsondata/schemas/NationalCalendar.json:
+  no-illogical-composition-keywords:
+    - '#/properties/litcal/items/oneOf'
+jsondata/schemas/DiocesanCalendar.json:
+  no-illogical-composition-keywords:
+    - '#/definitions/LitCal/items/oneOf'
+jsondata/schemas/WiderRegionCalendar.json:
+  no-illogical-composition-keywords:
+    - '#/definitions/LitCal/oneOf'
+jsondata/schemas/LitCalDecreesSource.json:
+  no-illogical-composition-keywords:
+    - '#/definitions/LitCalDecree/oneOf'
+jsondata/schemas/LitCalDecreesPath.json:
+  no-illogical-composition-keywords:
+    - '#/definitions/DecreeResponse/oneOf'
+    - '#/definitions/SingleDecreeResponse/oneOf'
+jsondata/schemas/LitCalDecreeWritePayload.json:
+  no-illogical-composition-keywords:
+    - '#/oneOf'
+jsondata/schemas/LitCalEventsPath.json:
+  no-illogical-composition-keywords:
+    - '#/properties/settings/oneOf'


### PR DESCRIPTION
Closes #908.

`composer lint:openapi` reported **74 warnings**. 72 were a single class of false positive repeated
once per referencing path, across **eight distinct pointers**.

That noise was not harmless. It concealed a real defect: the `GET /validations` example had been
published omitting the required `expected_locales` property, so anyone copying it produced a payload
the schema rejects. It survived among the noise until hunted deliberately (fixed in #906).

## Every one of the eight was verified by hand

Redocly's overlap check compares **top-level property names only**, and does not descend into what
actually discriminates these branches. Three different mechanisms are involved — which is why no
single fix covers them:

| # | Mechanism | Pointers |
| - | ------------------------------------ | -------- |
| 1 | Nested `const` on `metadata.action`, plus `metadata.property` where `action` alone is insufficient | 5 |
| 2 | `required` + `additionalProperties: false` — the `createNew` pair shares an action, but Fixed requires `day`+`month` while Mobile requires `strtotime`, and both close the object | 2 |
| 3 | Nullness — the four `settings` branches enumerate the legal combinations of `national_calendar` and `diocesan_calendar` being string or `null`, and both referenced definitions are non-nullable string enums | 1 |

**Worth flagging for review:** my first reading assumed mechanism 1 explained all eight. Checking each
individually showed it explains only five — the `createNew` fixed/mobile pairs and the `settings`
branches carry no discriminating `const` at all and are exclusive for entirely different reasons. Had
I extrapolated, the comment in the ignore file would have been confidently wrong about three of the
eight. The comment now documents all three mechanisms so the next reader does not take the same
shortcut.

## Why not Redocly's suggested fix

The warning advises "add a discriminator". An OpenAPI `discriminator` requires `propertyName` to name
a **top-level** property; these discriminate on `metadata.action`, which is nested.

Making a conforming discriminator possible would mean hoisting `action` to the top level of every
calendar item — changing the on-disk format of every national, diocesan and wider-region file, and
every handler that reads them. Considered and rejected as wildly disproportionate.

## Scope of the suppression

- Entries are **per-pointer**, not per-file or per-rule.
- `redocly.yaml` is untouched: the rule remains enabled via `extends: recommended`.
- A genuinely ambiguous `oneOf` added anywhere else still fails.

The comment block follows the precedent already set in this file by the `#787` entries: state what
was verified, how, and instruct future readers not to delete or widen it without re-confirming.

## Result

```text
before : 74 warnings, 11 problems explicitly ignored
after  :  2 warnings, 83 problems explicitly ignored
```

The remaining two are the `/validations` example, fixed in #906. **Once both land, the count is zero**
— which is the point: a clean baseline means the next real warning gets noticed.

## Verification

- `composer lint:openapi` — description valid, 2 warnings.
- `phpunit_tests/Schemas/` — 607 tests, 2282 assertions, green.
- `composer lint:md` — clean.
- Confirmed the remaining two warnings are the `/validations` example and nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyuj9umG6o8PzJ4BFf6Xp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API linting guidance to document and suppress false-positive warnings for several mutually exclusive schema definitions.
  * Added explanations of the validation rules ensuring these schema alternatives remain distinct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->