### PR TITLE
ci: lint the OpenAPI description, advisory only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,6 +132,70 @@ jobs:
       - name: Markdown lint
         run: npx --yes markdownlint-cli2 "**/*.md" "#node_modules" "#vendor" "#.aider*"
 
+  # Advisory, never gating. Redocly reports problems the PHP tooling cannot see —
+  # examples that do not validate against their own schema, unreachable $refs,
+  # missing operationIds. One of those had already shipped: the GET /validations
+  # example omitted a required property (#906), and nothing in CI looked.
+  #
+  # Deliberately NOT a required check. Redocly's `recommended` ruleset carries
+  # opinions we do not all share, and its `oneOf` overlap analysis produces known
+  # false positives here (#908). A gating job would invite blanket suppressions,
+  # which is the opposite of what this is for. It succeeds regardless and writes
+  # its findings to the run summary, so a reviewer sees them without being blocked.
+  openapi_lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: OpenAPI description lint (advisory)
+        run: |
+          set -o pipefail
+          # `|| true` on the pipeline, not on the step: a non-zero redocly exit must
+          # still let us publish the output rather than aborting the step silently.
+          npx --yes @redocly/cli lint 2>&1 | tee redocly.out || true
+
+          {
+            echo '## OpenAPI lint (advisory)'
+            echo
+            if grep -q 'Your API description is valid' redocly.out; then
+              echo ':white_check_mark: The description is valid.'
+            else
+              echo ':x: The description did **not** validate. This does not fail the build, but it should be looked at.'
+            fi
+            echo
+
+            warnings=$(grep -oE 'You have [0-9]+ warnings' redocly.out | grep -oE '[0-9]+' || echo 0)
+            ignored=$(grep -oE '[0-9]+ problems are explicitly ignored' redocly.out | grep -oE '^[0-9]+' || echo 0)
+
+            echo "| | Count |"
+            echo "| ----------------------- | ----- |"
+            echo "| Warnings                | ${warnings} |"
+            echo "| Explicitly ignored      | ${ignored} |"
+            echo
+
+            if [ "${warnings}" != "0" ]; then
+              echo 'Warnings are at zero on `development`. A non-zero count here means this branch introduced one.'
+              echo
+              echo '<details><summary>Full output</summary>'
+              echo
+              echo '```text'
+              cat redocly.out
+              echo '```'
+              echo
+              echo '</details>'
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          # Surface it in the PR's annotation list too, where a reviewer will see it
+          # without opening the run.
+          if [ "$(grep -oE 'You have [0-9]+ warnings' redocly.out | grep -oE '[0-9]+' || echo 0)" != "0" ]; then
+            echo "::warning title=OpenAPI lint::redocly reported warnings; development is at zero, so this branch likely introduced them. See the job summary."
+          fi
+
   deploy_payload:
     runs-on: ubuntu-latest
     # Least privilege, as jsondata_lint above: this job only reads the tree and


### PR DESCRIPTION
`composer lint:openapi` has existed for a while but ran in **no workflow**, so nothing checked the
description on a pull request.

That gap had already cost us. The `GET /validations` example omitted a required property and shipped;
it then survived undetected among 74 warnings until it was hunted by hand (fixed in #906). Redocly
sees a class of problem the PHP tooling cannot — examples that fail their own schema, unreachable
`$ref`s, missing `operationId`s.

## Advisory, and deliberately so

Not a required check, and not merely `continue-on-error`:

- **Redocly's `recommended` ruleset carries opinions we do not all share**, and its `oneOf` overlap
  analysis produces known false positives in this repo (#908, eight of them). A gating job would
  invite blanket suppressions — the opposite of what this is for.
- **`continue-on-error` alone renders as a green tick**, which is no cue at all. The job instead
  always succeeds and *publishes* what it found.

## What a reviewer actually sees

A table in the run summary:

```markdown
## OpenAPI lint (advisory)

:white_check_mark: The description is valid.

| | Count |
| ----------------------- | ----- |
| Warnings                | 0 |
| Explicitly ignored      | 83 |
```

…plus, when the count is non-zero, a `::warning::` annotation in the PR's check list and the full
redocly output in a collapsed `<details>` block.

**The baseline on `development` is zero warnings as of #909.** That is what makes a non-zero count
meaningful rather than background noise, and the summary states it explicitly so a reader knows a
warning here means *this branch introduced one*.

## Verification

Both branches were exercised locally against real output before pushing:

| Input | Result |
| ----------------------------------- | ------------------------------------------ |
| Current `development` | `Warnings 0`, `Explicitly ignored 83`, valid |
| Synthetic `You have 3 warnings.` | `warnings=3`, annotation emitted |
| Output without the validity line | invalid branch taken correctly |

`set -o pipefail` with `|| true` on the pipeline rather than the step, so a non-zero redocly exit
still lets the output be published instead of aborting silently.

Needs no PHP or vendor artifact — redocly runs through `npx`, like the existing `markdownlint` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyuj9umG6o8PzJ4BFf6Xp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated validation for the OpenAPI description during the build process.
  - Validation results are summarised clearly, with warnings highlighted for review.
  - The check is advisory and does not prevent other workflow tasks from completing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->