### PR TITLE
feat(data): source-data publisher — phase 2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -237,6 +237,10 @@ SOURCEDATA_CHANGE_REQUESTS=false
 # scripts/publish-sourcedata.php) — it is a bearer credential with write access, so see
 # docs/ops/change-request-runbook.md, "Credentials on disk", before widening either.
 # GITHUB_APP_PRIVATE_KEY_PATH=/etc/litcal/github-app.pem
+# NOTE: GITHUB_REPOSITORY is also a built-in GitHub Actions variable, injected into every job as
+# "owner/repo". Anything running inside Actions therefore inherits a well-formed value for it even
+# when nothing here sets one. Harmless in practice — the App id, installation id and key are still
+# required — but do not read a populated GITHUB_REPOSITORY as evidence that the publisher is set up.
 # GITHUB_REPOSITORY=Liturgical-Calendar/LiturgicalCalendarAPI
 # Branch each resource's first publish branches from (default: development)
 # GITHUB_BASE_BRANCH=development

--- a/.env.example
+++ b/.env.example
@@ -222,9 +222,11 @@ SOURCEDATA_CHANGE_REQUESTS=false
 ##
 # Source Data Publisher (phase 2)
 # Publishes approved change-request batches (SOURCEDATA_CHANGE_REQUESTS above) as commits
-# and rolling pull requests via a GitHub App. Without GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID,
-# GITHUB_APP_PRIVATE_KEY_PATH, and GITHUB_REPOSITORY all set, approved change requests
-# accumulate unpublished — GET /health reports this.
+# and rolling pull requests via a GitHub App. Unless GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID,
+# GITHUB_APP_PRIVATE_KEY_PATH, and GITHUB_REPOSITORY are all set AND well-formed, approved
+# change requests accumulate unpublished — GET /health reports this. A malformed value counts:
+# GITHUB_REPOSITORY must be exactly "owner/repo", so a pasted URL or a trailing slash is
+# reported the same way an absent value is.
 # Leave unset for a self-hosted instance that does not run the change-request queue.
 ##
 # GITHUB_APP_ID=

--- a/.env.example
+++ b/.env.example
@@ -218,3 +218,22 @@ ALLOW_ENV_ADMIN_FALLBACK=false
 # Leave false for a self-hosted instance that has neither.
 ##
 SOURCEDATA_CHANGE_REQUESTS=false
+
+##
+# Source Data Publisher (phase 2)
+# Publishes approved change-request batches (SOURCEDATA_CHANGE_REQUESTS above) as commits
+# and rolling pull requests via a GitHub App. Without GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID,
+# GITHUB_APP_PRIVATE_KEY_PATH, and GITHUB_REPOSITORY all set, approved change requests
+# accumulate unpublished — GET /health reports this.
+# Leave unset for a self-hosted instance that does not run the change-request queue.
+##
+# GITHUB_APP_ID=
+# GITHUB_APP_INSTALLATION_ID=
+# Private key path must live outside the deployed tree, not under the web root
+# GITHUB_APP_PRIVATE_KEY_PATH=/etc/litcal/github-app.pem
+# GITHUB_REPOSITORY=Liturgical-Calendar/LiturgicalCalendarAPI
+# Branch each resource's first publish branches from (default: development)
+# GITHUB_BASE_BRANCH=development
+# Commit committer identity for published commits (defaults shown)
+# GITHUB_APP_COMMITTER_NAME=Litcal Publisher
+# GITHUB_APP_COMMITTER_EMAIL=litcal-publisher[bot]@users.noreply.github.com

--- a/.env.example
+++ b/.env.example
@@ -229,7 +229,11 @@ SOURCEDATA_CHANGE_REQUESTS=false
 ##
 # GITHUB_APP_ID=
 # GITHUB_APP_INSTALLATION_ID=
-# Private key path must live outside the deployed tree, not under the web root
+# Private key path must live outside the deployed tree, not under the web root.
+# Mode 0600, owned by the user the publish cron job runs as. The installation token derived
+# from it is cached under <project>/cache/github_app_tokens/ (0700 dir, 0600 entries, set by
+# scripts/publish-sourcedata.php) — it is a bearer credential with write access, so see
+# docs/ops/change-request-runbook.md, "Credentials on disk", before widening either.
 # GITHUB_APP_PRIVATE_KEY_PATH=/etc/litcal/github-app.pem
 # GITHUB_REPOSITORY=Liturgical-Calendar/LiturgicalCalendarAPI
 # Branch each resource's first publish branches from (default: development)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
   from the added `disposition: "applied"` — except `DELETE /tests/{rite}/{test_name}`, which now returns
   `200` with that body instead of `204 No Content`, in disk mode too. Phase 1 stops at approval — nothing
   is published to GitHub yet, see `docs/ops/change-request-runbook.md`.
+* add the source-data change request publisher (phase 2): once a GitHub App is registered and configured,
+  a cron-driven runner turns each approved batch into a single commit on a per-resource branch plus a
+  rolling pull request, preserving the submitting editor as the commit author while the App is the
+  committer. `GET /health`'s new `source_data_publisher` block reports whether the publisher is actually
+  configured. Deployments that do not configure the GitHub App are unaffected: approved batches continue
+  to accumulate unpublished exactly as in phase 1. Known limitation: deleting a calendar or test through a
+  change request does not yet purge its OpenFGA authorization tuples — that purge is deferred to phase 3,
+  merge detection — see `docs/ops/change-request-runbook.md`.
 -->
 
 ## [v5.7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/releases/tag/v5.7) (December 15th 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@
   configured. Deployments that do not configure the GitHub App are unaffected: approved batches continue
   to accumulate unpublished exactly as in phase 1. Known limitation: deleting a calendar or test through a
   change request does not yet purge its OpenFGA authorization tuples — that purge is deferred to phase 3,
-  merge detection — see `docs/ops/change-request-runbook.md`.
+  merge detection — see `docs/ops/change-request-runbook.md`. A batch that fails to publish is retried on
+  the next tick and, after five consecutive failed attempts, parked: no longer attempted, so one
+  unpublishable batch cannot block every other editor's approved work. Parked batches are reported by
+  `GET /health`'s `source_data_publisher` block (`parked_batches`) and by each run's summary line, and are
+  retried by clearing `publish_attempts` — see the runbook's "Parked batches".
 -->
 
 ## [v5.7](https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI/releases/tag/v5.7) (December 15th 2025)

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -10,8 +10,9 @@ touching the filesystem; a resource admin reviews the batch and approves or reje
 already administers the resource still gets a batch — it is just auto-approved in the same request.
 
 See `docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md` for the full design,
-`.superpowers/sdd/2026-08-28-sourcedata-change-requests-phase1/` for the phase 1 implementation plan, and
-`.superpowers/sdd/2026-08-29-sourcedata-publisher-phase2/` for the phase 2 (publisher) implementation plan.
+`docs/superpowers/plans/2026-08-28-sourcedata-change-requests-phase1.md` for the phase 1 implementation
+plan, and `docs/superpowers/plans/2026-08-29-sourcedata-publisher-phase2.md` for the phase 2 (publisher)
+implementation plan.
 
 **Phase 1 stops at approval.** Without the phase 2 publisher configured and running, an approved batch
 sits at `publication_status = 'none'` indefinitely — nothing opens a pull request, nothing writes to

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -298,10 +298,21 @@ Publisher (phase 2)" block, and `docs/superpowers/plans/2026-08-29-sourcedata-pu
    branch, plus a pull request that stays open across every later batch for that same resource (a
    "rolling" PR).
 4. Stops early the moment one publish attempt genuinely fails, rather than hammering a possibly-broken
-   GitHub API with the rest of the queue. The next cron tick is the retry, not an in-process loop.
+   GitHub API with the rest of the queue. The next cron tick is the retry, not an in-process loop. Two
+   failures are deliberately NOT treated that way, because neither says anything about the health of the
+   API: a batch another runner already published (nothing to do), and a lost race for a resource's branch
+   (a GitHub `422` — see "Operational failure modes"). Both log and continue.
+5. Counts the attempt against the batch. After
+   `SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS` (5) CONSECUTIVE failed attempts a batch is
+   *parked*: no longer claimed, so the rest of the queue drains past it. See "Parked batches" below.
 
 `GET /health`'s `source_data_publisher` block reports whether the publisher is actually configured,
 independently of whether change-request queue mode itself is on — check it after any configuration change.
+**Read the nested block, not the top level.** A `warning` there does not change `/health`'s own top-level
+`status` field and does not change the HTTP status code: the endpoint still answers `200 ok` while the
+publisher is unconfigured or batches are parked. A monitoring check that only looks at the HTTP code, or
+only at `.status`, will never see either. Parse `.source_data_publisher.status` and
+`.source_data_publisher.parked_batches`.
 
 ### The publish lifecycle: `none` → `queued` → `open`
 
@@ -318,6 +329,11 @@ row of a batch at once (a batch is never mixed-status):
 
 `queued` is a **claim**, not a milestone on GitHub — nothing has been pushed yet while a batch sits there.
 `open` means a real pull request exists; it does not mean the PR merged, and does not mean CI passed.
+
+`publish_attempts` is a fourth thing again, and orthogonal to all of them: how many CONSECUTIVE attempts
+the publisher has spent on the batch. It is incremented when a claim is released (a failure) or reclaimed
+(a crash), reset when the batch publishes, and once it reaches 5 the batch is no longer claimed at all —
+see "Parked batches" below.
 
 Once a batch reaches `open`, `recordPublication()` also stamps four columns, on every row of the batch:
 
@@ -364,6 +380,89 @@ a publish that is still genuinely in flight gets treated as abandoned, a second 
 batch, and the first runner's now-stale `updateRef()` call fails with a non-fast-forward error when it
 finally returns — recoverable (see below), but entirely avoidable by respecting the invariant.
 
+### Parked batches
+
+A batch can fail *deterministically*: an illegal git-ref character in its `resource_id`, a tree-path
+conflict, a payload a later validation change rejects. Nothing about retrying such a batch will ever
+succeed, and because candidates are claimed oldest-first and the runner stops the tick on a failure, an
+unbounded retry means that one batch is re-attempted first on every tick and **every other editor's
+approved work is never reached at all** — with no error of its own, and no editor-visible symptom.
+
+So each batch gets `MAX_PUBLISH_ATTEMPTS` (5) CONSECUTIVE attempts, counted in the
+`publish_attempts` column. Both a caught failure (`releaseClaim()`) and an abandoned one
+(`reclaimStaleClaims()`, i.e. a crash) count — a batch that OOM-kills the publisher is caught by no
+error handler, so if a reclaim were free it would re-crash forever. A successful publish clears the
+counter, so a transient GitHub blip can never park a batch. Once the counter reaches 5 the batch stops
+being claimed and the queue drains past it.
+
+**Parking is not a dead-letter queue.** The design spec's error table promises a DLQ row for terminal
+failures; that was never built, and there is no DLQ table, no dead-letter status, and no automatic
+notification to the submitter. What actually happens is exactly and only this: the rows are left
+untouched, still `review_status = 'approved'` and `publication_status = 'none'`, with
+`publish_attempts >= 5`, and the publisher stops picking them up. Nothing is lost and nothing is
+rewritten; the batch simply waits for an operator.
+
+Because a parked batch produces no failure of its own, it is reported out of band in three places:
+
+- `GET /health` — `.source_data_publisher.parked_batches`, and `.source_data_publisher.status` becomes
+  `warning` (which does NOT change the top-level `status` or the HTTP code — see above);
+- the run's summary line — `publish-sourcedata published=… stopped_on_failure=… parked=N`;
+- `logs/publish-sourcedata.log` — a warning naming `parked_batches` on every run where N > 0.
+
+The exit code is deliberately unaffected: parking is what lets the rest of the queue drain, so a run that
+publishes everything it can and reports parked batches has done its job. **Monitor `parked`, not only the
+exit code.**
+
+To inspect and retry:
+
+```sql
+-- Which batches have stopped being attempted, and how much work is in them
+SELECT batch_id, resource_type, resource_id, submitted_by_sub,
+       MAX(publish_attempts) AS attempts, COUNT(*) AS file_count, MIN(created_at) AS submitted_at
+FROM sourcedata_change_requests
+WHERE review_status = 'approved' AND publication_status = 'none' AND publish_attempts >= 5
+GROUP BY batch_id, resource_type, resource_id, submitted_by_sub
+ORDER BY submitted_at ASC;
+
+-- Retry one, AFTER fixing whatever made it fail (see the log for the GitHub error)
+UPDATE sourcedata_change_requests SET publish_attempts = 0, updated_at = NOW()
+WHERE batch_id = '<batch-id>';
+```
+
+Clearing the counter without fixing the cause simply spends five more attempts and parks it again — the
+five failures are in `logs/publish-sourcedata.json.log` with the batch id and GitHub's own error text.
+If the proposal itself is unpublishable (a malformed `resource_id`, say), reject it through
+`POST /admin/change-requests/{batchId}/reject` with a reason, so the submitter learns why, rather than
+leaving it parked indefinitely.
+
+### Credentials on disk
+
+Two secrets touch the filesystem, and they have different lifetimes:
+
+- **The GitHub App private key** (`GITHUB_APP_PRIVATE_KEY_PATH`) must live OUTSIDE the deployed tree and
+  never under the web root — `/etc/litcal/github-app.pem`, owned by the user the cron job runs as, mode
+  `0600`. Only the path is ever put in the environment; the key bytes are read at use time and are never
+  logged, never placed in an exception message, and never committed.
+- **The derived installation token** is cached under `<project>/cache/github_app_tokens/` so that a
+  cron-invoked, short-lived process does not re-authenticate on every tick. It is a bearer credential
+  carrying `contents: write` and `pull_requests: write` on the repository and is valid for up to 50
+  minutes — it deserves the same care as the key it comes from. `scripts/publish-sourcedata.php` sets a
+  restrictive umask around the whole window in which the cache writes entries and chmods the namespace
+  directory to `0700`, so entries land at `0600` inside a `0700` directory (an earlier revision left them
+  at `0644` inside `0755`, world-readable to any local user). The chmod also repairs a directory an older
+  run created.
+
+Verify after a run, rather than assuming:
+
+```bash
+stat -c '%a %n' cache/github_app_tokens cache/github_app_tokens/*
+# expected: 700 cache/github_app_tokens, then 600 for each entry
+```
+
+If the directory is anything wider than `700`, something outside the publisher widened it (a `chmod -R`
+over `cache/`, a deploy step, a backup restore). Fix the mode and rotate the App's private key if the
+host is shared, since any token cached in that window may have been read.
+
 ### The benign double-publish
 
 If the GitHub writes inside `publish()` all succeed — commit created, ref updated, PR open or reused — but
@@ -386,13 +485,31 @@ same message is this benign double-publish, not evidence of a broken retry.
 - **0** — every batch this run claimed was published, or the queue was empty. A reclaimed stale claim is
   ordinary recovery and does not affect this; a run that reclaimed a batch and then successfully published
   everything else still exits 0.
-- **1** — either misconfiguration (bad `limit` argument, or the GitHub App / `GITHUB_REPOSITORY` not
-  configured), or a publish attempt genuinely failed and the run stopped early. In the latter case, approved
-  work remains queued and unpublished with no further retry until the next cron tick.
+- **1** — misconfiguration (bad `limit` argument, or the GitHub App / `GITHUB_REPOSITORY` not configured),
+  a database failure, or a publish attempt genuinely failed and the run stopped early.
 
-A monitoring check on this script should alert on a **non-zero exit**, not merely on the presence of a log
-entry — the "queued" state a failed batch is left in produces no user-visible symptom anywhere else. Detail
-on which batch and why is in `logs/publish-sourcedata.log` (human-readable) and
+**A failed batch is left at `publication_status = 'none'`, NOT `'queued'`.** `releaseClaim()` gives the
+claim up; `queued` means a claim someone still holds, which is exactly what the failure path releases. An
+operator who reacts to an exit-1 alert by hunting for `publication_status = 'queued'` will find nothing —
+these are the two columns this runbook opens by warning you not to conflate. What to look for instead:
+
+```sql
+-- Approved work that has been attempted and is waiting for another tick
+SELECT batch_id, resource_id, MAX(publish_attempts) AS attempts, MAX(updated_at) AS last_attempt
+FROM sourcedata_change_requests
+WHERE review_status = 'approved' AND publication_status = 'none' AND publish_attempts > 0
+GROUP BY batch_id, resource_id
+ORDER BY last_attempt DESC;
+```
+
+(A row genuinely sitting in `queued` means a claim is in flight right now, or a process died holding one —
+that is the grace-period reclaim's job, not this alert's.)
+
+The summary line also carries `parked=N`, which does **not** affect the exit code. A monitoring check on
+this script should therefore alert on a non-zero exit **and** on `parked` being non-zero (or, equivalently,
+on `/health`'s `.source_data_publisher.parked_batches`) — a run can exit 0 with work stuck, which is the
+whole point of parking it. Neither state produces a user-visible symptom anywhere else. Detail on which
+batch and why is in `logs/publish-sourcedata.log` (human-readable) and
 `logs/publish-sourcedata.json.log` (structured), both rotated. `GitHubApiException` carries GitHub's HTTP
 status alongside its message, so a `401`/`403` in either log is the signature of a stale or revoked
 installation token, not a transient failure.
@@ -409,9 +526,14 @@ installation token, not a transient failure.
   loss.** `GitHubGitDataClient::updateRef()` hardcodes `force: false` and is never given a way to force —
   intentionally, so that a branch another publish landed on between this publish's `getRef()` and its own
   `updateRef()` fails loudly, with GitHub's `422`, instead of silently overwriting that other editor's
-  commit. The failure propagates as a `GitHubApiException`, is caught by `PublishRunner`, releases the
-  claim, and stops the run; the batch is retried — by the next claim, once the branch is quiet — rather
-  than clobbering what is already there.
+  commit. The failure propagates as a `GitHubApiException`, is caught by `PublishRunner`, and releases the
+  claim; the batch is retried — by the next claim, once the branch is quiet — rather than clobbering what
+  is already there. A `422` does **not** stop the run and does **not** make it exit 1: it is expected,
+  self-healing, and proof that GitHub is up and answering, so treating it like a revoked credential would
+  page an operator for the design working. It is logged as a warning (`lost a race for its resource
+  branch`), and the attempt is still counted — so a batch that `422`s on every attempt is eventually
+  parked rather than retried forever, which is the case worth investigating: a branch nobody is
+  fast-forwarding, rather than two busy editors.
 - **A stale installation token.** GitHub installation tokens live one hour; `GitHubAppAuth` caches one for
   50 minutes so a token already in flight is never used in its final ten minutes. A token can still go bad
   before its cache entry expires if the App's installation is suspended or removed from the repository — the

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -527,11 +527,16 @@ installation token, not a transient failure.
 ### Operational failure modes
 
 - **An unconfigured publisher accumulates approved work silently.** If change-request queue mode is on but
-  the GitHub App credentials are missing or incomplete, `SourceDataPublisher::isConfigured()` returns
+  the GitHub App credentials are missing, incomplete, or **malformed**, `SourceDataPublisher::isConfigured()` returns
   `false`, `GET /health`'s `source_data_publisher` block reports `warning`, and every approved batch simply
   stays `publication_status = 'none'` forever — nothing about this looks like an error to an editor or a
   resource admin, since their own review workflow (`review_status`) completes normally. Watch `/health`,
   not the editor-facing endpoints, to catch this.
+
+  A set-but-malformed value lands here too, not only an absent one: `GITHUB_REPOSITORY` must be exactly
+  `owner/repo`, so a pasted repository URL or a trailing slash reports identically to leaving it blank.
+  `isConfigured()` and the publisher's own construction share one shape check precisely so `/health`
+  cannot call a value configured that a run would then reject.
 - **A non-fast-forward `422` is the expected symptom of two editors racing on one resource, not data
   loss.** `GitHubGitDataClient::updateRef()` hardcodes `force: false` and is never given a way to force —
   intentionally, so that a branch another publish landed on between this publish's `getRef()` and its own

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -395,6 +395,16 @@ error handler, so if a reclaim were free it would re-crash forever. A successful
 counter, so a transient GitHub blip can never park a batch. Once the counter reaches 5 the batch stops
 being claimed and the queue drains past it.
 
+**A batch that is merely slow can spend two attempts per cycle, not one**, so it parks after three
+cycles rather than five. The claim guard is `publication_status = 'queued'`, which identifies *a*
+claim and not *whose*: when the grace period elapses on a publish that is still alive, the reclaim
+spends one attempt, a second runner picks the batch up, and the first runner's own late failure then
+releases the second runner's live claim and spends another. This is bounded and visible (the batch
+parks and `/health` reports it) and it lands on the benign double-publish rather than on lost work,
+but it is why a batch that habitually runs near the grace period parks sooner than the number 5
+suggests. The fix would be a claim token compared on release — a schema change, deliberately not
+made. If you see this, raise the grace period or narrow the batch before raising the attempt bound.
+
 **Parking is not a dead-letter queue.** The design spec's error table promises a DLQ row for terminal
 failures; that was never built, and there is no DLQ table, no dead-letter status, and no automatic
 notification to the submitter. What actually happens is exactly and only this: the rows are left

--- a/docs/ops/change-request-runbook.md
+++ b/docs/ops/change-request-runbook.md
@@ -9,15 +9,26 @@ resource has their write recorded as a row (or several rows, grouped into one **
 touching the filesystem; a resource admin reviews the batch and approves or rejects it. A caller who
 already administers the resource still gets a batch — it is just auto-approved in the same request.
 
-See `docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md` for the full design, and
-`.superpowers/sdd/2026-08-28-sourcedata-change-requests-phase1/` for the phase 1 implementation plan.
+See `docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md` for the full design,
+`.superpowers/sdd/2026-08-28-sourcedata-change-requests-phase1/` for the phase 1 implementation plan, and
+`.superpowers/sdd/2026-08-29-sourcedata-publisher-phase2/` for the phase 2 (publisher) implementation plan.
 
-**Phase 1 stops at approval.** There is no publisher yet: an approved batch sits at
-`publication_status = 'none'` indefinitely — nothing opens a pull request, nothing writes to GitHub, and
-`jsondata/sourcedata` on disk is never touched by queue-mode writes at all. The Phase 2 GitHub App and
-`SourceDataPublishProcessor` are what will eventually walk approved batches and turn them into commits.
-Until that lands, "approved" means "recorded as approved in Postgres," full stop — treat it as a durable
-staging area, not as a change that has taken effect anywhere a calendar consumer can see.
+**Phase 1 stops at approval.** Without the phase 2 publisher configured and running, an approved batch
+sits at `publication_status = 'none'` indefinitely — nothing opens a pull request, nothing writes to
+GitHub, and `jsondata/sourcedata` on disk is never touched by queue-mode writes at all. "Approved" then
+means "recorded as approved in Postgres," full stop — a durable staging area, not a change that has taken
+effect anywhere a calendar consumer can see.
+
+**Phase 2 adds a publisher**, `SourceDataPublisher` (`src/Services/SourceData/SourceDataPublisher.php`),
+driven by a cron-invoked runner, `PublishRunner` (`src/Services/SourceData/PublishRunner.php`), via
+`scripts/publish-sourcedata.php`. It turns each approved batch into one commit on a per-resource branch
+plus a rolling pull request via a GitHub App. It requires that App to be registered and its credentials
+configured (a one-time human step; not covered here — see the phase 2 plan directory above) before it does
+anything at all. Until then, behaviour is identical to phase 1: `GET /health`'s `source_data_publisher`
+block reports a `warning` if change-request queue mode is on and the publisher is not configured, and
+approved batches accumulate unpublished exactly as they did before phase 2 existed. See
+"Publishing to GitHub (phase 2)" below for the full lifecycle, failure modes, and a limitation that is
+**not** closed by this phase.
 
 ## Which write mode a deployment is in
 
@@ -159,16 +170,19 @@ separate status columns, and conflating them is the most common way to misread t
   what `POST /admin/change-requests/{batchId}/approve|reject` and
   `POST /auth/change-requests/{batchId}/withdraw` move.
 - **`publication_status`** — GitHub's side of the same change: `none` → `queued` → `open` → `merged` /
-  `closed`. Phase 1 writes only `none`; the rest are reserved for the Phase 2 publisher (moves to `queued`
-  once a PR is being opened, `open` once it exists, then `merged` or `closed`) and Phase 3 merge polling.
+  `closed`. The phase 2 publisher writes `queued` and `open`; `merged` and `closed` are reserved for phase
+  3 merge polling, which does not exist yet. See "Publishing to GitHub (phase 2)" below for exactly what
+  each value means and what a row's `branch`/`commit_sha`/`pr_number`/`base_sha` columns hold once filled.
 
-They are kept separate on purpose: an `approved` batch that failed to push (Phase 2's problem, not yet
-possible in Phase 1) must stay distinguishable from one still awaiting review, and from one whose PR is
-open and waiting on CI. Flattening the two into one column would make "approved but the push failed"
-indistinguishable from "approved, awaiting review on the pull request."
+They are kept separate on purpose: an `approved` batch that failed to push must stay distinguishable from
+one still awaiting review, and from one whose PR is open and waiting on CI. Flattening the two into one
+column would make "approved but the push failed" indistinguishable from "approved, awaiting review on the
+pull request."
 
-**As of Phase 1: every row in the table has `publication_status = 'none'`, full stop.** There is no other
-value to see yet. Do not read `'none'` as an error state — it is the only state that exists so far.
+**Without the phase 2 publisher configured and running, every row in the table has
+`publication_status = 'none'`, full stop.** There is no other value to see. Do not read `'none'` as an
+error state — on a deployment that has not yet registered the GitHub App, it is the only state that
+exists.
 
 ## Inspecting the queue in SQL
 
@@ -271,19 +285,208 @@ contract.
 `has_more` at all — just `change_requests`, `total`, `limit`, `offset`. Comparing `offset + <page length>`
 against `total` is sufficient there.
 
-## Deliberately not in phase 1
+## Publishing to GitHub (phase 2)
 
-- **`base_sha` / rebase detection.** The column exists (`Version20260828120000` migration) but nothing
-  writes it yet. Its only source is GitHub's blob sha, which arrives with the Phase 2 publisher.
-- **Re-validating a payload against its JSON schema at approval time.** Phase 1 validates once, at submit.
-  Re-validation at the approval gate only becomes consequential once time can meaningfully pass between
-  submission and a publish action — which needs the Phase 2 publisher to exist first.
+Once the GitHub App is registered and its credentials are configured (see `.env.example`'s "Source Data
+Publisher (phase 2)" block, and `docs/superpowers/plans/2026-08-29-sourcedata-publisher-phase2.md`'s
+"Task 8: Register the GitHub App" for the one-time registration procedure), a cron job invokes
+`scripts/publish-sourcedata.php` on an interval. Each run:
 
-Neither is an oversight to be quietly forgotten; both are required before the publisher opens its first
-pull request.
+1. Reclaims any batch stranded `queued` past a grace period (see below).
+2. Claims up to `limit` (default 10) approved-and-unpublished batches, oldest first.
+3. Publishes each claimed batch via `SourceDataPublisher::publish()` — one commit on a per-resource
+   branch, plus a pull request that stays open across every later batch for that same resource (a
+   "rolling" PR).
+4. Stops early the moment one publish attempt genuinely fails, rather than hammering a possibly-broken
+   GitHub API with the rest of the queue. The next cron tick is the retry, not an in-process loop.
+
+`GET /health`'s `source_data_publisher` block reports whether the publisher is actually configured,
+independently of whether change-request queue mode itself is on — check it after any configuration change.
+
+### The publish lifecycle: `none` → `queued` → `open`
+
+`publication_status` moves through these values, all on the `sourcedata_change_requests` table, for every
+row of a batch at once (a batch is never mixed-status):
+
+| Value    | Set by                                 | Meaning                                                                                             |
+|----------|----------------------------------------|-----------------------------------------------------------------------------------------------------|
+| `none`   | phase 1 (submit), or a release/reclaim | Not yet claimed for publishing, or a failed/stranded attempt was put back so it is claimable again. |
+| `queued` | `claimNextPublishableBatch()`          | A claim held by one runner, mid-publish. Not yet on GitHub.                                         |
+| `open`   | `recordPublication()`                  | A pull request exists for this batch's commit.                                                      |
+| `merged` | phase 3 (not built yet)                | Reserved. Nothing in phase 2 writes this.                                                           |
+| `closed` | phase 3 (not built yet)                | Reserved. Nothing in phase 2 writes this.                                                           |
+
+`queued` is a **claim**, not a milestone on GitHub — nothing has been pushed yet while a batch sits there.
+`open` means a real pull request exists; it does not mean the PR merged, and does not mean CI passed.
+
+Once a batch reaches `open`, `recordPublication()` also stamps four columns, on every row of the batch:
+
+- **`branch`** — `litcal-data/<resource_type>/<resource_id>`, e.g. `litcal-data/national_calendar/roman/US`.
+  Stable per resource, which is what makes the pull request "rolling": every later approved batch for the
+  same resource lands on this same branch and reuses the same open PR instead of opening a competing one.
+- **`commit_sha`** — the sha of the commit this batch produced on that branch (the *latest* one, if the
+  batch was ever re-published — see "The benign double-publish" below).
+- **`pr_number`** — the pull request's number on GitHub.
+- **`base_sha`** — the commit the publish branched from: the branch's own head if the branch already
+  existed, or the configured base branch's head (`GITHUB_BASE_BRANCH`, default `development`) if this was
+  the resource's first publish. This is a **batch-level** value, written across every row of the batch,
+  and is distinct from what a phase 1 reading of this column might suggest — it is not a per-file blob sha
+  and not per-file rebase bookkeeping.
+
+### Stranded-claim recovery and the grace period
+
+A crash between `claimNextPublishableBatch()` and the publish finishing — a SIGKILL, an OOM kill, a cron
+timeout — leaves a batch `queued` with no process left running to release it. Without recovery, that batch
+is invisible to the operator, invisible to the editor, and indistinguishable from success on the editor's
+side, forever. `PublishRunner::runOnce()` reclaims any batch still `queued` past
+`PublishRunner::DEFAULT_GRACE_SECONDS` (1800 seconds) at the start of every run, before claiming anything
+new. A reclaim is ordinary recovery, not a failure: it never causes the run to stop early, and a batch it
+reclaims is immediately claimable again in that same run.
+
+**The grace period's value is not arbitrary and must not be lowered without re-deriving it.** The
+invariant is:
+
+```text
+grace_seconds > max_requests_per_batch * request_timeout_seconds
+```
+
+A publish issues one `createBlob` call per changed file, serially, followed by a fixed sequence
+(`getRef`/`createRef`, `getCommitTreeSha`, `createTree`, `createCommit`, `updateRef`,
+`findOpenPullRequest`/`openPullRequest`) — six calls. The widest batch this repository can produce today is
+the decrees corpus: `decrees.json` plus 14 `i18n/` locale files plus 7 `lectionary/` locale files, 22 blob
+writes, plus the six fixed calls — 28 requests. At `scripts/publish-sourcedata.php`'s 30-second per-request
+timeout, that is a worst case of 840 seconds for one publish that is merely slow, not dead. 1800 leaves
+comfortable headroom above 840.
+
+If either the request timeout or the widest batch this repository can produce grows, the grace period must
+grow with it. **Lowering `DEFAULT_GRACE_SECONDS` without checking this arithmetic will reclaim live work:**
+a publish that is still genuinely in flight gets treated as abandoned, a second runner republishes the same
+batch, and the first runner's now-stale `updateRef()` call fails with a non-fast-forward error when it
+finally returns — recoverable (see below), but entirely avoidable by respecting the invariant.
+
+### The benign double-publish
+
+If the GitHub writes inside `publish()` all succeed — commit created, ref updated, PR open or reused — but
+the final `recordPublication()` call then fails (a DB blip, a connection drop), the batch is left `queued`
+with real work already on GitHub that Postgres does not know about yet. That batch is retried, either by
+the grace-period reclaim or by a subsequent run's own failure handling. The retry re-runs `publish()` from
+scratch against the branch's new head — which is the commit the first attempt already pushed. Since the
+batch's content has not changed, the retry's tree is identical to its parent's tree, producing **one extra
+commit with an empty diff and the same commit message**, and it reuses the already-open pull request rather
+than opening a second one (`findOpenPullRequest()` finds it).
+
+This is not data loss and not a duplicate PR — it is a git artifact you should recognize on sight, not
+investigate as a bug: two adjacent commits on a `litcal-data/...` branch with identical content and the
+same message is this benign double-publish, not evidence of a broken retry.
+
+### Exit codes and monitoring
+
+`scripts/publish-sourcedata.php` exits:
+
+- **0** — every batch this run claimed was published, or the queue was empty. A reclaimed stale claim is
+  ordinary recovery and does not affect this; a run that reclaimed a batch and then successfully published
+  everything else still exits 0.
+- **1** — either misconfiguration (bad `limit` argument, or the GitHub App / `GITHUB_REPOSITORY` not
+  configured), or a publish attempt genuinely failed and the run stopped early. In the latter case, approved
+  work remains queued and unpublished with no further retry until the next cron tick.
+
+A monitoring check on this script should alert on a **non-zero exit**, not merely on the presence of a log
+entry — the "queued" state a failed batch is left in produces no user-visible symptom anywhere else. Detail
+on which batch and why is in `logs/publish-sourcedata.log` (human-readable) and
+`logs/publish-sourcedata.json.log` (structured), both rotated. `GitHubApiException` carries GitHub's HTTP
+status alongside its message, so a `401`/`403` in either log is the signature of a stale or revoked
+installation token, not a transient failure.
+
+### Operational failure modes
+
+- **An unconfigured publisher accumulates approved work silently.** If change-request queue mode is on but
+  the GitHub App credentials are missing or incomplete, `SourceDataPublisher::isConfigured()` returns
+  `false`, `GET /health`'s `source_data_publisher` block reports `warning`, and every approved batch simply
+  stays `publication_status = 'none'` forever — nothing about this looks like an error to an editor or a
+  resource admin, since their own review workflow (`review_status`) completes normally. Watch `/health`,
+  not the editor-facing endpoints, to catch this.
+- **A non-fast-forward `422` is the expected symptom of two editors racing on one resource, not data
+  loss.** `GitHubGitDataClient::updateRef()` hardcodes `force: false` and is never given a way to force —
+  intentionally, so that a branch another publish landed on between this publish's `getRef()` and its own
+  `updateRef()` fails loudly, with GitHub's `422`, instead of silently overwriting that other editor's
+  commit. The failure propagates as a `GitHubApiException`, is caught by `PublishRunner`, releases the
+  claim, and stops the run; the batch is retried — by the next claim, once the branch is quiet — rather
+  than clobbering what is already there.
+- **A stale installation token.** GitHub installation tokens live one hour; `GitHubAppAuth` caches one for
+  50 minutes so a token already in flight is never used in its final ten minutes. A token can still go bad
+  before its cache entry expires if the App's installation is suspended or removed from the repository — the
+  next token exchange or API call then fails with a `401`/`403` `GitHubApiException`, the run stops, and
+  every subsequent tick fails identically until the installation (or `GITHUB_APP_PRIVATE_KEY_PATH`) is
+  fixed. This is indistinguishable, from the exit code alone, from any other genuine publish failure —
+  check the log message for the HTTP status and GitHub's own error text.
+
+### Author vs. committer, and the unverified-email rule
+
+Every commit `SourceDataPublisher::publish()` creates has the editor who submitted the batch as its
+**author** (`submitted_by_name`, `submitted_by_email`) and the GitHub App as its **committer**
+(`GITHUB_APP_COMMITTER_NAME`/`GITHUB_APP_COMMITTER_EMAIL`). This split is the entire reason the design
+exists: it is what lets the repository history attribute a change to the person who actually made it, while
+the App remains the party that actually pushed it. Do not "simplify" this to a single identity — that would
+erase per-editor authorship from the git history entirely.
+
+An unverified email must never become the commit author email: presenting it as an authenticated identity
+would let anyone who can set an arbitrary address in their own profile forge authorship of a third party in
+a public repository. `authorFor()` uses `submitted_by_email` as the author email only when
+`submitted_by_email_verified` is true; otherwise it substitutes a fixed placeholder
+(`noreply@users.noreply.github.com`). This is an honest limitation, not a real per-editor identity: editors
+authenticate through Zitadel, not a GitHub account, so there is no identity mapping available to produce a
+genuine `<id>+<login>@users.noreply.github.com` address the way GitHub's own UI would. Every commit
+authored under an unverified email therefore carries the same placeholder address regardless of who
+actually submitted it — the author *name* still varies, but the email does not.
+
+## Known limitation: a deleted resource's editors keep access
+
+**Not closed by phase 2:** deleting a calendar or test through a change request does not purge its OpenFGA
+authorization tuples. Nothing between "PR merged" and "next redeploy" performs that purge, so a deleted
+diocese's former editors retain edit access on an object whose files are gone. This is deliberate — only
+merge detection (phase 3) knows the deletion actually happened — and it is a known limitation, not an
+oversight.
+
+In disk mode, `RegionalDataHandler::deleteCalendar()` (and `TestsHandler`'s equivalent
+`handleDeleteRequest()`) both remove the resource's files **and** purge its OpenFGA editor/viewer
+operational tuples via `ResourceTuplePurgeServiceInterface`, in the same request. In queue mode, that same
+purge is gated on the write actually having landed on disk (`disposition === 'applied'`) — which a queued
+delete never is. Publishing a delete-operation batch's PR does not make the deletion true on disk, and
+even an open PR can still be closed unmerged; purging authorization at publish time would revoke real
+access on the strength of a proposal rather than a fact. The corresponding purge is deferred to phase 3,
+at merge detection — the same moment the redeploy that follows a merge would actually remove the files, so
+authorization and files become true together instead of drifting apart.
+
+**Operator consequence:** if a change request deletes a diocesan or national calendar, or a test
+definition, before phase 3 ships, its former editors and admins keep their OpenFGA `editor`/`viewer`
+relations on that resource even after the deleting PR is merged and the files are gone from
+`jsondata/sourcedata`. If this needs to be closed out manually before phase 3 exists, purge the resource's
+operational tuples by hand through the same `ResourceTuplePurgeServiceInterface` mapping
+(`RegionalDataHandler::fgaObjectForRequest()` / `changeResourceForRequest()` for calendars,
+`TestsHandler::changeResourceForTest()` for test definitions) — the admin/governance tuple is deliberately
+retained by that purge, not removed, so the resource can be recreated without losing ownership.
+
+## Deliberately not in phase 1 or 2
+
+- **Re-validating a payload against its JSON schema at approval or publish time.** Both phases validate
+  once, at submit. Nothing re-checks a batch's content against its JSON schema between then and the
+  commit `SourceDataPublisher::publish()` pushes, even though real time — and potentially a schema
+  change — can pass in between.
+- **Purging OpenFGA authorization tuples for a deleted calendar or test definition once its deletion is
+  actually live on GitHub.** See "Known limitation: a deleted resource's editors keep access" above —
+  this is deliberate, not an oversight, and is scoped to phase 3.
+
+Neither is an oversight to be quietly forgotten; both are required before this system is considered
+complete.
+
+**`base_sha` was speculative in phase 1 and is now defined.** Phase 1's runbook predicted the column
+would eventually hold "GitHub's blob sha." That is not what phase 2 actually wrote: `recordPublication()`
+overwrites `base_sha` on **every row of a published batch** with the branch head commit sha the publish
+branched from (the `getRef()`/`getCommitTreeSha()` starting point in `SourceDataPublisher::publish()`),
+not a per-file blob sha and not per-file rebase bookkeeping. See "Publishing to GitHub (phase 2)" above.
 
 ## Retention / pruning
 
 There is no automated prune. Unlike the OpenFGA outbox, rows here are not transient operational state —
-they are the durable record of every proposal, decided or not, and (once Phase 2 exists) the paper trail
-between a submission and the pull request it became. Do not delete rows out of band.
+they are the durable record of every proposal, decided or not, and the paper trail between a submission
+and the pull request it became. Do not delete rows out of band.

--- a/docs/superpowers/plans/2026-08-29-sourcedata-publisher-phase2.md
+++ b/docs/superpowers/plans/2026-08-29-sourcedata-publisher-phase2.md
@@ -1,0 +1,878 @@
+# Source-Data Publisher (Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn an approved change request into a commit on a per-resource branch and a rolling pull request, so that
+edits made through the API reach the GitHub repository instead of being destroyed by the next deploy.
+
+**Architecture:** A cron-driven publisher claims one approved batch at a time from `sourcedata_change_requests`,
+authenticates as a GitHub App, and writes the batch through the Git Data API (blob → tree → commit → ref → PR) with the
+authenticated editor as commit author and the App as committer. The change-request table is itself the queue: its
+`publication_status` column already models `none → queued → open`, and `branch`, `commit_sha`, `pr_number` and
+`base_sha` are already there to be filled in.
+
+**Tech Stack:** PHP 8.4, `firebase/php-jwt` (RS256 App JWT), `guzzlehttp/guzzle` (GitHub REST), `symfony/cache`
+`FilesystemAdapter` (installation-token cache), Postgres via PDO, PHPUnit.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md`, section "Phase 2: the publisher".
+
+## Corrections to the spec, established before planning
+
+The spec was written before phase 1 existed. Two of its reuse claims do not survive contact with the merged code. Both
+are recorded here so no task is written against them:
+
+1. **"Outbox row (reuses ConsumerLoop / BackstopRunner / OutboxBackoff unchanged)" is only one-third true.**
+   `BackstopRunner::__construct()` types its first argument as the concrete `OutboxRepository`
+   (`src/Services/Outbox/BackstopRunner.php:26`), and `ConsumerLoop` needs a Redis stream plus an integer row id
+   (`src/Services/Outbox/ConsumerLoop.php:26-31`), while the unit of publication is a **batch**, not a row. The existing
+   outbox is also specifically OpenFGA-shaped: table `openfga_outbox`, and `OutboxOperation` has exactly two cases,
+   `write_tuple` and `delete_tuple`. Only `OutboxBackoff::secondsForAttempt(int $attempts): int` is genuinely reusable —
+   it is a pure static function. The publisher therefore gets its own small runner that **mirrors**
+   `BackstopRunner`'s locking discipline (`FOR UPDATE SKIP LOCKED` inside an explicit transaction, per the comment at
+   `BackstopRunner.php:36-42`) rather than inheriting from it.
+
+2. **No new queue table is needed.** `Version20260828120000` already ships `publication_status` with the five-state
+   CHECK constraint, plus `base_sha`, `branch`, `commit_sha`, `pr_number` and `merge_commit_sha`. Approved batches with
+   `publication_status = 'none'` are the work list.
+
+## Global Constraints
+
+- PHP >= 8.4. PSR-12 via `phpcs.xml`: 4-space indent, short array syntax `[]`, single quotes unless interpolating.
+- PHPStan level 10 (`composer analyse`) must pass. Never a blind cast of `mixed`.
+- `#[CoversClass]` on every test. A test that exercises a class must name it, or PHPUnit discards that coverage.
+- Postgres and OpenFGA are configured and reachable in dev and CI. A skipping repository test proves nothing and is a
+  defect, not an environment quirk.
+- Never use `--no-verify`. Run `composer parallel-lint && composer lint:fix && composer analyse` before every commit,
+  `composer lint:md` when Markdown changes.
+- Feature branches target `development`. Never `main`.
+- `jsondata/schemas/openapi.json` is canonical literal UTF-8 with **zero** `\uXXXX` escapes. Edit it as text; never
+  round-trip it through `json_decode`/`json_encode`. `composer lint:jsondata` — not `lint:openapi` — is what catches
+  encoding drift, and it must stay green.
+- Phase 2 never writes `publication_status = 'closed'`. That state and its effect on the accumulation base belong to
+  phase 3.
+- Phase 2 does **not** purge OpenFGA tuples for deleted calendars or tests. That is phase 3, at merge detection.
+  Task 9 requires the runbook to state the resulting gap explicitly.
+
+## File Structure
+
+| File                                                     | Responsibility                                              |
+| -------------------------------------------------------- | ----------------------------------------------------------- |
+| `src/Services/GitHub/GitHubAppAuth.php`                  | App JWT (RS256) → installation token, cached ~50 min        |
+| `src/Services/GitHub/GitHubGitDataClient.php`            | The Git Data + Pulls REST calls, one method each            |
+| `src/Services/GitHub/GitHubApiException.php`             | Typed failure carrying status and GitHub's message          |
+| `src/Services/SourceData/PublishablePayload.php`         | One batch flattened into paths, contents and operations     |
+| `src/Services/SourceData/SourceDataPublisher.php`        | Orchestrates one batch: branch → blobs → tree → commit → PR |
+| `src/Services/SourceData/PublishRunner.php`              | Claim, publish, settle; backoff on failure                  |
+| `scripts/publish-sourcedata.php`                         | Cron entry point calling `PublishRunner::runOnce()`         |
+| `src/Repositories/SourceDataChangeRequestRepository.php` | Age-based ancestor exclusion; claim and settle methods      |
+| `docs/ops/change-request-runbook.md`                     | Operator documentation, including the phase-3 purge gap     |
+
+---
+
+## Task 1: Age-based ancestor exclusion
+
+This lands first because it is a latent bug that activates the instant anything reaches `merged` — which Task 6 makes
+possible. Shipping the publisher without it would reintroduce the exact silent data loss phase 1 spent four rounds
+closing.
+
+**Files:**
+
+- Modify: `src/Repositories/SourceDataChangeRequestRepository.php` (the `UNPUBLISHED_PREDICATE` constant and both
+  `findUnpublished*` methods)
+- Test: `phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php`
+
+**Interfaces:**
+
+- Consumes: nothing new.
+- Produces: no signature changes. `findUnpublishedContent(string $path, string $sub): ?string` and
+  `findUnpublishedPathsUnder(string $pathPrefix, string $sub): array` keep their signatures; only which rows they
+  consider changes.
+
+**The rule:** for a given `(path, submitted_by_sub)`, ignore any row older than the newest row whose
+`publication_status = 'merged'`. Do not rewrite any row's status.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+public function testAnAncestorOlderThanAMergedRowIsNotUsedAsTheBase(): void
+{
+    $path = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+
+    // Batch A: approved, never published. Batch B accumulated onto it and was published.
+    $batchA = $this->repo->submitBatch(
+        ChangeResource::decrees(),
+        [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '["A"]']],
+        'editor-1',
+        'Alice',
+        'alice@example.test',
+        true
+    )['batch_id'];
+    $this->repo->approveBatch($batchA, 'admin-1');
+
+    $batchB = $this->repo->submitBatch(
+        ChangeResource::decrees(),
+        [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '["A","B"]']],
+        'editor-1',
+        'Alice',
+        'alice@example.test',
+        true
+    )['batch_id'];
+    $this->repo->approveBatch($batchB, 'admin-1');
+    $this->repo->markBatchPublicationStatus($batchB, ChangePublicationStatus::MERGED);
+
+    // A is older than the newest merged row for this path, so it must not become the base again.
+    self::assertNull(
+        $this->repo->findUnpublishedContent($path, 'editor-1'),
+        'a merged batch must not fall back to the ancestor it superseded'
+    );
+}
+```
+
+- [ ] **Step 2: Run it and watch it fail**
+
+```bash
+vendor/bin/phpunit --filter testAnAncestorOlderThanAMergedRowIsNotUsedAsTheBase \
+  phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
+```
+
+Expected: FAIL — it returns `'["A"]'`, batch A's content, because A is `approved`/`none` and so still matches the
+predicate. That failure IS the bug this task exists to fix; capture the output in your report.
+
+- [ ] **Step 3: Add the age floor to both queries**
+
+Keep `UNPUBLISHED_PREDICATE` as it is, and add the floor as a separate clause so the two ideas stay legible:
+
+```php
+    /**
+     * Rows that are not yet in the repository: still in review, or approved and awaiting publication.
+     *
+     * Deliberately wider than the supersede DELETE's `review_status = 'submitted'`: an approved batch has
+     * not reached disk in phase 1, and phase 2 publishes it later, so its content is still the submitter's
+     * work in flight.
+     */
+    private const UNPUBLISHED_PREDICATE = 'review_status IN (:submitted, :approved)
+                AND publication_status <> :merged';
+
+    /**
+     * Rows superseded by published content are excluded by AGE, not by rewriting their status.
+     *
+     * Accumulation makes each batch the submitter's cumulative proposal, so publishing batch B also
+     * publishes the content of the older batch A that B accumulated onto. A is then stale. Marking A
+     * `merged` would say it was published, which is false: the publisher selects approved rows that are
+     * not yet merged, so a broken containment assumption would make it skip A and lose its content
+     * silently. Excluding by age asserts nothing — A stays approved, visible and publishable — and the
+     * worst case degrades from lost data to a suboptimal rebuild base.
+     */
+    private const NOT_SUPERSEDED_BY_PUBLISHED = 'created_at > COALESCE((
+                    SELECT MAX(m.created_at)
+                      FROM sourcedata_change_requests m
+                     WHERE m.path = sourcedata_change_requests.path
+                       AND m.submitted_by_sub = sourcedata_change_requests.submitted_by_sub
+                       AND m.publication_status = :merged_floor
+                ), TIMESTAMPTZ \'-infinity\')';
+```
+
+Add `AND ' . self::NOT_SUPERSEDED_BY_PUBLISHED` to both `findUnpublishedContent()` and
+`findUnpublishedPathsUnder()`, and bind `:merged_floor` to `ChangePublicationStatus::MERGED->value` alongside the
+existing `unpublishedParams()`. Bind it as a distinct placeholder rather than reusing `:merged`, so the two clauses
+stay independently readable.
+
+- [ ] **Step 4: Add the sibling test that pins what must NOT change**
+
+```php
+public function testAnAncestorWithNoMergedDescendantIsStillTheBase(): void
+{
+    $path = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+
+    $batchA = $this->repo->submitBatch(
+        ChangeResource::decrees(),
+        [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '["A"]']],
+        'editor-1',
+        'Alice',
+        'alice@example.test',
+        true
+    )['batch_id'];
+    $this->repo->approveBatch($batchA, 'admin-1');
+
+    // Nothing is merged, so phase 1's behaviour must be untouched.
+    self::assertSame('["A"]', $this->repo->findUnpublishedContent($path, 'editor-1'));
+}
+```
+
+- [ ] **Step 5: Run both and the whole repository suite**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
+vendor/bin/phpunit phpunit_tests/Handlers/SourceDataChangeRequestSupersedeRegressionTest.php
+```
+
+Expected: PASS. The supersede regression suite must stay green unchanged — it encodes phase 1's guarantees, and this
+change must not alter any of them while nothing is merged.
+
+- [ ] **Step 6: Commit**
+
+```bash
+composer parallel-lint && composer lint:fix && composer analyse
+git add src/Repositories/SourceDataChangeRequestRepository.php phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
+git commit -m "fix(change-requests): exclude ancestors superseded by published content"
+```
+
+---
+
+## Task 2: Claim and settle a batch
+
+**Files:**
+
+- Modify: `src/Repositories/SourceDataChangeRequestRepository.php`
+- Test: `phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php` (create)
+
+**Interfaces:**
+
+- Produces, all on `SourceDataChangeRequestRepository`:
+  - `claimNextPublishableBatch(): ?string` — batch id, or null. Sets that batch's rows to `queued` inside the same
+    transaction that selected them, using `FOR UPDATE SKIP LOCKED` so two runners never claim the same batch.
+  - `markBatchPublicationStatus(string $batchId, ChangePublicationStatus $status): int`
+  - `recordPublication(string $batchId, string $branch, string $commitSha, ?int $prNumber, string $baseSha): int`
+  - `releaseClaim(string $batchId): int` — back to `none`, for a failed attempt.
+
+Only batches whose rows are **all** `review_status = 'approved'` and `publication_status = 'none'` are claimable. A
+batch is never mixed-status (`decideBatch()` transitions every still-submitted row in one `UPDATE`), so `MIN`/`MAX`
+over the batch is a safe test.
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+public function testClaimingReturnsAnApprovedBatchAndMarksItQueued(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+
+    self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+
+    foreach ($this->repo->getBatch($batchId) as $row) {
+        self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
+    }
+}
+
+public function testAnUnapprovedBatchIsNeverClaimed(): void
+{
+    $this->submitOnly('editor-1');
+
+    self::assertNull($this->repo->claimNextPublishableBatch(), 'submitted-but-undecided work is not publishable');
+}
+
+public function testAClaimedBatchIsNotClaimedTwice(): void
+{
+    $this->submitAndApprove('editor-1');
+
+    self::assertNotNull($this->repo->claimNextPublishableBatch());
+    self::assertNull($this->repo->claimNextPublishableBatch(), 'a queued batch must not be handed out again');
+}
+
+public function testReleasingAClaimMakesItPublishableAgain(): void
+{
+    $batchId = $this->submitAndApprove('editor-1');
+    $this->repo->claimNextPublishableBatch();
+
+    $this->repo->releaseClaim($batchId);
+
+    self::assertSame($batchId, $this->repo->claimNextPublishableBatch(), 'a failed attempt must be retryable');
+}
+```
+
+- [ ] **Step 2: Run and watch them fail**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+```
+
+Expected: FAIL with "Call to undefined method ... claimNextPublishableBatch()".
+
+- [ ] **Step 3: Implement the claim**
+
+```php
+    public function claimNextPublishableBatch(): ?string
+    {
+        // FOR UPDATE SKIP LOCKED only holds its locks for the surrounding transaction, so the
+        // select and the status update must share one — otherwise autocommit releases the lock
+        // immediately and two runners can claim the same batch. Same reasoning as
+        // BackstopRunner::runOnce(), which this mirrors rather than reuses.
+        $this->db->beginTransaction();
+        try {
+            $select = $this->db->prepare(
+                'SELECT batch_id
+                   FROM sourcedata_change_requests
+                  GROUP BY batch_id
+                 HAVING bool_and(review_status = :approved)
+                    AND bool_and(publication_status = :none)
+                  ORDER BY MIN(created_at) ASC
+                  LIMIT 1
+                    FOR UPDATE SKIP LOCKED'
+            );
+            $select->execute([
+                'approved' => ChangeReviewStatus::APPROVED->value,
+                'none'     => ChangePublicationStatus::NONE->value,
+            ]);
+
+            $batchId = $select->fetchColumn();
+            if (!is_string($batchId)) {
+                $this->db->commit();
+
+                return null;
+            }
+
+            $claim = $this->db->prepare(
+                'UPDATE sourcedata_change_requests
+                    SET publication_status = :queued, updated_at = NOW()
+                  WHERE batch_id = :batch_id'
+            );
+            $claim->execute([
+                'queued'   => ChangePublicationStatus::QUEUED->value,
+                'batch_id' => $batchId,
+            ]);
+
+            $this->db->commit();
+
+            return $batchId;
+        } catch (\Throwable $e) {
+            $this->db->rollBack();
+            throw $e;
+        }
+    }
+```
+
+`ORDER BY MIN(created_at) ASC` publishes oldest-approved-first, which keeps a busy resource from starving an old batch.
+
+- [ ] **Step 4: Implement the settle methods**
+
+```php
+    public function markBatchPublicationStatus(string $batchId, ChangePublicationStatus $status): int
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status = :status, updated_at = NOW()
+              WHERE batch_id = :batch_id'
+        );
+        $stmt->execute(['status' => $status->value, 'batch_id' => $batchId]);
+
+        return $stmt->rowCount();
+    }
+
+    public function recordPublication(
+        string $batchId,
+        string $branch,
+        string $commitSha,
+        ?int $prNumber,
+        string $baseSha
+    ): int {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status = :open,
+                    branch             = :branch,
+                    commit_sha         = :commit_sha,
+                    pr_number          = :pr_number,
+                    base_sha           = :base_sha,
+                    updated_at         = NOW()
+              WHERE batch_id = :batch_id'
+        );
+        $stmt->execute([
+            'open'       => ChangePublicationStatus::OPEN->value,
+            'branch'     => $branch,
+            'commit_sha' => $commitSha,
+            'pr_number'  => $prNumber,
+            'base_sha'   => $baseSha,
+            'batch_id'   => $batchId,
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    public function releaseClaim(string $batchId): int
+    {
+        return $this->markBatchPublicationStatus($batchId, ChangePublicationStatus::NONE);
+    }
+```
+
+- [ ] **Step 5: Run the tests, then commit**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+composer parallel-lint && composer lint:fix && composer analyse
+git add -A && git commit -m "feat(change-requests): claim and settle batches for publication"
+```
+
+---
+
+## Task 3: GitHub App authentication
+
+**Files:**
+
+- Create: `src/Services/GitHub/GitHubAppAuth.php`, `src/Services/GitHub/GitHubApiException.php`
+- Test: `phpunit_tests/Services/GitHub/GitHubAppAuthTest.php`
+
+**Interfaces:**
+
+- Produces:
+  - `GitHubAppAuth::__construct(string $appId, string $installationId, string $privateKeyPath, ClientInterface $http, CacheItemPoolInterface $cache)`
+  - `GitHubAppAuth::installationToken(): string` — cached, refreshed at ~50 minutes of the one-hour life
+  - `GitHubAppAuth::isConfigured(): bool` — static, mirroring `OpenFgaClient::isConfigured()`
+  - `GitHubApiException extends \RuntimeException` with `public readonly int $status`
+
+The App JWT is RS256-signed with `firebase/php-jwt`, `iss` = app id, `iat` backdated 60 seconds for clock skew, `exp`
+at most 10 minutes out (GitHub rejects longer). It is exchanged at
+`POST /app/installations/{installation_id}/access_tokens` for an installation token.
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+#[CoversClass(GitHubAppAuth::class)]
+final class GitHubAppAuthTest extends TestCase
+{
+    private function auth(array $responses, CacheItemPoolInterface $cache): GitHubAppAuth
+    {
+        $guzzle = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler($responses))]);
+
+        return new GitHubAppAuth('12345', '67890', self::keyPath(), $guzzle, $cache);
+    }
+
+    public function testItExchangesTheAppJwtForAnInstallationToken(): void
+    {
+        $auth = $this->auth(
+            [new GuzzleResponse(201, [], json_encode(['token' => 'ghs_abc', 'expires_at' => '2026-01-01T00:00:00Z']))],
+            new ArrayAdapter()
+        );
+
+        self::assertSame('ghs_abc', $auth->installationToken());
+    }
+
+    public function testTheTokenIsCachedRatherThanFetchedEveryCall(): void
+    {
+        // One response only: a second HTTP call would throw "queue is empty".
+        $auth = $this->auth(
+            [new GuzzleResponse(201, [], json_encode(['token' => 'ghs_abc', 'expires_at' => '2026-01-01T00:00:00Z']))],
+            new ArrayAdapter()
+        );
+
+        self::assertSame('ghs_abc', $auth->installationToken());
+        self::assertSame('ghs_abc', $auth->installationToken());
+    }
+
+    public function testAFailedExchangeRaisesGitHubApiExceptionCarryingTheStatus(): void
+    {
+        $auth = $this->auth([new GuzzleResponse(401, [], json_encode(['message' => 'Bad credentials']))], new ArrayAdapter());
+
+        try {
+            $auth->installationToken();
+            self::fail('a 401 must not be swallowed');
+        } catch (GitHubApiException $e) {
+            self::assertSame(401, $e->status);
+            self::assertStringContainsString('Bad credentials', $e->getMessage());
+        }
+    }
+}
+```
+
+`self::keyPath()` writes a throwaway RSA private key to the test's temp directory in `setUpBeforeClass()` and returns
+its path; remove it child-first in `tearDownAfterClass()`. Generate it with
+`openssl_pkey_new(['private_key_bits' => 2048, 'private_key_type' => OPENSSL_KEYTYPE_RSA])` so the suite needs no
+committed key material.
+
+- [ ] **Step 2: Run and watch it fail**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/GitHub/GitHubAppAuthTest.php
+```
+
+Expected: FAIL — class not found.
+
+- [ ] **Step 3: Implement `GitHubApiException`**
+
+```php
+final class GitHubApiException extends \RuntimeException
+{
+    public function __construct(public readonly int $status, string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $status, $previous);
+    }
+}
+```
+
+- [ ] **Step 4: Implement `GitHubAppAuth`**
+
+Key points the implementation must honour:
+
+- Read the private key with `file_get_contents()` on the configured **path**. Never accept the key itself through an
+  environment variable — it belongs outside the deployed tree.
+- `JWT::encode(['iat' => time() - 60, 'exp' => time() + 540, 'iss' => $appId], $key, 'RS256')`.
+- Cache under a key derived from the installation id, with a TTL of **3000 seconds** (50 minutes) against GitHub's
+  one-hour life, so a token is never used in its final ten minutes.
+- Any non-2xx from the exchange throws `GitHubApiException` carrying the status and GitHub's `message` field.
+
+- [ ] **Step 5: Run tests, then commit**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/GitHub/GitHubAppAuthTest.php
+composer parallel-lint && composer lint:fix && composer analyse
+git add -A && git commit -m "feat(github): authenticate as a GitHub App with a cached installation token"
+```
+
+---
+
+## Task 4: The Git Data client
+
+**Files:**
+
+- Create: `src/Services/GitHub/GitHubGitDataClient.php`
+- Test: `phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php`
+
+**Interfaces:**
+
+- Consumes: `GitHubAppAuth::installationToken()`, `GitHubApiException`.
+- Produces, on `GitHubGitDataClient`:
+
+```php
+public function getRef(string $branch): ?string;                          // head sha, or null on 404
+public function createRef(string $branch, string $fromSha): void;
+public function createBlob(string $content): string;                      // blob sha
+public function createTree(string $baseTreeSha, array $entries): string;  // tree sha
+public function createCommit(string $message, string $treeSha, string $parentSha, array $author): string;
+public function updateRef(string $branch, string $commitSha): void;       // force: false
+public function openPullRequest(string $branch, string $base, string $title, string $body): int;
+public function findOpenPullRequest(string $branch): ?int;
+```
+
+A tree entry is `['path' => string, 'mode' => '100644', 'type' => 'blob', 'sha' => string|null]`. **A null `sha` is
+how the Git Data API expresses a deletion** — that is the mechanism behind a `delete` change request, and it is easy
+to lose to a type declaration that forbids null.
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+public function testGetRefReturnsNullForAMissingBranch(): void
+{
+    $client = $this->client([new GuzzleResponse(404, [], json_encode(['message' => 'Not Found']))]);
+
+    self::assertNull($client->getRef('litcal-data/roman/nation/US'));
+}
+
+public function testUpdateRefRefusesToForcePush(): void
+{
+    $captured = [];
+    $client   = $this->clientCapturing($captured, [new GuzzleResponse(200, [], '{}')]);
+
+    $client->updateRef('litcal-data/roman/nation/US', 'abc123');
+
+    $body = json_decode((string) $captured[0]->getBody(), true);
+    // force:false turns a concurrent update into a retryable 422 instead of silently
+    // clobbering another editor's commit.
+    self::assertFalse($body['force'], 'the publisher must never force-push');
+}
+
+public function testATreeEntryMayCarryANullShaToExpressADeletion(): void
+{
+    $captured = [];
+    $client   = $this->clientCapturing($captured, [new GuzzleResponse(201, [], json_encode(['sha' => 'tree1']))]);
+
+    $client->createTree('base1', [
+        ['path' => 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json', 'mode' => '100644', 'type' => 'blob', 'sha' => null],
+    ]);
+
+    $body = json_decode((string) $captured[0]->getBody(), true);
+    self::assertNull($body['tree'][0]['sha'], 'a null sha is how the API deletes a path');
+    self::assertArrayHasKey('sha', $body['tree'][0], 'the key must be present and null, not omitted');
+}
+
+public function testANon2xxRaisesGitHubApiException(): void
+{
+    $client = $this->client([new GuzzleResponse(422, [], json_encode(['message' => 'Update is not a fast forward']))]);
+
+    $this->expectException(GitHubApiException::class);
+    $client->updateRef('litcal-data/roman/nation/US', 'abc123');
+}
+```
+
+- [ ] **Step 2: Run and watch them fail, then implement**
+
+Every request carries `Authorization: Bearer <installation token>`, `Accept: application/vnd.github+json` and
+`X-GitHub-Api-Version: 2022-11-28`. `getRef()` is the only method that treats 404 as a value rather than an error.
+When building the tree payload, use `json_encode` on an array that includes the `sha` key explicitly set to `null` —
+do not filter nulls out, or deletions silently become no-ops.
+
+- [ ] **Step 3: Run tests, then commit**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
+composer parallel-lint && composer lint:fix && composer analyse
+git add -A && git commit -m "feat(github): Git Data and Pulls client"
+```
+
+---
+
+## Task 5: Publish one batch
+
+**Files:**
+
+- Create: `src/Services/SourceData/PublishablePayload.php`, `src/Services/SourceData/SourceDataPublisher.php`
+- Test: `phpunit_tests/Services/SourceData/SourceDataPublisherTest.php`
+
+**Interfaces:**
+
+- Consumes: `GitHubGitDataClient` (Task 4), `SourceDataChangeRequestRepository::getBatch()` and
+  `recordPublication()` (Task 2).
+- Produces: `SourceDataPublisher::publish(string $batchId): PublishResult`, where `PublishResult` carries
+  `branch`, `commitSha`, `prNumber` and `baseSha`.
+
+**Branch naming:** `litcal-data/<resource_type>/<resource_id>`, e.g. `litcal-data/national_calendar/roman/US`. Stable
+per resource, so the rolling PR falls out for free. `resource_id` already contains a `/` for rite-qualified ids, which
+is legal in a git ref and intended.
+
+**Author vs committer:** the commit's `author` is the editor (`submitted_by_name`, `submitted_by_email`), the
+`committer` is the App. Only use the submitter's email when `submitted_by_email_verified` is true; otherwise use the
+GitHub `noreply` form, since an unverified address must never be presented as an authenticated identity.
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+public function testItCommitsWithTheEditorAsAuthorAndTheAppAsCommitter(): void
+{
+    $publisher = $this->publisherFor($this->approvedBatch('editor-1', 'Alice', 'alice@example.test', true));
+
+    $result = $publisher->publish($this->batchId);
+
+    $commit = $this->capturedCommitPayload();
+    self::assertSame('Alice', $commit['author']['name']);
+    self::assertSame('alice@example.test', $commit['author']['email']);
+    self::assertNotSame('alice@example.test', $commit['committer']['email'], 'the App is the committer');
+    self::assertSame('litcal-data/national_calendar/roman/US', $result->branch);
+}
+
+public function testAnUnverifiedEmailIsNeverUsedAsTheCommitAuthorEmail(): void
+{
+    $publisher = $this->publisherFor($this->approvedBatch('editor-1', 'Alice', 'alice@example.test', false));
+
+    $publisher->publish($this->batchId);
+
+    $commit = $this->capturedCommitPayload();
+    self::assertStringContainsString('noreply', $commit['author']['email']);
+}
+
+public function testAMissingBranchIsCreatedFromDevelopment(): void
+{
+    // getRef returns null for the feature branch, then the base branch's head is used to create it.
+    $publisher = $this->publisherFor($this->approvedBatch('editor-1', 'Alice', 'alice@example.test', true), branchExists: false);
+
+    $publisher->publish($this->batchId);
+
+    self::assertTrue($this->createRefWasCalled);
+}
+
+public function testADeleteOperationBecomesATreeEntryWithANullSha(): void
+{
+    $publisher = $this->publisherFor($this->approvedDeletionBatch('editor-1'));
+
+    $publisher->publish($this->batchId);
+
+    $tree = $this->capturedTreePayload();
+    self::assertNull($tree['tree'][0]['sha']);
+}
+
+public function testARollingPullRequestIsNotOpenedTwice(): void
+{
+    $publisher = $this->publisherFor($this->approvedBatch('editor-1', 'Alice', 'alice@example.test', true), openPr: 42);
+
+    $result = $publisher->publish($this->batchId);
+
+    self::assertSame(42, $result->prNumber, 'an existing open PR is reused, not duplicated');
+    self::assertFalse($this->openPullRequestWasCalled);
+}
+```
+
+- [ ] **Step 2: Run, watch them fail, then implement the sequence**
+
+```text
+getRef(branch)            null → createRef(branch, getRef(base))
+createBlob(content)       once per non-delete row
+createTree(parentTree)    one entry per row; delete rows carry sha: null
+createCommit(...)         author = editor, committer = App, parent = branch head
+updateRef(branch, sha)    force: false
+findOpenPullRequest()     → openPullRequest() only when null
+```
+
+One commit per batch, never batched across batches: batching would merge two editors into one commit and destroy the
+per-editor authorship this whole design exists to preserve.
+
+- [ ] **Step 3: Run tests, then commit**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/SourceData/SourceDataPublisherTest.php
+composer parallel-lint && composer lint:fix && composer analyse
+git add -A && git commit -m "feat(sourcedata): publish an approved batch as a commit and rolling PR"
+```
+
+---
+
+## Task 6: The runner
+
+**Files:**
+
+- Create: `src/Services/SourceData/PublishRunner.php`, `scripts/publish-sourcedata.php`
+- Test: `phpunit_tests/Services/SourceData/PublishRunnerTest.php`
+
+**Interfaces:**
+
+- Consumes: `claimNextPublishableBatch()`, `recordPublication()`, `releaseClaim()` (Task 2);
+  `SourceDataPublisher::publish()` (Task 5); `OutboxBackoff::secondsForAttempt(int): int`.
+- Produces: `PublishRunner::runOnce(int $limit = 10): int` — the number of batches published.
+
+- [ ] **Step 1: Write the failing tests**
+
+```php
+public function testASuccessfulPublishRecordsTheBranchCommitAndPr(): void
+{
+    $batchId = $this->approveOne('editor-1');
+
+    self::assertSame(1, $this->runner()->runOnce());
+
+    foreach ($this->repo->getBatch($batchId) as $row) {
+        self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+        self::assertNotNull($row['commit_sha']);
+        self::assertSame(7, $row['pr_number']);
+    }
+}
+
+public function testAFailedPublishReleasesTheClaimSoItIsRetried(): void
+{
+    $batchId = $this->approveOne('editor-1');
+
+    $runner = $this->runnerThatThrows(new GitHubApiException(422, 'Update is not a fast forward'));
+    self::assertSame(0, $runner->runOnce());
+
+    // Back to `none`, not stranded in `queued`: a batch nobody will ever pick up again is worse
+    // than one that retries, because it is invisible to the operator and to the editor alike.
+    foreach ($this->repo->getBatch($batchId) as $row) {
+        self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+    }
+}
+
+public function testAnEmptyQueueIsANoOp(): void
+{
+    self::assertSame(0, $this->runner()->runOnce());
+}
+```
+
+- [ ] **Step 2: Implement**
+
+`runOnce()` loops up to `$limit` times: claim, publish, record; on `GitHubApiException` or any `\Throwable`, log it,
+`releaseClaim()`, and stop the loop rather than hammering a failing API. `scripts/publish-sourcedata.php` is a thin
+CLI entry point suitable for cron, mirroring how the existing outbox backstop script is invoked.
+
+- [ ] **Step 3: Run tests, then commit**
+
+```bash
+vendor/bin/phpunit phpunit_tests/Services/SourceData/PublishRunnerTest.php
+composer parallel-lint && composer lint:fix && composer analyse
+git add -A && git commit -m "feat(sourcedata): cron runner that publishes approved batches"
+```
+
+---
+
+## Task 7: Configuration and mode reporting
+
+**Files:**
+
+- Modify: `.env.example`, `src/Health.php`
+- Test: `phpunit_tests/HealthSourceDataPublisherTest.php`
+
+**Interfaces:**
+
+- Produces: `Health::buildSourceDataPublisherStatus(): array{status: 'ok'|'warning', message: string}`, mirroring
+  `buildSourceDataWriteModeStatus()`.
+
+Add to `.env.example`, commented, with the private key path pointing outside the tree:
+
+```bash
+# Phase 2 publisher. Without all four, approved change requests accumulate unpublished.
+GITHUB_APP_ID=
+GITHUB_APP_INSTALLATION_ID=
+GITHUB_APP_PRIVATE_KEY_PATH=/etc/litcal/github-app.pem
+GITHUB_REPOSITORY=Liturgical-Calendar/LiturgicalCalendarAPI
+GITHUB_BASE_BRANCH=development
+```
+
+The health block must warn when queue mode is on but the publisher is unconfigured — that combination silently
+accumulates approved work nobody is publishing, which looks exactly like success to an editor.
+
+- [ ] **Step 1: Write the tests, run them, implement, run again, commit**
+
+```bash
+vendor/bin/phpunit phpunit_tests/HealthSourceDataPublisherTest.php
+composer parallel-lint && composer lint:fix && composer analyse
+git add -A && git commit -m "feat(health): report publisher configuration alongside write mode"
+```
+
+---
+
+## Task 8: Register the GitHub App (human step)
+
+This task is performed by the repository owner, not by an implementing agent. An agent reaching it should stop, print
+these instructions, and continue to Task 9 — every earlier task is testable against mocks and needs no credential.
+
+- [ ] **Step 1: Create the App** at <https://github.com/settings/apps/new>, owned by the `Liturgical-Calendar`
+      organisation.
+- [ ] **Step 2: Set repository permissions** — Contents: Read and write; Pull requests: Read and write;
+      Metadata: Read-only. No account permissions, no webhook.
+- [ ] **Step 3: Install it** on `Liturgical-Calendar/LiturgicalCalendarAPI` only.
+- [ ] **Step 4: Generate a private key**, download the `.pem`, and place it **outside the deployed tree** — e.g.
+      `/etc/litcal/github-app.pem`, mode `0400`, owned by the web-server user. The nginx location has been narrowed to
+      `public/`, but a signing key must not depend on that narrowing holding.
+- [ ] **Step 5: Record the ids.** The App id is on the App's settings page; the installation id is the trailing number
+      in the URL of the installation's settings page.
+- [ ] **Step 6: Fill `.env`** with the five keys from Task 7 and confirm `GET /health` reports the publisher as
+      configured.
+
+---
+
+## Task 9: Runbook and documentation
+
+**Files:**
+
+- Modify: `docs/ops/change-request-runbook.md`, `CHANGELOG.md`
+
+- [ ] **Step 1: Document the publish lifecycle** — `none → queued → open`, what each column means once filled, and
+      that phase 3 supplies `merged`/`closed`.
+- [ ] **Step 2: Document the operational failure modes** — an unconfigured publisher accumulating approved work; a
+      non-fast-forward `422` as the expected symptom of two editors racing on one resource, and that it retries rather
+      than clobbering; a stale installation token.
+- [ ] **Step 3: State the phase-3 gap explicitly.** Required wording in substance:
+
+> **Not closed by phase 2:** deleting a calendar or test through a change request does not purge its OpenFGA
+> authorization tuples. Nothing between "PR merged" and "next redeploy" performs that purge, so a deleted diocese's
+> former editors retain edit access on an object whose files are gone. This is deliberate — only merge detection
+> (phase 3) knows the deletion actually happened — and it is a known limitation, not an oversight.
+
+- [ ] **Step 4: CHANGELOG entry** under the commented unreleased block, matching the existing convention.
+- [ ] **Step 5: Lint and commit**
+
+```bash
+composer lint:md && composer lint:jsondata
+git add -A && git commit -m "docs(publisher): runbook for phase 2, including the phase-3 purge gap"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage.** Credential → Task 3 + Task 8. Publishing sequence → Task 5. `force: false` → Task 4 Step 1. One
+commit per change request → Task 5. Branch naming → Task 5. Generated PR body → Task 5 (`openPullRequest`). Ancestor
+landmine → Task 1. `closed` predicate → explicitly out of scope, recorded in Global Constraints. OpenFGA purge →
+explicitly phase 3, recorded in Global Constraints and Task 9 Step 3. Reuse and failure handling → Task 6, with the
+spec's over-claim about `BackstopRunner` and `ConsumerLoop` corrected up front.
+
+**Placeholders.** None: every code step carries real code, every test step a real assertion, and the one task with no
+code (Task 8) is a human procedure with concrete URLs, permissions and file modes.
+
+**Type consistency.** `claimNextPublishableBatch(): ?string`, `recordPublication(string, string, string, ?int, string): int`
+and `releaseClaim(string): int` are defined in Task 2 and used with those exact signatures in Task 6.
+`installationToken(): string` is defined in Task 3 and consumed in Task 4. `publish(string): PublishResult` is defined
+in Task 5 and consumed in Task 6. `ChangePublicationStatus` cases used are `NONE`, `QUEUED`, `OPEN`, `MERGED` — all
+present in the existing enum; `CLOSED` is deliberately never written.

--- a/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
+++ b/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
@@ -433,6 +433,21 @@ only phase 3 does. Phase 3 must state explicitly whether `closed` belongs in the
 relying on the review-status filter to carry it. Phase 2's age-based ancestor exclusion, decided above,
 is independent of this and does not depend on `closed` being handled either way.
 
+**Neither `Phase 3, not built` row above exists (2026-08-29).** Both were labelled Phase 2 when this spec was
+written, and phase 2 did not implement them, so the labels were corrected rather than left promising
+behaviour the code does not have.
+
+`base_sha` rebase detection cannot be built yet: nothing writes the column with a meaningful value, and
+`recordPublication()` overwrites every row's `base_sha` with the batch-level branch head at publish time, so
+the per-file bookkeeping a rebase check needs is not retained. Phase 3 must decide whether to keep per-file
+base shas before it can offer this at all.
+
+Schema re-validation at the approval gate is likewise absent — `approveBatch()` is a single status `UPDATE`.
+The exposure is a batch approved against one schema and published after that schema changed. It is bounded
+rather than silent: the resulting pull request runs `lint:jsondata` and schema validation in CI, so an
+incompatible payload fails visibly on the PR instead of reaching `development`. That is a backstop on the
+wrong side of the gate, though, and phase 3 should validate before publishing rather than rely on it.
+
 ### Reuse and failure handling
 
 **Superseded by what was built (2026-08-29).** This section originally proposed reusing the outbox
@@ -542,8 +557,8 @@ needs reverting, because nothing was ever live.**
 | Failure                                           | Behaviour                                                            |
 | ------------------------------------------------- | -------------------------------------------------------------------- |
 | Schema-invalid payload at submit                  | Rejected at the handler, as today — no row created                   |
-| `base_sha` moved between submit and approve       | **Phase 2.** Approval blocked; admin shown the diff and must rebase  |
-| Schema drift between submit and approve           | **Phase 2.** Re-validated at the gate; approval blocked on failure   |
+| `base_sha` moved between submit and approve       | **Phase 3, not built.** See the note below this table                |
+| Schema drift between submit and approve           | **Phase 3, not built.** See the note below this table                |
 | GitHub unreachable                                | Outbox retry with existing backoff; change stays `approved`/`queued` |
 | Publish terminal failure                          | DLQ row; surfaced in the admin UI with the GitHub error              |
 | Two editors submit against the same path          | Distinct rows; the unique partial index scopes it per submitter      |

--- a/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
+++ b/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
@@ -554,15 +554,34 @@ needs reverting, because nothing was ever live.**
 
 ## Error handling
 
-| Failure                                           | Behaviour                                                            |
-| ------------------------------------------------- | -------------------------------------------------------------------- |
-| Schema-invalid payload at submit                  | Rejected at the handler, as today — no row created                   |
-| `base_sha` moved between submit and approve       | **Phase 3, not built.** See the note below this table                |
-| Schema drift between submit and approve           | **Phase 3, not built.** See the note below this table                |
-| GitHub unreachable                                | Outbox retry with existing backoff; change stays `approved`/`queued` |
-| Publish terminal failure                          | DLQ row; surfaced in the admin UI with the GitHub error              |
-| Two editors submit against the same path          | Distinct rows; the unique partial index scopes it per submitter      |
-| Resource admin deleted between submit and approve | Approval re-checks OpenFGA; a stale scope cannot approve             |
+| Failure                                           | Behaviour                                                                          |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Schema-invalid payload at submit                  | Rejected at the handler, as today — no row created                                 |
+| `base_sha` moved between submit and approve       | **Phase 3, not built.** See the note below this table                              |
+| Schema drift between submit and approve           | **Phase 3, not built.** See the note below this table                              |
+| GitHub unreachable                                | Claim released to `none`, run stops, exit 1; retried next tick. See the note below |
+| Publish terminal failure                          | **No DLQ.** Parked after repeated attempts, reported as `parked_batches`           |
+| Two editors submit against the same path          | Distinct rows; the unique partial index scopes it per submitter                    |
+| Resource admin deleted between submit and approve | Approval re-checks OpenFGA; a stale scope cannot approve                           |
+
+**On the two publish-failure rows.** Both originally described outbox retries and a dead-letter queue. Neither
+exists: `PublishRunner` is not an outbox consumer, and `PublishRunner`'s own docblock states plainly that this
+feature has no dead-letter queue.
+
+What actually happens on a failed publish is that the runner catches **any** `\Throwable`, logs it, calls
+`releaseClaim()` — which returns the batch to `none`, **not** `queued`; the two columns must not be conflated —
+and stops the loop rather than moving to the next batch, because a down GitHub or a stale credential will fail
+every batch identically. The run reports `stoppedOnFailure` and the cron script exits 1. The next tick is the
+retry; there is no in-process backoff loop.
+
+Each such release counts an attempt. After `PublishRunner::MAX_PUBLISH_ATTEMPTS` consecutive attempts the batch
+is **parked**: excluded from claiming so one permanently-failing batch cannot block the rest of the queue, and
+surfaced as `parked_batches` in `GET /health`'s `source_data_publisher` block. Recovery is an operator resetting
+`publish_attempts`, documented in the runbook — not a DLQ, and not deletion.
+
+One exception: a non-fast-forward `422` is contention, not an outage, so it logs a warning and continues with
+the rest of the queue without setting `stoppedOnFailure`. It still consumes an attempt, so a branch that `422`s
+forever parks rather than retrying forever.
 
 ## Testing
 

--- a/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
+++ b/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
@@ -435,20 +435,34 @@ is independent of this and does not depend on `closed` being handled either way.
 
 ### Reuse and failure handling
 
-`ConsumerLoop` takes `OutboxProcessorInterface` by constructor injection
-(`src/Services/Outbox/ConsumerLoop.php:26`), so `SourceDataPublishProcessor` drops in behind a
-second Redis stream and a second systemd unit, with `BackstopRunner` covering the cracks.
+**Superseded by what was built (2026-08-29).** This section originally proposed reusing the outbox
+machinery wholesale. That did not survive contact with the code, and the paragraphs below record what
+exists so phase 3 is not designed against a fiction.
 
-| GitHub response          | `OutboxDisposition`                         |
-| ------------------------ | ------------------------------------------- |
-| 409 non-fast-forward     | `RETRY` — re-read the ref, rebuild the tree |
-| PR already open for head | `BENIGN_SUCCESS`                            |
-| 5xx, 429, network        | `RETRY` — existing backoff                  |
-| 422 validation           | `TERMINAL` — DLQ, surfaced in the admin UI  |
+`BackstopRunner` constructor-types the concrete `OutboxRepository`, and `ConsumerLoop` needs a Redis
+stream plus an integer row id — while the unit of publication is a **batch**. The outbox is also
+OpenFGA-shaped down to its enum, whose only cases are `write_tuple` and `delete_tuple`. Of the three,
+only `OutboxBackoff::secondsForAttempt()` was genuinely reusable. There is likewise no second queue
+table: `sourcedata_change_requests` already carries `publication_status` and the `branch`,
+`commit_sha`, `pr_number` and `base_sha` columns, so it is the queue.
 
-Publishing must be **serialised per resource**: two approved changes to one calendar append to the
-same branch. The existing idempotency-key unique index does not provide ordering, so the processor
-takes a Postgres advisory lock keyed on `resource_id` for the duration of a publish.
+What exists instead is `PublishRunner`, a cron-driven loop that claims one batch at a time
+(`FOR UPDATE SKIP LOCKED` inside one transaction, with the claimability predicate repeated on the
+lock query), publishes it, and on **any** `\Throwable` logs, releases the claim and stops rather than
+hammering a failing API. There is no `OutboxDisposition` mapping and no dead-letter queue: a failed
+batch simply returns to `none` and is retried on the next tick. Note the status codes differ from the
+table this replaced — a non-fast-forward `updateRef` is **422**, not 409.
+
+Serialisation per resource is achieved by `force: false` rather than by an advisory lock. Two runners
+publishing different batches of the same resource both target one branch; the loser gets a
+non-fast-forward 422, releases its claim, and retries against the moved ref. The claim itself is not
+per-resource, so this is serialisation by optimistic concurrency, not by mutual exclusion — which is
+why `force: false` is load-bearing rather than merely defensive.
+
+A crash between claim and record leaves a batch `queued`, which no exception handler can catch, so
+`PublishRunner` reclaims batches idle longer than `DEFAULT_GRACE_SECONDS`. That grace must exceed a
+whole publish's worst case — `maxRequestsPerBatch × requestTimeout`, since a publish issues one
+`createBlob` per changed file serially — not a single request's timeout.
 
 ### Side effects a merged deletion must still perform
 

--- a/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
+++ b/docs/superpowers/specs/2026-08-28-sourcedata-change-requests-design.md
@@ -390,6 +390,32 @@ every future handler. Neither is free: the containment assumption is exactly wha
 today, but a handler that stages a path _without_ reading its own unpublished content first would break
 it, and nothing enforces that it must.
 
+**Decided (2026-08-29): the second.** The base excludes any row older than the newest `merged` row for
+that `(path, submitter)`; no ancestor's status is rewritten.
+
+The deciding difference is not the SQL but what each option _writes_. Marking ancestors `merged` asserts
+that they were published. Under containment that is effectively true — their bytes are inside the
+published batch — but if containment ever breaks, the publisher, which selects approved rows that are not
+yet `merged`, skips a batch that was never published and its content is silently lost. Excluding by age
+rewrites nothing: the ancestor stays `approved` / `none`, so it remains visible, remains truthful, and
+remains publishable. The failure mode degrades from losing data to choosing a suboptimal rebuild base.
+
+That asymmetry decided it. Every serious defect on this branch was an invariant that was asserted but not
+enforced — the migration comment claiming one pending proposal per path, the repository docblock naming a
+decree case it had not fixed, the `#[CoversClass]` list that silently discarded real coverage. Containment
+is another unenforced assertion, so the option that does not depend on it wins.
+
+**The decrees layout stays as it is.** Splitting `decrees.json` into one file per decree was considered
+and rejected for now: the `i18n/<locale>.json` and `lectionary/<locale>.json` sidecars are aggregates too,
+across fourteen locales, so a decree edit would still rewrite shared files and the collision would remain.
+Removing it entirely means per-decree per-locale files — roughly 15 × 14 and growing — against ten source
+files that read `decrees.json`, plus schemas, the frontend editor and a data migration. Two facts also
+narrow the problem: the unique index is `(path, submitted_by_sub)`, so two editors editing two different
+decrees never collide, and APCu already caches the aggregate. The real argument for splitting is
+git-level: two rolling PRs both touching `decrees.json` will conflict even though the database rows do
+not. `force: false` turns that into a retryable error rather than data loss, so phase 2 can find out
+safely; revisit the layout only if it proves painful in practice.
+
 #### `publication_status <> 'merged'` admits `closed`
 
 The predicate excludes `merged` and nothing else, but `chk_scr_publication_status` also allows `closed` —
@@ -400,9 +426,12 @@ batch whose PR was closed unmerged therefore stays in the accumulation base fore
 `review_status = 'rejected'` happens to keep it out of the base today, because the base filters review
 status as well. That is a coincidence of phase 3's current design, not a decision: the predicate's
 justification (recorded in `SourceDataChangeRequestRepository`'s class docblock) reasons only about
-`merged` content being the repository, and never considered `closed` at all. Decide nothing now —
-but when phase 3 lands, state explicitly whether `closed` belongs in the exclusion, and stop relying on
-the review-status filter to carry it.
+`merged` content being the repository, and never considered `closed` at all.
+
+**Decided (2026-08-29):** phase 2 does not change this predicate, because phase 2 never writes `closed` —
+only phase 3 does. Phase 3 must state explicitly whether `closed` belongs in the exclusion and stop
+relying on the review-status filter to carry it. Phase 2's age-based ancestor exclusion, decided above,
+is independent of this and does not depend on `closed` being handled either way.
 
 ### Reuse and failure handling
 
@@ -442,6 +471,19 @@ publish-PR-merge-redeploy path touches OpenFGA. A deployment's file tree can be 
 with `main` while stale editor/viewer tuples for a deleted calendar remain live in OpenFGA
 indefinitely, because no step between "PR merged" (Phase 2/3) and "next redeploy" (infrastructure,
 outside this design) ever calls `purgeForObject()`.
+
+**Decided (2026-08-29): Phase 3, at merge detection.** Only merge detection knows the deletion actually
+happened — publishing a PR does not make it true, and a PR can still be closed unmerged. Purging at
+publish time would revoke real authorization on the strength of a proposal. This also matches how the
+file side already works: the redeploy that follows a merge is what removes the files, so authorization
+and files become true at the same moment rather than drifting apart in opposite directions.
+
+The cost is explicit and accepted: **until phase 3 ships, a calendar or test deleted through a change
+request keeps its OpenFGA tuples live, so its former editors retain edit access on an object whose files
+are gone.** That is a known limitation to be stated in the phase 2 runbook, not a surprise to be
+discovered later. Phase 2 must not silently appear to have closed it.
+
+The original requirement, which phase 3 inherits unchanged:
 
 **Requirement for Phase 2 (or, if merge detection ends up the more natural trigger, Phase 3):** when
 a `delete`-operation change request's batch is applied — either at publish time if publishing is

--- a/phpunit_tests/Handlers/Ops/HealthHandlerTest.php
+++ b/phpunit_tests/Handlers/Ops/HealthHandlerTest.php
@@ -52,6 +52,36 @@ final class HealthHandlerTest extends AbstractHandlerTestCase
         self::assertIsInt($consumer['oldest_pel_idle_seconds']);
     }
 
+    /**
+     * Both source-data blocks must actually reach the HTTP response.
+     *
+     * `Health::buildSourceDataWriteModeStatus()` and `buildSourceDataPublisherStatus()` have
+     * their own unit tests, but those exercise the builders, not the wiring. A block that is
+     * built and never surfaced is worse than one that is missing: the operator procedure for
+     * registering the GitHub App ends with "confirm /health reports the publisher configured",
+     * which would silently have nothing to confirm.
+     */
+    public function testGetSurfacesBothSourceDataBlocks(): void
+    {
+        $response = ( new HealthHandler() )->handle(
+            $this->requestFor('GET', '/health', [], [])
+        );
+
+        $body = $this->decodeJsonBody($response);
+
+        foreach (['source_data_writes', 'source_data_publisher'] as $block) {
+            self::assertArrayHasKey($block, $body, $block . ' must be reachable over HTTP');
+            self::assertIsArray($body[$block]);
+            /** @var array<string, mixed> $status */
+            $status = $body[$block];
+            self::assertArrayHasKey('status', $status);
+            self::assertContains($status['status'], ['ok', 'warning'], $block . ' reports an unexpected status');
+            self::assertArrayHasKey('message', $status);
+            self::assertIsString($status['message']);
+            self::assertNotSame('', $status['message'], $block . ' must explain itself, not just flag a state');
+        }
+    }
+
     public function testGetReturnsNotConfiguredWhenDbEnvAbsent(): void
     {
         // Clear DB_* env vars so Connection::isConfigured() returns false.

--- a/phpunit_tests/HealthSourceDataPublisherTest.php
+++ b/phpunit_tests/HealthSourceDataPublisherTest.php
@@ -9,6 +9,7 @@ use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -154,5 +155,38 @@ final class HealthSourceDataPublisherTest extends TestCase
 
         self::assertSame('ok', $status['status']);
         self::assertStringContainsString('nothing to publish', $status['message']);
+    }
+
+    /**
+     * A GITHUB_REPOSITORY that is set but malformed must NOT read as configured. Testing only
+     * for non-emptiness made this block report a healthy publisher for a value no run could
+     * ever publish with — the same silent accumulation the unconfigured branch exists to catch,
+     * reached through a value that is present rather than absent.
+     */
+    #[DataProvider('malformedRepositoryProvider')]
+    public function testAMalformedRepositoryIsNotConfigured(string $repository): void
+    {
+        $this->enableQueueMode();
+        $this->configurePublisher();
+        $_ENV['GITHUB_REPOSITORY'] = $repository;
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame('warning', $status['status']);
+        self::assertStringContainsString('accumulating unpublished', $status['message']);
+        self::assertStringContainsString('owner/repo', $status['message'], 'the operator needs to know what is wrong with it');
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function malformedRepositoryProvider(): array
+    {
+        return [
+            'pasted repository URL' => ['https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI'],
+            'trailing slash'        => ['Liturgical-Calendar/LiturgicalCalendarAPI/'],
+            'no owner'              => ['LiturgicalCalendarAPI'],
+            'three segments'        => ['github.com/owner/repo'],
+        ];
     }
 }

--- a/phpunit_tests/HealthSourceDataPublisherTest.php
+++ b/phpunit_tests/HealthSourceDataPublisherTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests;
+
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The `source_data_publisher` block of `/health` is how an operator finds out that approved
+ * change requests are actually being published to GitHub, rather than silently piling up.
+ *
+ * The dangerous state is queue mode on with the publisher unconfigured: editors submit,
+ * admins approve, everything reports success, and nothing is ever published — it looks
+ * exactly like a working system from every UI surface. That combination is the one branch
+ * that must warn; every other combination is quiet.
+ *
+ * Every branch is decided by environment alone, so no database, OpenFGA, or GitHub call is
+ * touched — mirrors {@see HealthSourceDataWriteModeTest}.
+ */
+#[CoversClass(Health::class)]
+#[CoversClass(SourceDataPublisher::class)]
+final class HealthSourceDataPublisherTest extends TestCase
+{
+    private const KEYS = [
+        SourceDataWriteMode::FLAG,
+        'DB_HOST',
+        'DB_NAME',
+        'DB_USER',
+        'DB_PASSWORD',
+        'OPENFGA_API_URL',
+        'OPENFGA_STORE_ID',
+        'OPENFGA_MODEL_ID',
+        'GITHUB_APP_ID',
+        'GITHUB_APP_INSTALLATION_ID',
+        'GITHUB_APP_PRIVATE_KEY_PATH',
+        'GITHUB_REPOSITORY',
+        'GITHUB_BASE_BRANCH',
+        'GITHUB_APP_COMMITTER_NAME',
+        'GITHUB_APP_COMMITTER_EMAIL',
+    ];
+
+    /** @var array<string, string|false> */
+    private array $originalEnv = [];
+
+    protected function setUp(): void
+    {
+        foreach (self::KEYS as $key) {
+            $this->originalEnv[$key] = $_ENV[$key] ?? false;
+            unset($_ENV[$key]);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->originalEnv as $key => $value) {
+            if (false === $value) {
+                unset($_ENV[$key]);
+            } else {
+                $_ENV[$key] = $value;
+            }
+        }
+        $this->originalEnv = [];
+    }
+
+    private function enableQueueMode(): void
+    {
+        $_ENV[SourceDataWriteMode::FLAG] = 'true';
+        $_ENV['DB_HOST']                 = 'localhost';
+        $_ENV['DB_NAME']                 = 'litcal';
+        $_ENV['DB_USER']                 = 'litcal';
+        $_ENV['DB_PASSWORD']             = 'secret';
+        $_ENV['OPENFGA_API_URL']         = 'http://localhost:8083';
+        $_ENV['OPENFGA_STORE_ID']        = 'store';
+        $_ENV['OPENFGA_MODEL_ID']        = 'model';
+    }
+
+    private function configurePublisher(): void
+    {
+        $_ENV['GITHUB_APP_ID']               = '12345';
+        $_ENV['GITHUB_APP_INSTALLATION_ID']  = '67890';
+        $_ENV['GITHUB_APP_PRIVATE_KEY_PATH'] = '/etc/litcal/github-app.pem';
+        $_ENV['GITHUB_REPOSITORY']           = 'Liturgical-Calendar/LiturgicalCalendarAPI';
+    }
+
+    public function testQueueModeOnAndPublisherConfiguredReportsOk(): void
+    {
+        $this->enableQueueMode();
+        $this->configurePublisher();
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame('ok', $status['status']);
+        self::assertStringContainsString('will publish', $status['message']);
+    }
+
+    public function testQueueModeOnAndPublisherUnconfiguredIsAWarningNamingTheConsequence(): void
+    {
+        $this->enableQueueMode();
+        // Publisher left entirely unconfigured.
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame('warning', $status['status']);
+        self::assertStringContainsString('accumulating unpublished', $status['message']);
+    }
+
+    public function testQueueModeOnAndPublisherMissingOneVariableIsAWarning(): void
+    {
+        $this->enableQueueMode();
+        $this->configurePublisher();
+        // A single missing variable is enough to make the publisher unable to run.
+        unset($_ENV['GITHUB_REPOSITORY']);
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame('warning', $status['status']);
+        self::assertStringContainsString('accumulating unpublished', $status['message']);
+    }
+
+    public function testQueueModeOffAndPublisherConfiguredReportsOkNotAnError(): void
+    {
+        // Queue mode off: flag unset and stack absent.
+        $this->configurePublisher();
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame('ok', $status['status']);
+        self::assertStringContainsString('nothing to publish', $status['message']);
+    }
+
+    public function testQueueModeOffAndPublisherUnconfiguredIsOkAndQuiet(): void
+    {
+        // Neither queue mode nor the publisher configured: the ordinary self-hoster.
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame('ok', $status['status']);
+        self::assertStringContainsString('nothing to publish', $status['message']);
+    }
+}

--- a/phpunit_tests/HealthSourceDataPublisherTest.php
+++ b/phpunit_tests/HealthSourceDataPublisherTest.php
@@ -49,11 +49,26 @@ final class HealthSourceDataPublisherTest extends TestCase
     /** @var array<string, string|false> */
     private array $originalEnv = [];
 
+    /** @var array<string, string|false> */
+    private array $originalGetenv = [];
+
     protected function setUp(): void
     {
+        // Both layers, not just $_ENV. `getEnvString()` reads $_ENV and falls back to getenv(),
+        // so an inherited process value survives an `unset($_ENV[...])` and decides the branch
+        // instead of the test doing so.
+        //
+        // This is not hypothetical, and it is why CI failed while every local run passed:
+        // GitHub Actions injects GITHUB_REPOSITORY into every job, as `owner/repo` — which is
+        // also a *valid* value for our variable of the same name. So the "one missing variable"
+        // case silently found a well-formed repository in the process environment and reported
+        // `ok` where the test asserts `warning`.
         foreach (self::KEYS as $key) {
-            $this->originalEnv[$key] = $_ENV[$key] ?? false;
+            $this->originalEnv[$key]    = $_ENV[$key] ?? false;
+            $processValue               = getenv($key);
+            $this->originalGetenv[$key] = $processValue;
             unset($_ENV[$key]);
+            putenv($key);
         }
 
         // The block now also reports parked batches, which is a DB read. These cases are about
@@ -73,7 +88,15 @@ final class HealthSourceDataPublisherTest extends TestCase
                 $_ENV[$key] = $value;
             }
         }
-        $this->originalEnv = [];
+        foreach ($this->originalGetenv as $key => $value) {
+            if (false === $value) {
+                putenv($key);
+            } else {
+                putenv($key . '=' . $value);
+            }
+        }
+        $this->originalEnv    = [];
+        $this->originalGetenv = [];
 
         // Drop the placeholder-credential connection (or the failed attempt at one) so the next
         // suite reconnects from the restored environment.
@@ -129,6 +152,7 @@ final class HealthSourceDataPublisherTest extends TestCase
         $this->configurePublisher();
         // A single missing variable is enough to make the publisher unable to run.
         unset($_ENV['GITHUB_REPOSITORY']);
+        putenv('GITHUB_REPOSITORY');
 
         $status = Health::buildSourceDataPublisherStatus();
 

--- a/phpunit_tests/HealthSourceDataPublisherTest.php
+++ b/phpunit_tests/HealthSourceDataPublisherTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests;
 
+use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Health;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
@@ -53,6 +54,13 @@ final class HealthSourceDataPublisherTest extends TestCase
             $this->originalEnv[$key] = $_ENV[$key] ?? false;
             unset($_ENV[$key]);
         }
+
+        // The block now also reports parked batches, which is a DB read. These cases are about
+        // the ENVIRONMENT-decided branches, so the connection must resolve from the placeholder
+        // credentials below (and fail, yielding zero) rather than from a live singleton some
+        // earlier test opened against the real database — otherwise whether this suite passes
+        // would depend on rows another suite happened to leave behind, and on test order.
+        Connection::close();
     }
 
     protected function tearDown(): void
@@ -65,6 +73,10 @@ final class HealthSourceDataPublisherTest extends TestCase
             }
         }
         $this->originalEnv = [];
+
+        // Drop the placeholder-credential connection (or the failed attempt at one) so the next
+        // suite reconnects from the restored environment.
+        Connection::close();
     }
 
     private function enableQueueMode(): void
@@ -96,6 +108,7 @@ final class HealthSourceDataPublisherTest extends TestCase
 
         self::assertSame('ok', $status['status']);
         self::assertStringContainsString('will publish', $status['message']);
+        self::assertSame(0, $status['parked_batches'], 'no database reachable here: the count degrades to zero');
     }
 
     public function testQueueModeOnAndPublisherUnconfiguredIsAWarningNamingTheConsequence(): void

--- a/phpunit_tests/Repositories/HealthParkedBatchesTest.php
+++ b/phpunit_tests/Repositories/HealthParkedBatchesTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Health;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * `/health`'s `source_data_publisher` block must report batches the publisher has STOPPED
+ * attempting.
+ *
+ * The attempt bound is what keeps one deterministically-failing batch from stranding every
+ * other editor's approved work — but a batch that is silently skipped is the same class of
+ * defect as one silently stranded: no error, no editor-visible symptom, and a review workflow
+ * that completed normally. This is the out-of-band signal that makes it visible, so it is
+ * asserted against a real Postgres rather than a mocked repository; the rest of that block is
+ * decided by environment alone and is covered by
+ * {@see \LiturgicalCalendar\Tests\HealthSourceDataPublisherTest}.
+ */
+#[CoversClass(Health::class)]
+final class HealthParkedBatchesTest extends RepositoryTestCase
+{
+    private SourceDataChangeRequestRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new SourceDataChangeRequestRepository(self::$pdo);
+    }
+
+    private function approveOne(string $nation): string
+    {
+        $batchId = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+            [
+                [
+                    'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+                    'operation' => ChangeOperation::CREATE,
+                    'content'   => '{"litcal":[]}',
+                ],
+            ],
+            'editor-' . $nation,
+            'Editor',
+            'editor@example.test',
+            true
+        )['batch_id'];
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+
+        return $batchId;
+    }
+
+    public function testAnUnattemptedQueueIsQuiet(): void
+    {
+        $this->approveOne('US');
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame(0, $status['parked_batches']);
+        self::assertSame('ok', $status['status']);
+    }
+
+    public function testAParkedBatchIsReportedRatherThanSilentlySkipped(): void
+    {
+        $parked = $this->approveOne('US');
+        $this->approveOne('DE');
+
+        self::$pdo->prepare('UPDATE sourcedata_change_requests SET publish_attempts = :n WHERE batch_id = :b')
+            ->execute(['n' => SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS, 'b' => $parked]);
+
+        $status = Health::buildSourceDataPublisherStatus();
+
+        self::assertSame(1, $status['parked_batches'], 'only the parked batch counts, not the queue behind it');
+        self::assertSame('warning', $status['status']);
+        self::assertStringContainsString('no longer being attempted', $status['message']);
+        self::assertStringContainsString('Parked batches', $status['message'], 'the operator needs somewhere to go');
+    }
+}

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -135,6 +135,42 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         }
     }
 
+    /**
+     * Regression test for the race a phase-2 review round caught: `releaseClaim()` used to
+     * delegate to `markBatchPublicationStatus()`, which is unconditional. A batch claimed by
+     * runner A but genuinely, successfully published by runner B in the meantime (a merely
+     * SLOW A, reclaimed by B after A's grace period elapsed but before A's own — now doomed —
+     * GitHub call returned) would have that unconditional release revert it from `open` back
+     * to `none` while it still carried B's real `commit_sha`/`pr_number` — silently
+     * re-publishing already-published work on the very next tick.
+     *
+     * `releaseClaim()` must now be a no-op (0 rows affected, `open` untouched) once the batch
+     * is no longer `queued`. Reproduces the race directly against the repository without
+     * needing two real processes: "B publishes" is simulated with a plain
+     * `recordPublication()` call, since from the repository's point of view that is
+     * indistinguishable from an actual second runner having done it.
+     */
+    public function testReleaseClaimIsANoOpOnceAnotherRunnerHasAlreadyPublished(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->repo->claimNextPublishableBatch();
+
+        // Runner B: publishes successfully while A's own attempt is (unbeknownst to A) still
+        // in flight.
+        $this->repo->recordPublication($batchId, 'litcal-data/national_calendar/roman/US', 'deadbeef', 42, 'base-sha');
+
+        // Runner A: its own GitHub call now fails for real (branch moved under it) and it
+        // tries to release the claim it believes it still holds.
+        $released = $this->repo->releaseClaim($batchId);
+        self::assertSame(0, $released, 'releaseClaim() must not affect rows once the batch is no longer queued');
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+            self::assertSame('deadbeef', $row['commit_sha']);
+            self::assertEquals(42, $row['pr_number']);
+        }
+    }
+
     public function testOlderApprovedBatchIsClaimedBeforeANewerOne(): void
     {
         $older = $this->submitAndApprove('editor-1', 'US');

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Repositories;
+
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use PDO;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Covers the publish-queue half of {@see SourceDataChangeRequestRepository}: claiming an
+ * approved batch for publication, and settling a claim (recording success, or releasing
+ * a failed attempt back to `none`).
+ *
+ * The class docblock on the repository explains why a batch is never mixed-status; this
+ * suite leans on that invariant the same way the repository's own claim query does.
+ */
+#[CoversClass(SourceDataChangeRequestRepository::class)]
+final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
+{
+    private SourceDataChangeRequestRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new SourceDataChangeRequestRepository(self::$pdo);
+    }
+
+    /** @return list<array{path: string, operation: ChangeOperation, content: ?string}> */
+    private function calendarFile(string $nation): array
+    {
+        return [
+            [
+                'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+                'operation' => ChangeOperation::CREATE,
+                'content'   => '{"litcal":[]}',
+            ],
+        ];
+    }
+
+    private function submitOnly(string $sub, string $nation = 'US'): string
+    {
+        return $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+            $this->calendarFile($nation),
+            $sub,
+            'Editor',
+            $sub . '@example.test',
+            true
+        )['batch_id'];
+    }
+
+    private function submitAndApprove(string $sub, string $nation = 'US'): string
+    {
+        $batchId = $this->submitOnly($sub, $nation);
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+
+        return $batchId;
+    }
+
+    /**
+     * Opens a second, independent PDO connection to the same test database. Used to prove
+     * the claim is genuinely atomic across connections, not merely well-behaved when
+     * called twice in a row on one connection (which {@see testAClaimedBatchIsNotClaimedTwice}
+     * already covers, but which alone could not distinguish "correctly locked" from
+     * "correctly re-checked the now-committed status").
+     */
+    private function secondConnection(): PDO
+    {
+        $host     = self::env('DB_HOST');
+        $port     = self::env('DB_PORT') ?? '5432';
+        $name     = self::env('DB_NAME');
+        $user     = self::env('DB_USER');
+        $password = self::env('DB_PASSWORD');
+
+        $pdo = new PDO(
+            sprintf('pgsql:host=%s;port=%s;dbname=%s', $host, $port, $name),
+            $user,
+            $password,
+            [
+                PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
+                PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                PDO::ATTR_EMULATE_PREPARES   => false,
+                PDO::ATTR_TIMEOUT            => 5,
+            ]
+        );
+        $pdo->exec("SET timezone TO 'Europe/Vatican'");
+
+        return $pdo;
+    }
+
+    public function testClaimingReturnsAnApprovedBatchAndMarksItQueued(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+
+        self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
+        }
+    }
+
+    public function testAnUnapprovedBatchIsNeverClaimed(): void
+    {
+        $this->submitOnly('editor-1');
+
+        self::assertNull($this->repo->claimNextPublishableBatch(), 'submitted-but-undecided work is not publishable');
+    }
+
+    public function testAClaimedBatchIsNotClaimedTwice(): void
+    {
+        $this->submitAndApprove('editor-1');
+
+        self::assertNotNull($this->repo->claimNextPublishableBatch());
+        self::assertNull($this->repo->claimNextPublishableBatch(), 'a queued batch must not be handed out again');
+    }
+
+    public function testReleasingAClaimMakesItPublishableAgain(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->repo->claimNextPublishableBatch();
+
+        $this->repo->releaseClaim($batchId);
+
+        self::assertSame($batchId, $this->repo->claimNextPublishableBatch(), 'a failed attempt must be retryable');
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
+        }
+    }
+
+    public function testOlderApprovedBatchIsClaimedBeforeANewerOne(): void
+    {
+        $older = $this->submitAndApprove('editor-1', 'US');
+        // Force a distinct, later created_at so ordering is unambiguous rather than
+        // relying on two inserts in the same transaction landing on different microseconds.
+        self::$pdo->exec('UPDATE sourcedata_change_requests SET created_at = created_at - INTERVAL \'1 hour\'');
+        $this->submitAndApprove('editor-2', 'DE');
+
+        self::assertSame($older, $this->repo->claimNextPublishableBatch());
+    }
+
+    public function testRecordPublicationSetsOpenStatusAndGitFields(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->repo->claimNextPublishableBatch();
+
+        $updated = $this->repo->recordPublication($batchId, 'publish/us-2026-08-29', 'deadbeef', 42, 'basecommitsha');
+        self::assertGreaterThan(0, $updated);
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+            self::assertSame('publish/us-2026-08-29', $row['branch']);
+            self::assertSame('deadbeef', $row['commit_sha']);
+            self::assertEquals(42, $row['pr_number']);
+            self::assertSame('basecommitsha', $row['base_sha']);
+        }
+    }
+
+    public function testRecordPublicationAcceptsANullPrNumber(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+        $this->repo->claimNextPublishableBatch();
+
+        $this->repo->recordPublication($batchId, 'publish/us-2026-08-29', 'deadbeef', null, 'basecommitsha');
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertNull($row['pr_number']);
+        }
+    }
+
+    /**
+     * The test that actually demonstrates atomicity, not just that a single caller's
+     * claim behaves. It reproduces the exact locking half of claimNextPublishableBatch()
+     * on a second, independent connection and holds it open in an uncommitted
+     * transaction — simulating "runner A is mid-claim" — then proves a second runner
+     * (this test's own $this->repo, on the original connection) cannot see or take the
+     * same row while that lock is held, and CAN take it the instant the lock is released.
+     *
+     * If the repository's SELECT and UPDATE did not share one transaction (i.e. if
+     * autocommit released the lock right after the SELECT), this test would fail: the
+     * second connection's claim would succeed while connection A's transaction is still
+     * open, because there would be no lock left to skip.
+     */
+    public function testConcurrentClaimsCannotSelectTheSameBatch(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1');
+
+        $connA = $this->secondConnection();
+        $connA->beginTransaction();
+        try {
+            // Reproduces the row-locking half of claimNextPublishableBatch(): a plain
+            // FOR UPDATE SKIP LOCKED against every row of the batch (Postgres rejects FOR
+            // UPDATE combined with GROUP BY, so the repository's own aggregate candidate
+            // query cannot itself hold the lock — see that method's docblock).
+            $lock = $connA->prepare(
+                'SELECT id
+                   FROM sourcedata_change_requests
+                  WHERE batch_id = :batch_id
+                    FOR UPDATE SKIP LOCKED'
+            );
+            $lock->execute(['batch_id' => $batchId]);
+            self::assertCount(
+                1,
+                $lock->fetchAll(PDO::FETCH_COLUMN),
+                'connection A must actually hold the row lock for this to be a meaningful test'
+            );
+
+            // Connection A's transaction is still open — the row lock is held. A second
+            // runner using a different connection must skip the locked row, not double-claim it.
+            self::assertNull(
+                $this->repo->claimNextPublishableBatch(),
+                'a row locked by an in-flight claim on another connection must not be handed out again'
+            );
+        } finally {
+            $connA->commit();
+        }
+
+        // Once connection A's transaction ends, the lock is released and the batch
+        // becomes claimable again — proving the null above was "locked, try later", not
+        // some unrelated bug swallowing the row.
+        self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+    }
+}

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -7,6 +7,7 @@ namespace LiturgicalCalendar\Tests\Repositories;
 use LiturgicalCalendar\Api\Enum\ChangeOperation;
 use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
 use LiturgicalCalendar\Api\Enum\ChangeReviewStatus;
+use LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\ChangeResource;
@@ -144,8 +145,10 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
      * to `none` while it still carried B's real `commit_sha`/`pr_number` — silently
      * re-publishing already-published work on the very next tick.
      *
-     * `releaseClaim()` must now be a no-op (0 rows affected, `open` untouched) once the batch
-     * is no longer `queued`. Reproduces the race directly against the repository without
+     * `releaseClaim()` must now be a no-op (nothing released, `open` untouched) once the batch
+     * is no longer `queued`, and must SAY SO — reporting `SETTLED_ELSEWHERE`, not a bare zero
+     * that a caller cannot tell apart from the batch having been released back to `none` by
+     * someone else's equally-failed attempt. Reproduces the race directly against the repository without
      * needing two real processes: "B publishes" is simulated with a plain
      * `recordPublication()` call, since from the repository's point of view that is
      * indistinguishable from an actual second runner having done it.
@@ -161,8 +164,12 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
 
         // Runner A: its own GitHub call now fails for real (branch moved under it) and it
         // tries to release the claim it believes it still holds.
-        $released = $this->repo->releaseClaim($batchId);
-        self::assertSame(0, $released, 'releaseClaim() must not affect rows once the batch is no longer queued');
+        $outcome = $this->repo->releaseClaim($batchId);
+        self::assertSame(
+            ClaimReleaseOutcome::SETTLED_ELSEWHERE,
+            $outcome,
+            'releaseClaim() must not affect rows once the batch is no longer queued, and must report why'
+        );
 
         foreach ($this->repo->getBatch($batchId) as $row) {
             self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
@@ -358,5 +365,103 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         $union = array_unique(array_merge($claimedA, $claimedB));
         sort($union);
         self::assertSame($expectedIds, $union, 'every approved batch must be claimed exactly once, by exactly one runner');
+    }
+
+    /**
+     * The distinction the final whole-branch review found missing, at the level that settles
+     * it: `releaseClaim()` affects zero rows for reasons that are semantic OPPOSITES, and a row
+     * count cannot tell them apart. `open` means another runner published the batch; `none`
+     * means nobody did — reached whenever another runner's own publish failed too, or whenever
+     * the grace-period reclaim released this batch out from under a merely-slow runner. The
+     * caller stops the run for one and carries on for the other, so this method must report
+     * WHICH.
+     */
+    public function testReleaseClaimReportsWhatItObservedNotJustWhetherItChangedAnything(): void
+    {
+        // 1. The live claim: released, and the failure is genuine.
+        $queued = $this->submitAndApprove('editor-1', 'US');
+        $this->repo->claimNextPublishableBatch();
+        self::assertSame(ClaimReleaseOutcome::RELEASED, $this->repo->releaseClaim($queued));
+
+        // 2. Already back at `none` — the sibling of `open`, and the one that used to read as
+        //    "settled, carry on" purely because both affect zero rows.
+        self::assertSame(ClaimReleaseOutcome::NOT_CLAIMED, $this->repo->releaseClaim($queued));
+
+        // 3. Published by someone else: the ONLY zero-row case that is not a failure.
+        $published = $this->submitAndApprove('editor-2', 'DE');
+        $this->repo->claimNextPublishableBatch();
+        $this->repo->recordPublication($published, 'litcal-data/national_calendar/roman/DE', 'sha', 7, 'base');
+        self::assertSame(ClaimReleaseOutcome::SETTLED_ELSEWHERE, $this->repo->releaseClaim($published));
+
+        // 4. No such batch: an unexplained state, never read optimistically.
+        self::assertSame(
+            ClaimReleaseOutcome::BATCH_MISSING,
+            $this->repo->releaseClaim('00000000-0000-4000-8000-000000000000')
+        );
+    }
+
+    /**
+     * A release is also the moment an attempt is counted, and the count is what eventually
+     * parks a batch that fails forever so the rest of the queue can drain past it. Counting it
+     * anywhere else would either miss the crash path or double-count the ordinary one.
+     */
+    public function testReleaseClaimCountsAnAttemptAndParksTheBatchAtTheBound(): void
+    {
+        $batchId = $this->submitAndApprove('editor-1', 'US');
+
+        for ($attempt = 1; $attempt <= SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS; $attempt++) {
+            self::assertSame($batchId, $this->repo->claimNextPublishableBatch(), "attempt {$attempt} must be claimable");
+            self::assertSame(ClaimReleaseOutcome::RELEASED, $this->repo->releaseClaim($batchId));
+
+            foreach ($this->repo->getBatch($batchId) as $row) {
+                self::assertEquals($attempt, $row['publish_attempts']);
+            }
+        }
+
+        self::assertNull(
+            $this->repo->claimNextPublishableBatch(),
+            'a batch that has spent every attempt must stop being claimed, or it blocks the queue forever'
+        );
+        self::assertSame(1, $this->repo->countParkedBatches(), 'and it must be visible while it is skipped');
+
+        // Parked, not dead-lettered: clearing the counter is all it takes to retry, which is
+        // what the runbook tells an operator to do.
+        self::$pdo->prepare('UPDATE sourcedata_change_requests SET publish_attempts = 0 WHERE batch_id = :b')
+            ->execute(['b' => $batchId]);
+        self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+        self::assertSame(0, $this->repo->countParkedBatches());
+    }
+
+    /**
+     * The skip list is a WITHIN-RUN exclusion, not a status: a batch passed over here is still
+     * perfectly claimable on the caller's next tick. Its whole job is to stop a caller that
+     * continues past a failure from immediately re-claiming the batch it just released, which
+     * — being back at `none` and the oldest — would otherwise be the next candidate.
+     */
+    public function testSkippedBatchIdsArePassedOverWithoutBeingParked(): void
+    {
+        $first  = $this->submitAndApprove('editor-1', 'US');
+        $second = $this->submitAndApprove('editor-2', 'DE');
+
+        self::assertSame($second, $this->repo->claimNextPublishableBatch([$first]));
+        self::assertSame(0, $this->repo->countParkedBatches(), 'skipping is not parking');
+        self::assertSame($first, $this->repo->claimNextPublishableBatch(), 'and it lasts only as long as the caller says');
+    }
+
+    public function testCountParkedBatchesIgnoresBatchesThatAreNoLongerWaiting(): void
+    {
+        $published = $this->submitAndApprove('editor-1', 'US');
+
+        // Exhaust the bound, then publish anyway (an operator retry, or phase 3).
+        self::$pdo->prepare('UPDATE sourcedata_change_requests SET publish_attempts = :n WHERE batch_id = :b')
+            ->execute(['n' => SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS, 'b' => $published]);
+        self::assertSame(1, $this->repo->countParkedBatches());
+
+        $this->repo->recordPublication($published, 'litcal-data/national_calendar/roman/US', 'sha', 7, 'base');
+        self::assertSame(
+            0,
+            $this->repo->countParkedBatches(),
+            'a batch that reached GitHub is not stuck, whatever its attempt history'
+        );
     }
 }

--- a/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestPublishQueueTest.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Tests\Repositories;
 
 use LiturgicalCalendar\Api\Enum\ChangeOperation;
 use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Enum\ChangeReviewStatus;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\ChangeResource;
@@ -225,5 +226,101 @@ final class SourceDataChangeRequestPublishQueueTest extends RepositoryTestCase
         // becomes claimable again — proving the null above was "locked, try later", not
         // some unrelated bug swallowing the row.
         self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+    }
+
+    /**
+     * Regression test for a race the earlier lock query missed entirely: it locked on
+     * `batch_id` alone, with no re-check of status. `FOR UPDATE SKIP LOCKED` only protects
+     * against a lock another transaction still HOLDS — it releases at COMMIT — so a runner
+     * that took its candidate snapshot before a different runner claims-and-commits the same
+     * batch would, at its own later lock step, find that batch's rows perfectly unlocked
+     * (now `queued`, but "unlocked" all the same) and claim them a second time.
+     *
+     * A single PHP process cannot demonstrate this even with two PDO connections: PHP is
+     * single-threaded, so two `claimNextPublishableBatch()` calls issued from one script,
+     * whatever connections they use, execute strictly one after another and never overlap in
+     * time. The race needs one runner's SELECT and another runner's COMMIT genuinely
+     * interleaved, which only real OS-level concurrency produces — hence two actual
+     * subprocesses (`phpunit_tests/fixtures/claim-race-worker.php`), each hammering
+     * `claimNextPublishableBatch()` against a shared pool of approved batches until it sees
+     * three consecutive misses, racing head-to-head with no artificial synchronisation
+     * between them.
+     *
+     * This is deliberately a real stress test over hand-sequenced SQL: a hand-sequenced test
+     * that reproduces the fixed query inline would keep passing even if the fix were later
+     * reverted in the repository, because its own copy of the query — not the repository's —
+     * is what gets asserted on. Calling the actual method from two real processes closes that
+     * gap: it exercises `claimNextPublishableBatch()` itself, on both sides of the race, so a
+     * regression in the repository's own query is what the test would catch.
+     *
+     * Measured against the pre-fix implementation (batch_id-only lock predicate), 100
+     * batches raced this way were double-claimed at a roughly 45% rate per batch — not a
+     * rare timing fluke. Against the fix, repeated runs show zero double-claims across every
+     * batch. See "Fix round 1" in `.superpowers/sdd/2026-08-29-sourcedata-publisher-phase2/task-2-report.md`
+     * for the raw before/after counts.
+     */
+    public function testTwoRealConcurrentRunnersNeverClaimTheSameBatch(): void
+    {
+        $batchCount  = 80;
+        $expectedIds = [];
+        for ($i = 0; $i < $batchCount; $i++) {
+            $expectedIds[] = $this->submitAndApprove("race-editor-{$i}", sprintf('Z%02d', $i));
+        }
+        sort($expectedIds);
+
+        $fixture = dirname(__DIR__) . '/fixtures/claim-race-worker.php';
+        self::assertFileExists($fixture);
+
+        $env         = [
+            'DB_HOST'     => (string) self::env('DB_HOST'),
+            'DB_PORT'     => (string) ( self::env('DB_PORT') ?? '5432' ),
+            'DB_NAME'     => (string) self::env('DB_NAME'),
+            'DB_USER'     => (string) self::env('DB_USER'),
+            'DB_PASSWORD' => (string) self::env('DB_PASSWORD'),
+            'PATH'        => (string) getenv('PATH'),
+        ];
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+
+        // Both subprocesses are launched — and therefore both running — before either pipe
+        // is read. proc_open() itself does not block, so this is what makes the two workers
+        // genuinely concurrent rather than sequential.
+        $procA = proc_open([PHP_BINARY, $fixture], $descriptors, $pipesA, null, $env);
+        $procB = proc_open([PHP_BINARY, $fixture], $descriptors, $pipesB, null, $env);
+        self::assertIsResource($procA, 'could not start worker A');
+        self::assertIsResource($procB, 'could not start worker B');
+
+        $outA = (string) stream_get_contents($pipesA[1]);
+        $errA = (string) stream_get_contents($pipesA[2]);
+        fclose($pipesA[1]);
+        fclose($pipesA[2]);
+        $exitA = proc_close($procA);
+
+        $outB = (string) stream_get_contents($pipesB[1]);
+        $errB = (string) stream_get_contents($pipesB[2]);
+        fclose($pipesB[1]);
+        fclose($pipesB[2]);
+        $exitB = proc_close($procB);
+
+        self::assertSame(0, $exitA, "worker A failed:\n{$errA}");
+        self::assertSame(0, $exitB, "worker B failed:\n{$errB}");
+
+        $claimedA = array_values(array_filter(explode("\n", trim($outA)), static fn (string $id): bool => $id !== ''));
+        $claimedB = array_values(array_filter(explode("\n", trim($outB)), static fn (string $id): bool => $id !== ''));
+
+        $doubleClaimed = array_values(array_intersect($claimedA, $claimedB));
+        self::assertSame(
+            [],
+            $doubleClaimed,
+            sprintf(
+                '%d of %d batches were claimed by BOTH concurrent runners: %s',
+                count($doubleClaimed),
+                $batchCount,
+                implode(', ', $doubleClaimed)
+            )
+        );
+
+        $union = array_unique(array_merge($claimedA, $claimedB));
+        sort($union);
+        self::assertSame($expectedIds, $union, 'every approved batch must be claimed exactly once, by exactly one runner');
     }
 }

--- a/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
@@ -853,6 +853,67 @@ final class SourceDataChangeRequestRepositoryTest extends RepositoryTestCase
         self::assertSame('withdrawn', $this->repo->getBatch($batchId)[0]['review_status']);
     }
 
+    /**
+     * The bug this task exists to fix: batch A is accumulated onto by batch B, and B is
+     * published (`merged`). A is older than B and was never itself published, so it must not
+     * resurface as the accumulation base for the next edit -- doing so would silently revert
+     * everything B added.
+     */
+    public function testAnAncestorOlderThanAMergedRowIsNotUsedAsTheBase(): void
+    {
+        $path = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+
+        // Batch A: approved, never published. Batch B accumulated onto it and was published.
+        $batchA = $this->repo->submitBatch(
+            ChangeResource::decrees(),
+            [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '["A"]']],
+            'editor-1',
+            'Alice',
+            'alice@example.test',
+            true
+        )['batch_id'];
+        $this->repo->approveBatch($batchA, 'admin-1');
+
+        $batchB = $this->repo->submitBatch(
+            ChangeResource::decrees(),
+            [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '["A","B"]']],
+            'editor-1',
+            'Alice',
+            'alice@example.test',
+            true
+        )['batch_id'];
+        $this->repo->approveBatch($batchB, 'admin-1');
+        $this->repo->markBatchPublicationStatus($batchB, ChangePublicationStatus::MERGED);
+
+        // A is older than the newest merged row for this path, so it must not become the base again.
+        self::assertNull(
+            $this->repo->findUnpublishedContent($path, 'editor-1'),
+            'a merged batch must not fall back to the ancestor it superseded'
+        );
+    }
+
+    /**
+     * The sibling of the above: while nothing for a path has ever been merged, the age floor
+     * must not change phase 1's behaviour at all.
+     */
+    public function testAnAncestorWithNoMergedDescendantIsStillTheBase(): void
+    {
+        $path = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+
+        $batchA = $this->repo->submitBatch(
+            ChangeResource::decrees(),
+            [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '["A"]']],
+            'editor-1',
+            'Alice',
+            'alice@example.test',
+            true
+        )['batch_id'];
+        $this->repo->approveBatch($batchA, 'admin-1');
+
+        // Nothing is merged, so phase 1's behaviour must be untouched.
+        self::assertSame('["A"]', $this->repo->findUnpublishedContent($path, 'editor-1'));
+    }
+
     public function testADecidedBatchCannotBeDecidedAgain(): void
     {
         $batchId = $this->submitUsa();

--- a/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
@@ -854,12 +854,6 @@ final class SourceDataChangeRequestRepositoryTest extends RepositoryTestCase
     }
 
     /**
-     * The bug this task exists to fix: batch A is accumulated onto by batch B, and B is
-     * published (`merged`). A is older than B and was never itself published, so it must not
-     * resurface as the accumulation base for the next edit -- doing so would silently revert
-     * everything B added.
-     */
-    /**
      * The enumeration half of the same rule.
      *
      * `findUnpublishedPathsUnder()` is what tells a handler which sidecar files exist for a
@@ -901,6 +895,12 @@ final class SourceDataChangeRequestRepositoryTest extends RepositoryTestCase
         );
     }
 
+    /**
+     * The bug this task exists to fix: batch A is accumulated onto by batch B, and B is
+     * published (`merged`). A is older than B and was never itself published, so it must not
+     * resurface as the accumulation base for the next edit -- doing so would silently revert
+     * everything B added.
+     */
     public function testAnAncestorOlderThanAMergedRowIsNotUsedAsTheBase(): void
     {
         $path = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';

--- a/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
@@ -914,6 +914,60 @@ final class SourceDataChangeRequestRepositoryTest extends RepositoryTestCase
         self::assertSame('["A"]', $this->repo->findUnpublishedContent($path, 'editor-1'));
     }
 
+    /**
+     * fix-round-1 regression: a row must not be excluded merely because its `created_at` TIES
+     * the newest merged row's -- only a row OLDER than the floor is superseded, and a tie is
+     * not older. Reachable the same way this class's other documented tie is: two independent
+     * transactions landing on the same microsecond, forced here exactly as
+     * {@see testListingBreaksATiedCreatedAtDeterministically()} forces one.
+     *
+     * C is emphatically NOT an ancestor of B here -- it is submitted only after B is already
+     * fully merged, so it cannot have been accumulated into B's content. Excluding C on the
+     * tie would reproduce, for an unrelated row, exactly the silent-data-loss defect
+     * {@see NOT_SUPERSEDED_BY_PUBLISHED} exists to prevent.
+     */
+    public function testATieWithTheMergedFloorDoesNotExcludeAnUnrelatedRow(): void
+    {
+        $path = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';
+
+        $batchB = $this->repo->submitBatch(
+            ChangeResource::decrees(),
+            [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '["B"]']],
+            'editor-1',
+            'Alice',
+            'alice@example.test',
+            true
+        )['batch_id'];
+        $this->repo->approveBatch($batchB, 'admin-1');
+        $this->repo->markBatchPublicationStatus($batchB, ChangePublicationStatus::MERGED);
+
+        // C is submitted only AFTER B is fully merged -- it cannot be B's ancestor.
+        $batchC = $this->repo->submitBatch(
+            ChangeResource::decrees(),
+            [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '["C"]']],
+            'editor-1',
+            'Alice',
+            'alice@example.test',
+            true
+        )['batch_id'];
+        $this->repo->approveBatch($batchC, 'admin-1');
+
+        // Force an exact tie between B's and C's created_at -- the scenario a strict `>` floor
+        // excluded wrongly.
+        $stmt = self::$pdo->prepare(
+            "UPDATE sourcedata_change_requests
+                SET created_at = TIMESTAMP '2026-01-01 00:00:00'
+              WHERE batch_id IN (:batch_b, :batch_c)"
+        );
+        $stmt->execute(['batch_b' => $batchB, 'batch_c' => $batchC]);
+
+        self::assertSame(
+            '["C"]',
+            $this->repo->findUnpublishedContent($path, 'editor-1'),
+            'a row tied with the merged floor must not be excluded -- a tie is not older'
+        );
+    }
+
     public function testADecidedBatchCannotBeDecidedAgain(): void
     {
         $batchId = $this->submitUsa();

--- a/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
+++ b/phpunit_tests/Repositories/SourceDataChangeRequestRepositoryTest.php
@@ -859,6 +859,48 @@ final class SourceDataChangeRequestRepositoryTest extends RepositoryTestCase
      * resurface as the accumulation base for the next edit -- doing so would silently revert
      * everything B added.
      */
+    /**
+     * The enumeration half of the same rule.
+     *
+     * `findUnpublishedPathsUnder()` is what tells a handler which sidecar files exist for a
+     * submitter, so a superseded ancestor left in its results reappears as a file the rebuild
+     * then reads. Phase 1's decree bug had exactly this shape — the content half was fixed
+     * while the enumeration half still swept the file away — so both halves get their own test
+     * rather than trusting that a shared constant keeps them in step.
+     */
+    public function testAnAncestorOlderThanAMergedRowIsNotEnumeratedEither(): void
+    {
+        $folder = 'jsondata/sourcedata/rite/roman/decrees/i18n';
+        $path   = $folder . '/cs.json';
+
+        $batchA = $this->repo->submitBatch(
+            ChangeResource::decrees(),
+            [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '{"A":"a"}']],
+            'editor-1',
+            'Alice',
+            'alice@example.test',
+            true
+        )['batch_id'];
+        $this->repo->approveBatch($batchA, 'admin-1');
+
+        $batchB = $this->repo->submitBatch(
+            ChangeResource::decrees(),
+            [['path' => $path, 'operation' => ChangeOperation::UPDATE, 'content' => '{"A":"a","B":"b"}']],
+            'editor-1',
+            'Alice',
+            'alice@example.test',
+            true
+        )['batch_id'];
+        $this->repo->approveBatch($batchB, 'admin-1');
+        $this->repo->markBatchPublicationStatus($batchB, ChangePublicationStatus::MERGED);
+
+        self::assertSame(
+            [],
+            $this->repo->findUnpublishedPathsUnder($folder . '/', 'editor-1'),
+            'a path whose only unpublished row is superseded by published content must not be enumerated'
+        );
+    }
+
     public function testAnAncestorOlderThanAMergedRowIsNotUsedAsTheBase(): void
     {
         $path = 'jsondata/sourcedata/rite/roman/decrees/decrees.json';

--- a/phpunit_tests/Services/GitHub/GitHubAppAuthTest.php
+++ b/phpunit_tests/Services/GitHub/GitHubAppAuthTest.php
@@ -159,4 +159,41 @@ final class GitHubAppAuthTest extends TestCase
             }
         }
     }
+
+    public function testFromEnvBuildsAnInstanceWhenConfiguredAndThrowsWhenNot(): void
+    {
+        $original = [
+            'GITHUB_APP_ID'               => $_ENV['GITHUB_APP_ID'] ?? null,
+            'GITHUB_APP_INSTALLATION_ID'  => $_ENV['GITHUB_APP_INSTALLATION_ID'] ?? null,
+            'GITHUB_APP_PRIVATE_KEY_PATH' => $_ENV['GITHUB_APP_PRIVATE_KEY_PATH'] ?? null,
+        ];
+
+        try {
+            unset($_ENV['GITHUB_APP_ID'], $_ENV['GITHUB_APP_INSTALLATION_ID'], $_ENV['GITHUB_APP_PRIVATE_KEY_PATH']);
+
+            $noHttp = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler([]))]);
+            $cache  = new ArrayAdapter();
+
+            try {
+                GitHubAppAuth::fromEnv($noHttp, $cache);
+                self::fail('fromEnv() should throw when the App credential is not configured');
+            } catch (\RuntimeException $e) {
+                self::assertStringContainsString('GitHub App is not configured', $e->getMessage());
+            }
+
+            $_ENV['GITHUB_APP_ID']               = '12345';
+            $_ENV['GITHUB_APP_INSTALLATION_ID']  = '67890';
+            $_ENV['GITHUB_APP_PRIVATE_KEY_PATH'] = self::keyPath();
+
+            self::assertInstanceOf(GitHubAppAuth::class, GitHubAppAuth::fromEnv($noHttp, $cache));
+        } finally {
+            foreach ($original as $name => $value) {
+                if ($value === null) {
+                    unset($_ENV[$name]);
+                } else {
+                    $_ENV[$name] = $value;
+                }
+            }
+        }
+    }
 }

--- a/phpunit_tests/Services/GitHub/GitHubAppAuthTest.php
+++ b/phpunit_tests/Services/GitHub/GitHubAppAuthTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\GitHub;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * No GitHub App exists yet — Task 3 builds the credential layer against a mocked HTTP client
+ * and a throwaway RSA key generated at runtime, so the suite needs no committed key material
+ * and no network access. Real credentials are wired in Task 8.
+ */
+#[CoversClass(GitHubAppAuth::class)]
+final class GitHubAppAuthTest extends TestCase
+{
+    private static string $keyDir;
+    private static string $keyPath;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $keyDir = sys_get_temp_dir() . '/github-app-auth-test-' . bin2hex(random_bytes(8));
+        if (!mkdir($keyDir, 0700, true) && !is_dir($keyDir)) {
+            self::fail(sprintf('Unable to create temp directory "%s"', $keyDir));
+        }
+        self::$keyDir = $keyDir;
+
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        if ($resource === false) {
+            self::fail('Unable to generate a throwaway RSA key for the test suite');
+        }
+
+        $exported = openssl_pkey_export($resource, $privateKeyPem);
+        if (!$exported || !is_string($privateKeyPem)) {
+            self::fail('Unable to export the throwaway RSA private key');
+        }
+
+        $keyPath = $keyDir . '/github-app.pem';
+        file_put_contents($keyPath, $privateKeyPem);
+        self::$keyPath = $keyPath;
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        // Child-first: a previous task on this branch leaked temp directories because cleanup
+        // only reached one level deep.
+        if (isset(self::$keyPath) && file_exists(self::$keyPath)) {
+            unlink(self::$keyPath);
+        }
+        if (isset(self::$keyDir) && is_dir(self::$keyDir)) {
+            rmdir(self::$keyDir);
+        }
+
+        parent::tearDownAfterClass();
+    }
+
+    private static function keyPath(): string
+    {
+        return self::$keyPath;
+    }
+
+    /** @param array<int, GuzzleResponse> $responses */
+    private function auth(array $responses, CacheItemPoolInterface $cache): GitHubAppAuth
+    {
+        $guzzle = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler($responses))]);
+
+        return new GitHubAppAuth('12345', '67890', self::keyPath(), $guzzle, $cache);
+    }
+
+    public function testItExchangesTheAppJwtForAnInstallationToken(): void
+    {
+        $auth = $this->auth(
+            [new GuzzleResponse(201, [], json_encode(['token' => 'ghs_abc', 'expires_at' => '2026-01-01T00:00:00Z']))],
+            new ArrayAdapter()
+        );
+
+        self::assertSame('ghs_abc', $auth->installationToken());
+    }
+
+    public function testTheTokenIsCachedRatherThanFetchedEveryCall(): void
+    {
+        // One response only: a second HTTP call would throw "queue is empty".
+        $auth = $this->auth(
+            [new GuzzleResponse(201, [], json_encode(['token' => 'ghs_abc', 'expires_at' => '2026-01-01T00:00:00Z']))],
+            new ArrayAdapter()
+        );
+
+        self::assertSame('ghs_abc', $auth->installationToken());
+        self::assertSame('ghs_abc', $auth->installationToken());
+    }
+
+    public function testDifferentInstallationsDoNotShareACacheEntry(): void
+    {
+        $cache  = new ArrayAdapter();
+        $guzzle = new GuzzleClient([
+            'handler' => HandlerStack::create(new MockHandler([
+                new GuzzleResponse(201, [], json_encode(['token' => 'ghs_one', 'expires_at' => '2026-01-01T00:00:00Z'])),
+                new GuzzleResponse(201, [], json_encode(['token' => 'ghs_two', 'expires_at' => '2026-01-01T00:00:00Z'])),
+            ])),
+        ]);
+
+        $authOne = new GitHubAppAuth('12345', '11111', self::keyPath(), $guzzle, $cache);
+        $authTwo = new GitHubAppAuth('12345', '22222', self::keyPath(), $guzzle, $cache);
+
+        self::assertSame('ghs_one', $authOne->installationToken());
+        self::assertSame('ghs_two', $authTwo->installationToken());
+    }
+
+    public function testAFailedExchangeRaisesGitHubApiExceptionCarryingTheStatus(): void
+    {
+        $auth = $this->auth([new GuzzleResponse(401, [], json_encode(['message' => 'Bad credentials']))], new ArrayAdapter());
+
+        try {
+            $auth->installationToken();
+            self::fail('a 401 must not be swallowed');
+        } catch (GitHubApiException $e) {
+            self::assertSame(401, $e->status);
+            self::assertStringContainsString('Bad credentials', $e->getMessage());
+        }
+    }
+
+    public function testIsConfiguredReflectsTheEnvironment(): void
+    {
+        $original = [
+            'GITHUB_APP_ID'               => $_ENV['GITHUB_APP_ID'] ?? null,
+            'GITHUB_APP_INSTALLATION_ID'  => $_ENV['GITHUB_APP_INSTALLATION_ID'] ?? null,
+            'GITHUB_APP_PRIVATE_KEY_PATH' => $_ENV['GITHUB_APP_PRIVATE_KEY_PATH'] ?? null,
+        ];
+
+        try {
+            unset($_ENV['GITHUB_APP_ID'], $_ENV['GITHUB_APP_INSTALLATION_ID'], $_ENV['GITHUB_APP_PRIVATE_KEY_PATH']);
+            self::assertFalse(GitHubAppAuth::isConfigured());
+
+            $_ENV['GITHUB_APP_ID']               = '12345';
+            $_ENV['GITHUB_APP_INSTALLATION_ID']  = '67890';
+            $_ENV['GITHUB_APP_PRIVATE_KEY_PATH'] = self::keyPath();
+            self::assertTrue(GitHubAppAuth::isConfigured());
+        } finally {
+            foreach ($original as $name => $value) {
+                if ($value === null) {
+                    unset($_ENV[$name]);
+                } else {
+                    $_ENV[$name] = $value;
+                }
+            }
+        }
+    }
+}

--- a/phpunit_tests/Services/GitHub/GitHubAppAuthTest.php
+++ b/phpunit_tests/Services/GitHub/GitHubAppAuthTest.php
@@ -68,6 +68,17 @@ final class GitHubAppAuthTest extends TestCase
         parent::tearDownAfterClass();
     }
 
+    /**
+     * Clear the three variables from BOTH `$_ENV` and the process environment.
+     */
+    private static function clearGithubAppEnv(): void
+    {
+        foreach (['GITHUB_APP_ID', 'GITHUB_APP_INSTALLATION_ID', 'GITHUB_APP_PRIVATE_KEY_PATH'] as $name) {
+            unset($_ENV[$name]);
+            putenv($name);
+        }
+    }
+
     private static function keyPath(): string
     {
         return self::$keyPath;
@@ -142,7 +153,10 @@ final class GitHubAppAuthTest extends TestCase
         ];
 
         try {
-            unset($_ENV['GITHUB_APP_ID'], $_ENV['GITHUB_APP_INSTALLATION_ID'], $_ENV['GITHUB_APP_PRIVATE_KEY_PATH']);
+            // getEnvString() reads $_ENV first and falls back to getenv(), so clearing only
+            // $_ENV leaves an inherited process value able to make this assertion pass or fail
+            // for reasons that have nothing to do with the code under test.
+            self::clearGithubAppEnv();
             self::assertFalse(GitHubAppAuth::isConfigured());
 
             $_ENV['GITHUB_APP_ID']               = '12345';
@@ -169,7 +183,10 @@ final class GitHubAppAuthTest extends TestCase
         ];
 
         try {
-            unset($_ENV['GITHUB_APP_ID'], $_ENV['GITHUB_APP_INSTALLATION_ID'], $_ENV['GITHUB_APP_PRIVATE_KEY_PATH']);
+            // getEnvString() reads $_ENV first and falls back to getenv(), so clearing only
+            // $_ENV leaves an inherited process value able to make this assertion pass or fail
+            // for reasons that have nothing to do with the code under test.
+            self::clearGithubAppEnv();
 
             $noHttp = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler([]))]);
             $cache  = new ArrayAdapter();

--- a/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
+++ b/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\GitHub;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Exercises the Git Data and Pulls wrapper entirely against a mocked HTTP client — same
+ * mock-first approach as {@see \LiturgicalCalendar\Tests\Services\GitHub\GitHubAppAuthTest}, no
+ * network and no credentials.
+ *
+ * `GitHubAppAuth::installationToken()` is a real collaborator rather than a stub — it is
+ * `final`, so PHPUnit cannot double it — but its cache is pre-warmed with a fake token before
+ * each client is built, so its own (separately mocked, empty) HTTP queue is never touched. That
+ * keeps the single queued response in every test reserved for the Git Data call actually under
+ * test.
+ */
+#[CoversClass(GitHubGitDataClient::class)]
+final class GitHubGitDataClientTest extends TestCase
+{
+    private const OWNER = 'Liturgical-Calendar';
+
+    private const REPO = 'LiturgicalCalendarAPI';
+
+    /**
+     * Matches the private key GitHubAppAuth::cacheKey() derives from installation id '67890':
+     * 'github_app_installation_token_' . preg_replace('/[^A-Za-z0-9_.]/', '_', $installationId).
+     */
+    private const AUTH_CACHE_KEY = 'github_app_installation_token_67890';
+
+    private function auth(): GitHubAppAuth
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem(self::AUTH_CACHE_KEY);
+        $item->set('ghs_test_token');
+        $cache->save($item);
+
+        // Empty queue: if installationToken() ever falls through to a real exchange instead of
+        // the cache hit above, this throws loudly ("mock queue is empty") instead of quietly
+        // consuming a response meant for the Git Data call under test.
+        $noHttp = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler([]))]);
+
+        return new GitHubAppAuth('12345', '67890', '/nonexistent/should-not-be-read.pem', $noHttp, $cache);
+    }
+
+    /** @param array<int, GuzzleResponse> $responses */
+    private function client(array $responses): GitHubGitDataClient
+    {
+        $guzzle = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler($responses))]);
+
+        return new GitHubGitDataClient(self::OWNER, self::REPO, $this->auth(), $guzzle);
+    }
+
+    /**
+     * @param array<int, RequestInterface> $captured
+     * @param array<int, GuzzleResponse>   $responses
+     */
+    private function clientCapturing(array &$captured, array $responses): GitHubGitDataClient
+    {
+        $handlerStack = HandlerStack::create(new MockHandler($responses));
+        $handlerStack->push(static function (callable $handler) use (&$captured): callable {
+            return static function (RequestInterface $request, array $options) use ($handler, &$captured) {
+                $captured[] = $request;
+
+                return $handler($request, $options);
+            };
+        });
+        $guzzle = new GuzzleClient(['handler' => $handlerStack]);
+
+        return new GitHubGitDataClient(self::OWNER, self::REPO, $this->auth(), $guzzle);
+    }
+
+    public function testGetRefReturnsNullForAMissingBranch(): void
+    {
+        $client = $this->client([new GuzzleResponse(404, [], json_encode(['message' => 'Not Found']))]);
+
+        self::assertNull($client->getRef('litcal-data/roman/nation/US'));
+    }
+
+    public function testGetRefReturnsTheHeadShaWhenTheBranchExists(): void
+    {
+        $client = $this->client([
+            new GuzzleResponse(200, [], json_encode(['ref' => 'refs/heads/development', 'object' => ['sha' => 'headsha1']])),
+        ]);
+
+        self::assertSame('headsha1', $client->getRef('development'));
+    }
+
+    public function testCreateRefSendsTheFullRefNameAndFromSha(): void
+    {
+        $captured = [];
+        $client   = $this->clientCapturing($captured, [new GuzzleResponse(201, [], '{}')]);
+
+        $client->createRef('litcal-data/roman/nation/US', 'basesha1');
+
+        self::assertSame('POST', $captured[0]->getMethod());
+        self::assertStringEndsWith('/git/refs', (string) $captured[0]->getUri());
+
+        $body = json_decode((string) $captured[0]->getBody(), true);
+        self::assertSame('refs/heads/litcal-data/roman/nation/US', $body['ref']);
+        self::assertSame('basesha1', $body['sha']);
+    }
+
+    public function testCreateBlobReturnsTheNewBlobSha(): void
+    {
+        $captured = [];
+        $client   = $this->clientCapturing($captured, [new GuzzleResponse(201, [], json_encode(['sha' => 'blob1']))]);
+
+        $sha = $client->createBlob('{"foo":"bar"}');
+
+        self::assertSame('blob1', $sha);
+
+        $body = json_decode((string) $captured[0]->getBody(), true);
+        self::assertSame('{"foo":"bar"}', $body['content']);
+        self::assertSame('utf-8', $body['encoding']);
+    }
+
+    public function testATreeEntryMayCarryANullShaToExpressADeletion(): void
+    {
+        $captured = [];
+        $client   = $this->clientCapturing($captured, [new GuzzleResponse(201, [], json_encode(['sha' => 'tree1']))]);
+
+        $client->createTree('base1', [
+            [
+                'path' => 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json',
+                'mode' => '100644',
+                'type' => 'blob',
+                'sha'  => null,
+            ],
+        ]);
+
+        $body = json_decode((string) $captured[0]->getBody(), true);
+        self::assertNull($body['tree'][0]['sha'], 'a null sha is how the API deletes a path');
+        self::assertArrayHasKey('sha', $body['tree'][0], 'the key must be present and null, not omitted');
+    }
+
+    public function testCreateTreeReturnsTheNewTreeSha(): void
+    {
+        $client = $this->client([new GuzzleResponse(201, [], json_encode(['sha' => 'tree2']))]);
+
+        $sha = $client->createTree('base2', [
+            ['path' => 'a.json', 'mode' => '100644', 'type' => 'blob', 'sha' => 'blobsha'],
+        ]);
+
+        self::assertSame('tree2', $sha);
+    }
+
+    public function testCreateCommitSendsTheSingleParentAndAuthorAndReturnsTheNewSha(): void
+    {
+        $captured = [];
+        $client   = $this->clientCapturing($captured, [new GuzzleResponse(201, [], json_encode(['sha' => 'commit1']))]);
+
+        $author = ['name' => 'Publisher Bot', 'email' => 'publisher@example.com'];
+        $sha    = $client->createCommit('publish batch', 'tree3', 'parent1', $author);
+
+        self::assertSame('commit1', $sha);
+
+        $body = json_decode((string) $captured[0]->getBody(), true);
+        self::assertSame('publish batch', $body['message']);
+        self::assertSame('tree3', $body['tree']);
+        self::assertSame(['parent1'], $body['parents']);
+        self::assertSame($author, $body['author']);
+    }
+
+    public function testUpdateRefRefusesToForcePush(): void
+    {
+        $captured = [];
+        $client   = $this->clientCapturing($captured, [new GuzzleResponse(200, [], '{}')]);
+
+        $client->updateRef('litcal-data/roman/nation/US', 'abc123');
+
+        $body = json_decode((string) $captured[0]->getBody(), true);
+        // force:false turns a concurrent update into a retryable 422 instead of silently
+        // clobbering another editor's commit.
+        self::assertFalse($body['force'], 'the publisher must never force-push');
+        self::assertSame('abc123', $body['sha']);
+    }
+
+    public function testUpdateRefEncodesEachBranchSegmentWithoutCollapsingTheSlashes(): void
+    {
+        $captured = [];
+        $client   = $this->clientCapturing($captured, [new GuzzleResponse(200, [], '{}')]);
+
+        $client->updateRef('litcal-data/roman/nation/US', 'abc123');
+
+        $path = $captured[0]->getUri()->getPath();
+        self::assertStringEndsWith('/git/refs/heads/litcal-data/roman/nation/US', $path);
+        self::assertStringNotContainsString('%2F', $path);
+    }
+
+    public function testOpenPullRequestReturnsTheNewPullNumber(): void
+    {
+        $captured = [];
+        $client   = $this->clientCapturing($captured, [new GuzzleResponse(201, [], json_encode(['number' => 42]))]);
+
+        $number = $client->openPullRequest('litcal-data/roman/nation/US', 'development', 'Publish US', 'body text');
+
+        self::assertSame(42, $number);
+
+        $body = json_decode((string) $captured[0]->getBody(), true);
+        self::assertSame('litcal-data/roman/nation/US', $body['head']);
+        self::assertSame('development', $body['base']);
+        self::assertSame('Publish US', $body['title']);
+        self::assertSame('body text', $body['body']);
+    }
+
+    public function testFindOpenPullRequestReturnsTheNumberOfAnExistingOpenPr(): void
+    {
+        $captured = [];
+        $client   = $this->clientCapturing($captured, [new GuzzleResponse(200, [], json_encode([['number' => 7]]))]);
+
+        self::assertSame(7, $client->findOpenPullRequest('litcal-data/roman/nation/US'));
+
+        $query = $captured[0]->getUri()->getQuery();
+        self::assertStringContainsString('state=open', $query);
+        self::assertStringContainsString('head=' . rawurlencode(self::OWNER . ':litcal-data/roman/nation/US'), $query);
+    }
+
+    public function testFindOpenPullRequestReturnsNullWhenNoneAreOpen(): void
+    {
+        $client = $this->client([new GuzzleResponse(200, [], '[]')]);
+
+        self::assertNull($client->findOpenPullRequest('litcal-data/roman/nation/US'));
+    }
+
+    public function testANon2xxRaisesGitHubApiException(): void
+    {
+        $client = $this->client([new GuzzleResponse(422, [], json_encode(['message' => 'Update is not a fast forward']))]);
+
+        $this->expectException(GitHubApiException::class);
+        $client->updateRef('litcal-data/roman/nation/US', 'abc123');
+    }
+
+    public function testANon2xxCarriesTheStatusAndGitHubMessage(): void
+    {
+        $client = $this->client([new GuzzleResponse(422, [], json_encode(['message' => 'Update is not a fast forward']))]);
+
+        try {
+            $client->updateRef('litcal-data/roman/nation/US', 'abc123');
+            self::fail('a 422 must not be swallowed');
+        } catch (GitHubApiException $e) {
+            self::assertSame(422, $e->status);
+            self::assertStringContainsString('Update is not a fast forward', $e->getMessage());
+        }
+    }
+
+    public function testANon2xxOnCreateBlobIsNotTreatedAsSuccess(): void
+    {
+        $client = $this->client([new GuzzleResponse(500, [], json_encode(['message' => 'Server Error']))]);
+
+        $this->expectException(GitHubApiException::class);
+        $client->createBlob('content');
+    }
+
+    public function testEveryRequestCarriesTheRequiredAuthAndVersionHeaders(): void
+    {
+        $captured = [];
+        $client   = $this->clientCapturing($captured, [
+            new GuzzleResponse(200, [], json_encode(['object' => ['sha' => 'headsha1']])),
+        ]);
+
+        $client->getRef('development');
+
+        $request = $captured[0];
+        self::assertSame('Bearer ghs_test_token', $request->getHeaderLine('Authorization'));
+        self::assertSame('application/vnd.github+json', $request->getHeaderLine('Accept'));
+        self::assertSame('2022-11-28', $request->getHeaderLine('X-GitHub-Api-Version'));
+    }
+}

--- a/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
+++ b/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
@@ -12,6 +12,7 @@ use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
 use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
 use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
@@ -262,6 +263,48 @@ final class GitHubGitDataClientTest extends TestCase
 
         $this->expectException(GitHubApiException::class);
         $client->createBlob('content');
+    }
+
+    /**
+     * The 404 asymmetry, checked per method rather than only through getRef().
+     *
+     * getRef() treats 404 as "the branch does not exist yet, create it". Every other call must
+     * treat it as a real failure: a 404 swallowed in createBlob(), createTree(), createCommit()
+     * or createRef() would drop the editor's work while the change request reported success.
+     */
+    #[DataProvider('methodsThatMustRejectA404')]
+    public function testA404IsAnErrorEverywhereExceptGetRef(string $label, callable $call): void
+    {
+        $client = $this->client([new GuzzleResponse(404, [], json_encode(['message' => 'Not Found']))]);
+
+        try {
+            $call($client);
+            self::fail($label . ' must not treat a 404 as success');
+        } catch (GitHubApiException $e) {
+            self::assertSame(404, $e->status, $label . ' should surface the 404');
+        }
+    }
+
+    /**
+     * @return array<string, array{0: string, 1: callable(GitHubGitDataClient): mixed}>
+     */
+    public static function methodsThatMustRejectA404(): array
+    {
+        return [
+            'createRef'    => ['createRef', static fn (GitHubGitDataClient $c): mixed => $c->createRef('litcal-data/x', 'abc123')],
+            'createBlob'   => ['createBlob', static fn (GitHubGitDataClient $c): mixed => $c->createBlob('{}')],
+            'createTree'   => ['createTree', static fn (GitHubGitDataClient $c): mixed => $c->createTree('base1', [])],
+            'createCommit' => [
+                'createCommit',
+                static fn (GitHubGitDataClient $c): mixed => $c->createCommit(
+                    'msg',
+                    'tree1',
+                    'parent1',
+                    ['name' => 'Alice', 'email' => 'alice@example.test']
+)
+            ],
+            'updateRef'    => ['updateRef', static fn (GitHubGitDataClient $c): mixed => $c->updateRef('litcal-data/x', 'abc123')],
+        ];
     }
 
     public function testEveryRequestCarriesTheRequiredAuthAndVersionHeaders(): void

--- a/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
+++ b/phpunit_tests/Services/GitHub/GitHubGitDataClientTest.php
@@ -158,13 +158,14 @@ final class GitHubGitDataClientTest extends TestCase
         self::assertSame('tree2', $sha);
     }
 
-    public function testCreateCommitSendsTheSingleParentAndAuthorAndReturnsTheNewSha(): void
+    public function testCreateCommitSendsTheSingleParentAuthorAndCommitterAndReturnsTheNewSha(): void
     {
         $captured = [];
         $client   = $this->clientCapturing($captured, [new GuzzleResponse(201, [], json_encode(['sha' => 'commit1']))]);
 
-        $author = ['name' => 'Publisher Bot', 'email' => 'publisher@example.com'];
-        $sha    = $client->createCommit('publish batch', 'tree3', 'parent1', $author);
+        $author    = ['name' => 'Alice', 'email' => 'alice@example.test'];
+        $committer = ['name' => 'Publisher Bot', 'email' => 'publisher@example.com'];
+        $sha       = $client->createCommit('publish batch', 'tree3', 'parent1', $author, $committer);
 
         self::assertSame('commit1', $sha);
 
@@ -173,6 +174,24 @@ final class GitHubGitDataClientTest extends TestCase
         self::assertSame('tree3', $body['tree']);
         self::assertSame(['parent1'], $body['parents']);
         self::assertSame($author, $body['author']);
+        self::assertSame($committer, $body['committer'], 'author and committer must be sent as distinct objects');
+    }
+
+    public function testGetCommitTreeShaReturnsTheTreeSha(): void
+    {
+        $client = $this->client([
+            new GuzzleResponse(200, [], json_encode(['sha' => 'commit1', 'tree' => ['sha' => 'tree9']])),
+        ]);
+
+        self::assertSame('tree9', $client->getCommitTreeSha('commit1'));
+    }
+
+    public function testGetCommitTreeShaRejectsA404(): void
+    {
+        $client = $this->client([new GuzzleResponse(404, [], json_encode(['message' => 'Not Found']))]);
+
+        $this->expectException(GitHubApiException::class);
+        $client->getCommitTreeSha('missing-commit');
     }
 
     public function testUpdateRefRefusesToForcePush(): void
@@ -291,19 +310,24 @@ final class GitHubGitDataClientTest extends TestCase
     public static function methodsThatMustRejectA404(): array
     {
         return [
-            'createRef'    => ['createRef', static fn (GitHubGitDataClient $c): mixed => $c->createRef('litcal-data/x', 'abc123')],
-            'createBlob'   => ['createBlob', static fn (GitHubGitDataClient $c): mixed => $c->createBlob('{}')],
-            'createTree'   => ['createTree', static fn (GitHubGitDataClient $c): mixed => $c->createTree('base1', [])],
-            'createCommit' => [
+            'createRef'        => ['createRef', static fn (GitHubGitDataClient $c): mixed => $c->createRef('litcal-data/x', 'abc123')],
+            'createBlob'       => ['createBlob', static fn (GitHubGitDataClient $c): mixed => $c->createBlob('{}')],
+            'createTree'       => ['createTree', static fn (GitHubGitDataClient $c): mixed => $c->createTree('base1', [])],
+            'createCommit'     => [
                 'createCommit',
                 static fn (GitHubGitDataClient $c): mixed => $c->createCommit(
                     'msg',
                     'tree1',
                     'parent1',
-                    ['name' => 'Alice', 'email' => 'alice@example.test']
-)
+                    ['name' => 'Alice', 'email' => 'alice@example.test'],
+                    ['name' => 'Publisher Bot', 'email' => 'publisher@example.com']
+                ),
             ],
-            'updateRef'    => ['updateRef', static fn (GitHubGitDataClient $c): mixed => $c->updateRef('litcal-data/x', 'abc123')],
+            'getCommitTreeSha' => [
+                'getCommitTreeSha',
+                static fn (GitHubGitDataClient $c): mixed => $c->getCommitTreeSha('commit1'),
+            ],
+            'updateRef'        => ['updateRef', static fn (GitHubGitDataClient $c): mixed => $c->updateRef('litcal-data/x', 'abc123')],
         ];
     }
 

--- a/phpunit_tests/Services/SourceData/ClaimVanishedSourceDataPublisher.php
+++ b/phpunit_tests/Services/SourceData/ClaimVanishedSourceDataPublisher.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
+use LiturgicalCalendar\Api\Services\SourceData\PublishResult;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherInterface;
+
+/**
+ * The SIBLING of the race {@see RaceLosingSourceDataPublisher} covers, and the one the final
+ * whole-branch review found unhandled.
+ *
+ * There, a second runner *published* this batch while this one was slow, so the batch is
+ * `open` by the time the release runs. Here, the second runner's own publish also FAILED — a
+ * GitHub outage fails every runner, not just one — so the batch is back at `none`, exactly as
+ * {@see SourceDataChangeRequestRepository::reclaimStaleClaims()} and
+ * {@see SourceDataChangeRequestRepository::releaseClaim()} both leave it. `publish()` here
+ * therefore moves the batch to `none` (standing in for that other runner) and then throws a
+ * 500 (standing in for this runner's own, equally-doomed call finally returning).
+ *
+ * Both cases make `releaseClaim()` affect zero rows. Only one of them means "settled by
+ * someone else". Reading a bare row count cannot tell them apart, which is why
+ * `releaseClaim()` reports the OBSERVED STATUS ({@see \LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome})
+ * rather than an integer.
+ */
+final class ClaimVanishedSourceDataPublisher implements SourceDataPublisherInterface
+{
+    public int $calls = 0;
+
+    public function __construct(private readonly SourceDataChangeRequestRepository $repo)
+    {
+    }
+
+    public function publish(string $batchId): PublishResult
+    {
+        $this->calls++;
+
+        // markBatchPublicationStatus() is unconditional, which is precisely what a concurrent
+        // reclaimStaleClaims() / releaseClaim() pair does to this row while this publish is in
+        // flight: it ends up `none`, claimable again, with nothing published anywhere.
+        $this->repo->markBatchPublicationStatus($batchId, ChangePublicationStatus::NONE);
+
+        throw new GitHubApiException(500, 'Server Error');
+    }
+}

--- a/phpunit_tests/Services/SourceData/FakeSourceDataPublisher.php
+++ b/phpunit_tests/Services/SourceData/FakeSourceDataPublisher.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\SourceData\PublishResult;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherInterface;
+
+/**
+ * Stands in for the real, `final` `SourceDataPublisher` in {@see PublishRunnerTest} (see
+ * {@see SourceDataPublisherInterface} for why a fake is used here rather than a mocked Guzzle
+ * stack). Mirrors the one side effect `PublishRunnerTest` depends on: a real
+ * `SourceDataPublisher::publish()` call records the publication on the repository before
+ * returning, so this fake does the same when it is not configured to throw, keeping the
+ * fixture honest about what a real publish leaves behind.
+ */
+final class FakeSourceDataPublisher implements SourceDataPublisherInterface
+{
+    public const BRANCH = 'litcal-data/national_calendar/roman/US';
+
+    public const COMMIT_SHA = 'deadbeef';
+
+    public const PR_NUMBER = 7;
+
+    public const BASE_SHA = 'base-sha';
+
+    public int $calls = 0;
+
+    public function __construct(
+        private readonly SourceDataChangeRequestRepository $repo,
+        private readonly ?\Throwable $throws = null
+    ) {
+    }
+
+    public function publish(string $batchId): PublishResult
+    {
+        $this->calls++;
+
+        if (null !== $this->throws) {
+            throw $this->throws;
+        }
+
+        $this->repo->recordPublication(
+            $batchId,
+            self::BRANCH,
+            self::COMMIT_SHA,
+            self::PR_NUMBER,
+            self::BASE_SHA
+        );
+
+        return new PublishResult(
+            self::BRANCH,
+            self::COMMIT_SHA,
+            self::PR_NUMBER,
+            self::BASE_SHA
+        );
+    }
+}

--- a/phpunit_tests/Services/SourceData/FakeSourceDataPublisher.php
+++ b/phpunit_tests/Services/SourceData/FakeSourceDataPublisher.php
@@ -28,9 +28,19 @@ final class FakeSourceDataPublisher implements SourceDataPublisherInterface
 
     public int $calls = 0;
 
+    /**
+     * @param \Throwable|null $throws          Thrown instead of publishing.
+     * @param string|null     $throwsForBatchId Narrows `$throws` to ONE batch id; every other
+     *                                          batch publishes normally. Null (the default)
+     *                                          means every batch throws. Needed to exercise a
+     *                                          failure the runner is expected to CONTINUE past,
+     *                                          which is only observable when there is a
+     *                                          subsequent batch left to publish.
+     */
     public function __construct(
         private readonly SourceDataChangeRequestRepository $repo,
-        private readonly ?\Throwable $throws = null
+        private readonly ?\Throwable $throws = null,
+        private readonly ?string $throwsForBatchId = null
     ) {
     }
 
@@ -38,7 +48,7 @@ final class FakeSourceDataPublisher implements SourceDataPublisherInterface
     {
         $this->calls++;
 
-        if (null !== $this->throws) {
+        if (null !== $this->throws && ( null === $this->throwsForBatchId || $batchId === $this->throwsForBatchId )) {
             throw $this->throws;
         }
 

--- a/phpunit_tests/Services/SourceData/PublishRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/PublishRunnerTest.php
@@ -6,6 +6,7 @@ namespace LiturgicalCalendar\Tests\Services\SourceData;
 
 use LiturgicalCalendar\Api\Enum\ChangeOperation;
 use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Enum\ChangeReviewStatus;
 use LiturgicalCalendar\Api\Enum\Rite;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\ChangeResource;
@@ -112,7 +113,11 @@ final class PublishRunnerTest extends RepositoryTestCase
     {
         $batchId = $this->approveOne('editor-1');
 
-        $runner = $this->runnerThatThrows(new GitHubApiException(422, 'Update is not a fast forward'));
+        // A 500 rather than the 422 this test used to throw: a 422 is branch CONTENTION, which
+        // the runner deliberately treats as expected and self-healing (see
+        // testALostBranchRaceContinuesTheRunButStaysVisible below). Any other status is an
+        // outage-shaped failure, which is what this test is about.
+        $runner = $this->runnerThatThrows(new GitHubApiException(500, 'Server Error'));
         $result = $runner->runOnce();
         self::assertSame(0, $result->published);
         self::assertTrue($result->stoppedOnFailure, 'the exit code depends on this to signal an operator');
@@ -341,6 +346,236 @@ final class PublishRunnerTest extends RepositoryTestCase
         foreach ($this->repo->getBatch($nextBatch) as $row) {
             self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
             self::assertSame(FakeSourceDataPublisher::COMMIT_SHA, $row['commit_sha']);
+        }
+    }
+
+    /**
+     * The SIBLING of the test above, and the defect the final whole-branch review found: a
+     * zero-row release is not one signal, it is two. `open` means another runner genuinely
+     * published this batch; `none` means another runner's publish FAILED too (or a reclaim
+     * fired) and nothing is published anywhere. The old code read both as "already settled
+     * (published) by another runner", so a GitHub outage — which fails every runner
+     * identically, producing exactly the `none` variant — reported success and re-claimed the
+     * same batch on every iteration of the very loop that exists to stop hammering.
+     *
+     * `$publisher->calls` is the load-bearing assertion: without the fix the same batch is
+     * claimed and attempted once per iteration, ten times in a default-limit run, with
+     * `stoppedOnFailure` false and the cron script exiting 0.
+     */
+    public function testABatchLeftAtNoneByAnotherRunnersFailedPublishIsThisRunsFailure(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test', [$testHandler]);
+        $publisher   = new ClaimVanishedSourceDataPublisher($this->repo);
+        $runner      = new PublishRunner($this->repo, $publisher, logger: $logger);
+
+        $result = $runner->runOnce();
+
+        self::assertTrue(
+            $result->stoppedOnFailure,
+            'a batch nobody published is a genuine failure, however the release row count reads'
+        );
+        self::assertSame(0, $result->published);
+        self::assertSame(1, $publisher->calls, 'the run must stop, not re-claim and re-attempt the same batch');
+        self::assertFalse(
+            $testHandler->hasInfoThatContains('already settled'),
+            'nothing was settled: claiming otherwise is the false success this test pins down'
+        );
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+        }
+    }
+
+    /**
+     * A lost race for a resource's branch is not an outage. Two runners publishing DIFFERENT
+     * batches of the SAME resource both target that resource's one branch, and
+     * `updateRef()`'s hardcoded `force: false` makes the loser fail with a `422` rather than
+     * clobber the winner. The runbook calls that expected and self-healing, so reporting it
+     * identically to a revoked credential — stopping the tick and exiting 1 — pages an
+     * operator for the design working as intended.
+     *
+     * It must not be silenced either: the warning is what distinguishes "two editors are busy
+     * on one resource" from "this branch has been stuck for a week".
+     */
+    public function testALostBranchRaceContinuesTheRunButStaysVisible(): void
+    {
+        $contended = $this->approveOne('editor-1', 'US');
+        $nextBatch = $this->approveOne('editor-2', 'DE');
+
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test', [$testHandler]);
+        $publisher   = new FakeSourceDataPublisher(
+            $this->repo,
+            new GitHubApiException(422, 'Update is not a fast forward'),
+            $contended
+        );
+        $runner      = new PublishRunner($this->repo, $publisher, logger: $logger);
+
+        $result = $runner->runOnce();
+
+        self::assertFalse($result->stoppedOnFailure, 'expected contention must not page an operator');
+        self::assertSame(1, $result->published);
+        self::assertTrue(
+            $testHandler->hasWarningThatContains('lost a race'),
+            'continuing must not mean going quiet'
+        );
+
+        // The contended batch is released, not stranded: the next tick republishes it onto the
+        // branch head the winner pushed.
+        foreach ($this->repo->getBatch($contended) as $row) {
+            self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+        }
+
+        // The rest of the queue drained rather than being abandoned for the tick.
+        foreach ($this->repo->getBatch($nextBatch) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+        }
+    }
+
+    /**
+     * `claimNextPublishableBatch()` was the one unwrapped DB call in `runOnce()`, inside a
+     * method whose own docblock justifies wrapping its two siblings so a DB outage cannot
+     * escape as a raw fatal with no summary line for the cron script to report. Same
+     * treatment, same reason.
+     */
+    public function testAFailureToClaimIsLoggedNotThrown(): void
+    {
+        $this->approveOne('editor-1');
+
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test', [$testHandler]);
+        $runner      = new PublishRunner(
+            new ThrowingClaimRepository(self::$pdo),
+            new FakeSourceDataPublisher($this->repo),
+            logger: $logger
+        );
+
+        $result = $runner->runOnce();
+
+        self::assertSame(0, $result->published);
+        self::assertTrue($result->stoppedOnFailure, 'a DB outage must reach the exit code, not a stack trace');
+        self::assertTrue($testHandler->hasErrorThatContains('Claiming the next publishable'));
+    }
+
+    /**
+     * Head-of-line blocking: the defect the final whole-branch review measured at five ticks,
+     * the same batch attempted every time, two other editors' approved work never attempted
+     * once. Candidates are ordered oldest-first, a failed publish returns its batch to `none`,
+     * and the runner stops on failure — so without a bound the oldest failing batch is
+     * re-claimed first on every tick, forever, and nothing behind it ever publishes.
+     *
+     * The bound is CONSECUTIVE attempts per batch. Once the oldest batch has spent them, it is
+     * parked (not claimed, not deleted, not dead-lettered) and the queue drains past it. The
+     * younger batch publishing on the very next tick is the assertion that matters; without the
+     * fix it publishes on no tick at all, however many run.
+     */
+    public function testABatchThatKeepsFailingIsEventuallySkippedSoTheQueueDrains(): void
+    {
+        $failing = $this->approveOne('editor-1', 'US');
+        $healthy = $this->approveOne('editor-2', 'DE');
+
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test', [$testHandler]);
+        $publisher   = new FakeSourceDataPublisher(
+            $this->repo,
+            new GitHubApiException(500, 'Server Error'),
+            $failing
+        );
+        $runner      = new PublishRunner($this->repo, $publisher, logger: $logger);
+
+        // Every attempt this batch is allowed. Each tick claims the OLDEST batch, which is the
+        // failing one, and stops — so the healthy batch is not reached in any of them.
+        for ($tick = 1; $tick <= SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS; $tick++) {
+            $result = $runner->runOnce();
+            self::assertTrue($result->stoppedOnFailure, "tick {$tick} must still report a genuine failure");
+            self::assertSame(0, $result->published);
+        }
+
+        self::assertSame(
+            SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS,
+            $publisher->calls,
+            'exactly one attempt per tick, on the same batch'
+        );
+        foreach ($this->repo->getBatch($healthy) as $row) {
+            self::assertSame(
+                ChangePublicationStatus::NONE->value,
+                $row['publication_status'],
+                'the younger batch is behind the failing one and has not been reached yet'
+            );
+        }
+
+        // The tick that used to be identical to the five before it.
+        $result = $runner->runOnce();
+
+        self::assertSame(1, $result->published, 'the queue must drain past a batch that has stopped being attempted');
+        self::assertFalse($result->stoppedOnFailure, 'a parked batch is not this run\'s failure');
+        self::assertSame(1, $result->parkedBatches, 'a parked batch must be reported, not silently skipped');
+        self::assertTrue(
+            $testHandler->hasWarningThatContains('exhausted their publish attempts'),
+            'a batch that stopped being attempted must reach the log, not only the health endpoint'
+        );
+
+        foreach ($this->repo->getBatch($healthy) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+        }
+
+        // Parked, not lost: still approved, still `none`, its rows untouched, and claimable
+        // again the moment an operator clears the counter.
+        foreach ($this->repo->getBatch($failing) as $row) {
+            self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+            self::assertSame(ChangeReviewStatus::APPROVED->value, $row['review_status']);
+            self::assertEquals(SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS, $row['publish_attempts']);
+        }
+    }
+
+    /**
+     * A transient failure must NOT park a batch. `recordPublication()` clears the counter, so
+     * the bound only ever fires on genuinely consecutive failures — otherwise a GitHub blip
+     * every few days would eventually park perfectly good work.
+     */
+    public function testASuccessfulPublishClearsEarlierFailedAttempts(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        $failing = $this->runnerThatThrows(new GitHubApiException(500, 'Server Error'));
+        $failing->runOnce();
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertEquals(1, $row['publish_attempts'], 'the failed attempt is counted');
+        }
+
+        $result = $this->runner()->runOnce();
+        self::assertSame(1, $result->published);
+        self::assertSame(0, $result->parkedBatches);
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+            self::assertEquals(0, $row['publish_attempts'], 'a batch that publishes carries no failure residue');
+        }
+    }
+
+    /**
+     * The sibling of the caught-failure path, and the one nothing else covers: a batch that
+     * KILLS the process (an OOM on a large payload) is caught by no `catch` at all. Its claim
+     * is recovered by the grace-period reclaim — so if a reclaim were free, that batch would be
+     * re-claimed and re-crash forever, the same permanent head-of-line block reached through
+     * the one path that runs no PHP. A reclaim therefore spends an attempt too.
+     */
+    public function testAReclaimedStaleClaimAlsoSpendsAnAttempt(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+        $this->repo->claimNextPublishableBatch();
+        $this->backdateUpdatedAt($batchId, minutesAgo: 20);
+
+        $runner = new PublishRunner($this->repo, new FakeSourceDataPublisher($this->repo), graceSeconds: 600);
+        $runner->runOnce(0);
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+            self::assertEquals(1, $row['publish_attempts'], 'an abandoned attempt is still an attempt');
         }
     }
 }

--- a/phpunit_tests/Services/SourceData/PublishRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/PublishRunnerTest.php
@@ -578,4 +578,71 @@ final class PublishRunnerTest extends RepositoryTestCase
             self::assertEquals(1, $row['publish_attempts'], 'an abandoned attempt is still an attempt');
         }
     }
+
+    /**
+     * Forgiving a 422 must depend on the release having actually been OBSERVED, not on the
+     * GitHub status alone.
+     *
+     * When `releaseClaimSafely()` returns null the release itself threw — the "same outage
+     * broke both" case it exists for — so the batch is still `queued` and nothing will touch it
+     * until the 1800-second reclaim. Continuing there exits 0 on a database failure purely
+     * because the GitHub error beside it happened to be a 422 (the same DB failure beside a 500
+     * stops the run), and the warning would assert the opposite of what happened: that the
+     * batch "stays claimable" and "the next tick republishes it".
+     */
+    public function testALostBranchRaceWhoseReleaseAlsoFailedIsStillThisRunsFailure(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test', [$testHandler]);
+        $runner      = new PublishRunner(
+            new ThrowingReleaseClaimRepository(self::$pdo),
+            new FakeSourceDataPublisher($this->repo, new GitHubApiException(422, 'Update is not a fast forward')),
+            logger: $logger
+        );
+
+        $result = $runner->runOnce();
+
+        self::assertTrue(
+            $result->stoppedOnFailure,
+            'whether a database outage trips the alarm must not depend on which GitHub status accompanied it'
+        );
+        self::assertSame(0, $result->published);
+        self::assertTrue($testHandler->hasErrorThatContains('Releasing the claim'));
+        self::assertFalse(
+            $testHandler->hasWarningThatContains('stays claimable'),
+            'the batch is stranded queued: saying otherwise sends an operator looking in the wrong place'
+        );
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
+        }
+    }
+
+    /**
+     * The sibling of the case above, and the one that would otherwise read an unexplained state
+     * optimistically: a 422 whose batch has vanished entirely. `ClaimReleaseOutcome`'s own rule
+     * is that `BATCH_MISSING` is never treated as settled; the contention branch must honour it
+     * rather than swallowing it because the status was 422.
+     */
+    public function testALostBranchRaceOnAVanishedBatchIsStillThisRunsFailure(): void
+    {
+        $this->approveOne('editor-1');
+
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test', [$testHandler]);
+        $publisher   = new VanishingBatchSourceDataPublisher(
+            self::$pdo,
+            new GitHubApiException(422, 'Update is not a fast forward')
+        );
+        $runner      = new PublishRunner($this->repo, $publisher, logger: $logger);
+
+        $result = $runner->runOnce();
+
+        self::assertTrue($result->stoppedOnFailure, 'an unexplained state is never read optimistically');
+        self::assertSame(0, $result->published);
+        self::assertSame(1, $publisher->calls);
+        self::assertFalse($testHandler->hasWarningThatContains('stays claimable'));
+    }
 }

--- a/phpunit_tests/Services/SourceData/PublishRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/PublishRunnerTest.php
@@ -297,4 +297,50 @@ final class PublishRunnerTest extends RepositoryTestCase
             self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
         }
     }
+
+    /**
+     * The concurrent case a review round caught missing: a runner whose own publish attempt
+     * is merely SLOW, not dead. `RaceLosingSourceDataPublisher` simulates a second runner
+     * recording a successful publication for the SAME batch before this run's own (first)
+     * attempt fails — reproducing the race without needing two real processes. This must not
+     * be treated as this run's failure: `releaseClaim()`'s own `publication_status = 'queued'`
+     * guard (see that method's docblock) makes the release a no-op, and `runOnce()` must read
+     * that as "already settled elsewhere" — continuing to the next batch, not stopping, and
+     * not setting `stoppedOnFailure`. Exit code 1 for a run whose actual work succeeded is
+     * exactly the false-alarm the previous fix round's item 1 existed to prevent; this test
+     * pins down that reaching it via this different path is equally wrong.
+     */
+    public function testABatchSettledByAnotherRunnerIsNotThisRunsFailure(): void
+    {
+        $raceBatch = $this->approveOne('editor-1', 'US');
+        $nextBatch = $this->approveOne('editor-2', 'DE');
+
+        $testHandler = new TestHandler();
+        $logger      = new Logger('test', [$testHandler]);
+        $publisher   = new RaceLosingSourceDataPublisher($this->repo, $raceBatch);
+        $runner      = new PublishRunner($this->repo, $publisher, logger: $logger);
+
+        $result = $runner->runOnce();
+
+        self::assertFalse(
+            $result->stoppedOnFailure,
+            'a batch another runner already published successfully must not read as this run failing'
+        );
+        self::assertSame(1, $result->published, 'only the batch this run itself actually published counts');
+        self::assertTrue($testHandler->hasInfoThatContains('already settled'));
+
+        // The race batch keeps the OTHER runner's real commit/PR — proof releaseClaim() left
+        // it alone rather than reverting it to `none`.
+        foreach ($this->repo->getBatch($raceBatch) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+            self::assertSame(RaceLosingSourceDataPublisher::OTHER_RUNNER_COMMIT_SHA, $row['commit_sha']);
+            self::assertEquals(RaceLosingSourceDataPublisher::OTHER_RUNNER_PR_NUMBER, $row['pr_number']);
+        }
+
+        // The loop continued past the race batch and published the next one normally.
+        foreach ($this->repo->getBatch($nextBatch) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+            self::assertSame(FakeSourceDataPublisher::COMMIT_SHA, $row['commit_sha']);
+        }
+    }
 }

--- a/phpunit_tests/Services/SourceData/PublishRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/PublishRunnerTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
+use LiturgicalCalendar\Api\Enum\Rite;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\ChangeResource;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
+use LiturgicalCalendar\Api\Services\SourceData\PublishRunner;
+use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Exercises `PublishRunner`'s orchestration — claim, publish, release-and-stop-on-failure —
+ * against a real Postgres-backed {@see SourceDataChangeRequestRepository} (a skipping
+ * repository test would prove nothing about the claim/release invariant this suite exists
+ * to pin down) and a lightweight {@see FakeSourceDataPublisher} standing in for the real,
+ * `final` {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher} — see
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherInterface} for why a
+ * fake is used here rather than a mocked Guzzle stack. No network, no credentials.
+ */
+#[CoversClass(PublishRunner::class)]
+final class PublishRunnerTest extends RepositoryTestCase
+{
+    private SourceDataChangeRequestRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repo = new SourceDataChangeRequestRepository(self::$pdo);
+    }
+
+    // -- Fixtures -----------------------------------------------------------------------------
+
+    private function approveOne(string $sub, string $nation = 'US'): string
+    {
+        $submission = $this->repo->submitBatch(
+            ChangeResource::nationalCalendar(Rite::ROMAN, $nation),
+            [
+                [
+                    'path'      => "jsondata/sourcedata/rite/roman/calendars/nations/{$nation}/{$nation}.json",
+                    'operation' => ChangeOperation::CREATE,
+                    'content'   => '{"litcal":[]}',
+                ],
+            ],
+            $sub,
+            'Editor',
+            $sub . '@example.test',
+            true
+        );
+        $batchId    = $submission['batch_id'];
+
+        $this->repo->approveBatch($batchId, 'reviewer-1');
+
+        return $batchId;
+    }
+
+    private function runner(?FakeSourceDataPublisher $publisher = null): PublishRunner
+    {
+        return new PublishRunner($this->repo, $publisher ?? new FakeSourceDataPublisher($this->repo));
+    }
+
+    private function runnerThatThrows(\Throwable $exception): PublishRunner
+    {
+        return $this->runner(new FakeSourceDataPublisher($this->repo, $exception));
+    }
+
+    // -- Tests --------------------------------------------------------------------------------
+
+    public function testASuccessfulPublishRecordsTheBranchCommitAndPr(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        self::assertSame(1, $this->runner()->runOnce());
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+            self::assertNotNull($row['commit_sha']);
+            self::assertSame(FakeSourceDataPublisher::PR_NUMBER, $row['pr_number']);
+        }
+    }
+
+    public function testAFailedPublishReleasesTheClaimSoItIsRetried(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        $runner = $this->runnerThatThrows(new GitHubApiException(422, 'Update is not a fast forward'));
+        self::assertSame(0, $runner->runOnce());
+
+        // Back to `none`, not stranded in `queued`: a batch nobody will ever pick up again is
+        // worse than one that retries, because it is invisible to the operator and to the
+        // editor alike.
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+        }
+    }
+
+    /**
+     * The brief is explicit that this must hold for ANY `\Throwable`, not only the expected
+     * `GitHubApiException` — a `TypeError` or an out-of-memory condition inside the publisher
+     * must not leave a batch stranded in `queued` either.
+     */
+    public function testANonGitHubThrowableAlsoReleasesTheClaim(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        $runner = $this->runnerThatThrows(new \TypeError('unexpected null'));
+        self::assertSame(0, $runner->runOnce());
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+        }
+    }
+
+    public function testAnEmptyQueueIsANoOp(): void
+    {
+        self::assertSame(0, $this->runner()->runOnce());
+    }
+
+    public function testALimitOfZeroClaimsNothing(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        self::assertSame(0, $this->runner()->runOnce(0));
+
+        // Never even claimed: still exactly as approveOne() left it, not queued-then-released.
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+        }
+    }
+
+    /**
+     * On failure the loop stops rather than moving on to the next approved batch — hammering
+     * a failing GitHub API with every remaining batch is how rate limits get exhausted. The
+     * fake publisher counts its own invocations so this test can assert the second batch was
+     * never even attempted, not merely that it also ended up back at `none` (which claim-then-
+     * release would produce too, and so would not distinguish the two).
+     */
+    public function testAFailureStopsTheLoopRatherThanTryingTheNextBatch(): void
+    {
+        $this->approveOne('editor-1', 'US');
+        $this->approveOne('editor-2', 'DE');
+
+        $publisher = new FakeSourceDataPublisher($this->repo, new GitHubApiException(500, 'boom'));
+        $runner    = $this->runner($publisher);
+
+        self::assertSame(0, $runner->runOnce());
+        self::assertSame(1, $publisher->calls, 'the second approved batch must never be attempted after the first failure');
+    }
+
+    public function testRunOnceStopsAtTheGivenLimit(): void
+    {
+        $this->approveOne('editor-1', 'US');
+        $this->approveOne('editor-2', 'DE');
+        $this->approveOne('editor-3', 'FR');
+
+        self::assertSame(2, $this->runner()->runOnce(2));
+    }
+}

--- a/phpunit_tests/Services/SourceData/PublishRunnerTest.php
+++ b/phpunit_tests/Services/SourceData/PublishRunnerTest.php
@@ -12,14 +12,17 @@ use LiturgicalCalendar\Api\Services\ChangeResource;
 use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
 use LiturgicalCalendar\Api\Services\SourceData\PublishRunner;
 use LiturgicalCalendar\Tests\Repositories\RepositoryTestCase;
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 /**
- * Exercises `PublishRunner`'s orchestration — claim, publish, release-and-stop-on-failure —
- * against a real Postgres-backed {@see SourceDataChangeRequestRepository} (a skipping
- * repository test would prove nothing about the claim/release invariant this suite exists
- * to pin down) and a lightweight {@see FakeSourceDataPublisher} standing in for the real,
- * `final` {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher} — see
+ * Exercises `PublishRunner`'s orchestration — reclaim-stale-claims, claim, publish,
+ * release-and-stop-on-failure — against a real Postgres-backed
+ * {@see SourceDataChangeRequestRepository} (a skipping repository test would prove nothing
+ * about the claim/release invariant this suite exists to pin down) and a lightweight
+ * {@see FakeSourceDataPublisher} standing in for the real, `final`
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher} — see
  * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherInterface} for why a
  * fake is used here rather than a mocked Guzzle stack. No network, no credentials.
  */
@@ -69,13 +72,34 @@ final class PublishRunnerTest extends RepositoryTestCase
         return $this->runner(new FakeSourceDataPublisher($this->repo, $exception));
     }
 
+    /**
+     * Backdates every row of a batch's `updated_at`, simulating a claim left behind by a
+     * process that crashed (SIGKILL / OOM / cron timeout) between claiming and finishing.
+     */
+    private function backdateUpdatedAt(string $batchId, int $minutesAgo): void
+    {
+        // The interval is interpolated (not bound) to match the existing
+        // testOlderApprovedBatchIsClaimedBeforeANewerOne precedent in
+        // SourceDataChangeRequestPublishQueueTest — Postgres' INTERVAL literal syntax does not
+        // take a bound parameter for the unit, and $minutesAgo is caller-controlled test data,
+        // never external input.
+        $stmt = self::$pdo->prepare(
+            "UPDATE sourcedata_change_requests
+                SET updated_at = NOW() - INTERVAL '{$minutesAgo} minutes'
+              WHERE batch_id = :batch_id"
+        );
+        $stmt->execute(['batch_id' => $batchId]);
+    }
+
     // -- Tests --------------------------------------------------------------------------------
 
     public function testASuccessfulPublishRecordsTheBranchCommitAndPr(): void
     {
         $batchId = $this->approveOne('editor-1');
 
-        self::assertSame(1, $this->runner()->runOnce());
+        $result = $this->runner()->runOnce();
+        self::assertSame(1, $result->published);
+        self::assertFalse($result->stoppedOnFailure);
 
         foreach ($this->repo->getBatch($batchId) as $row) {
             self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
@@ -89,7 +113,9 @@ final class PublishRunnerTest extends RepositoryTestCase
         $batchId = $this->approveOne('editor-1');
 
         $runner = $this->runnerThatThrows(new GitHubApiException(422, 'Update is not a fast forward'));
-        self::assertSame(0, $runner->runOnce());
+        $result = $runner->runOnce();
+        self::assertSame(0, $result->published);
+        self::assertTrue($result->stoppedOnFailure, 'the exit code depends on this to signal an operator');
 
         // Back to `none`, not stranded in `queued`: a batch nobody will ever pick up again is
         // worse than one that retries, because it is invisible to the operator and to the
@@ -109,23 +135,61 @@ final class PublishRunnerTest extends RepositoryTestCase
         $batchId = $this->approveOne('editor-1');
 
         $runner = $this->runnerThatThrows(new \TypeError('unexpected null'));
-        self::assertSame(0, $runner->runOnce());
+        $result = $runner->runOnce();
+        self::assertSame(0, $result->published);
+        self::assertTrue($result->stoppedOnFailure);
 
         foreach ($this->repo->getBatch($batchId) as $row) {
             self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
         }
     }
 
+    /**
+     * `releaseClaim()` itself is wrapped in `runOnce()`'s failure path: if the same outage
+     * that failed the publish also breaks the release call, that must be logged, not escape
+     * as a raw fatal — an operator greps logs, not stack traces. It still cannot un-strand
+     * the batch (that is what the grace-period reclaim is for), so the batch is asserted to
+     * remain `queued` here rather than `none`.
+     */
+    public function testAFailureToReleaseTheClaimIsLoggedNotThrown(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+
+        $throwingRepo = new ThrowingReleaseClaimRepository(self::$pdo);
+        $publisher    = new FakeSourceDataPublisher($this->repo, new GitHubApiException(500, 'boom'));
+        $testHandler  = new TestHandler();
+        $logger       = new Logger('test', [$testHandler]);
+
+        $runner = new PublishRunner($throwingRepo, $publisher, logger: $logger);
+
+        $result = $runner->runOnce();
+        self::assertSame(0, $result->published);
+        self::assertTrue($result->stoppedOnFailure);
+
+        self::assertTrue($testHandler->hasErrorThatContains('Publishing source-data change request batch failed'));
+        self::assertTrue($testHandler->hasErrorThatContains('Releasing the claim'));
+
+        // Could not be released — the batch is exactly as stuck as a real double-outage would
+        // leave it. The grace-period reclaim (tested separately) is what eventually recovers it.
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
+        }
+    }
+
     public function testAnEmptyQueueIsANoOp(): void
     {
-        self::assertSame(0, $this->runner()->runOnce());
+        $result = $this->runner()->runOnce();
+        self::assertSame(0, $result->published);
+        self::assertFalse($result->stoppedOnFailure);
     }
 
     public function testALimitOfZeroClaimsNothing(): void
     {
         $batchId = $this->approveOne('editor-1');
 
-        self::assertSame(0, $this->runner()->runOnce(0));
+        $result = $this->runner()->runOnce(0);
+        self::assertSame(0, $result->published);
+        self::assertFalse($result->stoppedOnFailure);
 
         // Never even claimed: still exactly as approveOne() left it, not queued-then-released.
         foreach ($this->repo->getBatch($batchId) as $row) {
@@ -148,7 +212,9 @@ final class PublishRunnerTest extends RepositoryTestCase
         $publisher = new FakeSourceDataPublisher($this->repo, new GitHubApiException(500, 'boom'));
         $runner    = $this->runner($publisher);
 
-        self::assertSame(0, $runner->runOnce());
+        $result = $runner->runOnce();
+        self::assertSame(0, $result->published);
+        self::assertTrue($result->stoppedOnFailure);
         self::assertSame(1, $publisher->calls, 'the second approved batch must never be attempted after the first failure');
     }
 
@@ -158,6 +224,77 @@ final class PublishRunnerTest extends RepositoryTestCase
         $this->approveOne('editor-2', 'DE');
         $this->approveOne('editor-3', 'FR');
 
-        self::assertSame(2, $this->runner()->runOnce(2));
+        $result = $this->runner()->runOnce(2);
+        self::assertSame(2, $result->published);
+        self::assertFalse($result->stoppedOnFailure);
+    }
+
+    /**
+     * The stale-claim reclaim this test exercises is the fix for a plan gap the review
+     * surfaced: without it, a crash (SIGKILL / OOM / cron timeout) between
+     * `claimNextPublishableBatch()` and the publish finishing leaves a batch `queued`
+     * forever, with nothing left running to release it. Backdating `updated_at` past the
+     * grace period reproduces exactly that "left behind by a dead process" state.
+     */
+    public function testAStaleQueuedBatchBecomesClaimableAgainAfterTheGracePeriod(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+        $this->repo->claimNextPublishableBatch();
+        $this->backdateUpdatedAt($batchId, minutesAgo: 20);
+
+        $runner = new PublishRunner($this->repo, new FakeSourceDataPublisher($this->repo), graceSeconds: 600);
+
+        // limit: 0 isolates the reclaim from any subsequent claim — this run only reclaims.
+        $result = $runner->runOnce(0);
+        self::assertSame(0, $result->published);
+        self::assertFalse($result->stoppedOnFailure, 'a reclaim is ordinary recovery, not a failure');
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::NONE->value, $row['publication_status']);
+        }
+
+        // "Becomes claimable again", not merely "back to none" as a status side effect.
+        self::assertSame($batchId, $this->repo->claimNextPublishableBatch());
+    }
+
+    /**
+     * A batch still well within the grace period is presumably being actively published by a
+     * live process — reclaiming it unconditionally would risk routine double-publishes
+     * instead of the rare, crash-only case this mechanism exists for.
+     */
+    public function testAQueuedBatchWithinTheGracePeriodIsNotReclaimed(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+        $this->repo->claimNextPublishableBatch();
+
+        $runner = new PublishRunner($this->repo, new FakeSourceDataPublisher($this->repo), graceSeconds: 600);
+        $runner->runOnce(0);
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::QUEUED->value, $row['publication_status']);
+        }
+    }
+
+    /**
+     * A stale reclaim followed immediately by a successful publish of that same batch, in one
+     * run — proving the reclaimed batch is not just "back to none" in isolation but genuinely
+     * flows through the rest of the loop, and that recovering it does not itself count as
+     * the kind of failure that should make the cron script exit non-zero.
+     */
+    public function testAReclaimedBatchIsPublishedInTheSameRun(): void
+    {
+        $batchId = $this->approveOne('editor-1');
+        $this->repo->claimNextPublishableBatch();
+        $this->backdateUpdatedAt($batchId, minutesAgo: 20);
+
+        $runner = new PublishRunner($this->repo, new FakeSourceDataPublisher($this->repo), graceSeconds: 600);
+
+        $result = $runner->runOnce();
+        self::assertSame(1, $result->published);
+        self::assertFalse($result->stoppedOnFailure);
+
+        foreach ($this->repo->getBatch($batchId) as $row) {
+            self::assertSame(ChangePublicationStatus::OPEN->value, $row['publication_status']);
+        }
     }
 }

--- a/phpunit_tests/Services/SourceData/PublishSourceDataScriptTest.php
+++ b/phpunit_tests/Services/SourceData/PublishSourceDataScriptTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LiturgicalCalendar\Tests\Services\SourceData;
 
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -31,9 +32,11 @@ use PHPUnit\Framework\TestCase;
 final class PublishSourceDataScriptTest extends TestCase
 {
     /**
+     * @param array<string, string> $githubEnv Overrides for the GITHUB_* variables.
+     *
      * @return array{stdout: string, stderr: string, exitCode: int}
      */
-    private function runScript(): array
+    private function runScript(array $githubEnv = []): array
     {
         $script = dirname(__DIR__, 3) . '/scripts/publish-sourcedata.php';
         self::assertFileExists($script);
@@ -42,14 +45,17 @@ final class PublishSourceDataScriptTest extends TestCase
         // variable already present in the environment wins over whatever a developer's local
         // .env* files say. This is what guarantees the run stops at "not configured" instead
         // of reaching for a real GitHub App on someone's workstation.
-        $env = [
-            'PATH'                        => getenv('PATH') === false ? '/usr/bin:/bin' : getenv('PATH'),
-            'HOME'                        => getenv('HOME') === false ? sys_get_temp_dir() : getenv('HOME'),
-            'GITHUB_APP_ID'               => '',
-            'GITHUB_APP_INSTALLATION_ID'  => '',
-            'GITHUB_APP_PRIVATE_KEY_PATH' => '',
-            'GITHUB_REPOSITORY'           => '',
-        ];
+        $env = array_merge(
+            [
+                'PATH'                        => getenv('PATH') === false ? '/usr/bin:/bin' : getenv('PATH'),
+                'HOME'                        => getenv('HOME') === false ? sys_get_temp_dir() : getenv('HOME'),
+                'GITHUB_APP_ID'               => '',
+                'GITHUB_APP_INSTALLATION_ID'  => '',
+                'GITHUB_APP_PRIVATE_KEY_PATH' => '',
+                'GITHUB_REPOSITORY'           => '',
+            ],
+            $githubEnv
+        );
 
         $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
         $process     = proc_open([PHP_BINARY, $script, '1'], $descriptors, $pipes, null, $env);
@@ -90,5 +96,56 @@ final class PublishSourceDataScriptTest extends TestCase
         // which is precisely why this runs out of process.
         self::assertStringNotContainsString('Uncaught', $result['stderr']);
         self::assertStringNotContainsString('Cannot process either request or response', $result['stderr']);
+    }
+
+    /**
+     * A GITHUB_REPOSITORY that is SET but malformed — the failure mode a value that is merely
+     * absent does not reach.
+     *
+     * `SourceDataPublisher::fromEnv()` throws `InvalidArgumentException` for anything that is
+     * not one `owner/repo` pair. That extends `LogicException`, not `RuntimeException`, so a
+     * `catch (\RuntimeException)` around the construction — which is what this script had, with
+     * a comment saying it covered exactly this case — missed it entirely: uncaught fatal, exit
+     * 255 (a code this script's own table does not list), a stack trace on a cron job's stderr,
+     * and no log line past "run starting". Meanwhile `isConfigured()` tested non-emptiness
+     * alone, so `/health` reported the publisher CONFIGURED. Exit code, log and health check all
+     * said healthy while nothing could ever publish.
+     *
+     * Each of these is one paste or one keystroke away for an operator.
+     *
+     * @param string $repository A plausible mistyping of `owner/repo`.
+     */
+    #[DataProvider('malformedRepositoryProvider')]
+    public function testAMalformedRepositoryIsReportedRatherThanFatal(string $repository): void
+    {
+        $result = $this->runScript([
+            // Enough App credential to get PAST GitHubAppAuth::fromEnv() (which validates
+            // presence, not the key file) so the run reaches the repository split. No network
+            // call happens: fromEnv() throws while wiring, before any client is used.
+            'GITHUB_APP_ID'               => '12345',
+            'GITHUB_APP_INSTALLATION_ID'  => '67890',
+            'GITHUB_APP_PRIVATE_KEY_PATH' => '/nonexistent/github-app.pem',
+            'GITHUB_REPOSITORY'           => $repository,
+        ]);
+
+        self::assertSame(
+            1,
+            $result['exitCode'],
+            "expected a reported error, not a fatal, got:\nSTDOUT: {$result['stdout']}\nSTDERR: {$result['stderr']}"
+        );
+        self::assertStringContainsString('GITHUB_REPOSITORY must be in the form "owner/repo"', $result['stderr']);
+        self::assertStringNotContainsString('Uncaught', $result['stderr']);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function malformedRepositoryProvider(): array
+    {
+        return [
+            'pasted repository URL' => ['https://github.com/Liturgical-Calendar/LiturgicalCalendarAPI'],
+            'trailing slash'        => ['Liturgical-Calendar/LiturgicalCalendarAPI/'],
+            'no owner'              => ['LiturgicalCalendarAPI'],
+        ];
     }
 }

--- a/phpunit_tests/Services/SourceData/PublishSourceDataScriptTest.php
+++ b/phpunit_tests/Services/SourceData/PublishSourceDataScriptTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Runs `scripts/publish-sourcedata.php` as a real process.
+ *
+ * Nothing else does, and that is how a fatal survived every one of this feature's unit tests:
+ * they inject a `Monolog\Logger` built by hand with a `TestHandler` and no processors, while
+ * the script asks `LoggerFactory` for one — which by default attaches
+ * {@see \LiturgicalCalendar\Api\Http\Logs\RequestResponseProcessor}, a processor that THROWS
+ * for any record whose context is not a request or a response. `PublishRunner` logs batch ids
+ * and exception classes, so with that default every log call it makes would throw — including
+ * the ones inside its catch blocks, before `releaseClaim()` could run, stranding the batch and
+ * killing the process with an uncaught `RuntimeException`. The class under test was perfectly
+ * correct; the wiring around it was not.
+ *
+ * A subprocess is the only way to assert that, since a fatal is not catchable in-process. The
+ * run is deliberately given no GitHub App, so it exercises the logger and its first record and
+ * then stops at a reported misconfiguration, before any network call — this test never touches
+ * GitHub, whatever a developer happens to have in their own `.env` files. It needs no database
+ * of its own for the same reason: whichever of the two configuration errors the host reaches
+ * first, the logging happened before it.
+ */
+#[CoversNothing]
+final class PublishSourceDataScriptTest extends TestCase
+{
+    /**
+     * @return array{stdout: string, stderr: string, exitCode: int}
+     */
+    private function runScript(): array
+    {
+        $script = dirname(__DIR__, 3) . '/scripts/publish-sourcedata.php';
+        self::assertFileExists($script);
+
+        // Empty strings, not absent keys: the script's Dotenv loader is IMMUTABLE, so a
+        // variable already present in the environment wins over whatever a developer's local
+        // .env* files say. This is what guarantees the run stops at "not configured" instead
+        // of reaching for a real GitHub App on someone's workstation.
+        $env = [
+            'PATH'                        => getenv('PATH') === false ? '/usr/bin:/bin' : getenv('PATH'),
+            'HOME'                        => getenv('HOME') === false ? sys_get_temp_dir() : getenv('HOME'),
+            'GITHUB_APP_ID'               => '',
+            'GITHUB_APP_INSTALLATION_ID'  => '',
+            'GITHUB_APP_PRIVATE_KEY_PATH' => '',
+            'GITHUB_REPOSITORY'           => '',
+        ];
+
+        $descriptors = [1 => ['pipe', 'w'], 2 => ['pipe', 'w']];
+        $process     = proc_open([PHP_BINARY, $script, '1'], $descriptors, $pipes, null, $env);
+        self::assertIsResource($process, 'could not start the publish script');
+
+        $stdout = (string) stream_get_contents($pipes[1]);
+        $stderr = (string) stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        return ['stdout' => $stdout, 'stderr' => $stderr, 'exitCode' => proc_close($process)];
+    }
+
+    public function testTheScriptRunsAndReportsMisconfigurationInsteadOfCrashing(): void
+    {
+        $result = $this->runScript();
+
+        self::assertSame(
+            1,
+            $result['exitCode'],
+            "expected a reported error, got:\nSTDOUT: {$result['stdout']}\nSTDERR: {$result['stderr']}"
+        );
+
+        // Both are legitimate stopping points for a run with no GitHub App, and which one is
+        // reached depends on where THIS host keeps its database credentials — the script reads
+        // .env* files itself, and its Dotenv loader is immutable, so an exported DB_HOST that
+        // is not also in a file does not reach it. Either message proves the same thing this
+        // test is for: the script reported its problem instead of dying on it.
+        self::assertMatchesRegularExpression(
+            '/GitHub App is not configured|database unavailable/',
+            $result['stderr'],
+            'the script must name what stopped it'
+        );
+
+        // The signature of the logger defect: the script got far enough to write its first log
+        // record (which happens before either of those errors can be reported), and that record
+        // did not blow up. A regression here is a PHP fatal, exit 255, not a failed assertion —
+        // which is precisely why this runs out of process.
+        self::assertStringNotContainsString('Uncaught', $result['stderr']);
+        self::assertStringNotContainsString('Cannot process either request or response', $result['stderr']);
+    }
+}

--- a/phpunit_tests/Services/SourceData/RaceLosingSourceDataPublisher.php
+++ b/phpunit_tests/Services/SourceData/RaceLosingSourceDataPublisher.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
+use LiturgicalCalendar\Api\Services\SourceData\PublishResult;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherInterface;
+
+/**
+ * Simulates the concurrent race a phase-2 review round caught: for one designated batch id,
+ * `publish()` first records a publication on the repository — standing in for a SECOND runner
+ * successfully finishing that same batch, exactly as {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::reclaimStaleClaims()}
+ * would let happen to a merely SLOW (not dead) first runner — and THEN throws, standing in for
+ * that first runner's own, now-doomed GitHub call (a non-fast-forward `updateRef()`, since the
+ * branch moved under it) finally returning.
+ *
+ * Every other batch id is published normally, mirroring {@see FakeSourceDataPublisher}'s
+ * successful path, so a single test can drive one race batch alongside ordinary ones.
+ */
+final class RaceLosingSourceDataPublisher implements SourceDataPublisherInterface
+{
+    /** What the SECOND runner recorded before the FIRST runner's own call fails. */
+    public const OTHER_RUNNER_BRANCH = 'litcal-data/national_calendar/roman/US';
+
+    public const OTHER_RUNNER_COMMIT_SHA = 'other-runner-sha';
+
+    public const OTHER_RUNNER_PR_NUMBER = 99;
+
+    public const OTHER_RUNNER_BASE_SHA = 'other-runner-base-sha';
+
+    public function __construct(
+        private readonly SourceDataChangeRequestRepository $repo,
+        private readonly string $raceBatchId
+    ) {
+    }
+
+    public function publish(string $batchId): PublishResult
+    {
+        if ($batchId === $this->raceBatchId) {
+            $this->repo->recordPublication(
+                $batchId,
+                self::OTHER_RUNNER_BRANCH,
+                self::OTHER_RUNNER_COMMIT_SHA,
+                self::OTHER_RUNNER_PR_NUMBER,
+                self::OTHER_RUNNER_BASE_SHA
+            );
+
+            throw new GitHubApiException(422, 'Update is not a fast forward');
+        }
+
+        $this->repo->recordPublication(
+            $batchId,
+            FakeSourceDataPublisher::BRANCH,
+            FakeSourceDataPublisher::COMMIT_SHA,
+            FakeSourceDataPublisher::PR_NUMBER,
+            FakeSourceDataPublisher::BASE_SHA
+        );
+
+        return new PublishResult(
+            FakeSourceDataPublisher::BRANCH,
+            FakeSourceDataPublisher::COMMIT_SHA,
+            FakeSourceDataPublisher::PR_NUMBER,
+            FakeSourceDataPublisher::BASE_SHA
+        );
+    }
+}

--- a/phpunit_tests/Services/SourceData/SourceDataPublisherTest.php
+++ b/phpunit_tests/Services/SourceData/SourceDataPublisherTest.php
@@ -1,0 +1,367 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response as GuzzleResponse;
+use InvalidArgumentException;
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use LiturgicalCalendar\Api\Services\SourceData\PublishablePayload;
+use LiturgicalCalendar\Api\Services\SourceData\PublishResult;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Exercises `SourceDataPublisher` against a real `GitHubGitDataClient` wired to a mocked HTTP
+ * transport (same mock-first approach as {@see \LiturgicalCalendar\Tests\Services\GitHub\GitHubGitDataClientTest})
+ * plus a stubbed `SourceDataChangeRequestRepository`. No network, no credentials, no database.
+ *
+ * The author/committer split and the null-sha deletion are asserted on the encoded HTTP request
+ * bodies actually sent to GitHub, not on `SourceDataPublisher`'s return value — a bug that built
+ * the right `PublishResult` while sending the wrong wire body would otherwise slip through.
+ */
+#[CoversClass(SourceDataPublisher::class)]
+#[CoversClass(PublishablePayload::class)]
+#[CoversClass(PublishResult::class)]
+final class SourceDataPublisherTest extends TestCase
+{
+    private const OWNER = 'Liturgical-Calendar';
+
+    private const REPO = 'LiturgicalCalendarAPI';
+
+    private const BASE_BRANCH = 'development';
+
+    private const BATCH_ID = 'batch-123';
+
+    private const COMMITTER_NAME = 'Litcal Publisher';
+
+    private const COMMITTER_EMAIL = 'publisher-app@example.test';
+
+    private const BRANCH_HEAD_SHA = 'branch-head-sha';
+
+    private const BASE_HEAD_SHA = 'base-head-sha';
+
+    private const BASE_TREE_SHA = 'base-tree-sha';
+
+    private const NEW_TREE_SHA = 'new-tree-sha';
+
+    private const NEW_COMMIT_SHA = 'new-commit-sha';
+
+    private const NEW_PR_NUMBER = 99;
+
+    /** Matches GitHubAppAuth::cacheKey() for installation id '67890'. */
+    private const AUTH_CACHE_KEY = 'github_app_installation_token_67890';
+
+    /** @var list<RequestInterface> */
+    private array $captured = [];
+
+    private bool $createRefWasCalled = false;
+
+    private bool $openPullRequestWasCalled = false;
+
+    /** @var array{0: string, 1: string, 2: string, 3: int|null, 4: string}|null */
+    private ?array $recordedPublication = null;
+
+    // -- Fixtures -----------------------------------------------------------------------------
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function approvedBatch(string $sub, ?string $name, ?string $email, bool $verified): array
+    {
+        return [
+            $this->row($sub, $name, $email, $verified, [
+                'path'      => 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json',
+                'operation' => ChangeOperation::CREATE->value,
+                'content'   => '{"litcal":[]}',
+            ]),
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function approvedDeletionBatch(string $sub): array
+    {
+        return [
+            $this->row($sub, 'Alice', 'alice@example.test', true, [
+                'path'      => 'jsondata/sourcedata/rite/roman/calendars/nations/US/US.json',
+                'operation' => ChangeOperation::DELETE->value,
+                'content'   => null,
+            ]),
+        ];
+    }
+
+    /**
+     * @param array{path: string, operation: string, content: ?string} $file
+     * @return array<string, mixed>
+     */
+    private function row(string $sub, ?string $name, ?string $email, bool $verified, array $file): array
+    {
+        return array_merge(
+            [
+                'id'                          => bin2hex(random_bytes(8)),
+                'batch_id'                    => self::BATCH_ID,
+                'resource_type'               => 'national_calendar',
+                'resource_id'                 => 'roman/US',
+                'submitted_by_sub'            => $sub,
+                'submitted_by_name'           => $name,
+                'submitted_by_email'          => $email,
+                'submitted_by_email_verified' => $verified,
+                'review_status'               => 'approved',
+                'publication_status'          => 'none',
+                'metadata'                    => [],
+                'permissions'                 => [],
+            ],
+            $file
+        );
+    }
+
+    // -- Wiring ---------------------------------------------------------------------------------
+
+    private function auth(): GitHubAppAuth
+    {
+        $cache = new ArrayAdapter();
+        $item  = $cache->getItem(self::AUTH_CACHE_KEY);
+        $item->set('ghs_test_token');
+        $cache->save($item);
+
+        // Empty queue: a fall-through to a real token exchange throws loudly instead of
+        // quietly consuming a response meant for the Git Data call under test.
+        $noHttp = new GuzzleClient(['handler' => HandlerStack::create(new MockHandler([]))]);
+
+        return new GitHubAppAuth('12345', '67890', '/nonexistent/should-not-be-read.pem', $noHttp, $cache);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function publisherFor(array $rows, bool $branchExists = true, ?int $openPr = null): SourceDataPublisher
+    {
+        $this->captured                 = [];
+        $this->createRefWasCalled       = false;
+        $this->openPullRequestWasCalled = false;
+        $this->recordedPublication      = null;
+
+        $handlerStack = HandlerStack::create(new MockHandler($this->responseQueueFor($rows, $branchExists, $openPr)));
+        $handlerStack->push(function (callable $handler): callable {
+            return function (RequestInterface $request, array $options) use ($handler) {
+                $this->captured[] = $request;
+
+                $path = $request->getUri()->getPath();
+                if ('POST' === $request->getMethod() && str_ends_with($path, '/git/refs')) {
+                    $this->createRefWasCalled = true;
+                }
+                if ('POST' === $request->getMethod() && str_ends_with($path, '/pulls')) {
+                    $this->openPullRequestWasCalled = true;
+                }
+
+                return $handler($request, $options);
+            };
+        });
+        $guzzle = new GuzzleClient(['handler' => $handlerStack]);
+        $client = new GitHubGitDataClient(self::OWNER, self::REPO, $this->auth(), $guzzle);
+
+        $repository = $this->createMock(SourceDataChangeRequestRepository::class);
+        $repository->method('getBatch')->with(self::BATCH_ID)->willReturn($rows);
+        $repository->method('recordPublication')->willReturnCallback(
+            function (string $batchId, string $branch, string $commitSha, ?int $prNumber, string $baseSha) use ($rows): int {
+                $this->recordedPublication = [$batchId, $branch, $commitSha, $prNumber, $baseSha];
+
+                return count($rows);
+            }
+        );
+
+        return new SourceDataPublisher($repository, $client, self::BASE_BRANCH, self::COMMITTER_NAME, self::COMMITTER_EMAIL);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @return list<GuzzleResponse>
+     */
+    private function responseQueueFor(array $rows, bool $branchExists, ?int $openPr): array
+    {
+        $responses = [];
+
+        if ($branchExists) {
+            $responses[] = new GuzzleResponse(200, [], json_encode(['object' => ['sha' => self::BRANCH_HEAD_SHA]]));
+        } else {
+            $responses[] = new GuzzleResponse(404, [], json_encode(['message' => 'Not Found']));
+            $responses[] = new GuzzleResponse(200, [], json_encode(['object' => ['sha' => self::BASE_HEAD_SHA]]));
+            $responses[] = new GuzzleResponse(201, [], '{}');
+        }
+
+        // getCommitTreeSha() on the branch head (whether pre-existing or just created).
+        $responses[] = new GuzzleResponse(
+            200,
+            [],
+            json_encode(['sha' => 'unused-commit-sha', 'tree' => ['sha' => self::BASE_TREE_SHA]])
+        );
+
+        $nonDeleteCount = count(array_filter(
+            $rows,
+            static fn (array $row): bool => ChangeOperation::DELETE->value !== $row['operation']
+        ));
+        for ($i = 0; $i < $nonDeleteCount; $i++) {
+            $responses[] = new GuzzleResponse(201, [], json_encode(['sha' => 'blob-sha-' . $i]));
+        }
+
+        $responses[] = new GuzzleResponse(201, [], json_encode(['sha' => self::NEW_TREE_SHA]));
+        $responses[] = new GuzzleResponse(201, [], json_encode(['sha' => self::NEW_COMMIT_SHA]));
+        $responses[] = new GuzzleResponse(200, [], '{}'); // updateRef
+
+        if (null !== $openPr) {
+            $responses[] = new GuzzleResponse(200, [], json_encode([['number' => $openPr]]));
+        } else {
+            $responses[] = new GuzzleResponse(200, [], '[]');
+            $responses[] = new GuzzleResponse(201, [], json_encode(['number' => self::NEW_PR_NUMBER]));
+        }
+
+        return $responses;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function capturedCommitPayload(): array
+    {
+        foreach ($this->captured as $request) {
+            if ('POST' === $request->getMethod() && str_ends_with($request->getUri()->getPath(), '/git/commits')) {
+                /** @var array<string, mixed> $decoded */
+                $decoded = json_decode((string) $request->getBody(), true);
+
+                return $decoded;
+            }
+        }
+
+        self::fail('createCommit() was never called');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function capturedTreePayload(): array
+    {
+        foreach ($this->captured as $request) {
+            if ('POST' === $request->getMethod() && str_ends_with($request->getUri()->getPath(), '/git/trees')) {
+                /** @var array<string, mixed> $decoded */
+                $decoded = json_decode((string) $request->getBody(), true);
+
+                return $decoded;
+            }
+        }
+
+        self::fail('createTree() was never called');
+    }
+
+    // -- Tests ------------------------------------------------------------------------------------
+
+    public function testItCommitsWithTheEditorAsAuthorAndTheAppAsCommitter(): void
+    {
+        $publisher = $this->publisherFor($this->approvedBatch('editor-1', 'Alice', 'alice@example.test', true));
+
+        $result = $publisher->publish(self::BATCH_ID);
+
+        $commit = $this->capturedCommitPayload();
+        self::assertSame('Alice', $commit['author']['name']);
+        self::assertSame('alice@example.test', $commit['author']['email']);
+        self::assertNotSame('alice@example.test', $commit['committer']['email'], 'the App is the committer');
+        self::assertSame(self::COMMITTER_EMAIL, $commit['committer']['email']);
+        self::assertSame('litcal-data/national_calendar/roman/US', $result->branch);
+        self::assertSame(self::NEW_COMMIT_SHA, $result->commitSha);
+        self::assertSame(self::NEW_PR_NUMBER, $result->prNumber);
+        self::assertSame(self::BRANCH_HEAD_SHA, $result->baseSha);
+
+        self::assertNotNull($this->recordedPublication, 'the batch must be recorded as published');
+        self::assertSame(
+            [self::BATCH_ID, 'litcal-data/national_calendar/roman/US', self::NEW_COMMIT_SHA, self::NEW_PR_NUMBER, self::BRANCH_HEAD_SHA],
+            $this->recordedPublication
+        );
+    }
+
+    public function testAnUnverifiedEmailIsNeverUsedAsTheCommitAuthorEmail(): void
+    {
+        $publisher = $this->publisherFor($this->approvedBatch('editor-1', 'Alice', 'alice@example.test', false));
+
+        $publisher->publish(self::BATCH_ID);
+
+        $commit = $this->capturedCommitPayload();
+        self::assertStringContainsString('noreply', $commit['author']['email']);
+    }
+
+    public function testAMissingBranchIsCreatedFromDevelopment(): void
+    {
+        // getRef returns null for the feature branch, then the base branch's head is used to create it.
+        $publisher = $this->publisherFor(
+            $this->approvedBatch('editor-1', 'Alice', 'alice@example.test', true),
+            branchExists: false
+        );
+
+        $result = $publisher->publish(self::BATCH_ID);
+
+        self::assertTrue($this->createRefWasCalled);
+        self::assertSame(self::BASE_HEAD_SHA, $result->baseSha);
+    }
+
+    public function testADeleteOperationBecomesATreeEntryWithANullSha(): void
+    {
+        $publisher = $this->publisherFor($this->approvedDeletionBatch('editor-1'));
+
+        $publisher->publish(self::BATCH_ID);
+
+        $tree = $this->capturedTreePayload();
+        self::assertNull($tree['tree'][0]['sha']);
+        self::assertArrayHasKey('sha', $tree['tree'][0], 'the key must be present and null, not omitted');
+    }
+
+    public function testARollingPullRequestIsNotOpenedTwice(): void
+    {
+        $publisher = $this->publisherFor(
+            $this->approvedBatch('editor-1', 'Alice', 'alice@example.test', true),
+            openPr: 42
+        );
+
+        $result = $publisher->publish(self::BATCH_ID);
+
+        self::assertSame(42, $result->prNumber, 'an existing open PR is reused, not duplicated');
+        self::assertFalse($this->openPullRequestWasCalled);
+    }
+
+    public function testPublishRejectsAnEmptyBatch(): void
+    {
+        $publisher = $this->publisherFor([]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $publisher->publish(self::BATCH_ID);
+    }
+
+    public function testSplitGithubRepositorySeparatesOwnerAndRepo(): void
+    {
+        $split = SourceDataPublisher::splitGithubRepository('Liturgical-Calendar/LiturgicalCalendarAPI');
+
+        self::assertSame('Liturgical-Calendar', $split['owner']);
+        self::assertSame('LiturgicalCalendarAPI', $split['repo']);
+    }
+
+    public function testSplitGithubRepositoryRejectsAValueWithNoSlash(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        SourceDataPublisher::splitGithubRepository('not-a-repository-reference');
+    }
+
+    public function testSplitGithubRepositoryRejectsAValueWithTooManySlashes(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        SourceDataPublisher::splitGithubRepository('too/many/slashes');
+    }
+}

--- a/phpunit_tests/Services/SourceData/ThrowingClaimRepository.php
+++ b/phpunit_tests/Services/SourceData/ThrowingClaimRepository.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+
+/**
+ * A real, Postgres-backed {@see SourceDataChangeRequestRepository} whose
+ * `claimNextPublishableBatch()` always throws — standing in for a database that goes away
+ * mid-run (a connection reset, a failover, a statement timeout).
+ *
+ * Used by {@see PublishRunnerTest::testAFailureToClaimIsLoggedNotThrown()} to prove
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner} wraps the claim call the
+ * same way it wraps its two siblings, `releaseClaim()` and `reclaimStaleClaims()`. It was the
+ * one unwrapped DB call in the loop, so a DB outage there escaped as a raw fatal with no
+ * `published=... stopped_on_failure=...` summary line for the cron script to report — the
+ * exact defect that class's own docblock justifies wrapping the other two against.
+ */
+final class ThrowingClaimRepository extends SourceDataChangeRequestRepository
+{
+    /**
+     * @param list<string> $skipBatchIds
+     */
+    public function claimNextPublishableBatch(array $skipBatchIds = []): ?string
+    {
+        throw new \RuntimeException('simulated outage: claimNextPublishableBatch failed');
+    }
+}

--- a/phpunit_tests/Services/SourceData/ThrowingReleaseClaimRepository.php
+++ b/phpunit_tests/Services/SourceData/ThrowingReleaseClaimRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+
+/**
+ * A real, Postgres-backed {@see SourceDataChangeRequestRepository} whose `releaseClaim()`
+ * always throws — standing in for the same outage that plausibly failed the publish attempt
+ * in the first place also breaking the release call. Every other method delegates to the real
+ * implementation, so fixtures set up through the normal repository remain visible.
+ *
+ * Used by {@see PublishRunnerTest::testAFailureToReleaseTheClaimIsLoggedNotThrown()} to prove
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner} wraps `releaseClaim()`
+ * itself rather than letting a second failure escape as a raw fatal.
+ */
+final class ThrowingReleaseClaimRepository extends SourceDataChangeRequestRepository
+{
+    public function releaseClaim(string $batchId): int
+    {
+        throw new \RuntimeException('simulated outage: releaseClaim failed too');
+    }
+}

--- a/phpunit_tests/Services/SourceData/ThrowingReleaseClaimRepository.php
+++ b/phpunit_tests/Services/SourceData/ThrowingReleaseClaimRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Tests\Services\SourceData;
 
+use LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 
 /**
@@ -18,7 +19,7 @@ use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
  */
 final class ThrowingReleaseClaimRepository extends SourceDataChangeRequestRepository
 {
-    public function releaseClaim(string $batchId): int
+    public function releaseClaim(string $batchId): ClaimReleaseOutcome
     {
         throw new \RuntimeException('simulated outage: releaseClaim failed too');
     }

--- a/phpunit_tests/Services/SourceData/VanishingBatchSourceDataPublisher.php
+++ b/phpunit_tests/Services/SourceData/VanishingBatchSourceDataPublisher.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Tests\Services\SourceData;
+
+use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
+use LiturgicalCalendar\Api\Services\SourceData\PublishResult;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisherInterface;
+use PDO;
+
+/**
+ * Deletes the batch's rows outright and then throws, so the runner's release genuinely
+ * observes {@see \LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome::BATCH_MISSING} against real
+ * Postgres rather than being handed a stubbed return value.
+ *
+ * Nothing in this feature deletes a claimed batch, which is exactly the point: an unexplained
+ * state must be read conservatively wherever it comes from — an out-of-band `DELETE`, a
+ * restore, a future feature — and never optimistically because the accompanying GitHub status
+ * happened to be one the runner otherwise forgives.
+ */
+final class VanishingBatchSourceDataPublisher implements SourceDataPublisherInterface
+{
+    public int $calls = 0;
+
+    public function __construct(
+        private readonly PDO $pdo,
+        private readonly GitHubApiException $throws
+    ) {
+    }
+
+    public function publish(string $batchId): PublishResult
+    {
+        $this->calls++;
+
+        $this->pdo->prepare('DELETE FROM sourcedata_change_requests WHERE batch_id = :batch_id')
+            ->execute(['batch_id' => $batchId]);
+
+        throw $this->throws;
+    }
+}

--- a/phpunit_tests/fixtures/claim-race-worker.php
+++ b/phpunit_tests/fixtures/claim-race-worker.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * Repeatedly calls SourceDataChangeRequestRepository::claimNextPublishableBatch() against a
+ * real Postgres connection until three consecutive calls return null, printing every claimed
+ * batch id to stdout (one per line).
+ *
+ * Run as its own OS process, two at a time, by
+ * {@see \LiturgicalCalendar\Tests\Repositories\SourceDataChangeRequestPublishQueueTest::testTwoRealConcurrentRunnersNeverClaimTheSameBatch()}.
+ *
+ * This has to be a genuinely separate process rather than a second PDO connection driven from
+ * the same PHP script: PHP is single-threaded, so two `claimNextPublishableBatch()` calls made
+ * from one process — even against two different connections — execute strictly one after the
+ * other and never overlap in time. The race this guards against needs real OS-level
+ * concurrency: one runner's SELECT and another runner's COMMIT genuinely interleaved, which
+ * only two independent processes hitting Postgres at once can produce.
+ *
+ * DB_HOST / DB_PORT / DB_NAME / DB_USER / DB_PASSWORD are read from the process environment,
+ * which the parent test populates explicitly via proc_open()'s env argument (rather than this
+ * script re-deriving them from .env* itself) so both workers are guaranteed to target the exact
+ * same database the parent test set up its fixture batches in.
+ */
+
+declare(strict_types=1);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+
+$pdo = new PDO(
+    sprintf(
+        'pgsql:host=%s;port=%s;dbname=%s',
+        (string) getenv('DB_HOST'),
+        (string) ( getenv('DB_PORT') ?: '5432' ),
+        (string) getenv('DB_NAME')
+    ),
+    (string) getenv('DB_USER'),
+    (string) getenv('DB_PASSWORD'),
+    [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]
+);
+
+$repo = new SourceDataChangeRequestRepository($pdo);
+
+$consecutiveMisses = 0;
+while ($consecutiveMisses < 3) {
+    $batchId = $repo->claimNextPublishableBatch();
+    if ($batchId === null) {
+        $consecutiveMisses++;
+        usleep(1000);
+        continue;
+    }
+    $consecutiveMisses = 0;
+    echo $batchId, "\n";
+}

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -4,11 +4,19 @@
 /**
  * Cron entry point for the source-data change-request publisher (phase 2).
  *
- * One-shot: claims up to a limit of approved-and-unpublished batches, publishes each as a
- * commit plus rolling pull request via the GitHub App, and stops early if a publish attempt
- * fails so a stale credential or a GitHub outage cannot hammer the API on every remaining
- * batch in the same run. See {@see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner}
- * for the claim/release contract this relies on.
+ * One-shot: reclaims any batch stranded `queued` past the grace period, then claims up to a
+ * limit of approved-and-unpublished batches and publishes each as a commit plus rolling pull
+ * request via the GitHub App, stopping early if a publish attempt fails so a stale credential
+ * or a GitHub outage cannot hammer the API on every remaining batch in the same run. See
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner} for the claim/release/reclaim
+ * contract this relies on.
+ *
+ * Exit codes:
+ *   0  Every claimed batch published, or the queue was empty. (A reclaimed stale claim is
+ *      ordinary recovery, not a failure, and does not affect this.)
+ *   1  Misconfiguration (bad arguments, GitHub App or GITHUB_REPOSITORY not set), OR a publish
+ *      attempt failed and the run stopped early — approved work remains queued unpublished;
+ *      see the log (publish-sourcedata.log / .json.log) for which batch and why.
  *
  * Usage:
  *   php scripts/publish-sourcedata.php [limit]
@@ -41,8 +49,6 @@ use GuzzleHttp\Client as GuzzleClient;
 use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
-use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
-use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
 use LiturgicalCalendar\Api\Services\SourceData\PublishRunner;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
@@ -62,26 +68,6 @@ Dotenv::createImmutable(
 )->safeLoad();
 
 // ---------------------------------------------------------------------------
-// Guard: the GitHub App credential must be configured. Without it, approved
-// batches accumulate unpublished — silently, since nothing about that state
-// looks like an error to an editor. Fail loudly here instead.
-// ---------------------------------------------------------------------------
-if (!GitHubAppAuth::isConfigured()) {
-    fwrite(
-        STDERR,
-        'Error: GitHub App is not configured. Set GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, '
-            . "and GITHUB_APP_PRIVATE_KEY_PATH.\n"
-    );
-    exit(1);
-}
-
-$githubRepository = trim((string) ( $_ENV['GITHUB_REPOSITORY'] ?? getenv('GITHUB_REPOSITORY') ?: '' ));
-if ($githubRepository === '') {
-    fwrite(STDERR, "Error: GITHUB_REPOSITORY is not configured (expected \"owner/repo\").\n");
-    exit(1);
-}
-
-// ---------------------------------------------------------------------------
 // Argument parsing: optional positional limit, default 10 (PublishRunner's own default).
 // ---------------------------------------------------------------------------
 $limit = 10;
@@ -95,38 +81,46 @@ if (isset($argv[1])) {
 
 // ---------------------------------------------------------------------------
 // Dependency wiring
+//
+// All environment-variable reads (the GitHub App credential, GITHUB_REPOSITORY, and their
+// optional companions) are routed through SourceDataPublisher::fromEnv() /
+// GitHubAppAuth::fromEnv() in src/, not read directly here. phpstan.neon.dist scans
+// `paths: [src]` only, so a script-level `(string) $_ENV[...]` blind cast would be invisible
+// to `composer analyse`; going through src/ keeps this script covered by the same PHPStan
+// level 10 pass as everything else.
 // ---------------------------------------------------------------------------
 $pdo  = Connection::getInstance();
 $repo = new SourceDataChangeRequestRepository($pdo);
-
-$appId          = (string) ( $_ENV['GITHUB_APP_ID'] ?? getenv('GITHUB_APP_ID') );
-$installationId = (string) ( $_ENV['GITHUB_APP_INSTALLATION_ID'] ?? getenv('GITHUB_APP_INSTALLATION_ID') );
-$privateKeyPath = (string) ( $_ENV['GITHUB_APP_PRIVATE_KEY_PATH'] ?? getenv('GITHUB_APP_PRIVATE_KEY_PATH') );
 
 $httpClient = new GuzzleClient();
 // Installation tokens are cached (PSR-6) for 50 minutes against GitHub's one-hour token life —
 // see GitHubAppAuth's own class docblock. A cron-invoked, short-lived CLI process needs that
 // cache to be filesystem-backed, not in-memory, or every single invocation would re-authenticate.
 $tokenCache = new FilesystemAdapter('github_app_tokens', 0, $projectRoot . '/cache');
-$auth       = new GitHubAppAuth($appId, $installationId, $privateKeyPath, $httpClient, $tokenCache);
 
-['owner' => $repoOwner, 'repo' => $repoName] = SourceDataPublisher::splitGithubRepository($githubRepository);
-$gitDataClient                               = new GitHubGitDataClient($repoOwner, $repoName, $auth, $httpClient);
+try {
+    $publisher = SourceDataPublisher::fromEnv($repo, $httpClient, $tokenCache);
+} catch (\RuntimeException $e) {
+    // Unconfigured GitHub App or GITHUB_REPOSITORY: approved batches accumulate unpublished —
+    // silently, since nothing about that state looks like an error to an editor. Fail loudly
+    // here instead.
+    fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
+    exit(1);
+}
 
-$baseBranch     = (string) ( $_ENV['GITHUB_BASE_BRANCH'] ?? getenv('GITHUB_BASE_BRANCH') ?: 'development' );
-$committerName  = (string) ( $_ENV['GITHUB_APP_COMMITTER_NAME'] ?? getenv('GITHUB_APP_COMMITTER_NAME') ?: 'Litcal Publisher' );
-$committerEmail = (string) (
-    $_ENV['GITHUB_APP_COMMITTER_EMAIL'] ?? getenv('GITHUB_APP_COMMITTER_EMAIL')
-    ?: 'litcal-publisher[bot]@users.noreply.github.com'
-);
-
-$publisher = new SourceDataPublisher($repo, $gitDataClient, $baseBranch, $committerName, $committerEmail);
-$logger    = LoggerFactory::create('publish-sourcedata');
-$runner    = new PublishRunner($repo, $publisher, $logger);
+$logger = LoggerFactory::create('publish-sourcedata');
+$runner = new PublishRunner($repo, $publisher, logger: $logger);
 
 // ---------------------------------------------------------------------------
 // Run
 // ---------------------------------------------------------------------------
-$published = $runner->runOnce($limit);
-fwrite(STDOUT, sprintf("publish-sourcedata published=%d\n", $published));
-exit(0);
+$result = $runner->runOnce($limit);
+fwrite(
+    STDOUT,
+    sprintf("publish-sourcedata published=%d stopped_on_failure=%s\n", $result->published, $result->stoppedOnFailure ? 'true' : 'false')
+);
+
+// A stopped-early run means approved work is stuck queued and unpublished with no further
+// retry until the next cron tick — that must be visible in the exit code, not just a log line
+// nothing watches, or a revoked credential silently piles up work indefinitely.
+exit($result->stoppedOnFailure ? 1 : 0);

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -13,10 +13,21 @@
  *
  * Exit codes:
  *   0  Every claimed batch published, or the queue was empty. (A reclaimed stale claim is
- *      ordinary recovery, not a failure, and does not affect this.)
- *   1  Misconfiguration (bad arguments, GitHub App or GITHUB_REPOSITORY not set), OR a publish
- *      attempt failed and the run stopped early — approved work remains queued unpublished;
- *      see the log (publish-sourcedata.log / .json.log) for which batch and why.
+ *      ordinary recovery, not a failure, and does not affect this. So is a batch that lost a
+ *      race for its resource branch — a GitHub 422 — which the next tick republishes.)
+ *   1  Misconfiguration (bad arguments, GitHub App or GITHUB_REPOSITORY not set), a database
+ *      failure, OR a publish attempt failed and the run stopped early. In the last case the
+ *      failed batch is back at `publication_status = 'none'` — NOT `queued`, which is a
+ *      live claim and is exactly what the failure path gives up. Look for approved batches
+ *      with `publication_status = 'none'` and a non-zero `publish_attempts`; see the log
+ *      (publish-sourcedata.log / .json.log) for which batch and why.
+ *
+ * The summary line also reports `parked=N`: approved batches that have exhausted
+ * SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS consecutive attempts and are no
+ * longer being claimed, so the rest of the queue can drain past them. A parked batch produces
+ * NO failure of its own — that is the point of parking it — so a run can exit 0 with work
+ * stuck. Monitor `parked` and GET /health's source_data_publisher block, not the exit code
+ * alone.
  *
  * Usage:
  *   php scripts/publish-sourcedata.php [limit]
@@ -109,10 +120,45 @@ $repo = new SourceDataChangeRequestRepository($pdo);
 // period is 1800 rather than the 600 an earlier draft of this comment assumed. If either the
 // timeout here or the widest batch grows, the grace period must grow with them.
 $httpClient = new GuzzleClient(['connect_timeout' => 10, 'timeout' => 30]);
+
+$logger = LoggerFactory::create('publish-sourcedata');
+// Opens the log handlers NOW, under the ordinary umask, before the restrictive one below.
+// Monolog's RotatingFileHandler creates its file lazily on the first record, so without this
+// the log files would be created mid-run at 0600 and become unreadable to anything that is not
+// the cron user — a side effect of protecting the token cache, on files that are not secrets.
+$logger->info('publish-sourcedata run starting.', ['limit' => $limit]);
+
+// ---------------------------------------------------------------------------
+// Installation-token cache
+//
 // Installation tokens are cached (PSR-6) for 50 minutes against GitHub's one-hour token life —
 // see GitHubAppAuth's own class docblock. A cron-invoked, short-lived CLI process needs that
 // cache to be filesystem-backed, not in-memory, or every single invocation would re-authenticate.
-$tokenCache = new FilesystemAdapter('github_app_tokens', 0, $projectRoot . '/cache');
+//
+// What lands on disk is a BEARER CREDENTIAL carrying `contents: write` and
+// `pull_requests: write` on the repository, valid for up to 50 minutes. The private key it is
+// derived from is handled carefully (a path in the environment, never the key bytes; never
+// logged); the token derived from it must be too, and Symfony's FilesystemAdapter creates its
+// directory and its entries with 0777/0666 masked by the process umask — 0755/0644 under the
+// usual 0022, i.e. readable by every local user.
+//
+// So: a restrictive umask for the whole window in which cache entries are written (the token
+// is fetched lazily, during the run, not here), plus an explicit chmod of the namespace
+// directory, which also repairs a directory an earlier, laxer run created. Either alone would
+// do — 0600 entries are unreadable, and entries of any mode inside a 0700 directory are
+// unreachable — but they fail in different ways (a umask does nothing to what already exists;
+// a directory mode can be widened by a well-meaning `chmod -R`), so both are set.
+// ---------------------------------------------------------------------------
+$previousUmask = umask(0o077);
+$tokenCache    = new FilesystemAdapter('github_app_tokens', 0, $projectRoot . '/cache');
+$tokenCacheDir = $projectRoot . '/cache/github_app_tokens';
+if (is_dir($tokenCacheDir) && !@chmod($tokenCacheDir, 0o700)) {
+    $logger->warning(
+        'Could not restrict permissions on the GitHub App token cache directory; the '
+            . 'installation token it holds may be readable by other local users.',
+        ['directory' => $tokenCacheDir]
+    );
+}
 
 try {
     $publisher = SourceDataPublisher::fromEnv($repo, $httpClient, $tokenCache);
@@ -120,23 +166,53 @@ try {
     // Unconfigured GitHub App or GITHUB_REPOSITORY: approved batches accumulate unpublished —
     // silently, since nothing about that state looks like an error to an editor. Fail loudly
     // here instead.
+    umask($previousUmask);
     fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
     exit(1);
 }
 
-$logger = LoggerFactory::create('publish-sourcedata');
 $runner = new PublishRunner($repo, $publisher, logger: $logger);
 
 // ---------------------------------------------------------------------------
 // Run
+//
+// Wrapped for the same reason PublishRunner wraps every one of its own DB calls: a failure
+// that escapes here is a raw PHP fatal on a cron job's stderr, with no summary line and no
+// structured log entry — an operator would have to find it by grepping stack traces. Nothing
+// inside runOnce() is expected to throw (it catches \Throwable at every fallible call), which
+// is exactly why an exception reaching this point deserves to be reported rather than
+// splashed.
 // ---------------------------------------------------------------------------
-$result = $runner->runOnce($limit);
+try {
+    $result = $runner->runOnce($limit);
+} catch (\Throwable $e) {
+    umask($previousUmask);
+    $logger->error(
+        'publish-sourcedata run failed with an unhandled exception.',
+        ['exception' => $e::class, 'message' => $e->getMessage()]
+    );
+    fwrite(STDERR, 'Error: ' . $e::class . ': ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+umask($previousUmask);
+
 fwrite(
     STDOUT,
-    sprintf("publish-sourcedata published=%d stopped_on_failure=%s\n", $result->published, $result->stoppedOnFailure ? 'true' : 'false')
+    sprintf(
+        "publish-sourcedata published=%d stopped_on_failure=%s parked=%d\n",
+        $result->published,
+        $result->stoppedOnFailure ? 'true' : 'false',
+        $result->parkedBatches
+    )
 );
 
-// A stopped-early run means approved work is stuck queued and unpublished with no further
+// A stopped-early run means approved work is back at `none`, unpublished, with no further
 // retry until the next cron tick — that must be visible in the exit code, not just a log line
 // nothing watches, or a revoked credential silently piles up work indefinitely.
+//
+// `parked` deliberately does NOT affect the exit code: parking is what lets the rest of the
+// queue drain, so a run that publishes everything it can and reports N parked batches has
+// succeeded at its job. That is also why it is on the summary line and in /health — the signal
+// has to exist somewhere, and this is not the channel for it.
 exit($result->stoppedOnFailure ? 1 : 0);

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -1,0 +1,132 @@
+#!/usr/bin/env php
+<?php
+
+/**
+ * Cron entry point for the source-data change-request publisher (phase 2).
+ *
+ * One-shot: claims up to a limit of approved-and-unpublished batches, publishes each as a
+ * commit plus rolling pull request via the GitHub App, and stops early if a publish attempt
+ * fails so a stale credential or a GitHub outage cannot hammer the API on every remaining
+ * batch in the same run. See {@see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner}
+ * for the claim/release contract this relies on.
+ *
+ * Usage:
+ *   php scripts/publish-sourcedata.php [limit]
+ *
+ * `limit` (optional, default 10) caps how many batches this single run will publish.
+ *
+ * Required environment variables (loaded from .env* files if present):
+ *   DB_HOST, DB_NAME, DB_USER, DB_PASSWORD (DB_PORT optional, defaults to 5432)
+ *   GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY_PATH, GITHUB_REPOSITORY
+ *
+ * Optional:
+ *   GITHUB_BASE_BRANCH          (default: development)
+ *   GITHUB_APP_COMMITTER_NAME   (default: Litcal Publisher)
+ *   GITHUB_APP_COMMITTER_EMAIL  (default: litcal-publisher[bot]@users.noreply.github.com)
+ */
+
+declare(strict_types=1);
+
+// Refuse any entry that is not the CLI — see the identical guard in every other scripts/*.php
+// for why this is not redundant with the shebang line above it.
+if (PHP_SAPI !== 'cli') {
+    http_response_code(404);
+    exit(1);
+}
+
+require_once dirname(__DIR__) . '/vendor/autoload.php';
+
+use Dotenv\Dotenv;
+use GuzzleHttp\Client as GuzzleClient;
+use LiturgicalCalendar\Api\Database\Connection;
+use LiturgicalCalendar\Api\Http\Logs\LoggerFactory;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use LiturgicalCalendar\Api\Services\SourceData\PublishRunner;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+
+// ---------------------------------------------------------------------------
+// Bootstrap: load environment from .env* files if present. Same chain as
+// bin/reconcile-outbox, for the same reason — CLI's variables_order may not
+// include "E", so a systemd EnvironmentFile or exported shell vars would not
+// reach $_ENV; Dotenv reading the files directly is what makes configuration
+// reach this script regardless.
+// ---------------------------------------------------------------------------
+$projectRoot = dirname(__DIR__);
+Dotenv::createImmutable(
+    $projectRoot,
+    ['.env', '.env.local', '.env.development', '.env.test', '.env.staging', '.env.production'],
+    false
+)->safeLoad();
+
+// ---------------------------------------------------------------------------
+// Guard: the GitHub App credential must be configured. Without it, approved
+// batches accumulate unpublished — silently, since nothing about that state
+// looks like an error to an editor. Fail loudly here instead.
+// ---------------------------------------------------------------------------
+if (!GitHubAppAuth::isConfigured()) {
+    fwrite(
+        STDERR,
+        'Error: GitHub App is not configured. Set GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, '
+            . "and GITHUB_APP_PRIVATE_KEY_PATH.\n"
+    );
+    exit(1);
+}
+
+$githubRepository = trim((string) ( $_ENV['GITHUB_REPOSITORY'] ?? getenv('GITHUB_REPOSITORY') ?: '' ));
+if ($githubRepository === '') {
+    fwrite(STDERR, "Error: GITHUB_REPOSITORY is not configured (expected \"owner/repo\").\n");
+    exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing: optional positional limit, default 10 (PublishRunner's own default).
+// ---------------------------------------------------------------------------
+$limit = 10;
+if (isset($argv[1])) {
+    if (!ctype_digit($argv[1]) || (int) $argv[1] < 1) {
+        fwrite(STDERR, sprintf("Error: limit must be a positive integer, got \"%s\".\n", $argv[1]));
+        exit(1);
+    }
+    $limit = (int) $argv[1];
+}
+
+// ---------------------------------------------------------------------------
+// Dependency wiring
+// ---------------------------------------------------------------------------
+$pdo  = Connection::getInstance();
+$repo = new SourceDataChangeRequestRepository($pdo);
+
+$appId          = (string) ( $_ENV['GITHUB_APP_ID'] ?? getenv('GITHUB_APP_ID') );
+$installationId = (string) ( $_ENV['GITHUB_APP_INSTALLATION_ID'] ?? getenv('GITHUB_APP_INSTALLATION_ID') );
+$privateKeyPath = (string) ( $_ENV['GITHUB_APP_PRIVATE_KEY_PATH'] ?? getenv('GITHUB_APP_PRIVATE_KEY_PATH') );
+
+$httpClient = new GuzzleClient();
+// Installation tokens are cached (PSR-6) for 50 minutes against GitHub's one-hour token life —
+// see GitHubAppAuth's own class docblock. A cron-invoked, short-lived CLI process needs that
+// cache to be filesystem-backed, not in-memory, or every single invocation would re-authenticate.
+$tokenCache = new FilesystemAdapter('github_app_tokens', 0, $projectRoot . '/cache');
+$auth       = new GitHubAppAuth($appId, $installationId, $privateKeyPath, $httpClient, $tokenCache);
+
+['owner' => $repoOwner, 'repo' => $repoName] = SourceDataPublisher::splitGithubRepository($githubRepository);
+$gitDataClient                               = new GitHubGitDataClient($repoOwner, $repoName, $auth, $httpClient);
+
+$baseBranch     = (string) ( $_ENV['GITHUB_BASE_BRANCH'] ?? getenv('GITHUB_BASE_BRANCH') ?: 'development' );
+$committerName  = (string) ( $_ENV['GITHUB_APP_COMMITTER_NAME'] ?? getenv('GITHUB_APP_COMMITTER_NAME') ?: 'Litcal Publisher' );
+$committerEmail = (string) (
+    $_ENV['GITHUB_APP_COMMITTER_EMAIL'] ?? getenv('GITHUB_APP_COMMITTER_EMAIL')
+    ?: 'litcal-publisher[bot]@users.noreply.github.com'
+);
+
+$publisher = new SourceDataPublisher($repo, $gitDataClient, $baseBranch, $committerName, $committerEmail);
+$logger    = LoggerFactory::create('publish-sourcedata');
+$runner    = new PublishRunner($repo, $publisher, $logger);
+
+// ---------------------------------------------------------------------------
+// Run
+// ---------------------------------------------------------------------------
+$published = $runner->runOnce($limit);
+fwrite(STDOUT, sprintf("publish-sourcedata published=%d\n", $published));
+exit(0);

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -201,10 +201,19 @@ if (is_dir($tokenCacheDir) && !@chmod($tokenCacheDir, 0o700)) {
 
 try {
     $publisher = SourceDataPublisher::fromEnv($repo, $httpClient, $tokenCache);
-} catch (\RuntimeException $e) {
+} catch (\Throwable $e) {
     // Unconfigured GitHub App or GITHUB_REPOSITORY: approved batches accumulate unpublished —
     // silently, since nothing about that state looks like an error to an editor. Fail loudly
     // here instead.
+    //
+    // \Throwable, not \RuntimeException, and this is the difference between an alarm and
+    // silence. fromEnv() also throws InvalidArgumentException — a LogicException, not a
+    // RuntimeException — when GITHUB_REPOSITORY is set but is not an "owner/repo" pair, which
+    // is one pasted repository URL or one trailing slash away for any operator. A narrower
+    // catch let that escape as an uncaught fatal: exit 255 (a code this script's own table does
+    // not list), a stack trace on a cron job's stderr that usually goes nowhere, and not one
+    // log line past "run starting". Same reasoning as the two sibling wraps around this one:
+    // whatever goes wrong, the operator gets a message and an exit code, never a stack trace.
     umask($previousUmask);
     $logger->error('publish-sourcedata is not configured; nothing was published.', ['message' => $e->getMessage()]);
     fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -15,7 +15,8 @@
  *   0  Every claimed batch published, or the queue was empty. (A reclaimed stale claim is
  *      ordinary recovery, not a failure, and does not affect this. So is a batch that lost a
  *      race for its resource branch — a GitHub 422 — which the next tick republishes.)
- *   1  Misconfiguration (bad arguments, GitHub App or GITHUB_REPOSITORY not set), a database
+ *   1  Misconfiguration (bad arguments, GitHub App or GITHUB_REPOSITORY unset OR malformed —
+ *      GITHUB_REPOSITORY must be exactly "owner/repo"), a database
  *      failure, OR a publish attempt failed and the run stopped early. In the last case the
  *      failed batch is back at `publication_status = 'none'` — NOT `queued`, which is a
  *      live claim and is exactly what the failure path gives up. Look for approved batches
@@ -215,7 +216,14 @@ try {
     // log line past "run starting". Same reasoning as the two sibling wraps around this one:
     // whatever goes wrong, the operator gets a message and an exit code, never a stack trace.
     umask($previousUmask);
-    $logger->error('publish-sourcedata is not configured; nothing was published.', ['message' => $e->getMessage()]);
+    // The class goes in the context because this catch is now \Throwable: the reachable
+    // surface today is only the two configuration exceptions, but that is a property of
+    // fromEnv() not doing I/O, not a guarantee. Without it, a future TypeError here would
+    // read as "not configured" and send an operator auditing four correct variables.
+    $logger->error(
+        'publish-sourcedata is not configured; nothing was published.',
+        ['exception' => $e::class, 'message' => $e->getMessage()]
+    );
     fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
     exit(1);
 }

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -95,17 +95,19 @@ $repo = new SourceDataChangeRequestRepository($pdo);
 // Explicit timeouts, not Guzzle's default (no timeout at all — a hung TCP handshake or a
 // GitHub response that never completes would otherwise run indefinitely). This is what keeps
 // PublishRunner's "still running" and "abandoned" distinguishable at all: without a bound
-// here, a single request can silently outlive PublishRunner::DEFAULT_GRACE_SECONDS (600s),
-// making it the common case — not the rare one — that a second cron tick reclaims a batch
-// whose first publish attempt is still genuinely in flight (see PublishRunner's class
-// docblock, "A merely SLOW process is not a dead one"). connect_timeout: 10s is generous for
-// TLS+DNS to api.github.com. timeout: 30s per request is generous for any single Git Data
-// call (getRef/createBlob/createTree/createCommit/updateRef/findOpenPullRequest/
-// openPullRequest); a batch issues one createBlob per changed file plus a handful of fixed
-// calls, and change-request batches are per-resource file sets (a calendar plus its i18n
-// files) — a handful of requests, not dozens — so even a worst-case run of every request
-// hitting its full 30s ceiling stays comfortably under the 600s grace period, leaving real
-// margin rather than a coin-flip.
+// here, a whole publish can silently outlive PublishRunner::DEFAULT_GRACE_SECONDS, making it
+// the common case — not the rare one — that a second cron tick reclaims a batch whose first
+// publish attempt is still genuinely in flight (see PublishRunner's class docblock, "A merely
+// SLOW process is not a dead one"). connect_timeout: 10s is generous for TLS+DNS to
+// api.github.com. timeout: 30s per request is generous for any single Git Data call.
+//
+// The quantity that must stay under the grace period is the WHOLE publish, not one request.
+// A batch issues one createBlob per changed file, serially, then six fixed calls. The widest
+// batch this repository can produce is the decrees corpus — decrees.json plus 14 i18n locales
+// plus 7 lectionary locales — so 22 blob writes plus 6 is 28 requests, or 840s if every one
+// hit its full ceiling. That is dozens of requests, not a handful, and it is why the grace
+// period is 1800 rather than the 600 an earlier draft of this comment assumed. If either the
+// timeout here or the widest batch grows, the grace period must grow with them.
 $httpClient = new GuzzleClient(['connect_timeout' => 10, 'timeout' => 30]);
 // Installation tokens are cached (PSR-6) for 50 minutes against GitHub's one-hour token life —
 // see GitHubAppAuth's own class docblock. A cron-invoked, short-lived CLI process needs that

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -91,6 +91,36 @@ if (isset($argv[1])) {
 }
 
 // ---------------------------------------------------------------------------
+// Logging
+//
+// Set up FIRST, before anything that can fail, so that every failure below has somewhere to
+// go besides stderr — a cron job's stderr is seen only if something is capturing it.
+// ---------------------------------------------------------------------------
+try {
+    // includeProcessors: FALSE — the sixth argument, and it is load-bearing rather than
+    // cosmetic. LoggerFactory's default attaches RequestResponseProcessor, which THROWS a
+    // RuntimeException for any record whose context does not carry type => request|response.
+    // PublishRunner logs batch ids and exception classes, so with the default every single
+    // log call it makes — including the ones inside its catch blocks — would throw from
+    // inside the failure handling, before releaseClaim() ever ran, stranding the batch and
+    // killing the process. Every other non-HTTP caller of this factory passes false for the
+    // same reason; only the HTTP error middleware, which really does log requests and
+    // responses, passes true.
+    $logger = LoggerFactory::create('publish-sourcedata', null, 30, false, true, false);
+} catch (\Throwable $e) {
+    // Nothing to log WITH, so this is the one failure that can only reach stderr. Still not a
+    // raw fatal: an operator gets one line naming the cause instead of a stack trace.
+    fwrite(STDERR, 'Error: could not open the publish-sourcedata log: ' . $e->getMessage() . "\n");
+    exit(1);
+}
+
+// Opens the log handlers NOW, under the ordinary umask, before the restrictive one below.
+// Monolog's RotatingFileHandler creates its file lazily on the first record, so without this
+// the log files would be created mid-run at 0600 and become unreadable to anything that is not
+// the cron user — a side effect of protecting the token cache, on files that are not secrets.
+$logger->info('publish-sourcedata run starting.', ['limit' => $limit]);
+
+// ---------------------------------------------------------------------------
 // Dependency wiring
 //
 // All environment-variable reads (the GitHub App credential, GITHUB_REPOSITORY, and their
@@ -99,9 +129,24 @@ if (isset($argv[1])) {
 // `paths: [src]` only, so a script-level `(string) $_ENV[...]` blind cast would be invisible
 // to `composer analyse`; going through src/ keeps this script covered by the same PHPStan
 // level 10 pass as everything else.
+//
+// The database bootstrap is wrapped for the same reason the run below is, and it is the
+// SIBLING of that one rather than a duplicate of it: PublishRunner catches every DB failure
+// that happens DURING a run, but a database that is already down when the cron job starts
+// fails here instead — earlier than anything PublishRunner can see — and would escape as an
+// uncaught RuntimeException with no log entry and no summary line.
 // ---------------------------------------------------------------------------
-$pdo  = Connection::getInstance();
-$repo = new SourceDataChangeRequestRepository($pdo);
+try {
+    $pdo  = Connection::getInstance();
+    $repo = new SourceDataChangeRequestRepository($pdo);
+} catch (\Throwable $e) {
+    $logger->error(
+        'publish-sourcedata could not reach the database; no batch was claimed.',
+        ['exception' => $e::class, 'message' => $e->getMessage()]
+    );
+    fwrite(STDERR, 'Error: database unavailable: ' . $e->getMessage() . "\n");
+    exit(1);
+}
 
 // Explicit timeouts, not Guzzle's default (no timeout at all — a hung TCP handshake or a
 // GitHub response that never completes would otherwise run indefinitely). This is what keeps
@@ -121,12 +166,6 @@ $repo = new SourceDataChangeRequestRepository($pdo);
 // timeout here or the widest batch grows, the grace period must grow with them.
 $httpClient = new GuzzleClient(['connect_timeout' => 10, 'timeout' => 30]);
 
-$logger = LoggerFactory::create('publish-sourcedata');
-// Opens the log handlers NOW, under the ordinary umask, before the restrictive one below.
-// Monolog's RotatingFileHandler creates its file lazily on the first record, so without this
-// the log files would be created mid-run at 0600 and become unreadable to anything that is not
-// the cron user — a side effect of protecting the token cache, on files that are not secrets.
-$logger->info('publish-sourcedata run starting.', ['limit' => $limit]);
 
 // ---------------------------------------------------------------------------
 // Installation-token cache
@@ -167,6 +206,7 @@ try {
     // silently, since nothing about that state looks like an error to an editor. Fail loudly
     // here instead.
     umask($previousUmask);
+    $logger->error('publish-sourcedata is not configured; nothing was published.', ['message' => $e->getMessage()]);
     fwrite(STDERR, 'Error: ' . $e->getMessage() . "\n");
     exit(1);
 }

--- a/scripts/publish-sourcedata.php
+++ b/scripts/publish-sourcedata.php
@@ -92,7 +92,21 @@ if (isset($argv[1])) {
 $pdo  = Connection::getInstance();
 $repo = new SourceDataChangeRequestRepository($pdo);
 
-$httpClient = new GuzzleClient();
+// Explicit timeouts, not Guzzle's default (no timeout at all — a hung TCP handshake or a
+// GitHub response that never completes would otherwise run indefinitely). This is what keeps
+// PublishRunner's "still running" and "abandoned" distinguishable at all: without a bound
+// here, a single request can silently outlive PublishRunner::DEFAULT_GRACE_SECONDS (600s),
+// making it the common case — not the rare one — that a second cron tick reclaims a batch
+// whose first publish attempt is still genuinely in flight (see PublishRunner's class
+// docblock, "A merely SLOW process is not a dead one"). connect_timeout: 10s is generous for
+// TLS+DNS to api.github.com. timeout: 30s per request is generous for any single Git Data
+// call (getRef/createBlob/createTree/createCommit/updateRef/findOpenPullRequest/
+// openPullRequest); a batch issues one createBlob per changed file plus a handful of fixed
+// calls, and change-request batches are per-resource file sets (a calendar plus its i18n
+// files) — a handful of requests, not dozens — so even a worst-case run of every request
+// hitting its full 30s ceiling stays comfortably under the 600s grace period, leaving real
+// margin rather than a coin-flip.
+$httpClient = new GuzzleClient(['connect_timeout' => 10, 'timeout' => 30]);
 // Installation tokens are cached (PSR-6) for 50 minutes against GitHub's one-hour token life —
 // see GitHubAppAuth's own class docblock. A cron-invoked, short-lived CLI process needs that
 // cache to be filesystem-backed, not in-memory, or every single invocation would re-authenticate.

--- a/src/Enum/ClaimReleaseOutcome.php
+++ b/src/Enum/ClaimReleaseOutcome.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Enum;
+
+/**
+ * What {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::releaseClaim()}
+ * actually observed, as opposed to how many rows it happened to touch.
+ *
+ * This type exists because a row count cannot answer the only question the caller has. A
+ * release is guarded on `publication_status = 'queued'`, so it affects zero rows for
+ * MULTIPLE, semantically opposite reasons:
+ *
+ * - the batch is `open`/`merged`/`closed` — another runner genuinely published it, and this
+ *   runner's failed attempt is a harmless duplicate of finished work;
+ * - the batch is `none` — another runner's publish failed too (a GitHub outage fails every
+ *   runner identically), or {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::reclaimStaleClaims()}
+ *   released it. Nothing is published anywhere, and the failure is real;
+ * - the batch is gone entirely.
+ *
+ * Collapsing those into `0` and reading it as "already published elsewhere" is exactly the
+ * critical defect the final whole-branch review of this feature found: a genuine outage
+ * reported success and defeated the runner's stop-don't-hammer rule. The caller must branch
+ * on the OBSERVED STATE, and this enum is what makes those branches explicit at the call site
+ * instead of inferred from an integer.
+ *
+ * @see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner::runOnce()
+ */
+enum ClaimReleaseOutcome: string
+{
+    /**
+     * The batch was still `queued` and is now back to `none`: this runner's claim was the live
+     * one, and its publish genuinely failed. Retryable, and a real failure for the run.
+     */
+    case RELEASED = 'released';
+
+    /**
+     * The batch is `open`, `merged` or `closed`: someone else finished it while this runner's
+     * doomed attempt was still in flight. Not this run's failure — its work was simply
+     * redundant. Releasing here would have reverted a real, successful publication.
+     */
+    case SETTLED_ELSEWHERE = 'settled_elsewhere';
+
+    /**
+     * The batch is `none`: nobody holds a claim on it and nobody published it. Reached when a
+     * concurrent runner's own publish failed and released it first, when the grace-period
+     * reclaim fired on this (merely slow, still alive) runner, or when a concurrent
+     * transaction moved the row out of `queued` between this statement's snapshot and its row
+     * lock. In every one of those readings the work is still unpublished, so this is a real
+     * failure — the opposite of {@see self::SETTLED_ELSEWHERE}, despite affecting the same
+     * zero rows.
+     */
+    case NOT_CLAIMED = 'not_claimed';
+
+    /**
+     * No row with this `batch_id` exists at all. Not reachable through this feature's own
+     * write paths (nothing deletes a claimed batch), so it means something outside them
+     * touched the table. Treated as a failure: an unexplained state is never read
+     * optimistically.
+     */
+    case BATCH_MISSING = 'batch_missing';
+
+    /**
+     * True when the batch's work is known to be finished on GitHub — the ONLY outcome a failed
+     * publish attempt may treat as a non-failure.
+     */
+    public function isSettled(): bool
+    {
+        return self::SETTLED_ELSEWHERE === $this;
+    }
+}

--- a/src/Handlers/Ops/HealthHandler.php
+++ b/src/Handlers/Ops/HealthHandler.php
@@ -17,9 +17,12 @@ use Psr\Http\Message\ServerRequestInterface;
  *
  * Returns a JSON object summarising the operational health of the API,
  * including the openfga_outbox block for observability of the async
- * OpenFGA reconciliation subsystem, and a source_data_writes block reporting
+ * OpenFGA reconciliation subsystem, a source_data_writes block reporting
  * whether this deployment writes source-data edits to disk or records them
- * as change requests — see {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode}.
+ * as change requests — see {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode}
+ * — and a source_data_publisher block reporting whether the phase-2 GitHub App publisher
+ * that turns approved change requests into commits can actually run — see
+ * {@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher::isConfigured()}.
  *
  * This endpoint is unauthenticated and publicly accessible so that
  * monitoring infrastructure (load-balancers, uptime checks, etc.) can
@@ -59,10 +62,11 @@ final class HealthHandler extends AbstractHandler
         }
 
         $result = [
-            'status'             => $overall,
-            'database'           => $dbStatus,
-            'openfga_outbox'     => Health::buildOutboxStats(),
-            'source_data_writes' => Health::buildSourceDataWriteModeStatus(),
+            'status'                => $overall,
+            'database'              => $dbStatus,
+            'openfga_outbox'        => Health::buildOutboxStats(),
+            'source_data_writes'    => Health::buildSourceDataWriteModeStatus(),
+            'source_data_publisher' => Health::buildSourceDataPublisherStatus(),
         ];
 
         $body = json_encode($result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);

--- a/src/Health.php
+++ b/src/Health.php
@@ -5357,8 +5357,9 @@ class Health implements MessageComponentInterface
             return [
                 'status'         => 'warning',
                 'message'        => 'change request queue mode is on but the source data publisher is not configured '
-                    . '(GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY_PATH, GITHUB_REPOSITORY); '
-                    . 'approved change requests are accumulating unpublished',
+                    . '(GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY_PATH, and GITHUB_REPOSITORY '
+                    . 'in the form owner/repo — a value that is set but malformed counts as unconfigured, because no '
+                    . 'run can publish with it); approved change requests are accumulating unpublished',
                 'parked_batches' => $parked,
             ];
         }

--- a/src/Health.php
+++ b/src/Health.php
@@ -37,6 +37,7 @@ use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
 use LiturgicalCalendar\Api\Services\TestRunPolicy;
 use LiturgicalCalendar\Api\Services\WsCallerResolver;
 use LiturgicalCalendar\Api\Repositories\OutboxRepository;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
 use LiturgicalCalendar\Api\Services\WebSocketMessageValidator;
 use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
@@ -5327,41 +5328,93 @@ class Health implements MessageComponentInterface
      * do (configured or not) is the ordinary, quiet case for a self-hosted instance that does
      * not run the change-request queue.
      *
+     * It also reports `parked_batches`: approved batches that have exhausted
+     * {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS}
+     * consecutive publish attempts and are therefore no longer being claimed, so the rest of
+     * the queue can drain past them. That bound is what stops one deterministically-failing
+     * batch from stranding every other editor's work — but a batch that has silently stopped
+     * being attempted is the same class of defect as one stranded mid-publish, so it is
+     * reported here rather than only in the publisher's own log. It is a `warning`, not an
+     * error: nothing is lost, and clearing `publish_attempts` retries the batch (see the
+     * change-request runbook, "Parked batches").
+     *
      * Designed to be called from HealthHandler (HTTP context), mirroring
      * {@see Health::buildSourceDataWriteModeStatus()} — same "static method here, consumed by
-     * the HTTP handler" shape.
+     * the HTTP handler" shape. The parked count is read through the same
+     * `Connection::isConfigured()` + catch-everything guard {@see buildOutboxStats()} uses: a
+     * database that is down must degrade this block to zero, not break the endpoint monitoring
+     * relies on.
      *
-     * @return array{status: 'ok'|'warning', message: string}
+     * @return array{status: 'ok'|'warning', message: string, parked_batches: int}
      */
     public static function buildSourceDataPublisherStatus(): array
     {
         $queueModeOn = SourceDataWriteMode::changeRequestsEnabled();
         $configured  = SourceDataPublisher::isConfigured();
+        $parked      = self::parkedChangeRequestBatches();
 
         if ($queueModeOn && !$configured) {
             return [
-                'status'  => 'warning',
-                'message' => 'change request queue mode is on but the source data publisher is not configured '
+                'status'         => 'warning',
+                'message'        => 'change request queue mode is on but the source data publisher is not configured '
                     . '(GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY_PATH, GITHUB_REPOSITORY); '
                     . 'approved change requests are accumulating unpublished',
+                'parked_batches' => $parked,
+            ];
+        }
+
+        if ($parked > 0) {
+            return [
+                'status'         => 'warning',
+                'message'        => sprintf(
+                    '%d approved change request batch(es) have exhausted %d consecutive publish attempts and are no '
+                        . 'longer being attempted; the rest of the queue is draining past them. See the '
+                        . 'change-request runbook, "Parked batches", for how to inspect and retry them',
+                    $parked,
+                    SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS
+                ),
+                'parked_batches' => $parked,
             ];
         }
 
         if ($configured) {
             return [
-                'status'  => 'ok',
-                'message' => $queueModeOn
+                'status'         => 'ok',
+                'message'        => $queueModeOn
                     ? 'source data publisher is configured and will publish approved change requests to GitHub'
                     : 'source data publisher is configured, but change request queue mode is off, so there is '
                         . 'nothing to publish',
+                'parked_batches' => $parked,
             ];
         }
 
         return [
-            'status'  => 'ok',
-            'message' => 'source data publisher is not configured (change request queue mode is off, so there is '
+            'status'         => 'ok',
+            'message'        => 'source data publisher is not configured (change request queue mode is off, so there is '
                 . 'nothing to publish)',
+            'parked_batches' => $parked,
         ];
+    }
+
+    /**
+     * Approved batches the publisher has given up on, or 0 when there is no database to ask.
+     *
+     * Deliberately swallows everything, exactly as {@see buildOutboxStats()} does: /health is
+     * unauthenticated infrastructure monitoring polls, and an unreachable database is already
+     * reported by its own `database` field. Turning that into a 500 here would take the whole
+     * endpoint down over a secondary statistic.
+     */
+    private static function parkedChangeRequestBatches(): int
+    {
+        if (!Connection::isConfigured()) {
+            return 0;
+        }
+
+        try {
+            return ( new SourceDataChangeRequestRepository(Connection::getInstance()) )->countParkedBatches();
+        } catch (\Throwable) {
+            return 0;
+        }
     }
 
     /**

--- a/src/Health.php
+++ b/src/Health.php
@@ -32,6 +32,7 @@ use LiturgicalCalendar\Api\Models\Auth\TestTarget;
 use LiturgicalCalendar\Api\Models\Auth\WsCaller;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableInventory;
 use LiturgicalCalendar\Api\Models\ValidationsPath\CheckableItem;
+use LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher;
 use LiturgicalCalendar\Api\Services\SourceData\SourceDataWriteMode;
 use LiturgicalCalendar\Api\Services\TestRunPolicy;
 use LiturgicalCalendar\Api\Services\WsCallerResolver;
@@ -5309,6 +5310,57 @@ class Health implements MessageComponentInterface
         return [
             'status'  => 'ok',
             'message' => 'source data writes go to disk (no change request stack configured)',
+        ];
+    }
+
+    /**
+     * Build the source_data_publisher block for the HTTP /health endpoint.
+     *
+     * Reports whether the phase-2 GitHub App publisher ({@see SourceDataPublisher}) can
+     * actually run, and flags the one way that matters: change-request queue mode
+     * ({@see SourceDataWriteMode::changeRequestsEnabled()}) is on, but the publisher is not
+     * configured ({@see SourceDataPublisher::isConfigured()}). In that state editors submit,
+     * admins approve, everything reports success — and nothing is ever published; approved
+     * work silently piles up looking exactly like a working system from every UI surface.
+     *
+     * Queue mode being off is never itself a problem here — the publisher having nothing to
+     * do (configured or not) is the ordinary, quiet case for a self-hosted instance that does
+     * not run the change-request queue.
+     *
+     * Designed to be called from HealthHandler (HTTP context), mirroring
+     * {@see Health::buildSourceDataWriteModeStatus()} — same "static method here, consumed by
+     * the HTTP handler" shape.
+     *
+     * @return array{status: 'ok'|'warning', message: string}
+     */
+    public static function buildSourceDataPublisherStatus(): array
+    {
+        $queueModeOn = SourceDataWriteMode::changeRequestsEnabled();
+        $configured  = SourceDataPublisher::isConfigured();
+
+        if ($queueModeOn && !$configured) {
+            return [
+                'status'  => 'warning',
+                'message' => 'change request queue mode is on but the source data publisher is not configured '
+                    . '(GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, GITHUB_APP_PRIVATE_KEY_PATH, GITHUB_REPOSITORY); '
+                    . 'approved change requests are accumulating unpublished',
+            ];
+        }
+
+        if ($configured) {
+            return [
+                'status'  => 'ok',
+                'message' => $queueModeOn
+                    ? 'source data publisher is configured and will publish approved change requests to GitHub'
+                    : 'source data publisher is configured, but change request queue mode is off, so there is '
+                        . 'nothing to publish',
+            ];
+        }
+
+        return [
+            'status'  => 'ok',
+            'message' => 'source data publisher is not configured (change request queue mode is off, so there is '
+                . 'nothing to publish)',
         ];
     }
 

--- a/src/Migrations/Version20260829120000.php
+++ b/src/Migrations/Version20260829120000.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Migrations;
+
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Bound how many times one batch may be attempted before the publisher stops attempting it.
+ *
+ * Without a bound, ONE deterministically-failing batch stalls the entire queue forever:
+ * candidates are ordered oldest-first, a failed publish returns the batch to `none`, and the
+ * runner stops on failure — so the oldest failing batch is re-claimed first on every tick and
+ * every tick aborts before reaching anything else. Every other editor's approved work is never
+ * attempted, with no error of its own to show for it. Reachable through ordinary use: an
+ * illegal git-ref character in a `resource_id`, a tree-path conflict, or a payload a later
+ * validation change rejects.
+ *
+ * `publish_attempts` counts CONSECUTIVE attempts against a batch:
+ * `SourceDataChangeRequestRepository::releaseClaim()` and `reclaimStaleClaims()` both increment
+ * it (a crash consumes an attempt exactly as a caught failure does — otherwise a batch that
+ * OOM-kills the process on every attempt loops forever, the same defect reached through the
+ * one path that catches nothing), and `recordPublication()` resets it, so a batch that finally
+ * publishes carries no residue. Once it reaches
+ * `SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS` the batch stops being claimable and
+ * the rest of the queue drains past it.
+ *
+ * A parked batch must never be a silent one — that is the same class of bug as a stranded one.
+ * It is surfaced in `GET /health`'s `source_data_publisher` block, in every run's log line, and
+ * in the runbook's SQL.
+ */
+final class Version20260829120000 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add sourcedata_change_requests.publish_attempts (bounded publish retries, phase 2)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('ALTER TABLE sourcedata_change_requests ADD COLUMN publish_attempts INTEGER NOT NULL DEFAULT 0');
+        $this->addSql(
+            'ALTER TABLE sourcedata_change_requests '
+            . 'ADD CONSTRAINT chk_scr_publish_attempts_non_negative CHECK (publish_attempts >= 0)'
+        );
+        $this->addSql(
+            'COMMENT ON COLUMN sourcedata_change_requests.publish_attempts IS '
+            . "'Consecutive publish attempts; at MAX_PUBLISH_ATTEMPTS the batch is parked (no longer claimed) and reported by /health'"
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->abortIf(
+            !( $this->connection->getDatabasePlatform() instanceof PostgreSQLPlatform ),
+            'This migration targets PostgreSQL only.'
+        );
+
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP CONSTRAINT IF EXISTS chk_scr_publish_attempts_non_negative');
+        $this->addSql('ALTER TABLE sourcedata_change_requests DROP COLUMN IF EXISTS publish_attempts');
+    }
+}

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -806,17 +806,51 @@ class SourceDataChangeRequestRepository
 
     /**
      * Release a failed publish attempt: put a `queued` batch back to `none` so it is
-     * claimable again on the next run. Built on {@see markBatchPublicationStatus()} rather
-     * than duplicating its UPDATE — that method already exists (phase 1's own regression
-     * test needed it) and is unconditional on `review_status`, which is exactly right
-     * here: a claim can only ever have been taken from an approved batch in the first
-     * place, so nothing further needs re-checking on release.
+     * claimable again on the next run.
      *
-     * @return int Rows transitioned.
+     * Deliberately NOT built on {@see markBatchPublicationStatus()} — that method is
+     * unconditional by design (it is also how `merged`/`closed` get set later, which must
+     * stay unconditional) and this call must NOT be. This method carries its own guard,
+     * `AND publication_status = 'queued'`, so it releases only a claim the caller still
+     * holds. Do not "simplify" this back into a delegating call to
+     * `markBatchPublicationStatus()` — that is the exact regression this guard exists to
+     * prevent.
+     *
+     * Why the guard matters: a caller here is, by construction, a runner whose OWN publish
+     * attempt just failed — but "failed" can mean the process was merely SLOW, not dead. If
+     * {@see reclaimStaleClaims()}'s grace period elapses while that runner's publish is still
+     * genuinely in flight, a second runner can claim, publish, and {@see recordPublication()}
+     * the very same batch (moving it to `open` with a real `commit_sha`/`pr_number`) before
+     * the first runner's own GitHub call returns. The first runner's call then fails for real
+     * (a non-fast-forward `updateRef()`, since the branch moved under it) and its caller
+     * calls `releaseClaim()`. An unconditional release would revert that batch to `none`
+     * while it still carries the successful publish's real commit and PR — silently
+     * re-publishing already-published, successful work on the very next tick, indistinguishable
+     * from a genuine failure. The `publication_status = 'queued'` guard makes this call a
+     * no-op in that case (0 rows affected) instead: the row is already `open`, so it matches
+     * nothing. {@see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner} uses that
+     * "0 rows" result as the signal that the batch was settled by someone else, not that this
+     * runner's release failed.
+     *
+     * @return int Rows transitioned. Zero means the batch was no longer `queued` when this
+     *             ran — most likely because another runner already published it.
      */
     public function releaseClaim(string $batchId): int
     {
-        return $this->markBatchPublicationStatus($batchId, ChangePublicationStatus::NONE);
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status = :none,
+                    updated_at = NOW()
+              WHERE batch_id = :batch_id
+                AND publication_status = :queued'
+        );
+        $stmt->execute([
+            'none'     => ChangePublicationStatus::NONE->value,
+            'queued'   => ChangePublicationStatus::QUEUED->value,
+            'batch_id' => $batchId,
+        ]);
+
+        return $stmt->rowCount();
     }
 
     /**

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -922,10 +922,27 @@ class SourceDataChangeRequestRepository
      * Deliberately NOT built on {@see markBatchPublicationStatus()} — that method is
      * unconditional by design (it is also how `merged`/`closed` get set later, which must
      * stay unconditional) and this call must NOT be. This method carries its own guard,
-     * `AND publication_status = 'queued'`, so it releases only a claim the caller still
-     * holds. Do not "simplify" this back into a delegating call to
+     * `AND publication_status = 'queued'`, so it releases only a batch that is under SOME
+     * claim. Do not "simplify" this back into a delegating call to
      * `markBatchPublicationStatus()` — that is the exact regression this guard exists to
      * prevent.
+     *
+     * # What the guard does NOT provide: ownership
+     *
+     * `queued` identifies *a* claim, not *whose*. There is no claim token, so a runner whose
+     * publish failed late can release a claim a DIFFERENT runner has since taken. Reachable
+     * without anything exotic: A claims -> the grace period elapses and {@see reclaimStaleClaims()}
+     * releases A's claim (spending an attempt) -> B claims and starts publishing -> A's own
+     * call finally fails and A releases, which now revokes B's LIVE claim (spending a second
+     * attempt) and puts the batch back to `none` while B is still working. Consequences, both
+     * bounded and visible: a legitimately slow batch can spend TWO of its
+     * {@see MAX_PUBLISH_ATTEMPTS} per cycle rather than one, so it parks in three cycles
+     * rather than five; and a third runner can claim and publish concurrently with B without a
+     * second reclaim being involved — which lands on the benign double-publish
+     * ({@see \LiturgicalCalendar\Api\Services\SourceData\SourceDataPublisher}'s `force: false`
+     * plus a retry), never on lost work. Closing it properly means a claim token compared on
+     * release, not a stricter status guard; that is a schema change, and it is deliberately
+     * NOT made here. Do not read the guard as ownership in the meantime.
      *
      * Why the guard matters: a caller here is, by construction, a runner whose OWN publish
      * attempt just failed — but "failed" can mean the process was merely SLOW, not dead. If
@@ -1023,9 +1040,13 @@ class SourceDataChangeRequestRepository
      * (an OOM on a large payload, a segfault) is caught by nothing, so if a reclaim were free
      * that batch would be re-claimed and re-crash forever — the same permanent head-of-line
      * block, reached through the one path that runs no PHP at all. The cost is that a merely
-     * slow publish, reclaimed while still alive, spends one attempt it did not deserve; a
-     * batch parked that way is visible in `/health` and un-parked by clearing
-     * `publish_attempts`, which is strictly better than a queue nobody can drain.
+     * slow publish, reclaimed while still alive, spends attempts it did not deserve: up to TWO
+     * per cycle, not one, because the reclaim here spends one and the slow runner's own late
+     * `releaseClaim()` — which cannot tell that the claim it is releasing now belongs to
+     * someone else, see that method's "What the guard does NOT provide" section — spends
+     * another. So such a batch parks after three cycles rather than five. A batch parked that
+     * way is visible in `/health` and un-parked by clearing `publish_attempts`, which is
+     * strictly better than a queue nobody can drain.
      *
      * Recovers from a crash between {@see claimNextPublishableBatch()} and the publish
      * finishing — a SIGKILL, an OOM kill, or a cron timeout — that leaves a batch `queued`

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -8,6 +8,7 @@ use LiturgicalCalendar\Api\Database\Connection;
 use LiturgicalCalendar\Api\Enum\ChangeOperation;
 use LiturgicalCalendar\Api\Enum\ChangePublicationStatus;
 use LiturgicalCalendar\Api\Enum\ChangeReviewStatus;
+use LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome;
 use LiturgicalCalendar\Api\Services\ChangeResource;
 use PDO;
 
@@ -645,12 +646,92 @@ class SourceDataChangeRequestRepository
     }
 
     /**
+     * How many CONSECUTIVE publish attempts a batch gets before the publisher stops claiming
+     * it ("parks" it).
+     *
+     * The bound exists because a batch can fail deterministically — an illegal git-ref
+     * character in a `resource_id`, a tree-path conflict, a payload a later validation change
+     * rejects — and the runner stops the whole tick on a failure. Oldest-first ordering then
+     * means that one batch is re-claimed first on every tick and every tick aborts before
+     * reaching anything else: one editor's broken proposal indefinitely blocks every other
+     * editor's good work, with nothing but a repeated log line to show for it.
+     *
+     * Five, not one: a GitHub blip, a token exchange that races an expiry, a transient 5xx must
+     * NOT park a batch, and {@see recordPublication()} resets the counter, so the bound only
+     * ever fires on failures that are genuinely consecutive. Five ticks of a cron interval is
+     * long enough to ride out a transient outage and short enough that the queue is not held
+     * hostage for a day.
+     *
+     * Parking is not deletion and not a dead-letter queue (this feature has none): the rows
+     * are untouched, the batch stays `approved`/`none`, and clearing `publish_attempts` back
+     * to 0 makes it claimable again. It must never be silent, which is why
+     * {@see countParkedBatches()} feeds `GET /health` and the runner's own log line.
+     */
+    public const MAX_PUBLISH_ATTEMPTS = 5;
+
+    /**
+     * How many batches have exhausted {@see MAX_PUBLISH_ATTEMPTS} and are therefore no longer
+     * being attempted.
+     *
+     * A batch that has silently stopped being attempted is the same class of defect as one
+     * stranded `queued`: invisible to the operator, invisible to the editor, indistinguishable
+     * from success on the editor's side. This is the number that makes it visible — reported by
+     * `GET /health`'s `source_data_publisher` block and by every publish run's summary line.
+     *
+     * Counts only batches that would otherwise be claimable (`approved`, `none`), so a batch
+     * whose attempts happen to be non-zero but which went on to publish, or which was rejected
+     * or withdrawn afterwards, is not reported as stuck.
+     */
+    public function countParkedBatches(): int
+    {
+        $stmt = $this->db->prepare(
+            'SELECT COUNT(*) AS parked
+               FROM (
+                   SELECT batch_id
+                     FROM sourcedata_change_requests
+                    GROUP BY batch_id
+                   HAVING bool_and(review_status = :approved)
+                      AND bool_and(publication_status = :none)
+                      AND bool_and(publish_attempts >= :max_attempts)
+               ) AS parked_batches'
+        );
+        $stmt->execute([
+            'approved'     => ChangeReviewStatus::APPROVED->value,
+            'none'         => ChangePublicationStatus::NONE->value,
+            'max_attempts' => self::MAX_PUBLISH_ATTEMPTS,
+        ]);
+
+        /** @var array<string, mixed>|false $row */
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+
+        return false === $row ? 0 : self::requireInt($row['parked'] ?? null, 'parked');
+    }
+
+    /**
      * Atomically claim the oldest approved-and-unpublished batch, or null if none exists.
      *
      * "Claimable" means every row of the batch is `review_status = 'approved'` AND
-     * `publication_status = 'none'` — a batch is never mixed-status (`decideBatch()` and
-     * `withdrawBatch()` each transition every still-submitted row of a batch in one
-     * `UPDATE`), so aggregating with `bool_and(...)` over the whole batch is a safe test.
+     * `publication_status = 'none'` AND `publish_attempts < MAX_PUBLISH_ATTEMPTS` — a batch is
+     * never mixed-status (`decideBatch()` and `withdrawBatch()` each transition every
+     * still-submitted row of a batch in one `UPDATE`, and every publish-side write below acts
+     * on the whole batch), so aggregating with `bool_and(...)` over the whole batch is a safe
+     * test.
+     *
+     * The attempts bound is what stops ONE failing batch from stranding the whole queue.
+     * Candidates are ordered oldest-first and a failed publish returns its batch to `none`, so
+     * without the bound the oldest failing batch is re-claimed first on every tick, forever,
+     * and no other editor's approved work is ever reached. See {@see MAX_PUBLISH_ATTEMPTS}.
+     * The predicate is repeated on the LOCK query for the same reason the status predicate is
+     * (see below): the candidate snapshot can be stale by the time the lock runs, and a batch
+     * another runner pushed over the bound in that window is `none` and unlocked, so the status
+     * predicate alone would happily claim it.
+     *
+     * `$skipBatchIds` excludes batches the CALLER has already attempted in its current run.
+     * They are not parked — a single failure must stay retryable on the next tick — but a
+     * batch released back to `none` is instantly the oldest candidate again, so without this
+     * a caller that continues past a failure re-claims the very batch it just failed on. That
+     * is in-process retry by another name, and it is what the runner's "stop, don't hammer"
+     * rule exists to avoid.
      *
      * `FOR UPDATE SKIP LOCKED` only holds its row lock for the lifetime of the surrounding
      * transaction. Without an explicit transaction wrapping BOTH the row lock and the
@@ -695,8 +776,10 @@ class SourceDataChangeRequestRepository
      * in {@see \LiturgicalCalendar\Tests\Repositories\SourceDataChangeRequestPublishQueueTest::testTwoRealConcurrentRunnersNeverClaimTheSameBatch()},
      * which races two real OS processes against `claimNextPublishableBatch()` itself rather
      * than against a hand-copied query, so a regression here is what that test would catch.
+     *
+     * @param list<string> $skipBatchIds Batch ids to pass over, however claimable they look.
      */
-    public function claimNextPublishableBatch(): ?string
+    public function claimNextPublishableBatch(array $skipBatchIds = []): ?string
     {
         $this->db->beginTransaction();
         try {
@@ -706,11 +789,13 @@ class SourceDataChangeRequestRepository
                   GROUP BY batch_id
                  HAVING bool_and(review_status = :approved)
                     AND bool_and(publication_status = :none)
+                    AND bool_and(publish_attempts < :max_attempts)
                   ORDER BY MIN(created_at) ASC'
             );
             $candidates->execute([
-                'approved' => ChangeReviewStatus::APPROVED->value,
-                'none'     => ChangePublicationStatus::NONE->value,
+                'approved'     => ChangeReviewStatus::APPROVED->value,
+                'none'         => ChangePublicationStatus::NONE->value,
+                'max_attempts' => self::MAX_PUBLISH_ATTEMPTS,
             ]);
 
             $lock = $this->db->prepare(
@@ -719,6 +804,7 @@ class SourceDataChangeRequestRepository
                   WHERE batch_id = :batch_id
                     AND review_status = :approved
                     AND publication_status = :none
+                    AND publish_attempts < :max_attempts
                     FOR UPDATE SKIP LOCKED'
             );
 
@@ -727,10 +813,19 @@ class SourceDataChangeRequestRepository
                 $batchId  = self::requireString($candidate['batch_id'] ?? null, 'batch_id');
                 $rowCount = self::requireInt($candidate['row_count'] ?? null, 'row_count');
 
+                if (in_array($batchId, $skipBatchIds, true)) {
+                    // Already attempted (and failed) in the caller's current run. Its release
+                    // put it back to `none`, so it is the oldest claimable candidate again and
+                    // would be re-claimed immediately, re-attempted, and re-released — an
+                    // in-process retry loop the caller explicitly does not want.
+                    continue;
+                }
+
                 $lock->execute([
-                    'batch_id' => $batchId,
-                    'approved' => ChangeReviewStatus::APPROVED->value,
-                    'none'     => ChangePublicationStatus::NONE->value,
+                    'batch_id'     => $batchId,
+                    'approved'     => ChangeReviewStatus::APPROVED->value,
+                    'none'         => ChangePublicationStatus::NONE->value,
+                    'max_attempts' => self::MAX_PUBLISH_ATTEMPTS,
                 ]);
                 $lockedRowCount = count($lock->fetchAll(PDO::FETCH_COLUMN));
 
@@ -768,8 +863,10 @@ class SourceDataChangeRequestRepository
     /**
      * Record that a claimed batch reached GitHub as an open pull request.
      *
-     * Sets `publication_status` to `open` and stamps the git-side identifiers the batch
-     * was published under. `base_sha` is the commit the publisher branched from — distinct
+     * Sets `publication_status` to `open`, stamps the git-side identifiers the batch was
+     * published under, and clears `publish_attempts` — the bound in {@see MAX_PUBLISH_ATTEMPTS}
+     * counts CONSECUTIVE failures, so a batch that eventually succeeds must not carry the
+     * failures it recovered from into whatever phase 3 does with it. `base_sha` is the commit the publisher branched from — distinct
      * from each row's own `base_sha`, which is per-file accumulation-base bookkeeping set
      * at submission time.
      *
@@ -789,6 +886,7 @@ class SourceDataChangeRequestRepository
                     commit_sha         = :commit_sha,
                     pr_number          = :pr_number,
                     base_sha           = :base_sha,
+                    publish_attempts   = 0,
                     updated_at         = NOW()
               WHERE batch_id = :batch_id'
         );
@@ -806,7 +904,12 @@ class SourceDataChangeRequestRepository
 
     /**
      * Release a failed publish attempt: put a `queued` batch back to `none` so it is
-     * claimable again on the next run.
+     * claimable again on the next run, and count the attempt against
+     * {@see MAX_PUBLISH_ATTEMPTS}.
+     *
+     * The increment rides on the SAME guarded `UPDATE` as the release, so an attempt is
+     * counted exactly when a claim is actually given back — never when this call is a no-op
+     * because someone else already settled the batch.
      *
      * Deliberately NOT built on {@see markBatchPublicationStatus()} — that method is
      * unconditional by design (it is also how `merged`/`closed` get set later, which must
@@ -828,21 +931,45 @@ class SourceDataChangeRequestRepository
      * re-publishing already-published, successful work on the very next tick, indistinguishable
      * from a genuine failure. The `publication_status = 'queued'` guard makes this call a
      * no-op in that case (0 rows affected) instead: the row is already `open`, so it matches
-     * nothing. {@see \LiturgicalCalendar\Api\Services\SourceData\PublishRunner} uses that
-     * "0 rows" result as the signal that the batch was settled by someone else, not that this
-     * runner's release failed.
+     * nothing.
      *
-     * @return int Rows transitioned. Zero means the batch was no longer `queued` when this
-     *             ran — most likely because another runner already published it.
+     * # Why this returns a status and not a row count
+     *
+     * The guard makes "zero rows" ambiguous, and the two readings are opposites. `open` means
+     * another runner genuinely published this batch, so this runner's failure was redundant
+     * work. `none` means nothing is published anywhere — another runner's publish failed too
+     * (a GitHub outage fails every runner identically), or {@see reclaimStaleClaims()}
+     * released this batch out from under a merely-slow runner. Reading the second as the first
+     * is precisely the critical defect the final review of this feature found: a real outage
+     * reported success and re-claimed the same batch every iteration of the loop that exists
+     * to stop hammering. So this reports {@see ClaimReleaseOutcome}, and the caller branches on
+     * the observed state rather than on an integer.
+     *
+     * The observation and the release are ONE statement, deliberately. A `SELECT` after a
+     * zero-row `UPDATE` would report a status the row may already have left; a data-modifying
+     * CTE reads the pre-`UPDATE` version from the same snapshot the `UPDATE` evaluates against,
+     * so the reported status is the one the release actually acted on.
      */
-    public function releaseClaim(string $batchId): int
+    public function releaseClaim(string $batchId): ClaimReleaseOutcome
     {
         $stmt = $this->db->prepare(
-            'UPDATE sourcedata_change_requests
-                SET publication_status = :none,
-                    updated_at = NOW()
-              WHERE batch_id = :batch_id
-                AND publication_status = :queued'
+            'WITH observed AS (
+                 SELECT publication_status
+                   FROM sourcedata_change_requests
+                  WHERE batch_id = :batch_id
+                  LIMIT 1
+             ),
+             released AS (
+                 UPDATE sourcedata_change_requests
+                    SET publication_status = :none,
+                        publish_attempts   = publish_attempts + 1,
+                        updated_at = NOW()
+                  WHERE batch_id = :batch_id
+                    AND publication_status = :queued
+                 RETURNING id
+             )
+             SELECT ( SELECT publication_status FROM observed ) AS observed_status,
+                    ( SELECT COUNT(*) FROM released )          AS released_rows'
         );
         $stmt->execute([
             'none'     => ChangePublicationStatus::NONE->value,
@@ -850,12 +977,47 @@ class SourceDataChangeRequestRepository
             'batch_id' => $batchId,
         ]);
 
-        return $stmt->rowCount();
+        /** @var array<string, mixed>|false $row */
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        if (false === $row) {
+            return ClaimReleaseOutcome::BATCH_MISSING;
+        }
+
+        if (self::requireInt($row['released_rows'] ?? null, 'released_rows') > 0) {
+            return ClaimReleaseOutcome::RELEASED;
+        }
+
+        $observed = $row['observed_status'] ?? null;
+        if (!is_string($observed)) {
+            return ClaimReleaseOutcome::BATCH_MISSING;
+        }
+
+        // A `queued` observation that released nothing means a concurrent transaction moved
+        // the row between this statement's snapshot and its row lock. Nothing was released and
+        // nothing is known to be published, which is the NOT_CLAIMED reading — the
+        // conservative one, and the one that keeps an unexplained state out of the
+        // "settled, carry on" branch.
+        return match (ChangePublicationStatus::tryFrom($observed)) {
+            ChangePublicationStatus::OPEN,
+            ChangePublicationStatus::MERGED,
+            ChangePublicationStatus::CLOSED => ClaimReleaseOutcome::SETTLED_ELSEWHERE,
+            default                         => ClaimReleaseOutcome::NOT_CLAIMED,
+        };
     }
 
     /**
      * Release any row stranded `queued` whose `updated_at` is older than `$cutoff`, back to
-     * `none`, so it is claimable again.
+     * `none`, so it is claimable again — counting the abandoned attempt against
+     * {@see MAX_PUBLISH_ATTEMPTS}, exactly as {@see releaseClaim()} does.
+     *
+     * The increment here is not bookkeeping symmetry, it closes the sibling of the defect the
+     * bound exists for. A caught failure consumes an attempt; a batch that KILLS the process
+     * (an OOM on a large payload, a segfault) is caught by nothing, so if a reclaim were free
+     * that batch would be re-claimed and re-crash forever — the same permanent head-of-line
+     * block, reached through the one path that runs no PHP at all. The cost is that a merely
+     * slow publish, reclaimed while still alive, spends one attempt it did not deserve; a
+     * batch parked that way is visible in `/health` and un-parked by clearing
+     * `publish_attempts`, which is strictly better than a queue nobody can drain.
      *
      * Recovers from a crash between {@see claimNextPublishableBatch()} and the publish
      * finishing — a SIGKILL, an OOM kill, or a cron timeout — that leaves a batch `queued`
@@ -882,6 +1044,7 @@ class SourceDataChangeRequestRepository
         $stmt = $this->db->prepare(
             'UPDATE sourcedata_change_requests
                 SET publication_status = :none,
+                    publish_attempts   = publish_attempts + 1,
                     updated_at = NOW()
               WHERE publication_status = :queued
                 AND updated_at < :cutoff'

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -188,8 +188,34 @@ class SourceDataChangeRequestRepository
      * not yet merged, so a broken containment assumption would make it skip A and lose its content
      * silently. Excluding by age asserts nothing — A stays approved, visible and publishable — and the
      * worst case degrades from lost data to a suboptimal rebuild base.
+     *
+     * `>=`, not `>`: on an exact `created_at` tie the row must NOT be excluded. `created_at` is a
+     * transaction timestamp, and this class's own ORDER BY comment already documents exact-microsecond
+     * ties between independent transactions as a real, reproducible Postgres phenomenon — so a tie
+     * between the merged floor and some OTHER, unrelated row for the same `(path, submitter)` is
+     * reachable, and excluding it on `>` alone was verified (fix-round-1) to reproduce this exact
+     * defect for that row: a live, never-superseded batch dropped from the accumulation base and
+     * silently lost on the next edit, precisely the failure this predicate exists to prevent.
+     *
+     * A row-value tiebreak against `id`, matching the ORDER BY's `id DESC`, was tried and rejected:
+     * `id` is `gen_random_uuid()`, carrying no temporal information, so `(created_at, id) > (floor,
+     * floor_id)` does not resolve a genuine tie correctly — it answers by the luck of which random
+     * UUID sorts higher, verified live to flip the excluded side depending only on that. It replaces
+     * one deterministic bug with a coin flip on both edges rather than closing either. `id DESC` is a
+     * safe tiebreak in the ORDER BY because every candidate there is equally valid "newest" content
+     * and any deterministic choice is acceptable; it is not a safe tiebreak here because this
+     * predicate has one correct answer per row and id carries no signal toward it.
+     *
+     * The mirror-image risk `>=` accepts — a true ancestor A tying EXACTLY with the descendant batch
+     * that accumulated it and was later merged — requires two sequential, independently-triggered
+     * transactions (A's original submission, then, after a human/API approval step, the later
+     * resubmission that becomes the merged batch) to land on the identical Postgres microsecond.
+     * Nothing in this class's write path can produce that; it is reachable only by forcing `created_at`
+     * directly, the same way the ORDER BY's own tie tests do. Given a choice between a demonstrated,
+     * reachable bug and a not-reachable one, and given the row-id alternative does not reliably close
+     * either, `>=` is the correct edge.
      */
-    private const NOT_SUPERSEDED_BY_PUBLISHED = 'created_at > COALESCE((
+    private const NOT_SUPERSEDED_BY_PUBLISHED = 'created_at >= COALESCE((
                     SELECT MAX(m.created_at)
                       FROM sourcedata_change_requests m
                      WHERE m.path = sourcedata_change_requests.path

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -108,6 +108,20 @@ use PDO;
  * double-count. (Phase 1 only ever writes `none`; the predicate is written for the phases
  * that will not.)
  *
+ * # A merged row's own ancestors must also drop out
+ *
+ * `publication_status <> 'merged'` alone is not enough once a batch actually reaches
+ * `merged`: accumulation means batch B's content already contains the older batch A's, so
+ * publishing B also publishes A's content — but A itself stays `approved`/`none` forever,
+ * because nothing ever marks an ancestor merged (see {@see NOT_SUPERSEDED_BY_PUBLISHED} for
+ * why). Without a further check, A would still match {@see UNPUBLISHED_PREDICATE} and, being
+ * older than nothing, would become the newest surviving row for its `(path, submitter)` the
+ * instant B is excluded by its own `merged` status — silently reverting everything B added on
+ * the next accumulation. {@see NOT_SUPERSEDED_BY_PUBLISHED} closes this by excluding any row
+ * older than the newest `merged` row for the same `(path, submitter)`, on top of
+ * `UNPUBLISHED_PREDICATE` rather than folded into it, so the two ideas — "not yet published"
+ * and "not superseded by something that was" — stay independently readable.
+ *
  * # Ordering is load-bearing
  *
  * Because `idx_scr_unique_pending_path_submitter` covers only `submitted`, several rows can
@@ -164,6 +178,24 @@ class SourceDataChangeRequestRepository
      */
     private const UNPUBLISHED_PREDICATE = 'review_status IN (:submitted, :approved)
                 AND publication_status <> :merged';
+
+    /**
+     * Rows superseded by published content are excluded by AGE, not by rewriting their status.
+     *
+     * Accumulation makes each batch the submitter's cumulative proposal, so publishing batch B also
+     * publishes the content of the older batch A that B accumulated onto. A is then stale. Marking A
+     * `merged` would say it was published, which is false: the publisher selects approved rows that are
+     * not yet merged, so a broken containment assumption would make it skip A and lose its content
+     * silently. Excluding by age asserts nothing — A stays approved, visible and publishable — and the
+     * worst case degrades from lost data to a suboptimal rebuild base.
+     */
+    private const NOT_SUPERSEDED_BY_PUBLISHED = 'created_at > COALESCE((
+                    SELECT MAX(m.created_at)
+                      FROM sourcedata_change_requests m
+                     WHERE m.path = sourcedata_change_requests.path
+                       AND m.submitted_by_sub = sourcedata_change_requests.submitted_by_sub
+                       AND m.publication_status = :merged_floor
+                ), TIMESTAMPTZ \'-infinity\')';
 
     private PDO $db;
 
@@ -362,16 +394,22 @@ class SourceDataChangeRequestRepository
     }
 
     /**
-     * The bound values {@see self::UNPUBLISHED_PREDICATE} expects.
+     * The bound values {@see self::UNPUBLISHED_PREDICATE} and
+     * {@see self::NOT_SUPERSEDED_BY_PUBLISHED} expect.
      *
-     * @return array{submitted: string, approved: string, merged: string}
+     * `merged` and `merged_floor` are bound separately, even though they carry the same
+     * value, so the two clauses stay independently readable rather than coupled through a
+     * shared placeholder name.
+     *
+     * @return array{submitted: string, approved: string, merged: string, merged_floor: string}
      */
     private static function unpublishedParams(): array
     {
         return [
-            'submitted' => ChangeReviewStatus::SUBMITTED->value,
-            'approved'  => ChangeReviewStatus::APPROVED->value,
-            'merged'    => ChangePublicationStatus::MERGED->value,
+            'submitted'    => ChangeReviewStatus::SUBMITTED->value,
+            'approved'     => ChangeReviewStatus::APPROVED->value,
+            'merged'       => ChangePublicationStatus::MERGED->value,
+            'merged_floor' => ChangePublicationStatus::MERGED->value,
         ];
     }
 
@@ -405,6 +443,7 @@ class SourceDataChangeRequestRepository
               WHERE path = :path
                 AND submitted_by_sub = :sub
                 AND ' . self::UNPUBLISHED_PREDICATE . '
+                AND ' . self::NOT_SUPERSEDED_BY_PUBLISHED . '
               ORDER BY ( review_status = :submitted ) DESC, created_at DESC, id DESC
               LIMIT 1'
         );
@@ -447,6 +486,7 @@ class SourceDataChangeRequestRepository
                FROM sourcedata_change_requests
               WHERE submitted_by_sub = :sub
                 AND ' . self::UNPUBLISHED_PREDICATE . '
+                AND ' . self::NOT_SUPERSEDED_BY_PUBLISHED . '
                 AND LEFT(path, :prefix_length) = :prefix
               ORDER BY path ASC'
         );
@@ -546,6 +586,33 @@ class SourceDataChangeRequestRepository
             'batch_id'  => $batchId,
             'sub'       => $submittedBySub,
             'submitted' => ChangeReviewStatus::SUBMITTED->value,
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Set `publication_status` on every row of a batch, unconditionally on `review_status`.
+     *
+     * This is the write the publisher (phase 2, {@see NOT_SUPERSEDED_BY_PUBLISHED}) uses to record
+     * that a batch reached the repository. It does not touch `review_status` — publication and
+     * review are independent axes, and a batch is always approved before it is publishable, so
+     * gating this on review status would be redundant with the publisher's own selection query
+     * rather than a safety net.
+     *
+     * @return int Rows transitioned.
+     */
+    public function markBatchPublicationStatus(string $batchId, ChangePublicationStatus $status): int
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status = :status,
+                    updated_at = NOW()
+              WHERE batch_id = :batch_id'
+        );
+        $stmt->execute([
+            'status'   => $status->value,
+            'batch_id' => $batchId,
         ]);
 
         return $stmt->rowCount();

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -675,6 +675,26 @@ class SourceDataChangeRequestRepository
      * (any of) that batch's row locks, `SKIP LOCKED` drops those rows from the result, the
      * counts no longer match, and this method moves on to the next-oldest candidate rather
      * than blocking or taking a partial claim.
+     *
+     * The locking SELECT repeats `review_status = :approved AND publication_status = :none`,
+     * even though the candidate SELECT already filtered on exactly that via `HAVING`. This
+     * is NOT redundant, and must not be deleted as a simplification: the two SELECTs are
+     * separated in time by an unbounded amount of work (the candidate list can be long, and
+     * the loop can retry several times), and nothing locks a candidate's rows between when
+     * it is read off the candidate cursor and when this SELECT runs. If some other runner
+     * claims and COMMITS that exact batch in that window, its rows are `queued` — not
+     * locked, since a COMMIT releases every lock the winning transaction held — and a
+     * locking predicate of `WHERE batch_id = :batch_id FOR UPDATE SKIP LOCKED` alone would
+     * find all N rows perfectly unlocked and available, lock them, see `lockedRowCount ===
+     * rowCount` from the now-stale candidate snapshot, and claim the same batch a second
+     * time. Repeating the status predicate here means `FOR UPDATE` re-evaluates it against
+     * the latest COMMITTED row version at lock time (standard READ COMMITTED behaviour), so
+     * a batch some other runner already committed to `queued` matches zero rows here,
+     * `lockedRowCount !== rowCount` fires, and this method correctly moves on instead of
+     * double-claiming. Demonstrated against live Postgres with two independent connections
+     * in {@see \LiturgicalCalendar\Tests\Repositories\SourceDataChangeRequestPublishQueueTest::testTwoRealConcurrentRunnersNeverClaimTheSameBatch()},
+     * which races two real OS processes against `claimNextPublishableBatch()` itself rather
+     * than against a hand-copied query, so a regression here is what that test would catch.
      */
     public function claimNextPublishableBatch(): ?string
     {
@@ -697,6 +717,8 @@ class SourceDataChangeRequestRepository
                 'SELECT id
                    FROM sourcedata_change_requests
                   WHERE batch_id = :batch_id
+                    AND review_status = :approved
+                    AND publication_status = :none
                     FOR UPDATE SKIP LOCKED'
             );
 
@@ -705,7 +727,11 @@ class SourceDataChangeRequestRepository
                 $batchId  = self::requireString($candidate['batch_id'] ?? null, 'batch_id');
                 $rowCount = self::requireInt($candidate['row_count'] ?? null, 'row_count');
 
-                $lock->execute(['batch_id' => $batchId]);
+                $lock->execute([
+                    'batch_id' => $batchId,
+                    'approved' => ChangeReviewStatus::APPROVED->value,
+                    'none'     => ChangePublicationStatus::NONE->value,
+                ]);
                 $lockedRowCount = count($lock->fetchAll(PDO::FETCH_COLUMN));
 
                 if ($lockedRowCount !== $rowCount) {

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -645,6 +645,155 @@ class SourceDataChangeRequestRepository
     }
 
     /**
+     * Atomically claim the oldest approved-and-unpublished batch, or null if none exists.
+     *
+     * "Claimable" means every row of the batch is `review_status = 'approved'` AND
+     * `publication_status = 'none'` — a batch is never mixed-status (`decideBatch()` and
+     * `withdrawBatch()` each transition every still-submitted row of a batch in one
+     * `UPDATE`), so aggregating with `bool_and(...)` over the whole batch is a safe test.
+     *
+     * `FOR UPDATE SKIP LOCKED` only holds its row lock for the lifetime of the surrounding
+     * transaction. Without an explicit transaction wrapping BOTH the row lock and the
+     * `queued` UPDATE, Postgres autocommit would release the lock the instant the locking
+     * SELECT finished, and a second runner's SELECT could see the very same rows as
+     * unlocked and still `none` before the first runner ever marks them `queued` —
+     * double-claiming one editor's work as two separate publish attempts under one
+     * branch. Same reasoning as
+     * {@see \LiturgicalCalendar\Api\Services\Outbox\BackstopRunner::runOnce()}, which this
+     * mirrors rather than reuses: that class is constructor-typed to the concrete
+     * OutboxRepository and bound to the OpenFGA outbox, so it isn't reusable here.
+     *
+     * Postgres rejects `FOR UPDATE` combined with `GROUP BY` ("FOR UPDATE is not allowed
+     * with GROUP BY clause"), so the aggregate `HAVING` that identifies a claimable batch
+     * cannot itself take the row lock the way a flat, ungrouped query (like
+     * OutboxRepository::pickupPending()) can. This is a two-step query instead: an
+     * unlocked aggregate SELECT finds candidate batch ids oldest-first (`ORDER BY
+     * MIN(created_at) ASC`, so a resource that is busy publishing cannot starve an older
+     * approved batch waiting behind it), and the loop below then takes a real `FOR UPDATE
+     * SKIP LOCKED` lock on every row of one candidate at a time. A batch is claimed only
+     * when every one of its rows was actually locked — if a concurrent claim already holds
+     * (any of) that batch's row locks, `SKIP LOCKED` drops those rows from the result, the
+     * counts no longer match, and this method moves on to the next-oldest candidate rather
+     * than blocking or taking a partial claim.
+     */
+    public function claimNextPublishableBatch(): ?string
+    {
+        $this->db->beginTransaction();
+        try {
+            $candidates = $this->db->prepare(
+                'SELECT batch_id, COUNT(*) AS row_count
+                   FROM sourcedata_change_requests
+                  GROUP BY batch_id
+                 HAVING bool_and(review_status = :approved)
+                    AND bool_and(publication_status = :none)
+                  ORDER BY MIN(created_at) ASC'
+            );
+            $candidates->execute([
+                'approved' => ChangeReviewStatus::APPROVED->value,
+                'none'     => ChangePublicationStatus::NONE->value,
+            ]);
+
+            $lock = $this->db->prepare(
+                'SELECT id
+                   FROM sourcedata_change_requests
+                  WHERE batch_id = :batch_id
+                    FOR UPDATE SKIP LOCKED'
+            );
+
+            while (( $candidate = $candidates->fetch(PDO::FETCH_ASSOC) ) !== false) {
+                /** @var array<string, mixed> $candidate */
+                $batchId  = self::requireString($candidate['batch_id'] ?? null, 'batch_id');
+                $rowCount = self::requireInt($candidate['row_count'] ?? null, 'row_count');
+
+                $lock->execute(['batch_id' => $batchId]);
+                $lockedRowCount = count($lock->fetchAll(PDO::FETCH_COLUMN));
+
+                if ($lockedRowCount !== $rowCount) {
+                    // Contested: another runner already holds part (or all) of this
+                    // batch's row locks. Leave it alone and try the next-oldest candidate.
+                    continue;
+                }
+
+                $claim = $this->db->prepare(
+                    'UPDATE sourcedata_change_requests
+                        SET publication_status = :queued,
+                            updated_at = NOW()
+                      WHERE batch_id = :batch_id'
+                );
+                $claim->execute([
+                    'queued'   => ChangePublicationStatus::QUEUED->value,
+                    'batch_id' => $batchId,
+                ]);
+
+                $this->db->commit();
+
+                return $batchId;
+            }
+
+            $this->db->commit();
+
+            return null;
+        } catch (\Throwable $e) {
+            $this->db->rollBack();
+            throw $e;
+        }
+    }
+
+    /**
+     * Record that a claimed batch reached GitHub as an open pull request.
+     *
+     * Sets `publication_status` to `open` and stamps the git-side identifiers the batch
+     * was published under. `base_sha` is the commit the publisher branched from — distinct
+     * from each row's own `base_sha`, which is per-file accumulation-base bookkeeping set
+     * at submission time.
+     *
+     * @return int Rows transitioned.
+     */
+    public function recordPublication(
+        string $batchId,
+        string $branch,
+        string $commitSha,
+        ?int $prNumber,
+        string $baseSha
+    ): int {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status = :open,
+                    branch             = :branch,
+                    commit_sha         = :commit_sha,
+                    pr_number          = :pr_number,
+                    base_sha           = :base_sha,
+                    updated_at         = NOW()
+              WHERE batch_id = :batch_id'
+        );
+        $stmt->execute([
+            'open'       => ChangePublicationStatus::OPEN->value,
+            'branch'     => $branch,
+            'commit_sha' => $commitSha,
+            'pr_number'  => $prNumber,
+            'base_sha'   => $baseSha,
+            'batch_id'   => $batchId,
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
+     * Release a failed publish attempt: put a `queued` batch back to `none` so it is
+     * claimable again on the next run. Built on {@see markBatchPublicationStatus()} rather
+     * than duplicating its UPDATE — that method already exists (phase 1's own regression
+     * test needed it) and is unconditional on `review_status`, which is exactly right
+     * here: a claim can only ever have been taken from an approved batch in the first
+     * place, so nothing further needs re-checking on release.
+     *
+     * @return int Rows transitioned.
+     */
+    public function releaseClaim(string $batchId): int
+    {
+        return $this->markBatchPublicationStatus($batchId, ChangePublicationStatus::NONE);
+    }
+
+    /**
      * The `review_status = 'submitted'` predicate is what makes a decision
      * single-shot: re-deciding an approved batch matches no rows.
      *

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -820,6 +820,48 @@ class SourceDataChangeRequestRepository
     }
 
     /**
+     * Release any row stranded `queued` whose `updated_at` is older than `$cutoff`, back to
+     * `none`, so it is claimable again.
+     *
+     * Recovers from a crash between {@see claimNextPublishableBatch()} and the publish
+     * finishing — a SIGKILL, an OOM kill, or a cron timeout — that leaves a batch `queued`
+     * with nothing left running to release it. Without this, that batch is never picked up
+     * again: invisible to the operator, invisible to the editor, indistinguishable from
+     * success on the editor's side. Mirrors
+     * {@see \LiturgicalCalendar\Api\Services\Outbox\BackstopRunner}'s grace-window pattern
+     * (a cutoff computed by the caller, not by this method) rather than reusing it — that
+     * class is constructor-typed to the concrete `OutboxRepository` and bound to the OpenFGA
+     * outbox, so it isn't reusable here, same as {@see claimNextPublishableBatch()}'s own
+     * docblock explains for the claim side.
+     *
+     * Deliberately unlocked, unlike `claimNextPublishableBatch()`'s `FOR UPDATE SKIP LOCKED`:
+     * reclaiming a batch that is, in fact, still being actively published by a live process
+     * is tolerated rather than prevented. The worst case is a second, concurrent publish
+     * attempt landing on the same branch, which `SourceDataPublisher::publish()` already
+     * handles safely — a non-fast-forward `updateRef()` on whichever attempt loses the race,
+     * which the runner retries on its next tick.
+     *
+     * @return int Rows transitioned.
+     */
+    public function reclaimStaleClaims(\DateTimeImmutable $cutoff): int
+    {
+        $stmt = $this->db->prepare(
+            'UPDATE sourcedata_change_requests
+                SET publication_status = :none,
+                    updated_at = NOW()
+              WHERE publication_status = :queued
+                AND updated_at < :cutoff'
+        );
+        $stmt->execute([
+            'none'   => ChangePublicationStatus::NONE->value,
+            'queued' => ChangePublicationStatus::QUEUED->value,
+            'cutoff' => $cutoff->format('Y-m-d H:i:s.uP'),
+        ]);
+
+        return $stmt->rowCount();
+    }
+
+    /**
      * The `review_status = 'submitted'` predicate is what makes a decision
      * single-shot: re-deciding an approved batch matches no rows.
      *

--- a/src/Repositories/SourceDataChangeRequestRepository.php
+++ b/src/Repositories/SourceDataChangeRequestRepository.php
@@ -681,6 +681,14 @@ class SourceDataChangeRequestRepository
      * Counts only batches that would otherwise be claimable (`approved`, `none`), so a batch
      * whose attempts happen to be non-zero but which went on to publish, or which was rejected
      * or withdrawn afterwards, is not reported as stuck.
+     *
+     * The attempts test is `bool_or(>= MAX)`, deliberately the exact COMPLEMENT of the claim
+     * query's `bool_and(< MAX)` rather than its mirror image. Every row of an approved batch
+     * moves together today, so the two spellings agree — but if a batch ever did hold rows on
+     * both sides of the bound, `bool_and(>= MAX)` would report it as neither claimable NOR
+     * parked: stuck and invisible, which is the precise failure this count exists to prevent.
+     * Complementary predicates make that hole unreachable by construction instead of by
+     * argument.
      */
     public function countParkedBatches(): int
     {
@@ -692,7 +700,7 @@ class SourceDataChangeRequestRepository
                     GROUP BY batch_id
                    HAVING bool_and(review_status = :approved)
                       AND bool_and(publication_status = :none)
-                      AND bool_and(publish_attempts >= :max_attempts)
+                      AND bool_or(publish_attempts >= :max_attempts)
                ) AS parked_batches'
         );
         $stmt->execute([

--- a/src/Services/GitHub/GitHubApiException.php
+++ b/src/Services/GitHub/GitHubApiException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\GitHub;
+
+/**
+ * Raised whenever the GitHub API responds with a non-2xx status.
+ *
+ * Carries the HTTP status alongside GitHub's `message` field so callers can distinguish, for
+ * example, an expired installation (401/403) from a transient failure (5xx) without re-parsing
+ * the response body.
+ */
+final class GitHubApiException extends \RuntimeException
+{
+    public function __construct(public readonly int $status, string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $status, $previous);
+    }
+}

--- a/src/Services/GitHub/GitHubAppAuth.php
+++ b/src/Services/GitHub/GitHubAppAuth.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\GitHub;
+
+use Firebase\JWT\JWT;
+use GuzzleHttp\Psr7\Request;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use RuntimeException;
+
+/**
+ * Authenticates as a GitHub App and exchanges the App JWT for an installation access token.
+ *
+ * The private key is read from a filesystem path rather than an environment variable: in
+ * production it lives outside the deployed tree (`/etc/litcal/github-app.pem`), and a key
+ * threaded through the environment would end up in process listings and crash dumps.
+ *
+ * Installation tokens are cached (PSR-6) for 3000 seconds — 50 minutes — against GitHub's
+ * one-hour token life, so a token already in flight is never used in its final ten minutes.
+ */
+final class GitHubAppAuth
+{
+    private const API_BASE_URL = 'https://api.github.com';
+
+    /**
+     * GitHub rejects an App JWT whose `exp` is more than 10 minutes out. 540 seconds leaves
+     * headroom for the 60-second backdated `iat` plus request latency while staying under
+     * that ceiling.
+     */
+    private const JWT_TTL_SECONDS = 540;
+
+    private const JWT_CLOCK_SKEW_SECONDS = 60;
+
+    /** Installation tokens live one hour; cache for 50 minutes so the final 10 are never served. */
+    private const CACHE_TTL_SECONDS = 3000;
+
+    public function __construct(
+        private readonly string $appId,
+        private readonly string $installationId,
+        private readonly string $privateKeyPath,
+        private readonly ClientInterface $http,
+        private readonly CacheItemPoolInterface $cache
+    ) {
+    }
+
+    /**
+     * Check if the GitHub App environment variables are configured.
+     *
+     * Mirrors {@see \LiturgicalCalendar\Api\Services\OpenFgaClient::isConfigured()}.
+     */
+    public static function isConfigured(): bool
+    {
+        $appId          = self::getEnvString('GITHUB_APP_ID');
+        $installationId = self::getEnvString('GITHUB_APP_INSTALLATION_ID');
+        $privateKeyPath = self::getEnvString('GITHUB_APP_PRIVATE_KEY_PATH');
+
+        return $appId !== '' && $installationId !== '' && $privateKeyPath !== '';
+    }
+
+    /**
+     * Get an environment variable as a string.
+     */
+    private static function getEnvString(string $name): string
+    {
+        $value = $_ENV[$name] ?? null;
+        if (is_string($value) && trim($value) !== '') {
+            return trim($value);
+        }
+
+        $envValue = getenv($name);
+        if (is_string($envValue) && trim($envValue) !== '') {
+            return trim($envValue);
+        }
+
+        return '';
+    }
+
+    /**
+     * Return a cached installation access token, fetching and caching a fresh one if needed.
+     *
+     * @throws GitHubApiException If the token exchange fails
+     * @throws RuntimeException   If the private key cannot be read
+     */
+    public function installationToken(): string
+    {
+        $cacheKey = $this->cacheKey();
+        $item     = $this->cache->getItem($cacheKey);
+
+        if ($item->isHit()) {
+            $cached = $item->get();
+            if (is_string($cached) && $cached !== '') {
+                return $cached;
+            }
+        }
+
+        $token = $this->fetchInstallationToken();
+
+        $item->set($token);
+        $item->expiresAfter(self::CACHE_TTL_SECONDS);
+        $this->cache->save($item);
+
+        return $token;
+    }
+
+    /**
+     * PSR-6 cache keys are restricted to `[A-Za-z0-9_.]`, and the key must include the
+     * installation id so that two installations sharing a cache pool cannot collide.
+     */
+    private function cacheKey(): string
+    {
+        $safeInstallationId = preg_replace('/[^A-Za-z0-9_.]/', '_', $this->installationId);
+
+        return 'github_app_installation_token_' . $safeInstallationId;
+    }
+
+    /**
+     * RS256-sign an App JWT and exchange it for an installation access token.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status
+     * @throws RuntimeException   If the private key cannot be read
+     */
+    private function fetchInstallationToken(): string
+    {
+        $privateKey = file_get_contents($this->privateKeyPath);
+        if ($privateKey === false) {
+            throw new RuntimeException(
+                sprintf('Unable to read GitHub App private key at "%s"', $this->privateKeyPath)
+            );
+        }
+
+        $now = time();
+        $jwt = JWT::encode(
+            [
+                'iat' => $now - self::JWT_CLOCK_SKEW_SECONDS,
+                'exp' => $now + self::JWT_TTL_SECONDS,
+                'iss' => $this->appId,
+            ],
+            $privateKey,
+            'RS256'
+        );
+
+        $url     = self::API_BASE_URL . '/app/installations/' . rawurlencode($this->installationId) . '/access_tokens';
+        $request = new Request(
+            'POST',
+            $url,
+            [
+                'Authorization' => 'Bearer ' . $jwt,
+                'Accept'        => 'application/vnd.github+json',
+                'User-Agent'    => 'LiturgicalCalendarAPI-GitHubApp',
+            ]
+        );
+
+        try {
+            $response = $this->http->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            throw new RuntimeException(
+                sprintf('GitHub installation token request failed: %s', $e->getMessage()),
+                0,
+                $e
+            );
+        }
+
+        $status       = $response->getStatusCode();
+        $responseBody = (string) $response->getBody();
+
+        /** @var mixed $decoded */
+        $decoded = json_decode($responseBody, true);
+        $decoded = is_array($decoded) ? $decoded : [];
+
+        if ($status < 200 || $status >= 300) {
+            $message = isset($decoded['message']) && is_string($decoded['message'])
+                ? $decoded['message']
+                : 'Unknown error';
+
+            throw new GitHubApiException($status, sprintf('GitHub API error (HTTP %d): %s', $status, $message));
+        }
+
+        $token = $decoded['token'] ?? null;
+        if (!is_string($token) || $token === '') {
+            throw new GitHubApiException(
+                $status,
+                'GitHub installation token exchange succeeded but the response carried no token'
+            );
+        }
+
+        return $token;
+    }
+}

--- a/src/Services/GitHub/GitHubAppAuth.php
+++ b/src/Services/GitHub/GitHubAppAuth.php
@@ -61,6 +61,35 @@ final class GitHubAppAuth
     }
 
     /**
+     * Build an instance from `GITHUB_APP_ID`, `GITHUB_APP_INSTALLATION_ID`, and
+     * `GITHUB_APP_PRIVATE_KEY_PATH`. Mirrors
+     * {@see \LiturgicalCalendar\Api\Services\OpenFgaClient::fromEnv()}: every `mixed`
+     * `$_ENV`/`getenv()` read is routed through the already-narrowed {@see getEnvString()}
+     * here in `src/`, rather than left for a CLI script to read (and blindly cast) directly —
+     * `phpstan.neon.dist` scans `paths: [src]` only, so a script-level `(string) $_ENV[...]`
+     * is invisible to `composer analyse`.
+     *
+     * @throws RuntimeException If any of the three variables is unset or empty. Callers that
+     *         want to distinguish "unconfigured" from other failures ahead of time should
+     *         check {@see isConfigured()} first.
+     */
+    public static function fromEnv(ClientInterface $http, CacheItemPoolInterface $cache): self
+    {
+        $appId          = self::getEnvString('GITHUB_APP_ID');
+        $installationId = self::getEnvString('GITHUB_APP_INSTALLATION_ID');
+        $privateKeyPath = self::getEnvString('GITHUB_APP_PRIVATE_KEY_PATH');
+
+        if ('' === $appId || '' === $installationId || '' === $privateKeyPath) {
+            throw new RuntimeException(
+                'GitHub App is not configured. Set GITHUB_APP_ID, GITHUB_APP_INSTALLATION_ID, '
+                    . 'and GITHUB_APP_PRIVATE_KEY_PATH.'
+            );
+        }
+
+        return new self($appId, $installationId, $privateKeyPath, $http, $cache);
+    }
+
+    /**
      * Get an environment variable as a string.
      */
     private static function getEnvString(string $name): string

--- a/src/Services/GitHub/GitHubGitDataClient.php
+++ b/src/Services/GitHub/GitHubGitDataClient.php
@@ -1,0 +1,306 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\GitHub;
+
+use GuzzleHttp\Psr7\Request;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+/**
+ * Thin wrapper over the GitHub Git Data and Pulls REST endpoints, used to assemble and land a
+ * commit for one approved source-data change request batch.
+ *
+ * Every call authenticates with a fresh {@see GitHubAppAuth::installationToken()} (cached inside
+ * that collaborator, so this class never caches a token itself) and talks to a single
+ * `{$owner}/{$repo}` target fixed at construction.
+ *
+ * `getRef()` is the only method here that treats a 404 as a value rather than an error: a missing
+ * branch means "create it". Every other non-2xx response — including a 404 anywhere else — raises
+ * {@see GitHubApiException}.
+ */
+final class GitHubGitDataClient
+{
+    private const API_BASE_URL = 'https://api.github.com';
+
+    private const API_VERSION = '2022-11-28';
+
+    public function __construct(
+        private readonly string $owner,
+        private readonly string $repo,
+        private readonly GitHubAppAuth $auth,
+        private readonly ClientInterface $http
+    ) {
+    }
+
+    /**
+     * Fetch the head sha of `heads/{$branch}`, or null if the branch does not exist.
+     *
+     * A missing branch is the normal, expected state before the first publication of a given
+     * resource — it is what tells the caller to {@see createRef()} rather than update. Every
+     * other caller in this class treats a 404 as a real failure.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx, non-404 status
+     */
+    public function getRef(string $branch): ?string
+    {
+        $response = $this->send('GET', '/git/ref/heads/' . self::encodeRefSegment($branch), null);
+
+        if ($response->getStatusCode() === 404) {
+            return null;
+        }
+
+        $decoded = $this->decodeOrThrow($response);
+
+        $object = $decoded['object'] ?? null;
+        $sha    = is_array($object) ? ( $object['sha'] ?? null ) : null;
+        if (!is_string($sha) || $sha === '') {
+            throw new GitHubApiException(
+                $response->getStatusCode(),
+                'GitHub returned a ref with no usable object.sha'
+            );
+        }
+
+        return $sha;
+    }
+
+    /**
+     * Create `refs/heads/{$branch}` pointing at `$fromSha`.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status
+     */
+    public function createRef(string $branch, string $fromSha): void
+    {
+        $this->request('POST', '/git/refs', [
+            'ref' => 'refs/heads/' . $branch,
+            'sha' => $fromSha,
+        ]);
+    }
+
+    /**
+     * Create a blob from UTF-8 text content and return its sha.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status
+     */
+    public function createBlob(string $content): string
+    {
+        $response = $this->send('POST', '/git/blobs', [
+            'content'  => $content,
+            'encoding' => 'utf-8',
+        ]);
+
+        return $this->extractSha($response, 'blob');
+    }
+
+    /**
+     * Create a tree layered on `$baseTreeSha` and return its sha.
+     *
+     * A tree entry with `sha: null` deletes the path from the resulting tree — that is the Git
+     * Data API's mechanism for expressing a `delete` change request, and it is the reason the
+     * body must be built (and JSON-encoded) without ever stripping null values out of an entry.
+     *
+     * @param list<array{path: string, mode: string, type: string, sha: string|null}> $entries
+     * @throws GitHubApiException If GitHub responds with a non-2xx status
+     */
+    public function createTree(string $baseTreeSha, array $entries): string
+    {
+        $response = $this->send('POST', '/git/trees', [
+            'base_tree' => $baseTreeSha,
+            'tree'      => $entries,
+        ]);
+
+        return $this->extractSha($response, 'tree');
+    }
+
+    /**
+     * Create a single-parent commit and return its sha.
+     *
+     * @param array{name: string, email: string, date?: string} $author
+     * @throws GitHubApiException If GitHub responds with a non-2xx status
+     */
+    public function createCommit(string $message, string $treeSha, string $parentSha, array $author): string
+    {
+        $response = $this->send('POST', '/git/commits', [
+            'message' => $message,
+            'tree'    => $treeSha,
+            'parents' => [$parentSha],
+            'author'  => $author,
+        ]);
+
+        return $this->extractSha($response, 'commit');
+    }
+
+    /**
+     * Fast-forward `heads/{$branch}` to `$commitSha`.
+     *
+     * `force` is hardcoded to `false` and is not exposed as a parameter: a non-fast-forward
+     * update must fail with a retryable 422 rather than silently clobbering another editor's
+     * commit landed on the same branch between our {@see getRef()} and this call.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status (including a
+     *                            non-fast-forward 422)
+     */
+    public function updateRef(string $branch, string $commitSha): void
+    {
+        $this->request('PATCH', '/git/refs/heads/' . self::encodeRefSegment($branch), [
+            'sha'   => $commitSha,
+            'force' => false,
+        ]);
+    }
+
+    /**
+     * Open a pull request from `$branch` onto `$base` and return its number.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status
+     */
+    public function openPullRequest(string $branch, string $base, string $title, string $body): int
+    {
+        $response = $this->send('POST', '/pulls', [
+            'title' => $title,
+            'body'  => $body,
+            'head'  => $branch,
+            'base'  => $base,
+        ]);
+        $decoded  = $this->decodeOrThrow($response);
+
+        $number = $decoded['number'] ?? null;
+        if (!is_int($number)) {
+            throw new GitHubApiException(
+                $response->getStatusCode(),
+                'GitHub returned a pull request with no usable number'
+            );
+        }
+
+        return $number;
+    }
+
+    /**
+     * Find the number of an already-open pull request whose head is `$branch`, or null if none.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status
+     */
+    public function findOpenPullRequest(string $branch): ?int
+    {
+        $query = http_build_query([
+            'state' => 'open',
+            'head'  => $this->owner . ':' . $branch,
+        ]);
+
+        $decoded = $this->request('GET', '/pulls?' . $query, null);
+
+        $first = $decoded[0] ?? null;
+        if (!is_array($first)) {
+            return null;
+        }
+
+        $number = $first['number'] ?? null;
+
+        return is_int($number) ? $number : null;
+    }
+
+    /**
+     * URL-encode a `/`-separated branch name segment-by-segment, preserving the slashes as path
+     * hierarchy instead of collapsing them into `%2F` — a plain {@see rawurlencode()} of the
+     * whole branch name would turn every `/` into `%2F` and 404 against a ref path built from
+     * `litcal-data/<resource_type>/<resource_id>`.
+     */
+    private static function encodeRefSegment(string $branch): string
+    {
+        return implode('/', array_map('rawurlencode', explode('/', $branch)));
+    }
+
+    /**
+     * @throws GitHubApiException If the response status is not 2xx, or the sha is missing
+     */
+    private function extractSha(ResponseInterface $response, string $what): string
+    {
+        $decoded = $this->decodeOrThrow($response);
+
+        $sha = $decoded['sha'] ?? null;
+        if (!is_string($sha) || $sha === '') {
+            throw new GitHubApiException(
+                $response->getStatusCode(),
+                sprintf('GitHub created a %s but returned no usable sha', $what)
+            );
+        }
+
+        return $sha;
+    }
+
+    /**
+     * Send a request, decode its JSON body, and throw on any non-2xx status.
+     *
+     * @param array<string, mixed>|null $body
+     * @return array<int|string, mixed>
+     * @throws GitHubApiException If GitHub responds with a non-2xx status
+     */
+    private function request(string $method, string $path, ?array $body): array
+    {
+        $response = $this->send($method, $path, $body);
+
+        return $this->decodeOrThrow($response);
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     * @throws GitHubApiException If the response status is not 2xx
+     */
+    private function decodeOrThrow(ResponseInterface $response): array
+    {
+        $status  = $response->getStatusCode();
+        $decoded = $this->decode($response);
+
+        if ($status < 200 || $status >= 300) {
+            $message = isset($decoded['message']) && is_string($decoded['message'])
+                ? $decoded['message']
+                : 'Unknown error';
+
+            throw new GitHubApiException($status, sprintf('GitHub API error (HTTP %d): %s', $status, $message));
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array<int|string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        /** @var mixed $decoded */
+        $decoded = json_decode((string) $response->getBody(), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed>|null $body
+     * @throws RuntimeException If the transport itself fails (never for a non-2xx status, which
+     *                          is handled by the caller once it has a response to inspect)
+     */
+    private function send(string $method, string $path, ?array $body): ResponseInterface
+    {
+        $headers = [
+            'Authorization'        => 'Bearer ' . $this->auth->installationToken(),
+            'Accept'               => 'application/vnd.github+json',
+            'X-GitHub-Api-Version' => self::API_VERSION,
+        ];
+
+        $requestBody = null;
+        if ($body !== null) {
+            $headers['Content-Type'] = 'application/json';
+            $requestBody             = json_encode($body, JSON_THROW_ON_ERROR);
+        }
+
+        $url     = self::API_BASE_URL . '/repos/' . $this->owner . '/' . $this->repo . $path;
+        $request = new Request($method, $url, $headers, $requestBody);
+
+        try {
+            return $this->http->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            throw new RuntimeException(sprintf('GitHub API request failed: %s', $e->getMessage()), 0, $e);
+        }
+    }
+}

--- a/src/Services/GitHub/GitHubGitDataClient.php
+++ b/src/Services/GitHub/GitHubGitDataClient.php
@@ -26,6 +26,8 @@ final class GitHubGitDataClient
 {
     private const API_BASE_URL = 'https://api.github.com';
 
+    private const USER_AGENT = 'LiturgicalCalendarAPI-GitHubApp';
+
     private const API_VERSION = '2022-11-28';
 
     public function __construct(
@@ -286,6 +288,11 @@ final class GitHubGitDataClient
             'Authorization'        => 'Bearer ' . $this->auth->installationToken(),
             'Accept'               => 'application/vnd.github+json',
             'X-GitHub-Api-Version' => self::API_VERSION,
+            // GitHub rejects a request with no User-Agent as 403. Guzzle injects a default,
+            // but this class takes any PSR-18 ClientInterface by design, and a bare one sends
+            // none — so set it here rather than depending on which client was injected.
+            // Matches GitHubAppAuth, which identifies itself the same way.
+            'User-Agent'           => self::USER_AGENT,
         ];
 
         $requestBody = null;

--- a/src/Services/GitHub/GitHubGitDataClient.php
+++ b/src/Services/GitHub/GitHubGitDataClient.php
@@ -120,19 +120,54 @@ final class GitHubGitDataClient
     /**
      * Create a single-parent commit and return its sha.
      *
+     * `$committer` is a required, separate argument rather than left to GitHub's default —
+     * GitHub's Create-a-commit endpoint defaults an omitted `committer` to the value of
+     * `author`, which would silently collapse SourceDataPublisher's author/committer split
+     * (the editor as author, the App as committer) the moment either side forgot to pass it.
+     *
      * @param array{name: string, email: string, date?: string} $author
+     * @param array{name: string, email: string, date?: string} $committer
      * @throws GitHubApiException If GitHub responds with a non-2xx status
      */
-    public function createCommit(string $message, string $treeSha, string $parentSha, array $author): string
+    public function createCommit(string $message, string $treeSha, string $parentSha, array $author, array $committer): string
     {
         $response = $this->send('POST', '/git/commits', [
-            'message' => $message,
-            'tree'    => $treeSha,
-            'parents' => [$parentSha],
-            'author'  => $author,
+            'message'   => $message,
+            'tree'      => $treeSha,
+            'parents'   => [$parentSha],
+            'author'    => $author,
+            'committer' => $committer,
         ]);
 
         return $this->extractSha($response, 'commit');
+    }
+
+    /**
+     * The tree sha a commit points at, needed as `createTree()`'s `$baseTreeSha`.
+     *
+     * `getRef()` only ever returns a commit sha (a branch head), but `createTree()`'s
+     * `base_tree` parameter is a Git tree object sha, not a commit sha — the two are
+     * different object types and GitHub's API is strict about it. This is the one extra
+     * round trip that resolves a branch head into the tree sha to layer new entries onto.
+     *
+     * @throws GitHubApiException If GitHub responds with a non-2xx status, or the commit
+     *                            carries no usable tree.sha
+     */
+    public function getCommitTreeSha(string $commitSha): string
+    {
+        $response = $this->send('GET', '/git/commits/' . rawurlencode($commitSha), null);
+        $decoded  = $this->decodeOrThrow($response);
+
+        $tree = $decoded['tree'] ?? null;
+        $sha  = is_array($tree) ? ( $tree['sha'] ?? null ) : null;
+        if (!is_string($sha) || $sha === '') {
+            throw new GitHubApiException(
+                $response->getStatusCode(),
+                'GitHub returned a commit with no usable tree.sha'
+            );
+        }
+
+        return $sha;
     }
 
     /**

--- a/src/Services/SourceData/PublishResult.php
+++ b/src/Services/SourceData/PublishResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+/**
+ * The git-side outcome of publishing one approved change-request batch.
+ *
+ * Mirrors exactly what {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::recordPublication()}
+ * persists, so a caller can pass this straight through without re-deriving any of it.
+ */
+final readonly class PublishResult
+{
+    public function __construct(
+        /** `litcal-data/<resource_type>/<resource_id>`, stable per resource. */
+        public string $branch,
+        /** The sha of the commit just created and fast-forwarded onto `$branch`. */
+        public string $commitSha,
+        /** The rolling pull request's number, whether just opened or already open. */
+        public ?int $prNumber,
+        /**
+         * The commit `$branch` pointed at before this publish — the parent of `$commitSha`,
+         * and (on the branch's first publish) the base branch's head at that moment. Distinct
+         * from a row's own per-file `base_sha`, which is accumulation-base bookkeeping set at
+         * submission time.
+         */
+        public string $baseSha
+    ) {
+    }
+}

--- a/src/Services/SourceData/PublishRunResult.php
+++ b/src/Services/SourceData/PublishRunResult.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+/**
+ * What one {@see PublishRunner::runOnce()} pass did.
+ *
+ * `published` alone cannot distinguish "the queue was empty" from "a publish attempt failed
+ * and the loop stopped early" — both can produce the same count (zero, or some smaller number
+ * than `$limit`). That distinction is exactly what a cron-invoked script's exit code needs to
+ * signal: an empty queue is success, but a stopped-early run means approved work is piling up
+ * unpublished and an operator should be paged, not just logged past.
+ */
+final readonly class PublishRunResult
+{
+    public function __construct(
+        /** Batches actually published during this run, whether or not it later stopped early. */
+        public int $published,
+        /** True if the run stopped because a publish attempt threw, rather than an empty queue. */
+        public bool $stoppedOnFailure = false
+    ) {
+    }
+}

--- a/src/Services/SourceData/PublishRunResult.php
+++ b/src/Services/SourceData/PublishRunResult.php
@@ -19,7 +19,16 @@ final readonly class PublishRunResult
         /** Batches actually published during this run, whether or not it later stopped early. */
         public int $published,
         /** True if the run stopped because a publish attempt threw, rather than an empty queue. */
-        public bool $stoppedOnFailure = false
+        public bool $stoppedOnFailure = false,
+        /**
+         * Approved batches that have exhausted
+         * {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS}
+         * and are no longer being claimed. Reported on EVERY run, including successful ones:
+         * a parked batch produces no failure of its own — that is the whole point of parking
+         * it — so a run that publishes everything else and exits 0 is exactly the run that
+         * would otherwise hide it.
+         */
+        public int $parkedBatches = 0
     ) {
     }
 }

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+/**
+ * Cron-driven runner: claims approved change-request batches one at a time and publishes
+ * each as a commit and rolling pull request via {@see SourceDataPublisherInterface}.
+ *
+ * # A batch must never be stranded
+ *
+ * `SourceDataChangeRequestRepository::claimNextPublishableBatch()` marks a batch `queued`.
+ * If publication then fails and nothing puts the batch back to `none`, that batch is never
+ * picked up again — invisible to the operator, invisible to the editor, and indistinguishable
+ * from success on the editor's side. That is strictly worse than a batch that retries. So
+ * every path out of a failed publish here calls `releaseClaim()` before returning — for ANY
+ * `\Throwable`, not only {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubApiException}. A
+ * `TypeError` or an out-of-memory error thrown from inside the publisher must not leave work
+ * stranded any more than an expected GitHub API failure would.
+ *
+ * # Stop, don't hammer
+ *
+ * A failed publish stops the loop rather than moving on to the next batch. If GitHub is down
+ * or the installation credential has gone stale, every remaining batch would fail the same
+ * way; retrying immediately in-process would just exhaust the rate limit faster. The cron
+ * interval that re-invokes {@see runOnce()}, not an in-process retry, is what re-attempts —
+ * which is also why {@see \LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff} is not used
+ * here: there is no in-process retry loop to pace, only a single straight-line pass per tick.
+ */
+final class PublishRunner
+{
+    private readonly LoggerInterface $logger;
+
+    public function __construct(
+        private readonly SourceDataChangeRequestRepository $repository,
+        private readonly SourceDataPublisherInterface $publisher,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->logger = $logger ?? new NullLogger();
+    }
+
+    /**
+     * Claim, publish, and (via the publisher) record up to `$limit` approved batches.
+     *
+     * Returns as soon as the queue is exhausted, or as soon as one publish attempt fails —
+     * whichever comes first. A failed attempt's claim is released before this returns, so
+     * the batch is claimable again on the next run.
+     *
+     * @return int Batches actually published.
+     */
+    public function runOnce(int $limit = 10): int
+    {
+        $published = 0;
+
+        for ($i = 0; $i < $limit; $i++) {
+            $batchId = $this->repository->claimNextPublishableBatch();
+            if (null === $batchId) {
+                break;
+            }
+
+            try {
+                $this->publisher->publish($batchId);
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'Publishing source-data change request batch failed; claim released for retry.',
+                    [
+                        'batch_id'  => $batchId,
+                        'exception' => $e::class,
+                        'message'   => $e->getMessage(),
+                    ]
+                );
+                $this->repository->releaseClaim($batchId);
+                break;
+            }
+
+            $published++;
+        }
+
+        return $published;
+    }
+}

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace LiturgicalCalendar\Api\Services\SourceData;
 
+use LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -52,17 +54,63 @@ use Psr\Log\NullLogger;
  * genuinely and successfully published — recorded `open` with a real `commit_sha` and
  * `pr_number` — back to `none`, causing it to be silently republished next tick while still
  * carrying the first publish's real identifiers. `SourceDataChangeRequestRepository::releaseClaim()`
- * therefore only releases a row that is still `queued` (see that method's own docblock); once
- * another runner has moved it to `open`, this runner's release matches zero rows. That zero
- * is the signal, not an error: it means "this batch is not stranded, someone else finished
- * it", so `runOnce()` treats it as ordinary — it does NOT set `stoppedOnFailure`, and the loop
- * `continue`s to the next batch rather than stopping, because nothing about the underlying
- * GitHub API is actually failing. A release that DOES affect a row (or that throws) is a
- * genuine failure and still stops the loop with `stoppedOnFailure: true`, per "Stop, don't
- * hammer" below. See {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient} /
+ * therefore only releases a row that is still `queued` (see that method's own docblock).
+ *
+ * What that guard does NOT do is make "released nothing" mean "someone else published it".
+ * The guard fails to match for several reasons, and they are semantic opposites:
+ * `open`/`merged`/`closed` means another runner genuinely finished the batch, while `none`
+ * means nothing is published anywhere — reached whenever another runner's own publish failed
+ * too (one GitHub outage fails every runner identically) or whenever `reclaimStaleClaims()`
+ * released this batch out from under a merely-slow runner, which it does on every tick. An
+ * earlier revision of this class inferred "settled" from a zero row count, so a real outage
+ * logged success, left `stoppedOnFailure` false, and re-claimed the same batch on every
+ * iteration of the loop that exists to stop hammering — the exact opposite of both rules
+ * below. `releaseClaim()` therefore reports the OBSERVED STATUS as a
+ * {@see \LiturgicalCalendar\Api\Enum\ClaimReleaseOutcome}, and `runOnce()` branches on it:
+ * only `SETTLED_ELSEWHERE` continues without failing; `RELEASED`, `NOT_CLAIMED`,
+ * `BATCH_MISSING` and a release that throws are all genuine failures that stop the loop with
+ * `stoppedOnFailure: true`, per "Stop, don't hammer" below. See
+ * {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient} /
  * `scripts/publish-sourcedata.php`'s HTTP client wiring for the timeout that keeps "still
  * running" and "abandoned" distinguishable in the first place — an unbounded request could
  * outlive the grace period indefinitely, making this race far more likely than intended.
+ *
+ * # Contention is not an outage
+ *
+ * Two runners publishing DIFFERENT batches of the SAME resource both target that resource's
+ * one branch, and `updateRef()`'s hardcoded `force: false` means the loser gets a `422`
+ * non-fast-forward rather than clobbering the winner's commit. That is the design working:
+ * expected, self-healing (the next tick republishes onto the head the winner pushed), and
+ * proof that GitHub is healthy and answering. Stopping the whole tick for it — and exiting 1,
+ * paging an operator — would report an outage for a race the design deliberately allows. A
+ * `422` therefore logs a WARNING (it must stay visible; a silenced race is how a genuinely
+ * stuck branch hides) and continues with the rest of the queue, while every other failure
+ * still stops. The batch is not let off: the attempt is counted, so a batch that `422`s
+ * forever is parked by the bounded-attempts rule below rather than retried forever.
+ *
+ * # One bad batch must not strand the queue
+ *
+ * "Stop, don't hammer" below has a sharp edge of its own: candidates are ordered oldest-first
+ * and a failed publish returns its batch to `none`, so a batch that fails DETERMINISTICALLY —
+ * an illegal git-ref character in a `resource_id`, a tree-path conflict, a payload a later
+ * validation change rejects — is re-claimed first on every tick and every tick aborts before
+ * reaching anything else. One editor's broken proposal then blocks every other editor's good
+ * work indefinitely, and the only symptom is a log line repeating.
+ *
+ * Two bounds close that. Across runs,
+ * {@see SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS} caps CONSECUTIVE attempts per
+ * batch (`releaseClaim()` and `reclaimStaleClaims()` count them, `recordPublication()` resets
+ * them, so a transient GitHub blip cannot park anything); once a batch reaches the cap it stops
+ * being claimable and the queue drains past it. Within one run, a batch this pass already
+ * attempted is passed to `claimNextPublishableBatch()` as a skip id, because a batch just
+ * released to `none` is instantly the oldest candidate again — so a `continue` would otherwise
+ * re-claim the very batch it just failed on, which is in-process retry by another name.
+ *
+ * A parked batch is NOT a dead-lettered one — this feature has no dead-letter queue, and the
+ * rows are untouched and still `approved`. But it must never be a SILENT one, which would be
+ * the same class of defect as the stranded batch above: every run reports
+ * {@see PublishRunResult::$parkedBatches}, logs a warning when it is non-zero, and
+ * `GET /health`'s `source_data_publisher` block reports it out of band.
  *
  * # Stop, don't hammer
  *
@@ -126,16 +174,34 @@ final class PublishRunner
     public function runOnce(int $limit = 10): PublishRunResult
     {
         if (!$this->reclaimStaleClaimsSafely()) {
-            return new PublishRunResult(0, stoppedOnFailure: true);
+            return $this->result(0, stoppedOnFailure: true);
         }
 
         $published = 0;
+        /** @var list<string> $attempted Batches this run already tried; never tried twice. */
+        $attempted = [];
 
         for ($i = 0; $i < $limit; $i++) {
-            $batchId = $this->repository->claimNextPublishableBatch();
+            try {
+                $batchId = $this->repository->claimNextPublishableBatch($attempted);
+            } catch (\Throwable $e) {
+                $this->logger->error(
+                    'Claiming the next publishable source-data change request batch failed; '
+                        . 'stopping this run rather than looping against an unhealthy database.',
+                    [
+                        'exception' => $e::class,
+                        'message'   => $e->getMessage(),
+                    ]
+                );
+
+                return $this->result($published, stoppedOnFailure: true);
+            }
+
             if (null === $batchId) {
                 break;
             }
+
+            $attempted[] = $batchId;
 
             try {
                 $this->publisher->publish($batchId);
@@ -149,33 +215,128 @@ final class PublishRunner
                     ]
                 );
 
-                $releasedRows = $this->releaseClaimSafely($batchId);
+                $outcome = $this->releaseClaimSafely($batchId);
 
-                if (0 === $releasedRows) {
-                    // Guaranteed by SourceDataChangeRequestRepository::releaseClaim()'s own
-                    // `publication_status = 'queued'` guard: zero rows means this batch was no
-                    // longer queued by the time we tried to release it, i.e. another runner
-                    // already published it successfully. Not this run's failure — move on.
+                if (null !== $outcome && $outcome->isSettled()) {
+                    // The ONLY non-failure reading of a zero-row release, and it is a positive
+                    // observation rather than an inference: the batch is `open`/`merged`/
+                    // `closed`, so another runner genuinely published it while this runner's
+                    // doomed attempt was still in flight. Nothing about GitHub is failing;
+                    // this attempt was simply redundant. Move on to the next batch.
                     $this->logger->info(
                         'Batch was already settled (published) by another runner before this '
                             . "run's own release could take effect; not counted as a failure.",
-                        ['batch_id' => $batchId]
+                        ['batch_id' => $batchId, 'release_outcome' => $outcome->value]
                     );
                     continue;
                 }
 
-                // Either releaseClaim() genuinely released a still-queued claim (a real
-                // failure, now retryable), or it threw and releaseClaimSafely() already
-                // logged that (still a real failure — the batch just could not be confirmed
-                // un-stranded from here). Either way this is a real failure: stop rather than
-                // hammer a failing API with the rest of the queue.
-                return new PublishRunResult($published, stoppedOnFailure: true);
+                if ($this->isBranchContention($e)) {
+                    // Two batches of the SAME resource target one branch, so the loser of that
+                    // race gets a 422. See the class docblock's "Contention is not an outage".
+                    $this->logger->warning(
+                        'Publishing this batch lost a race for its resource branch (GitHub 422); '
+                            . 'the batch stays claimable and the next tick republishes it onto the '
+                            . 'branch head the winner pushed. Continuing with the rest of the queue.',
+                        [
+                            'batch_id'        => $batchId,
+                            'message'         => $e->getMessage(),
+                            'release_outcome' => $outcome->value ?? 'release_failed',
+                        ]
+                    );
+                    continue;
+                }
+
+                // Everything else is a real failure, whichever way the release read:
+                // RELEASED (this runner held the live claim and its publish failed),
+                // NOT_CLAIMED (`none` — nobody published it and nobody holds it, so the work
+                // is still undone), BATCH_MISSING (an unexplained state, never read
+                // optimistically), or null (the release itself threw, already logged by
+                // releaseClaimSafely()). Stop rather than hammer a failing API with the rest
+                // of the queue.
+                $this->logger->warning(
+                    'Stopping this run after a failed publish attempt.',
+                    ['batch_id' => $batchId, 'release_outcome' => $outcome->value ?? 'release_failed']
+                );
+
+                return $this->result($published, stoppedOnFailure: true);
             }
 
             $published++;
         }
 
-        return new PublishRunResult($published);
+        return $this->result($published);
+    }
+
+    /**
+     * Assemble a {@see PublishRunResult}, attaching the parked-batch count every run reports.
+     *
+     * Every return from {@see runOnce()} goes through here so that no exit path can drop the
+     * count: a batch that has stopped being attempted is exactly as invisible as one stranded
+     * `queued`, and the runs most likely to leave batches parked are the ones that end early.
+     */
+    private function result(int $published, bool $stoppedOnFailure = false): PublishRunResult
+    {
+        return new PublishRunResult($published, $stoppedOnFailure, $this->parkedBatchCountSafely());
+    }
+
+    /**
+     * Count (and, when non-zero, log) batches that have exhausted
+     * {@see SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS}.
+     *
+     * Wrapped for the same reason every other DB call in this class is: reporting how much work
+     * is stuck must never be the thing that turns a completed run into a raw fatal. A count
+     * that cannot be read is reported as 0 and logged, rather than guessed at.
+     */
+    private function parkedBatchCountSafely(): int
+    {
+        try {
+            $parked = $this->repository->countParkedBatches();
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Counting parked source-data change request batches failed; this run reports 0 '
+                    . 'parked batches, which may understate what is actually stuck.',
+                [
+                    'exception' => $e::class,
+                    'message'   => $e->getMessage(),
+                ]
+            );
+
+            return 0;
+        }
+
+        if ($parked > 0) {
+            $this->logger->warning(
+                'Approved source-data change request batches have exhausted their publish attempts '
+                    . 'and are no longer being attempted; they need an operator. See the '
+                    . 'change-request runbook, "Parked batches".',
+                [
+                    'parked_batches' => $parked,
+                    'max_attempts'   => SourceDataChangeRequestRepository::MAX_PUBLISH_ATTEMPTS,
+                ]
+            );
+        }
+
+        return $parked;
+    }
+
+    /**
+     * Is this failure the expected symptom of two runners racing for one resource's branch,
+     * rather than an unhealthy GitHub?
+     *
+     * `updateRef()` hardcodes `force: false`, so the loser of that race gets a `422` instead
+     * of clobbering the winner's commit — see the class docblock's "Contention is not an
+     * outage". Matched on the HTTP status alone, never on GitHub's message text, which is not
+     * a contract. Other `422`s exist (a validation error on `createRef()` or
+     * `openPullRequest()`), and they get the same treatment for the same reason: a `422` is
+     * GitHub answering, in detail, about THIS request. It says nothing about the next batch,
+     * which is what makes continuing safe — and the attempt is still counted against the
+     * batch's bounded attempts, so a batch that `422`s forever is eventually parked rather
+     * than retried forever.
+     */
+    private function isBranchContention(\Throwable $e): bool
+    {
+        return $e instanceof GitHubApiException && 422 === $e->status;
     }
 
     /**
@@ -184,11 +345,14 @@ final class PublishRunner
      * very plausibly also breaks this call — but an operator greping logs should find a
      * structured entry, not a stack trace with no context.
      *
-     * @return int|null The row count from `releaseClaim()` (0 means the batch was already
-     *                   settled elsewhere, not a failure — see the class docblock), or null if
-     *                   `releaseClaim()` itself threw.
+     * @return ClaimReleaseOutcome|null What `releaseClaim()` observed (see that enum: only
+     *                   {@see ClaimReleaseOutcome::SETTLED_ELSEWHERE} is a non-failure), or
+     *                   null if `releaseClaim()` itself threw. Null is treated as a failure by
+     *                   the caller: a thrown exception gives no positive "already settled"
+     *                   observation the way a clean status read does, and an unknown state is
+     *                   read conservatively.
      */
-    private function releaseClaimSafely(string $batchId): ?int
+    private function releaseClaimSafely(string $batchId): ?ClaimReleaseOutcome
     {
         try {
             return $this->repository->releaseClaim($batchId);

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -21,7 +21,23 @@ use Psr\Log\NullLogger;
  * every path out of a failed publish here calls `releaseClaim()` before returning — for ANY
  * `\Throwable`, not only {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubApiException}. A
  * `TypeError` or an out-of-memory error thrown from inside the publisher must not leave work
- * stranded any more than an expected GitHub API failure would.
+ * stranded any more than an expected GitHub API failure would. `releaseClaim()` itself is
+ * wrapped too: if the same outage that failed the publish also breaks that call, the batch
+ * still cannot be un-stranded from here, but the exception is logged rather than escaping as
+ * a raw fatal that an operator would have to find by grepping stack traces instead of logs.
+ *
+ * # A crash must not strand a batch either
+ *
+ * The above only covers a `\Throwable` this process actually catches. A SIGKILL, an OOM kill,
+ * or a cron timeout between `claimNextPublishableBatch()` and the publish finishing leaves a
+ * batch `queued` with nothing left running to release it — the same silent-loss failure mode,
+ * reached a different way. `runOnce()` therefore reclaims any batch still `queued` past a
+ * grace period at the START of every run, before claiming anything new, mirroring
+ * {@see \LiturgicalCalendar\Api\Services\Outbox\BackstopRunner}'s grace-window pattern rather
+ * than reusing it (that class is constructor-typed to the OpenFGA outbox's own repository).
+ * A reclaim is ordinary recovery, not a failure: it never sets
+ * {@see PublishRunResult::$stoppedOnFailure}, and a batch it reclaims is simply claimable
+ * again in the very same run.
  *
  * # Stop, don't hammer
  *
@@ -34,27 +50,39 @@ use Psr\Log\NullLogger;
  */
 final class PublishRunner
 {
+    /**
+     * A publish attempt is bounded by however long its sequence of GitHub API calls takes
+     * (one `getRef`/`createRef`, one `createBlob` per changed file, `createTree`,
+     * `createCommit`, `updateRef`, and `findOpenPullRequest`/`openPullRequest`) — minutes, not
+     * seconds, is the right order of magnitude for "this process is almost certainly dead",
+     * as opposed to {@see \LiturgicalCalendar\Api\Services\Outbox\BackstopRunner}'s 60-second
+     * default for a single fire-and-forget OpenFGA call.
+     */
+    private const DEFAULT_GRACE_SECONDS = 600;
+
     private readonly LoggerInterface $logger;
 
     public function __construct(
         private readonly SourceDataChangeRequestRepository $repository,
         private readonly SourceDataPublisherInterface $publisher,
+        private readonly int $graceSeconds = self::DEFAULT_GRACE_SECONDS,
         ?LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?? new NullLogger();
     }
 
     /**
-     * Claim, publish, and (via the publisher) record up to `$limit` approved batches.
+     * Reclaim stale claims, then claim, publish, and (via the publisher) record up to
+     * `$limit` approved batches.
      *
      * Returns as soon as the queue is exhausted, or as soon as one publish attempt fails —
      * whichever comes first. A failed attempt's claim is released before this returns, so
      * the batch is claimable again on the next run.
-     *
-     * @return int Batches actually published.
      */
-    public function runOnce(int $limit = 10): int
+    public function runOnce(int $limit = 10): PublishRunResult
     {
+        $this->reclaimStaleClaims();
+
         $published = 0;
 
         for ($i = 0; $i < $limit; $i++) {
@@ -74,13 +102,59 @@ final class PublishRunner
                         'message'   => $e->getMessage(),
                     ]
                 );
-                $this->repository->releaseClaim($batchId);
-                break;
+                $this->releaseClaimSafely($batchId);
+
+                return new PublishRunResult($published, stoppedOnFailure: true);
             }
 
             $published++;
         }
 
-        return $published;
+        return new PublishRunResult($published);
+    }
+
+    /**
+     * Release a claim without letting a failure here escape as a raw fatal. It cannot
+     * un-strand the batch either way if it throws — the same outage that failed the publish
+     * very plausibly also breaks this call — but an operator greping logs should find a
+     * structured entry, not a stack trace with no context.
+     */
+    private function releaseClaimSafely(string $batchId): void
+    {
+        try {
+            $this->repository->releaseClaim($batchId);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Releasing the claim on a failed source-data publish batch also failed; '
+                    . 'the batch remains queued and needs manual recovery or the grace-period reclaim.',
+                [
+                    'batch_id'  => $batchId,
+                    'exception' => $e::class,
+                    'message'   => $e->getMessage(),
+                ]
+            );
+        }
+    }
+
+    /**
+     * Release any batch stranded `queued` past the grace period back to `none`, so it is
+     * claimable again in this same run. See the class docblock's "A crash must not strand a
+     * batch either" section for why this exists.
+     */
+    private function reclaimStaleClaims(): void
+    {
+        $cutoff = ( new \DateTimeImmutable('now', new \DateTimeZone('Europe/Vatican')) )
+            ->modify("-{$this->graceSeconds} seconds");
+
+        $reclaimed = $this->repository->reclaimStaleClaims($cutoff);
+        if ($reclaimed > 0) {
+            $this->logger->warning(
+                'Reclaimed source-data change request rows stranded in queued past the grace period.',
+                [
+                    'rows_reclaimed' => $reclaimed,
+                    'grace_seconds'  => $this->graceSeconds,
+                ]
+            );
+        }
     }
 }

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -249,10 +249,17 @@ final class PublishRunner
                     // accompanied it happened to be a 422 — the same DB failure beside a 500
                     // stops the run — and would read an unexplained state optimistically,
                     // against ClaimReleaseOutcome's own rule.
+                    // "stays claimable" holds for every attempt but the last: the release that
+                    // reports RELEASED is also the one that spends an attempt, so the attempt that
+                    // reaches the bound parks the batch in the same breath as this message. Said
+                    // plainly here rather than left to contradict the parked warning and the
+                    // `parked` count that the very same run emits.
                     $this->logger->warning(
                         'Publishing this batch lost a race for its resource branch (GitHub 422); '
                             . 'the batch stays claimable and the next tick republishes it onto the '
-                            . 'branch head the winner pushed. Continuing with the rest of the queue.',
+                            . 'branch head the winner pushed — unless this attempt was its last, in '
+                            . 'which case it is parked and this run reports it as such. '
+                            . 'Continuing with the rest of the queue.',
                         [
                             'batch_id'        => $batchId,
                             'message'         => $e->getMessage(),

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -231,9 +231,24 @@ final class PublishRunner
                     continue;
                 }
 
-                if ($this->isBranchContention($e)) {
+                if (
+                    $this->isBranchContention($e)
+                    && null !== $outcome
+                    && ClaimReleaseOutcome::BATCH_MISSING !== $outcome
+                ) {
                     // Two batches of the SAME resource target one branch, so the loser of that
                     // race gets a 422. See the class docblock's "Contention is not an outage".
+                    //
+                    // Gated on the release having actually been OBSERVED, not on the GitHub
+                    // status alone. The message below promises the batch "stays claimable" and
+                    // that "the next tick republishes it" — true when the release reported
+                    // RELEASED or NOT_CLAIMED, and false when the release itself threw (null:
+                    // the same outage broke both, and the batch is left `queued` until the
+                    // grace-period reclaim) or when the batch has vanished. Continuing there
+                    // would exit 0 on a database failure purely because the GitHub error that
+                    // accompanied it happened to be a 422 — the same DB failure beside a 500
+                    // stops the run — and would read an unexplained state optimistically,
+                    // against ClaimReleaseOutcome's own rule.
                     $this->logger->warning(
                         'Publishing this batch lost a race for its resource branch (GitHub 422); '
                             . 'the batch stays claimable and the next tick republishes it onto the '

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -84,11 +84,24 @@ final class PublishRunner
      * as opposed to {@see \LiturgicalCalendar\Api\Services\Outbox\BackstopRunner}'s 60-second
      * default for a single fire-and-forget OpenFGA call. This is a probabilistic cutoff, not a
      * guarantee — see the class docblock's "A merely SLOW process is not a dead one" section —
-     * so it must stay comfortably above the HTTP client's own request timeout
-     * (`scripts/publish-sourcedata.php`'s Guzzle wiring), or a slow-but-alive publish becomes
-     * the common case instead of a rare one.
+     * so it must stay comfortably above the WHOLE publish's worst-case duration, not above a
+     * single request's timeout.
+     *
+     * That distinction matters, because a publish issues one `createBlob` per changed file,
+     * serially, and only then the six fixed calls (getRef, getCommitTreeSha, createTree,
+     * createCommit, updateRef, findOpenPullRequest). The decrees corpus is the widest batch
+     * this repository can produce today — `decrees.json` plus 14 `i18n/` locales plus 7
+     * `lectionary/` locales — so 22 blob writes plus 6 fixed calls is 28 requests. At the
+     * script's 30-second request timeout that is 840 seconds worst case, which a 600-second
+     * grace would have cut straight through: the reclaim would have fired on live work
+     * whenever GitHub was merely slow, rather than only on work that was abandoned.
+     *
+     * 1800 leaves headroom above that 840 while still bounding how long a genuinely crashed
+     * batch waits to be picked back up. If either the request timeout or the widest batch
+     * grows, this must grow with them — the invariant is
+     * `grace > maxRequestsPerBatch * requestTimeout`, not any particular number.
      */
-    private const DEFAULT_GRACE_SECONDS = 600;
+    private const DEFAULT_GRACE_SECONDS = 1800;
 
     private readonly LoggerInterface $logger;
 

--- a/src/Services/SourceData/PublishRunner.php
+++ b/src/Services/SourceData/PublishRunner.php
@@ -37,16 +37,42 @@ use Psr\Log\NullLogger;
  * than reusing it (that class is constructor-typed to the OpenFGA outbox's own repository).
  * A reclaim is ordinary recovery, not a failure: it never sets
  * {@see PublishRunResult::$stoppedOnFailure}, and a batch it reclaims is simply claimable
- * again in the very same run.
+ * again in the very same run. `reclaimStaleClaims()` is itself wrapped for the same reason
+ * `releaseClaim()` is: a DB outage during the reclaim step must not surface as a raw PHP
+ * fatal with no `published=... stopped_on_failure=...` line for the cron script to report.
+ *
+ * # A merely SLOW process is not a dead one — the reclaim's own sharp edge
+ *
+ * The grace period distinguishes "dead" from "alive" only probabilistically: a publish that
+ * is simply taking longer than the grace window (a large batch, a slow GitHub response) is
+ * still alive when a second runner reclaims and re-publishes its batch. When the first
+ * runner's own, now-doomed GitHub call finally returns — a non-fast-forward `updateRef()`,
+ * since the branch moved under it — its catch calls `releaseClaim()` too. If that call were
+ * unconditional, it would revert a batch that a *different* runner had, in the meantime,
+ * genuinely and successfully published — recorded `open` with a real `commit_sha` and
+ * `pr_number` — back to `none`, causing it to be silently republished next tick while still
+ * carrying the first publish's real identifiers. `SourceDataChangeRequestRepository::releaseClaim()`
+ * therefore only releases a row that is still `queued` (see that method's own docblock); once
+ * another runner has moved it to `open`, this runner's release matches zero rows. That zero
+ * is the signal, not an error: it means "this batch is not stranded, someone else finished
+ * it", so `runOnce()` treats it as ordinary — it does NOT set `stoppedOnFailure`, and the loop
+ * `continue`s to the next batch rather than stopping, because nothing about the underlying
+ * GitHub API is actually failing. A release that DOES affect a row (or that throws) is a
+ * genuine failure and still stops the loop with `stoppedOnFailure: true`, per "Stop, don't
+ * hammer" below. See {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient} /
+ * `scripts/publish-sourcedata.php`'s HTTP client wiring for the timeout that keeps "still
+ * running" and "abandoned" distinguishable in the first place — an unbounded request could
+ * outlive the grace period indefinitely, making this race far more likely than intended.
  *
  * # Stop, don't hammer
  *
- * A failed publish stops the loop rather than moving on to the next batch. If GitHub is down
- * or the installation credential has gone stale, every remaining batch would fail the same
- * way; retrying immediately in-process would just exhaust the rate limit faster. The cron
- * interval that re-invokes {@see runOnce()}, not an in-process retry, is what re-attempts —
- * which is also why {@see \LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff} is not used
- * here: there is no in-process retry loop to pace, only a single straight-line pass per tick.
+ * A genuinely failed publish stops the loop rather than moving on to the next batch. If
+ * GitHub is down or the installation credential has gone stale, every remaining batch would
+ * fail the same way; retrying immediately in-process would just exhaust the rate limit
+ * faster. The cron interval that re-invokes {@see runOnce()}, not an in-process retry, is
+ * what re-attempts — which is also why {@see \LiturgicalCalendar\Api\Services\Outbox\OutboxBackoff}
+ * is not used here: there is no in-process retry loop to pace, only a single straight-line
+ * pass per tick.
  */
 final class PublishRunner
 {
@@ -56,7 +82,11 @@ final class PublishRunner
      * `createCommit`, `updateRef`, and `findOpenPullRequest`/`openPullRequest`) — minutes, not
      * seconds, is the right order of magnitude for "this process is almost certainly dead",
      * as opposed to {@see \LiturgicalCalendar\Api\Services\Outbox\BackstopRunner}'s 60-second
-     * default for a single fire-and-forget OpenFGA call.
+     * default for a single fire-and-forget OpenFGA call. This is a probabilistic cutoff, not a
+     * guarantee — see the class docblock's "A merely SLOW process is not a dead one" section —
+     * so it must stay comfortably above the HTTP client's own request timeout
+     * (`scripts/publish-sourcedata.php`'s Guzzle wiring), or a slow-but-alive publish becomes
+     * the common case instead of a rare one.
      */
     private const DEFAULT_GRACE_SECONDS = 600;
 
@@ -75,13 +105,16 @@ final class PublishRunner
      * Reclaim stale claims, then claim, publish, and (via the publisher) record up to
      * `$limit` approved batches.
      *
-     * Returns as soon as the queue is exhausted, or as soon as one publish attempt fails —
-     * whichever comes first. A failed attempt's claim is released before this returns, so
-     * the batch is claimable again on the next run.
+     * Returns as soon as the queue is exhausted, or as soon as one publish attempt
+     * *genuinely* fails — whichever comes first. A batch whose own release turns out to be a
+     * no-op (already settled by another runner — see the class docblock) is not treated as a
+     * failure: this run moves on to the next batch instead of stopping.
      */
     public function runOnce(int $limit = 10): PublishRunResult
     {
-        $this->reclaimStaleClaims();
+        if (!$this->reclaimStaleClaimsSafely()) {
+            return new PublishRunResult(0, stoppedOnFailure: true);
+        }
 
         $published = 0;
 
@@ -95,15 +128,34 @@ final class PublishRunner
                 $this->publisher->publish($batchId);
             } catch (\Throwable $e) {
                 $this->logger->error(
-                    'Publishing source-data change request batch failed; claim released for retry.',
+                    'Publishing source-data change request batch failed.',
                     [
                         'batch_id'  => $batchId,
                         'exception' => $e::class,
                         'message'   => $e->getMessage(),
                     ]
                 );
-                $this->releaseClaimSafely($batchId);
 
+                $releasedRows = $this->releaseClaimSafely($batchId);
+
+                if (0 === $releasedRows) {
+                    // Guaranteed by SourceDataChangeRequestRepository::releaseClaim()'s own
+                    // `publication_status = 'queued'` guard: zero rows means this batch was no
+                    // longer queued by the time we tried to release it, i.e. another runner
+                    // already published it successfully. Not this run's failure — move on.
+                    $this->logger->info(
+                        'Batch was already settled (published) by another runner before this '
+                            . "run's own release could take effect; not counted as a failure.",
+                        ['batch_id' => $batchId]
+                    );
+                    continue;
+                }
+
+                // Either releaseClaim() genuinely released a still-queued claim (a real
+                // failure, now retryable), or it threw and releaseClaimSafely() already
+                // logged that (still a real failure — the batch just could not be confirmed
+                // un-stranded from here). Either way this is a real failure: stop rather than
+                // hammer a failing API with the rest of the queue.
                 return new PublishRunResult($published, stoppedOnFailure: true);
             }
 
@@ -118,11 +170,15 @@ final class PublishRunner
      * un-strand the batch either way if it throws — the same outage that failed the publish
      * very plausibly also breaks this call — but an operator greping logs should find a
      * structured entry, not a stack trace with no context.
+     *
+     * @return int|null The row count from `releaseClaim()` (0 means the batch was already
+     *                   settled elsewhere, not a failure — see the class docblock), or null if
+     *                   `releaseClaim()` itself threw.
      */
-    private function releaseClaimSafely(string $batchId): void
+    private function releaseClaimSafely(string $batchId): ?int
     {
         try {
-            $this->repository->releaseClaim($batchId);
+            return $this->repository->releaseClaim($batchId);
         } catch (\Throwable $e) {
             $this->logger->error(
                 'Releasing the claim on a failed source-data publish batch also failed; '
@@ -133,6 +189,8 @@ final class PublishRunner
                     'message'   => $e->getMessage(),
                 ]
             );
+
+            return null;
         }
     }
 
@@ -140,13 +198,35 @@ final class PublishRunner
      * Release any batch stranded `queued` past the grace period back to `none`, so it is
      * claimable again in this same run. See the class docblock's "A crash must not strand a
      * batch either" section for why this exists.
+     *
+     * Wrapped for the same reason {@see releaseClaimSafely()} is: a DB outage here must not
+     * escape as a raw PHP fatal with no structured log and no `PublishRunResult` for the
+     * caller to report.
+     *
+     * @return bool False if `reclaimStaleClaims()` itself threw (logged here); true otherwise,
+     *              regardless of how many rows (if any) were actually reclaimed.
      */
-    private function reclaimStaleClaims(): void
+    private function reclaimStaleClaimsSafely(): bool
     {
         $cutoff = ( new \DateTimeImmutable('now', new \DateTimeZone('Europe/Vatican')) )
             ->modify("-{$this->graceSeconds} seconds");
 
-        $reclaimed = $this->repository->reclaimStaleClaims($cutoff);
+        try {
+            $reclaimed = $this->repository->reclaimStaleClaims($cutoff);
+        } catch (\Throwable $e) {
+            $this->logger->error(
+                'Reclaiming stale source-data publish claims failed; skipping this run rather '
+                    . 'than claiming new work against a possibly-unhealthy database.',
+                [
+                    'exception'     => $e::class,
+                    'message'       => $e->getMessage(),
+                    'grace_seconds' => $this->graceSeconds,
+                ]
+            );
+
+            return false;
+        }
+
         if ($reclaimed > 0) {
             $this->logger->warning(
                 'Reclaimed source-data change request rows stranded in queued past the grace period.',
@@ -156,5 +236,7 @@ final class PublishRunner
                 ]
             );
         }
+
+        return true;
     }
 }

--- a/src/Services/SourceData/PublishablePayload.php
+++ b/src/Services/SourceData/PublishablePayload.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use InvalidArgumentException;
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use RuntimeException;
+
+/**
+ * One approved change-request batch, flattened and type-narrowed from
+ * {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::getBatch()}'s
+ * `array<string, mixed>` rows into what {@see SourceDataPublisher} needs to build a commit.
+ *
+ * Every row in a batch shares one resource and one submitter — they are written and
+ * transitioned together, exactly as
+ * {@see \LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository::hydrateBatch()}
+ * already assumes when it collapses a batch with `MIN()` — so those fields are read once, off
+ * the first row, rather than re-validated as agreeing across every row.
+ */
+final readonly class PublishablePayload
+{
+    /**
+     * @param list<array{path: string, operation: ChangeOperation, content: ?string}> $files
+     *        Ordered exactly as `getBatch()` returned them (by path). A `delete` row's
+     *        `content` is null; every other operation's content is guaranteed non-null by
+     *        {@see fromBatchRows()}.
+     */
+    private function __construct(
+        public string $resourceType,
+        public string $resourceId,
+        public ?string $submittedByName,
+        public ?string $submittedByEmail,
+        public bool $submittedByEmailVerified,
+        public array $files
+    ) {
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $rows One batch's rows, as returned by
+     *                                                `SourceDataChangeRequestRepository::getBatch()`.
+     * @throws InvalidArgumentException If `$rows` is empty — there is nothing to publish.
+     * @throws RuntimeException         If a row is missing a field this class relies on, or has
+     *                                  the wrong type for it — a schema/query mismatch, not a
+     *                                  reachable data state.
+     */
+    public static function fromBatchRows(array $rows): self
+    {
+        if ($rows === []) {
+            throw new InvalidArgumentException('Cannot build a PublishablePayload from an empty batch');
+        }
+
+        $first = $rows[0];
+
+        $files = array_values(array_map(
+            static function (array $row): array {
+                $operation = ChangeOperation::from(self::requireString($row, 'operation'));
+                $content   = self::optionalString($row, 'content');
+
+                // No aggregate file is ever staged for deletion (they are rewritten in
+                // place, never removed) — see the repository's findUnpublishedContent()
+                // docblock — so a non-delete row with no content is a data-integrity
+                // violation, not a state this class should paper over.
+                if ($operation !== ChangeOperation::DELETE && $content === null) {
+                    throw new RuntimeException(sprintf(
+                        'Change request row for path "%s" has operation "%s" but no content',
+                        self::requireString($row, 'path'),
+                        $operation->value
+                    ));
+                }
+
+                return [
+                    'path'      => self::requireString($row, 'path'),
+                    'operation' => $operation,
+                    'content'   => $content,
+                ];
+            },
+            $rows
+        ));
+
+        return new self(
+            self::requireString($first, 'resource_type'),
+            self::requireString($first, 'resource_id'),
+            self::optionalString($first, 'submitted_by_name'),
+            self::optionalString($first, 'submitted_by_email'),
+            self::requireBool($first, 'submitted_by_email_verified'),
+            $files
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private static function requireString(array $row, string $key): string
+    {
+        $value = $row[$key] ?? null;
+        if (!is_string($value) || $value === '') {
+            throw new RuntimeException(sprintf(
+                'Expected change request column "%s" to be a non-empty string, got %s',
+                $key,
+                get_debug_type($value)
+            ));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private static function optionalString(array $row, string $key): ?string
+    {
+        $value = $row[$key] ?? null;
+        if ($value === null) {
+            return null;
+        }
+        if (!is_string($value)) {
+            throw new RuntimeException(sprintf(
+                'Expected change request column "%s" to be a string or null, got %s',
+                $key,
+                get_debug_type($value)
+            ));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private static function requireBool(array $row, string $key): bool
+    {
+        $value = $row[$key] ?? null;
+        if (!is_bool($value)) {
+            throw new RuntimeException(sprintf(
+                'Expected change request column "%s" to be a bool, got %s',
+                $key,
+                get_debug_type($value)
+            ));
+        }
+
+        return $value;
+    }
+}

--- a/src/Services/SourceData/SourceDataPublisher.php
+++ b/src/Services/SourceData/SourceDataPublisher.php
@@ -237,6 +237,21 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
     }
 
     /**
+     * True when the publisher has everything it needs to actually publish: the GitHub App
+     * credential ({@see GitHubAppAuth::isConfigured()}) plus `GITHUB_REPOSITORY`.
+     *
+     * `GITHUB_BASE_BRANCH`, `GITHUB_APP_COMMITTER_NAME`, and `GITHUB_APP_COMMITTER_EMAIL` are
+     * deliberately not checked here: {@see fromEnv()} defaults all three when unset or empty,
+     * so their absence never leaves the publisher unable to run — only the four checked here
+     * do. Mirrors {@see GitHubAppAuth::isConfigured()} and is consumed by
+     * {@see \LiturgicalCalendar\Api\Health::buildSourceDataPublisherStatus()}.
+     */
+    public static function isConfigured(): bool
+    {
+        return GitHubAppAuth::isConfigured() && '' !== self::getEnvString('GITHUB_REPOSITORY');
+    }
+
+    /**
      * Build a fully wired instance from environment variables: `GITHUB_APP_ID`,
      * `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY_PATH` (via
      * {@see GitHubAppAuth::fromEnv()}), `GITHUB_REPOSITORY` (required), and the optional

--- a/src/Services/SourceData/SourceDataPublisher.php
+++ b/src/Services/SourceData/SourceDataPublisher.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use InvalidArgumentException;
+use LiturgicalCalendar\Api\Enum\ChangeOperation;
+use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use RuntimeException;
+
+/**
+ * Turns one approved change-request batch into a single commit on a per-resource branch,
+ * plus a rolling pull request.
+ *
+ * # Sequence
+ *
+ * ```text
+ * getRef(branch)            null -> createRef(branch, getRef(baseBranch))
+ * getCommitTreeSha(head)    resolve the branch head commit to the tree it points at
+ * createBlob(content)       once per non-delete row
+ * createTree(baseTree)      one entry per row; delete rows carry sha: null
+ * createCommit(...)         author = editor, committer = the App, parent = branch head
+ * updateRef(branch, sha)    always force: false
+ * findOpenPullRequest()     -> openPullRequest() only when null
+ * ```
+ *
+ * # One commit per batch, never merged across batches
+ *
+ * A batch is exactly one call to {@see publish()} and produces exactly one commit. Batching
+ * several approved batches into one commit would merge two editors' work into a single
+ * author, destroying the per-editor authorship this whole design exists to preserve — see the
+ * author/committer split below.
+ *
+ * # Branch naming
+ *
+ * `litcal-data/<resource_type>/<resource_id>` — e.g. `litcal-data/national_calendar/roman/US`.
+ * `resource_id` already contains a `/` for rite-qualified ids
+ * ({@see \LiturgicalCalendar\Api\Services\RiteScopedObjectId}); that is legal in a git ref and
+ * intended. The name is stable per resource, which is what makes the pull request "rolling":
+ * every later batch for the same resource lands on the same branch and is picked up by
+ * {@see findOpenPullRequest()} instead of opening a second, competing pull request.
+ *
+ * # Author vs committer
+ *
+ * The commit's `author` is the editor who submitted the batch (`submitted_by_name`,
+ * `submitted_by_email`); the `committer` is this publisher's own configured identity (the
+ * GitHub App). This split is the entire reason the design exists: it lets the repository
+ * history attribute a change to the person who actually made it, while the App remains the
+ * party that actually pushed it.
+ *
+ * An unverified email must never become the commit author email — presenting it as an
+ * authenticated identity would let anyone who can set an arbitrary address in their profile
+ * forge authorship of a third party in a public repository. {@see authorFor()} uses
+ * `submitted_by_email` only when `submitted_by_email_verified` is true; otherwise it falls
+ * back to a GitHub `noreply`-style placeholder. There is no real per-editor noreply mapping
+ * available here (editors authenticate through Zitadel, not a GitHub account), so the
+ * fallback is a fixed address rather than a genuine `<id>+<login>@users.noreply.github.com`.
+ */
+final class SourceDataPublisher
+{
+    private const TREE_ENTRY_MODE = '100644';
+
+    private const TREE_ENTRY_TYPE = 'blob';
+
+    /**
+     * @see class docblock, "Author vs committer" — used only when
+     * `submitted_by_email_verified` is false or the email is missing.
+     */
+    private const UNVERIFIED_AUTHOR_EMAIL = 'noreply@users.noreply.github.com';
+
+    private const FALLBACK_AUTHOR_NAME = 'Unknown Editor';
+
+    public function __construct(
+        private readonly SourceDataChangeRequestRepository $repository,
+        private readonly GitHubGitDataClient $client,
+        /** The branch a resource's first publish branches from, e.g. `development`. */
+        private readonly string $baseBranch,
+        /** The App's display name, used as the commit `committer.name`. */
+        private readonly string $committerName,
+        /** The App's email, used as the commit `committer.email`. */
+        private readonly string $committerEmail
+    ) {
+    }
+
+    /**
+     * Publish one approved batch and record the result on every row.
+     *
+     * @throws InvalidArgumentException If the batch does not exist (empty row set).
+     * @throws RuntimeException         If the configured base branch does not exist on GitHub.
+     * @throws \LiturgicalCalendar\Api\Services\GitHub\GitHubApiException If any GitHub call fails —
+     *         in particular, a non-fast-forward `updateRef()` on a branch another publish landed
+     *         on concurrently, which the caller is expected to retry.
+     */
+    public function publish(string $batchId): PublishResult
+    {
+        $rows = $this->repository->getBatch($batchId);
+        if ($rows === []) {
+            throw new InvalidArgumentException(sprintf('No change request batch found for id "%s"', $batchId));
+        }
+
+        $payload = PublishablePayload::fromBatchRows($rows);
+        $branch  = self::branchFor($payload);
+
+        $headSha = $this->client->getRef($branch);
+        if (null === $headSha) {
+            $headSha = $this->client->getRef($this->baseBranch);
+            if (null === $headSha) {
+                throw new RuntimeException(sprintf('Base branch "%s" does not exist on GitHub', $this->baseBranch));
+            }
+            $this->client->createRef($branch, $headSha);
+        }
+
+        $baseTreeSha = $this->client->getCommitTreeSha($headSha);
+        $treeEntries = $this->buildTreeEntries($payload);
+        $treeSha     = $this->client->createTree($baseTreeSha, $treeEntries);
+
+        $commitSha = $this->client->createCommit(
+            $this->commitMessageFor($payload, $batchId),
+            $treeSha,
+            $headSha,
+            $this->authorFor($payload),
+            ['name' => $this->committerName, 'email' => $this->committerEmail]
+        );
+
+        $this->client->updateRef($branch, $commitSha);
+
+        $prNumber = $this->client->findOpenPullRequest($branch);
+        if (null === $prNumber) {
+            $prNumber = $this->client->openPullRequest(
+                $branch,
+                $this->baseBranch,
+                $this->pullRequestTitleFor($payload),
+                $this->pullRequestBodyFor($payload, $batchId)
+            );
+        }
+
+        $this->repository->recordPublication($batchId, $branch, $commitSha, $prNumber, $headSha);
+
+        return new PublishResult($branch, $commitSha, $prNumber, $headSha);
+    }
+
+    private static function branchFor(PublishablePayload $payload): string
+    {
+        return sprintf('litcal-data/%s/%s', $payload->resourceType, $payload->resourceId);
+    }
+
+    /**
+     * @return list<array{path: string, mode: string, type: string, sha: string|null}>
+     */
+    private function buildTreeEntries(PublishablePayload $payload): array
+    {
+        $entries = [];
+        foreach ($payload->files as $file) {
+            $entries[] = [
+                'path' => $file['path'],
+                'mode' => self::TREE_ENTRY_MODE,
+                'type' => self::TREE_ENTRY_TYPE,
+                // A delete carries sha: null, the Git Data API's mechanism for removing a
+                // path from the resulting tree. PublishablePayload::fromBatchRows() already
+                // guarantees every non-delete row has non-null content, so createBlob() here
+                // never receives null.
+                'sha'  => ChangeOperation::DELETE === $file['operation']
+                    ? null
+                    : $this->client->createBlob((string) $file['content']),
+            ];
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @return array{name: string, email: string}
+     */
+    private function authorFor(PublishablePayload $payload): array
+    {
+        $email = $payload->submittedByEmailVerified && null !== $payload->submittedByEmail
+            ? $payload->submittedByEmail
+            : self::UNVERIFIED_AUTHOR_EMAIL;
+
+        return [
+            'name'  => $payload->submittedByName ?? self::FALLBACK_AUTHOR_NAME,
+            'email' => $email,
+        ];
+    }
+
+    private function commitMessageFor(PublishablePayload $payload, string $batchId): string
+    {
+        return sprintf('Publish %s/%s (batch %s)', $payload->resourceType, $payload->resourceId, $batchId);
+    }
+
+    private function pullRequestTitleFor(PublishablePayload $payload): string
+    {
+        return sprintf('Source data: %s/%s', $payload->resourceType, $payload->resourceId);
+    }
+
+    private function pullRequestBodyFor(PublishablePayload $payload, string $batchId): string
+    {
+        $paths = implode("\n", array_map(
+            static fn (array $file): string => '- ' . $file['path'],
+            $payload->files
+        ));
+
+        return sprintf(
+            "Automated publish of approved change request batch `%s`, submitted by %s.\n\nFiles:\n%s",
+            $batchId,
+            $payload->submittedByName ?? self::FALLBACK_AUTHOR_NAME,
+            $paths
+        );
+    }
+
+    /**
+     * Split a `GITHUB_REPOSITORY` value of the form `owner/repo` — e.g.
+     * `Liturgical-Calendar/LiturgicalCalendarAPI` — into the two strings
+     * {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient}'s constructor takes
+     * explicitly. `GITHUB_REPOSITORY` is a single environment value; the client deliberately
+     * does not parse it itself, so whoever wires the client up must split it first.
+     *
+     * @return array{owner: string, repo: string}
+     * @throws InvalidArgumentException If `$githubRepository` is not exactly one `/`-separated
+     *                                  `owner/repo` pair with both halves non-empty.
+     */
+    public static function splitGithubRepository(string $githubRepository): array
+    {
+        $parts = explode('/', $githubRepository);
+        if (2 !== count($parts) || '' === $parts[0] || '' === $parts[1]) {
+            throw new InvalidArgumentException(
+                sprintf('GITHUB_REPOSITORY must be in the form "owner/repo", got "%s"', $githubRepository)
+            );
+        }
+
+        return ['owner' => $parts[0], 'repo' => $parts[1]];
+    }
+}

--- a/src/Services/SourceData/SourceDataPublisher.php
+++ b/src/Services/SourceData/SourceDataPublisher.php
@@ -226,11 +226,34 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
      */
     public static function splitGithubRepository(string $githubRepository): array
     {
-        $parts = explode('/', $githubRepository);
-        if (2 !== count($parts) || '' === $parts[0] || '' === $parts[1]) {
+        $parsed = self::parseGithubRepository($githubRepository);
+        if (null === $parsed) {
             throw new InvalidArgumentException(
                 sprintf('GITHUB_REPOSITORY must be in the form "owner/repo", got "%s"', $githubRepository)
             );
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * The single definition of what a well-formed `GITHUB_REPOSITORY` is, shared by
+     * {@see splitGithubRepository()} (which throws) and {@see isConfigured()} (which reports).
+     *
+     * Kept in ONE place on purpose. When the shape rule lived only inside the throwing
+     * splitter, `isConfigured()` tested non-emptiness alone — so a value that was set but
+     * malformed (a pasted repository URL, a trailing slash, a bare repo name with no owner)
+     * made `GET /health` report the publisher `configured` while every run died on it. Two
+     * copies of the rule would drift back into exactly that.
+     *
+     * @return array{owner: string, repo: string}|null Null when the value is not exactly one
+     *         `/`-separated pair with both halves non-empty.
+     */
+    private static function parseGithubRepository(string $githubRepository): ?array
+    {
+        $parts = explode('/', $githubRepository);
+        if (2 !== count($parts) || '' === $parts[0] || '' === $parts[1]) {
+            return null;
         }
 
         return ['owner' => $parts[0], 'repo' => $parts[1]];
@@ -238,7 +261,15 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
 
     /**
      * True when the publisher has everything it needs to actually publish: the GitHub App
-     * credential ({@see GitHubAppAuth::isConfigured()}) plus `GITHUB_REPOSITORY`.
+     * credential ({@see GitHubAppAuth::isConfigured()}) plus a WELL-FORMED `GITHUB_REPOSITORY`.
+     *
+     * The shape check is not fussiness. `fromEnv()` rejects anything that is not an
+     * `owner/repo` pair, so a set-but-malformed value — a pasted repository URL, a trailing
+     * slash, a bare repo name — means no run can ever publish. Testing only for non-emptiness
+     * made this method answer `configured`, and `/health` then reported a healthy publisher
+     * while approved work accumulated: the precise failure mode this block exists to catch,
+     * reached through a value that is present rather than absent. The rule itself lives in
+     * {@see parseGithubRepository()}, shared with the splitter, so the two can never disagree.
      *
      * `GITHUB_BASE_BRANCH`, `GITHUB_APP_COMMITTER_NAME`, and `GITHUB_APP_COMMITTER_EMAIL` are
      * deliberately not checked here: {@see fromEnv()} defaults all three when unset or empty,
@@ -248,7 +279,8 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
      */
     public static function isConfigured(): bool
     {
-        return GitHubAppAuth::isConfigured() && '' !== self::getEnvString('GITHUB_REPOSITORY');
+        return GitHubAppAuth::isConfigured()
+            && null !== self::parseGithubRepository(self::getEnvString('GITHUB_REPOSITORY'));
     }
 
     /**

--- a/src/Services/SourceData/SourceDataPublisher.php
+++ b/src/Services/SourceData/SourceDataPublisher.php
@@ -58,7 +58,7 @@ use RuntimeException;
  * available here (editors authenticate through Zitadel, not a GitHub account), so the
  * fallback is a fixed address rather than a genuine `<id>+<login>@users.noreply.github.com`.
  */
-final class SourceDataPublisher
+final class SourceDataPublisher implements SourceDataPublisherInterface
 {
     private const TREE_ENTRY_MODE = '100644';
 

--- a/src/Services/SourceData/SourceDataPublisher.php
+++ b/src/Services/SourceData/SourceDataPublisher.php
@@ -7,7 +7,10 @@ namespace LiturgicalCalendar\Api\Services\SourceData;
 use InvalidArgumentException;
 use LiturgicalCalendar\Api\Enum\ChangeOperation;
 use LiturgicalCalendar\Api\Repositories\SourceDataChangeRequestRepository;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth;
 use LiturgicalCalendar\Api\Services\GitHub\GitHubGitDataClient;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Http\Client\ClientInterface;
 use RuntimeException;
 
 /**
@@ -231,5 +234,66 @@ final class SourceDataPublisher implements SourceDataPublisherInterface
         }
 
         return ['owner' => $parts[0], 'repo' => $parts[1]];
+    }
+
+    /**
+     * Build a fully wired instance from environment variables: `GITHUB_APP_ID`,
+     * `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY_PATH` (via
+     * {@see GitHubAppAuth::fromEnv()}), `GITHUB_REPOSITORY` (required), and the optional
+     * `GITHUB_BASE_BRANCH` / `GITHUB_APP_COMMITTER_NAME` / `GITHUB_APP_COMMITTER_EMAIL`.
+     *
+     * Mirrors {@see \LiturgicalCalendar\Api\Services\OpenFgaClient::fromEnv()}: centralizes
+     * every `mixed` `$_ENV`/`getenv()` read in `src/`, behind the already-narrowed
+     * {@see getEnvString()} below, rather than leaving a CLI script to read (and blindly
+     * cast) them directly — `phpstan.neon.dist` scans `paths: [src]` only, so a
+     * script-level `(string) $_ENV[...]` is invisible to `composer analyse`.
+     *
+     * @throws RuntimeException         If the GitHub App credential is not configured (see
+     *                                  {@see GitHubAppAuth::fromEnv()}) or `GITHUB_REPOSITORY`
+     *                                  is unset or empty.
+     * @throws InvalidArgumentException If `GITHUB_REPOSITORY` is not a valid "owner/repo" pair.
+     */
+    public static function fromEnv(
+        SourceDataChangeRequestRepository $repository,
+        ClientInterface $http,
+        CacheItemPoolInterface $installationTokenCache
+    ): self {
+        $auth = GitHubAppAuth::fromEnv($http, $installationTokenCache);
+
+        $githubRepository = self::getEnvString('GITHUB_REPOSITORY');
+        if ('' === $githubRepository) {
+            throw new RuntimeException('GITHUB_REPOSITORY is not configured (expected "owner/repo").');
+        }
+        ['owner' => $owner, 'repo' => $repo] = self::splitGithubRepository($githubRepository);
+
+        $client = new GitHubGitDataClient($owner, $repo, $auth, $http);
+
+        $baseBranch     = self::getEnvString('GITHUB_BASE_BRANCH') ?: 'development';
+        $committerName  = self::getEnvString('GITHUB_APP_COMMITTER_NAME') ?: 'Litcal Publisher';
+        $committerEmail = self::getEnvString('GITHUB_APP_COMMITTER_EMAIL')
+            ?: 'litcal-publisher[bot]@users.noreply.github.com';
+
+        return new self($repository, $client, $baseBranch, $committerName, $committerEmail);
+    }
+
+    /**
+     * Get an environment variable as a string, or '' if unset/empty. Mirrors
+     * {@see \LiturgicalCalendar\Api\Services\GitHub\GitHubAppAuth}'s own private helper of the
+     * same name (duplicated rather than shared — same precedent as
+     * {@see \LiturgicalCalendar\Api\Services\OpenFgaClient}'s own copy).
+     */
+    private static function getEnvString(string $name): string
+    {
+        $value = $_ENV[$name] ?? null;
+        if (is_string($value) && '' !== trim($value)) {
+            return trim($value);
+        }
+
+        $envValue = getenv($name);
+        if (is_string($envValue) && '' !== trim($envValue)) {
+            return trim($envValue);
+        }
+
+        return '';
     }
 }

--- a/src/Services/SourceData/SourceDataPublisherInterface.php
+++ b/src/Services/SourceData/SourceDataPublisherInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LiturgicalCalendar\Api\Services\SourceData;
+
+use InvalidArgumentException;
+use LiturgicalCalendar\Api\Services\GitHub\GitHubApiException;
+use RuntimeException;
+
+/**
+ * The single seam {@see PublishRunner} depends on.
+ *
+ * {@see SourceDataPublisher} is deliberately `final` (its own docblock explains why: the
+ * author/committer split it implements is the entire point of the design, and that is not
+ * something a subclass should be able to weaken). Its own test suite already exercises the
+ * git-wire protocol end to end against a mocked Guzzle transport
+ * ({@see \LiturgicalCalendar\Tests\Services\SourceData\SourceDataPublisherTest}). `PublishRunner`
+ * only needs to exercise orchestration — claim, publish, record, release-and-stop-on-failure —
+ * so it depends on this narrow interface instead of the concrete class, letting its own tests
+ * use a lightweight fake rather than re-deriving that Guzzle wiring for no additional coverage.
+ */
+interface SourceDataPublisherInterface
+{
+    /**
+     * Publish one approved batch and record the result on every row.
+     *
+     * @throws InvalidArgumentException If the batch does not exist (empty row set).
+     * @throws RuntimeException         If the configured base branch does not exist on GitHub.
+     * @throws GitHubApiException       If any GitHub call fails — in particular, a non-fast-forward
+     *         `updateRef()` on a branch another publish landed on concurrently, which the caller
+     *         is expected to retry.
+     */
+    public function publish(string $batchId): PublishResult;
+}


### PR DESCRIPTION
Refs #902. Phase 2 of the source-data change requests design: **the publisher**. 26 commits, 37 files, +7,031/−55.

Phase 1 (#912) made source-data edits become change requests in Postgres instead of files on disk, because the
deployed server has no git checkout and an `rsync --archive --delete` deploy destroyed anything written there —
which is how the St John Henry Newman decree was nearly lost (#903). Approved requests then sat in Postgres with
nothing to publish them. This is that publisher.

## What it does

```text
approved batch  →  claim (Postgres)
                →  GitHub App auth (RS256 JWT → installation token, cached 50 min)
                →  blob → tree → commit → ref → pull request
                →  publication_status: none → queued → open
```

A cron runner claims one batch at a time and publishes it to a **stable per-resource branch**
(`litcal-data/<resource_type>/<resource_id>`), so the pull request rolls. The commit's **author is the editor**
and the **committer is the App** — that split is the whole point, and it is what preserves per-editor authorship
in the repository.

Phase 3 (merge detection) supplies `merged`/`closed`; nothing here writes them.

## Design decisions worth knowing before review

- **Ancestor exclusion is by age, not by status.** Publishing a batch also publishes the older batch it accumulated
  onto. Marking that ancestor `merged` would assert it was published — and if the containment assumption ever broke,
  the publisher (which selects approved-and-not-merged rows) would skip a batch that was never published and lose it.
  Excluding by age asserts nothing, so the worst case degrades from lost data to a suboptimal rebuild base.
- **`releaseClaim()` reports an observed status, not a row count.** Zero rows conflated "another runner published it"
  with "it was reclaimed to `none`" — and the latter made a real GitHub outage report exit 0 and hammer the API.
- **`force: false`, always.** Serialisation per resource is optimistic concurrency, not mutual exclusion: the loser of
  a same-resource race gets a 422 and retries against the moved ref. That makes `force: false` load-bearing rather
  than merely defensive.
- **A 422 is not an outage.** GitHub answering in detail is positive evidence the API is healthy — the opposite of what
  stop-don't-hammer exists for. It still consumes an attempt, so a branch that 422s forever parks rather than retrying
  forever.
- **A crash strands a batch**, which no exception handler can catch, so batches idle past a grace period are reclaimed.
  The grace is sized against a *whole publish* (`maxRequestsPerBatch × requestTimeout` — the decrees corpus is 28
  requests), not against one request.

## Two defects worth calling out, because both had green test suites

- **The runner's own logger threw on every record it wrote.** The cron script took `LoggerFactory::create()`'s default
  `includeProcessors: true`, which attaches a processor that throws on non-request context. The runner logs batch ids —
  so in production every log call would have thrown, *including those inside its catch blocks, before `releaseClaim()`
  ran*, stranding the batch. Every test injected a hand-built logger with no processors; the class was right, the
  wiring was wrong, and no test crossed that seam.
- **A malformed `GITHUB_REPOSITORY` was an uncaught fatal that every alarm channel called healthy.** The script caught
  only `\RuntimeException` while `fromEnv()` throws `InvalidArgumentException`. Result: exit 255 (undocumented), nothing
  logged past "run starting", and `/health` reporting `configured` because the check tested non-emptiness. A pasted repo
  URL would have accumulated approved work forever with no signal anywhere.

Eleven defects were found in total — four concurrency, two production-only. Every one was found by *running* something;
none by reading. Three were in areas a previous review had already declared correct.

## Not in this PR

- **OpenFGA tuples are not purged for deleted calendars or tests.** Nothing between "PR merged" and "next redeploy"
  performs that purge, so a deleted diocese's former editors retain edit access on an object whose files are gone. This
  is deliberate — only merge detection knows the deletion actually happened — and the runbook states it explicitly.
- **Claim ownership** (a claim token compared in `releaseClaim()`'s `WHERE`) is deferred to phase 3, which must touch the
  same columns and contract anyway. Today a late release can revoke another runner's live claim; bounded, visible, and
  non-destructive.
- **A GitHub App is not registered yet.** Everything is built and tested against mocks. Registration is a documented
  operator step: Contents RW / Pull requests RW / Metadata R, with the private key by path **outside the deployed tree**.
  Until it is set, `/health` reports the publisher unconfigured and approved work accumulates — visibly.

## Verification

4,136 tests / 492,454 assertions / 0 failures. PHPStan level 10 clean on `src` **and** standalone on
`scripts/publish-sourcedata.php` (CI's `phpstan.neon.dist` scans `paths: [src]` only). phpcs, `lint:md`, `lint:jsondata`
all clean. Concurrency is tested with two real OS subprocesses via `proc_open`, because PHP is single-threaded and no
in-process test can make two claims genuinely concurrent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGyuj9umG6o8PzJ4BFf6Xp


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated publishing of approved source-data changes to GitHub through commits and rolling pull requests.
  - Added retry handling, stale-claim recovery and parking for repeatedly failed batches.
  - Added publisher configuration options and cron-based execution with clear success and failure summaries.
  - Extended health reporting to show publisher readiness and parked batches.

- **Documentation**
  - Updated operational guidance, release notes and design documentation for publishing workflows, monitoring and known limitations.

- **Tests**
  - Added comprehensive coverage for publishing, retries, concurrency, authentication, GitHub operations and health reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->